### PR TITLE
Fix self-hosted deploy authentication

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,17 +37,11 @@ jobs:
           if parts < (2, 31, 0):
               raise SystemExit(f"git {version} is too old for GIT_CONFIG_COUNT; need git >= 2.31.0")
           PY
-          AUTH_HEADER="$(python3 - <<'PY'
-          import base64
-          import os
-          print(base64.b64encode(f"x-access-token:{os.environ['GITHUB_TOKEN']}".encode()).decode())
-          PY
-          )"
           GIT_CONFIG_COUNT=1 \
           GIT_CONFIG_KEY_0=http.https://github.com/.extraheader \
-          GIT_CONFIG_VALUE_0="AUTHORIZATION: basic ${AUTH_HEADER}" \
+          GIT_CONFIG_VALUE_0="AUTHORIZATION: bearer ${GITHUB_TOKEN}" \
             git fetch origin main
-          unset AUTH_HEADER GITHUB_TOKEN
+          unset GITHUB_TOKEN
           git reset --hard FETCH_HEAD
 
       - name: Install / refresh Python deps

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     # Runs on the self-hosted runner installed on the Jetson.
@@ -17,7 +20,7 @@ jobs:
     steps:
       - name: Pull latest main
         env:
-          GH_PAT: ${{ secrets.GH_PAT }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           cd /home/zoe/assistant
           git remote set-url origin https://github.com/jason-easyazz/zoe-ai-assistant.git
@@ -34,11 +37,17 @@ jobs:
           if parts < (2, 31, 0):
               raise SystemExit(f"git {version} is too old for GIT_CONFIG_COUNT; need git >= 2.31.0")
           PY
+          AUTH_HEADER="$(python3 - <<'PY'
+          import base64
+          import os
+          print(base64.b64encode(f"x-access-token:{os.environ['GITHUB_TOKEN']}".encode()).decode())
+          PY
+          )"
           GIT_CONFIG_COUNT=1 \
           GIT_CONFIG_KEY_0=http.https://github.com/.extraheader \
-          GIT_CONFIG_VALUE_0="AUTHORIZATION: bearer ${GH_PAT}" \
+          GIT_CONFIG_VALUE_0="AUTHORIZATION: basic ${AUTH_HEADER}" \
             git fetch origin main
-          unset GH_PAT
+          unset AUTH_HEADER GITHUB_TOKEN
           git reset --hard FETCH_HEAD
 
       - name: Install / refresh Python deps

