### PR TITLE
Remove duplicate JournalEntryResponse model

### DIFF
--- a/services/zoe-core/main.py
+++ b/services/zoe-core/main.py
@@ -310,17 +310,6 @@ class JournalEntryResponse(BaseModel):
     health_info: Optional[dict]
     created_at: str
     updated_at: Optional[str] = None
-# CORS middleware for calendar access
-class JournalEntryResponse(BaseModel):
-    id: int
-    title: Optional[str]
-    content: str
-    mood: Optional[str]
-    mood_score: Optional[float]
-    mood_confidence: Optional[int]
-    photo: Optional[str]
-    health_info: Optional[dict]
-
 # Add middleware for request logging
 from fastapi import Request
 


### PR DESCRIPTION
## Summary
- remove duplicate JournalEntryResponse model definition
- ensure journal endpoints reference unified response model

## Testing
- `pytest` *(fails: module 'zoe_core_main' has no attribute 'extract_entities_advanced'; FileNotFoundError for main_complex_with_auth.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a0be4caf3c8332ab8f05dd57eb2f8c