### PR TITLE
Add Multica Hermes engineering workflow

### DIFF
--- a/docs/guides/MULTICA_HERMES_PR_LOOP.md
+++ b/docs/guides/MULTICA_HERMES_PR_LOOP.md
@@ -1,0 +1,59 @@
+# Multica Hermes PR Loop
+
+This workflow lets Zoe track engineering work from a Multica issue through Hermes implementation, GitHub PR creation, Greptile review, and human merge readiness.
+
+## Required Setup
+
+- `ZOE_MULTICA=true`
+- `MULTICA_BASE_URL`, `MULTICA_API_TOKEN`, and `MULTICA_WORKSPACE_ID`
+- `HERMES_MULTICA_AGENT_ID` set to the Hermes agent ID in Multica
+- Hermes running on `HERMES_API_URL` or `http://127.0.0.1:8642`
+- GitHub auth available to Hermes through `gh` or `GITHUB_TOKEN`
+- Greptile auth through `GREPTILE_API_KEY` or `~/.config/zoe/greptile.env`
+
+## Flow
+
+1. A user, API caller, Multica webhook, board approval, or Board Review autopilot creates an `engineering_tasks` row.
+2. Zoe queues Hermes with a structured prompt requiring `PR_URL=`, `BLOCKER=`, `TESTS=`, and `SUMMARY=`.
+3. Hermes implements on a feature branch, opens a PR, and uses `github-greptile-loop`.
+4. Zoe reconciles the linked `background_tasks` row and records the PR URL.
+5. Zoe checks Greptile through MCP-compatible tools and updates workflow phase plus Multica issue status.
+6. The workflow stops at `ready_for_human`, `blocked`, `cancelled`, or `done`.
+
+## API Smoke Procedure
+
+Run these on the Zoe host after migrations are applied:
+
+```bash
+curl -sf http://127.0.0.1:8000/health
+curl -sf http://127.0.0.1:8000/api/system/status
+```
+
+Draft a dry engineering workflow through chat:
+
+```text
+offload hermes to make a docs-only test PR that changes no production behavior
+```
+
+This should create a queued workflow that still needs approval before Hermes changes code. Start one through the admin API, board approval, or a Hermes-assigned Multica issue, then check progress:
+
+```text
+what's the hermes engineering status
+```
+
+Expected state changes after approval/start:
+
+- `queued` after task creation.
+- `hermes_running` once the background task is enqueued.
+- `pr_open` after Hermes returns a `PR_URL=...`.
+- `ready_for_human` when Greptile reports target confidence and no actionable findings.
+- `blocked` if Hermes reports `BLOCKER=...` or completes without a PR URL.
+
+## Local Verification
+
+```bash
+python3 -m pytest services/zoe-data/tests/test_engineering_workflow.py -q
+python3 -m py_compile services/zoe-data/engineering_workflow.py services/zoe-data/greptile_client.py
+python3 tools/audit/validate_structure.py
+python3 tools/audit/validate_critical_files.py
+```

--- a/docs/guides/MULTICA_HERMES_PR_LOOP.md
+++ b/docs/guides/MULTICA_HERMES_PR_LOOP.md
@@ -6,6 +6,7 @@ This workflow lets Zoe track engineering work from a Multica issue through Herme
 
 - `ZOE_MULTICA=true`
 - `MULTICA_BASE_URL`, `MULTICA_API_TOKEN`, and `MULTICA_WORKSPACE_ID`
+- `MULTICA_WEBHOOK_SECRET` for any webhook path that starts Hermes
 - `HERMES_MULTICA_AGENT_ID` set to the Hermes agent ID in Multica
 - Hermes running on `HERMES_API_URL` or `http://127.0.0.1:8642`
 - GitHub auth available to Hermes through `gh` or `GITHUB_TOKEN`
@@ -19,6 +20,8 @@ This workflow lets Zoe track engineering work from a Multica issue through Herme
 4. Zoe reconciles the linked `background_tasks` row and records the PR URL.
 5. Zoe checks Greptile through MCP-compatible tools and updates workflow phase plus Multica issue status.
 6. The workflow stops at `ready_for_human`, `blocked`, `cancelled`, or `done`.
+
+Multica webhooks can sync proposal status without the secret, but they cannot start Hermes unless they send either `Authorization: Bearer $MULTICA_WEBHOOK_SECRET` or `X-Multica-Webhook-Token: $MULTICA_WEBHOOK_SECRET`.
 
 ## API Smoke Procedure
 

--- a/services/zoe-data/alembic/versions/0009_engineering_tasks.py
+++ b/services/zoe-data/alembic/versions/0009_engineering_tasks.py
@@ -1,0 +1,73 @@
+"""0009 — Durable engineering workflow state."""
+
+from alembic import op
+
+revision = "0009"
+down_revision = "0008"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        ALTER TABLE background_tasks
+        ADD COLUMN IF NOT EXISTS multica_issue_id TEXT
+    """)
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS engineering_tasks (
+            id TEXT PRIMARY KEY,
+            user_id TEXT NOT NULL,
+            title TEXT NOT NULL,
+            task TEXT NOT NULL,
+            source TEXT NOT NULL DEFAULT 'api',
+            source_id TEXT,
+            multica_issue_id TEXT,
+            background_task_id INTEGER,
+            idempotency_key TEXT UNIQUE,
+            phase TEXT NOT NULL DEFAULT 'queued',
+            status TEXT NOT NULL DEFAULT 'active',
+            branch TEXT,
+            pr_number INTEGER,
+            pr_url TEXT,
+            greptile_status TEXT,
+            greptile_confidence INTEGER,
+            greptile_unaddressed_count INTEGER,
+            round_count INTEGER NOT NULL DEFAULT 0,
+            max_rounds INTEGER NOT NULL DEFAULT 5,
+            target_confidence INTEGER NOT NULL DEFAULT 5,
+            blocker_reason TEXT,
+            last_error TEXT,
+            cost_estimated_usd REAL NOT NULL DEFAULT 0.0,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            completed_at TEXT
+        )
+    """)
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_engineering_tasks_multica "
+        "ON engineering_tasks (multica_issue_id)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_engineering_tasks_phase "
+        "ON engineering_tasks (phase, status)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_engineering_tasks_background "
+        "ON engineering_tasks (background_task_id)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_background_tasks_multica "
+        "ON background_tasks (multica_issue_id)"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS idx_background_tasks_multica")
+    op.execute("DROP INDEX IF EXISTS idx_engineering_tasks_background")
+    op.execute("DROP INDEX IF EXISTS idx_engineering_tasks_phase")
+    op.execute("DROP INDEX IF EXISTS idx_engineering_tasks_multica")
+    op.execute("DROP TABLE IF EXISTS engineering_tasks")
+    op.execute("""
+        ALTER TABLE background_tasks
+        DROP COLUMN IF EXISTS multica_issue_id
+    """)

--- a/services/zoe-data/background_runner.py
+++ b/services/zoe-data/background_runner.py
@@ -61,6 +61,7 @@ async def enqueue_background_task(
     session_id: str | None = None,
     panel_id: str | None = None,
     request_depth: int = 0,
+    multica_issue_id: str | None = None,
 ) -> int:
     """Insert a task row and kick off the async runner. Returns the new task id."""
     if request_depth > _MAX_REQUEST_DEPTH:
