### PR TITLE
feat: add matrix chat UI

### DIFF
--- a/services/zoe-core/main.py
+++ b/services/zoe-core/main.py
@@ -886,13 +886,26 @@ async def send_matrix_message(message_data: dict):
     """Send message via Matrix"""
     if not integration_manager.services_status["matrix"]:
         raise HTTPException(status_code=503, detail="Matrix service not available")
-    
+
     try:
         async with httpx.AsyncClient(timeout=10.0) as client:
             response = await client.post(f"{CONFIG['matrix_url']}/api/send", json=message_data)
             return response.json()
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Matrix send error: {str(e)}")
+
+@app.get("/api/matrix/receive")
+async def receive_matrix_messages(room_id: str):
+    """Receive Matrix messages"""
+    if not integration_manager.services_status["matrix"]:
+        raise HTTPException(status_code=503, detail="Matrix service not available")
+
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            response = await client.get(f"{CONFIG['matrix_url']}/api/receive", params={"room_id": room_id})
+            return response.json()
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Matrix receive error: {str(e)}")
 
 # SETTINGS AND CONFIGURATION
 

--- a/services/zoe-ui/dist/index.html
+++ b/services/zoe-ui/dist/index.html
@@ -306,6 +306,32 @@
         }
 
         /* Chat Interface */
+        .matrix-wrapper {
+            display: flex;
+            gap: 20px;
+        }
+        .matrix-rooms {
+            width: 200px;
+            background: rgba(255, 255, 255, 0.6);
+            backdrop-filter: blur(40px);
+            border: 1px solid rgba(255, 255, 255, 0.4);
+            border-radius: 25px;
+            padding: 10px;
+            box-shadow: 0 20px 60px rgba(0, 0, 0, 0.05);
+            max-height: 400px;
+            overflow-y: auto;
+        }
+        .matrix-room {
+            padding: 8px;
+            border-radius: 10px;
+            cursor: pointer;
+        }
+        .matrix-room.active {
+            background: rgba(123, 97, 255, 0.2);
+        }
+        .matrix-message {
+            margin-bottom: 10px;
+        }
         .chat-container {
             background: rgba(255, 255, 255, 0.6);
             backdrop-filter: blur(40px);
@@ -620,15 +646,18 @@
             </div>
 
             <!-- Chat Interface -->
-            <div class="chat-container">
-                <div class="chat-messages" id="chatMessages">
-                    <!-- Messages will be populated here -->
-                </div>
-                
-                <div class="chat-input-group">
-                    <input type="text" class="chat-input" id="chatInput" placeholder="Type your message..." autofocus>
-                    <button class="voice-btn" id="voiceBtn" onclick="toggleVoice()">🎤</button>
-                    <button class="send-btn" onclick="sendMessage()">→</button>
+            <div class="matrix-wrapper">
+                <div class="matrix-rooms" id="matrixRooms"></div>
+                <div class="chat-container">
+                    <div class="chat-messages" id="chatMessages">
+                        <!-- Messages will be populated here -->
+                    </div>
+
+                    <div class="chat-input-group">
+                        <input type="text" class="chat-input" id="chatInput" placeholder="Type your message..." autofocus>
+                        <button class="voice-btn" id="voiceBtn" onclick="toggleVoice()">🎤</button>
+                        <button class="send-btn" onclick="sendMessage()">→</button>
+                    </div>
                 </div>
             </div>
 
@@ -887,6 +916,8 @@
         });
 
     </script>
+    <script src="js/api.js"></script>
+    <script src="js/matrix.js"></script>
     <script src="js/overlay.js"></script>
 </body>
 </html>

--- a/services/zoe-ui/dist/js/api.js
+++ b/services/zoe-ui/dist/js/api.js
@@ -11,12 +11,40 @@ window.zoeAPI = {
             return { error: error.message };
         }
     },
