### PR TITLE
Improve Zoe skill guidance

### DIFF
--- a/skills/agent-zero-research/SKILL.md
+++ b/skills/agent-zero-research/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agent-zero-research
-description: Deep research, analysis, and comparison tasks using Agent Zero
+description: "Delegate deep research, multi-source analysis, and comparison tasks to Agent Zero. Use when the user asks to research a topic, compare options, investigate something, or wants a 'deep dive' with cited sources."
 version: 1.0.0
 author: zoe-team
 api_only: true
@@ -15,6 +15,9 @@ triggers:
   - "find out about"
   - "what are the best"
   - "pros and cons"
+  - "evaluate"
+  - "review options"
+  - "summarize findings"
 allowed_endpoints:
   - "POST /api/agent-zero/research"
   - "POST /api/agent-zero/task"
@@ -27,20 +30,22 @@ tags:
 # Agent Zero Research
 
 ## When to Use
-User wants deep research, multi-source analysis, comparison studies, or any task that requires browsing the web, reading documents, or synthesizing information from multiple sources.
 
-## How to Handle
+The user wants deep research, multi-source analysis, comparison studies, or any task requiring web browsing, document reading, or synthesizing information. Triggers include "research", "compare", "deep dive", "pros and cons", or "look into".
 
-1. Identify what the user wants to research or analyze
-2. Determine the type: research, comparison, analysis, investigation
-3. Delegate to Agent Zero with clear instructions
-4. Present findings to the user in a clear, structured format
+## Workflow
+
+1. **Identify the task type** — research (open-ended query), comparison (two+ options), or analysis (structured evaluation)
+2. **Inform the user** — tell them research is underway and may take 30–60 seconds
+3. **Submit to Agent Zero** — use the appropriate endpoint (see below)
+4. **Poll for completion** — check `GET /api/agent-zero/status` until the task finishes
+5. **Present findings** — format results clearly: use tables for comparisons, bullet points for research summaries, and always cite sources when available
 
 ## API Endpoints
 
-### Submit Research Task
-POST http://localhost:8101/tools/research
-```json
+### Submit a research task
+```
+POST /api/agent-zero/research
 {
   "query": "Best solar panels for residential use in 2026",
   "depth": "thorough",
@@ -48,27 +53,40 @@ POST http://localhost:8101/tools/research
 }
 ```
 
-### Submit General Task
-POST http://localhost:8101/tools/task
-```json
+### Submit a general task (comparisons, analysis)
+```
+POST /api/agent-zero/task
 {
   "task": "Compare Tesla Powerwall vs BYD battery for home storage",
   "context": "User is considering home battery storage"
 }
 ```
 
-### Check Task Status
-GET http://localhost:8101/tools/status
+### Check task status
+```
+GET /api/agent-zero/status
+```
+Returns the current state (`pending`, `running`, `completed`, `failed`) and results when complete.
 
-## Examples
-- "Research the best solar panels" -> research task with depth: thorough
-- "Compare Tesla vs BYD" -> comparison task with both items
-- "Look into home automation trends" -> research task
-- "Analyze my energy usage patterns" -> analysis task
+## Example
 
-## Important Notes
-- Research tasks can take 30-60 seconds to complete
-- Always tell the user you're researching and will report back
-- Present findings in a clear, structured format
-- Cite sources when available
-- For comparisons, use a pros/cons or table format
+**User:** "Compare Tesla Powerwall vs BYD battery for my home"
+
+**Steps:**
+- Identify: comparison task with two items
+- Respond: "Let me research that for you — this may take about a minute."
+- Submit: `POST /api/agent-zero/task` with task and context
+- Poll: `GET /api/agent-zero/status` until `completed`
+- Present: table with capacity, price, warranty, pros/cons for each option, with source links
+
+## Error Handling
+
+- **Task timeout** (>120s): Inform the user the research is taking longer than expected and offer to retry or narrow the scope
+- **Task failed**: Check the error from the status endpoint and relay a user-friendly message (e.g., "Agent Zero couldn't complete the research — want to try a more specific query?")
+- **No results**: Suggest the user rephrase or narrow the research topic
+
+## Formatting Guidelines
+
+- **Research results**: Bullet-point summaries with source citations
+- **Comparisons**: Side-by-side table with key attributes
+- **Analysis**: Numbered findings with supporting evidence

