### PR TITLE
Fix Multica client env refresh

### DIFF
--- a/services/zoe-data/multica_client.py
+++ b/services/zoe-data/multica_client.py
@@ -20,9 +20,6 @@ import httpx
 
 logger = logging.getLogger(__name__)
 
-_MULTICA_BASE_URL = os.environ.get("MULTICA_BASE_URL", "")
-_MULTICA_API_TOKEN = os.environ.get("MULTICA_API_TOKEN", "")
-_MULTICA_WORKSPACE_ID = os.environ.get("MULTICA_WORKSPACE_ID", "")
 _TIMEOUT = 10.0
 
 
@@ -30,9 +27,11 @@ class MULClient:
     """Multica board client — wraps the Multica REST API."""
 
     def __init__(self) -> None:
-        self._base = (_MULTICA_BASE_URL or "").rstrip("/")
-        self._token = _MULTICA_API_TOKEN or ""
-        self._workspace = _MULTICA_WORKSPACE_ID or ""
+        # Read env at instantiation time so callers that import this module
+        # before EnvironmentFile/.env loading still get the live Multica config.
+        self._base = (os.environ.get("MULTICA_BASE_URL", "") or "").rstrip("/")
+        self._token = os.environ.get("MULTICA_API_TOKEN", "") or ""
+        self._workspace = os.environ.get("MULTICA_WORKSPACE_ID", "") or ""
 
     def is_configured(self) -> bool:
         """Return True only if all required env vars are set."""
@@ -134,7 +133,12 @@ _client: MULClient | None = None
 
 def get_multica_client() -> MULClient:
     global _client
-    if _client is None:
+    current = (
+        (os.environ.get("MULTICA_BASE_URL", "") or "").rstrip("/"),
+        os.environ.get("MULTICA_API_TOKEN", "") or "",
+        os.environ.get("MULTICA_WORKSPACE_ID", "") or "",
+    )
+    if _client is None or (_client._base, _client._token, _client._workspace) != current:
         _client = MULClient()
     return _client
 

--- a/services/zoe-data/multica_client.py
+++ b/services/zoe-data/multica_client.py
@@ -132,7 +132,7 @@ _client: MULClient | None = None
 
 
 def get_multica_client() -> MULClient:
-    global _client
+    global _client, _cached_self_imp_agent_id, _cached_self_imp_project_id
     current = (
         (os.environ.get("MULTICA_BASE_URL", "") or "").rstrip("/"),
         os.environ.get("MULTICA_API_TOKEN", "") or "",
@@ -140,6 +140,8 @@ def get_multica_client() -> MULClient:
     )
     if _client is None or (_client._base, _client._token, _client._workspace) != current:
         _client = MULClient()
+        _cached_self_imp_agent_id = None
+        _cached_self_imp_project_id = None
     return _client
 
 

--- a/services/zoe-data/multica_client.py
+++ b/services/zoe-data/multica_client.py
@@ -23,15 +23,22 @@ logger = logging.getLogger(__name__)
 _TIMEOUT = 10.0
 
 
+def _multica_env_key() -> tuple[str, str, str]:
+    """Return a comparable snapshot of the current Multica env vars."""
+    return (
+        os.environ.get("MULTICA_BASE_URL", "").rstrip("/"),
+        os.environ.get("MULTICA_API_TOKEN", ""),
+        os.environ.get("MULTICA_WORKSPACE_ID", ""),
+    )
+
+
 class MULClient:
     """Multica board client — wraps the Multica REST API."""
 
     def __init__(self) -> None:
         # Read env at instantiation time so callers that import this module
         # before EnvironmentFile/.env loading still get the live Multica config.
-        self._base = (os.environ.get("MULTICA_BASE_URL", "") or "").rstrip("/")
-        self._token = os.environ.get("MULTICA_API_TOKEN", "") or ""
-        self._workspace = os.environ.get("MULTICA_WORKSPACE_ID", "") or ""
+        self._base, self._token, self._workspace = _multica_env_key()
 
     def is_configured(self) -> bool:
         """Return True only if all required env vars are set."""
@@ -133,11 +140,7 @@ _client: MULClient | None = None
 
 def get_multica_client() -> MULClient:
     global _client, _cached_self_imp_agent_id, _cached_self_imp_project_id
-    current = (
-        (os.environ.get("MULTICA_BASE_URL", "") or "").rstrip("/"),
-        os.environ.get("MULTICA_API_TOKEN", "") or "",
-        os.environ.get("MULTICA_WORKSPACE_ID", "") or "",
-    )
+    current = _multica_env_key()
     if _client is None or (_client._base, _client._token, _client._workspace) != current:
         _client = MULClient()
         _cached_self_imp_agent_id = None

--- a/services/zoe-data/tests/test_multica_client.py
+++ b/services/zoe-data/tests/test_multica_client.py
@@ -21,8 +21,12 @@ def test_mul_client_reads_env_at_instantiation(monkeypatch):
 
 def test_get_multica_client_refreshes_cached_client_when_env_changes(monkeypatch):
     original_client = multica_client._client
