### PR TITLE
Configure zoe-core to use Ollama 3b model

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -9,3 +9,7 @@ services:
     ports:
       - "11434:11434"
     restart: unless-stopped
+  zoe-core:
+    environment:
+      - OLLAMA_URL=http://zoe-ollama:11434
+      - OLLAMA_MODEL=llama3.2:3b


### PR DESCRIPTION
## Summary
- point zoe-core to local ollama service and set default model

## Testing
- `docker compose exec zoe-ollama ollama pull llama3.2:1b` (fails: command not found)
- `docker compose exec zoe-ollama ollama pull llama3.2:3b` (fails: command not found)
- `docker compose exec zoe-ollama ollama pull mistral:latest` (fails: command not found)
- `docker compose exec zoe-ollama ollama list` (fails: command not found)
- `docker compose up -d zoe-core` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_6897121bae548332bfa1d307769f180b