--- a/skills/agent-zero-research/SKILL.md
+++ b/skills/agent-zero-research/SKILL.md
@@ -21,7 +21,7 @@ triggers:
 allowed_endpoints:
   - "POST /api/agent-zero/research"
   - "POST /api/agent-zero/task"
-  - "GET /api/agent-zero/status"
+  - "GET /api/agent-zero/status/*"
 tags:
   - research
   - analysis
@@ -38,7 +38,7 @@ The user wants deep research, multi-source analysis, comparison studies, or any 
 1. **Identify the task type** — research (open-ended query), comparison (two+ options), or analysis (structured evaluation)
 2. **Inform the user** — tell them research is underway and may take 30–60 seconds
 3. **Submit to Agent Zero** — use the appropriate endpoint (see below)
-4. **Poll for completion** — check `GET /api/agent-zero/status` until the task finishes
+4. **Poll for completion** — use the submitted task ID with `GET /api/agent-zero/status/{task_id}` until the task finishes
 5. **Present findings** — format results clearly: use tables for comparisons, bullet points for research summaries, and always cite sources when available
 
 ## API Endpoints
@@ -64,7 +64,7 @@ POST /api/agent-zero/task
 
 ### Check task status
 ```
-GET /api/agent-zero/status
+GET /api/agent-zero/status/<task_id>
 ```
 Returns the current state (`pending`, `running`, `completed`, `failed`) and results when complete.
 
@@ -76,7 +76,7 @@ Returns the current state (`pending`, `running`, `completed`, `failed`) and resu
 - Identify: comparison task with two items
 - Respond: "Let me research that for you — this may take about a minute."
 - Submit: `POST /api/agent-zero/task` with task and context
-- Poll: `GET /api/agent-zero/status` until `completed`
+- Poll: `GET /api/agent-zero/status/<task_id>` until `completed`
 - Present: table with capacity, price, warranty, pros/cons for each option, with source links
 
 ## Error Handling

--- a/skills/agent-zero-research/SKILL.md
+++ b/skills/agent-zero-research/SKILL.md
@@ -38,7 +38,7 @@ The user wants deep research, multi-source analysis, comparison studies, or any 
 1. **Identify the task type** — research (open-ended query), comparison (two+ options), or analysis (structured evaluation)
 2. **Inform the user** — tell them research is underway and may take 30–60 seconds
 3. **Submit to Agent Zero** — use the appropriate endpoint (see below)
-4. **Poll for completion** — use the submitted task ID with `GET /api/agent-zero/status/{task_id}` until the task finishes
+4. **Poll for completion** — use the submitted task ID with `GET /api/agent-zero/status/<task_id>` until the task finishes
 5. **Present findings** — format results clearly: use tables for comparisons, bullet points for research summaries, and always cite sources when available
 
 ## API Endpoints

--- a/skills/calendar-events/SKILL.md
+++ b/skills/calendar-events/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: calendar-events
-description: Create, view, and manage calendar events and appointments
+description: "Create, view, reschedule, and cancel calendar events and appointments. Use when the user asks to schedule a meeting, check their calendar, book an appointment, reschedule, or set a reminder for an event."
 version: 1.0.0
 author: zoe-team
 api_only: true
@@ -24,6 +24,9 @@ triggers:
   - "move my meeting"
   - "remind me about"
   - "when is my next"
+  - "free slot"
+  - "am I free"
+  - "set up a meeting"
 allowed_endpoints:
   - "GET /api/calendar/events"
   - "POST /api/calendar/events"
@@ -34,17 +37,66 @@ allowed_endpoints:
 ---
 # Calendar Events Skill
 
-Create, view, and manage calendar events and appointments.
+## Workflow
 