@@ -72,16 +73,21 @@ async def enqueue_background_task(
     async with get_db_ctx() as db:
         row = await db.fetchrow(
             """INSERT INTO background_tasks
-               (user_id, session_id, panel_id, task, status, created_at, checkout_run_id, request_depth)
-               VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING id""",
-            user_id, session_id, panel_id, task, "pending", now, run_id, request_depth,
+               (user_id, session_id, panel_id, task, status, created_at,
+                checkout_run_id, request_depth, multica_issue_id)
+               VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9) RETURNING id""",
+            user_id, session_id, panel_id, task, "pending", now,
+            run_id, request_depth, multica_issue_id,
         )
         task_id: int = row["id"]
 
     # Fire off the runner coroutine
     fut = asyncio.ensure_future(_run_task(task_id, task, user_id, session_id, panel_id=panel_id))
     _running[task_id] = fut
-    logger.info("background_runner: enqueued task #%d for user=%s depth=%d", task_id, user_id, request_depth)
+    logger.info(
+        "background_runner: enqueued task #%d for user=%s depth=%d multica=%s",
+        task_id, user_id, request_depth, multica_issue_id,
+    )
     return task_id
 
 
@@ -109,6 +115,11 @@ async def _run_task(
         if not result:
             result = "(No result returned)"
         await _set_status("done", result)
+        try:
+            from engineering_workflow import reconcile_background_task  # type: ignore[import]
+            await reconcile_background_task(task_id)
+        except Exception as _ew_exc:
+            logger.debug("background_runner: engineering reconcile failed: %s", _ew_exc)
         logger.info("background_runner: task #%d completed (%d chars)", task_id, len(result))
 
         # Auto-deploy the linked evolution proposal when the task completes.
@@ -174,6 +185,11 @@ async def _run_task(
     except Exception as exc:
         logger.warning("background_runner: task #%d failed: %s", task_id, exc)
         await _set_status("error", f"Task failed: {exc}")
+        try:
+            from engineering_workflow import reconcile_background_task  # type: ignore[import]
+            await reconcile_background_task(task_id)
+        except Exception as _ew_exc:
+            logger.debug("background_runner: engineering reconcile failed: %s", _ew_exc)
         try:
             from push import broadcaster
             await broadcaster.broadcast(user_id, "background_task_error", {

--- a/services/zoe-data/engineering_workflow.py
+++ b/services/zoe-data/engineering_workflow.py
@@ -1,0 +1,443 @@
+"""Durable Multica -> Hermes -> PR workflow coordination.
+
+This module owns workflow state. Hermes still does the implementation work; Zoe
+tracks phases, links Multica/background task rows, and records review progress.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+ACTIVE_PHASES = {
+    "queued",
+    "hermes_running",
+    "pr_open",
+    "greptile_wait",
+    "fixing",
+}
+TERMINAL_PHASES = {"ready_for_human", "done", "blocked", "cancelled"}
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _row(row: Any) -> dict[str, Any] | None:
+    return dict(row) if row else None
+
+
+def _parse_pr_url(text: str) -> tuple[str | None, int | None]:
+    match = re.search(r"https://github\.com/([^/\s]+/[^/\s]+)/pull/(\d+)", text or "")
+    if not match:
+        return None, None
+    return match.group(0), int(match.group(2))
+
+
+def _parse_blocker(text: str) -> str | None:
+    match = re.search(r"(?im)^BLOCKER\s*=\s*(.+)$", text or "")
+    if match:
+        return match.group(1).strip()[:1000]
+    return None
+
+
+def build_hermes_prompt(task: str, *, workflow_id: str, max_rounds: int, target_confidence: int) -> str:
+    """Return the structured task sent to Hermes."""
+    return (
+        "Use the local Zoe engineering workflow for this task.\n"
+        "- Use `zoe-engineering` first.\n"
+        "- Use `source-code-context` or Graphify when needed.\n"
+        "- Keep the change PR-sized and do not push to main.\n"
+        "- Create a feature branch, commit verified changes, push, and open a PR.\n"
+        "- Use `github-greptile-loop` after the PR exists.\n"
+        "- Stop and report BLOCKER=... for missing auth, dirty tree, secrets, destructive operations, "
+        "database/dockers changes needing human approval, or ambiguous product decisions.\n\n"
+        "Required final response format:\n"
+        "PR_URL=<GitHub PR URL, or blank if blocked>\n"
+        "BLOCKER=<reason, or blank>\n"
+        "TESTS=<commands/checks run>\n"
+        "SUMMARY=<short summary>\n\n"
+        f"workflow_id={workflow_id}\n"
+        f"max_rounds={max_rounds}\n"
+        f"target_confidence={target_confidence}\n\n"
+        f"Task:\n{task}"
+    )
+
+
+async def create_engineering_task(
+    *,
+    user_id: str,
+    task: str,
+    title: str | None = None,
+    source: str = "api",
+    source_id: str | None = None,
+    multica_issue_id: str | None = None,
+    idempotency_key: str | None = None,
+    max_rounds: int = 5,
+    target_confidence: int = 5,
+) -> dict[str, Any]:
+    """Create or return an idempotent engineering task row."""
+    from db_pool import get_db_ctx
+
+    task = task.strip()
+    if not task:
+        raise ValueError("task is required")
+    title = (title or task.splitlines()[0])[:160]
+    now = _now()
+
+    async with get_db_ctx() as db:
+        if idempotency_key:
+            existing = await db.fetchrow(
+                "SELECT * FROM engineering_tasks WHERE idempotency_key=$1",
+                idempotency_key,
+            )
+            if existing:
+                return dict(existing)
+        if multica_issue_id:
+            existing = await db.fetchrow(
+                """SELECT * FROM engineering_tasks
+                   WHERE multica_issue_id=$1 AND phase = ANY($2::text[])
+                   ORDER BY updated_at DESC LIMIT 1""",
+                multica_issue_id,
+                list(ACTIVE_PHASES),
+            )
+            if existing:
+                return dict(existing)
+
+        workflow_id = str(uuid.uuid4())
+        row = await db.fetchrow(
+            """INSERT INTO engineering_tasks
+               (id, user_id, title, task, source, source_id, multica_issue_id,
+                idempotency_key, phase, status, max_rounds, target_confidence,
+                created_at, updated_at)
+               VALUES ($1,$2,$3,$4,$5,$6,$7,$8,'queued','active',$9,$10,$11,$12)
+               RETURNING *""",
+            workflow_id,
+            user_id,
+            title,
+            task,
+            source,
+            source_id,
+            multica_issue_id,
+            idempotency_key,
+            max_rounds,
+            target_confidence,
+            now,
+            now,
+        )
+    return dict(row)
+
+
+async def get_engineering_task(task_id: str) -> dict[str, Any] | None:
+    from db_pool import get_db_ctx
+
+    async with get_db_ctx() as db:
+        return _row(await db.fetchrow("SELECT * FROM engineering_tasks WHERE id=$1", task_id))
+
+
+async def list_engineering_tasks(limit: int = 20, status: str | None = None) -> list[dict[str, Any]]:
+    from db_pool import get_db_ctx
+
+    limit = max(1, min(limit, 100))
+    async with get_db_ctx() as db:
+        if status:
+            rows = await db.fetch(
+                "SELECT * FROM engineering_tasks WHERE status=$1 ORDER BY updated_at DESC LIMIT $2",
+                status,
+                limit,
+            )
+        else:
+            rows = await db.fetch(
+                "SELECT * FROM engineering_tasks ORDER BY updated_at DESC LIMIT $1",
+                limit,
+            )
+    return [dict(row) for row in rows]
+
+
+async def start_engineering_task(task_id: str) -> dict[str, Any]:
+    """Queue Hermes for a workflow if it has not already been queued."""
+    from background_runner import enqueue_background_task
+    from db_pool import get_db_ctx
+
+    task = await get_engineering_task(task_id)
+    if not task:
+        raise ValueError(f"engineering task not found: {task_id}")
+    if task.get("background_task_id") and task.get("phase") != "queued":
+        return task
+
+    prompt = build_hermes_prompt(
+        task["task"],
+        workflow_id=task_id,
+        max_rounds=int(task.get("max_rounds") or 5),
+        target_confidence=int(task.get("target_confidence") or 5),
+    )
+    background_task_id = await enqueue_background_task(
+        prompt,
+        task["user_id"],
+        multica_issue_id=task.get("multica_issue_id"),
+    )
+    now = _now()
+    async with get_db_ctx() as db:
+        row = await db.fetchrow(
+            """UPDATE engineering_tasks
+               SET background_task_id=$1, phase='hermes_running', updated_at=$2
+               WHERE id=$3
+               RETURNING *""",
+            background_task_id,
+            now,
+            task_id,
+        )
+    await sync_multica_issue(dict(row), note="Hermes implementation started.")
+    return dict(row)
+
+
+async def create_and_start_engineering_task(**kwargs: Any) -> dict[str, Any]:
+    task = await create_engineering_task(**kwargs)
+    if task.get("phase") == "queued":
+        task = await start_engineering_task(task["id"])
+    return task
+
+
+async def reconcile_background_task(background_task_id: int) -> dict[str, Any] | None:
+    """Advance an engineering workflow from its linked background task result."""
+    from db_pool import get_db_ctx
+
+    async with get_db_ctx() as db:
+        workflow = await db.fetchrow(
+            "SELECT * FROM engineering_tasks WHERE background_task_id=$1",
+            background_task_id,
+        )
+        if not workflow:
+            return None
+        background = await db.fetchrow(
+            "SELECT id, status, result FROM background_tasks WHERE id=$1",
+            background_task_id,
+        )
+        if not background:
+            return dict(workflow)
+
+        now = _now()
+        if background["status"] in ("error", "blocked"):
+            row = await db.fetchrow(
+                """UPDATE engineering_tasks
+                   SET phase='blocked', status='blocked', blocker_reason=$1,
+                       last_error=$1, updated_at=$2, completed_at=$2
+                   WHERE id=$3 RETURNING *""",
+                background["result"] or background["status"],
+                now,
+                workflow["id"],
+            )
+            await sync_multica_issue(dict(row), note=f"Blocked: {row['blocker_reason']}")
+            return dict(row)
+
+        if background["status"] != "done":
+            return dict(workflow)
+
+        result = background["result"] or ""
+        blocker = _parse_blocker(result)
+        pr_url, pr_number = _parse_pr_url(result)
+        if blocker:
+            row = await db.fetchrow(
+                """UPDATE engineering_tasks
+                   SET phase='blocked', status='blocked', blocker_reason=$1,
+                       updated_at=$2, completed_at=$2
+                   WHERE id=$3 RETURNING *""",
+                blocker,
+                now,
+                workflow["id"],
+            )
+            await sync_multica_issue(dict(row), note=f"Blocked: {blocker}")
+            return dict(row)
+
+        if not pr_url:
+            row = await db.fetchrow(
+                """UPDATE engineering_tasks
+                   SET phase='blocked', status='blocked',
+                       blocker_reason='Hermes completed without PR_URL',
+                       updated_at=$1, completed_at=$1
+                   WHERE id=$2 RETURNING *""",
+                now,
+                workflow["id"],
+            )
+            await sync_multica_issue(dict(row), note="Blocked: Hermes completed without PR_URL.")
+            return dict(row)
+
+        row = await db.fetchrow(
+            """UPDATE engineering_tasks
+               SET phase='pr_open', pr_url=$1, pr_number=$2, updated_at=$3
+               WHERE id=$4 RETURNING *""",
+            pr_url,
+            pr_number,
+            now,
+            workflow["id"],
+        )
+    await sync_multica_issue(dict(row), note=f"PR opened: {pr_url}")
+    return dict(row)
+
+
+async def update_greptile_state(
+    task_id: str,
+    *,
+    greptile_status: str,
+    confidence: int | None = None,
+    unaddressed_count: int | None = None,
+) -> dict[str, Any]:
+    from db_pool import get_db_ctx
+
+    current = await get_engineering_task(task_id)
+    target_confidence = int((current or {}).get("target_confidence") or 5)
+    phase = "ready_for_human"
+    status = "active"
+    if unaddressed_count and unaddressed_count > 0:
+        phase = "greptile_wait"
+    elif confidence is not None and confidence < target_confidence:
+        phase = "greptile_wait"
+
+    now = _now()
+    async with get_db_ctx() as db:
+        row = await db.fetchrow(
+            """UPDATE engineering_tasks
+               SET greptile_status=$1, greptile_confidence=$2,
+                   greptile_unaddressed_count=$3, phase=$4, status=$5,
+                   updated_at=$6
+               WHERE id=$7 RETURNING *""",
+            greptile_status,
+            confidence,
+            unaddressed_count,
+            phase,
+            status,
+            now,
+            task_id,
+        )
+    note = f"Greptile: {greptile_status}"
+    if confidence is not None:
+        note += f", confidence {confidence}/5"
+    if unaddressed_count is not None:
+        note += f", unaddressed {unaddressed_count}"
+    await sync_multica_issue(dict(row), note=note)
+    return dict(row)
+
+
+async def check_greptile_for_task(task_id: str) -> dict[str, Any]:
+    """Fetch live Greptile state for a workflow PR and persist it."""
+    from greptile_client import DEFAULT_REPO, get_pr_status
+
+    task = await get_engineering_task(task_id)
+    if not task:
+        raise ValueError(f"engineering task not found: {task_id}")
+    pr_number = task.get("pr_number")
+    if not pr_number and task.get("pr_url"):
+        _, pr_number = _parse_pr_url(task["pr_url"])
+    if not pr_number:
+        raise ValueError("engineering task has no PR number")
+    status = await get_pr_status(
+        repo=os.environ.get("ZOE_GITHUB_REPO", DEFAULT_REPO),
+        pr_number=pr_number,
+        default_branch=os.environ.get("ZOE_GITHUB_DEFAULT_BRANCH", "main"),
+    )
+    return await update_greptile_state(
+        task_id,
+        greptile_status=status.get("reviewCompleteness") or "reviewed",
+        confidence=status.get("confidenceScore"),
+        unaddressed_count=status.get("unaddressedCount"),
+    )
+
+
+async def retry_engineering_task(task_id: str) -> dict[str, Any]:
+    """Clear blocker state and start another Hermes round."""
+    from db_pool import get_db_ctx
+
+    task = await get_engineering_task(task_id)
+    if not task:
+        raise ValueError(f"engineering task not found: {task_id}")
+    round_count = int(task.get("round_count") or 0)
+    max_rounds = int(task.get("max_rounds") or 5)
+    if round_count >= max_rounds:
+        raise ValueError(f"max rounds reached ({round_count}/{max_rounds})")
+    now = _now()
+    async with get_db_ctx() as db:
+        await db.execute(
+            """UPDATE engineering_tasks
+               SET phase='queued', status='active', background_task_id=NULL,
+                   blocker_reason=NULL, last_error=NULL, round_count=$1,
+                   updated_at=$2
+               WHERE id=$3""",
+            round_count + 1,
+            now,
+            task_id,
+        )
+    return await start_engineering_task(task_id)
+
+
+async def cancel_engineering_task(task_id: str, reason: str = "cancelled") -> dict[str, Any]:
+    from db_pool import get_db_ctx
+
+    now = _now()
+    async with get_db_ctx() as db:
+        row = await db.fetchrow(
+            """UPDATE engineering_tasks
+               SET phase='cancelled', status='cancelled', blocker_reason=$1,
+                   updated_at=$2, completed_at=$2
+               WHERE id=$3 RETURNING *""",
+            reason,
+            now,
+            task_id,
+        )
+    if not row:
+        raise ValueError(f"engineering task not found: {task_id}")
+    await sync_multica_issue(dict(row), note=f"Cancelled: {reason}")
+    return dict(row)
+
+
+async def sync_multica_issue(task: dict[str, Any], *, note: str = "") -> None:
+    """Best-effort Multica status/description update for a workflow."""
+    multica_issue_id = task.get("multica_issue_id")
+    if not multica_issue_id:
+        return
+    try:
+        from multica_client import get_multica_client
+
+        client = get_multica_client()
+        if not client.is_configured():
+            return
+        issue = await client.get_issue(multica_issue_id)
+        current = issue.get("description", "") if isinstance(issue, dict) else ""
+        lines = [
+            "",
+            "---",
+            f"Engineering workflow: `{task['id']}`",
+            f"Phase: `{task.get('phase')}`",
+        ]
+        if task.get("pr_url"):
+            lines.append(f"PR: {task['pr_url']}")
+        if task.get("greptile_status"):
+            lines.append(f"Greptile: {task['greptile_status']}")
+        if task.get("blocker_reason"):
+            lines.append(f"Blocker: {task['blocker_reason']}")
+        if note:
+            lines.append(f"Update: {note}")
+        description = (current.split("\n---\nEngineering workflow:", 1)[0]).rstrip()
+        status = {
+            "queued": "todo",
+            "hermes_running": "in_progress",
+            "pr_open": "in_review",
+            "greptile_wait": "in_review",
+            "fixing": "in_progress",
+            "ready_for_human": "in_review",
+            "done": "done",
+            "blocked": "in_review",
+            "cancelled": "cancelled",
+        }.get(task.get("phase"))
+        await client.update_issue(
+            multica_issue_id,
+            status=status,
+            description=description + "\n" + "\n".join(lines),
+        )
+    except Exception as exc:
+        logger.debug("engineering_workflow: Multica sync failed: %s", exc)

--- a/services/zoe-data/engineering_workflow.py
+++ b/services/zoe-data/engineering_workflow.py
@@ -165,11 +165,22 @@ async def start_engineering_task(task_id: str) -> dict[str, Any]:
     from background_runner import enqueue_background_task
     from db_pool import get_db_ctx
 
-    task = await get_engineering_task(task_id)
+    now = _now()
+    async with get_db_ctx() as db:
+        task = await db.fetchrow(
+            """UPDATE engineering_tasks
+               SET phase='hermes_running', updated_at=$1
+               WHERE id=$2 AND phase='queued' AND background_task_id IS NULL
+               RETURNING *""",
+            now,
+            task_id,
+        )
     if not task:
+        existing = await get_engineering_task(task_id)
+        if existing:
+            return existing
         raise ValueError(f"engineering task not found: {task_id}")
-    if task.get("background_task_id") and task.get("phase") != "queued":
-        return task
+    task = dict(task)
 
     prompt = build_hermes_prompt(
         task["task"],
@@ -177,20 +188,34 @@ async def start_engineering_task(task_id: str) -> dict[str, Any]:
         max_rounds=int(task.get("max_rounds") or 5),
         target_confidence=int(task.get("target_confidence") or 5),
     )
-    background_task_id = await enqueue_background_task(
-        prompt,
-        task["user_id"],
-        multica_issue_id=task.get("multica_issue_id"),
-    )
-    now = _now()
+    try:
+        background_task_id = await enqueue_background_task(
+            prompt,
+            task["user_id"],
+            multica_issue_id=task.get("multica_issue_id"),
+        )
+    except Exception as exc:
+        async with get_db_ctx() as db:
+            row = await db.fetchrow(
+                """UPDATE engineering_tasks
+                   SET phase='blocked', status='blocked', blocker_reason=$1,
+                       last_error=$1, updated_at=$2, completed_at=$2
+                   WHERE id=$3 RETURNING *""",
+                f"Hermes enqueue failed: {exc}",
+                _now(),
+                task_id,
+            )
+        if row:
+            await sync_multica_issue(dict(row), note=f"Blocked: {row['blocker_reason']}")
+        raise
     async with get_db_ctx() as db:
         row = await db.fetchrow(
             """UPDATE engineering_tasks
-               SET background_task_id=$1, phase='hermes_running', updated_at=$2
+               SET background_task_id=$1, updated_at=$2
                WHERE id=$3
                RETURNING *""",
             background_task_id,
-            now,
+            _now(),
             task_id,
         )
     await sync_multica_issue(dict(row), note="Hermes implementation started.")

--- a/services/zoe-data/engineering_workflow.py
+++ b/services/zoe-data/engineering_workflow.py
@@ -399,6 +399,8 @@ async def retry_engineering_task(task_id: str) -> dict[str, Any]:
     task = await get_engineering_task(task_id)
     if not task:
         raise ValueError(f"engineering task not found: {task_id}")
+    if task.get("phase") in TERMINAL_PHASES:
+        return task
     round_count = int(task.get("round_count") or 0)
     max_rounds = int(task.get("max_rounds") or 5)
     if round_count >= max_rounds:
@@ -410,7 +412,7 @@ async def retry_engineering_task(task_id: str) -> dict[str, Any]:
                SET phase='queued', status='active', background_task_id=NULL,
                    blocker_reason=NULL, last_error=NULL, round_count=$1,
                    updated_at=$2
-               WHERE id=$3""",
+               WHERE id=$3 AND phase NOT IN ('done', 'cancelled')""",
             round_count + 1,
             now,
             task_id,
@@ -427,12 +429,16 @@ async def cancel_engineering_task(task_id: str, reason: str = "cancelled") -> di
             """UPDATE engineering_tasks
                SET phase='cancelled', status='cancelled', blocker_reason=$1,
                    updated_at=$2, completed_at=$2
-               WHERE id=$3 RETURNING *""",
+               WHERE id=$3 AND phase NOT IN ('done', 'cancelled')
+               RETURNING *""",
             reason,
             now,
             task_id,
         )
     if not row:
+        existing = await get_engineering_task(task_id)
+        if existing:
+            return existing
         raise ValueError(f"engineering task not found: {task_id}")
     await sync_multica_issue(dict(row), note=f"Cancelled: {reason}")
     return dict(row)

--- a/services/zoe-data/engineering_workflow.py
+++ b/services/zoe-data/engineering_workflow.py
@@ -240,6 +240,8 @@ async def reconcile_background_task(background_task_id: int) -> dict[str, Any] |
         )
         if not workflow:
             return None
+        if workflow["phase"] in ("cancelled", "done"):
+            return dict(workflow)
         background = await db.fetchrow(
             "SELECT id, status, result FROM background_tasks WHERE id=$1",
             background_task_id,
@@ -253,11 +255,14 @@ async def reconcile_background_task(background_task_id: int) -> dict[str, Any] |
                 """UPDATE engineering_tasks
                    SET phase='blocked', status='blocked', blocker_reason=$1,
                        last_error=$1, updated_at=$2, completed_at=$2
-                   WHERE id=$3 RETURNING *""",
+                   WHERE id=$3 AND phase NOT IN ('cancelled', 'done')
+                   RETURNING *""",
                 background["result"] or background["status"],
                 now,
                 workflow["id"],
             )
