### PR TITLE
Expose Zoe tools MCP in Cursor config

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -5,8 +5,15 @@
       "args": ["-m", "graphify.serve", "/home/zoe/assistant/graphify-out/graph.json"]
     },
     "zoe-tools": {
-      "command": "/usr/bin/python3",
-      "args": ["/home/zoe/bin/zoe-tools-mcp.py"],
+      "command": "/home/zoe/.local/bin/uv",
+      "args": [
+        "run",
+        "--with",
+        "fastmcp",
+        "--with",
+        "httpx",
+        "/home/zoe/bin/zoe-tools-mcp.py"
+      ],
       "env": {
         "ZOE_DATA_URL": "http://127.0.0.1:8000",
         "MULTICA_API_URL": "http://127.0.0.1:8080"

--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -3,6 +3,14 @@
     "graphify": {
       "command": "/home/zoe/.local/share/uv/tools/graphifyy/bin/python",
       "args": ["-m", "graphify.serve", "/home/zoe/assistant/graphify-out/graph.json"]
+    },
+    "zoe-tools": {
+      "command": "/usr/bin/python3",
+      "args": ["/home/zoe/bin/zoe-tools-mcp.py"],
+      "env": {
+        "ZOE_DATA_URL": "http://127.0.0.1:8000",
+        "MULTICA_API_URL": "http://127.0.0.1:8080"
+      }
     }
   }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,10 @@ For reviewable development work:
 - Use `zoe-greptile-loop` to delegate heavier fix/re-review loops to Hermes.
 - Do not treat Greptile as a replacement for local Zoe verification; run focused tests and live health checks before marking work merge-ready.
 
+## Cursor MCP
+
+The tracked Cursor MCP config intentionally includes only non-secret local servers. `zoe-tools` launches the operator-local helper at `/home/zoe/bin/zoe-tools-mcp.py` through `uv run --with fastmcp --with httpx`; provision that helper on Zoe hosts before relying on the repo-local MCP entry. Keep token-backed servers such as Greptile in user-global Cursor config or environment-backed local config, never in tracked repo files.
+
 ## Hermes-First Delegation
 
 Hermes is Zoe's default engineering and browser agent. Use it for planning, code review, implementation repair, architecture analysis, Greptile loops, Graphify-guided codebase work, Multica board repair, generated knowledge refresh, and browser work through Zoe's CloakBrowser tools.


### PR DESCRIPTION
## Summary
- Adds the local `zoe-tools` MCP server to the tracked Cursor MCP config.
- Keeps token-backed Greptile access out of the repo and in user-global Cursor config.

## Test plan
- `python3 -m json.tool .cursor/mcp.json >/dev/null`
- `git diff --check`
- pre-commit validation


Made with [Cursor](https://cursor.com)