### PR TITLE
fix: avoid duplicate ollama container

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,7 @@ ZOE_UI_PORT=8080
 ZOE_CORE_PORT=8000
 
 # AI Configuration
-OLLAMA_HOST=ollama:11434
+OLLAMA_HOST=zoe-ollama:11434
 WHISPER_HOST=whisper:9000
 TTS_HOST=coqui-tts:5002
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ cp .env.example .env  # update if needed
 
 - `ZOE_UI_PORT` (default `8080`)
 - `ZOE_CORE_PORT` (default `8000`)
-- `OLLAMA_HOST` (default `ollama:11434`)
+- `OLLAMA_HOST` (default `zoe-ollama:11434`)
 - `WHISPER_HOST` (default `whisper:9000`)
 - `TTS_HOST` (default `coqui-tts:5002`)
 

--- a/config/docker-compose.yml
+++ b/config/docker-compose.yml
@@ -24,9 +24,9 @@ services:
     environment:
       - PYTHONUNBUFFERED=1
       - DATABASE_PATH=/app/data/zoe.db
-      - OLLAMA_URL=http://ollama:11434
+      - OLLAMA_URL=http://zoe-ollama:11434
     depends_on:
-      - ollama
+      - zoe-ollama
       - redis
     networks:
       - zoe_network
@@ -46,7 +46,7 @@ services:
       - zoe_network
 
   # Local AI Model Server (Ollama)
-  ollama:
+  zoe-ollama:
     image: ollama/ollama:0.1.32
     container_name: zoe-ollama
     restart: unless-stopped

--- a/docker-compose-backup.yml
+++ b/docker-compose-backup.yml
@@ -26,11 +26,11 @@ services:
     environment:
       - PYTHONUNBUFFERED=1
       - DATABASE_PATH=/app/data/zoe.db
-      - OLLAMA_URL=http://ollama:11434
+      - OLLAMA_URL=http://zoe-ollama:11434
       - REDIS_URL=redis://redis:6379
       - CORS_ORIGINS=http://localhost:8080,http://localhost:3000
     depends_on:
-      - ollama
+      - zoe-ollama
       - redis
     networks:
       - zoe_network
@@ -41,7 +41,7 @@ services:
       retries: 3
 
   # Local AI Model Server
-  ollama:
+  zoe-ollama:
     image: ollama/ollama:0.1.32
     container_name: zoe-ollama
     restart: unless-stopped

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,14 +1,4 @@
 services:
-  zoe-ollama:
-    image: ollama/ollama:latest
-    command: serve
-    environment:
-      - OLLAMA_HOST=0.0.0.0:11434
-    volumes:
-      - ./data/ollama:/root/.ollama
-    ports:
-      - "11434:11434"
-    restart: unless-stopped
   zoe-core:
     environment:
       - OLLAMA_URL=http://zoe-ollama:11434

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,12 @@
 
 services:
-  ollama:
+  zoe-ollama:
     image: ollama/ollama:latest
-    container_name: ollama
+    container_name: zoe-ollama
     command: >
       bash -c "ollama pull mistral:latest && ollama serve"
+    environment:
+      - OLLAMA_HOST=0.0.0.0
     ports:
       - "11434:11434"
     volumes:
@@ -62,7 +64,7 @@ services:
     networks:
       - zoe-net
     depends_on:
-      - ollama
+      - zoe-ollama
 
   zoe-ui:
     build: ./zoe-ui

--- a/scripts/create-backend.py
+++ b/scripts/create-backend.py
@@ -38,7 +38,7 @@ logger = logging.getLogger(__name__)
 CONFIG = {
     "version": "3.1.0",
     "database_path": os.getenv("DATABASE_PATH", "/app/data/zoe.db"),
-    "ollama_url": os.getenv("OLLAMA_URL", "http://ollama:11434"),
+    "ollama_url": os.getenv("OLLAMA_URL", "http://zoe-ollama:11434"),
     "redis_url": os.getenv("REDIS_URL", "redis://redis:6379"),
     "cors_origins": os.getenv("CORS_ORIGINS", "http://localhost:8080").split(","),
     "max_context_length": int(os.getenv("MAX_CONTEXT_LENGTH", "2048")),

--- a/services/zoe-core/integrations/n8n.py
+++ b/services/zoe-core/integrations/n8n.py
@@ -19,7 +19,7 @@ class N8NService:
         self.n8n_url = os.getenv('N8N_URL', 'http://zoe-n8n:5678')
         self.enabled = os.getenv('N8N_ENABLED', 'true').lower() == 'true'
         self.api_key = os.getenv('N8N_API_KEY', '')
-        self.ollama_url = os.getenv('OLLAMA_URL', 'http://ollama:11434')
+        self.ollama_url = os.getenv('OLLAMA_URL', 'http://zoe-ollama:11434')
         
     async def trigger_workflow(self, workflow_id: str, data: Dict[str, Any]) -> Optional[Dict]:
         """Trigger an n8n workflow with data"""

--- a/setup-repo.sh
+++ b/setup-repo.sh
@@ -194,7 +194,7 @@ API_PORT=8000
 
 # AI Configuration
 OLLAMA_MODEL=llama3.2:3b
-OLLAMA_HOST=ollama:11434
+OLLAMA_HOST=zoe-ollama:11434
 
 # Voice Settings
 VOICE_ENABLED=true

--- a/zoe-core/app/api/streaming_chat_implementation.py
+++ b/zoe-core/app/api/streaming_chat_implementation.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter
 from fastapi.responses import StreamingResponse
 import httpx
 
-OLLAMA_HOST = os.getenv("OLLAMA_HOST", "ollama:11434")
+OLLAMA_HOST = os.getenv("OLLAMA_HOST", "zoe-ollama:11434")
 
 router = APIRouter(prefix="/api/chat", tags=["chat"])
 

--- a/zoe-core/integrations/n8n.py
+++ b/zoe-core/integrations/n8n.py
@@ -19,7 +19,7 @@ class N8NService:
         self.n8n_url = os.getenv('N8N_URL', 'http://zoe-n8n:5678')
         self.enabled = os.getenv('N8N_ENABLED', 'true').lower() == 'true'
         self.api_key = os.getenv('N8N_API_KEY', '')
-        self.ollama_url = os.getenv('OLLAMA_URL', 'http://ollama:11434')
+        self.ollama_url = os.getenv('OLLAMA_URL', 'http://zoe-ollama:11434')
         
     async def trigger_workflow(self, workflow_id: str, data: Dict[str, Any]) -> Optional[Dict]:
         """Trigger an n8n workflow with data"""


### PR DESCRIPTION
## Summary
- rename Ollama service to `zoe-ollama` in docker-compose files
- remove duplicate Ollama definition from override
- update default host references in env files and integrations

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68972a60deac8332a37371e11718f655