+            if not row:
+                return dict(workflow)
             await sync_multica_issue(dict(row), note=f"Blocked: {row['blocker_reason']}")
             return dict(row)
 
@@ -272,11 +277,14 @@ async def reconcile_background_task(background_task_id: int) -> dict[str, Any] |
                 """UPDATE engineering_tasks
                    SET phase='blocked', status='blocked', blocker_reason=$1,
                        updated_at=$2, completed_at=$2
-                   WHERE id=$3 RETURNING *""",
+                   WHERE id=$3 AND phase NOT IN ('cancelled', 'done')
+                   RETURNING *""",
                 blocker,
                 now,
                 workflow["id"],
             )
+            if not row:
+                return dict(workflow)
             await sync_multica_issue(dict(row), note=f"Blocked: {blocker}")
             return dict(row)
 
@@ -286,22 +294,28 @@ async def reconcile_background_task(background_task_id: int) -> dict[str, Any] |
                    SET phase='blocked', status='blocked',
                        blocker_reason='Hermes completed without PR_URL',
                        updated_at=$1, completed_at=$1
-                   WHERE id=$2 RETURNING *""",
+                   WHERE id=$2 AND phase NOT IN ('cancelled', 'done')
+                   RETURNING *""",
                 now,
                 workflow["id"],
             )
+            if not row:
+                return dict(workflow)
             await sync_multica_issue(dict(row), note="Blocked: Hermes completed without PR_URL.")
             return dict(row)
 
         row = await db.fetchrow(
             """UPDATE engineering_tasks
                SET phase='pr_open', pr_url=$1, pr_number=$2, updated_at=$3