--- a/docs/deployment/RUNNER_SETUP.md
+++ b/docs/deployment/RUNNER_SETUP.md
@@ -32,23 +32,21 @@ Replace `1000` with the output of `id -u` on the Jetson.
 loginctl enable-linger zoe
 ```
 
-## GitHub Secrets
+## GitHub Credentials
 
-Set these in **repo Settings → Secrets and variables → Actions**:
-
-| Secret | Value |
-|--------|-------|
-| `GH_PAT` | Personal Access Token with `repo` scope. Can reuse the same token from `questionable-decisions`. |
-
-No SSH keys, no `JETSON_HOST`, no tunnel config needed.
+No repo secrets, SSH keys, `JETSON_HOST`, or tunnel config are needed for deploy.
+The workflow uses GitHub Actions' built-in read-only `GITHUB_TOKEN` to fetch `main`
+on the self-hosted runner.
 
 ## Verifying a deployment
 
 After pushing to `main`, watch the Actions tab. The deploy job will:
 1. `git reset --hard origin/main` in `/home/zoe/assistant`
 2. `pip3 install --user` the pinned deps
-3. `systemctl --user restart zoe-data.service`
-4. Wait 6s then hit `GET /api/proactive/schedule` — expects HTTP 401 (auth required = service healthy)
+3. Apply Zoe data/auth database migrations
+4. Rebuild/restart `zoe-auth`
+5. `systemctl --user restart zoe-data.service`
+6. Wait 6s then hit the push and proactive health endpoints
 
 If the health check step passes, deployment succeeded.
 
@@ -59,3 +57,7 @@ If the health check step passes, deployment succeeded.
 **`systemctl --user` fails in the job:** Ensure `XDG_RUNTIME_DIR` is set in the runner `.env` and `loginctl enable-linger zoe` has been run.
 
 **`git reset --hard` fails with lock error:** A previous deploy may have crashed mid-run. SSH onto the Jetson and run `git -C /home/zoe/assistant reset --hard origin/main` manually.
+
+**`Pull latest main` fails with `invalid credentials`:** The workflow should be
+using its built-in `GITHUB_TOKEN`. Check that `deploy.yml` still grants
+`contents: read` permission and does not depend on a stale `GH_PAT` secret.

--- a/scripts/deploy/migrate.sh
+++ b/scripts/deploy/migrate.sh
@@ -93,6 +93,8 @@ run_auth_ddl_with_docker_psql() {
     -e "PGPASSWORD=${PG_PARTS[3]}" \
     zoe-database \
     psql \
+      -h 127.0.0.1 \
+      -p "${PG_PARTS[1]}" \
       -U "${PG_PARTS[2]}" \
       -d "${PG_PARTS[4]}" \
       -v ON_ERROR_STOP=1 \

--- a/scripts/deploy/migrate.sh
+++ b/scripts/deploy/migrate.sh
@@ -89,16 +89,31 @@ run_auth_ddl_with_docker_psql() {
       ;;
   esac
 
-  docker exec -i \
-    -e "PGPASSWORD=${PG_PARTS[3]}" \
-    zoe-database \
-    psql \
+  {
+    printf '%s:%s:%s:%s:%s\n' \
+      "$(escape_pgpass "127.0.0.1")" \
+      "$(escape_pgpass "${PG_PARTS[1]}")" \
+      "$(escape_pgpass "${PG_PARTS[4]}")" \
+      "$(escape_pgpass "${PG_PARTS[2]}")" \
+      "$(escape_pgpass "${PG_PARTS[3]}")"
+    cat "${AUTH_DDL}"
+  } | docker exec -i zoe-database sh -c '
+    set -eu
+    port="$1"
+    database="$2"
+    username="$3"
+    pgpassfile="$(mktemp)"
+    trap '\''rm -f "${pgpassfile}"'\'' EXIT
+    chmod 600 "${pgpassfile}"
+    IFS= read -r pgpass_entry
+    printf "%s\n" "${pgpass_entry}" > "${pgpassfile}"
+    PGPASSFILE="${pgpassfile}" psql \
       -h 127.0.0.1 \
-      -p "${PG_PARTS[1]}" \
-      -U "${PG_PARTS[2]}" \
-      -d "${PG_PARTS[4]}" \
-      -v ON_ERROR_STOP=1 \
-    < "${AUTH_DDL}"
+      -p "${port}" \
+      -U "${username}" \
+      -d "${database}" \
+      -v ON_ERROR_STOP=1
+  ' sh "${PG_PARTS[1]}" "${PG_PARTS[4]}" "${PG_PARTS[2]}"
 }
 
 database_container_running() {

--- a/scripts/deploy/migrate.sh
+++ b/scripts/deploy/migrate.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 ZOE_DATA_DIR="${ROOT_DIR}/services/zoe-data"
+AUTH_DDL="${ROOT_DIR}/scripts/setup/migrate_auth_to_postgres.sql"
 
 load_env_file() {
   local file="$1"
@@ -30,9 +31,7 @@ echo "Applying zoe-data Alembic migrations..."
   POSTGRES_URL="${POSTGRES_URL}" python3 -m alembic upgrade head
 )
 
-if command -v psql >/dev/null 2>&1; then
-  echo "Applying zoe-auth PostgreSQL DDL..."
-  mapfile -t PG_PARTS < <(python3 - <<'PY'
+mapfile -t PG_PARTS < <(python3 - <<'PY'
 import os
 from urllib.parse import unquote, urlparse
 
@@ -44,30 +43,75 @@ print(unquote(url.password or ""))
 print(unquote((url.path or "/").lstrip("/")))
 PY
 )
-  escape_pgpass() {
-    local value="$1"
-    value="${value//\\/\\\\}"
-    value="${value//:/\\:}"
-    printf '%s' "$value"
-  }
-  PGPASSFILE="$(mktemp)"
-  trap 'rm -f "${PGPASSFILE}"' EXIT
+
+if [[ -z "${PG_PARTS[2]}" || -z "${PG_PARTS[4]}" ]]; then
+  echo "POSTGRES_URL must include a username and database name" >&2
+  exit 1
+fi
+
+escape_pgpass() {
+  local value="$1"
+  value="${value//\\/\\\\}"
+  value="${value//:/\\:}"
+  printf '%s' "$value"
+}
+
+run_auth_ddl_with_host_psql() {
+  local pgpassfile
+  pgpassfile="$(mktemp)"
+  trap 'rm -f "${pgpassfile}"' RETURN
   printf '%s:%s:%s:%s:%s\n' \
     "$(escape_pgpass "${PG_PARTS[0]}")" \
     "$(escape_pgpass "${PG_PARTS[1]}")" \
     "$(escape_pgpass "${PG_PARTS[4]}")" \
     "$(escape_pgpass "${PG_PARTS[2]}")" \
-    "$(escape_pgpass "${PG_PARTS[3]}")" > "${PGPASSFILE}"
-  chmod 600 "${PGPASSFILE}"
-  PGPASSFILE="${PGPASSFILE}" psql \
+    "$(escape_pgpass "${PG_PARTS[3]}")" > "${pgpassfile}"
+  chmod 600 "${pgpassfile}"
+  PGPASSFILE="${pgpassfile}" psql \
     -h "${PG_PARTS[0]}" \
     -p "${PG_PARTS[1]}" \
     -U "${PG_PARTS[2]}" \
     -d "${PG_PARTS[4]}" \
     -v ON_ERROR_STOP=1 \
-    -f "${ROOT_DIR}/scripts/setup/migrate_auth_to_postgres.sql"
+    -f "${AUTH_DDL}"
+}
+
+run_auth_ddl_with_docker_psql() {
+  if ! command -v docker >/dev/null 2>&1; then
+    return 1
+  fi
+
+  case "${PG_PARTS[0]}" in
+    localhost|127.0.0.1|::1|zoe-database) ;;
+    *)
+      echo "Host psql is unavailable and POSTGRES_URL points to ${PG_PARTS[0]}, not the local zoe-database container" >&2
+      return 1
+      ;;
+  esac
+
+  docker exec -i \
+    -e "PGPASSWORD=${PG_PARTS[3]}" \
+    zoe-database \
+    psql \
+      -U "${PG_PARTS[2]}" \
+      -d "${PG_PARTS[4]}" \
+      -v ON_ERROR_STOP=1 \
+    < "${AUTH_DDL}"
+}
+
+database_container_running() {
+  command -v docker >/dev/null 2>&1 \
+    && [[ "$(docker inspect -f '{{.State.Running}}' zoe-database 2>/dev/null || true)" == "true" ]]
+}
+
+echo "Applying zoe-auth PostgreSQL DDL..."
+if command -v psql >/dev/null 2>&1; then
+  run_auth_ddl_with_host_psql
+elif database_container_running; then
+  echo "Host psql not found; using psql inside zoe-database container..."
+  run_auth_ddl_with_docker_psql
 else
-  echo "psql is required to apply zoe-auth DDL" >&2
+  echo "psql is required on the host, or the zoe-database container must be running" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- Replace the stale `GH_PAT` deploy fetch with the built-in read-only GitHub Actions token.
- Add a migration fallback that runs `psql` inside the existing `zoe-database` container when host `psql` is unavailable.
- Update runner setup docs to match the active deploy path.

## Test plan
- `python3 tools/audit/validate_structure.py`
- `python3 tools/audit/validate_critical_files.py`
- YAML parse check for `.github/workflows/deploy.yml` and `.github/workflows/validate.yml`
- `bash -n scripts/deploy/migrate.sh`
- `docker exec -i zoe-database psql -U zoe -d zoe -v ON_ERROR_STOP=1 -c 'SELECT 1;'`
- `git diff --check`


Made with [Cursor](https://cursor.com)