### PR TITLE
fix: redact archived LiteLLM credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,4 @@ POSTGRES_URL=postgresql://zoe:replace-with-db-password@localhost:5432/zoe
 POSTGRES_APSCHEDULER_URL=postgresql+psycopg2://zoe:replace-with-db-password@localhost:5432/zoe
 ZOE_CALENDAR_SYNC_ENABLED=false
 ZOE_CALENDAR_SYNC_PROVIDER=keeper
+LITELLM_API_KEY=replace-with-litellm-key

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+KEEPER_BASE_URL=http://zoe-keeper:8787
+KEEPER_AUTH_TOKEN=replace-with-strong-token
+POSTGRES_URL=postgresql://zoe:replace-with-db-password@localhost:5432/zoe
+POSTGRES_APSCHEDULER_URL=postgresql+psycopg2://zoe:replace-with-db-password@localhost:5432/zoe
+ZOE_CALENDAR_SYNC_ENABLED=false
+ZOE_CALENDAR_SYNC_PROVIDER=keeper

--- a/.gitignore
+++ b/.gitignore
@@ -144,6 +144,7 @@ credentials/
 # API Keys and Secrets
 *.env
 .env.*
+!.env.example
 secrets/
 api_keys/
 **/api_keys.json

--- a/.zoe/manifest.json
+++ b/.zoe/manifest.json
@@ -113,7 +113,6 @@
     "LICENSE",
     ".gitignore",
     ".dockerignore",
-    ".env",
     ".env.example",
     ".cursorrules",
     ".graphifyignore",
@@ -122,8 +121,7 @@
     "warmup_models.py",
     "home-profile.json",
     "VERSION",
-    "CAPABILITIES.md",
-    ".env.openclaw-secrets"
+    "CAPABILITIES.md"
   ],
   "safe_to_delete_patterns": [
     "**/*.pyc",
@@ -162,7 +160,6 @@
     "CAPABILITIES.md",
     "services/zoe-ui/dist/js/widgets/core/multica-board.js",
     "services/zoe-data/proactive/triggers/evolution_weekly_digest.py",
-    ".env.openclaw-secrets",
     "services/zoe-ui/dist/touch/js/timers-global.js"
   ]
 }

--- a/docs/architecture/LITELLM_INTEGRATION.md
+++ b/docs/architecture/LITELLM_INTEGRATION.md
@@ -88,7 +88,7 @@ router_settings:
     powerful: [claude-3-5-sonnet, gpt-4o-mini]
 
 general_settings:
-  master_key: "sk-..."               # API authentication
+  master_key: "replace-with-litellm-key" # API authentication
   cache: true                        # Enable Redis caching
   cache_params:
     host: "zoe-redis"
@@ -118,7 +118,7 @@ provider = LiteLLMProvider()  # Default provider
 ```bash
 curl -X POST http://zoe-litellm:8001/v1/chat/completions \
   -H "Content-Type: application/json" \
-  -H "Authorization: Bearer sk-f3320300bb32df8f176495bb888ba7c8f87a0d01c2371b50f767b9ead154175f" \
+  -H "Authorization: Bearer REDACTED_RETIRED_LITELLM_KEY" \
   -d '{
     "model": "local-model",
     "messages": [{"role": "user", "content": "Hello"}],

--- a/docs/architecture/SERVICE_HEALTH_FIX.md
+++ b/docs/architecture/SERVICE_HEALTH_FIX.md
@@ -148,7 +148,7 @@ zoe-litellm:
 
 ```yaml
 general_settings:
-  master_key: "sk-f3320300bb32df8f176495bb888ba7c8f87a0d01c2371b50f767b9ead154175f"
+  master_key: "REDACTED_RETIRED_LITELLM_KEY"
   disable_database_usage: true
   disable_spend_logs: true
   disable_otel_logging: true

--- a/docs/archive/retired-services/zoe-core/llm_provider.py
+++ b/docs/archive/retired-services/zoe-core/llm_provider.py
@@ -81,7 +81,7 @@ class LiteLLMProvider(LLMProvider):
                         "temperature": kwargs.get("temperature", 0.7),
                         "max_tokens": kwargs.get("max_tokens", 512)
                     },
-                    headers={"Authorization": "Bearer sk-f3320300bb32df8f176495bb888ba7c8f87a0d01c2371b50f767b9ead154175f"}
+                    headers={"Authorization": "Bearer REDACTED_RETIRED_LITELLM_KEY"}
                 )
                 result = response.json()
                 return result["choices"][0]["message"]["content"]
@@ -104,7 +104,7 @@ class LiteLLMProvider(LLMProvider):
                         "temperature": kwargs.get("temperature", 0.7),
                         "max_tokens": kwargs.get("max_tokens", 512)
                     },
