### PR TITLE
docs: align PR-first workflow guidance

### DIFF
--- a/.cursor/rules/agentic-workflow.mdc
+++ b/.cursor/rules/agentic-workflow.mdc
@@ -15,4 +15,6 @@ Plan first for broad or risky work. Keep changes surgical. Prefer existing Zoe p
 
 Use the small-PR loop for reviewable work: split large changes, push a focused PR, let Greptile review independently, then use **Greptile MCP first** (`get_merge_request`, `list_merge_request_comments`, `trigger_code_review`) or the operator-local CLI `~/bin/greptile-mcp.py` (install path varies by host; see `/grep-loop`) before falling back to `gh` scraping or Hermes.
 
+`main` is protected. Do not push directly, bypass branch protection, or use administrator merges unless the operator explicitly asks for that emergency path. If GitHub blocks a green PR because repo auto-merge is disabled or another policy requires human action, report the blocker and keep the PR ready rather than forcing it.
+
 Verify from a user perspective before commit: focused tests, `validate_structure.py`, `validate_critical_files.py`, live `/health` and `/api/system/status`, and any relevant systemd timers or MCP tools.

--- a/.cursor/rules/project-context.mdc
+++ b/.cursor/rules/project-context.mdc
@@ -7,6 +7,8 @@ alwaysApply: true
 
 Zoe production code lives in `/home/zoe/assistant`. The live web/chat API is `services/zoe-data/` running host uvicorn on port 8000. `services/zoe-core/` is retired reference code; do not extend it for new features.
 
+Repository changes should land through pull requests. Keep `main` protected and treat direct pushes or admin merges as emergency-only operator-approved actions.
+
 Use one production chat router: `services/zoe-data/routers/chat.py`. Natural-language routing belongs in `intent_router.py`, Zoe Agent, Hermes, or OpenClaw; do not add brittle command-detection branches to `chat.py`.
 
 Before file changes, follow `.zoe/AI_ASSISTANT_CHECKLIST.md`: validate structure, respect `.zoe/manifest.json`, and keep root markdown at or below 10 files. Do not delete files without the cleanup safety process.

--- a/.greptile/rules.md
+++ b/.greptile/rules.md
@@ -9,6 +9,7 @@ Greptile should review Zoe as a local-first, multi-user assistant with a host-ru
 - Prefer small, surgical fixes that match existing Zoe patterns.
 - Do not suggest parallel `_new`, `_old`, `_fixed`, or backup files.
 - Treat hardcoded absolute paths outside approved Zoe roots as portability risks unless they are documented local operator paths.
+- Zoe uses a PR-first workflow with protected `main`; do not recommend direct pushes, admin bypasses, or force pushes as normal fixes.
 
 ## Architecture
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,11 +29,13 @@ Currently useful cached sources include FastAPI, ChromaDB, LiveKit, faster-whisp
 ## Greptile PR loop
 
 For reviewable development work:
+- Work from feature branches and open pull requests; `main` is protected.
+- Do not bypass branch protection or use administrator merges unless the operator explicitly asks for that emergency path.
 - Keep PRs small; use `/split-to-prs` when a branch grows too large.
 - Let Greptile review every PR independently.
 - Use Cursor's Greptile MCP to fetch review status/comments.
 - Use `zoe-greptile-loop` to delegate heavier fix/re-review loops to Hermes.
-- Do not treat Greptile as a replacement for local Zoe verification; run focused tests and live health checks before merging.
+- Do not treat Greptile as a replacement for local Zoe verification; run focused tests and live health checks before marking work merge-ready.
 
 ## Hermes-First Delegation
 

--- a/docs/guides/root-reference/QUALITY_MAINTENANCE_GUIDE.md
+++ b/docs/guides/root-reference/QUALITY_MAINTENANCE_GUIDE.md
@@ -59,6 +59,10 @@ df -h / | tail -1 | awk '{print "Disk Usage: " $5 " of " $2}'
 
 ### Pre-Commit Checklist
 
+> Current workflow: work on feature branches, open PRs, wait for Validate /
+> GitGuardian / Greptile, and keep protected `main` merges on the normal GitHub
+> path. Admin or force-push bypasses require explicit operator approval.
+
 ```bash
 # 1. Run automated pre-commit hooks (already installed)
 git commit -m "Your message"


### PR DESCRIPTION
## Summary
- Adds protected-main and PR-first workflow guidance to active agent/Cursor/Greptile rules.
- Clarifies that admin bypass or force-push paths require explicit operator approval.
- Updates the quality guide with the current Validate/GitGuardian/Greptile PR gate.

## Test plan
- `python3 tools/audit/validate_structure.py`
- `python3 tools/audit/validate_critical_files.py`
- `git diff --check`
- searched active rule files for PR/protected-main and Graphify guidance consistency

Made with [Cursor](https://cursor.com)