+    original_agent_id = multica_client._cached_self_imp_agent_id
+    original_project_id = multica_client._cached_self_imp_project_id
     try:
         multica_client._client = None
+        multica_client._cached_self_imp_agent_id = "agent-old"
+        multica_client._cached_self_imp_project_id = "project-old"
         monkeypatch.delenv("MULTICA_BASE_URL", raising=False)
         monkeypatch.delenv("MULTICA_API_TOKEN", raising=False)
         monkeypatch.delenv("MULTICA_WORKSPACE_ID", raising=False)
@@ -41,5 +45,9 @@ def test_get_multica_client_refreshes_cached_client_when_env_changes(monkeypatch
         assert refreshed._base == "https://multica.example"
         assert refreshed._token == "token-2"
         assert refreshed._workspace == "workspace-2"
+        assert multica_client._cached_self_imp_agent_id is None
+        assert multica_client._cached_self_imp_project_id is None
     finally:
         multica_client._client = original_client
+        multica_client._cached_self_imp_agent_id = original_agent_id
+        multica_client._cached_self_imp_project_id = original_project_id

--- a/services/zoe-data/tests/test_multica_client.py
+++ b/services/zoe-data/tests/test_multica_client.py
@@ -24,15 +24,19 @@ def test_get_multica_client_refreshes_cached_client_when_env_changes(monkeypatch
     original_agent_id = multica_client._cached_self_imp_agent_id
     original_project_id = multica_client._cached_self_imp_project_id
     try:
+        monkeypatch.setenv("MULTICA_BASE_URL", "https://multica.example")
+        monkeypatch.setenv("MULTICA_API_TOKEN", "token-1")
+        monkeypatch.setenv("MULTICA_WORKSPACE_ID", "workspace-1")
         multica_client._client = None
+        stale = multica_client.get_multica_client()
+
+        assert stale.is_configured() is True
+        assert stale._token == "token-1"
+        assert stale._workspace == "workspace-1"
+
+        # Simulate workspace-resource IDs cached for the initial Multica workspace.
         multica_client._cached_self_imp_agent_id = "agent-old"
         multica_client._cached_self_imp_project_id = "project-old"
-        monkeypatch.delenv("MULTICA_BASE_URL", raising=False)
-        monkeypatch.delenv("MULTICA_API_TOKEN", raising=False)
-        monkeypatch.delenv("MULTICA_WORKSPACE_ID", raising=False)
-
-        stale = multica_client.get_multica_client()
-        assert stale.is_configured() is False
 
         monkeypatch.setenv("MULTICA_BASE_URL", "https://multica.example")
         monkeypatch.setenv("MULTICA_API_TOKEN", "token-2")

--- a/services/zoe-data/tests/test_multica_client.py
+++ b/services/zoe-data/tests/test_multica_client.py
@@ -1,0 +1,45 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import multica_client
+
+
+def test_mul_client_reads_env_at_instantiation(monkeypatch):
+    monkeypatch.setenv("MULTICA_BASE_URL", "https://multica.example/")
+    monkeypatch.setenv("MULTICA_API_TOKEN", "token-1")
+    monkeypatch.setenv("MULTICA_WORKSPACE_ID", "workspace-1")
+
+    client = multica_client.MULClient()
+
+    assert client._base == "https://multica.example"
+    assert client._token == "token-1"
+    assert client._workspace == "workspace-1"
+    assert client.is_configured() is True
+
+
+def test_get_multica_client_refreshes_cached_client_when_env_changes(monkeypatch):
+    original_client = multica_client._client
+    try:
+        multica_client._client = None
+        monkeypatch.delenv("MULTICA_BASE_URL", raising=False)
+        monkeypatch.delenv("MULTICA_API_TOKEN", raising=False)
+        monkeypatch.delenv("MULTICA_WORKSPACE_ID", raising=False)
+
+        stale = multica_client.get_multica_client()
+        assert stale.is_configured() is False
+
+        monkeypatch.setenv("MULTICA_BASE_URL", "https://multica.example")
+        monkeypatch.setenv("MULTICA_API_TOKEN", "token-2")
+        monkeypatch.setenv("MULTICA_WORKSPACE_ID", "workspace-2")
+
+        refreshed = multica_client.get_multica_client()
+
+        assert refreshed is not stale
+        assert refreshed.is_configured() is True
+        assert refreshed._base == "https://multica.example"
+        assert refreshed._token == "token-2"
+        assert refreshed._workspace == "workspace-2"
+    finally:
+        multica_client._client = original_client


### PR DESCRIPTION
## Summary
- Read Multica environment configuration when `MULClient` instances are created instead of at module import time.
- Refresh the cached Multica client when relevant environment values change.
- Add regression coverage for delayed env loading and cache refresh behavior.

## Test plan
- `python3 -m pytest services/zoe-data/tests/test_multica_client.py -q`
- `python3 tools/audit/validate_structure.py`
- `python3 tools/audit/validate_critical_files.py`


Made with [Cursor](https://cursor.com)