-               WHERE id=$4 RETURNING *""",
+               WHERE id=$4 AND phase NOT IN ('cancelled', 'done')
+               RETURNING *""",
             pr_url,
             pr_number,
             now,
             workflow["id"],
         )
+        if not row:
+            return dict(workflow)
     await sync_multica_issue(dict(row), note=f"PR opened: {pr_url}")
     return dict(row)
 

--- a/services/zoe-data/engineering_workflow.py
+++ b/services/zoe-data/engineering_workflow.py
@@ -345,7 +345,8 @@ async def update_greptile_state(
                SET greptile_status=$1, greptile_confidence=$2,
                    greptile_unaddressed_count=$3, phase=$4, status=$5,
                    updated_at=$6
-               WHERE id=$7 RETURNING *""",
+               WHERE id=$7 AND phase NOT IN ('cancelled', 'done')
+               RETURNING *""",
             greptile_status,
             confidence,
             unaddressed_count,
@@ -354,6 +355,9 @@ async def update_greptile_state(
             now,
             task_id,
         )
+    if not row:
+        current = await get_engineering_task(task_id)
+        return current or {}
     note = f"Greptile: {greptile_status}"
     if confidence is not None:
         note += f", confidence {confidence}/5"

--- a/services/zoe-data/greptile_client.py
+++ b/services/zoe-data/greptile_client.py
@@ -1,0 +1,126 @@
+"""Async client for Greptile's HTTP MCP endpoint."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+MCP_URL = os.environ.get("GREPTILE_MCP_URL", "https://api.greptile.com/mcp")
+ENV_FILE = Path(os.environ.get("GREPTILE_ENV_FILE", Path.home() / ".config/zoe/greptile.env"))
+DEFAULT_REMOTE = "github"
+DEFAULT_BRANCH = "main"
+DEFAULT_REPO = os.environ.get("ZOE_GITHUB_REPO", "jason-easyazz/zoe-ai-assistant")
+
+
+class GreptileAuthError(RuntimeError):
+    """Raised when Greptile credentials are unavailable."""
+
+
+def _load_api_key() -> str:
+    key = (os.environ.get("GREPTILE_API_KEY") or "").strip()
+    if key:
+        return key
+    if ENV_FILE.is_file():
+        for line in ENV_FILE.read_text().splitlines():
+            line = line.strip()
+            if line.startswith("GREPTILE_API_KEY="):
+                return line.split("=", 1)[1].strip()
+    raise GreptileAuthError("Greptile API key missing")
+
+
+async def _mcp_call(tool: str, arguments: dict[str, Any]) -> Any:
+    payload = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {"name": tool, "arguments": arguments},
+    }
+    headers = {
+        "Authorization": f"Bearer {_load_api_key()}",
+        "Content-Type": "application/json",
+        "Accept": "application/json, text/event-stream",
+    }
+    async with httpx.AsyncClient(timeout=90) as client:
+        resp = await client.post(MCP_URL, json=payload, headers=headers)
+        resp.raise_for_status()
+        data = resp.json()
+    if data.get("error"):
+        raise RuntimeError(f"Greptile MCP error: {data['error']}")
+    result = data.get("result") or {}
+    content = result.get("content") or []
+    if content and content[0].get("type") == "text":
+        text = content[0].get("text") or ""
+        try:
+            return json.loads(text)
+        except json.JSONDecodeError:
+            return {"raw": text}
+    return result
+
+
+def _repo_args(repo: str, default_branch: str) -> dict[str, Any]:
+    return {"name": repo, "remote": DEFAULT_REMOTE, "defaultBranch": default_branch}
+
+
+async def get_pr_status(
+    repo: str = DEFAULT_REPO,
+    pr_number: int | str = 0,
+    default_branch: str = DEFAULT_BRANCH,
+) -> dict[str, Any]:
+    pr = int(pr_number)
+    data = await _mcp_call("get_merge_request", {**_repo_args(repo, default_branch), "prNumber": pr})
+    mr = data.get("mergeRequest") or data
+    analysis = mr.get("reviewAnalysis") or {}
+    body = mr.get("description") or ""
+    confidence = None
+    import re
+
+    match = re.search(r"Confidence Score:\s*(\d)/5", body, re.I)
+    if match:
+        confidence = int(match.group(1))
+    return {
+        "repo": repo,
+        "prNumber": pr,
+        "title": mr.get("title"),
+        "state": mr.get("state"),
+        "reviewCompleteness": analysis.get("reviewCompleteness"),
+        "unaddressedCount": len(analysis.get("unaddressedComments") or []),
+        "hasNewCommitsSinceReview": analysis.get("hasNewCommitsSinceReview"),
+        "lastReviewDate": analysis.get("lastReviewDate"),
+        "confidenceScore": confidence,
+        "codeReviews": mr.get("codeReviews") or [],
+    }
+
+
+async def list_pr_comments(
+    repo: str = DEFAULT_REPO,
+    pr_number: int | str = 0,
+    default_branch: str = DEFAULT_BRANCH,
+    greptile_only: bool = True,
+    unaddressed_only: bool = True,
+) -> dict[str, Any]:
+    pr = int(pr_number)
+    params: dict[str, Any] = {**_repo_args(repo, default_branch), "prNumber": pr}
+    if greptile_only:
+        params["greptileGenerated"] = True
+    if unaddressed_only:
+        params["addressed"] = False
+    data = await _mcp_call("list_merge_request_comments", params)
+    comments = data.get("comments") or []
+    return {"repo": repo, "prNumber": pr, "total": len(comments), "comments": comments}
+
+
+async def trigger_review(
+    repo: str = DEFAULT_REPO,
+    pr_number: int | str = 0,
+    default_branch: str = DEFAULT_BRANCH,
+    branch: str | None = None,
+) -> dict[str, Any]:
+    pr = int(pr_number)
+    args = {**_repo_args(repo, default_branch), "prNumber": pr}
+    if branch:
+        args["branch"] = branch
+    return await _mcp_call("trigger_code_review", args)

--- a/services/zoe-data/intent_router.py
+++ b/services/zoe-data/intent_router.py
@@ -163,6 +163,18 @@ _HA_FULL_SETUP_RE = re.compile(
     re.IGNORECASE,
 )
 
+_ENGINEERING_TASK_RE = re.compile(
+    r"^(?:offload|delegate|assign|ask)\s+(?:this\s+)?(?:to\s+)?hermes\s+(?:to\s+)?(?P<task>.+)$"
+    r"|^(?:create|start|queue)\s+(?:an?\s+)?engineering\s+task\s+(?:for\s+)?(?P<task2>.+)$",
+    re.I,
+)
+
+_ENGINEERING_STATUS_RE = re.compile(
+    r"\b(?:engineering|hermes)\s+(?:task|workflow|pr)\s+(?:status|progress)\b"
+    r"|\bwhat'?s?\s+(?:the\s+)?(?:hermes|engineering)\s+(?:status|progress)\b",
+    re.I,
+)
+
 
 def _is_ha_full_setup_message(t: str) -> bool:
     """True when the user wants the full HA bootstrap (onboarding, token, proxy trust, bridge)."""
@@ -1103,22 +1115,12 @@ def detect_intent(
     if _BOARD_RE.search(t):
         return Intent("board_status", {})
 
-    _ENGINEERING_TASK_RE = re.compile(
-        r"^(?:offload|delegate|assign|ask)\s+(?:this\s+)?(?:to\s+)?hermes\s+(?:to\s+)?(?P<task>.+)$"
-        r"|^(?:create|start|queue)\s+(?:an?\s+)?engineering\s+task\s+(?:for\s+)?(?P<task2>.+)$",
-        re.I,
-    )
     _eng_match = _ENGINEERING_TASK_RE.search(text.strip())
     if _eng_match:
         task_text = (_eng_match.group("task") or _eng_match.group("task2") or "").strip()
         if task_text:
             return Intent("engineering_task_create", {"task": task_text})
 
-    _ENGINEERING_STATUS_RE = re.compile(
-        r"\b(?:engineering|hermes)\s+(?:task|workflow|pr)\s+(?:status|progress)\b"
-        r"|\bwhat'?s?\s+(?:the\s+)?(?:hermes|engineering)\s+(?:status|progress)\b",
-        re.I,
-    )
     if _ENGINEERING_STATUS_RE.search(t):
         return Intent("engineering_task_status", {})
 

--- a/services/zoe-data/intent_router.py
+++ b/services/zoe-data/intent_router.py
@@ -1103,6 +1103,25 @@ def detect_intent(
     if _BOARD_RE.search(t):
         return Intent("board_status", {})
 
+    _ENGINEERING_TASK_RE = re.compile(
+        r"^(?:offload|delegate|assign|ask)\s+(?:this\s+)?(?:to\s+)?hermes\s+(?:to\s+)?(?P<task>.+)$"
+        r"|^(?:create|start|queue)\s+(?:an?\s+)?engineering\s+task\s+(?:for\s+)?(?P<task2>.+)$",
+        re.I,
+    )
+    _eng_match = _ENGINEERING_TASK_RE.search(text.strip())
+    if _eng_match:
+        task_text = (_eng_match.group("task") or _eng_match.group("task2") or "").strip()
+        if task_text:
+            return Intent("engineering_task_create", {"task": task_text})
+
+    _ENGINEERING_STATUS_RE = re.compile(
+        r"\b(?:engineering|hermes)\s+(?:task|workflow|pr)\s+(?:status|progress)\b"
+        r"|\bwhat'?s?\s+(?:the\s+)?(?:hermes|engineering)\s+(?:status|progress)\b",
+        re.I,
+    )
+    if _ENGINEERING_STATUS_RE.search(t):
+        return Intent("engineering_task_status", {})
+
     # ── Evolution proposals ────────────────────────────────────────────────────
     _EVOLVE_REVIEW_RE = re.compile(
         r'what\s+(?:needs?|could)\s+(?:be\s+)?improv(?:ing|ed|ement)\b'
@@ -1436,6 +1455,45 @@ async def execute_intent(intent: Intent, user_id: str = "family-admin") -> Optio
             logger.warning("board_status: %s", exc)
             return "I couldn't check the task board right now. Try again in a moment."
 
+    # ── Engineering Workflow ──────────────────────────────────────────────────
+    if intent.name == "engineering_task_create":
+        task_text = intent.slots.get("task", "").strip()
+        if not task_text:
+            return "What should Hermes work on?"
+        try:
+            from engineering_workflow import create_engineering_task  # type: ignore[import]
+            workflow = await create_engineering_task(
+                user_id=user_id or "family-admin",
+                title=task_text[:120],
+                task=task_text,
+                source="chat",
+                idempotency_key=None,
+            )
+            return (
+                "I've drafted that as a Hermes engineering workflow. It needs approval before Hermes starts changing code.\n\n"
+                f"- Workflow: `{workflow['id']}`\n"
+                f"- Phase: `{workflow['phase']}`\n"
+                "Approve it from the engineering task API or Multica board when you're ready."
+            )
+        except Exception as exc:
+            logger.warning("engineering_task_create: %s", exc)
+            return "I couldn't queue that engineering task right now."
+
+    if intent.name == "engineering_task_status":
+        try:
+            from engineering_workflow import list_engineering_tasks  # type: ignore[import]
+            tasks = await list_engineering_tasks(limit=5, status="active")
+            if not tasks:
+                return "No active Hermes engineering workflows right now."
+            lines = ["**Active Hermes engineering workflows:**"]
+            for item in tasks:
+                pr = f" | PR: {item['pr_url']}" if item.get("pr_url") else ""
+                lines.append(f"- `{item['id']}` — {item['phase']} — {item['title'][:80]}{pr}")
+            return "\n".join(lines)
+        except Exception as exc:
+            logger.warning("engineering_task_status: %s", exc)
+            return "I couldn't check Hermes engineering workflow status right now."
+
     # ── Evolution Proposals Review ─────────────────────────────────────────────
     if intent.name == "evolution_proposals_review":
         try:
@@ -1483,21 +1541,32 @@ async def execute_intent(intent: Intent, user_id: str = "family-admin") -> Optio
             if not mc.is_configured():
                 return (
                     "Multica isn't connected, so I can't check the board. "
-                    "The agents (Hermes, OpenClaw) have natural-language autopilots that will "
-                    "review and fix issues on the next scheduled run (every 15 minutes)."
+                    "Configure Multica before using the Hermes board-review workflow."
                 )
             todo_issues = await mc.list_issues(status="todo")
             in_progress = await mc.list_issues(status="in_progress")
             total_open = len(todo_issues) + len(in_progress)
             if total_open == 0:
                 return "Board is clear — no open issues. The agents will keep it that way."
+            try:
+                from multica_autopilot_sync import _run_board_review  # type: ignore[import]
+                await _run_board_review()
+                triggered = True
+            except Exception:
+                triggered = False
             lines = [
-                f"**Board has {total_open} open issue(s).** Triggering the self-healing loop:\n",
+                f"**Board has {total_open} open issue(s).**\n",
                 f"- **{len(todo_issues)} todo** / **{len(in_progress)} in-progress**\n",
-                "The Board Review autopilot (Hermes, every 15 min) will triage and fix "
-                "eligible issues automatically. Issues needing credentials or human judgement "
-                "will trigger a push notification to you.\n",
             ]
+            if triggered:
+                lines.append(
+                    "I triggered the Hermes board-review dispatcher for Hermes-assigned issues. "
+                    "Issues needing credentials or human judgement will be marked for review.\n"
+                )
+            else:
+                lines.append(
+                    "I could read the board, but couldn't trigger the Hermes dispatcher just now.\n"
+                )
             if todo_issues:
                 lines.append("\n**Oldest open items:**")
                 for item in todo_issues[:4]:

--- a/services/zoe-data/main.py
+++ b/services/zoe-data/main.py
@@ -300,7 +300,7 @@ async def lifespan(app: FastAPI):
 
                 issues = await client.list_issues(status="in_progress")
                 for issue in issues or []:
-                    # Check if linked background task completed
+                    # Check whether a linked engineering workflow has reached a terminal state.
                     issue_id = issue.get("id")
                     title = issue.get("title", "")
                     if not issue_id:
@@ -309,20 +309,28 @@ async def lifespan(app: FastAPI):
                         from db_pool import get_db_ctx  # type: ignore[import]
                         async with get_db_ctx() as _db:
                             rows = await _db.fetch(
-                                """SELECT id, status, user_id FROM background_tasks
-                                   WHERE (payload->>'multica_issue_id')=$1
-                                   ORDER BY created_at DESC LIMIT 1""",
+                                """SELECT id, phase, status, user_id FROM engineering_tasks
+                                   WHERE multica_issue_id=$1
+                                   ORDER BY updated_at DESC LIMIT 1""",
                                 str(issue_id),
                             )
-                        if rows and rows[0]["status"] == "done":
-                            await client.update_issue(issue_id, status="done")
-                            logger.info("multica_poll: closed issue %s ('%s') — task done", issue_id, title[:40])
+                        if rows and rows[0]["phase"] in ("done", "ready_for_human"):
+                            new_status = "done" if rows[0]["phase"] == "done" else "in_review"
+                            await client.update_issue(issue_id, status=new_status)
+                            logger.info(
+                                "multica_poll: advanced issue %s ('%s') — engineering phase=%s",
+                                issue_id, title[:40], rows[0]["phase"],
+                            )
                             # Push WebSocket notification to all connected clients
                             try:
                                 await broadcaster.broadcast(
                                     "all",
                                     "multica_task_done",
-                                    {"multica_issue_id": str(issue_id), "title": title},
+                                    {
+                                        "multica_issue_id": str(issue_id),
+                                        "title": title,
+                                        "phase": rows[0]["phase"],
+                                    },
                                 )
                             except Exception as _push_exc:
                                 logger.debug("multica_poll: ws push failed: %s", _push_exc)

--- a/services/zoe-data/mcp_server.py
+++ b/services/zoe-data/mcp_server.py
@@ -380,6 +380,48 @@ TOOLS = [
             "required": ["agent_name", "task"],
         },
     },
+    {
+        "name": "greptile_pr_status",
+        "description": "Get Greptile review status for a GitHub pull request without scraping GitHub comments.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "repo": {"type": "string", "description": "owner/repo", "default": "jason-easyazz/zoe-ai-assistant"},
+                "pr_number": {"type": "integer", "description": "Pull request number"},
+                "default_branch": {"type": "string", "default": "main"},
+            },
+            "required": ["pr_number"],
+        },
+    },
+    {
+        "name": "greptile_pr_comments",
+        "description": "List Greptile comments for a GitHub pull request, filtered to unaddressed Greptile comments by default.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "repo": {"type": "string", "description": "owner/repo", "default": "jason-easyazz/zoe-ai-assistant"},
+                "pr_number": {"type": "integer", "description": "Pull request number"},
+                "default_branch": {"type": "string", "default": "main"},
+                "greptile_only": {"type": "boolean", "default": True},
+                "unaddressed_only": {"type": "boolean", "default": True},
+            },
+            "required": ["pr_number"],
+        },
+    },
+    {
+        "name": "greptile_trigger_review",
+        "description": "Trigger a Greptile code review for a GitHub pull request.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "repo": {"type": "string", "description": "owner/repo", "default": "jason-easyazz/zoe-ai-assistant"},
+                "pr_number": {"type": "integer", "description": "Pull request number"},
+                "default_branch": {"type": "string", "default": "main"},
+                "branch": {"type": "string", "description": "Current PR branch"},
+            },
+            "required": ["pr_number"],
+        },
+    },
     # --- Journal tools ---
     {
         "name": "journal_create_entry",
@@ -1729,6 +1771,42 @@ async def _execute_tool(db, name: str, args: dict):
             return graphify_search(query)
         except Exception as exc:
             return {"error": f"Graphify search failed: {exc}"}
+
+    elif name == "greptile_pr_status":
+        try:
+            from greptile_client import get_pr_status  # type: ignore[import]
+            return await get_pr_status(
+                repo=args.get("repo") or "jason-easyazz/zoe-ai-assistant",
+                pr_number=args.get("pr_number"),
+                default_branch=args.get("default_branch") or "main",
+            )
+        except Exception as exc:
+            return {"error": f"Greptile PR status failed: {exc}"}
+
+    elif name == "greptile_pr_comments":
+        try:
+            from greptile_client import list_pr_comments  # type: ignore[import]
+            return await list_pr_comments(
+                repo=args.get("repo") or "jason-easyazz/zoe-ai-assistant",
+                pr_number=args.get("pr_number"),
+                default_branch=args.get("default_branch") or "main",
+                greptile_only=bool(args.get("greptile_only", True)),
+                unaddressed_only=bool(args.get("unaddressed_only", True)),
+            )
+        except Exception as exc:
+            return {"error": f"Greptile PR comments failed: {exc}"}
+
+    elif name == "greptile_trigger_review":
+        try:
+            from greptile_client import trigger_review  # type: ignore[import]
+            return await trigger_review(
+                repo=args.get("repo") or "jason-easyazz/zoe-ai-assistant",
+                pr_number=args.get("pr_number"),
+                default_branch=args.get("default_branch") or "main",
+                branch=args.get("branch"),
+            )
+        except Exception as exc:
+            return {"error": f"Greptile trigger review failed: {exc}"}
 
     elif name == "zoe_self_capabilities":
         import datetime

--- a/services/zoe-data/multica_autopilot_sync.py
+++ b/services/zoe-data/multica_autopilot_sync.py
@@ -256,6 +256,41 @@ async def _run_platform_health_check() -> None:
     raise RuntimeError(f"Platform health check failed (exit {proc.returncode})")
 
 
+async def _run_board_review() -> None:
+    """Dispatch Hermes-assigned open Multica issues into engineering workflows."""
+    try:
+        from multica_client import get_multica_client  # type: ignore[import]
+        from engineering_workflow import create_and_start_engineering_task  # type: ignore[import]
+
+        client = get_multica_client()
+        if not client.is_configured():
+            return
+        dispatched = 0
+        for status in ("todo", "in_progress"):
+            issues = await client.list_issues(status=status)
+            for issue in issues or []:
+                issue_id = str(issue.get("id") or "")
+                if not issue_id:
+                    continue
+                if str(issue.get("assignee_id") or "") != _HERMES_AGENT_ID:
+                    continue
+                title = issue.get("title") or issue.get("identifier") or "Multica engineering task"
+                description = issue.get("description") or ""
+                await create_and_start_engineering_task(
+                    user_id="family-admin",
+                    title=title,
+                    task=f"Work this Hermes-assigned Multica issue.\n\nTitle: {title}\n\n{description}",
+                    source="board_review_autopilot",
+                    source_id=issue_id,
+                    multica_issue_id=issue_id,
+                    idempotency_key=f"multica:{issue_id}",
+                )
+                dispatched += 1
+        logger.info("autopilot: board review dispatched %d issue(s)", dispatched)
+    except Exception as exc:
+        logger.warning("_run_board_review: %s", exc)
+
+
 # ── Title → task function mapping ────────────────────────────────────────────
 
 _TITLE_TO_TASK: dict[str, Callable] = {
@@ -274,6 +309,9 @@ _TITLE_TO_TASK: dict[str, Callable] = {
     "reminder scan": _run_reminder_scan,
     "platform health check": _run_platform_health_check,
     "health check": _run_platform_health_check,
+    "board review": _run_board_review,
+    "multica board review": _run_board_review,
+    "hermes board review": _run_board_review,
 }
 
 

--- a/services/zoe-data/routers/system.py
+++ b/services/zoe-data/routers/system.py
@@ -1,4 +1,5 @@
 import asyncio
+import hmac
 import json
 import logging
 import os
@@ -1256,6 +1257,19 @@ async def board_cancel(task_id: str, user: dict = Depends(get_current_user)):
     return {"ok": True, "task_id": task_id, "status": "cancelled"}
 
 
+def _multica_webhook_dispatch_allowed(request: Request) -> bool:
+    """Return True when a webhook is allowed to start code-changing work."""
+    secret = os.environ.get("MULTICA_WEBHOOK_SECRET", "").strip()
+    if not secret:
+        return False
+    auth = request.headers.get("authorization", "")
+    token = request.headers.get("x-multica-webhook-token", "")
+    return (
+        hmac.compare_digest(auth, f"Bearer {secret}")
+        or hmac.compare_digest(token, secret)
+    )
+
+
 @_agent_card_router.post("/board/webhook")
 async def multica_webhook(request: Request):
     """Receive Multica webhook events and update evolution proposal status."""
@@ -1299,11 +1313,14 @@ async def multica_webhook(request: Request):
                 "Multica webhook: %s issue=%s assignee=%s",
                 event, issue.get("identifier"), issue.get("assignee_id"),
             )
-            hermes_agent_id = os.environ.get(
-                "HERMES_MULTICA_AGENT_ID",
-                "019ae0a7-62f1-47fe-9d46-75fd0ae5d570",
-            )
+            from multica_autopilot_sync import _HERMES_AGENT_ID as hermes_agent_id  # type: ignore[import]
             if str(issue.get("assignee_id") or "") == hermes_agent_id:
+                if not _multica_webhook_dispatch_allowed(request):
+                    logger.warning(
+                        "Multica webhook: skipped Hermes dispatch for issue=%s; webhook dispatch auth missing",
+                        issue.get("identifier") or issue.get("id"),
+                    )
+                    return {"ok": True, "dispatched": False, "reason": "dispatch auth required"}
                 try:
                     from engineering_workflow import create_and_start_engineering_task  # type: ignore[import]
                     issue_id = str(issue.get("id") or "")

--- a/services/zoe-data/routers/system.py
+++ b/services/zoe-data/routers/system.py
@@ -700,6 +700,22 @@ class _A2ATaskRequest(BaseModel):
     stream: bool = False
 
 
+class _EngineeringTaskRequest(BaseModel):
+    task: str
+    title: str | None = None
+    source: str = "api"
+    source_id: str | None = None
+    multica_issue_id: str | None = None
+    idempotency_key: str | None = None
+    max_rounds: int = 5
+    target_confidence: int = 5
+    start: bool = True
+
+
+class _EngineeringTaskCancelRequest(BaseModel):
+    reason: str = "cancelled by operator"
+
+
 @_agent_card_router.post("/tasks")
 async def a2a_task(body: _A2ATaskRequest, user: dict = Depends(get_a2a_caller)):
     """
@@ -799,6 +815,86 @@ async def a2a_task_result(task_id: str, user: dict = Depends(get_a2a_caller)):
         "created_at": row["created_at"],
         "completed_at": row["completed_at"],
     }
