### PR TITLE
Add configurable settings page with integration links

### DIFF
--- a/services/zoe-ui/dist/index.html
+++ b/services/zoe-ui/dist/index.html
@@ -152,6 +152,12 @@
             gap: 20px;
         }
 
+        .nav-right {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+        }
+
         .mini-orb {
             width: 40px;
             height: 40px;
@@ -181,6 +187,23 @@
             font-size: 20px;
             cursor: pointer;
             transition: all 0.2s ease;
+        }
+
+        .settings-btn {
+            width: 40px;
+            height: 40px;
+            border: none;
+            background: rgba(255, 255, 255, 0.3);
+            border-radius: 50%;
+            color: #666;
+            font-size: 18px;
+            cursor: pointer;
+            transition: all 0.2s ease;
+        }
+
+        .settings-btn:hover {
+            background: rgba(123, 97, 255, 0.2);
+            color: #7B61FF;
         }
 
         .close-btn:hover {
@@ -546,7 +569,10 @@
                     <div class="fluid-layer"></div>
                 </div>
             </div>
-            <button class="close-btn" onclick="exitToOrb()">×</button>
+            <div class="nav-right">
+                <button class="settings-btn" onclick="window.location.href='settings.html'">⚙️</button>
+                <button class="close-btn" onclick="exitToOrb()">×</button>
+            </div>
         </div>
 
         <div class="main-container">
@@ -824,6 +850,16 @@
             chatMessages.appendChild(messageDiv);
             chatMessages.scrollTop = chatMessages.scrollHeight;
         }
+
+        document.addEventListener('DOMContentLoaded', () => {
+            const voiceEnabled = localStorage.getItem('voice-toggle') !== 'false';
+            if (!voiceEnabled) {
+                const voiceBtn = document.getElementById('voiceBtn');
+                if (voiceBtn) voiceBtn.style.display = 'none';
+                const overlayVoiceBtn = document.querySelector('#overlay .voice-btn');
+                if (overlayVoiceBtn) overlayVoiceBtn.style.display = 'none';
+            }
+        });
 
     </script>
     <script src="js/overlay.js"></script>

--- a/services/zoe-ui/dist/settings.html
+++ b/services/zoe-ui/dist/settings.html
@@ -1,0 +1,136 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Zoe Settings</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'SF Pro Display', system-ui, sans-serif;
+            background: linear-gradient(135deg, #fafbfc 0%, #f1f3f6 100%);
+            margin: 0;
+            padding: 0;
+        }
+        .nav-bar {
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            height: 70px;
+            background: rgba(255, 255, 255, 0.8);
+            backdrop-filter: blur(40px);
+            border-bottom: 1px solid rgba(255, 255, 255, 0.3);
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            padding: 0 20px;
+            z-index: 110;
+        }
+        .nav-left {
+            display: flex;
+            align-items: center;
+            gap: 20px;
+        }
+        .mini-orb {
+            width: 40px;
+            height: 40px;
+            border-radius: 50%;
+            background: linear-gradient(135deg, #7B61FF 0%, #5AE0E0 100%);
+            cursor: pointer;
+            position: relative;
+            overflow: hidden;
+            transition: transform 0.2s ease;
+        }
+        .mini-orb:hover {
+            transform: scale(1.1);
+        }
+        .mini-orb .fluid-layer {
+            animation: breathe 2s ease-in-out infinite;
+            position: absolute;
+            inset: 0;
+            border-radius: 50%;
+            background: radial-gradient(circle at 30% 30%, rgba(255,255,255,0.3) 0%, transparent 70%);
+        }
+        @keyframes breathe {
+            0%,100% { transform: scale(1); opacity: 0.8; }
+            50% { transform: scale(1.1); opacity: 1; }
+        }
+        .close-btn {
+            width: 40px;
+            height: 40px;
+            border: none;
+            background: rgba(255, 255, 255, 0.3);
+            border-radius: 50%;
+            color: #666;
+            font-size: 20px;
+            cursor: pointer;
+            transition: all 0.2s ease;
+        }
+        .close-btn:hover {
+            background: rgba(255, 100, 100, 0.2);
+            color: #ff6b6b;
+        }
+        .settings-container {
+            max-width: 600px;
+            margin: 100px auto;
+            padding: 20px;
+        }
+        .settings-section {
+            margin-bottom: 40px;
+        }
+        .settings-section h2 {
+            margin-bottom: 10px;
+            font-size: 20px;
+            color: #333;
+        }
+        .integration-link {
+            display: block;
+            background: rgba(255, 255, 255, 0.8);
+            padding: 15px 20px;
+            border-radius: 12px;
+            margin-bottom: 10px;
+            text-decoration: none;
+            color: #333;
+            transition: background 0.2s ease;
+        }
+        .integration-link:hover {
+            background: rgba(123, 97, 255, 0.1);
+        }
+    </style>
+</head>
+<body>
+    <div class="nav-bar">
+        <div class="nav-left">
+            <div class="mini-orb" onclick="window.location.href='index.html'">
+                <div class="fluid-layer"></div>
+            </div>
+        </div>
+        <button class="close-btn" onclick="window.location.href='index.html'">×</button>
+    </div>
+    <div class="settings-container">
+        <h1>Zoe Settings</h1>
+        <div class="settings-section">
+            <h2>General</h2>
+            <label><input type="checkbox" id="voice-toggle" checked> Enable Voice</label><br>
+            <label><input type="checkbox" id="notifications-toggle" checked> Enable Notifications</label>
+        </div>
+        <div class="settings-section">
+            <h2>Integrations</h2>
+            <a class="integration-link" href="http://localhost:9003" target="_blank">Matrix</a>
+            <a class="integration-link" href="http://localhost:5678" target="_blank">n8n</a>
+            <a class="integration-link" href="http://localhost:8123" target="_blank">Home Assistant</a>
+        </div>
+    </div>
+    <script>
+        document.querySelectorAll('input[type="checkbox"]').forEach(cb => {
+            const saved = localStorage.getItem(cb.id);
+            if (saved !== null) {
+                cb.checked = saved === 'true';
+            }
+            cb.addEventListener('change', () => {
+                localStorage.setItem(cb.id, cb.checked);
+            });
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add standalone settings page to manage Zoe options and reach Matrix, n8n and Home Assistant tools
- Expose settings through new gear button in main UI and style support
- Hide voice controls when disabled via stored settings

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689579d2cc948332af46b17e00696461