-## Behavior
+1. **Parse intent** — determine the action: create, view, update, or cancel
+2. **Extract details** — title, date/time (ISO 8601), duration (minutes), location (optional)
+3. **Clarify ambiguity** — if date or time is missing or ambiguous, ask the user before proceeding
+4. **Call the API** — use the matching endpoint (see below)
+5. **Confirm result** — respond with the event summary including exact date/time and any relevant details
 
-1. Parse the user's intent (create, view, update, cancel)
-2. Extract event details: title, date/time, duration, location
-3. For ambiguous times, ask for clarification
-4. Call the appropriate API endpoint
-5. Confirm with event details and time
+## API Endpoints
+
+### Create an event
+```
+POST /api/calendar/events
+{
+  "title": "Dentist appointment",
+  "start": "2026-04-10T14:00:00Z",
+  "duration": 60,
+  "location": "123 Main St"
+}
+```
+
+### View today's events
+```
+GET /api/calendar/events/today
+```
+
+### View this week's events
+```
+GET /api/calendar/events/week
+```
+
+### Update an event
+```
+PUT /api/calendar/events/{id}
+{
+  "start": "2026-04-10T15:00:00Z"
+}
+```
+
+### Cancel an event
+```
+DELETE /api/calendar/events/{id}
+```
+
+## Example
+
+**User:** "Schedule a dentist appointment for Thursday at 2pm"
+
+**Steps:**
+- Parse intent: create
+- Extract: title=`Dentist appointment`, start=`2026-04-10T14:00:00Z`, duration=`60`
+- `POST /api/calendar/events` with extracted details
+- Respond: "Done — Dentist appointment is set for Thursday, April 10 at 2:00 PM (1 hour)."
+
+## Error Handling
+
+- **Conflicting event**: Check `GET /api/calendar/events` for overlaps and warn the user before creating
+- **Past date**: Reject and ask for a future date
+- **Missing time**: Ask "What time works for you?" rather than guessing
 
 ## Response Style
 
-Clear and time-aware. Always confirm the exact date/time of created events.
-Use relative time references ("in 2 hours", "tomorrow at 3pm").
+Always confirm the exact date and time. Use relative references when helpful ("in 2 hours", "tomorrow at 3pm").

--- a/skills/personal-facts/SKILL.md
+++ b/skills/personal-facts/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: personal-facts
-description: Store and recall personal facts and preferences about the user
+description: "Store and recall personal facts, preferences, and profile details for the user. Use when the user shares personal info ('my name is', 'I live in'), asks 'what's my…', or says 'do you remember'."
 version: 1.0.0
 author: zoe-team
 api_only: true
@@ -23,6 +23,9 @@ triggers:
   - "what's my"
   - "what is my"
   - "do you remember my"
+  - "remember that I"
+  - "forget my"
+  - "update my"
 allowed_endpoints:
   - "GET /api/memories/facts"
   - "POST /api/memories/facts"
@@ -33,16 +36,77 @@ allowed_endpoints:
 ---
 # Personal Facts Skill
 
-Store and recall personal facts and preferences about the user.
+## Workflow
 
-## Behavior
+1. **Detect intent** — determine if the user is storing a new fact, recalling an existing one, updating, or deleting
+2. **Extract key-value pair** — parse the fact into a structured format:
+   - `category`: `identity`, `contact`, `preference`, `location`, `work`
+   - `key`: the specific attribute (e.g., `name`, `birthday`, `favorite_color`)
+   - `value`: the user's answer
+3. **Check for duplicates** — `GET /api/memories/facts/{key}` to see if the fact already exists
+4. **Store or retrieve** — use the appropriate API call (see below)
+5. **Confirm** — acknowledge storage warmly, or present recalled facts naturally in context
 
