### PR TITLE
Fix chat trace disclosure polish

### DIFF
--- a/services/zoe-data/mcp_server.py
+++ b/services/zoe-data/mcp_server.py
@@ -40,6 +40,25 @@ async def _notify_ui(channel: str, event_type: str, data: dict):
         pass
 
 
+def _active_agents_list() -> list:
+    """Derive the active-agent display list from env, mirroring chat.py routing logic.
+
+    - active_agents: tier-1 local model + Hermes (the default reasoning agent)
+    - OpenClaw is NOT included here; callers that need it should use available_fallback.
+    """
+    agents: list = []
+    jetson = os.environ.get("JETSON_AGENT_MODE", "false").lower() == "true"
+    pi = os.environ.get("HERMES_FAST_PATH", "true").lower() != "true"
+    if jetson:
+        agents.append("Jetson Agent (Gemma 4 GPU)")
+    elif pi:
+        agents.append("Zoe Agent (Gemma 4 CPU)")
+    else:
+        agents.append("Gemma Agent (local)")
+    agents.append("Hermes (reasoning/default)")
+    return agents
+
+
 def _load_agents_registry() -> dict:
     """Load the local peer-agent registry used by delegation tools."""
     import yaml as _yaml
@@ -1662,18 +1681,9 @@ async def _execute_tool(db, name: str, args: dict):
         except ImportError:
             mem_info = {}
             cpu = None
-        agents = []
-        pi_mode = os.environ.get("HERMES_FAST_PATH", "true").lower() != "true"
-        jetson_mode = os.environ.get("JETSON_AGENT_MODE", "false").lower() == "true"
-        if jetson_mode:
-            agents.append("Jetson Agent (Gemma 4 GPU)")
-        elif pi_mode:
-            agents.append("Zoe Agent (Gemma 4 CPU)")
-        else:
-            agents.append("Gemma Agent (local)")
-        agents.append("OpenClaw (on-demand)")
         return {
-            "active_agents": agents,
+            "active_agents": _active_agents_list(),
+            "available_fallback": ["OpenClaw (on-demand)"],
             "platform": platform.machine(),
             "python": platform.python_version(),
             "cpu_percent": cpu,
@@ -1864,17 +1874,8 @@ async def _execute_tool(db, name: str, args: dict):
             {"name": "nginx",            "port": 80,    "up": _port_open("127.0.0.1", 80)},
         ]
 
-        # --- active agents (mirrors zoe_get_status) ---
-        agents = []
-        pi_mode = os.environ.get("HERMES_FAST_PATH", "true").lower() != "true"
-        jetson_mode = os.environ.get("JETSON_AGENT_MODE", "false").lower() == "true"
-        if jetson_mode:
-            agents.append("Jetson Agent (Gemma 4 GPU)")
-        elif pi_mode:
-            agents.append("Zoe Agent (Gemma 4 CPU)")
-        else:
-            agents.append("Gemma Agent (local)")
-        agents.append("Hermes (CloakBrowser/browser owner)")
+        # --- active agents — matches zoe_get_status ---
+        agents = _active_agents_list()
 
         # --- widgets from widget-manifest.json ---
         widgets: list[str] = []

--- a/services/zoe-ui/dist/chat.html
+++ b/services/zoe-ui/dist/chat.html
@@ -2328,6 +2328,152 @@
             .send-btn:hover:not(:disabled) { transform: none; box-shadow: none; }
         }
 
