### PR TITLE
Fix Hermes routing delegation

### DIFF
--- a/services/zoe-data/mcp_server.py
+++ b/services/zoe-data/mcp_server.py
@@ -40,6 +40,15 @@ async def _notify_ui(channel: str, event_type: str, data: dict):
         pass
 
 
+def _load_agents_registry() -> dict:
+    """Load the local peer-agent registry used by delegation tools."""
+    import yaml as _yaml
+
+    reg_path = os.path.join(os.path.dirname(__file__), "agents_registry.yml")
+    with open(reg_path) as reg_file:
+        return _yaml.safe_load(reg_file) or {}
+
+
 async def _get_weather_default_location(db) -> dict:
     """System-level weather fallback location (admin-configured or env default)."""
     try:
@@ -1741,11 +1750,7 @@ async def _execute_tool(db, name: str, args: dict):
                 )
             }
         try:
-            import yaml as _yaml
-            import os as _os
-            _reg_path = _os.path.join(_os.path.dirname(__file__), "agents_registry.yml")
-            with open(_reg_path) as _f:
-                _reg = _yaml.safe_load(_f)
+            _reg = _load_agents_registry()
             _info = _reg.get("agents", {}).get(agent_name)
             if not _info:
                 return {"error": f"Unknown agent: {agent_name}"}
@@ -1760,9 +1765,11 @@ async def _execute_tool(db, name: str, args: dict):
                 )
                 return {
                     "agent": "hermes",
-                    "status": "queued",
-                    "task_id": task_id,
-                    "result_endpoint": f"/api/agent/tasks/{task_id}",
+                    "result": {
+                        "status": "queued",
+                        "task_id": task_id,
+                        "result_endpoint": f"/api/agent/tasks/{task_id}",
+                    },
                 }
             from a2a_client import get_a2a_client  # type: ignore[import]
             _client = get_a2a_client()

--- a/services/zoe-data/mcp_server.py
+++ b/services/zoe-data/mcp_server.py
@@ -1774,7 +1774,7 @@ async def _execute_tool(db, name: str, args: dict):
             )
             return result
         except Exception as exc:
-            return {"error": f"A2A delegate failed: {exc}"}
+            return {"error": f"Agent delegation failed: {exc}"}
 
     elif name == "zoe_sync_knowledge":
         try:

--- a/services/zoe-data/mcp_server.py
+++ b/services/zoe-data/mcp_server.py
@@ -1751,11 +1751,10 @@ async def _execute_tool(db, name: str, args: dict):
                 return {"error": f"Unknown agent: {agent_name}"}
             if agent_name == "hermes":
                 from background_runner import enqueue_background_task  # type: ignore[import]
-                caller_user_id = _uid_raw or "family-admin"
                 session_id = args.get("session_id") or None
                 task_id = await enqueue_background_task(
                     task,
-                    str(caller_user_id),
+                    str(user_id),
                     session_id=str(session_id) if session_id else None,
                     request_depth=int(args.get("request_depth") or 0),
                 )

--- a/services/zoe-data/mcp_server.py
+++ b/services/zoe-data/mcp_server.py
@@ -44,9 +44,13 @@ def _load_agents_registry() -> dict:
     """Load the local peer-agent registry used by delegation tools."""
     import yaml as _yaml
 
-    reg_path = os.path.join(os.path.dirname(__file__), "agents_registry.yml")
-    with open(reg_path) as reg_file:
-        return _yaml.safe_load(reg_file) or {}
+    reg_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "agents_registry.yml")
+    try:
+        with open(reg_path) as reg_file:
+            return _yaml.safe_load(reg_file) or {}
+    except (FileNotFoundError, _yaml.YAMLError) as exc:
+        _mcp_log.warning("Could not load agents registry at %s: %s", reg_path, exc)
+        return {"agents": {}, "squads": {}}
 
 
 async def _get_weather_default_location(db) -> dict:

--- a/services/zoe-data/mcp_server.py
+++ b/services/zoe-data/mcp_server.py
@@ -374,6 +374,15 @@ TOOLS = [
                     "description": "Required true when agent_name is openclaw; prevents accidental non-Hermes delegation.",
                     "default": False,
                 },
