### PR TITLE
Add journal and tasks UI pages

### DIFF
--- a/services/zoe-ui/dist/calendar.html
+++ b/services/zoe-ui/dist/calendar.html
@@ -913,11 +913,13 @@
                     <div class="fluid-layer"></div>
                 </div>
                 <div class="nav-menu">
-                    <a href="index.html" class="nav-item">Chat</a>
-                    <a href="dashboard.html" class="nav-item">Dashboard</a>
-                    <a href="calendar.html" class="nav-item active">Calendar</a>
-                    <a href="settings.html" class="nav-item">Settings</a>
-                </div>
+                <a href="index.html" class="nav-item">Chat</a>
+                <a href="dashboard.html" class="nav-item">Dashboard</a>
+                <a href="calendar.html" class="nav-item active">Calendar</a>
+                <a href="journal.html" class="nav-item">Journal</a>
+                <a href="tasks.html" class="nav-item">Tasks</a>
+                <a href="settings.html" class="nav-item">Settings</a>
+            </div>
             </div>
             <button class="close-btn" onclick="exitToOrb()">×</button>
         </div>

--- a/services/zoe-ui/dist/dashboard.html
+++ b/services/zoe-ui/dist/dashboard.html
@@ -68,6 +68,8 @@
                 <a href="index.html" class="nav-item">Chat</a>
                 <a href="dashboard.html" class="nav-item active">Dashboard</a>
                 <a href="calendar.html" class="nav-item">Calendar</a>
+                <a href="journal.html" class="nav-item">Journal</a>
+                <a href="tasks.html" class="nav-item">Tasks</a>
                 <a href="settings.html" class="nav-item">Settings</a>
             </div>
         </div>

--- a/services/zoe-ui/dist/index.html
+++ b/services/zoe-ui/dist/index.html
@@ -591,6 +591,8 @@
                     <a href="index.html" class="nav-item active">Chat</a>
                     <a href="dashboard.html" class="nav-item">Dashboard</a>
                     <a href="calendar.html" class="nav-item">Calendar</a>
+                    <a href="journal.html" class="nav-item">Journal</a>
+                    <a href="tasks.html" class="nav-item">Tasks</a>
                     <a href="settings.html" class="nav-item">Settings</a>
                 </div>
             </div>