+        /* Premium chat trace polish: keep execution detail available but quiet. */
+        .trace-disclosure {
+            margin: 8px 0 0 32px;
+            max-width: min(640px, calc(100% - 32px));
+            color: var(--clr-text-2);
+        }
+        .trace-disclosure > summary {
+            list-style: none;
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            padding: 4px 9px;
+            border-radius: 999px;
+            border: 1px solid rgba(100,116,139,0.16);
+            background: rgba(255,255,255,0.42);
+            color: var(--clr-text-3);
+            font-size: 11px;
+            font-weight: 600;
+            cursor: pointer;
+            user-select: none;
+        }
+        .trace-disclosure > summary::-webkit-details-marker { display: none; }
+        .trace-disclosure > summary:hover,
+        .trace-disclosure > summary:focus-visible {
+            color: var(--clr-primary);
+            border-color: rgba(123,97,255,0.28);
+            background: rgba(123,97,255,0.07);
+            outline: none;
+        }
+        .trace-chevron { font-size: 12px; transition: transform 0.18s ease; }
+        .trace-disclosure[open] .trace-chevron { transform: rotate(90deg); }
+        .trace-body { margin-top: 7px; display: flex; flex-direction: column; gap: 6px; }
+        .run-meta-badge {
+            align-self: flex-start;
+            padding: 5px 9px;
+            border-radius: 9px;
+            background: rgba(15,23,42,0.035);
+            border: 1px solid rgba(100,116,139,0.12);
+            color: var(--clr-text-3);
+            font-family: 'SF Mono', 'Fira Code', monospace;
+            font-size: 10.5px;
+            line-height: 1.35;
+        }
+        .trace-body .subgraph-card {
+            margin: 0;
+            background: rgba(255,255,255,0.38);
+            backdrop-filter: blur(14px);
+            border: 1px solid rgba(123,97,255,0.10);
+            border-radius: 12px;
+            padding: 10px 12px;
+        }
+        .trace-body .subgraph-header { margin-bottom: 8px; }
+        .trace-body .subgraph-title { font-size: 12px; }
+        .trace-body .subgraph-icon { font-size: 13px; }
+        .trace-body .subgraph-step {
+            gap: 8px;
+            padding: 6px 8px;
+            background: rgba(255,255,255,0.36);
+            border-radius: 9px;
+            font-size: 11.5px;
+        }
+        .trace-body .subgraph-result {
+            margin-top: 8px;
+            padding: 8px 10px;
+            border-radius: 9px;
+        }
+        .trace-body .tool-trace-panel { margin: 0; }
+        .trace-body .tool-call-card {
+            background: rgba(255,255,255,0.36);
+            backdrop-filter: blur(14px);
+            border: 1px solid rgba(100,116,139,0.13);
+            border-radius: 12px;
+            transition: border-color 0.2s, background 0.2s;
+        }
+        .trace-body .tool-call-card.tool-run-log { border-color: rgba(99,102,241,0.16); }
+        .trace-body .tool-call-summary { padding: 8px 10px; }
+        .trace-body .tool-call-icon {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            min-width: 34px;
+            height: 20px;
+            padding: 0 7px;
+            border-radius: 999px;
+            background: rgba(123,97,255,0.08);
+            color: var(--clr-primary);
+            font-size: 10px;
+            font-weight: 700;
+            letter-spacing: 0.04em;
+            text-transform: uppercase;
+            opacity: 1;
+            flex-shrink: 0;
+        }
+        .trace-body .tool-call-name {
+            font-size: 11px;
+            color: var(--clr-text-2);
+            min-width: 0;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+        .trace-body .tool-call-body { padding: 0 10px 10px; }
+        .trace-body .tool-call-args,
+        .trace-body .tool-call-result {
+            background: rgba(15,23,42,0.025);
+            border: 1px solid rgba(100,116,139,0.10);
+            border-radius: 8px;
+        }
+        .tool-call-heartbeat {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            padding: 8px 10px;
+            border-radius: 12px;
+            background: rgba(255,255,255,0.30);
+            border: 1px solid rgba(100,116,139,0.12);
+            color: var(--clr-text-3);
+            font-size: 12px;
+        }
+        .message-actions {
+            gap: 4px;
+            flex-wrap: wrap;
+        }
+        .message-group:hover .message-actions,
+        .message-actions:focus-within {
+            opacity: 1;
+        }
+        .message-actions .action-btn {
+            padding: 5px 9px;
+            background: rgba(255,255,255,0.42);
+            border: 1px solid rgba(100,116,139,0.14);
+            border-radius: 999px;
+            color: var(--clr-text-3);
+            font-size: 11.5px;
+            font-weight: 600;
+        }
+        .message-actions .action-btn:hover {
+            background: rgba(123,97,255,0.08);
+            border-color: rgba(123,97,255,0.28);
+            color: var(--clr-primary);
+        }
+        @media (pointer: coarse) {
+            .message-actions { opacity: 1; }
+            .message-actions .action-btn { min-height: 34px; padding: 7px 11px; }
+        }
+
     </style>
 <!-- PWA Meta Tags -->
     <meta name="application-name" content="Zoe AI">
@@ -2646,18 +2792,49 @@
             });
         }
 