+
+
+# ── Engineering workflow tasks ────────────────────────────────────────────────
+
+@_agent_card_router.post("/engineering/tasks")
+async def create_engineering_workflow_task(
+    body: _EngineeringTaskRequest,
+    user: dict = Depends(require_admin),
+):
+    """Create and optionally start a durable Multica/Hermes/PR workflow."""
+    from engineering_workflow import create_and_start_engineering_task, create_engineering_task
+
+    kwargs = {
+        "user_id": user.get("user_id", "admin"),
+        "task": body.task,
+        "title": body.title,
+        "source": body.source,
+        "source_id": body.source_id,
+        "multica_issue_id": body.multica_issue_id,
+        "idempotency_key": body.idempotency_key,
+        "max_rounds": body.max_rounds,
+        "target_confidence": body.target_confidence,
+    }
+    task = await (create_and_start_engineering_task(**kwargs) if body.start else create_engineering_task(**kwargs))
+    return {"ok": True, "task": task}
+
+
+@_agent_card_router.get("/engineering/tasks")
+async def list_engineering_workflow_tasks(
+    limit: int = 20,
+    status: str | None = None,
+    user: dict = Depends(require_admin),
+):
+    from engineering_workflow import list_engineering_tasks
+
+    return {"tasks": await list_engineering_tasks(limit=limit, status=status)}
+
+
+@_agent_card_router.get("/engineering/tasks/{task_id}")
+async def get_engineering_workflow_task(task_id: str, user: dict = Depends(require_admin)):
+    from engineering_workflow import get_engineering_task
+
+    task = await get_engineering_task(task_id)
+    if not task:
+        raise HTTPException(status_code=404, detail="Engineering task not found")
+    return {"task": task}
+
+
+@_agent_card_router.post("/engineering/tasks/{task_id}/retry")
+async def retry_engineering_workflow_task(task_id: str, user: dict = Depends(require_admin)):
+    from engineering_workflow import retry_engineering_task
+
+    try:
+        return {"ok": True, "task": await retry_engineering_task(task_id)}
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@_agent_card_router.post("/engineering/tasks/{task_id}/cancel")
+async def cancel_engineering_workflow_task(
+    task_id: str,
+    body: _EngineeringTaskCancelRequest,
+    user: dict = Depends(require_admin),
+):
+    from engineering_workflow import cancel_engineering_task
+
+    try:
+        return {"ok": True, "task": await cancel_engineering_task(task_id, body.reason)}
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+@_agent_card_router.post("/engineering/tasks/{task_id}/greptile/check")
+async def check_engineering_workflow_greptile(task_id: str, user: dict = Depends(require_admin)):
+    from engineering_workflow import check_greptile_for_task
+
+    try:
+        return {"ok": True, "task": await check_greptile_for_task(task_id)}
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
 # ── A2A Registry + Peer Cards + Squad ────────────────────────────────────────