+                "session_id": {
+                    "type": "string",
+                    "description": "Optional Zoe session id to associate with the delegated Hermes task.",
+                },
+                "request_depth": {
+                    "type": "integer",
+                    "description": "Delegation depth guard for nested agent calls.",
+                    "default": 0,
+                },
             },
             "required": ["agent_name", "task"],
         },
@@ -1740,6 +1749,22 @@ async def _execute_tool(db, name: str, args: dict):
             _info = _reg.get("agents", {}).get(agent_name)
             if not _info:
                 return {"error": f"Unknown agent: {agent_name}"}
+            if agent_name == "hermes":
+                from background_runner import enqueue_background_task  # type: ignore[import]
+                caller_user_id = _uid_raw or "family-admin"
+                session_id = args.get("session_id") or None
+                task_id = await enqueue_background_task(
+                    task,
+                    str(caller_user_id),
+                    session_id=str(session_id) if session_id else None,
+                    request_depth=int(args.get("request_depth") or 0),
+                )
+                return {
+                    "agent": "hermes",
+                    "status": "queued",
+                    "task_id": task_id,
+                    "result_endpoint": f"/api/agent/tasks/{task_id}",
+                }
             from a2a_client import get_a2a_client  # type: ignore[import]
             _client = get_a2a_client()
             result = await _client.submit_task(

--- a/services/zoe-data/mcp_server.py
+++ b/services/zoe-data/mcp_server.py
@@ -1754,10 +1754,6 @@ async def _execute_tool(db, name: str, args: dict):
                 )
             }
         try:
-            _reg = _load_agents_registry()
-            _info = _reg.get("agents", {}).get(agent_name)
-            if not _info:
-                return {"error": f"Unknown agent: {agent_name}"}
             if agent_name == "hermes":
                 from background_runner import enqueue_background_task  # type: ignore[import]
                 session_id = args.get("session_id") or None
@@ -1775,6 +1771,10 @@ async def _execute_tool(db, name: str, args: dict):
                         "result_endpoint": f"/api/agent/tasks/{task_id}",
                     },
                 }
+            _reg = _load_agents_registry()
+            _info = _reg.get("agents", {}).get(agent_name)
+            if not _info:
+                return {"error": f"Unknown agent: {agent_name}"}
             from a2a_client import get_a2a_client  # type: ignore[import]
             _client = get_a2a_client()
             result = await _client.submit_task(

--- a/services/zoe-data/routers/system.py
+++ b/services/zoe-data/routers/system.py
@@ -986,6 +986,25 @@ async def delegate_to_agent(
             ),
         )
 
