### PR TITLE
fix: align UI routes with active integrations

### DIFF
--- a/modules/zoe-music/main.py
+++ b/modules/zoe-music/main.py
@@ -116,13 +116,12 @@ async def _get_active_player() -> str | None:
 
 async def _ha_service(service: str, extra: dict | None = None):
     payload = {
-        "type": "service",
-        "domain": "media_player",
-        "service": service,
-        "data": {"entity_id": DEFAULT_PLAYER, **(extra or {})},
+        "entity_id": DEFAULT_PLAYER,
+        "action": service,
+        "data": extra or {},
     }
     async with httpx.AsyncClient(timeout=8.0) as c:
-        r = await c.post(f"{HA_BRIDGE_URL}/execute", json=payload)
+        r = await c.post(f"{HA_BRIDGE_URL}/devices/control", json=payload)
         r.raise_for_status()
 
 

--- a/services/zoe-data/intent_router.py
+++ b/services/zoe-data/intent_router.py
@@ -1798,17 +1798,15 @@ async def _execute_music_intent(intent: Intent, user_id: str) -> Optional[str]:
                     _query = "music"  # final fallback
 
             payload = {
-                "type": "service",
-                "domain": "media_player",
-                "service": "play_media",
+                "entity_id": _os.environ.get("ZOE_DEFAULT_MEDIA_PLAYER", "media_player.all"),
+                "action": "play_media",
                 "data": {
-                    "entity_id": _os.environ.get("ZOE_DEFAULT_MEDIA_PLAYER", "media_player.all"),
                     "media_content_id": _query,
                     "media_content_type": "music",
                 },
             }
             async with _httpx.AsyncClient(timeout=8.0) as c:
-                await c.post(f"{ha_url}/execute", json=payload)
+                await c.post(f"{ha_url}/devices/control", json=payload)
 
             # Fire-and-forget: 5-signal play event logger
             async def _log_play_event() -> None:
@@ -1974,16 +1972,12 @@ async def _execute_music_intent(intent: Intent, user_id: str) -> Optional[str]:
                 if cmd == "mute":    extra = {"is_volume_muted": True}
                 if cmd == "unmute":  extra = {"is_volume_muted": False}
                 payload = {
-                    "type": "service",
-                    "domain": "media_player",
-                    "service": svc,
-                    "data": {
-                        "entity_id": _os.environ.get("ZOE_DEFAULT_MEDIA_PLAYER", "media_player.all"),
-                        **extra,
-                    },
+                    "entity_id": _os.environ.get("ZOE_DEFAULT_MEDIA_PLAYER", "media_player.all"),
+                    "action": svc,
+                    "data": extra,
                 }
                 async with _httpx.AsyncClient(timeout=8.0) as c:
-                    await c.post(f"{ha_url}/execute", json=payload)
+                    await c.post(f"{ha_url}/devices/control", json=payload)
 
                 # Log skip/pause events for taste learning
                 _evt_type = None
@@ -2031,16 +2025,12 @@ async def _execute_music_intent(intent: Intent, user_id: str) -> Optional[str]:
             level = int(slots.get("level", 50))
             vol = max(0, min(100, level)) / 100.0
             payload = {
-                "type": "service",
-                "domain": "media_player",
-                "service": "volume_set",
-                "data": {
-                    "entity_id": _os.environ.get("ZOE_DEFAULT_MEDIA_PLAYER", "media_player.all"),
-                    "volume_level": vol,
-                },
+                "entity_id": _os.environ.get("ZOE_DEFAULT_MEDIA_PLAYER", "media_player.all"),
+                "action": "volume_set",
+                "data": {"volume_level": vol},
             }
             async with _httpx.AsyncClient(timeout=8.0) as c:
-                await c.post(f"{ha_url}/execute", json=payload)
+                await c.post(f"{ha_url}/devices/control", json=payload)
             try:
                 import asyncio as _asyncio
                 from database import log_music_event as _log
