### PR TITLE
Add deployment folder for v3.1 enhancements

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -1,0 +1,11 @@
+# Deployment for v3.1 Enhancements
+
+This directory contains scripts and configuration for deploying the enhanced backend and frontend.
+
+## Quick start
+
+```bash
+./deploy.sh
+```
+
+The script uses `configs/docker-compose.enhanced.yml` to start the services.

--- a/deployment/backend/main_enhanced.py
+++ b/deployment/backend/main_enhanced.py
@@ -1,0 +1,14 @@
+"""Simple enhanced backend server for v3.1 deployments."""
+
+from http.server import HTTPServer, SimpleHTTPRequestHandler
+
+
+def run() -> None:
+    """Start a basic HTTP server."""
+    server = HTTPServer(("0.0.0.0", 8000), SimpleHTTPRequestHandler)
+    print("Enhanced backend running on http://0.0.0.0:8000")
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    run()

--- a/deployment/configs/docker-compose.enhanced.yml
+++ b/deployment/configs/docker-compose.enhanced.yml
@@ -1,0 +1,18 @@
+services:
+  enhanced-backend:
+    image: python:3.11-slim
+    working_dir: /app
+    volumes:
+      - ../backend:/app
+    command: ["python", "main_enhanced.py"]
+    ports:
+      - "8001:8000"
+
+  enhanced-frontend:
+    image: node:18-alpine
+    working_dir: /usr/src/app
+    volumes:
+      - ../frontend:/usr/src/app
+    command: ["node", "integration.js"]
+    ports:
+      - "8081:8080"

--- a/deployment/deploy.sh
+++ b/deployment/deploy.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+docker compose -f configs/docker-compose.enhanced.yml up -d

--- a/deployment/frontend/integration.js
+++ b/deployment/frontend/integration.js
@@ -1,0 +1,7 @@
+export function initIntegration() {
+  console.log('Frontend integration v3.1 active');
+}
+
+if (typeof window !== 'undefined') {
+  initIntegration();
+}


### PR DESCRIPTION
## Summary
- add deployment scripts, backend, frontend, and docker compose config for v3.1

## Testing
- `pytest` *(fails: jinja2 must be installed to use Jinja2Templates)*

------
https://chatgpt.com/codex/tasks/task_e_6896acb51c08833283fc4f6e398f383a