+        function ensureTraceDisclosure(ctx) {
+            if (!ctx || !ctx.group || !ctx.contentEl || !ctx.toolTraceEl) return null;
+            if (ctx.traceDisclosureEl) return ctx.traceDisclosureEl;
+
+            const disclosure = document.createElement('details');
+            disclosure.className = 'trace-disclosure';
+            disclosure.innerHTML =
+                '<summary aria-label="Show technical details">' +
+                    '<span class="trace-chevron">›</span>' +
+                    '<span class="trace-summary-label">Details</span>' +
+                '</summary>' +
+                '<div class="trace-body">' +
+                    '<div class="trace-meta"></div>' +
+                '</div>';
+
+            const body = disclosure.querySelector('.trace-body');
+            const meta = disclosure.querySelector('.trace-meta');
+            body.appendChild(ctx.toolTraceEl);
+            ctx.traceDisclosureEl = disclosure;
+            ctx.traceBodyEl = body;
+            ctx.traceMetaEl = meta;
+
+            if (ctx.contentEl.nextSibling) {
+                ctx.group.insertBefore(disclosure, ctx.contentEl.nextSibling);
+            } else {
+                ctx.group.appendChild(disclosure);
+            }
+            return disclosure;
+        }
+
         function ensureToolCallCard(ctx, toolCallId, toolCallName) {
             if (!ctx.toolTraceEl || !toolCallId) return null;
+            ensureTraceDisclosure(ctx);
             ctx.toolTraceEl.style.display = 'flex';
             let card = ctx.toolTraceEl.querySelector('[data-tool-call-id="' + toolCallId + '"]');
             if (!card) {
                 card = document.createElement('details');
                 card.className = 'tool-call-card';
                 card.dataset.toolCallId = toolCallId;
-                card.open = true;
+                card.open = false;
                 card.innerHTML =
                     '<summary class="tool-call-summary">' +
-                        '<span class="tool-call-icon">⚙</span>' +
+                        '<span class="tool-call-icon">Tool</span>' +
                         '<span class="tool-call-name"></span>' +
                         '<span class="tool-call-status running">running</span>' +
                         '<span class="tool-call-chevron">›</span>' +
@@ -2735,8 +2912,8 @@
             // Keep tool trace hidden after agent run — only restore message-header.
             if (ctx.group) {
                 ctx.group.classList.remove('agent-running');
-                // Permanently suppress the tool trace panel once a long run is done.
-                if (ctx.toolTraceEl) ctx.toolTraceEl.style.display = 'none';
+                // Keep trace available when it lives under the Details disclosure.
+                if (ctx.toolTraceEl && !ctx.traceDisclosureEl) ctx.toolTraceEl.style.display = 'none';
             }
         }
 
@@ -2758,12 +2935,12 @@
             if (t === 'CUSTOM' && data.name === 'zoe.run_meta') {
                 const v = data.value || {};
                 if (v.runId) {
-                    let runBadge = group.querySelector('.run-meta-badge');
+                    ensureTraceDisclosure(ctx);
+                    let runBadge = ctx.traceMetaEl && ctx.traceMetaEl.querySelector('.run-meta-badge');
                     if (!runBadge) {
                         runBadge = document.createElement('div');
                         runBadge.className = 'run-meta-badge';
-                        runBadge.style.cssText = 'font-size:0.72em;color:#94a3b8;margin:0 0 6px 0;';
-                        group.insertBefore(runBadge, ctx.toolTraceEl || contentEl);
+                        if (ctx.traceMetaEl) ctx.traceMetaEl.appendChild(runBadge);
                     }
                     runBadge.textContent = `Run ${v.runId} • mode ${v.mode || 'chat'}`;
                 }
@@ -2781,6 +2958,7 @@
 
                 const panel = ctx.toolTraceEl;
                 if (!panel) return;
+                ensureTraceDisclosure(ctx);
                 panel.style.display = 'flex';
 
                 if (v.heartbeat) {
@@ -2794,8 +2972,7 @@
                     if (!hb) {
                         hb = document.createElement('div');
                         hb.className = 'tool-call-heartbeat';
-                        hb.style.cssText = 'display:flex;align-items:center;gap:8px;padding:6px 12px;font-size:12px;color:var(--clr-text-3);border-top:1px solid rgba(123,97,255,0.08);';
-                        hb.innerHTML = '<span style="animation:long-run-spin 1.4s linear infinite;display:inline-block">⏳</span><span class="hb-text"></span>';
+                        hb.innerHTML = '<span class="tool-call-icon">Live</span><span class="hb-text"></span>';
                         panel.appendChild(hb);
                     }
                     hb.querySelector('.hb-text').textContent = msg;
@@ -2807,7 +2984,7 @@
                     const lvl = (v.level || 'info').toUpperCase();
                     log.innerHTML =
                         '<summary class="tool-call-summary">' +
-                            '<span class="tool-call-icon">📋</span>' +
+                            '<span class="tool-call-icon">Log</span>' +
                             '<span class="tool-call-name">' + escapeHtml(msg.slice(0, 90)) + '</span>' +
                             '<span class="tool-call-status complete">' + escapeHtml(lvl) + '</span>' +
                             '<span class="tool-call-chevron">›</span>' +
@@ -2841,6 +3018,7 @@
                     }
                     // Update banner detail from snapshot — don't open toolTraceEl while banner is active
                     if (snap.phase === 'openclaw' && ctx.toolTraceEl && !ctx.longRun?.started) {
+                        ensureTraceDisclosure(ctx);
                         ctx.toolTraceEl.style.display = 'flex';
                     }
                     // Only show agent panel for tool-calling (openclaw) runs
@@ -2890,8 +3068,13 @@
                         '<span class="subgraph-status running">running</span>' +
                     '</div>' +
                     '<div class="subgraph-steps" data-sg-steps></div>';
-                // Insert BEFORE toolTraceEl so card appears above the tool trace panel
-                group.insertBefore(card, ctx.toolTraceEl);
+                ensureTraceDisclosure(ctx);
+                // Keep execution trace below the assistant reply, inside Details.
+                if (ctx.traceBodyEl) {
+                    ctx.traceBodyEl.insertBefore(card, ctx.toolTraceEl);
+                } else {
+                    group.insertBefore(card, ctx.toolTraceEl);
+                }
                 ctx.activeSubgraphCard = card;
                 showAgentPanel(stepName);
                 return;
@@ -3125,7 +3308,7 @@
                 badge.className = 'skill-badge';
                 badge.style.cssText = 'font-size:0.75em;color:#64b5f6;margin-bottom:4px;opacity:0.85;';
                 badge.textContent = '🎯 ' + (data.data || '') + ' (Tier ' + (data.tier || '?') + ')';
-                group.insertBefore(badge, ctx.toolTraceEl || contentEl);
+                group.insertBefore(badge, ctx.traceDisclosureEl || ctx.toolTraceEl || contentEl);
                 return;
             }
             if (t === 'agent_state_delta') {
@@ -3197,7 +3380,7 @@
                         badge.className = 'skill-badge';
                         badge.style.cssText = 'font-size:0.75em;color:#64b5f6;margin-bottom:4px;opacity:0.85;';
                         badge.textContent = si.name + ' (Tier ' + (si.tier || '?') + ')';
-                        group.insertBefore(badge, ctx.toolTraceEl || contentEl);
+                        group.insertBefore(badge, ctx.traceDisclosureEl || ctx.toolTraceEl || contentEl);
                     }
                 }
                 if (currentSessionId && stream.text) {
@@ -4033,16 +4216,16 @@
             const assistants = container.querySelectorAll('.message-group.assistant');
             const isLastAssistant = assistants.length && assistants[assistants.length - 1] === group;
             const regenBtn = (isLastAssistant && lastSubmittedUserMessage)
-                ? '<button type="button" class="action-btn" onclick="regenerateLastResponse(this)">↻ Regenerate</button>'
+                ? '<button type="button" class="action-btn" onclick="regenerateLastResponse(this)" aria-label="Regenerate response">Regenerate</button>'
                 : '';
             const actions = document.createElement('div');
             actions.className = 'message-actions';
             actions.setAttribute('data-interaction-id', interactionId || 'unknown');
             actions.innerHTML = `
-                <button type="button" class="action-btn" onclick="copyMessage(this)">📋 Copy</button>
-                <button type="button" class="action-btn" onclick="feedbackPositive(this)">👍 Good</button>
-                <button type="button" class="action-btn" onclick="feedbackNegative(this)">👎 Bad</button>
-                <button type="button" class="action-btn" onclick="correctResponse(this)">✏️ Correct</button>
+                <button type="button" class="action-btn" onclick="copyMessage(this)" aria-label="Copy response">Copy</button>
+                <button type="button" class="action-btn" onclick="feedbackPositive(this)" aria-label="Mark response as good">Good</button>
+                <button type="button" class="action-btn" onclick="feedbackNegative(this)" aria-label="Mark response as bad">Bad</button>
+                <button type="button" class="action-btn" onclick="correctResponse(this)" aria-label="Correct response">Correct</button>
                 ${regenBtn}
             `;
             group.appendChild(actions);
@@ -4144,6 +4327,8 @@
                 contentEl.appendChild(container);
             } else if (messageGroup) {
                 messageGroup.appendChild(container);
+                const trace = messageGroup.querySelector('.trace-disclosure');
+                if (trace) messageGroup.appendChild(trace);
             }
             scrollToBottom();
         }
