### PR TITLE
Fix deploy fetch token header

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,7 +42,7 @@ jobs:
           import os
           print(base64.b64encode(f"x-access-token:{os.environ['GITHUB_TOKEN']}".encode()).decode())
           PY
-          )"
+          )" || exit 1
           echo "::add-mask::${AUTH_HEADER}"
           GIT_CONFIG_COUNT=1 \
           GIT_CONFIG_KEY_0=http.https://github.com/.extraheader \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,11 +37,18 @@ jobs:
           if parts < (2, 31, 0):
               raise SystemExit(f"git {version} is too old for GIT_CONFIG_COUNT; need git >= 2.31.0")
           PY
+          AUTH_HEADER="$(python3 - <<'PY'
+          import base64
+          import os
+          print(base64.b64encode(f"x-access-token:{os.environ['GITHUB_TOKEN']}".encode()).decode())
+          PY
+          )"
+          echo "::add-mask::${AUTH_HEADER}"
           GIT_CONFIG_COUNT=1 \
           GIT_CONFIG_KEY_0=http.https://github.com/.extraheader \
-          GIT_CONFIG_VALUE_0="AUTHORIZATION: bearer ${GITHUB_TOKEN}" \
+          GIT_CONFIG_VALUE_0="AUTHORIZATION: basic ${AUTH_HEADER}" \
             git fetch origin main
-          unset GITHUB_TOKEN
+          unset AUTH_HEADER GITHUB_TOKEN
           git reset --hard FETCH_HEAD
 
       - name: Install / refresh Python deps


### PR DESCRIPTION
## Summary
- Switch the self-hosted deploy fetch from unsupported bearer auth to GitHub's supported basic auth header.
- Explicitly mask the derived basic auth token before using it in git's extraheader.

## Test plan
- YAML parse check for `.github/workflows/deploy.yml` and `.github/workflows/validate.yml`
- Shell smoke test for the basic auth header encoding
- `git diff --check`


Made with [Cursor](https://cursor.com)