@@ -1106,10 +1202,11 @@ async def get_agent_board():
 
 
 @_agent_card_router.post("/board/approve")
-async def board_approve(task_id: str, user: dict = Depends(get_current_user)):
+async def board_approve(task_id: str, user: dict = Depends(require_admin)):
     """Create a Multica board issue for agent execution (Hermes by default)."""
     try:
         from multica_client import MULClient  # type: ignore[import]
+        from engineering_workflow import create_and_start_engineering_task  # type: ignore[import]
         client = MULClient()
         if not client.is_configured():
             return {"ok": False, "reason": "Multica not configured — route via Hermes manually"}
@@ -1118,7 +1215,19 @@ async def board_approve(task_id: str, user: dict = Depends(get_current_user)):
             description=f"Approved via Zoe chat. Task ID: {task_id}",
             priority="medium",
         )
-        return {"ok": True, "issue": issue}
+        issue_id = issue.get("id") if isinstance(issue, dict) else None
+        workflow = None
+        if issue_id:
+            workflow = await create_and_start_engineering_task(
+                user_id=user.get("user_id", "admin"),
+                title=f"Task: {task_id}",
+                task=f"Implement approved Zoe board task `{task_id}`. Open a PR and run Greptile review.",
+                source="board_approve",
+                source_id=task_id,
+                multica_issue_id=issue_id,
+                idempotency_key=f"board_approve:{task_id}",
+            )
+        return {"ok": True, "issue": issue, "engineering_task": workflow}
     except Exception as exc:
         return {"ok": False, "reason": str(exc)}
 