--- a/services/zoe-ui/dist/journal.html
+++ b/services/zoe-ui/dist/journal.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Zoe - Journal</title>
+    <style>
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+        body { font-family: -apple-system, BlinkMacSystemFont, 'SF Pro Display', system-ui, sans-serif; background: linear-gradient(135deg, #fafbfc 0%, #f1f3f6 100%); min-height: 100vh; }
+        .nav-bar { position: fixed; top: 0; left: 0; right: 0; height: 70px; background: rgba(255,255,255,0.8); backdrop-filter: blur(40px); border-bottom: 1px solid rgba(255,255,255,0.3); display: flex; align-items: center; padding: 0 20px; z-index: 10; }
+        .nav-left { display: flex; align-items: center; gap: 20px; }
+        .nav-menu { display: flex; gap: 20px; }
+        .nav-item { color: #666; text-decoration: none; font-size: 13px; font-weight: 400; transition: color 0.3s ease; }
+        .nav-item:hover, .nav-item.active { color: #7B61FF; }
+        .mini-orb { width: 40px; height: 40px; border-radius: 50%; background: linear-gradient(135deg, #7B61FF 0%, #5AE0E0 100%); cursor: pointer; position: relative; overflow: hidden; }
+        .mini-orb .fluid-layer { position: absolute; inset: 0; border-radius: 50%; background: radial-gradient(circle at 30% 30%, rgba(255,255,255,0.3) 0%, transparent 70%); animation: breathe 2s ease-in-out infinite; }
+        @keyframes breathe { 0%,100% { transform: scale(1); } 50% { transform: scale(1.1); } }
+        .main-container { max-width: 800px; margin: 100px auto 40px; padding: 0 20px; display: flex; flex-direction: column; gap: 20px; }
+        .journal-entry { background: rgba(255,255,255,0.8); border-radius: 12px; padding: 15px; box-shadow: 0 2px 4px rgba(0,0,0,0.05); }
+        .journal-date { font-size: 12px; color: #666; margin-bottom: 8px; }
+        .journal-content { font-size: 14px; white-space: pre-wrap; }
+        .journal-new textarea { width: 100%; height: 100px; padding: 10px; border-radius: 8px; border: 1px solid #ccc; resize: vertical; }
+        .journal-new button { margin-top: 10px; padding: 10px 20px; border: none; border-radius: 20px; background: linear-gradient(135deg, #7B61FF 0%, #5AE0E0 100%); color: #fff; cursor: pointer; }
+    </style>
+</head>
+<body>
+    <div class="nav-bar">
+        <div class="nav-left">
+            <div class="mini-orb" onclick="window.location.href='index.html'">
+                <div class="fluid-layer"></div>
+            </div>
+            <div class="nav-menu">
+                <a href="index.html" class="nav-item">Chat</a>
+                <a href="dashboard.html" class="nav-item">Dashboard</a>
+                <a href="calendar.html" class="nav-item">Calendar</a>
+                <a href="journal.html" class="nav-item active">Journal</a>
+                <a href="tasks.html" class="nav-item">Tasks</a>
+                <a href="settings.html" class="nav-item">Settings</a>
+            </div>
+        </div>
+    </div>
+
+    <div class="main-container">
+        <h1>Journal</h1>
+        <div id="journalEntries"></div>
+        <div class="journal-new">
+            <textarea id="journalInput" placeholder="Write a new entry..."></textarea>
+            <button id="saveJournal">Save Entry</button>
+        </div>
+    </div>
+
+    <script>
+    async function loadJournal() {
+        try {
+            const res = await fetch('/api/journal');
+            const entries = await res.json();
+            const container = document.getElementById('journalEntries');
+            container.innerHTML = '';
+            entries.forEach(e => {
+                const entryDiv = document.createElement('div');
+                entryDiv.className = 'journal-entry';
+                const dateDiv = document.createElement('div');
+                dateDiv.className = 'journal-date';
+                dateDiv.textContent = new Date(e.created_at).toLocaleString();
+                const contentDiv = document.createElement('div');
+                contentDiv.className = 'journal-content';
+                contentDiv.textContent = e.content;
+                entryDiv.appendChild(dateDiv);
+                entryDiv.appendChild(contentDiv);
+                container.appendChild(entryDiv);
+            });
+        } catch (err) {
+            console.error('Failed to load journal', err);
+        }
+    }
+
+    async function saveJournal() {
+        const textarea = document.getElementById('journalInput');
+        const content = textarea.value.trim();
+        if (!content) return;
+        try {
+            await fetch('/api/journal', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ content })
+            });
+            textarea.value = '';
+            loadJournal();
+        } catch (err) {
+            console.error('Failed to save journal', err);
+        }
+    }
+
+    document.getElementById('saveJournal').addEventListener('click', saveJournal);
+    document.addEventListener('DOMContentLoaded', loadJournal);
+    </script>
+    <script src="js/overlay.js"></script>
+</body>
+</html>

--- a/services/zoe-ui/dist/settings.html
+++ b/services/zoe-ui/dist/settings.html
@@ -69,6 +69,8 @@
                 <a href="index.html" class="nav-item">Chat</a>
                 <a href="dashboard.html" class="nav-item">Dashboard</a>
                 <a href="calendar.html" class="nav-item">Calendar</a>
+                <a href="journal.html" class="nav-item">Journal</a>
+                <a href="tasks.html" class="nav-item">Tasks</a>
                 <a href="settings.html" class="nav-item active">Settings</a>
             </div>
         </div>

--- a/services/zoe-ui/dist/tasks.html
+++ b/services/zoe-ui/dist/tasks.html
@@ -1,0 +1,158 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Zoe - Tasks</title>
+    <style>
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+        body { font-family: -apple-system, BlinkMacSystemFont, 'SF Pro Display', system-ui, sans-serif; background: linear-gradient(135deg, #fafbfc 0%, #f1f3f6 100%); min-height: 100vh; }
+        .nav-bar { position: fixed; top: 0; left: 0; right: 0; height: 70px; background: rgba(255,255,255,0.8); backdrop-filter: blur(40px); border-bottom: 1px solid rgba(255,255,255,0.3); display: flex; align-items: center; padding: 0 20px; z-index: 10; }
+        .nav-left { display: flex; align-items: center; gap: 20px; }
+        .nav-menu { display: flex; gap: 20px; }
+        .nav-item { color: #666; text-decoration: none; font-size: 13px; font-weight: 400; transition: color 0.3s ease; }
+        .nav-item:hover, .nav-item.active { color: #7B61FF; }
+        .mini-orb { width: 40px; height: 40px; border-radius: 50%; background: linear-gradient(135deg, #7B61FF 0%, #5AE0E0 100%); cursor: pointer; position: relative; overflow: hidden; }
+        .mini-orb .fluid-layer { position: absolute; inset: 0; border-radius: 50%; background: radial-gradient(circle at 30% 30%, rgba(255,255,255,0.3) 0%, transparent 70%); animation: breathe 2s ease-in-out infinite; }
+        @keyframes breathe { 0%,100% { transform: scale(1); } 50% { transform: scale(1.1); } }
+        .main-container { max-width: 800px; margin: 100px auto 40px; padding: 0 20px; display: flex; flex-direction: column; gap: 20px; }
+        .task-input { display: flex; gap: 10px; }
+        .task-input input { flex: 1; padding: 10px; border-radius: 8px; border: 1px solid #ccc; }
+        .task-input button { padding: 10px 20px; border: none; border-radius: 20px; background: linear-gradient(135deg, #7B61FF 0%, #5AE0E0 100%); color: #fff; cursor: pointer; }
+        .task-list { list-style: none; display: flex; flex-direction: column; gap: 10px; }
+        .task-item { display: flex; align-items: center; gap: 10px; background: rgba(255,255,255,0.8); padding: 10px 15px; border-radius: 12px; box-shadow: 0 2px 4px rgba(0,0,0,0.05); }
+        .task-title { flex: 1; }
+        .task-actions button { background: none; border: none; cursor: pointer; font-size: 16px; }
+    </style>
+</head>
+<body>
+    <div class="nav-bar">
+        <div class="nav-left">
+            <div class="mini-orb" onclick="window.location.href='index.html'">
+                <div class="fluid-layer"></div>
+            </div>
+            <div class="nav-menu">
+                <a href="index.html" class="nav-item">Chat</a>
+                <a href="dashboard.html" class="nav-item">Dashboard</a>
+                <a href="calendar.html" class="nav-item">Calendar</a>
+                <a href="journal.html" class="nav-item">Journal</a>
+                <a href="tasks.html" class="nav-item active">Tasks</a>
+                <a href="settings.html" class="nav-item">Settings</a>
+            </div>
+        </div>
+    </div>
+
+    <div class="main-container">
+        <h1>Tasks</h1>
+        <div class="task-input">
+            <input id="newTaskTitle" placeholder="New task..." />
+            <button id="addTask">Add</button>
+        </div>
+        <ul id="taskList" class="task-list"></ul>
+    </div>
+
+    <script>
+    async function loadTasks() {
+        try {
+            const res = await fetch('/api/tasks');
+            const tasks = await res.json();
+            const list = document.getElementById('taskList');
+            list.innerHTML = '';
+            tasks.forEach(t => {
+                const li = document.createElement('li');
+                li.className = 'task-item';
+
+                const checkbox = document.createElement('input');
+                checkbox.type = 'checkbox';
+                checkbox.checked = t.status === 'completed';
+                checkbox.addEventListener('change', () => toggleTask(t.id, checkbox.checked));
+
+                const span = document.createElement('span');
+                span.className = 'task-title';
+                span.textContent = t.title;
+
+                const actions = document.createElement('div');
+                actions.className = 'task-actions';
+
+                const editBtn = document.createElement('button');
+                editBtn.textContent = '✏️';
+                editBtn.addEventListener('click', () => editTask(t.id, t.title));
+
+                const delBtn = document.createElement('button');
+                delBtn.textContent = '🗑️';
+                delBtn.addEventListener('click', () => deleteTask(t.id));
+
+                actions.appendChild(editBtn);
+                actions.appendChild(delBtn);
+
+                li.appendChild(checkbox);
+                li.appendChild(span);
+                li.appendChild(actions);
+                list.appendChild(li);
+            });
+        } catch (err) {
+            console.error('Failed to load tasks', err);
+        }
+    }
+
+    async function addTask() {
+        const input = document.getElementById('newTaskTitle');
+        const title = input.value.trim();
+        if (!title) return;
+        try {
+            await fetch('/api/tasks', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ title })
+            });
+            input.value = '';
+            loadTasks();
+        } catch (err) {
+            console.error('Failed to add task', err);
+        }
+    }
+
+    async function toggleTask(id, done) {
+        try {
+            await fetch(`/api/tasks/${id}`, {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ status: done ? 'completed' : 'pending' })
+            });
+            loadTasks();
+        } catch (err) {
+            console.error('Failed to update task', err);
+        }
+    }
+
+    async function editTask(id, currentTitle) {
+        const title = prompt('Edit task', currentTitle);
+        if (title === null) return;
+        try {
+            await fetch(`/api/tasks/${id}`, {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ title })
+            });
+            loadTasks();
+        } catch (err) {
+            console.error('Failed to edit task', err);
+        }
+    }
+
+    async function deleteTask(id) {
+        if (!confirm('Delete this task?')) return;
+        try {
+            await fetch(`/api/tasks/${id}`, { method: 'DELETE' });
+            loadTasks();
+        } catch (err) {
+            console.error('Failed to delete task', err);
+        }
+    }
+
+    document.getElementById('addTask').addEventListener('click', addTask);
+    document.addEventListener('DOMContentLoaded', loadTasks);
+    </script>
+    <script src="js/overlay.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add new Journal page listing entries and allowing new additions via `/api/journal`
- Add new Tasks page with CRUD actions using `/api/tasks`
- Update navigation across UI to link to Journal and Tasks pages

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68959c4faf508332bdcdb6e926bf80fc