### PR TITLE
Surface Hermes progress in chat

### DIFF
--- a/services/zoe-data/routers/chat.py
+++ b/services/zoe-data/routers/chat.py
@@ -2466,6 +2466,7 @@ def _hermes_progress_events(event_name: str, payload) -> list:
                 "level": "info",
                 "message": label,
                 "source": "hermes",
+                "phase": "hermes_tool" if tool and tool != "Hermes" else "hermes",
                 "event": event_name,
                 "payload": payload if isinstance(payload, dict) else {"value": payload},
             },
@@ -2515,10 +2516,10 @@ async def _iter_hermes_stream_events(
                         break
                     if sse_event and sse_event != "message":
                         try:
-                            payload = json.loads(data_str)
+                            progress_payload = json.loads(data_str)
                         except json.JSONDecodeError:
-                            payload = {"message": data_str}
-                        yield {"kind": "progress", "event": sse_event, "payload": payload}
+                            progress_payload = {"message": data_str}
+                        yield {"kind": "progress", "event": sse_event, "payload": progress_payload}
                         sse_event = ""
                         continue
                     try:

--- a/services/zoe-data/routers/chat.py
+++ b/services/zoe-data/routers/chat.py
@@ -2522,6 +2522,7 @@ async def _iter_hermes_stream_events(
                         yield {"kind": "progress", "event": sse_event, "payload": progress_payload}
                         sse_event = ""
                         continue
+                    sse_event = ""
                     try:
                         chunk = json.loads(data_str)
                         delta = chunk.get("choices", [{}])[0].get("delta", {})

--- a/services/zoe-data/routers/chat.py
+++ b/services/zoe-data/routers/chat.py
@@ -1527,7 +1527,7 @@ async def chat_stream_generator(
                 )
             )
             response_text = ""
-            async for token in _iter_hermes_text_chunks(
+            async for hermes_event in _iter_hermes_stream_events(
                 message_for_processing,
                 session_id,
                 user_id,
@@ -1535,6 +1535,14 @@ async def chat_stream_generator(
                 portrait=_h_portrait,
                 facts=_h_combined_facts,
             ):
+                if hermes_event.get("kind") == "progress":
+                    for progress_event in _hermes_progress_events(
+                        hermes_event.get("event", "hermes.progress"),
+                        hermes_event.get("payload", {}),
+                    ):
+                        yield emit(progress_event)
+                    continue
+                token = hermes_event.get("text", "")
                 response_text += token
                 yield emit(
                     TextMessageChunkEvent(
@@ -2125,7 +2133,7 @@ async def chat_stream_generator(
                             )
                         )
                         response_text = full_response
-                        async for token in _iter_hermes_text_chunks(
+                        async for hermes_event in _iter_hermes_stream_events(
                             oc_task_text,
                             session_id,
                             user_id,
@@ -2133,6 +2141,14 @@ async def chat_stream_generator(
                             portrait=pi_portrait or "",
                             facts=pi_db_memory or "",
                         ):
+                            if hermes_event.get("kind") == "progress":
+                                for progress_event in _hermes_progress_events(
+                                    hermes_event.get("event", "hermes.progress"),
+                                    hermes_event.get("payload", {}),
+                                ):
+                                    yield emit(progress_event)
+                                continue
+                            token = hermes_event.get("text", "")
                             response_text += token
                             yield recorder.emit(
                                 enc,
@@ -2408,7 +2424,56 @@ def _build_hermes_payload(
     )
 
 
-async def _iter_hermes_text_chunks(
+def _hermes_progress_message(event_name: str, payload) -> tuple[str, str]:
+    if not isinstance(payload, dict):
+        text = str(payload or event_name)
+        return "Hermes", text
+    tool = (
+        payload.get("tool")
+        or payload.get("tool_name")
+        or payload.get("name")
+        or payload.get("skill")
+        or "Hermes"
+    )
+    detail = (
+        payload.get("message")
+        or payload.get("detail")
+        or payload.get("status")
+        or payload.get("phase")
+        or payload.get("step")
+        or event_name
+    )
+    return str(tool), str(detail)
+
+
+def _hermes_progress_events(event_name: str, payload) -> list:
+    tool, detail = _hermes_progress_message(event_name, payload)
+    label = f"{tool}: {detail}" if tool and tool != "Hermes" else detail
+    return [
+        StateSnapshotEvent(
+            type=EventType.STATE_SNAPSHOT,
+            snapshot={
+                "status": "generating",
+                "phase": "hermes_tool" if tool and tool != "Hermes" else "hermes",
+                "model": "Hermes Agent",
+                "detail": label,
+                "event": event_name,
+            },
+        ),
+        CustomEvent(
+            name="zoe.run_log",
+            value={
+                "level": "info",
+                "message": label,
+                "source": "hermes",
+                "event": event_name,
+                "payload": payload if isinstance(payload, dict) else {"value": payload},
+            },
+        ),
+    ]
+
+
+async def _iter_hermes_stream_events(
     message: str,
     session_id: str,
     user_id: str,
@@ -2417,7 +2482,7 @@ async def _iter_hermes_text_chunks(
     portrait: str = "",
     facts: str = "",
 ):
-    """Yield Hermes text tokens only; callers own AG-UI lifecycle and persistence."""
+    """Yield Hermes stream events; callers own AG-UI lifecycle and persistence."""
     import aiohttp
 
     full_text: list[str] = []
@@ -2437,13 +2502,25 @@ async def _iter_hermes_text_chunks(
                 json=payload,
                 timeout=aiohttp.ClientTimeout(total=120),
             ) as resp:
+                sse_event = ""
                 async for raw_line in resp.content:
                     line = raw_line.decode("utf-8", errors="replace").strip()
+                    if line.startswith("event:"):
+                        sse_event = line[6:].strip()
+                        continue
                     if not line.startswith("data:"):
                         continue
                     data_str = line[5:].strip()
                     if data_str == "[DONE]":
                         break
+                    if sse_event and sse_event != "message":
+                        try:
+                            payload = json.loads(data_str)
+                        except json.JSONDecodeError:
+                            payload = {"message": data_str}
+                        yield {"kind": "progress", "event": sse_event, "payload": payload}
+                        sse_event = ""
+                        continue
                     try:
                         chunk = json.loads(data_str)
                         delta = chunk.get("choices", [{}])[0].get("delta", {})
@@ -2452,12 +2529,12 @@ async def _iter_hermes_text_chunks(
                         continue
                     if token:
                         full_text.append(token)
-                        yield token
+                        yield {"kind": "token", "text": token}
     except Exception as exc:
         _hermes_error = True
         error_token = f"\n\n*[Hermes Agent error: {exc}]*"
         full_text.append(error_token)
-        yield error_token
+        yield {"kind": "token", "text": error_token}
     finally:
         # Log to llm_call_log so evolution_notice can include Hermes in health checks.
         # latency_ms < 0 is used as the error signal by evolution_notice.py.
@@ -2485,6 +2562,28 @@ async def _iter_hermes_text_chunks(
                 pass
 
         asyncio.ensure_future(_log_hermes_call())
+
+
+async def _iter_hermes_text_chunks(
+    message: str,
+    session_id: str,
+    user_id: str,
+    *,
+    username: str = "",
+    portrait: str = "",
+    facts: str = "",
+):
+    """Yield Hermes text tokens only; callers own AG-UI lifecycle and persistence."""
+    async for event in _iter_hermes_stream_events(
+        message,
+        session_id,
+        user_id,
+        username=username,
+        portrait=portrait,
+        facts=facts,
+    ):
+        if event.get("kind") == "token":
+            yield event.get("text", "")
 
 def _load_zoe_self_compact_for_chat() -> str:
     """Load compact Zoe self-description from file; falls back to empty string."""
@@ -2551,7 +2650,7 @@ async def _hermes_stream_generator(
     yield recorder.emit(enc, TextMessageStartEvent(type=EventType.TEXT_MESSAGE_START, message_id=assistant_message_id, role="assistant"))
 
     full_text = []
-    async for token in _iter_hermes_text_chunks(
+    async for hermes_event in _iter_hermes_stream_events(
         message,
         session_id,
         user_id,
@@ -2559,6 +2658,14 @@ async def _hermes_stream_generator(
         portrait=portrait,
         facts=facts,
     ):
+        if hermes_event.get("kind") == "progress":
+            for progress_event in _hermes_progress_events(
+                hermes_event.get("event", "hermes.progress"),
+                hermes_event.get("payload", {}),
+            ):
+                yield recorder.emit(enc, progress_event)
+            continue
+        token = hermes_event.get("text", "")
         full_text.append(token)
         yield recorder.emit(enc, TextMessageChunkEvent(
             type=EventType.TEXT_MESSAGE_CHUNK,

--- a/services/zoe-data/tests/test_hermes_routing.py
+++ b/services/zoe-data/tests/test_hermes_routing.py
@@ -154,9 +154,9 @@ async def test_force_hermes_uses_single_chat_run_and_persists_once(monkeypatch):
     async def fake_empty(*args, **kwargs):
         return ""
 
-    async def fake_hermes_tokens(*args, **kwargs):
-        yield "Hermes "
-        yield "answer"
+    async def fake_hermes_events(*args, **kwargs):
+        yield {"kind": "token", "text": "Hermes "}
+        yield {"kind": "token", "text": "answer"}
 
     async def fake_persist(user_id, session_id, user_text, assistant_text):
         persisted_candidates.append((user_id, session_id, user_text, assistant_text))
@@ -168,7 +168,7 @@ async def test_force_hermes_uses_single_chat_run_and_persists_once(monkeypatch):
     monkeypatch.setattr(chat_router, "_safe_load_portrait", fake_empty)
     monkeypatch.setattr(chat_router, "_mempalace_load_user_facts", fake_empty)
     monkeypatch.setattr(chat_router, "_build_memory_context", fake_empty)
-    monkeypatch.setattr(chat_router, "_iter_hermes_text_chunks", fake_hermes_tokens)
+    monkeypatch.setattr(chat_router, "_iter_hermes_stream_events", fake_hermes_events)
     monkeypatch.setattr(chat_router, "_record_run_state", fake_record_run_state)
     monkeypatch.setattr(chat_router, "_persist_ag_ui_run", fake_persist_agui)
     monkeypatch.setattr(chat_router, "_persist_memory_candidates", fake_persist)
@@ -208,6 +208,59 @@ async def test_force_hermes_uses_single_chat_run_and_persists_once(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_force_hermes_surfaces_progress_events(monkeypatch):
+    async def fake_empty(*args, **kwargs):
+        return ""
+
+    async def fake_record_run_state(*args, **kwargs):
+        return None
+
+    async def fake_hermes_events(*args, **kwargs):
+        yield {
+            "kind": "progress",
+            "event": "hermes.tool.progress",
+            "payload": {"tool": "browser", "message": "Opening docs"},
+        }
+        yield {"kind": "token", "text": "Done"}
+
+    monkeypatch.setattr(chat_router, "_ensure_user_and_chat_session", fake_empty)
+    monkeypatch.setattr(chat_router, "_save_chat_message", fake_empty)
+    monkeypatch.setattr(chat_router, "_check_frustration", lambda *_, **__: None)
+    monkeypatch.setattr(chat_router, "_GUARDED_AUTO", False)
+    monkeypatch.setattr(chat_router, "_safe_load_portrait", fake_empty)
+    monkeypatch.setattr(chat_router, "_mempalace_load_user_facts", fake_empty)
+    monkeypatch.setattr(chat_router, "_build_memory_context", fake_empty)
+    monkeypatch.setattr(chat_router, "_iter_hermes_stream_events", fake_hermes_events)
+    monkeypatch.setattr(chat_router, "_record_run_state", fake_record_run_state)
+    monkeypatch.setattr(chat_router, "_persist_ag_ui_run", fake_empty)
+    monkeypatch.setattr(chat_router, "_persist_memory_candidates", fake_empty)
+
+    blocks = [
+        block
+        async for block in chat_router.chat_stream_generator(
+            "talk to hermes",
+            "session-hermes-progress",
+            {"user_id": "user-1", "username": "Zoe"},
+            force_agent="hermes",
+        )
+    ]
+
+    events = _decode_agui_events(blocks)
+    assert any(
+        event["type"] == "STATE_SNAPSHOT"
+        and event.get("snapshot", {}).get("phase") == "hermes_tool"
+        and event.get("snapshot", {}).get("detail") == "browser: Opening docs"
+        for event in events
+    )
+    assert any(
+        event["type"] == "CUSTOM"
+        and event.get("name") == "zoe.run_log"
+        and event.get("value", {}).get("source") == "hermes"
+        for event in events
+    )
+
+
+@pytest.mark.asyncio
 async def test_force_hermes_error_records_hermes_mode(monkeypatch):
     recorded_runs = []
     agui_runs = []
@@ -218,9 +271,9 @@ async def test_force_hermes_error_records_hermes_mode(monkeypatch):
     async def fake_empty(*args, **kwargs):
         return ""
 
-    async def fake_hermes_tokens(*args, **kwargs):
+    async def fake_hermes_events(*args, **kwargs):
         raise RuntimeError("hermes down")
-        yield ""
+        yield {}
 
     async def fake_persist_agui(session_id, run_id, events):
         agui_runs.append((session_id, run_id, events))
@@ -232,7 +285,7 @@ async def test_force_hermes_error_records_hermes_mode(monkeypatch):
     monkeypatch.setattr(chat_router, "_safe_load_portrait", fake_empty)
     monkeypatch.setattr(chat_router, "_mempalace_load_user_facts", fake_empty)
     monkeypatch.setattr(chat_router, "_build_memory_context", fake_empty)
-    monkeypatch.setattr(chat_router, "_iter_hermes_text_chunks", fake_hermes_tokens)
+    monkeypatch.setattr(chat_router, "_iter_hermes_stream_events", fake_hermes_events)
     monkeypatch.setattr(chat_router, "_record_run_state", fake_record_run_state)
     monkeypatch.setattr(chat_router, "_persist_ag_ui_run", fake_persist_agui)
 
@@ -309,9 +362,9 @@ async def test_zoe_agent_hermes_escalation_stays_in_parent_agui_run(monkeypatch)
     async def fake_zoe_stream(*args, **kwargs):
         yield "__ESCALATE_HERMES__:deep work|Hermes task"
 
-    async def fake_hermes_tokens(*args, **kwargs):
-        yield "Deep "
-        yield "answer"
+    async def fake_hermes_events(*args, **kwargs):
+        yield {"kind": "token", "text": "Deep "}
+        yield {"kind": "token", "text": "answer"}
 
     async def fake_persist(user_id, session_id, user_text, assistant_text):
         persisted_candidates.append((user_id, session_id, user_text, assistant_text))
@@ -326,7 +379,7 @@ async def test_zoe_agent_hermes_escalation_stays_in_parent_agui_run(monkeypatch)
     monkeypatch.setattr(chat_router, "_mempalace_load_user_facts", fake_empty)
     monkeypatch.setattr(chat_router, "_safe_load_portrait", fake_empty)
     monkeypatch.setattr(chat_router, "run_zoe_agent_streaming", fake_zoe_stream)
-    monkeypatch.setattr(chat_router, "_iter_hermes_text_chunks", fake_hermes_tokens)
+    monkeypatch.setattr(chat_router, "_iter_hermes_stream_events", fake_hermes_events)
     monkeypatch.setattr(chat_router, "_record_run_state", fake_record_run_state)
     monkeypatch.setattr(chat_router, "_persist_ag_ui_run", fake_persist_agui)
     monkeypatch.setattr(chat_router, "_persist_memory_candidates", fake_persist)

--- a/services/zoe-ui/dist/chat.html
+++ b/services/zoe-ui/dist/chat.html
@@ -2962,7 +2962,7 @@
             if (t === 'CUSTOM' && data.name === 'zoe.run_log') {
                 const v = data.value || {};
                 const msg = String(v.message || '');
-                if (v.source === 'hermes' && !v.phase) showAgentPanel('Hermes Agent');
+                // Hermes agent-panel activation is handled by the paired STATE_SNAPSHOT.
 
                 // Always update the thinking indicator text
                 if (thinkingIndicator && thinkingIndicator.parentNode && msg) {

--- a/services/zoe-ui/dist/chat.html
+++ b/services/zoe-ui/dist/chat.html
@@ -2962,7 +2962,7 @@
             if (t === 'CUSTOM' && data.name === 'zoe.run_log') {
                 const v = data.value || {};
                 const msg = String(v.message || '');
-                if (v.source === 'hermes') showAgentPanel('Hermes Agent');
+                if (v.source === 'hermes' && !v.phase) showAgentPanel('Hermes Agent');
 
                 // Always update the thinking indicator text
                 if (thinkingIndicator && thinkingIndicator.parentNode && msg) {

--- a/services/zoe-ui/dist/chat.html
+++ b/services/zoe-ui/dist/chat.html
@@ -2962,6 +2962,7 @@
             if (t === 'CUSTOM' && data.name === 'zoe.run_log') {
                 const v = data.value || {};
                 const msg = String(v.message || '');
+                if (v.source === 'hermes') showAgentPanel('Hermes Agent');
 
                 // Always update the thinking indicator text
                 if (thinkingIndicator && thinkingIndicator.parentNode && msg) {
@@ -3023,24 +3024,27 @@
                         const phase = snap.phase ? String(snap.phase) : '';
                         if (detail) {
                             el.textContent = detail;
-                        } else if (phase === 'openclaw') {
-                            el.textContent = 'OpenClaw: ' + (snap.model || 'agent') + '…';
+                        } else if (phase === 'openclaw' || phase === 'hermes' || phase === 'hermes_tool') {
+                            const label = phase === 'openclaw' ? 'OpenClaw' : 'Hermes';
+                            el.textContent = label + ': ' + (snap.model || 'agent') + '…';
                         } else {
                             el.textContent = 'Zoe is typing… (' + (snap.model || 'AI') + ')';
                         }
                     }
                     // Update banner detail from snapshot — don't open toolTraceEl while banner is active
-                    if (snap.phase === 'openclaw' && ctx.toolTraceEl && !ctx.longRun?.started) {
+                    if ((snap.phase === 'openclaw' || snap.phase === 'hermes_tool') && ctx.toolTraceEl && !ctx.longRun?.started) {
                         ensureTraceDisclosure(ctx);
                         ctx.toolTraceEl.style.display = 'flex';
                     }
-                    // Only show agent panel for tool-calling (openclaw) runs
-                    if (snap.phase === 'openclaw') {
-                        showAgentPanel(snap.model || 'OpenClaw');
+                    const isAgentPhase = snap.phase === 'openclaw' || snap.phase === 'hermes' || snap.phase === 'hermes_tool';
+                    if (isAgentPhase) {
+                        showAgentPanel(snap.model || (snap.phase === 'openclaw' ? 'OpenClaw' : 'Hermes Agent'));
                         const liveDetail = snap.detail
                             ? String(snap.detail)
-                            : 'Zoe is using the agent system (OpenClaw) to fulfil this request. Complex tasks like building widgets, pages, or new skills can take 1–3 minutes. You can cancel at any time.';
-                        showLongRunNotice(ctx, { detail: liveDetail });
+                            : 'Zoe is using the agent system to fulfil this request. Complex tasks can take 1–3 minutes. You can cancel at any time.';
+                        if (snap.phase === 'openclaw' || snap.phase === 'hermes_tool') {
+                            showLongRunNotice(ctx, { detail: liveDetail });
+                        }
                     } else if (snap.status === 'generating') {
                         // Non-openclaw phases: only surface the tile if we've
                         // been waiting a while (>20s) — small talk shouldn't

--- a/services/zoe-ui/dist/sw.js
+++ b/services/zoe-ui/dist/sw.js
@@ -8,7 +8,7 @@
 importScripts('https://storage.googleapis.com/workbox-cdn/releases/7.0.0/workbox-sw.js');
 
 // Zoe UI Version 4.17.3 - public modules (with or without trailing path segment)
-const SW_VERSION = '4.63.3'; // address premium chat trace review notes
+const SW_VERSION = '4.63.4'; // surface Hermes progress in chat traces
 const CACHE_NAME = `zoe-ui-v${SW_VERSION}`;
 
 // Verify Workbox loaded

--- a/services/zoe-ui/dist/sw.js
+++ b/services/zoe-ui/dist/sw.js
@@ -8,7 +8,7 @@
 importScripts('https://storage.googleapis.com/workbox-cdn/releases/7.0.0/workbox-sw.js');
 
 // Zoe UI Version 4.17.3 - public modules (with or without trailing path segment)
-const SW_VERSION = '4.63.4'; // surface Hermes progress in chat traces
+const SW_VERSION = '4.63.5'; // avoid duplicate Hermes panel activation
 const CACHE_NAME = `zoe-ui-v${SW_VERSION}`;
 
 // Verify Workbox loaded

--- a/services/zoe-ui/dist/sw.js
+++ b/services/zoe-ui/dist/sw.js
@@ -8,7 +8,7 @@
 importScripts('https://storage.googleapis.com/workbox-cdn/releases/7.0.0/workbox-sw.js');
 
 // Zoe UI Version 4.17.3 - public modules (with or without trailing path segment)
-const SW_VERSION = '4.63.5'; // avoid duplicate Hermes panel activation
+const SW_VERSION = '4.63.6'; // tighten Hermes progress trace handling
 const CACHE_NAME = `zoe-ui-v${SW_VERSION}`;
 
 // Verify Workbox loaded

--- a/services/zoe-ui/dist/touch/chat.html
+++ b/services/zoe-ui/dist/touch/chat.html
@@ -2562,7 +2562,7 @@
             }
             if (t === 'CUSTOM' && data.name === 'zoe.run_log') {
                 const v = data.value || {};
-                if (v.source === 'hermes' && !v.phase) showAgentPanel('Hermes Agent');
+                // Hermes agent-panel activation is handled by the paired STATE_SNAPSHOT.
                 if (thinkingIndicator && thinkingIndicator.parentNode && v.message) {
                     const tx = thinkingIndicator.querySelector('span:last-child');
                     if (tx) tx.textContent = String(v.message);

--- a/services/zoe-ui/dist/touch/chat.html
+++ b/services/zoe-ui/dist/touch/chat.html
@@ -2562,6 +2562,7 @@
             }
             if (t === 'CUSTOM' && data.name === 'zoe.run_log') {
                 const v = data.value || {};
+                if (v.source === 'hermes') showAgentPanel('Hermes Agent');
                 if (thinkingIndicator && thinkingIndicator.parentNode && v.message) {
                     const tx = thinkingIndicator.querySelector('span:last-child');
                     if (tx) tx.textContent = String(v.message);
@@ -2603,19 +2604,20 @@
                         const phase = snap.phase ? String(snap.phase) : '';
                         if (detail) {
                             el.textContent = detail;
-                        } else if (phase === 'openclaw') {
-                            el.textContent = 'OpenClaw: ' + (snap.model || 'agent') + '…';
+                        } else if (phase === 'openclaw' || phase === 'hermes' || phase === 'hermes_tool') {
+                            const label = phase === 'openclaw' ? 'OpenClaw' : 'Hermes';
+                            el.textContent = label + ': ' + (snap.model || 'agent') + '…';
                         } else {
                             el.textContent = 'Zoe is typing… (' + (snap.model || 'AI') + ')';
                         }
                     }
-                    if (snap.phase === 'openclaw' && ctx.toolTraceEl) {
+                    if ((snap.phase === 'openclaw' || snap.phase === 'hermes_tool') && ctx.toolTraceEl) {
                         ensureTraceDisclosure(ctx);
                         ctx.toolTraceEl.style.display = 'flex';
                     }
-                    // Only show agent panel for tool-calling (openclaw) runs
-                    if (snap.phase === 'openclaw') {
-                        showAgentPanel(snap.model || 'OpenClaw');
+                    const isAgentPhase = snap.phase === 'openclaw' || snap.phase === 'hermes' || snap.phase === 'hermes_tool';
+                    if (isAgentPhase) {
+                        showAgentPanel(snap.model || (snap.phase === 'openclaw' ? 'OpenClaw' : 'Hermes Agent'));
                     }
                 }
                 return;

--- a/services/zoe-ui/dist/touch/chat.html
+++ b/services/zoe-ui/dist/touch/chat.html
@@ -2562,7 +2562,7 @@
             }
             if (t === 'CUSTOM' && data.name === 'zoe.run_log') {
                 const v = data.value || {};
-                if (v.source === 'hermes') showAgentPanel('Hermes Agent');
+                if (v.source === 'hermes' && !v.phase) showAgentPanel('Hermes Agent');
                 if (thinkingIndicator && thinkingIndicator.parentNode && v.message) {
                     const tx = thinkingIndicator.querySelector('span:last-child');
                     if (tx) tx.textContent = String(v.message);


### PR DESCRIPTION
## Summary
- parses Hermes SSE progress events and maps them into AG-UI `STATE_SNAPSHOT` and `zoe.run_log` events
- updates desktop and touch chat to show Hermes/Hermes-tool phases in the existing Active and Details UI
- bumps the service worker version so cached chat UI picks up the change

## Test plan
- `python3 -m pytest services/zoe-data/tests/test_hermes_routing.py services/zoe-data/tests/test_ag_ui_chat_contract.py -q`
- `python3 -m py_compile services/zoe-data/routers/chat.py services/zoe-data/tests/test_hermes_routing.py`
- inline `node --check` for `services/zoe-ui/dist/chat.html` and `services/zoe-ui/dist/touch/chat.html`
- `python3 tools/audit/validate_structure.py`
- `python3 tools/audit/validate_critical_files.py`


Made with [Cursor](https://cursor.com)