+    if agent_name == "hermes":
+        from background_runner import enqueue_background_task  # type: ignore[import]
+        user_id = user.get("user_id", "unknown")
+        session_id = body.get("session_id") or None
+        task_id = await enqueue_background_task(
+            task,
+            user_id,
+            session_id=session_id,
+            request_depth=int(body.get("request_depth") or 0),
+        )
+        return {
+            "agent": agent_name,
+            "result": {
+                "status": "queued",
+                "task_id": task_id,
+                "result_endpoint": f"/api/agent/tasks/{task_id}",
+            },
+        }
+
     from a2a_client import get_a2a_client  # type: ignore[import]
     client = get_a2a_client()
     result = await client.submit_task(

--- a/services/zoe-data/routers/system.py
+++ b/services/zoe-data/routers/system.py
@@ -972,10 +972,6 @@ async def delegate_to_agent(
     if not agent_name or not task:
         raise HTTPException(status_code=400, detail="agent_name (or agent) and task (or goal) are required")
 
-    registry = _load_registry()
-    agent_info = registry.get("agents", {}).get(agent_name)
-    if not agent_info:
-        raise HTTPException(status_code=404, detail=f"Unknown agent: {agent_name}")
     if agent_name == "openclaw" and not bool(body.get("allow_openclaw", False)):
         raise HTTPException(
             status_code=400,
@@ -1004,6 +1000,11 @@ async def delegate_to_agent(
                 "result_endpoint": f"/api/agent/tasks/{task_id}",
             },
         }
+
+    registry = _load_registry()
+    agent_info = registry.get("agents", {}).get(agent_name)
+    if not agent_info:
+        raise HTTPException(status_code=404, detail=f"Unknown agent: {agent_name}")
 
     from a2a_client import get_a2a_client  # type: ignore[import]
     client = get_a2a_client()

--- a/services/zoe-data/routers/voice_tts.py
+++ b/services/zoe-data/routers/voice_tts.py
@@ -2787,11 +2787,10 @@ async def voice_command(
                         if delta.startswith(("__ESCALATE__:", "__ESCALATE_BG__:", "__ESCALATE_HERMES__:")):
                             try:
                                 is_bg = delta.startswith("__ESCALATE_BG__:")
-                                is_hermes = delta.startswith("__ESCALATE_HERMES__:")
                                 _, body = delta.split(":", 1)
                                 reason, _, oc_task = body.partition("|")
                                 hermes_prompt = (oc_task or text).strip()
-                                logger.info("voice/command stream escalation -> Hermes background=%s hermes=%s reason=%s", is_bg, is_hermes, reason or "unspecified")
+                                logger.info("voice/command stream escalation -> Hermes background=%s reason=%s", is_bg, reason or "unspecified")
                                 if is_bg:
                                     from background_runner import enqueue_background_task
                                     asyncio.ensure_future(enqueue_background_task(hermes_prompt, effective_user, session_id))
@@ -2896,11 +2895,10 @@ async def voice_command(
                     try:
                         from push import broadcaster as _bc_escalate
                         is_bg = delta.startswith("__ESCALATE_BG__:")
-                        is_hermes = delta.startswith("__ESCALATE_HERMES__:")
                         _, body = delta.split(":", 1)
                         reason, _, oc_task = body.partition("|")
                         hermes_prompt = (oc_task or text).strip()
-                        logger.info("voice/command escalation -> Hermes background=%s hermes=%s reason=%s", is_bg, is_hermes, reason or "unspecified")
+                        logger.info("voice/command escalation -> Hermes background=%s reason=%s", is_bg, reason or "unspecified")
                         if is_bg:
                             from background_runner import enqueue_background_task
                             asyncio.ensure_future(enqueue_background_task(hermes_prompt, effective_user, session_id))

--- a/services/zoe-data/routers/voice_tts.py
+++ b/services/zoe-data/routers/voice_tts.py
@@ -2787,15 +2787,18 @@ async def voice_command(
                         if delta.startswith(("__ESCALATE__:", "__ESCALATE_BG__:", "__ESCALATE_HERMES__:")):
                             try:
                                 is_bg = delta.startswith("__ESCALATE_BG__:")
+                                is_hermes = delta.startswith("__ESCALATE_HERMES__:")
                                 _, body = delta.split(":", 1)
                                 reason, _, oc_task = body.partition("|")
                                 hermes_prompt = (oc_task or text).strip()
-                                logger.info("voice/command stream escalation -> Hermes background=%s reason=%s", is_bg, reason or "unspecified")
+                                logger.info("voice/command stream escalation -> Hermes background=%s hermes=%s reason=%s", is_bg, is_hermes, reason or "unspecified")
                                 if is_bg:
                                     from background_runner import enqueue_background_task
                                     asyncio.ensure_future(enqueue_background_task(hermes_prompt, effective_user, session_id))
                                     delta = "I'll work on that in the background and let you know when it's done."
                                 else:
+                                    # Voice foreground turns should answer aloud when possible;
+                                    # long-running work still uses the explicit background marker.
                                     try:
                                         await _bc_stream.broadcast("all", "voice:responding", {
                                             "panel_id": panel_id,
@@ -2893,15 +2896,18 @@ async def voice_command(
                     try:
                         from push import broadcaster as _bc_escalate
                         is_bg = delta.startswith("__ESCALATE_BG__:")
+                        is_hermes = delta.startswith("__ESCALATE_HERMES__:")
                         _, body = delta.split(":", 1)
                         reason, _, oc_task = body.partition("|")
                         hermes_prompt = (oc_task or text).strip()
-                        logger.info("voice/command escalation -> Hermes background=%s reason=%s", is_bg, reason or "unspecified")
+                        logger.info("voice/command escalation -> Hermes background=%s hermes=%s reason=%s", is_bg, is_hermes, reason or "unspecified")
                         if is_bg:
                             from background_runner import enqueue_background_task
                             asyncio.ensure_future(enqueue_background_task(hermes_prompt, effective_user, session_id))
                             delta = "I'll work on that in the background and let you know when it's done."
                         else:
+                            # Voice foreground turns should answer aloud when possible;
+                            # long-running work still uses the explicit background marker.
                             try:
                                 await _bc_escalate.broadcast("all", "voice:responding", {
                                     "panel_id": panel_id,

--- a/services/zoe-data/routers/voice_tts.py
+++ b/services/zoe-data/routers/voice_tts.py
@@ -2784,7 +2784,7 @@ async def voice_command(
                     ):
                         if not delta:
                             continue
-                        if delta.startswith("__ESCALATE__:") or delta.startswith("__ESCALATE_BG__:"):
+                        if delta.startswith(("__ESCALATE__:", "__ESCALATE_BG__:", "__ESCALATE_HERMES__:")):
                             try:
                                 is_bg = delta.startswith("__ESCALATE_BG__:")
                                 _, body = delta.split(":", 1)
@@ -2889,7 +2889,7 @@ async def voice_command(
             ):
                 if not delta:
                     continue
-                if delta.startswith("__ESCALATE__:") or delta.startswith("__ESCALATE_BG__:"):
+                if delta.startswith(("__ESCALATE__:", "__ESCALATE_BG__:", "__ESCALATE_HERMES__:")):
                     try:
                         from push import broadcaster as _bc_escalate
                         is_bg = delta.startswith("__ESCALATE_BG__:")

--- a/services/zoe-data/routers/voice_tts.py
+++ b/services/zoe-data/routers/voice_tts.py
@@ -78,6 +78,16 @@ async def _load_voice_history(session_id: str, limit: int = 3) -> list[dict]:
     return []
 
 
+_VOICE_ESCALATION_MARKERS = ("__ESCALATE__:", "__ESCALATE_BG__:", "__ESCALATE_HERMES__:")
+
+
+def _parse_voice_escalation_delta(delta: str, fallback_prompt: str) -> tuple[bool, str, str]:
+    """Return whether the voice escalation should be queued plus reason and task text."""
+    _, body = delta.split(":", 1)
+    reason, _, oc_task = body.partition("|")
+    return delta.startswith("__ESCALATE_BG__:"), reason, (oc_task or fallback_prompt).strip()
+
+
 # ── Voice text pre-processor ───────────────────────────────────────────────
 # Cleans LLM output for TTS synthesis: strips markdown, converts units,
 # expands abbreviations.  Run before ANY synthesis call on voice paths.
@@ -2784,12 +2794,9 @@ async def voice_command(
                     ):
                         if not delta:
                             continue
-                        if delta.startswith(("__ESCALATE__:", "__ESCALATE_BG__:", "__ESCALATE_HERMES__:")):
+                        if delta.startswith(_VOICE_ESCALATION_MARKERS):
                             try:
-                                is_bg = delta.startswith("__ESCALATE_BG__:")
-                                _, body = delta.split(":", 1)
-                                reason, _, oc_task = body.partition("|")
-                                hermes_prompt = (oc_task or text).strip()
+                                is_bg, reason, hermes_prompt = _parse_voice_escalation_delta(delta, text)
                                 logger.info("voice/command stream escalation -> Hermes background=%s reason=%s", is_bg, reason or "unspecified")
                                 if is_bg:
                                     from background_runner import enqueue_background_task
@@ -2891,13 +2898,10 @@ async def voice_command(
             ):
                 if not delta:
                     continue
-                if delta.startswith(("__ESCALATE__:", "__ESCALATE_BG__:", "__ESCALATE_HERMES__:")):
+                if delta.startswith(_VOICE_ESCALATION_MARKERS):
                     try:
                         from push import broadcaster as _bc_escalate
-                        is_bg = delta.startswith("__ESCALATE_BG__:")
-                        _, body = delta.split(":", 1)
-                        reason, _, oc_task = body.partition("|")
-                        hermes_prompt = (oc_task or text).strip()
+                        is_bg, reason, hermes_prompt = _parse_voice_escalation_delta(delta, text)
                         logger.info("voice/command escalation -> Hermes background=%s reason=%s", is_bg, reason or "unspecified")
                         if is_bg:
                             from background_runner import enqueue_background_task

--- a/services/zoe-data/tests/test_hermes_routing.py
+++ b/services/zoe-data/tests/test_hermes_routing.py
@@ -1,0 +1,167 @@
+import asyncio
+import os
+import sys
+import types
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import mcp_server
+import zoe_agent
+from routers import system
+
+
+@pytest.mark.asyncio
+async def test_dispatch_escalate_to_hermes_returns_marker():
+    result = await zoe_agent._dispatch_tool(
+        "escalate_to_hermes",
+        {"reason": "architecture review", "task": "Review Hermes routing"},
+        user_id="test-user",
+    )
+
+    assert result == "__ESCALATE_HERMES__:architecture review|Review Hermes routing"
+
+
+@pytest.mark.asyncio
+async def test_run_zoe_agent_returns_hermes_escalation_marker(monkeypatch):
+    async def none_async(*args, **kwargs):
+        return ""
+
+    async def fake_llm_call(*args, **kwargs):
+        return "", "escalate_to_hermes", {"reason": "deep work", "task": "Use Hermes"}
+
+    monkeypatch.setattr(zoe_agent, "_check_fast_response", lambda *_: None)
+    monkeypatch.setattr(zoe_agent, "_chat_capability_shortcut", none_async)
+    monkeypatch.setattr(zoe_agent, "_load_user_portrait", none_async)
+    monkeypatch.setattr(zoe_agent, "_mempalace_load_user_facts", none_async)
+    monkeypatch.setattr(zoe_agent, "_build_memory_context", none_async)
+    monkeypatch.setattr(zoe_agent, "_load_open_loops", none_async)
+    monkeypatch.setattr(zoe_agent, "_load_pending_suggestions", none_async)
+    monkeypatch.setattr(zoe_agent, "_context_enhance", none_async)
+    monkeypatch.setattr(zoe_agent, "_select_skills", lambda *_: set())
+    monkeypatch.setattr(zoe_agent, "_build_tools", lambda *_: [])
+    monkeypatch.setattr(zoe_agent, "_classify_tone", lambda *_: "")
+    monkeypatch.setattr(zoe_agent, "_llm_call", fake_llm_call)
+    monkeypatch.setattr(zoe_agent, "_fire_memory_capture", lambda *_, **__: None)
+
+    result = await zoe_agent.run_zoe_agent(
+        "please hand this to hermes",
+        "test-session",
+        user_id="test-user",
+    )
+
+    assert result == "__ESCALATE_HERMES__:deep work|Use Hermes"
+
+
+@pytest.mark.asyncio
+async def test_mcp_a2a_delegate_hermes_queues_background_task(monkeypatch):
+    calls = []
+
+    async def fake_enqueue(task, user_id, session_id=None, panel_id=None, request_depth=0, multica_issue_id=None):
+        calls.append(
+            {
+                "task": task,
+                "user_id": user_id,
+                "session_id": session_id,
+                "request_depth": request_depth,
+            }
+        )
+        return 123
+
+    monkeypatch.setitem(
+        sys.modules,
+        "background_runner",
+        types.SimpleNamespace(enqueue_background_task=fake_enqueue),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "a2a_client",
+        types.SimpleNamespace(get_a2a_client=lambda: (_ for _ in ()).throw(AssertionError("A2A should not be used for Hermes"))),
+    )
+
+    result = await mcp_server._execute_tool(
+        db=None,
+        name="a2a_delegate",
+        args={
+            "_user_id": "test-user",
+            "agent_name": "hermes",
+            "task": "Investigate routing",
+            "session_id": "session-1",
+            "request_depth": 2,
+        },
+    )
+
+    assert result == {
+        "agent": "hermes",
+        "status": "queued",
+        "task_id": 123,
+        "result_endpoint": "/api/agent/tasks/123",
+    }
+    assert calls == [
+        {
+            "task": "Investigate routing",
+            "user_id": "test-user",
+            "session_id": "session-1",
+            "request_depth": 2,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_system_delegate_to_hermes_queues_background_task(monkeypatch):
+    calls = []
+
+    async def fake_enqueue(task, user_id, session_id=None, panel_id=None, request_depth=0, multica_issue_id=None):
+        calls.append(
+            {
+                "task": task,
+                "user_id": user_id,
+                "session_id": session_id,
+                "request_depth": request_depth,
+            }
+        )
+        return 456
+
+    monkeypatch.setattr(
+        system,
+        "_load_registry",
+        lambda: {"agents": {"hermes": {"base_url": "http://localhost:8642"}}},
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "background_runner",
+        types.SimpleNamespace(enqueue_background_task=fake_enqueue),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "a2a_client",
+        types.SimpleNamespace(get_a2a_client=lambda: (_ for _ in ()).throw(AssertionError("A2A should not be used for Hermes"))),
+    )
+
+    result = await system.delegate_to_agent(
+        {
+            "agent_name": "hermes",
+            "task": "Investigate routing",
+            "session_id": "session-2",
+            "request_depth": 1,
+        },
+        user={"user_id": "test-user"},
+    )
+
+    assert result == {
+        "agent": "hermes",
+        "result": {
+            "status": "queued",
+            "task_id": 456,
+            "result_endpoint": "/api/agent/tasks/456",
+        },
+    }
+    assert calls == [
+        {
+            "task": "Investigate routing",
+            "user_id": "test-user",
+            "session_id": "session-2",
+            "request_depth": 1,
+        }
+    ]

--- a/services/zoe-data/tests/test_hermes_routing.py
+++ b/services/zoe-data/tests/test_hermes_routing.py
@@ -12,6 +12,24 @@ import zoe_agent
 from routers import system
 
 
+def _patch_agent_context(monkeypatch):
+    async def none_async(*args, **kwargs):
+        return ""
+
+    monkeypatch.setattr(zoe_agent, "_check_fast_response", lambda *_: None)
+    monkeypatch.setattr(zoe_agent, "_chat_capability_shortcut", none_async)
+    monkeypatch.setattr(zoe_agent, "_load_user_portrait", none_async)
+    monkeypatch.setattr(zoe_agent, "_mempalace_load_user_facts", none_async)
+    monkeypatch.setattr(zoe_agent, "_build_memory_context", none_async)
+    monkeypatch.setattr(zoe_agent, "_load_open_loops", none_async)
+    monkeypatch.setattr(zoe_agent, "_load_pending_suggestions", none_async)
+    monkeypatch.setattr(zoe_agent, "_context_enhance", none_async)
+    monkeypatch.setattr(zoe_agent, "_select_skills", lambda *_: set())
+    monkeypatch.setattr(zoe_agent, "_build_tools", lambda *_: [])
+    monkeypatch.setattr(zoe_agent, "_classify_tone", lambda *_: "")
+    monkeypatch.setattr(zoe_agent, "_fire_memory_capture", lambda *_, **__: None)
+
+
 @pytest.mark.asyncio
 async def test_dispatch_escalate_to_hermes_returns_marker():
     result = await zoe_agent._dispatch_tool(
@@ -25,25 +43,11 @@ async def test_dispatch_escalate_to_hermes_returns_marker():
 
 @pytest.mark.asyncio
 async def test_run_zoe_agent_returns_hermes_escalation_marker(monkeypatch):
-    async def none_async(*args, **kwargs):
-        return ""
-
     async def fake_llm_call(*args, **kwargs):
         return "", "escalate_to_hermes", {"reason": "deep work", "task": "Use Hermes"}
 
-    monkeypatch.setattr(zoe_agent, "_check_fast_response", lambda *_: None)
-    monkeypatch.setattr(zoe_agent, "_chat_capability_shortcut", none_async)
-    monkeypatch.setattr(zoe_agent, "_load_user_portrait", none_async)
-    monkeypatch.setattr(zoe_agent, "_mempalace_load_user_facts", none_async)
-    monkeypatch.setattr(zoe_agent, "_build_memory_context", none_async)
-    monkeypatch.setattr(zoe_agent, "_load_open_loops", none_async)
-    monkeypatch.setattr(zoe_agent, "_load_pending_suggestions", none_async)
-    monkeypatch.setattr(zoe_agent, "_context_enhance", none_async)
-    monkeypatch.setattr(zoe_agent, "_select_skills", lambda *_: set())
-    monkeypatch.setattr(zoe_agent, "_build_tools", lambda *_: [])
-    monkeypatch.setattr(zoe_agent, "_classify_tone", lambda *_: "")
+    _patch_agent_context(monkeypatch)
     monkeypatch.setattr(zoe_agent, "_llm_call", fake_llm_call)
-    monkeypatch.setattr(zoe_agent, "_fire_memory_capture", lambda *_, **__: None)
 
     result = await zoe_agent.run_zoe_agent(
         "please hand this to hermes",
@@ -52,6 +56,51 @@ async def test_run_zoe_agent_returns_hermes_escalation_marker(monkeypatch):
     )
 
     assert result == "__ESCALATE_HERMES__:deep work|Use Hermes"
+
+
+@pytest.mark.asyncio
+async def test_run_zoe_agent_streaming_yields_hermes_escalation_marker(monkeypatch):
+    class FakeResponse:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_):
+            return None
+
+        def raise_for_status(self):
+            return None
+
+        async def aiter_lines(self):
+            yield 'data: {"choices":[{"delta":{"tool_calls":[{"function":{"name":"escalate_to_hermes","arguments":"{\\"reason\\": \\"deep work\\", \\"task\\": \\"Use Hermes\\"}"}}]}}]}'
+            yield "data: [DONE]"
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_):
+            return None
+
+        def stream(self, *args, **kwargs):
+            return FakeResponse()
+
+    _patch_agent_context(monkeypatch)
+    monkeypatch.setattr(zoe_agent.httpx, "AsyncClient", FakeClient)
+
+    chunks = [
+        chunk
+        async for chunk in zoe_agent.run_zoe_agent_streaming(
+            "please hand this to hermes",
+            "test-session",
+            user_id="test-user",
+        )
+    ]
+
+    assert "__THINKING__:escalate_to_hermes" in chunks
+    assert chunks[-1] == "__ESCALATE_HERMES__:deep work|Use Hermes"
 
 
 @pytest.mark.asyncio

--- a/services/zoe-data/tests/test_hermes_routing.py
+++ b/services/zoe-data/tests/test_hermes_routing.py
@@ -9,7 +9,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 import mcp_server
 import zoe_agent
-from routers import system
+from routers import system, voice_tts
 
 
 def _patch_agent_context(monkeypatch):
@@ -103,6 +103,28 @@ async def test_run_zoe_agent_streaming_yields_hermes_escalation_marker(monkeypat
     assert chunks[-1] == "__ESCALATE_HERMES__:deep work|Use Hermes"
 
 
+def test_voice_hermes_marker_stays_foreground():
+    is_background, reason, prompt = voice_tts._parse_voice_escalation_delta(
+        "__ESCALATE_HERMES__:deep work|Use Hermes",
+        "fallback prompt",
+    )
+
+    assert is_background is False
+    assert reason == "deep work"
+    assert prompt == "Use Hermes"
+
+
+def test_voice_background_marker_queues_work():
+    is_background, reason, prompt = voice_tts._parse_voice_escalation_delta(
+        "__ESCALATE_BG__:long task|Run later",
+        "fallback prompt",
+    )
+
+    assert is_background is True
+    assert reason == "long task"
+    assert prompt == "Run later"
+
+
 @pytest.mark.asyncio
 async def test_mcp_a2a_delegate_hermes_queues_background_task(monkeypatch):
     calls = []
@@ -162,6 +184,15 @@ async def test_mcp_a2a_delegate_hermes_queues_background_task(monkeypatch):
             "request_depth": 2,
         }
     ]
+
+
+def test_mcp_agents_registry_missing_file_fails_softly(monkeypatch):
+    def fake_open(*args, **kwargs):
+        raise FileNotFoundError("missing registry")
+
+    monkeypatch.setattr("builtins.open", fake_open)
+
+    assert mcp_server._load_agents_registry() == {"agents": {}, "squads": {}}
 
 
 @pytest.mark.asyncio

--- a/services/zoe-data/tests/test_hermes_routing.py
+++ b/services/zoe-data/tests/test_hermes_routing.py
@@ -153,7 +153,7 @@ async def test_mcp_a2a_delegate_hermes_queues_background_task(monkeypatch):
     monkeypatch.setattr(
         mcp_server,
         "_load_agents_registry",
-        lambda: {"agents": {"hermes": {"base_url": "http://localhost:8642"}}},
+        lambda: (_ for _ in ()).throw(AssertionError("Hermes should not require agents_registry.yml")),
     )
 
     result = await mcp_server._execute_tool(
@@ -213,7 +213,7 @@ async def test_system_delegate_to_hermes_queues_background_task(monkeypatch):
     monkeypatch.setattr(
         system,
         "_load_registry",
-        lambda: {"agents": {"hermes": {"base_url": "http://localhost:8642"}}},
+        lambda: (_ for _ in ()).throw(AssertionError("Hermes should not require agents_registry.yml")),
     )
     monkeypatch.setitem(
         sys.modules,

--- a/services/zoe-data/tests/test_hermes_routing.py
+++ b/services/zoe-data/tests/test_hermes_routing.py
@@ -128,6 +128,11 @@ async def test_mcp_a2a_delegate_hermes_queues_background_task(monkeypatch):
         "a2a_client",
         types.SimpleNamespace(get_a2a_client=lambda: (_ for _ in ()).throw(AssertionError("A2A should not be used for Hermes"))),
     )
+    monkeypatch.setattr(
+        mcp_server,
+        "_load_agents_registry",
+        lambda: {"agents": {"hermes": {"base_url": "http://localhost:8642"}}},
+    )
 
     result = await mcp_server._execute_tool(
         db=None,
@@ -143,9 +148,11 @@ async def test_mcp_a2a_delegate_hermes_queues_background_task(monkeypatch):
 
     assert result == {
         "agent": "hermes",
-        "status": "queued",
-        "task_id": 123,
-        "result_endpoint": "/api/agent/tasks/123",
+        "result": {
+            "status": "queued",
+            "task_id": 123,
+            "result_endpoint": "/api/agent/tasks/123",
+        },
     }
     assert calls == [
         {

--- a/services/zoe-data/zoe_agent.py
+++ b/services/zoe-data/zoe_agent.py
@@ -3512,8 +3512,7 @@ async def run_zoe_agent(
             logger.debug("zoe_agent: tool_result=%s", tool_result[:200])
 
             # Escalation signal — return immediately for chat.py to handle.
-            # Catches both __ESCALATE__: (foreground) and __ESCALATE_BG__: (background).
-            if tool_result.startswith(("__ESCALATE__:", "__ESCALATE_BG__:")):
+            if tool_result.startswith(("__ESCALATE__:", "__ESCALATE_BG__:", "__ESCALATE_HERMES__:")):
                 logger.info("zoe_agent: escalation triggered — %s", tool_result[:80])
                 _fire_memory_capture(message, response_text, user_id=user_id)
                 return tool_result
@@ -3977,8 +3976,7 @@ async def run_zoe_agent_streaming(
             tool_result = await _dispatch_tool(tool_name, tool_args or {}, user_id=user_id)
 
             # Escalation signal — yield marker and stop; chat.py handles routing.
-            # Catches both __ESCALATE__: (foreground) and __ESCALATE_BG__: (background).
-            if tool_result.startswith(("__ESCALATE__:", "__ESCALATE_BG__:")):
+            if tool_result.startswith(("__ESCALATE__:", "__ESCALATE_BG__:", "__ESCALATE_HERMES__:")):
                 logger.info("zoe_agent streaming: escalation triggered — %s", tool_result[:80])
                 _fire_memory_capture(message, collected, user_id=user_id)
                 yield tool_result


### PR DESCRIPTION
## Summary
- Propagate `__ESCALATE_HERMES__` from Zoe Agent sync and streaming loops so chat can actually route Hermes escalations.
- Route Hermes A2A/delegate requests through Zoe background tasks instead of posting to the nonexistent Hermes `/api/agent/tasks` endpoint.
- Extend voice escalation marker handling and add focused routing regression tests.

## Test plan
- `PYTHONPATH=services/zoe-data pytest services/zoe-data/tests/test_hermes_routing.py services/zoe-data/tests/test_guest_policy.py services/zoe-data/tests/test_voice_scope.py services/zoe-data/tests/test_chat_session_title.py services/zoe-data/tests/test_ui_orchestrator_types.py -x -q --override-ini=asyncio_mode=auto`
- `python3 tools/audit/validate_structure.py && python3 tools/audit/validate_critical_files.py`
- Restarted local `zoe-data.service` on the feature branch and verified `/health` plus `/api/system/status`.
- Live `/api/chat` streaming smoke with `force_agent=hermes` returned `HERMES_SMOKE_OK` and emitted `RUN_STARTED`, `STATE_SNAPSHOT`, `TEXT_MESSAGE_*`, and `RUN_FINISHED`.

## Notes
- Cursor browser automation could not load localhost/LAN `chat.html` in this environment and returned `chrome-error://chromewebdata`; the live chat-path verification was performed through the same `/api/chat` SSE endpoint used by the UI.
- The branch was created via GitHub Git API because repeated `git push` attempts failed with GitHub remote `Internal Server Error` while branch creation via API succeeded.

Made with [Cursor](https://cursor.com)