-    async getHealth() {
+      async getHealth() {
         try {
             const response = await fetch('/health');
             return await response.json();
         } catch (error) {
             return { status: 'error' };
         }
-    }
-};
+      },
+      async getMatrixRooms() {
+          try {
+              const response = await fetch('/api/matrix/rooms');
+              return await response.json();
+          } catch (error) {
+              return { error: error.message };
+          }
+      },
+      async sendMatrixMessage(room_id, message) {
+          try {
+              const response = await fetch('/api/matrix/send', {
+                  method: 'POST',
+                  headers: { 'Content-Type': 'application/json' },
+                  body: JSON.stringify({ room_id, message })
+              });
+              return await response.json();
+          } catch (error) {
+              return { error: error.message };
+          }
+      },
+      async receiveMatrixMessages(room_id) {
+          try {
+              const response = await fetch(`/api/matrix/receive?room_id=${encodeURIComponent(room_id)}`);
+              return await response.json();
+          } catch (error) {
+              return { error: error.message };
+          }
+      }
+  };

--- a/services/zoe-ui/dist/js/matrix.js
+++ b/services/zoe-ui/dist/js/matrix.js
@@ -1,0 +1,56 @@
+let currentRoomId = null;
+let pollHandle = null;
+
+async function loadRooms() {
+    const data = await window.zoeAPI.getMatrixRooms();
+    const list = document.getElementById('matrixRooms');
+    if (!list) return;
+    list.innerHTML = '';
+    if (!data.rooms) return;
+    Object.entries(data.rooms).forEach(([id, name]) => {
+        const div = document.createElement('div');
+        div.className = 'matrix-room';
+        div.textContent = name;
+        div.onclick = () => selectRoom(id, div);
+        list.appendChild(div);
+    });
+    // Auto-select first room
+    const first = list.querySelector('.matrix-room');
+    if (first) first.click();
+}
+
+async function selectRoom(roomId, element) {
+    currentRoomId = roomId;
+    document.querySelectorAll('.matrix-room').forEach(r => r.classList.remove('active'));
+    if (element) element.classList.add('active');
+    await loadMessages();
+    if (pollHandle) clearInterval(pollHandle);
+    pollHandle = setInterval(loadMessages, 5000);
+}
+
+async function loadMessages() {
+    if (!currentRoomId) return;
+    const data = await window.zoeAPI.receiveMatrixMessages(currentRoomId);
+    const container = document.getElementById('chatMessages');
+    if (!container) return;
+    container.innerHTML = '';
+    (data.messages || []).forEach(msg => {
+        const div = document.createElement('div');
+        div.className = 'matrix-message';
+        div.textContent = `${msg.sender}: ${msg.message}`;
+        container.appendChild(div);
+    });
+    container.scrollTop = container.scrollHeight;
+}
+
+window.sendMessage = async function() {
+    const input = document.getElementById('chatInput');
+    if (!input) return;
+    const message = input.value.trim();
+    if (!message || !currentRoomId) return;
+    await window.zoeAPI.sendMatrixMessage(currentRoomId, message);
+    input.value = '';
+    await loadMessages();
+};
+
+document.addEventListener('DOMContentLoaded', loadRooms);

--- a/services/zoe-ui/dist/settings.html
+++ b/services/zoe-ui/dist/settings.html
@@ -264,6 +264,7 @@
         </div>
         <div class="settings-section">
             <h2>Integrations</h2>
+            <label><input type="checkbox" id="matrix-sync-toggle"> Enable Matrix Sync</label><br>
             <a class="integration-link" href="http://localhost:9003" target="_blank">Matrix</a>
             <a class="integration-link" href="http://localhost:5678" target="_blank">n8n</a>
             <a class="integration-link" href="http://localhost:8123" target="_blank">Home Assistant</a>
@@ -279,6 +280,26 @@
                 localStorage.setItem(cb.id, cb.checked);
             });
         });
+
+        // Load Matrix sync setting from server
+        fetch('/api/settings').then(r => r.json()).then(data => {
+            const cb = document.getElementById('matrix-sync-toggle');
+            if (cb && data.integrations) {
+                cb.checked = data.integrations.matrix_enabled;
+            }
+        });
+
+        // Update server when Matrix sync toggled
+        const matrixToggle = document.getElementById('matrix-sync-toggle');
+        if (matrixToggle) {
+            matrixToggle.addEventListener('change', () => {
+                fetch('/api/settings', {
+                    method: 'PUT',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ integrations: { matrix_enabled: matrixToggle.checked } })
+                });
+            });
+        }
     </script>
 
 </body>


### PR DESCRIPTION
## Summary
- track Matrix room messages and expose `/api/receive`
- expose `/api/matrix/receive` through core API
- add Matrix chat sidebar with room list and polling client
- allow enabling Matrix sync in settings

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68959c5d860c8332a4dcc11624128672