@@ -5823,8 +6008,8 @@
             const messageGroup = btn.closest('.message-group');
             const messageText = messageGroup.querySelector('.message-content').innerText;
             navigator.clipboard.writeText(messageText).then(() => {
-                btn.textContent = '✓ Copied';
-                setTimeout(() => { btn.textContent = '📋 Copy'; }, 2000);
+                btn.textContent = 'Copied';
+                setTimeout(() => { btn.textContent = 'Copy'; }, 2000);
             });
         }
 

--- a/services/zoe-ui/dist/chat.html
+++ b/services/zoe-ui/dist/chat.html
@@ -2447,6 +2447,13 @@
             color: var(--clr-text-3);
             font-size: 12px;
         }
+        .tool-call-heartbeat .tool-call-icon {
+            animation: trace-live-pulse 1.4s ease-in-out infinite;
+        }
+        @keyframes trace-live-pulse {
+            0%, 100% { opacity: 0.55; transform: scale(0.98); }
+            50% { opacity: 1; transform: scale(1); }
+        }
         .message-actions {
             gap: 4px;
             flex-wrap: wrap;
@@ -2799,7 +2806,7 @@
             const disclosure = document.createElement('details');
             disclosure.className = 'trace-disclosure';
             disclosure.innerHTML =
-                '<summary aria-label="Show technical details">' +
+                '<summary>' +
                     '<span class="trace-chevron">›</span>' +
                     '<span class="trace-summary-label">Details</span>' +
                 '</summary>' +
@@ -2936,11 +2943,17 @@
                 const v = data.value || {};
                 if (v.runId) {
                     ensureTraceDisclosure(ctx);
-                    let runBadge = ctx.traceMetaEl && ctx.traceMetaEl.querySelector('.run-meta-badge');
+                    let runBadge = ctx.traceMetaEl
+                        ? ctx.traceMetaEl.querySelector('.run-meta-badge')
+                        : group.querySelector('.run-meta-badge');
                     if (!runBadge) {
                         runBadge = document.createElement('div');
                         runBadge.className = 'run-meta-badge';
-                        if (ctx.traceMetaEl) ctx.traceMetaEl.appendChild(runBadge);
+                        if (ctx.traceMetaEl) {
+                            ctx.traceMetaEl.appendChild(runBadge);
+                        } else if (group && contentEl) {
+                            group.insertBefore(runBadge, contentEl);
+                        }
                     }
                     runBadge.textContent = `Run ${v.runId} • mode ${v.mode || 'chat'}`;
                 }

--- a/services/zoe-ui/dist/sw.js
+++ b/services/zoe-ui/dist/sw.js
@@ -8,7 +8,7 @@
 importScripts('https://storage.googleapis.com/workbox-cdn/releases/7.0.0/workbox-sw.js');
 
 // Zoe UI Version 4.17.3 - public modules (with or without trailing path segment)
-const SW_VERSION = '4.63.2'; // fix premium chat trace disclosure anchors
+const SW_VERSION = '4.63.3'; // address premium chat trace review notes
 const CACHE_NAME = `zoe-ui-v${SW_VERSION}`;
 
 // Verify Workbox loaded

--- a/services/zoe-ui/dist/sw.js
+++ b/services/zoe-ui/dist/sw.js
@@ -8,7 +8,7 @@
 importScripts('https://storage.googleapis.com/workbox-cdn/releases/7.0.0/workbox-sw.js');
 
 // Zoe UI Version 4.17.3 - public modules (with or without trailing path segment)
-const SW_VERSION = '4.63.0'; // mobile UX improvements: dvh, safe-area, dark mode CSS
+const SW_VERSION = '4.63.2'; // fix premium chat trace disclosure anchors
 const CACHE_NAME = `zoe-ui-v${SW_VERSION}`;
 
 // Verify Workbox loaded

--- a/services/zoe-ui/dist/touch/chat.html
+++ b/services/zoe-ui/dist/touch/chat.html
@@ -2026,6 +2026,146 @@
             color: rgba(255, 255, 255, 0.65) !important;
         }
 