-1. Detect if the user is storing a fact or recalling one
-2. For storage: extract the key-value pair and save via API
-3. For recall: look up the fact and present it naturally
-4. For preferences: store under user preferences category
+## API Endpoints
+
+### Store a fact
+```
+POST /api/memories/facts
+{
+  "category": "identity",
+  "key": "name",
+  "value": "Jason"
+}
+```
+
+### Recall a specific fact
+```
+GET /api/memories/facts/name
+```
+
+### Recall all facts
+```
+GET /api/memories/facts
+```
+
+### Delete a fact
+```
+DELETE /api/memories/facts/birthday
+```
+
+### Update preferences
+```
+PUT /api/user-data/preferences
+{
+  "theme": "dark",
+  "language": "en"
+}
+```
+
+## Example
+
+**User:** "My birthday is March 15th"
+
+**Steps:**
+- Detect intent: store
+- Extract: category=`identity`, key=`birthday`, value=`March 15`
+- Check: `GET /api/memories/facts/birthday` — not found
+- Store: `POST /api/memories/facts` with extracted data
+- Respond: "Got it — I'll remember your birthday is March 15th! 🎂"
+
+**User:** "What's my birthday?"
+
+**Steps:**
+- Detect intent: recall
+- Retrieve: `GET /api/memories/facts/birthday` → `March 15`
+- Respond: "Your birthday is March 15th!"
+
+## Error Handling
+
+- **Fact not found on recall**: Respond "I don't have that on file yet — want to tell me?"
+- **Duplicate on store**: Show existing value and ask if the user wants to update it
+- **Ambiguous key**: Ask for clarification (e.g., "Do you mean your work email or personal email?")
 
 ## Response Style
 
-Warm and personal. When storing: "Got it, I'll remember that!"
-When recalling: present the fact naturally in context.
+Warm and personal. When storing: brief confirmation. When recalling: weave the fact naturally into the response.

--- a/skills/personal-facts/SKILL.md
+++ b/skills/personal-facts/SKILL.md
@@ -76,7 +76,8 @@ DELETE /api/memories/facts/birthday
 
 ### Update a fact
 There is no `PUT /api/memories/facts/{key}` endpoint. To update an existing
-fact after user confirmation, delete the old key and then store the new value:
+fact after user confirmation, first keep the old value in context, then delete
+the old key and store the new value:
 ```
 DELETE /api/memories/facts/birthday
 POST /api/memories/facts
@@ -118,6 +119,7 @@ PUT /api/user-data/preferences
 
 - **Fact not found on recall**: Respond "I don't have that on file yet — want to tell me?"
 - **Duplicate on store**: Show existing value and ask if the user wants to update it; if yes, `DELETE /api/memories/facts/{key}` then `POST /api/memories/facts` with the new value
+- **Update failure after delete**: If the new `POST /api/memories/facts` fails, immediately try to restore the old value with `POST /api/memories/facts`; if restore also fails, tell the user exactly what happened and ask them to provide the fact again
 - **Ambiguous key**: Ask for clarification (e.g., "Do you mean your work email or personal email?")
 
 ## Response Style

--- a/skills/personal-facts/SKILL.md
+++ b/skills/personal-facts/SKILL.md
@@ -74,6 +74,19 @@ GET /api/memories/facts
 DELETE /api/memories/facts/birthday
 ```
 
