### PR TITLE
Ensure API methods are wrapped and fix diagnostics

### DIFF
--- a/services/zoe-ui/dist/js/api.js
+++ b/services/zoe-ui/dist/js/api.js
@@ -11,20 +11,21 @@ window.zoeAPI = {
             return { error: error.message };
         }
     },
-      async getHealth() {
+    async getHealth() {
         try {
             const response = await fetch('/health');
             return await response.json();
         } catch (error) {
             return { status: 'error' };
         }
-
     },
     async getDiagnostics() {
         try {
             const response = await fetch('/api/diagnostics');
-
-
+            return await response.json();
+        } catch (error) {
+            return { status: 'error' };
+        }
     },
     async getModules() {
         try {
@@ -41,42 +42,37 @@ window.zoeAPI = {
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ name, enabled })
             });
-
+            return await response.json();
+        } catch (error) {
+            return { error: error.message };
+        }
+    },
+    async getMatrixRooms() {
+        try {
+            const response = await fetch('/api/matrix/rooms');
+            return await response.json();
+        } catch (error) {
+            return { error: error.message };
+        }
+    },
+    async sendMatrixMessage(room_id, message) {
+        try {
+            const response = await fetch('/api/matrix/send', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ room_id, message })
+            });
+            return await response.json();
+        } catch (error) {
+            return { error: error.message };
+        }
+    },
+    async receiveMatrixMessages(room_id) {
+        try {
+            const response = await fetch(`/api/matrix/receive?room_id=${encodeURIComponent(room_id)}`);
             return await response.json();
         } catch (error) {
             return { error: error.message };
         }
     }
 };
-
-      },
-      async getMatrixRooms() {
-          try {
-              const response = await fetch('/api/matrix/rooms');
-              return await response.json();
-          } catch (error) {
-              return { error: error.message };
-          }
-      },
-      async sendMatrixMessage(room_id, message) {
-          try {
-              const response = await fetch('/api/matrix/send', {
-                  method: 'POST',
-                  headers: { 'Content-Type': 'application/json' },
-                  body: JSON.stringify({ room_id, message })
-              });
-              return await response.json();
-          } catch (error) {
-              return { error: error.message };
-          }
-      },
-      async receiveMatrixMessages(room_id) {
-          try {
-              const response = await fetch(`/api/matrix/receive?room_id=${encodeURIComponent(room_id)}`);
-              return await response.json();
-          } catch (error) {
-              return { error: error.message };
-          }
-      }
-  };
-


### PR DESCRIPTION
## Summary
- Wrap all API and Matrix helper methods inside `window.zoeAPI`
- Complete `getDiagnostics` to return JSON results
- Remove stray braces and ensure single object closing

## Testing
- `pytest` *(fails: IndentationError in services/zoe-core/main.py)*

------
https://chatgpt.com/codex/tasks/task_e_6895da7c7090833288ff331e5dcc29af