-                    headers={"Authorization": "Bearer sk-f3320300bb32df8f176495bb888ba7c8f87a0d01c2371b50f767b9ead154175f"}
+                    headers={"Authorization": "Bearer REDACTED_RETIRED_LITELLM_KEY"}
                 ) as response:
                     async for line in response.aiter_lines():
                         if line.startswith("data: "):

--- a/docs/archive/retired-services/zoe-core/route_llm.py
+++ b/docs/archive/retired-services/zoe-core/route_llm.py
@@ -19,7 +19,7 @@ class ZoeRouter:
         if self.enabled:
             # Set dummy API key if not provided (required by LiteLLM even for custom api_base)
             if not os.getenv("OPENAI_API_KEY"):
-                os.environ["OPENAI_API_KEY"] = "sk-dummy-key-for-local-llm"
+                os.environ["OPENAI_API_KEY"] = "REDACTED_DUMMY_LOCAL_LLM_KEY"
             
             # ✅ UPDATED 2025-11-18: Using TESTED OPTIMIZED models (see MODEL_TEST_ANALYSIS.md)
             # NOW using llama.cpp server (zoe-llamacpp) with tested winning models

--- a/docs/archive/retired-services/zoe-core/routers/chat.py
+++ b/docs/archive/retired-services/zoe-core/routers/chat.py
@@ -1451,7 +1451,7 @@ async def generate_streaming_response(message: str, context: Dict, memories: Dic
                 # LiteLLM requires authentication
                 headers = {}
                 if "litellm" in llm_url:
-                    headers["Authorization"] = "Bearer sk-f3320300bb32df8f176495bb888ba7c8f87a0d01c2371b50f767b9ead154175f"
+                    headers["Authorization"] = "Bearer REDACTED_RETIRED_LITELLM_KEY"
                 
                 async with client.stream(
                     "POST",
@@ -1890,7 +1890,7 @@ async def generate_response(message: str, context: Dict, memories: Dict, user_co
                 # LiteLLM requires authentication
                 headers = {}
                 if "litellm" in llm_url:
-                    headers["Authorization"] = "Bearer sk-f3320300bb32df8f176495bb888ba7c8f87a0d01c2371b50f767b9ead154175f"
+                    headers["Authorization"] = "Bearer REDACTED_RETIRED_LITELLM_KEY"
                 
                 async with httpx.AsyncClient(timeout=fallback_config.timeout) as client:
                     response = await client.post(

--- a/docs/archive/retired-services/zoe-litellm/minimal_config.yaml
+++ b/docs/archive/retired-services/zoe-litellm/minimal_config.yaml
@@ -113,7 +113,7 @@ router_settings:
     - llama3.2-3b: ["local-fast"]
 
 general_settings:
-  master_key: "sk-f3320300bb32df8f176495bb888ba7c8f87a0d01c2371b50f767b9ead154175f"
+  master_key: "REDACTED_RETIRED_LITELLM_KEY"
   disable_database_usage: true
   disable_spend_logs: true
   disable_otel_logging: true

--- a/docs/archive/status-reports-2025/LITELLM_IMPLEMENTATION_SUMMARY.md
+++ b/docs/archive/status-reports-2025/LITELLM_IMPLEMENTATION_SUMMARY.md
@@ -190,7 +190,7 @@ Expected: All checks pass ✅
 
 ```bash
 curl http://localhost:8001/v1/models \
-  -H "Authorization: Bearer sk-f3320300bb32df8f176495bb888ba7c8f87a0d01c2371b50f767b9ead154175f"
+  -H "Authorization: Bearer REDACTED_RETIRED_LITELLM_KEY"
 ```
 
 Expected: 5 models listed
@@ -200,7 +200,7 @@ Expected: 5 models listed
 ```bash
 curl -X POST http://localhost:8001/v1/chat/completions \
   -H "Content-Type: application/json" \
-  -H "Authorization: Bearer sk-f3320300bb32df8f176495bb888ba7c8f87a0d01c2371b50f767b9ead154175f" \
+  -H "Authorization: Bearer REDACTED_RETIRED_LITELLM_KEY" \
   -d '{
     "model": "local-model",
     "messages": [{"role": "user", "content": "Say hello"}],
@@ -336,7 +336,7 @@ docker logs zoe-litellm --tail 50
 
 ### Master Key
 ```
-sk-f3320300bb32df8f176495bb888ba7c8f87a0d01c2371b50f767b9ead154175f
+REDACTED_RETIRED_LITELLM_KEY
 ```
 (Stored in `minimal_config.yaml`)
 

--- a/docs/archive/status-reports-2025/SYSTEM_AUDIT_RESULTS.md
+++ b/docs/archive/status-reports-2025/SYSTEM_AUDIT_RESULTS.md
@@ -109,7 +109,7 @@ LLM Call via LiteLLM Service
 
 3. **Verify Models Available**:
    ```bash
-   curl -H "Authorization: Bearer sk-f3320300bb32df8f176495bb888ba7c8f87a0d01c2371b50f767b9ead154175f" \
+   curl -H "Authorization: Bearer REDACTED_RETIRED_LITELLM_KEY" \
      http://localhost:8001/v1/models
    ```
 

--- a/docs/governance/LITELLM_RULES.md
+++ b/docs/governance/LITELLM_RULES.md
@@ -150,7 +150,7 @@ response = await call_litellm(model=models["fast"], ...)
 ```python
 # ✅ CORRECT - Always authenticate via environment variable
 import os
-LITELLM_KEY = os.environ.get("LITELLM_API_KEY", "")
+LITELLM_KEY = os.environ["LITELLM_API_KEY"]  # raises KeyError if missing
 
 headers = {
     "Authorization": f"Bearer {LITELLM_KEY}",

--- a/docs/governance/LITELLM_RULES.md
+++ b/docs/governance/LITELLM_RULES.md
@@ -148,9 +148,9 @@ response = await call_litellm(model=models["fast"], ...)
 ### 3. Include Master Key
 
 ```python
-# ✅ CORRECT - Always authenticate
+# ✅ CORRECT - Always authenticate via environment variable
 import os
-LITELLM_KEY = "REDACTED_RETIRED_LITELLM_KEY"
+LITELLM_KEY = os.environ.get("LITELLM_API_KEY", "")
 
 headers = {
     "Authorization": f"Bearer {LITELLM_KEY}",

--- a/docs/governance/LITELLM_RULES.md
+++ b/docs/governance/LITELLM_RULES.md
@@ -150,7 +150,7 @@ response = await call_litellm(model=models["fast"], ...)
 ```python
 # ✅ CORRECT - Always authenticate
 import os
-LITELLM_KEY = "sk-f3320300bb32df8f176495bb888ba7c8f87a0d01c2371b50f767b9ead154175f"
+LITELLM_KEY = "REDACTED_RETIRED_LITELLM_KEY"
 
 headers = {
     "Authorization": f"Bearer {LITELLM_KEY}",

--- a/docs/reviews/SECURITY_FIXES_2025-11-17.md
+++ b/docs/reviews/SECURITY_FIXES_2025-11-17.md
@@ -24,7 +24,7 @@ Comprehensive fix implementation addressing all 6 critical and high-severity iss
 **Before:**
 ```yaml
 healthcheck:
-  test: ["CMD-SHELL", "curl -f http://localhost:8001/health -H 'Authorization: Bearer sk-f3320300bb32df8f176495bb888ba7c8f87a0d01c2371b50f767b9ead154175f' || exit 0"]
+  test: ["CMD-SHELL", "curl -f http://localhost:8001/health -H 'Authorization: Bearer REDACTED_RETIRED_LITELLM_KEY' || exit 0"]
 ```
 
 **After:**
@@ -304,8 +304,8 @@ python3 tests/unit/test_architecture.py
 
 ```bash
 # API Keys (CRITICAL - NEVER commit these)
-OPENAI_API_KEY=sk-your-actual-key-here
-ANTHROPIC_API_KEY=sk-ant-your-actual-key-here
+OPENAI_API_KEY=replace-with-openai-key
+ANTHROPIC_API_KEY=replace-with-anthropic-key
 
 # n8n Authentication (CRITICAL - use strong random password)
 N8N_BASIC_AUTH_PASSWORD=$(openssl rand -base64 32)

--- a/scripts/utilities/archive/20251008_121422/create_simple_reliable_router.py
+++ b/scripts/utilities/archive/20251008_121422/create_simple_reliable_router.py
@@ -54,7 +54,7 @@ Always mention these capabilities when relevant and provide detailed, helpful re
         async with httpx.AsyncClient(timeout=10.0) as client:
             response = await client.post(
                 "http://zoe-litellm:8001/v1/chat/completions",
-                headers={"Authorization": "Bearer sk-your-secret-key-here"},
+                headers={"Authorization": "Bearer replace-with-litellm-key"},
                 json={
                     "model": "gemma3-ultra-fast",  # Fast, reliable model
                     "messages": messages,

--- a/scripts/utilities/comprehensive_integrated_test.py
+++ b/scripts/utilities/comprehensive_integrated_test.py
@@ -7,6 +7,7 @@ Tests all optimized tools working together for Samantha-level intelligence
 import asyncio
 import httpx
 import json
+import os
 import time
 import logging
 from typing import Dict, List
@@ -188,9 +189,16 @@ class ComprehensiveIntegratedTester:
         logger.info("⚡ Testing LiteLLM integration...")
         
         try:
+            litellm_api_key = os.environ.get("LITELLM_API_KEY")
+            if not litellm_api_key:
+                return {
+                    "success": False,
+                    "error": "LITELLM_API_KEY is not set"
+                }
+
             async with httpx.AsyncClient(timeout=10.0) as client:
                 # Test LiteLLM health with proper authentication
-                headers = {"Authorization": "Bearer replace-with-litellm-key"}
+                headers = {"Authorization": f"Bearer {litellm_api_key}"}
                 litellm_response = await client.get("http://localhost:8001/health", headers=headers)
                 
                 if litellm_response.status_code == 200:

--- a/scripts/utilities/comprehensive_integrated_test.py
+++ b/scripts/utilities/comprehensive_integrated_test.py
@@ -190,7 +190,7 @@ class ComprehensiveIntegratedTester:
         try:
             async with httpx.AsyncClient(timeout=10.0) as client:
                 # Test LiteLLM health with proper authentication
-                headers = {"Authorization": "Bearer sk-your-secret-key-here"}
+                headers = {"Authorization": "Bearer replace-with-litellm-key"}
                 litellm_response = await client.get("http://localhost:8001/health", headers=headers)
                 
                 if litellm_response.status_code == 200:

--- a/scripts/utilities/comprehensive_system_optimization.py
+++ b/scripts/utilities/comprehensive_system_optimization.py
@@ -7,6 +7,7 @@ Tests and optimizes all tools: LLM, Mem Agent, LiteLLM, RouteLLM, MCP, LightRAG
 import asyncio
 import httpx
 import json
+import os
 import time
 import logging
 from typing import Dict, List, Any
@@ -317,6 +318,19 @@ class SystemOptimizer:
                 "expected_model": "qwen2.5-workhorse"
             }
         ]
+        litellm_api_key = os.environ.get("LITELLM_API_KEY")
+        if not litellm_api_key:
+            return [
+                OptimizationResult(
+                    component="RouteLLM",
+                    test_name=test["name"],
+                    response_time=0,
+                    success=False,
+                    optimization_score=0,
+                    error_message="LITELLM_API_KEY is not set"
+                )
+                for test in routing_tests
+            ]
         
         for test in routing_tests:
             start_time = time.time()
@@ -324,7 +338,7 @@ class SystemOptimizer:
                 async with httpx.AsyncClient(timeout=30.0) as client:
                     response = await client.post(
                         f"{self.services['litellm']}/chat/completions",
-                        headers={"Authorization": "Bearer replace-with-litellm-key"},
+                        headers={"Authorization": f"Bearer {litellm_api_key}"},
                         json={
                             "model": "gemma3-ultra-fast",  # Test with specific model
                             "messages": [

--- a/scripts/utilities/comprehensive_system_optimization.py
+++ b/scripts/utilities/comprehensive_system_optimization.py
@@ -324,7 +324,7 @@ class SystemOptimizer:
                 async with httpx.AsyncClient(timeout=30.0) as client:
                     response = await client.post(
                         f"{self.services['litellm']}/chat/completions",
-                        headers={"Authorization": "Bearer sk-1234567890abcdef"},
+                        headers={"Authorization": "Bearer replace-with-litellm-key"},
                         json={
                             "model": "gemma3-ultra-fast",  # Test with specific model
                             "messages": [

--- a/tools/audit/validate_structure.py
+++ b/tools/audit/validate_structure.py
@@ -47,6 +47,8 @@ def get_all_project_files() -> Set[str]:
         for filename in filenames:
             full_path = Path(root) / filename
             relative_path = str(full_path.relative_to(PROJECT_ROOT))
+            if filename == '.env' or (filename.startswith('.env.') and filename != '.env.example'):
+                continue
             files.add(relative_path)
     
     return files


### PR DESCRIPTION
## Summary
- Redacts credential-shaped LiteLLM/OpenAI examples from archived docs and retired service code.
- Keeps real `.env*` secrets ignored while making `.env.example` trackable.
- Updates the structure validator and manifest so local secret files do not appear as approved root clutter or orphan failures.

## Test plan
- `rg 'sk-[A-Za-z0-9][A-Za-z0-9_-]{16,}|Bearer\\s+sk-[A-Za-z0-9_-]{16,}|master_key:\\s*\"sk-' ...`
- `python3 -m py_compile tools/audit/validate_structure.py scripts/utilities/comprehensive_system_optimization.py scripts/utilities/comprehensive_integrated_test.py scripts/utilities/archive/20251008_121422/create_simple_reliable_router.py`
- `python3 tools/audit/validate_structure.py`
- `python3 tools/audit/validate_critical_files.py`
- `python3 -m json.tool .zoe/manifest.json >/dev/null`
- `git diff --check`

Made with [Cursor](https://cursor.com)