@@ -1190,6 +1299,28 @@ async def multica_webhook(request: Request):
                 "Multica webhook: %s issue=%s assignee=%s",
                 event, issue.get("identifier"), issue.get("assignee_id"),
             )
+            hermes_agent_id = os.environ.get(
+                "HERMES_MULTICA_AGENT_ID",
+                "019ae0a7-62f1-47fe-9d46-75fd0ae5d570",
+            )
+            if str(issue.get("assignee_id") or "") == hermes_agent_id:
+                try:
+                    from engineering_workflow import create_and_start_engineering_task  # type: ignore[import]
+                    issue_id = str(issue.get("id") or "")
+                    title = issue.get("title") or issue.get("identifier") or "Multica engineering task"
+                    description = issue.get("description") or ""
+                    if issue_id:
+                        await create_and_start_engineering_task(
+                            user_id="family-admin",
+                            title=title,
+                            task=f"Work this Hermes-assigned Multica issue.\n\nTitle: {title}\n\n{description}",
+                            source="multica_webhook",
+                            source_id=issue_id,
+                            multica_issue_id=issue_id,
+                            idempotency_key=f"multica:{issue_id}",
+                        )
+                except Exception as dispatch_exc:
+                    logger.warning("Multica webhook: Hermes dispatch failed: %s", dispatch_exc)
 
         elif event == "issue.created" and issue:
             logger.info(
@@ -1382,22 +1513,29 @@ async def evolution_proposal_action(
                     proposal_id, exc,
                 )
 
-            # Queue a Hermes background task to implement the proposal;
-            # when it completes, the task runner will advance status → deployed.
+            # Queue a tracked engineering workflow to implement the proposal.
             try:
-                from background_runner import enqueue_background_task  # type: ignore[import]
+                from engineering_workflow import create_and_start_engineering_task  # type: ignore[import]
                 _task_desc = (
                     f"Implement evolution proposal {proposal_id}: "
                     f"{proposal['title']}. "
                     f"{proposal['description']}"
                 )
-                task_id = await enqueue_background_task(
-                    _task_desc,
-                    user["user_id"],
+                _workflow = await create_and_start_engineering_task(
+                    user_id=user["user_id"],
+                    title=proposal["title"],
+                    task=_task_desc,
+                    source="evolution_proposal",
+                    source_id=proposal_id,
+                    multica_issue_id=multica_issue_id,
+                    idempotency_key=f"evolution:{proposal_id}",
                 )
-                logger.info("evolution_approve: queued implement task %s for proposal %s", task_id, proposal_id)
+                logger.info(
+                    "evolution_approve: queued engineering workflow %s for proposal %s",
+                    _workflow.get("id"), proposal_id,
+                )
             except Exception as exc:
-                logger.warning("evolution_approve: could not queue implement task: %s", exc)
+                logger.warning("evolution_approve: could not queue engineering workflow: %s", exc)
             return {"ok": True, "action": "approved", "multica_issue_id": multica_issue_id}
 
         elif action == "deploy":

--- a/services/zoe-data/tests/test_engineering_workflow.py
+++ b/services/zoe-data/tests/test_engineering_workflow.py
@@ -124,3 +124,37 @@ async def test_start_engineering_task_returns_existing_when_already_claimed(monk
     task = await engineering_workflow.start_engineering_task("wf-claimed")
 
     assert task == existing
+
+
+@pytest.mark.asyncio
+async def test_reconcile_does_not_overwrite_cancelled_workflow(monkeypatch):
+    workflow = {
+        "id": "wf-cancelled",
+        "phase": "cancelled",
+        "status": "cancelled",
+        "background_task_id": 42,
+    }
+
+    class FakeDB:
+        async def fetchrow(self, sql, *args):
+            if "WHERE background_task_id=$1" in sql:
+                return workflow
+            raise AssertionError(f"unexpected query after terminal workflow: {sql}")
+
+    class FakeCtx:
+        async def __aenter__(self):
+            return FakeDB()
+
+        async def __aexit__(self, *_):
+            return None
+
+    monkeypatch.setitem(sys.modules, "db_pool", types.SimpleNamespace(get_db_ctx=lambda: FakeCtx()))
+
+    async def fake_sync(*_, **__):
+        raise AssertionError("terminal workflow should not sync new state")
+
+    monkeypatch.setattr(engineering_workflow, "sync_multica_issue", fake_sync)
+
+    updated = await engineering_workflow.reconcile_background_task(42)
+
+    assert updated == workflow

--- a/services/zoe-data/tests/test_engineering_workflow.py
+++ b/services/zoe-data/tests/test_engineering_workflow.py
@@ -86,3 +86,41 @@ async def test_reconcile_background_task_records_pr(monkeypatch):
     assert updated["phase"] == "pr_open"
     assert updated["pr_number"] == 77
     assert updated["pr_url"].endswith("/pull/77")
+
+
+@pytest.mark.asyncio
+async def test_start_engineering_task_returns_existing_when_already_claimed(monkeypatch):
+    existing = {
+        "id": "wf-claimed",
+        "phase": "hermes_running",
+        "background_task_id": 99,
+    }
+
+    class FakeDB:
+        async def fetchrow(self, sql, *args):
+            if "UPDATE engineering_tasks" in sql:
+                return None
+            if "SELECT * FROM engineering_tasks WHERE id=$1" in sql:
+                return existing
+            raise AssertionError(f"unexpected query: {sql}")
+
+    class FakeCtx:
+        async def __aenter__(self):
+            return FakeDB()
+
+        async def __aexit__(self, *_):
+            return None
+
+    async def fail_enqueue(*_, **__):
+        raise AssertionError("enqueue should not be called for an already claimed workflow")
+
+    monkeypatch.setitem(sys.modules, "db_pool", types.SimpleNamespace(get_db_ctx=lambda: FakeCtx()))
+    monkeypatch.setitem(
+        sys.modules,
+        "background_runner",
+        types.SimpleNamespace(enqueue_background_task=fail_enqueue),
+    )
+
+    task = await engineering_workflow.start_engineering_task("wf-claimed")
+
+    assert task == existing

--- a/services/zoe-data/tests/test_engineering_workflow.py
+++ b/services/zoe-data/tests/test_engineering_workflow.py
@@ -158,3 +158,45 @@ async def test_reconcile_does_not_overwrite_cancelled_workflow(monkeypatch):
     updated = await engineering_workflow.reconcile_background_task(42)
 
     assert updated == workflow
+
+
+@pytest.mark.asyncio
+async def test_update_greptile_state_does_not_overwrite_terminal_workflow(monkeypatch):
+    workflow = {
+        "id": "wf-done",
+        "phase": "done",
+        "status": "done",
+        "target_confidence": 5,
+    }
+
+    class FakeDB:
+        async def fetchrow(self, sql, *args):
+            if "UPDATE engineering_tasks" in sql:
+                assert "phase NOT IN ('cancelled', 'done')" in sql
+                return None
+            if "SELECT * FROM engineering_tasks WHERE id=$1" in sql:
+                return workflow
+            raise AssertionError(f"unexpected query: {sql}")
+
+    class FakeCtx:
+        async def __aenter__(self):
+            return FakeDB()
+
+        async def __aexit__(self, *_):
+            return None
+
+    monkeypatch.setitem(sys.modules, "db_pool", types.SimpleNamespace(get_db_ctx=lambda: FakeCtx()))
+
+    async def fake_sync(*_, **__):
+        raise AssertionError("terminal workflow should not sync Greptile state")
+
+    monkeypatch.setattr(engineering_workflow, "sync_multica_issue", fake_sync)
+
+    updated = await engineering_workflow.update_greptile_state(
+        "wf-done",
+        greptile_status="clean",
+        confidence=5,
+        unaddressed_count=0,
+    )
+
+    assert updated == workflow

--- a/services/zoe-data/tests/test_engineering_workflow.py
+++ b/services/zoe-data/tests/test_engineering_workflow.py
@@ -1,0 +1,88 @@
+import sys
+import types
+
+import pytest
+
+import engineering_workflow
+
+
+def test_build_hermes_prompt_requires_pr_contract():
+    prompt = engineering_workflow.build_hermes_prompt(
+        "Fix the thing",
+        workflow_id="wf-1",
+        max_rounds=3,
+        target_confidence=5,
+    )
+
+    assert "zoe-engineering" in prompt
+    assert "github-greptile-loop" in prompt
+    assert "PR_URL=" in prompt
+    assert "BLOCKER=" in prompt
+    assert "do not push to main" in prompt
+
+
+def test_parse_pr_url_extracts_github_pull_request():
+    pr_url, pr_number = engineering_workflow._parse_pr_url(
+        "Done\nPR_URL=https://github.com/jason-easyazz/zoe-ai-assistant/pull/123\n"
+    )
+
+    assert pr_url == "https://github.com/jason-easyazz/zoe-ai-assistant/pull/123"
+    assert pr_number == 123
+
+
+@pytest.mark.asyncio
+async def test_reconcile_background_task_records_pr(monkeypatch):
+    workflow = {
+        "id": "wf-1",
+        "user_id": "family-admin",
+        "title": "Test workflow",
+        "task": "Do work",
+        "phase": "hermes_running",
+        "status": "active",
+        "background_task_id": 42,
+        "multica_issue_id": None,
+    }
+    background = {
+        "id": 42,
+        "status": "done",
+        "result": "SUMMARY=done\nPR_URL=https://github.com/jason-easyazz/zoe-ai-assistant/pull/77\n",
+    }
+
+    class FakeDB:
+        async def fetchrow(self, sql, *args):
+            if "WHERE background_task_id=$1" in sql:
+                return workflow
+            if "FROM background_tasks" in sql:
+                return background
+            if "SET phase='pr_open'" in sql:
+                workflow.update(
+                    {
+                        "phase": "pr_open",
+                        "pr_url": args[0],
+                        "pr_number": args[1],
+                        "updated_at": args[2],
+                    }
+                )
+                return workflow
+            raise AssertionError(f"unexpected query: {sql}")
+
+    class FakeCtx:
+        async def __aenter__(self):
+            return FakeDB()
+
+        async def __aexit__(self, *_):
+            return None
+
+    fake_db_pool = types.SimpleNamespace(get_db_ctx=lambda: FakeCtx())
+    monkeypatch.setitem(sys.modules, "db_pool", fake_db_pool)
+
+    async def fake_sync(*_, **__):
+        return None
+
+    monkeypatch.setattr(engineering_workflow, "sync_multica_issue", fake_sync)
+
+    updated = await engineering_workflow.reconcile_background_task(42)
+
+    assert updated["phase"] == "pr_open"
+    assert updated["pr_number"] == 77
+    assert updated["pr_url"].endswith("/pull/77")

--- a/services/zoe-data/tests/test_engineering_workflow.py
+++ b/services/zoe-data/tests/test_engineering_workflow.py
@@ -200,3 +200,77 @@ async def test_update_greptile_state_does_not_overwrite_terminal_workflow(monkey
     )
 
     assert updated == workflow
+
+
+@pytest.mark.asyncio
+async def test_retry_engineering_task_does_not_reopen_terminal_workflow(monkeypatch):
+    workflow = {
+        "id": "wf-done",
+        "phase": "done",
+        "status": "done",
+        "round_count": 1,
+        "max_rounds": 5,
+    }
+
+    class FakeDB:
+        async def fetchrow(self, sql, *args):
+            if "SELECT * FROM engineering_tasks WHERE id=$1" in sql:
+                return workflow
+            raise AssertionError(f"unexpected query: {sql}")
+
+        async def execute(self, sql, *args):
+            raise AssertionError("terminal workflow should not be reset to queued")
+
+    class FakeCtx:
+        async def __aenter__(self):
+            return FakeDB()
+
+        async def __aexit__(self, *_):
+            return None
+
+    monkeypatch.setitem(sys.modules, "db_pool", types.SimpleNamespace(get_db_ctx=lambda: FakeCtx()))
+
+    async def fail_start(*_, **__):
+        raise AssertionError("terminal workflow should not start another Hermes run")
+
+    monkeypatch.setattr(engineering_workflow, "start_engineering_task", fail_start)
+
+    updated = await engineering_workflow.retry_engineering_task("wf-done")
+
+    assert updated == workflow
+
+
+@pytest.mark.asyncio
+async def test_cancel_engineering_task_does_not_overwrite_done_workflow(monkeypatch):
+    workflow = {
+        "id": "wf-done",
+        "phase": "done",
+        "status": "done",
+    }
+
+    class FakeDB:
+        async def fetchrow(self, sql, *args):
+            if "UPDATE engineering_tasks" in sql:
+                assert "phase NOT IN ('done', 'cancelled')" in sql
+                return None
+            if "SELECT * FROM engineering_tasks WHERE id=$1" in sql:
+                return workflow
+            raise AssertionError(f"unexpected query: {sql}")
+
+    class FakeCtx:
+        async def __aenter__(self):
+            return FakeDB()
+
+        async def __aexit__(self, *_):
+            return None
+
+    monkeypatch.setitem(sys.modules, "db_pool", types.SimpleNamespace(get_db_ctx=lambda: FakeCtx()))
+
+    async def fake_sync(*_, **__):
+        raise AssertionError("already terminal workflow should not sync cancellation")
+
+    monkeypatch.setattr(engineering_workflow, "sync_multica_issue", fake_sync)
+
+    updated = await engineering_workflow.cancel_engineering_task("wf-done")
+
+    assert updated == workflow

--- a/tools/audit/validate_structure.py
+++ b/tools/audit/validate_structure.py
@@ -45,6 +45,8 @@ def get_all_project_files() -> Set[str]:
             dirs.remove('.git')
         
         for filename in filenames:
+            if filename == '.git':
+                continue
             full_path = Path(root) / filename
             relative_path = str(full_path.relative_to(PROJECT_ROOT))
             if filename == '.env' or (filename.startswith('.env.') and filename != '.env.example'):


### PR DESCRIPTION
## Summary
- Add durable engineering task state to link Multica issues, Hermes background execution, PR URLs, Greptile status, blockers, and cost metadata.
- Wire admin APIs, Multica board approval/webhooks, board-review autopilot dispatch, and chat status intents into the workflow.
- Expose Greptile MCP-compatible PR tools to Hermes/Zoe and document the live smoke procedure.

## Test plan
- `python3 tools/audit/validate_structure.py`
- `python3 tools/audit/validate_critical_files.py`
- `git diff --check`
- `python3 -m pytest services/zoe-data/tests/test_engineering_workflow.py -q`
- `python3 -m py_compile services/zoe-data/engineering_workflow.py services/zoe-data/greptile_client.py services/zoe-data/background_runner.py services/zoe-data/main.py services/zoe-data/routers/system.py services/zoe-data/multica_autopilot_sync.py services/zoe-data/intent_router.py services/zoe-data/mcp_server.py services/zoe-data/alembic/versions/0009_engineering_tasks.py`
- `curl -sf http://127.0.0.1:8000/health`
- `curl -sf http://127.0.0.1:8000/api/system/status`


Made with [Cursor](https://cursor.com)