### PR TITLE
fix: avoid persisting deploy credentials

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,9 +22,15 @@ jobs:
           cd /home/zoe/assistant
           git remote set-url origin https://github.com/jason-easyazz/zoe-ai-assistant.git
           python3 - <<'PY'
+          import re
           import subprocess
-          version = subprocess.check_output(["git", "--version"], text=True).strip().split()[-1]
-          parts = tuple(int(part) for part in version.split(".")[:3])
+          raw = subprocess.check_output(["git", "--version"], text=True).strip()
+          match = re.search(r"\bversion\s+([0-9]+(?:\.[0-9]+){1,2})", raw)
+          if not match:
+              raise SystemExit(f"could not parse git version from: {raw}")
+          version = match.group(1)
+          parts = tuple(int(part) for part in version.split("."))
+          parts = parts + (0,) * (3 - len(parts))
           if parts < (2, 31, 0):
               raise SystemExit(f"git {version} is too old for GIT_CONFIG_COUNT; need git >= 2.31.0")
           PY

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,13 @@ jobs:
         run: |
           cd /home/zoe/assistant
           git remote set-url origin https://github.com/jason-easyazz/zoe-ai-assistant.git
+          python3 - <<'PY'
+          import subprocess
+          version = subprocess.check_output(["git", "--version"], text=True).strip().split()[-1]
+          parts = tuple(int(part) for part in version.split(".")[:3])
+          if parts < (2, 31, 0):
+              raise SystemExit(f"git {version} is too old for GIT_CONFIG_COUNT; need git >= 2.31.0")
+          PY
           GIT_CONFIG_COUNT=1 \
           GIT_CONFIG_KEY_0=http.https://github.com/.extraheader \
           GIT_CONFIG_VALUE_0="AUTHORIZATION: bearer ${GH_PAT}" \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,6 +38,7 @@ jobs:
           GIT_CONFIG_KEY_0=http.https://github.com/.extraheader \
           GIT_CONFIG_VALUE_0="AUTHORIZATION: bearer ${GH_PAT}" \
             git fetch origin main
+          unset GH_PAT
           git reset --hard FETCH_HEAD
 
       - name: Install / refresh Python deps

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,12 +16,14 @@ jobs:
 
     steps:
       - name: Pull latest main
+        env:
+          GH_PAT: ${{ secrets.GH_PAT }}
         run: |
           cd /home/zoe/assistant
-          git remote set-url origin \
-            https://x-access-token:${{ secrets.GH_PAT }}@github.com/jason-easyazz/zoe-ai-assistant.git
-          git fetch origin main
-          git reset --hard origin/main
+          git remote set-url origin https://github.com/jason-easyazz/zoe-ai-assistant.git
+          git -c "http.https://github.com/.extraheader=AUTHORIZATION: bearer ${GH_PAT}" \
+            fetch origin main
+          git reset --hard FETCH_HEAD
 
       - name: Install / refresh Python deps
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,8 +21,10 @@ jobs:
         run: |
           cd /home/zoe/assistant
           git remote set-url origin https://github.com/jason-easyazz/zoe-ai-assistant.git
-          git -c "http.https://github.com/.extraheader=AUTHORIZATION: bearer ${GH_PAT}" \
-            fetch origin main
+          GIT_CONFIG_COUNT=1 \
+          GIT_CONFIG_KEY_0=http.https://github.com/.extraheader \
+          GIT_CONFIG_VALUE_0="AUTHORIZATION: bearer ${GH_PAT}" \
+            git fetch origin main
           git reset --hard FETCH_HEAD
 
       - name: Install / refresh Python deps


### PR DESCRIPTION
## Summary
- Stop storing a PAT-bearing URL in the production checkout's `origin` remote during deploy.
- Fetch `main` with a transient Git HTTP auth header and reset to `FETCH_HEAD`.

## Test plan
- Parsed `.github/workflows/deploy.yml` with PyYAML.
- Pre-commit validation passed.


Made with [Cursor](https://cursor.com)