### PR TITLE
Resolve Ollama service conflicts

### DIFF
--- a/config/docker-compose.yml
+++ b/config/docker-compose.yml
@@ -24,9 +24,9 @@ services:
     environment:
       - PYTHONUNBUFFERED=1
       - DATABASE_PATH=/app/data/zoe.db
-      - OLLAMA_URL=http://zoe-ollama:11434
+      - OLLAMA_URL=http://config-ollama:11434
     depends_on:
-      - zoe-ollama
+      - config-ollama
       - redis
     networks:
       - zoe_network
@@ -46,12 +46,12 @@ services:
       - zoe_network
 
   # Local AI Model Server (Ollama)
-  zoe-ollama:
+  config-ollama:
     image: ollama/ollama:0.1.32
-    container_name: zoe-ollama
+    container_name: config-zoe-ollama
     restart: unless-stopped
     ports:
-      - "11434:11434"
+      - "11435:11434"
     volumes:
       - ollama_data:/root/.ollama
     environment:

--- a/docker-compose-backup.yml
+++ b/docker-compose-backup.yml
@@ -26,11 +26,11 @@ services:
     environment:
       - PYTHONUNBUFFERED=1
       - DATABASE_PATH=/app/data/zoe.db
-      - OLLAMA_URL=http://zoe-ollama:11434
+      - OLLAMA_URL=http://backup-ollama:11434
       - REDIS_URL=redis://redis:6379
       - CORS_ORIGINS=http://localhost:8080,http://localhost:3000
     depends_on:
-      - zoe-ollama
+      - backup-ollama
       - redis
     networks:
       - zoe_network
@@ -41,12 +41,12 @@ services:
       retries: 3
 
   # Local AI Model Server
-  zoe-ollama:
+  backup-ollama:
     image: ollama/ollama:0.1.32
-    container_name: zoe-ollama
+    container_name: backup-zoe-ollama
     restart: unless-stopped
     ports:
-      - "11434:11434"
+      - "11436:11434"
     volumes:
       - ollama_data:/root/.ollama
     environment:

--- a/services/zoe-core/main.backup.py
+++ b/services/zoe-core/main.backup.py
@@ -32,7 +32,7 @@ logger = logging.getLogger(__name__)
 CONFIG = {
     "version": "3.1.0",
     "database_path": os.getenv("DATABASE_PATH", "/app/data/zoe.db"),
-    "ollama_url": os.getenv("OLLAMA_URL", "http://ollama:11434"),
+    "ollama_url": os.getenv("OLLAMA_URL", "http://zoe-ollama:11434"),
     "cors_origins": os.getenv("CORS_ORIGINS", "http://localhost:8080").split(","),
     "max_context_length": int(os.getenv("MAX_CONTEXT_LENGTH", "2048")),
     "max_conversation_history": int(os.getenv("MAX_CONVERSATION_HISTORY", "20")),


### PR DESCRIPTION
## Summary
- rename secondary Ollama services and assign unique ports
- update environment variables and dependencies to use new service names
- fix backup script default to zoe-ollama

## Testing
- `pytest`
- `docker-compose version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68972ee2e4f483329c81dddc0fd27e43