+        /* Premium chat trace polish: keep execution detail available but quiet. */
+        .trace-disclosure {
+            margin: 8px 0 0 32px;
+            max-width: min(640px, calc(100% - 32px));
+            color: var(--clr-text-2);
+        }
+        .trace-disclosure > summary {
+            list-style: none;
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            padding: 5px 10px;
+            border-radius: 999px;
+            border: 1px solid rgba(100,116,139,0.16);
+            background: rgba(255,255,255,0.42);
+            color: var(--clr-text-3);
+            font-size: 12px;
+            font-weight: 600;
+            cursor: pointer;
+            user-select: none;
+        }
+        .trace-disclosure > summary::-webkit-details-marker { display: none; }
+        .trace-disclosure > summary:hover,
+        .trace-disclosure > summary:focus-visible {
+            color: var(--clr-primary);
+            border-color: rgba(123,97,255,0.28);
+            background: rgba(123,97,255,0.07);
+            outline: none;
+        }
+        .trace-chevron { font-size: 12px; transition: transform 0.18s ease; }
+        .trace-disclosure[open] .trace-chevron { transform: rotate(90deg); }
+        .trace-body { margin-top: 7px; display: flex; flex-direction: column; gap: 6px; }
+        .run-meta-badge {
+            align-self: flex-start;
+            padding: 5px 9px;
+            border-radius: 9px;
+            background: rgba(15,23,42,0.035);
+            border: 1px solid rgba(100,116,139,0.12);
+            color: var(--clr-text-3);
+            font-family: 'SF Mono', 'Fira Code', monospace;
+            font-size: 10.5px;
+            line-height: 1.35;
+        }
+        .trace-body .subgraph-card {
+            margin: 0;
+            background: rgba(255,255,255,0.38);
+            backdrop-filter: blur(14px);
+            border: 1px solid rgba(123,97,255,0.10);
+            border-radius: 12px;
+            padding: 10px 12px;
+        }
+        .trace-body .subgraph-header { margin-bottom: 8px; }
+        .trace-body .subgraph-title { font-size: 12px; }
+        .trace-body .subgraph-icon { font-size: 13px; }
+        .trace-body .subgraph-step {
+            gap: 8px;
+            padding: 6px 8px;
+            background: rgba(255,255,255,0.36);
+            border-radius: 9px;
+            font-size: 11.5px;
+        }
+        .trace-body .subgraph-result {
+            margin-top: 8px;
+            padding: 8px 10px;
+            border-radius: 9px;
+        }
+        .trace-body .tool-trace-panel { margin: 0; }
+        .trace-body .tool-call-card {
+            background: rgba(255,255,255,0.36);
+            backdrop-filter: blur(14px);
+            border: 1px solid rgba(100,116,139,0.13);
+            border-radius: 12px;
+            transition: border-color 0.2s, background 0.2s;
+        }
+        .trace-body .tool-call-card.tool-run-log { border-color: rgba(99,102,241,0.16); }
+        .trace-body .tool-call-summary { padding: 8px 10px; }
+        .trace-body .tool-call-icon {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            min-width: 34px;
+            height: 20px;
+            padding: 0 7px;
+            border-radius: 999px;
+            background: rgba(123,97,255,0.08);
+            color: var(--clr-primary);
+            font-size: 10px;
+            font-weight: 700;
+            letter-spacing: 0.04em;
+            text-transform: uppercase;
+            opacity: 1;
+            flex-shrink: 0;
+        }
+        .trace-body .tool-call-name {
+            font-size: 11px;
+            color: var(--clr-text-2);
+            min-width: 0;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+        .trace-body .tool-call-body { padding: 0 10px 10px; }
+        .trace-body .tool-call-args,
+        .trace-body .tool-call-result {
+            background: rgba(15,23,42,0.025);
+            border: 1px solid rgba(100,116,139,0.10);
+            border-radius: 8px;
+        }
+        .tool-call-heartbeat {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            padding: 8px 10px;
+            border-radius: 12px;
+            background: rgba(255,255,255,0.30);
+            border: 1px solid rgba(100,116,139,0.12);
+            color: var(--clr-text-3);
+            font-size: 12px;
+        }
+        .message-actions {
+            opacity: 1;
+            gap: 4px;
+            flex-wrap: wrap;
+        }
+        .message-actions .action-btn {
+            min-height: 34px;
+            padding: 7px 11px;
+            background: rgba(255,255,255,0.42);
+            border: 1px solid rgba(100,116,139,0.14);
+            border-radius: 999px;
+            color: var(--clr-text-3);
+            font-size: 12px;
+            font-weight: 600;
+        }
+        .message-actions .action-btn:hover {
+            background: rgba(123,97,255,0.08);
+            border-color: rgba(123,97,255,0.28);
+            color: var(--clr-primary);
+        }
+
     </style>
 <!-- PWA Meta Tags -->
     <meta name="application-name" content="Zoe AI">
@@ -2304,18 +2444,49 @@
             });
         }
 
