### PR TITLE
Add events API and improve UI navigation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     ports:
       - "11434:11434"
     volumes:
-      - ollama_models:/root/.ollama
+      - ./data/ollama:/root/.ollama
     networks:
       - zoe-network
     restart: unless-stopped
@@ -119,7 +119,6 @@ services:
     restart: unless-stopped
 
 volumes:
-  ollama_models:
   redis_data:
   whisper_models:
   tts_models:

--- a/services/zoe-ui/dist/index.html
+++ b/services/zoe-ui/dist/index.html
@@ -616,7 +616,7 @@
                 <div class="nav-menu">
                     <a href="index.html" class="nav-item active">Chat</a>
                     <a href="dashboard.html" class="nav-item">Dashboard</a>
-                    <a href="calendar.html" class="nav-item">Calendar</a>
+                    <a href="#" class="nav-item" onclick="switchView('calendar.html')">Calendar</a>
 
                     <a href="workflows.html" class="nav-item">Workflows</a>
 
@@ -648,7 +648,7 @@
             <!-- Zoe Greeting -->
             <div class="zoe-greeting">
                 <h1>Hi, I'm Zoe</h1>
-                <p>Your personal AI companion. How can I help you today?</p>
+                <p>Hey! What's up?</p>
             </div>
 
             <!-- Chat Interface -->
@@ -925,5 +925,6 @@
     <script src="js/api.js"></script>
     <script src="js/matrix.js"></script>
     <script src="js/overlay.js"></script>
+    <script src="js/nav.js"></script>
 </body>
 </html>

--- a/services/zoe-ui/dist/js/api.js
+++ b/services/zoe-ui/dist/js/api.js
@@ -6,6 +6,7 @@ window.zoeAPI = {
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ message })
             });
+            if (!response.ok) throw new Error('Chat service unavailable');
             return await response.json();
         } catch (error) {
             return { error: error.message };
@@ -70,6 +71,115 @@ window.zoeAPI = {
     async receiveMatrixMessages(room_id) {
         try {
             const response = await fetch(`/api/matrix/receive?room_id=${encodeURIComponent(room_id)}`);
+            return await response.json();
+        } catch (error) {
+            return { error: error.message };
+        }
+    },
+    async getDashboard() {
+        try {
+            const response = await fetch('/api/dashboard');
+            if (!response.ok) throw new Error('Dashboard unavailable');
+            return await response.json();
+        } catch (error) {
+            return { error: error.message };
+        }
+    },
+    async createTask(task) {
+        try {
+            const response = await fetch('/api/tasks', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(task)
+            });
+            return await response.json();
+        } catch (error) {
+            return { error: error.message };
+        }
+    },
+    async getTasks() {
+        try {
+            const response = await fetch('/api/tasks');
+            return await response.json();
+        } catch (error) {
+            return { error: error.message };
+        }
+    },
+    async createJournal(entry) {
+        try {
+            const response = await fetch('/api/journal', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(entry)
+            });
+            return await response.json();
+        } catch (error) {
+            return { error: error.message };
+        }
+    },
+    async getJournal() {
+        try {
+            const response = await fetch('/api/journal');
+            return await response.json();
+        } catch (error) {
+            return { error: error.message };
+        }
+    },
+    async getSettings() {
+        try {
+            const response = await fetch('/api/settings');
+            return await response.json();
+        } catch (error) {
+            return { error: error.message };
+        }
+    },
+    async updateSettings(settings) {
+        try {
+            const response = await fetch('/api/settings', {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(settings)
+            });
+            return await response.json();
+        } catch (error) {
+            return { error: error.message };
+        }
+    },
+    async getEvents(params = '') {
+        try {
+            const response = await fetch(`/api/events${params}`);
+            return await response.json();
+        } catch (error) {
+            return { error: error.message };
+        }
+    },
+    async createEvent(event) {
+        try {
+            const response = await fetch('/api/events', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(event)
+            });
+            return await response.json();
+        } catch (error) {
+            return { error: error.message };
+        }
+    },
+    async updateEvent(id, event) {
+        try {
+            const response = await fetch(`/api/events/${id}`, {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(event)
+            });
+            return await response.json();
+        } catch (error) {
+            return { error: error.message };
+        }
+    },
+    async deleteEvent(id) {
+        try {
+            const response = await fetch(`/api/events/${id}`, { method: 'DELETE' });
             return await response.json();
         } catch (error) {
             return { error: error.message };

--- a/services/zoe-ui/dist/js/nav.js
+++ b/services/zoe-ui/dist/js/nav.js
@@ -18,6 +18,10 @@ function showSection(sectionName) {
     }
 }
 
+function switchView(view) {
+    window.location.href = view;
+}
+
 document.addEventListener('DOMContentLoaded', () => {
     document.querySelectorAll('.nav-item').forEach(item => {
         item.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- make Zoe's personality greet casually and respond concisely
- add CRUD endpoints for events and expose new API helpers in UI
- persist Ollama models via host volume and refine orb UI navigation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895f1eb13b4833285fe5669b2953ee4