@@ -2437,9 +2427,10 @@ async def _execute_smart_home_intent(intent: Intent, user_id: str) -> Optional[s
         elif action == "brighten":
             data["brightness_pct"] = 100
 
-        payload = {"type": "service", "domain": "light", "service": service, "data": data}
+        data.pop("entity_id", None)
+        payload = {"entity_id": entity_id, "action": service, "data": data}
         async with _httpx.AsyncClient(timeout=8.0) as c:
-            await c.post(f"{ha_url}/execute", json=payload)
+            await c.post(f"{ha_url}/devices/control", json=payload)
 
         action_labels = {
             "turn_on":  "on",

--- a/services/zoe-data/routers/ha_control.py
+++ b/services/zoe-data/routers/ha_control.py
@@ -6,9 +6,9 @@ directly without going through the full chat → OpenClaw pipeline.
 Authenticates via session OR device token (same as voice endpoints).
 
 Routes:
-  POST /api/ha/control         — call a HA service (toggle, turn_on, turn_off, etc.)
-  GET  /api/ha/entities        — list entities for a domain / area
-  GET  /api/ha/state/{entity}  — get current state of a single entity
+  POST /api/ha/control        — call a HA service (toggle, turn_on, turn_off, etc.)
+  GET  /api/ha/entities       — list entities for a domain / area
+  GET  /api/ha/state/{entity} — get current state of a single entity
 """
 import logging
 import os
@@ -76,7 +76,7 @@ async def list_entities(
 async def get_entity_state(entity_id: str, caller: dict = Depends(_require_caller)):
     """Get current state of a single HA entity."""
     try:
-        return await _bridge_get(f"/state/{entity_id}")
+        return await _bridge_get(f"/entities/{entity_id}")
     except httpx.ConnectError:
         raise HTTPException(status_code=503, detail="HA bridge offline")
     except httpx.HTTPStatusError as exc:

--- a/services/zoe-ui/dist/cooking.html
+++ b/services/zoe-ui/dist/cooking.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="refresh" content="0; url=/touch/cooking.html">
+  <title>Zoe Cooking</title>
+</head>
+<body>
+  <p>Opening <a href="/touch/cooking.html">Cooking</a>...</p>
+</body>
+</html>

--- a/services/zoe-ui/dist/games.html
+++ b/services/zoe-ui/dist/games.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="refresh" content="0; url=/touch/games.html">
+  <title>Zoe Games</title>
+</head>
+<body>
+  <p>Opening <a href="/touch/games.html">Games</a>...</p>
+</body>
+</html>

--- a/services/zoe-ui/dist/music.html
+++ b/services/zoe-ui/dist/music.html
@@ -934,7 +934,7 @@
     <script>
     /* ── Music Player Controller ─────────────────────────────────────────── */
 
-    const MA_WS  = 'ws://localhost:8095/ws';
+    const MA_WS  = `${window.location.protocol === 'https:' ? 'wss' : 'ws'}://${window.location.host}/modules/music-assistant/ws`;
 
     const S = {
         ws: null,
@@ -1422,7 +1422,7 @@
 
     /* ── Setup wizard ────────────────────────────────────────────────────── */
 
-    const MA_EXTERNAL_URL = `http://${window.location.hostname}:8095`;
+    const MA_EXTERNAL_URL = `${window.location.origin}/modules/music-assistant/`;
 
     // Well-known providers we always show in the setup grid.
     const KNOWN_PROVIDERS = [

--- a/services/zoe-ui/dist/smart-home.html
+++ b/services/zoe-ui/dist/smart-home.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="refresh" content="0; url=/touch/smart-home.html">
+  <title>Zoe Smart Home</title>
+</head>
+<body>
+  <p>Opening <a href="/touch/smart-home.html">Smart Home</a>...</p>
+</body>
+</html>

--- a/services/zoe-ui/dist/touch/developer/index.html
+++ b/services/zoe-ui/dist/touch/developer/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="refresh" content="0; url=/developer/">
+  <title>Zoe Developer</title>
+</head>
+<body>
+  <p>Opening <a href="/developer/">Developer</a>...</p>
+</body>
+</html>

--- a/services/zoe-ui/dist/touch/games.html
+++ b/services/zoe-ui/dist/touch/games.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Zoe Games</title>
+  <style>
+    body { margin: 0; min-height: 100vh; font-family: system-ui, sans-serif; background: #0f172a; color: #e2e8f0; display: grid; place-items: center; }
+    main { width: min(720px, calc(100vw - 32px)); }
+    h1 { margin-bottom: 8px; }
+    p { color: #94a3b8; }
+    .grid { display: grid; gap: 12px; margin-top: 24px; }
+    a { display: block; padding: 18px 20px; border: 1px solid rgba(148, 163, 184, .35); border-radius: 16px; color: #e2e8f0; text-decoration: none; background: rgba(15, 23, 42, .65); }
+    a:focus, a:hover { border-color: #38bdf8; }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>Games</h1>
+    <p>Choose a game or activity module.</p>
+    <div class="grid">
+      <a href="/modules/qd/">Questionable Decisions</a>
+      <a href="/modules/jag-board/">JAG Board</a>
+      <a href="/modules/orbit/">Orbit</a>
+      <a href="/touch/dashboard.html">Back to Touch Dashboard</a>
+    </div>
+  </main>
+</body>
+</html>

--- a/services/zoe-ui/nginx.conf
+++ b/services/zoe-ui/nginx.conf
@@ -29,6 +29,9 @@ server {
         try_files $uri $uri/ /developer/index.html;
     }
 
+    location ^~ /_preview/ { return 404; }
+    location ^~ /js/_archive/ { return 404; }
+
     # A2A agent discovery — exact match takes priority over generic /.well-known/
     location = /.well-known/agent.json {
         proxy_pass http://host.docker.internal:8000/.well-known/agent.json;
@@ -198,7 +201,7 @@ server {
 
     location ^~ /modules/orbit {
         resolver 127.0.0.11 valid=30s;
-        set $orbit_upstream http://zoe-orbit:8202;
+        set $orbit_upstream http://orbit:8202;
         rewrite ^/modules/orbit/?(.*)$ /$1 break;
         proxy_pass $orbit_upstream;
         proxy_http_version 1.1;
@@ -237,6 +240,10 @@ server {
         proxy_pass        http://host.docker.internal:8095/;
         proxy_http_version 1.1;
         proxy_set_header   Host $host;
+        proxy_set_header   Upgrade $http_upgrade;
+        proxy_set_header   Connection $connection_upgrade;
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
     }
 
     location /modules/agent-zero/ {
@@ -246,7 +253,7 @@ server {
     }
 
     location /multica-api/ {
-        proxy_pass http://zoe-multica-backend:8080/;
+        proxy_pass http://multica-backend:8080/;
         proxy_set_header Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -321,6 +328,9 @@ server {
         alias /usr/share/nginx/html/developer/;
         try_files $uri $uri/ /developer/index.html;
     }
+
+    location ^~ /_preview/ { return 404; }
+    location ^~ /js/_archive/ { return 404; }
 
     # A2A agent discovery — exact match takes priority over generic /.well-known/
     location = /.well-known/agent.json {
@@ -413,6 +423,21 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
+    # Hermes Agent OpenAI-compatible API — HTTPS parity with the port 80 server.
+    location /hermes/ {
+        proxy_pass http://host.docker.internal:8642/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_buffering off;
+        proxy_request_buffering off;
+        proxy_read_timeout 120s;
+        proxy_send_timeout 120s;
+        proxy_connect_timeout 10s;
+    }
+
     location /ws/ {
         proxy_pass http://host.docker.internal:8000/ws/;
         proxy_http_version 1.1;
@@ -474,7 +499,7 @@ server {
 
     location ^~ /modules/orbit {
         resolver 127.0.0.11 valid=30s;
-        set $orbit_upstream http://zoe-orbit:8202;
+        set $orbit_upstream http://orbit:8202;
         rewrite ^/modules/orbit/?(.*)$ /$1 break;
         proxy_pass $orbit_upstream;
         proxy_http_version 1.1;
@@ -508,6 +533,10 @@ server {
         proxy_pass        http://host.docker.internal:8095/;
         proxy_http_version 1.1;
         proxy_set_header   Host $host;
+        proxy_set_header   Upgrade $http_upgrade;
+        proxy_set_header   Connection $connection_upgrade;
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
     }
 
     location /modules/agent-zero/ {
@@ -517,7 +546,7 @@ server {
     }
 
     location /multica-api/ {
-        proxy_pass http://zoe-multica-backend:8080/;
+        proxy_pass http://multica-backend:8080/;
         proxy_set_header Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
## Summary
- Replaces retired HA bridge `/execute` calls with `/devices/control` payloads.
- Fixes HA state proxying to the live bridge entity endpoint.
- Adds missing static targets for clicked desktop/touch nav routes.
- Updates nginx service names, HTTPS `/hermes/`, Music Assistant WebSocket proxying, and static preview/archive denial config.

## Test plan
- `PYTHONPYCACHEPREFIX=/tmp/zoe-pycache python3 -m py_compile services/zoe-data/intent_router.py services/zoe-data/routers/ha_control.py modules/zoe-music/main.py`
- `docker compose config --quiet`
- `docker compose exec -T zoe-ui nginx -t`
- `python3 tools/audit/validate_structure.py`
- `python3 tools/audit/validate_critical_files.py`
- `git diff --check`
- `curl http://localhost:8007/entities` returned 200
- `curl http://localhost/games.html`, `/cooking.html`, `/smart-home.html` returned 200

Note: live static deny smoke still reflected the currently loaded container config until deploy/recreate; nginx syntax validates the updated config.

Made with [Cursor](https://cursor.com)