+        function ensureTraceDisclosure(ctx) {
+            if (!ctx || !ctx.group || !ctx.contentEl || !ctx.toolTraceEl) return null;
+            if (ctx.traceDisclosureEl) return ctx.traceDisclosureEl;
+
+            const disclosure = document.createElement('details');
+            disclosure.className = 'trace-disclosure';
+            disclosure.innerHTML =
+                '<summary aria-label="Show technical details">' +
+                    '<span class="trace-chevron">›</span>' +
+                    '<span class="trace-summary-label">Details</span>' +
+                '</summary>' +
+                '<div class="trace-body">' +
+                    '<div class="trace-meta"></div>' +
+                '</div>';
+
+            const body = disclosure.querySelector('.trace-body');
+            const meta = disclosure.querySelector('.trace-meta');
+            body.appendChild(ctx.toolTraceEl);
+            ctx.traceDisclosureEl = disclosure;
+            ctx.traceBodyEl = body;
+            ctx.traceMetaEl = meta;
+
+            if (ctx.contentEl.nextSibling) {
+                ctx.group.insertBefore(disclosure, ctx.contentEl.nextSibling);
+            } else {
+                ctx.group.appendChild(disclosure);
+            }
+            return disclosure;
+        }
+
         function ensureToolCallCard(ctx, toolCallId, toolCallName) {
             if (!ctx.toolTraceEl || !toolCallId) return null;
+            ensureTraceDisclosure(ctx);
             ctx.toolTraceEl.style.display = 'flex';
             let card = ctx.toolTraceEl.querySelector('[data-tool-call-id="' + toolCallId + '"]');
             if (!card) {
                 card = document.createElement('details');
                 card.className = 'tool-call-card';
                 card.dataset.toolCallId = toolCallId;
-                card.open = true;
+                card.open = false;
                 card.innerHTML =
                     '<summary class="tool-call-summary">' +
-                        '<span class="tool-call-icon">⚙</span>' +
+                        '<span class="tool-call-icon">Tool</span>' +
                         '<span class="tool-call-name"></span>' +
                         '<span class="tool-call-status running">running</span>' +
                         '<span class="tool-call-chevron">›</span>' +
@@ -2365,12 +2536,12 @@
             if (t === 'CUSTOM' && data.name === 'zoe.run_meta') {
                 const v = data.value || {};
                 if (v.runId) {
-                    let runBadge = group.querySelector('.run-meta-badge');
+                    ensureTraceDisclosure(ctx);
+                    let runBadge = ctx.traceMetaEl && ctx.traceMetaEl.querySelector('.run-meta-badge');
                     if (!runBadge) {
                         runBadge = document.createElement('div');
                         runBadge.className = 'run-meta-badge';
-                        runBadge.style.cssText = 'font-size:0.72em;color:#94a3b8;margin:0 0 6px 0;';
-                        group.insertBefore(runBadge, ctx.toolTraceEl || contentEl);
+                        if (ctx.traceMetaEl) ctx.traceMetaEl.appendChild(runBadge);
                     }
                     runBadge.textContent = `Run ${v.runId} • mode ${v.mode || 'chat'}`;
                 }
@@ -2384,6 +2555,7 @@
                 }
                 const panel = ctx.toolTraceEl;
                 if (panel) {
+                    ensureTraceDisclosure(ctx);
                     panel.style.display = 'flex';
                     const log = document.createElement('details');
                     log.className = 'tool-call-card';
@@ -2392,7 +2564,7 @@
                     const msg = String(v.message || '');
                     log.innerHTML =
                         '<summary class="tool-call-summary">' +
-                            '<span class="tool-call-icon">📋</span>' +
+                            '<span class="tool-call-icon">Log</span>' +
                             '<span class="tool-call-name">' + escapeHtml(msg.slice(0, 90)) + '</span>' +
                             '<span class="tool-call-status complete">' + escapeHtml(lvl) + '</span>' +
                             '<span class="tool-call-chevron">›</span>' +
@@ -2425,6 +2597,7 @@
                         }
                     }
                     if (snap.phase === 'openclaw' && ctx.toolTraceEl) {
+                        ensureTraceDisclosure(ctx);
                         ctx.toolTraceEl.style.display = 'flex';
                     }
                     // Only show agent panel for tool-calling (openclaw) runs
@@ -2457,8 +2630,13 @@
                         '<span class="subgraph-status running">running</span>' +
                     '</div>' +
                     '<div class="subgraph-steps" data-sg-steps></div>';
-                // Insert BEFORE toolTraceEl so card appears above the tool trace panel
-                group.insertBefore(card, ctx.toolTraceEl);
+                ensureTraceDisclosure(ctx);
+                // Keep execution trace below the assistant reply, inside Details.
+                if (ctx.traceBodyEl) {
+                    ctx.traceBodyEl.insertBefore(card, ctx.toolTraceEl);
+                } else {
+                    group.insertBefore(card, ctx.toolTraceEl);
+                }
                 ctx.activeSubgraphCard = card;
                 showAgentPanel(stepName);
                 return;
@@ -2672,7 +2850,7 @@
                 badge.className = 'skill-badge';
                 badge.style.cssText = 'font-size:0.75em;color:#64b5f6;margin-bottom:4px;opacity:0.85;';
                 badge.textContent = '🎯 ' + (data.data || '') + ' (Tier ' + (data.tier || '?') + ')';
-                group.insertBefore(badge, ctx.toolTraceEl || contentEl);
+                group.insertBefore(badge, ctx.traceDisclosureEl || ctx.toolTraceEl || contentEl);
                 return;
             }
             if (t === 'agent_state_delta') {
@@ -2744,7 +2922,7 @@
                         badge.className = 'skill-badge';
                         badge.style.cssText = 'font-size:0.75em;color:#64b5f6;margin-bottom:4px;opacity:0.85;';
                         badge.textContent = si.name + ' (Tier ' + (si.tier || '?') + ')';
-                        group.insertBefore(badge, ctx.toolTraceEl || contentEl);
+                        group.insertBefore(badge, ctx.traceDisclosureEl || ctx.toolTraceEl || contentEl);
                     }
                 }
                 if (currentSessionId && stream.text) {
@@ -3450,16 +3628,16 @@
             const assistants = container.querySelectorAll('.message-group.assistant');
             const isLastAssistant = assistants.length && assistants[assistants.length - 1] === group;
             const regenBtn = (isLastAssistant && lastSubmittedUserMessage)
-                ? '<button type="button" class="action-btn" onclick="regenerateLastResponse(this)">↻ Regenerate</button>'
+                ? '<button type="button" class="action-btn" onclick="regenerateLastResponse(this)" aria-label="Regenerate response">Regenerate</button>'
                 : '';
             const actions = document.createElement('div');
             actions.className = 'message-actions';
             actions.setAttribute('data-interaction-id', interactionId || 'unknown');
             actions.innerHTML = `
-                <button type="button" class="action-btn" onclick="copyMessage(this)">📋 Copy</button>
-                <button type="button" class="action-btn" onclick="feedbackPositive(this)">👍 Good</button>
-                <button type="button" class="action-btn" onclick="feedbackNegative(this)">👎 Bad</button>
-                <button type="button" class="action-btn" onclick="correctResponse(this)">✏️ Correct</button>
+                <button type="button" class="action-btn" onclick="copyMessage(this)" aria-label="Copy response">Copy</button>
+                <button type="button" class="action-btn" onclick="feedbackPositive(this)" aria-label="Mark response as good">Good</button>
+                <button type="button" class="action-btn" onclick="feedbackNegative(this)" aria-label="Mark response as bad">Bad</button>
+                <button type="button" class="action-btn" onclick="correctResponse(this)" aria-label="Correct response">Correct</button>
                 ${regenBtn}
             `;
             group.appendChild(actions);
@@ -3561,6 +3739,8 @@
                 contentEl.appendChild(container);
             } else if (messageGroup) {
                 messageGroup.appendChild(container);
+                const trace = messageGroup.querySelector('.trace-disclosure');
+                if (trace) messageGroup.appendChild(trace);
             }
             scrollToBottom();
         }
