### PR TITLE
Add multi-user authentication and admin management UI

### DIFF
--- a/services/zoe-ui/dist/js/user-management.js
+++ b/services/zoe-ui/dist/js/user-management.js
@@ -1,0 +1,76 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const userDisplay = document.getElementById('currentUserDisplay');
+    fetch('/api/whoami').then(res => {
+        if (!res.ok) throw new Error();
+        return res.json();
+    }).then(data => {
+        if (userDisplay) {
+            userDisplay.textContent = `${data.username} (${data.role})`;
+        }
+        if (data.role === 'admin') {
+            const section = document.getElementById('userManagementSection');
+            if (section) section.style.display = 'block';
+            loadUsers();
+        }
+    }).catch(() => {
+        if (userDisplay) userDisplay.textContent = 'Not logged in';
+    });
+
+    const addBtn = document.getElementById('addUserBtn');
+    if (addBtn) addBtn.addEventListener('click', addUser);
+});
+
+function loadUsers() {
+    fetch('/api/users/list').then(r => r.json()).then(data => {
+        const list = document.getElementById('userList');
+        if (!list) return;
+        list.innerHTML = '';
+        data.users.forEach(u => {
+            const li = document.createElement('li');
+            li.textContent = `${u.username} (${u.role})`;
+            const roleSelect = document.createElement('select');
+            ['user','admin'].forEach(role => {
+                const opt = document.createElement('option');
+                opt.value = role;
+                opt.textContent = role;
+                if (role === u.role) opt.selected = true;
+                roleSelect.appendChild(opt);
+            });
+            roleSelect.onchange = () => changeRole(u.username, roleSelect.value);
+            const delBtn = document.createElement('button');
+            delBtn.textContent = 'Delete';
+            delBtn.onclick = () => deleteUser(u.username);
+            li.appendChild(roleSelect);
+            li.appendChild(delBtn);
+            list.appendChild(li);
+        });
+    });
+}
+
+function addUser() {
+    const username = document.getElementById('newUsername').value;
+    const passcode = document.getElementById('newPasscode').value;
+    const role = document.getElementById('newRole').value;
+    fetch('/api/users/register', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({username, passcode, role})
+    }).then(res => {
+        if (!res.ok) throw new Error('Failed');
+        return res.json();
+    }).then(() => {
+        loadUsers();
+    });
+}
+
+function deleteUser(username) {
+    fetch(`/api/users/${username}`, {method: 'DELETE'}).then(() => loadUsers());
+}
+
+function changeRole(username, role) {
+    fetch(`/api/users/${username}/role`, {
+        method: 'PATCH',
+        headers: {'Content-Type':'application/json'},
+        body: JSON.stringify({role})
+    }).then(() => loadUsers());
+}

--- a/services/zoe-ui/dist/settings.html
+++ b/services/zoe-ui/dist/settings.html
@@ -72,6 +72,7 @@
                 <a href="settings.html" class="nav-item active">Settings</a>
             </div>
         </div>
+        <div id="currentUserDisplay" class="nav-item"></div>
         <button class="close-btn" onclick="exitToOrb()">×</button>
     </div>
 
@@ -90,6 +91,19 @@
             <h1>Settings</h1>
             <p>Manage your preferences here.</p>
             <!-- TODO: Add settings options -->
+            <div id="userManagementSection" style="display:none;margin-top:20px;">
+                <h2>User Management</h2>
+                <ul id="userList"></ul>
+                <div style="margin-top:10px;">
+                    <input id="newUsername" placeholder="Username">
+                    <input id="newPasscode" type="password" placeholder="Passcode">
+                    <select id="newRole">
+                        <option value="user">User</option>
+                        <option value="admin">Admin</option>
+                    </select>
+                    <button id="addUserBtn">Add User</button>
+                </div>
+            </div>
         </div>
     </div>
 </div>
@@ -150,6 +164,7 @@
         }
 </script>
 <script src="js/overlay.js"></script>
+<script src="js/user-management.js"></script>
 
     <title>Zoe Settings</title>
     <style>


### PR DESCRIPTION
## Summary
- Add persistent multi-user system with role-based access control and session endpoints
- Introduce admin-only user management UI on settings page with current user display

## Testing
- `pip install -r services/zoe-core/requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68959bbd28c08332817ddcc554a6c50d