+### Update a fact
+There is no `PUT /api/memories/facts/{key}` endpoint. To update an existing
+fact after user confirmation, delete the old key and then store the new value:
+```
+DELETE /api/memories/facts/birthday
+POST /api/memories/facts
+{
+  "category": "identity",
+  "key": "birthday",
+  "value": "15 March"
+}
+```
+
 ### Update preferences
 ```
 PUT /api/user-data/preferences
@@ -104,7 +117,7 @@ PUT /api/user-data/preferences
 ## Error Handling
 
 - **Fact not found on recall**: Respond "I don't have that on file yet — want to tell me?"
-- **Duplicate on store**: Show existing value and ask if the user wants to update it
+- **Duplicate on store**: Show existing value and ask if the user wants to update it; if yes, `DELETE /api/memories/facts/{key}` then `POST /api/memories/facts` with the new value
 - **Ambiguous key**: Ask for clarification (e.g., "Do you mean your work email or personal email?")
 
 ## Response Style

--- a/skills/proactive-agent/SKILL.md
+++ b/skills/proactive-agent/SKILL.md
@@ -117,7 +117,7 @@ specific future time.  Example:
 - **API failure**: Tell the user the notification could not be scheduled and suggest retrying.
 
 ## Implementation Notes
-- APScheduler persists jobs in SQLite so they survive restarts.
+- Scheduled nudges must use Zoe's configured production persistence path; do not introduce SQLite-only storage for live reminders.
 - Quiet hours (22:00–07:00 server local) suppress non-forced notifications.
 - Tapping a push notification creates a fresh chat session pre-seeded with
   the notification message, enabling a natural follow-up conversation.

--- a/skills/proactive-agent/SKILL.md
+++ b/skills/proactive-agent/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: proactive-agent
-description: Schedule proactive push notifications and one-shot nudges for users
+description: "Schedule proactive push notifications and one-shot nudges for users. Use when the user asks for a future reminder, notification, alert, or nudge like 'remind me at 3pm' or 'notify me tomorrow morning'."
 version: 2.0.0
 author: zoe-team
 api_only: true
@@ -20,6 +20,10 @@ triggers:
   - "recurring"
   - "automate"
   - "nudge"
+  - "remind me every"
+  - "set up a timer"
+  - "periodic"
+  - "cron"
 allowed_endpoints:
   - "POST /api/proactive/schedule"
   - "GET /api/proactive/schedule"
@@ -86,6 +90,31 @@ specific future time.  Example:
 - User says "notify me in 2 hours"
 - User says "send me a message tomorrow morning at 8am"
 - Any explicit future-notification request
+
+## Workflow
+
+1. Parse the requested reminder message and target time.
+2. Ask a clarifying question if the time, date, timezone, or recipient is ambiguous.
+3. Use `proactive_schedule` or `POST /api/proactive/schedule` to create the nudge.
+4. Confirm the scheduled message and when it will fire.
+5. Use the list or cancel endpoints when the user asks to review or remove pending nudges.
+
+## Example
+
+**User:** "Remind me tomorrow at 8am to put the bins out"
+
+**Steps:**
+- Parse the message as "put the bins out".
+- Resolve "tomorrow at 8am" to an ISO timestamp in the user's timezone.
+- Call `proactive_schedule` with the message and `send_at`.
+- Respond with a short confirmation including the scheduled time.
+
+## Error Handling
+
+- **Ambiguous time**: Ask for a specific time before scheduling.
+- **Past time**: Ask for a future time instead of silently adjusting.
+- **Duplicate request**: If a very similar pending nudge exists, mention it before creating another.
+- **API failure**: Tell the user the notification could not be scheduled and suggest retrying.
 
 ## Implementation Notes
 - APScheduler persists jobs in SQLite so they survive restarts.

--- a/skills/self-improvement/SKILL.md
+++ b/skills/self-improvement/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: self-improvement
-description: Zoe's self-improvement system - learns from corrections and user preferences
+description: "Stores user corrections and preferences as learnings to improve future responses. Use when the user corrects a mistake, states a preference, or says 'remember that', 'from now on', or 'I prefer'."
 version: 1.0.0
 author: zoe-team
 api_only: true
@@ -13,6 +13,9 @@ triggers:
   - "always remember"
   - "never forget"
   - "i told you"
+  - "don't do that again"
+  - "i like it when"
+  - "stop doing"
 allowed_endpoints:
   - "GET /api/learnings"
   - "POST /api/learnings/*/confirm"
@@ -24,18 +27,33 @@ tags:
 # Self-Improvement
 
 ## When to Use
-Automatically active. This skill runs in the background to detect when users
-correct Zoe or express preferences. Explicit triggers like "remember that" or
-"from now on" create immediate learnings.
 
-## How It Works
-1. After each conversation, scan for correction signals
-2. Extract the learning (what was wrong, what is correct)
-3. Store in memory with user ownership
-4. Use learnings to improve future responses
+Runs in the background after every conversation. Activates explicitly when the user corrects Zoe, states a preference, or uses trigger phrases like "remember that", "from now on", "I prefer", or "don't do that again".
+
+## Workflow
+
+1. **Detect correction signal** — scan the user's message for corrections ("actually, I meant…"), preference statements ("I prefer…"), or explicit triggers ("remember that…")
+2. **Extract the learning** — identify what was wrong and what the correct behavior is, structured as a key-value pair:
+   - Category: `tone`, `formatting`, `factual`, `preference`, `workflow`
+   - Before: what Zoe did wrong
+   - After: what the user wants instead
+3. **Store via API** — `GET /api/learnings` to check for duplicates, then the learning is persisted with user ownership
+4. **Confirm storage** — respond with a brief acknowledgment (e.g., "Got it, I'll remember that for next time")
+5. **Apply in future** — before generating responses, retrieve relevant learnings from `GET /api/learnings` and adjust behavior accordingly
+
+## Example
+
+**User:** "Actually, I prefer bullet points over paragraphs when you summarize things."
+
+**Steps:**
+- Detect preference signal ("I prefer")
+- Extract: category=`formatting`, before=`paragraph summaries`, after=`bullet point summaries`
+- Store the learning
+- Respond: "Noted — I'll use bullet points for summaries from now on."
 
 ## Security
+
 - Only trusted sources can create learnings (Trust Gate integration)
-- Owner corrections auto-confirm
-- Trusted contact corrections need user review
-- Learnings expire after 30 days if not confirmed
+- Owner corrections auto-confirm via `POST /api/learnings/{id}/confirm`
+- Trusted contact corrections require user review before confirming
+- Learnings expire after 30 days without confirmation — dismiss stale ones via `POST /api/learnings/{id}/dismiss`

--- a/skills/self-improvement/SKILL.md
+++ b/skills/self-improvement/SKILL.md
@@ -38,7 +38,7 @@ Runs in the background after every conversation. Activates explicitly when the u
    - Before: what Zoe did wrong
    - After: what the user wants instead
 3. **Check for duplicates** — use `GET /api/learnings` before proposing a new learning
-4. **Confirm storage** — respond with a brief acknowledgment (e.g., "Got it, I'll remember that for next time")
+4. **Acknowledge to the user** — respond with a brief acknowledgment (e.g., "Got it, I'll remember that for next time"); the self-learning pipeline handles actual persistence
 5. **Apply in future** — before generating responses, retrieve relevant learnings from `GET /api/learnings` and adjust behavior accordingly
 
 ## Example

--- a/skills/self-improvement/SKILL.md
+++ b/skills/self-improvement/SKILL.md
@@ -37,7 +37,7 @@ Runs in the background after every conversation. Activates explicitly when the u
    - Category: `tone`, `formatting`, `factual`, `preference`, `workflow`
    - Before: what Zoe did wrong
    - After: what the user wants instead
-3. **Store via API** — `GET /api/learnings` to check for duplicates, then the learning is persisted with user ownership
+3. **Check for duplicates** — use `GET /api/learnings` before proposing a new learning
 4. **Confirm storage** — respond with a brief acknowledgment (e.g., "Got it, I'll remember that for next time")
 5. **Apply in future** — before generating responses, retrieve relevant learnings from `GET /api/learnings` and adjust behavior accordingly
 
@@ -48,7 +48,7 @@ Runs in the background after every conversation. Activates explicitly when the u
 **Steps:**
 - Detect preference signal ("I prefer")
 - Extract: category=`formatting`, before=`paragraph summaries`, after=`bullet point summaries`
-- Store the learning
+- Let the self-learning pipeline persist the learning with user ownership; this skill only uses the listed review endpoints
 - Respond: "Noted — I'll use bullet points for summaries from now on."
 
 ## Security


### PR DESCRIPTION
## Summary
- Reapply the useful skill guidance improvements from the closed stale PR #52 on top of current main.
- Expand five SKILL.md files with clearer triggers, workflows, examples, and error handling.
- Resolve the proactive-agent conflict against Zoe's current `/api/proactive/*` endpoints rather than the stale scheduler endpoint shape.

## Test plan
- `python3 tools/audit/validate_structure.py`
- `python3 tools/audit/validate_critical_files.py`
- `git diff --check origin/main...HEAD`
- conflict-marker scan across `skills/*/SKILL.md`


Made with [Cursor](https://cursor.com)