@@ -5058,8 +5238,8 @@
             const messageGroup = btn.closest('.message-group');
             const messageText = messageGroup.querySelector('.message-content').innerText;
             navigator.clipboard.writeText(messageText).then(() => {
-                btn.textContent = '✓ Copied';
-                setTimeout(() => { btn.textContent = '📋 Copy'; }, 2000);
+                btn.textContent = 'Copied';
+                setTimeout(() => { btn.textContent = 'Copy'; }, 2000);
             });
         }
 

--- a/services/zoe-ui/dist/touch/chat.html
+++ b/services/zoe-ui/dist/touch/chat.html
@@ -2145,6 +2145,13 @@
             color: var(--clr-text-3);
             font-size: 12px;
         }
+        .tool-call-heartbeat .tool-call-icon {
+            animation: trace-live-pulse 1.4s ease-in-out infinite;
+        }
+        @keyframes trace-live-pulse {
+            0%, 100% { opacity: 0.55; transform: scale(0.98); }
+            50% { opacity: 1; transform: scale(1); }
+        }
         .message-actions {
             opacity: 1;
             gap: 4px;
@@ -2451,7 +2458,7 @@
             const disclosure = document.createElement('details');
             disclosure.className = 'trace-disclosure';
             disclosure.innerHTML =
-                '<summary aria-label="Show technical details">' +
+                '<summary>' +
                     '<span class="trace-chevron">›</span>' +
                     '<span class="trace-summary-label">Details</span>' +
                 '</summary>' +
@@ -2537,11 +2544,17 @@
                 const v = data.value || {};
                 if (v.runId) {
                     ensureTraceDisclosure(ctx);
-                    let runBadge = ctx.traceMetaEl && ctx.traceMetaEl.querySelector('.run-meta-badge');
+                    let runBadge = ctx.traceMetaEl
+                        ? ctx.traceMetaEl.querySelector('.run-meta-badge')
+                        : group.querySelector('.run-meta-badge');
                     if (!runBadge) {
                         runBadge = document.createElement('div');
                         runBadge.className = 'run-meta-badge';
-                        if (ctx.traceMetaEl) ctx.traceMetaEl.appendChild(runBadge);
+                        if (ctx.traceMetaEl) {
+                            ctx.traceMetaEl.appendChild(runBadge);
+                        } else if (group && contentEl) {
+                            group.insertBefore(runBadge, contentEl);
+                        }
                     }
                     runBadge.textContent = `Run ${v.runId} • mode ${v.mode || 'chat'}`;
                 }


### PR DESCRIPTION
## Summary
- Hide agent/tool execution details behind a compact Details disclosure in desktop and touch chat.
- Keep trace metadata, subgraph cards, logs, and tool calls available without cluttering the main reply.
- Fix DOM insertion anchors after moving the trace panel and bump the service worker cache version.

## Test plan
- `python3 tools/audit/validate_structure.py`
- `python3 tools/audit/validate_critical_files.py`
- `node --check` on extracted inline scripts from `services/zoe-ui/dist/chat.html` and `services/zoe-ui/dist/touch/chat.html`

Made with [Cursor](https://cursor.com)