### PR TITLE
feat: add selectable AI models

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ services:
   zoe-ollama:
     image: ollama/ollama:latest
     container_name: zoe-ollama
+    command: >
+      bash -c "ollama pull llama3.2:3b && ollama pull mistral:7b && ollama serve"
     ports:
       - "11434:11434"
     volumes:

--- a/services/zoe-ui/dist/js/settings.js
+++ b/services/zoe-ui/dist/js/settings.js
@@ -1,0 +1,60 @@
+// Settings page logic for model selection
+
+async function loadModelSettings() {
+    const radios = document.querySelectorAll('input[name="model"]');
+    const statusElems = {
+        'llama3.2:3b': document.getElementById('llama-status'),
+        'mistral:7b': document.getElementById('mistral-status')
+    };
+
+    try {
+        const resp = await fetch('/api/models/status');
+        const data = await resp.json();
+        data.forEach(m => {
+            const el = statusElems[m.name];
+            if (el) {
+                el.textContent = m.available ? '✅' : '⚠️';
+            }
+        });
+    } catch (e) {
+        console.error('Status load failed', e);
+    }
+
+    try {
+        const resp = await fetch('/api/settings/model');
+        const data = await resp.json();
+        radios.forEach(r => {
+            if (r.value === data.active_model) {
+                r.checked = true;
+            }
+        });
+    } catch (e) {
+        console.error('Active model load failed', e);
+    }
+
+    radios.forEach(r => {
+        r.addEventListener('change', async () => {
+            const selected = document.querySelector('input[name="model"]:checked').value;
+            if (statusElems[selected]) {
+                statusElems[selected].textContent = '⏳';
+            }
+            try {
+                await fetch('/api/settings/model', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ model_name: selected })
+                });
+                if (statusElems[selected]) {
+                    statusElems[selected].textContent = '✅';
+                }
+            } catch (e) {
+                console.error('Model switch failed', e);
+                if (statusElems[selected]) {
+                    statusElems[selected].textContent = '⚠️';
+                }
+            }
+        });
+    });
+}
+
+document.addEventListener('DOMContentLoaded', loadModelSettings);

--- a/services/zoe-ui/dist/settings.html
+++ b/services/zoe-ui/dist/settings.html
@@ -52,6 +52,9 @@
         .settings-content.active { display: block; }
         .module-item { display: flex; align-items: center; justify-content: space-between; padding: 8px 0; border-bottom: 1px solid rgba(0,0,0,0.05); }
         .module-item label { display: flex; align-items: center; gap: 10px; color: #333; font-weight: 300; }
+        .model-options { display: flex; flex-direction: column; gap: 10px; margin-top: 20px; }
+        .model-option { display: flex; align-items: center; gap: 10px; }
+        .model-status { margin-left: 6px; }
     </style>
 </head>
 <body>
@@ -102,7 +105,21 @@
             <h1>Settings</h1>
             <p>Manage your preferences here.</p>
 
-            <!-- TODO: Add settings options -->
+            <div class="settings-section">
+                <h3>🧠 AI Model Selection</h3>
+                <div class="model-options">
+                    <label class="model-option">
+                        <input type="radio" name="model" value="llama3.2:3b">
+                        <span>Llama 3.2 (3B) - Faster, efficient</span>
+                        <div class="model-status" id="llama-status">●</div>
+                    </label>
+                    <label class="model-option">
+                        <input type="radio" name="model" value="mistral:7b">
+                        <span>Mistral 7B - More capable, original</span>
+                        <div class="model-status" id="mistral-status">●</div>
+                    </label>
+                </div>
+            </div>
             <div id="userManagementSection" style="display:none;margin-top:20px;">
                 <h2>User Management</h2>
                 <ul id="userList"></ul>
@@ -155,6 +172,7 @@
 </script>
 <script src="js/overlay.js"></script>
 <script src="js/user-management.js"></script>
+<script src="js/settings.js"></script>
 
 
     <title>Zoe Settings</title>


### PR DESCRIPTION
## Summary
- add settings helpers and API endpoints for switching AI models
- support Llama 3.2 and Mistral 7B with dynamic fallback
- expose model selection UI and persist models in docker compose

## Testing
- `pytest tests/test_extract_entities.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6895dc1983c88332ad71b5d06c60c014