### PR TITLE
fix: add bounded Greploop guard workflow

### DIFF
--- a/.cursor/rules/agentic-workflow.mdc
+++ b/.cursor/rules/agentic-workflow.mdc
@@ -17,7 +17,7 @@ Build the minimal working feature first. After it works, run a cleanup pass for 
 
 For Hermes-backed engineering work, prefer the local Hermes skills `zoe-engineering`, `source-code-context`, `code-structure-cleanup`, `github-greptile-loop`, `zoe-graphify`, and `zoe-status-refresh` when available. These are operator-level Hermes skills under `~/.hermes/skills`, not Zoe runtime user-facing skills.
 
-Use the small-PR loop for reviewable work: split large changes, push a focused PR, let Greptile review independently, then use **Greptile MCP first** (`get_merge_request`, `list_merge_request_comments`, `trigger_code_review`) or the operator-local CLI `~/bin/greptile-mcp.py` (install path varies by host; see `/grep-loop`) before falling back to `gh` scraping or Hermes.
+Use the small-PR loop for reviewable work: split large changes, push a focused PR, let Greptile review independently, then use Zoe's Greploop guard when an engineering task id exists. Otherwise use **Greptile MCP first** (`get_merge_request`, `list_merge_request_comments`, `trigger_code_review`) or the operator-local CLI `~/bin/greptile-mcp.py` (install path varies by host; see Cursor `/grep-loop`) before falling back to `gh` scraping. For heavier repair loops, delegate to Hermes `github-greptile-loop`. Read the PR diff before fixing comments and stop to split if the PR is too large for reliable review.
 
 `main` is protected. Do not push directly, bypass branch protection, or use administrator merges unless the operator explicitly asks for that emergency path. If GitHub blocks a green PR because repo auto-merge is disabled or another policy requires human action, report the blocker and keep the PR ready rather than forcing it.
 

--- a/.cursor/rules/session-bootstrap.mdc
+++ b/.cursor/rules/session-bootstrap.mdc
@@ -1,0 +1,17 @@
+---
+description: Mechanical preflight for non-trivial Zoe engineering sessions
+alwaysApply: true
+---
+
+# Session Bootstrap
+
+Before non-trivial edits, report the mechanical state in a short preflight:
+
+- repo root, branch, remote, and dirty files;
+- relevant stack/key files for the task;
+- deploy or runtime path affected, if any;
+- tracker state when relevant: Multica, GitHub PR, Linear, or issue id;
+- tool availability when relevant: Graphify, Greptile MCP/CLI, `gh`, validators, Hermes;
+- risks, missing context, and whether the task should be split.
+
+For tiny one-line edits, use judgment. For PR repair, prefer Zoe's Greploop guard before broad expensive-agent repair. Cheap models must receive one validated packet at a time, never a broad "fix the PR" task.

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -87,6 +87,8 @@ jobs:
             services/zoe-data/tests/test_voice_scope.py \
             services/zoe-data/tests/test_chat_session_title.py \
             services/zoe-data/tests/test_ui_orchestrator_types.py \
+            services/zoe-data/tests/test_greptile_client.py \
+            services/zoe-data/tests/test_greploop_guard.py \
             -x -q \
             --override-ini="asyncio_mode=auto"
           PYTHONPATH="${{ github.workspace }}/services/zoe-auth:${{ github.workspace }}/services/zoe-auth/tests" pytest \

--- a/.gitignore
+++ b/.gitignore
@@ -260,3 +260,4 @@ graphify-out/manifest.json
 graphify-out/cost.json
 graphify-out/cache/
 !.cursor/mcp.json
+.cursor/tmp/

--- a/.greptile/rules.md
+++ b/.greptile/rules.md
@@ -7,6 +7,7 @@ Greptile should review Zoe as a local-first, multi-user assistant with a host-ru
 - Find correctness, security, data-loss, privacy, and user-facing regressions before style nits.
 - Call out missing tests when the change touches routing, memory, database writes, auth, agent delegation, voice, or AG-UI behavior.
 - Prefer small, surgical fixes that match existing Zoe patterns.
+- Flag PRs that are too large or bundle unrelated product decisions; recommend splitting before deep review.
 - Do not suggest parallel `_new`, `_old`, `_fixed`, or backup files.
 - Treat hardcoded absolute paths outside approved Zoe roots as portability risks unless they are documented local operator paths.
 - Zoe uses a PR-first workflow with protected `main`; do not recommend direct pushes, admin bypasses, or force pushes as normal fixes.
@@ -37,3 +38,11 @@ For new user-facing features, check for:
 ## Graphify And Context
 
 Use `graphify-out/GRAPH_REPORT.md` as map context when fresh, but treat it as stale if its "Built from commit" differs from `git rev-parse HEAD`. Do not ask contributors to run `graphify update .` or install Graphify hooks; this repo uses the safe full extract and `cluster-only . --no-viz` report-refresh commands documented in `.cursor/rules/graphify.mdc`.
+
+For SDK, framework, MCP, or package integrations, expect the implementation to be checked against `opensrc` or upstream source before relying on uncertain docs. Call out guessed APIs, unexplained replacement dependencies, or new packages less than 14 days old without explicit operator approval.
+
+## Code Structure Cleanup
+
+After feature work, flag duplicated runtime mechanics that should live in a service-layer helper: repeated provider calls, command execution, parsing, validation, payload transforms, or readiness/retry mechanics. Keep domain policy in routes, actions, intents, or UI handlers.
+
+Service helpers should use explicit parameters, structured returns, consistent error semantics, and avoid hidden global state or unrelated database mutation.

--- a/.zoe/AI_ASSISTANT_CHECKLIST.md
+++ b/.zoe/AI_ASSISTANT_CHECKLIST.md
@@ -69,6 +69,13 @@
 
 ## 🔧 BEFORE CODE CHANGES
 
+### Agentic Engineering Loop
+- [ ] Keep the task small: one feature, one fix, or one reviewable unit
+- [ ] Search existing Zoe code before creating new abstractions
+- [ ] For uncertain package/SDK/framework APIs, use `opensrc` or upstream source before guessing
+- [ ] Build the minimal working version first; do not mix broad refactors into the feature pass
+- [ ] If the work is too large for one PR, split it before implementation
+
 ### Architecture Rules
 - [ ] Single source of truth (no duplicates)
 - [ ] Use intelligent systems (don't replace them)
@@ -87,6 +94,15 @@
 - [ ] User isolation enforced
 
 ## ✅ AFTER MAKING CHANGES
+
+### Agentic Workflow Checks:
+1. [ ] Feature or fix works locally, or blocker is clearly stated
+2. [ ] Cleanup pass checked for duplicated runtime mechanics
+3. [ ] Repeated provider calls, parsing, validation, command execution, or payload transforms were moved to service-layer helpers where appropriate
+4. [ ] Domain policy stayed in routes, actions, intents, or UI handlers
+5. [ ] For package integrations, source files/examples referenced during implementation are named in the summary
+6. [ ] Mergeable work is prepared as a small PR and sent through Greptile/review loop when appropriate
+7. [ ] Cheap-model PR repair uses a generated guard packet, never a broad "fix the PR" prompt
 
 ### Validation Steps:
 1. [ ] Run: `python3 tools/audit/validate_structure.py`
@@ -142,6 +158,9 @@ ls -1 *.md | wc -l
 - Creating prohibited patterns
 - Hardcoding database paths
 - Removing authentication from endpoints
+- Huge or unclear PR that should be split before review
+- Agent is guessing package APIs instead of checking source
+- Cleanup pass is turning into a whole-app refactor
 
 ## 📖 REFERENCE DOCS
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@ Rules:
 - Prefer `opensrc path pypi:<package>` or `opensrc path owner/repo` to locate already-fetched source.
 - Search package source directly when debugging integrations, for example:
   `rg "class FastAPI" "$(opensrc path pypi:fastapi)"`
+- When source context informs an implementation, report the package files, examples, or tests that were used.
 - Do not vendor opensrc cache contents into Zoe.
 - Be cautious with brand-new dependencies; avoid adopting packages less than about 14 days old unless the user explicitly accepts the risk.
 
@@ -32,6 +33,8 @@ Build the smallest working feature first, then run a cleanup pass before review.
 
 Use the cleanup pass to remove duplicated runtime mechanics: repeated provider calls, parsing, validation, command execution, payload transforms, or business logic. Keep product/domain policy in routes, actions, intents, and UI handlers. Move only reusable mechanics into service-layer helpers.
 
+Service helpers should be small capability blocks with explicit parameters, structured returns, consistent failure semantics, and no hidden global state or unrelated database mutation.
+
 Do not refactor the whole app as cleanup. Do not create `_new`, `_fixed`, `_v2`, `_old`, backup, or duplicate router files.
 
 ## Greptile PR loop
@@ -41,6 +44,8 @@ For reviewable development work:
 - Do not bypass branch protection or use administrator merges unless the operator explicitly asks for that emergency path.
 - Keep PRs small; use `/split-to-prs` when a branch grows too large.
 - Let Greptile review every PR independently.
+- For Zoe engineering tasks, prefer `scripts/maintenance/greploop_guard.py --packet-only` or `--once` before broad expensive-agent repair.
+- Cheap models must receive one generated fix packet for one finding or CI failure; never hand them the whole PR.
 - Use Cursor's Greptile MCP to fetch review status/comments.
 - Use the `github-greptile-loop` Hermes skill to delegate heavier fix/re-review loops.
 - Do not treat Greptile as a replacement for local Zoe verification; run focused tests and live health checks before marking work merge-ready.
@@ -53,6 +58,8 @@ The tracked Cursor MCP config intentionally includes only non-secret local serve
 
 Hermes is Zoe's default engineering and browser agent. Use it for planning, code review, implementation repair, architecture analysis, Greptile loops, Graphify-guided codebase work, Multica board repair, generated knowledge refresh, and browser work through Zoe's CloakBrowser tools.
 
-Local Zoe Hermes engineering skills live under `~/.hermes/skills`, including `zoe-engineering`, `source-code-context`, `code-structure-cleanup`, `github-greptile-loop`, `zoe-graphify`, and `zoe-status-refresh`. They are operator-level Hermes skills, not user-facing Zoe runtime skills under `skills/`.
+Local Zoe Hermes engineering skills live under `~/.hermes/skills`, including `zoe-engineering`, `agentic-engineering-workflow`, `source-code-context`, `code-structure-cleanup`, `github-greptile-loop`, `grep-loop-review-workflow`, `zoe-graphify`, and `zoe-status-refresh`. They are operator-level Hermes skills, not user-facing Zoe runtime skills under `skills/`.
+
+The `agentic-engineering-workflow` and `grep-loop-review-workflow` names are kept as compatibility entrypoints for the Micky-style workflow pack, but they map onto Zoe's Hermes-first Graphify/opensrc/Greptile process rather than introducing a second parallel system.
 
 OpenClaw remains installed and available as a future/manual fallback. Do not route ordinary coding, planning, review, board work, browser work, or background work to OpenClaw by default; Hermes owns those paths unless the user explicitly asks to use OpenClaw.

--- a/docs/governance/ZOE_DESIGN_PRINCIPLES.md
+++ b/docs/governance/ZOE_DESIGN_PRINCIPLES.md
@@ -139,10 +139,10 @@ These bias toward caution on non-trivial work. For typo fixes and one-liners, us
 - Harness engineering overview (video): <https://www.youtube.com/watch?v=Xxuxg8PcBvc>.
 - Papers: <https://arxiv.org/abs/2603.25723>, <https://arxiv.org/abs/2603.28052v1>.
 - Related governance: `docs/governance/CRITICAL_FILES.md`, `docs/governance/DOCKER_NETWORKING_RULES.md`, `docs/governance/CLEANUP_SAFETY.md`, `docs/governance/MANIFEST_SYSTEM.md`.
-- Enforceable rule mirror: `.cursorrules` (root).
+- Enforceable rule mirrors: `.cursor/rules/*.mdc` plus legacy `.cursorrules` for older tools.
 
 ---
 
 ## Amendment process
 
-This charter is amended via a PR that (a) edits this file, (b) updates `.cursorrules` if an enforceable rule changes, and (c) states in the commit message which section was amended and why. Silent code changes must not answer an open question in section 7; either answer the question here first, or keep the code neutral.
+This charter is amended via a PR that (a) edits this file, (b) updates the relevant `.cursor/rules/*.mdc` file and legacy `.cursorrules` mirror if an enforceable rule changes, and (c) states in the commit message which section was amended and why. Silent code changes must not answer an open question in section 7; either answer the question here first, or keep the code neutral.

--- a/docs/guides/CURSOR_BEST_PRACTICES.md
+++ b/docs/guides/CURSOR_BEST_PRACTICES.md
@@ -28,7 +28,7 @@ For architecture or cross-module questions, start with Graphify. If the graph is
 7. Verify with focused tests and Zoe validators.
 8. Use a small PR and Greptile review loop for mergeable work.
 
-Keep domain policy in routes, actions, intents, and UI handlers. Move only reusable mechanics into service-layer helpers.
+Keep domain policy in routes, actions, intents, and UI handlers. Move only reusable mechanics into service-layer helpers. Service helpers should use explicit parameters, structured returns, consistent failure semantics, and avoid hidden global state or unrelated database mutation.
 
 ## Source Context
 
@@ -42,6 +42,8 @@ opensrc path owner/repo
 Keep external source caches outside the repo under `~/.opensrc/repos/`. Do not vendor reference repos into `/home/zoe/assistant`.
 
 Avoid adding dependencies younger than 14 days unless the operator explicitly approves the risk.
+
+When source context informs an implementation, name the package files, examples, or tests used in the final summary.
 
 ## Hermes And Skills
 
@@ -69,8 +71,10 @@ For reviewable changes:
 3. Push a focused PR against `main`.
 4. Let Greptile review independently.
 5. Use Greptile MCP first, or `~/bin/greptile-mcp.py` (install path varies by host; see `/grep-loop`) if MCP tools are unavailable.
-6. Fix real correctness, security, data-loss, behavior, or test findings.
-7. Re-run focused tests and trigger Greptile re-review.
+6. For Zoe engineering tasks, run `python3 scripts/maintenance/greploop_guard.py --task-id <id> --packet-only` before broad expensive-agent repair.
+7. Read the PR diff first; if it is too large or bundled, split before running the loop.
+8. Fix real correctness, security, data-loss, behavior, or test findings.
+9. Re-run focused tests and trigger Greptile re-review.
 
 Do not push directly to `main`, bypass branch protection, or force-push protected branches.
 

--- a/docs/guides/HERMES_ENGINEERING_SKILLS.md
+++ b/docs/guides/HERMES_ENGINEERING_SKILLS.md
@@ -11,16 +11,16 @@ These are operator-level Hermes skills. They are not Zoe runtime skills under `/
 ## Core Zoe Skills
 
 `zoe-engineering`
-: Default Zoe engineering workflow. It tells Hermes to use Graphify first, use `opensrc` for package source, keep work PR-sized, build the minimal feature first, run cleanup after the feature works, use Greptile, and verify with Zoe validators.
+: Default Zoe engineering workflow and Zoe's local umbrella equivalent of `agentic-engineering-workflow`. It tells Hermes to use Graphify first, use `opensrc` for package source, keep work PR-sized, build the minimal feature first, run cleanup after the feature works, use Greptile, and verify with Zoe validators.
 
 `source-code-context`
 : Use when integrating packages, SDKs, MCP servers, browser tools, or open-source services. It tells Hermes to inspect local source under `~/.opensrc/repos` before guessing APIs.
 
 `code-structure-cleanup`
-: Use after a feature works. It guides Hermes to extract only repeated runtime mechanics into service-layer helpers while keeping domain policy in routes, actions, intents, and UI handlers.
+: Use after a feature works. It guides Hermes to extract only repeated runtime mechanics into service-layer helpers while keeping domain policy in routes, actions, intents, and UI handlers. Service helpers should use explicit parameters, structured returns, consistent failure semantics, and no hidden global state.
 
 `github-greptile-loop`
-: Use for PR review and repair loops. It fetches live Greptile state, fixes real findings, verifies, pushes, and triggers re-review until the PR is clean or a human decision is needed.
+: Use for PR review and repair loops. It fetches live Greptile state, checks whether the PR should be split, uses Zoe's Greploop guard for bounded packet-based repair when available, fixes real findings, verifies, pushes, and triggers re-review until the PR is clean or a human decision is needed.
 
 `zoe-graphify`
 : Use for broad Zoe architecture or cross-module work. It points Hermes at `graphify-out/GRAPH_REPORT.md` and the safe Graphify refresh commands.

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,15 +1,15 @@
-# Graph Report - .  (2026-05-24)
+# Graph Report - .  (2026-05-26)
 
 ## Corpus Check
 - cluster-only mode — file stats not available
 
 ## Summary
-- 10787 nodes · 16292 edges · 763 communities (548 shown, 215 thin omitted)
-- Extraction: 94% EXTRACTED · 6% INFERRED · 0% AMBIGUOUS · INFERRED: 959 edges (avg confidence: 0.76)
+- 10963 nodes · 16487 edges · 834 communities (542 shown, 292 thin omitted)
+- Extraction: 94% EXTRACTED · 6% INFERRED · 0% AMBIGUOUS · INFERRED: 977 edges (avg confidence: 0.76)
 - Token cost: 0 input · 0 output
 
 ## Graph Freshness
-- Built from commit: `e4f660a4`
+- Built from commit: `6a9fb8ea`
 - Run `git rev-parse HEAD` and compare to check if the graph is stale.
 - Run `graphify update .` after code changes (no API cost).
 
@@ -418,7 +418,6 @@
 - [[_COMMUNITY_Community 401|Community 401]]
 - [[_COMMUNITY_Community 402|Community 402]]
 - [[_COMMUNITY_Community 403|Community 403]]
-- [[_COMMUNITY_Community 404|Community 404]]
 - [[_COMMUNITY_Community 405|Community 405]]
 - [[_COMMUNITY_Community 406|Community 406]]
 - [[_COMMUNITY_Community 407|Community 407]]
@@ -540,7 +539,6 @@
 - [[_COMMUNITY_Community 523|Community 523]]
 - [[_COMMUNITY_Community 524|Community 524]]
 - [[_COMMUNITY_Community 525|Community 525]]
-- [[_COMMUNITY_Community 526|Community 526]]
 - [[_COMMUNITY_Community 527|Community 527]]
 - [[_COMMUNITY_Community 528|Community 528]]
 - [[_COMMUNITY_Community 529|Community 529]]
@@ -548,6 +546,7 @@
 - [[_COMMUNITY_Community 531|Community 531]]
 - [[_COMMUNITY_Community 532|Community 532]]
 - [[_COMMUNITY_Community 533|Community 533]]
+- [[_COMMUNITY_Community 534|Community 534]]
 - [[_COMMUNITY_Community 535|Community 535]]
 - [[_COMMUNITY_Community 536|Community 536]]
 - [[_COMMUNITY_Community 537|Community 537]]
@@ -560,26 +559,26 @@
 - [[_COMMUNITY_Community 544|Community 544]]
 - [[_COMMUNITY_Community 545|Community 545]]
 - [[_COMMUNITY_Community 546|Community 546]]
-- [[_COMMUNITY_Community 547|Community 547]]
 - [[_COMMUNITY_Community 548|Community 548]]
 - [[_COMMUNITY_Community 549|Community 549]]
 - [[_COMMUNITY_Community 550|Community 550]]
 - [[_COMMUNITY_Community 551|Community 551]]
 - [[_COMMUNITY_Community 552|Community 552]]
+- [[_COMMUNITY_Community 553|Community 553]]
 - [[_COMMUNITY_Community 554|Community 554]]
+- [[_COMMUNITY_Community 555|Community 555]]
+- [[_COMMUNITY_Community 556|Community 556]]
 - [[_COMMUNITY_Community 557|Community 557]]
 - [[_COMMUNITY_Community 558|Community 558]]
 - [[_COMMUNITY_Community 559|Community 559]]
+- [[_COMMUNITY_Community 560|Community 560]]
 - [[_COMMUNITY_Community 561|Community 561]]
-- [[_COMMUNITY_Community 562|Community 562]]
-- [[_COMMUNITY_Community 563|Community 563]]
+- [[_COMMUNITY_Community 564|Community 564]]
 - [[_COMMUNITY_Community 565|Community 565]]
 - [[_COMMUNITY_Community 566|Community 566]]
-- [[_COMMUNITY_Community 567|Community 567]]
 - [[_COMMUNITY_Community 568|Community 568]]
 - [[_COMMUNITY_Community 569|Community 569]]
 - [[_COMMUNITY_Community 570|Community 570]]
-- [[_COMMUNITY_Community 571|Community 571]]
 - [[_COMMUNITY_Community 572|Community 572]]
 - [[_COMMUNITY_Community 573|Community 573]]
 - [[_COMMUNITY_Community 574|Community 574]]
@@ -616,25 +615,25 @@
 - [[_COMMUNITY_Community 605|Community 605]]
 - [[_COMMUNITY_Community 606|Community 606]]
 - [[_COMMUNITY_Community 607|Community 607]]
+- [[_COMMUNITY_Community 608|Community 608]]
 - [[_COMMUNITY_Community 609|Community 609]]
 - [[_COMMUNITY_Community 610|Community 610]]
+- [[_COMMUNITY_Community 611|Community 611]]
 - [[_COMMUNITY_Community 612|Community 612]]
 - [[_COMMUNITY_Community 613|Community 613]]
 - [[_COMMUNITY_Community 614|Community 614]]
 - [[_COMMUNITY_Community 615|Community 615]]
-- [[_COMMUNITY_Community 616|Community 616]]
 - [[_COMMUNITY_Community 617|Community 617]]
 - [[_COMMUNITY_Community 618|Community 618]]
-- [[_COMMUNITY_Community 619|Community 619]]
 - [[_COMMUNITY_Community 620|Community 620]]
+- [[_COMMUNITY_Community 621|Community 621]]
+- [[_COMMUNITY_Community 622|Community 622]]
+- [[_COMMUNITY_Community 623|Community 623]]
+- [[_COMMUNITY_Community 624|Community 624]]
+- [[_COMMUNITY_Community 625|Community 625]]
+- [[_COMMUNITY_Community 626|Community 626]]
+- [[_COMMUNITY_Community 627|Community 627]]
 - [[_COMMUNITY_Community 628|Community 628]]
-- [[_COMMUNITY_Community 629|Community 629]]
-- [[_COMMUNITY_Community 630|Community 630]]
-- [[_COMMUNITY_Community 631|Community 631]]
-- [[_COMMUNITY_Community 632|Community 632]]
-- [[_COMMUNITY_Community 633|Community 633]]
-- [[_COMMUNITY_Community 634|Community 634]]
-- [[_COMMUNITY_Community 635|Community 635]]
 - [[_COMMUNITY_Community 636|Community 636]]
 - [[_COMMUNITY_Community 637|Community 637]]
 - [[_COMMUNITY_Community 638|Community 638]]
@@ -664,6 +663,7 @@
 - [[_COMMUNITY_Community 662|Community 662]]
 - [[_COMMUNITY_Community 663|Community 663]]
 - [[_COMMUNITY_Community 664|Community 664]]
+- [[_COMMUNITY_Community 665|Community 665]]
 - [[_COMMUNITY_Community 666|Community 666]]
 - [[_COMMUNITY_Community 667|Community 667]]
 - [[_COMMUNITY_Community 668|Community 668]]
@@ -671,7 +671,6 @@
 - [[_COMMUNITY_Community 670|Community 670]]
 - [[_COMMUNITY_Community 671|Community 671]]
 - [[_COMMUNITY_Community 672|Community 672]]
-- [[_COMMUNITY_Community 673|Community 673]]
 - [[_COMMUNITY_Community 674|Community 674]]
 - [[_COMMUNITY_Community 675|Community 675]]
 - [[_COMMUNITY_Community 676|Community 676]]
@@ -679,14 +678,14 @@
 - [[_COMMUNITY_Community 678|Community 678]]
 - [[_COMMUNITY_Community 679|Community 679]]
 - [[_COMMUNITY_Community 680|Community 680]]
+- [[_COMMUNITY_Community 681|Community 681]]
+- [[_COMMUNITY_Community 682|Community 682]]
+- [[_COMMUNITY_Community 683|Community 683]]
+- [[_COMMUNITY_Community 684|Community 684]]
 - [[_COMMUNITY_Community 685|Community 685]]
 - [[_COMMUNITY_Community 686|Community 686]]
 - [[_COMMUNITY_Community 687|Community 687]]
 - [[_COMMUNITY_Community 688|Community 688]]
-- [[_COMMUNITY_Community 689|Community 689]]
-- [[_COMMUNITY_Community 690|Community 690]]
-- [[_COMMUNITY_Community 691|Community 691]]
-- [[_COMMUNITY_Community 692|Community 692]]
 - [[_COMMUNITY_Community 693|Community 693]]
 - [[_COMMUNITY_Community 694|Community 694]]
 - [[_COMMUNITY_Community 695|Community 695]]
@@ -757,1376 +756,1451 @@
 - [[_COMMUNITY_Community 760|Community 760]]
 - [[_COMMUNITY_Community 761|Community 761]]
 - [[_COMMUNITY_Community 762|Community 762]]
+- [[_COMMUNITY_Community 763|Community 763]]
+- [[_COMMUNITY_Community 764|Community 764]]
+- [[_COMMUNITY_Community 765|Community 765]]
+- [[_COMMUNITY_Community 766|Community 766]]
+- [[_COMMUNITY_Community 767|Community 767]]
+- [[_COMMUNITY_Community 768|Community 768]]
+- [[_COMMUNITY_Community 769|Community 769]]
+- [[_COMMUNITY_Community 770|Community 770]]
+- [[_COMMUNITY_Community 771|Community 771]]
+- [[_COMMUNITY_Community 772|Community 772]]
+- [[_COMMUNITY_Community 773|Community 773]]
+- [[_COMMUNITY_Community 774|Community 774]]
+- [[_COMMUNITY_Community 775|Community 775]]
+- [[_COMMUNITY_Community 776|Community 776]]
+- [[_COMMUNITY_Community 777|Community 777]]
+- [[_COMMUNITY_Community 778|Community 778]]
+- [[_COMMUNITY_Community 779|Community 779]]
+- [[_COMMUNITY_Community 780|Community 780]]
+- [[_COMMUNITY_Community 781|Community 781]]
+- [[_COMMUNITY_Community 782|Community 782]]
+- [[_COMMUNITY_Community 783|Community 783]]
+- [[_COMMUNITY_Community 784|Community 784]]
+- [[_COMMUNITY_Community 785|Community 785]]
+- [[_COMMUNITY_Community 786|Community 786]]
+- [[_COMMUNITY_Community 787|Community 787]]
+- [[_COMMUNITY_Community 788|Community 788]]
+- [[_COMMUNITY_Community 789|Community 789]]
+- [[_COMMUNITY_Community 790|Community 790]]
+- [[_COMMUNITY_Community 791|Community 791]]
+- [[_COMMUNITY_Community 792|Community 792]]
+- [[_COMMUNITY_Community 793|Community 793]]
+- [[_COMMUNITY_Community 794|Community 794]]
+- [[_COMMUNITY_Community 795|Community 795]]
+- [[_COMMUNITY_Community 796|Community 796]]
+- [[_COMMUNITY_Community 797|Community 797]]
+- [[_COMMUNITY_Community 798|Community 798]]
+- [[_COMMUNITY_Community 799|Community 799]]
+- [[_COMMUNITY_Community 800|Community 800]]
+- [[_COMMUNITY_Community 801|Community 801]]
+- [[_COMMUNITY_Community 802|Community 802]]
+- [[_COMMUNITY_Community 803|Community 803]]
+- [[_COMMUNITY_Community 804|Community 804]]
+- [[_COMMUNITY_Community 805|Community 805]]
+- [[_COMMUNITY_Community 806|Community 806]]
+- [[_COMMUNITY_Community 807|Community 807]]
+- [[_COMMUNITY_Community 808|Community 808]]
+- [[_COMMUNITY_Community 809|Community 809]]
+- [[_COMMUNITY_Community 810|Community 810]]
+- [[_COMMUNITY_Community 811|Community 811]]
+- [[_COMMUNITY_Community 812|Community 812]]
+- [[_COMMUNITY_Community 813|Community 813]]
+- [[_COMMUNITY_Community 814|Community 814]]
+- [[_COMMUNITY_Community 815|Community 815]]
+- [[_COMMUNITY_Community 816|Community 816]]
+- [[_COMMUNITY_Community 817|Community 817]]
+- [[_COMMUNITY_Community 818|Community 818]]
+- [[_COMMUNITY_Community 819|Community 819]]
+- [[_COMMUNITY_Community 820|Community 820]]
+- [[_COMMUNITY_Community 821|Community 821]]
+- [[_COMMUNITY_Community 822|Community 822]]
+- [[_COMMUNITY_Community 823|Community 823]]
+- [[_COMMUNITY_Community 824|Community 824]]
+- [[_COMMUNITY_Community 825|Community 825]]
+- [[_COMMUNITY_Community 826|Community 826]]
+- [[_COMMUNITY_Community 827|Community 827]]
+- [[_COMMUNITY_Community 828|Community 828]]
+- [[_COMMUNITY_Community 829|Community 829]]
+- [[_COMMUNITY_Community 830|Community 830]]
+- [[_COMMUNITY_Community 831|Community 831]]
+- [[_COMMUNITY_Community 832|Community 832]]
+- [[_COMMUNITY_Community 833|Community 833]]
 
 ## God Nodes (most connected - your core abstractions)
-1. `main()` - 308 edges
-2. `init()` - 171 edges
+1. `main()` - 309 edges
+2. `init()` - 172 edges
 3. `Troubleshooting` - 106 edges
 4. `require_feature_access()` - 93 edges
 5. `code:json ({)` - 84 edges
 6. `list()` - 74 edges
 7. `get_db()` - 72 edges
-8. `GameManager` - 54 edges
-9. `chat()` - 52 edges
-10. `Testing` - 50 edges
+8. `OpenClaw` - 57 edges
+9. `GameManager` - 54 edges
+10. `chat()` - 53 edges
 
 ## Surprising Connections (you probably didn't know these)
+- `Secret/API Key Detection` --conceptually_related_to--> `Commit Message Validation`  [INFERRED]
+  docs/governance/ENHANCED_ENFORCEMENT.md → tools/audit/validate_commit_message.py
 - `Get Similar Tracks` --calls--> `get_recommendation_engine()`  [INFERRED]
   docs/api/MUSIC_API.md → modules/zoe-music/services/music/recommendation_engine.py
-- `lifespan()` --calls--> `PeopleHealthTrigger`  [INFERRED]
-  services/zoe-data/main.py → docs/guides/people_crm.md
-- `lifespan()` --calls--> `PeopleBirthdayTrigger`  [INFERRED]
-  services/zoe-data/main.py → docs/guides/people_crm.md
-- `MatrixUser` --uses--> `Authentication`  [INFERRED]
-  services/zoe-auth/sso/matrix.py → docs/api/MUSIC_API.md
-- `MatrixIntegration` --uses--> `Authentication`  [INFERRED]
-  services/zoe-auth/sso/matrix.py → docs/api/MUSIC_API.md
+- `home-assistant` --uses--> `OutputType`  [INFERRED]
+  CAPABILITIES.md → modules/zoe-music/services/music/outputs/base.py
+- `home-assistant` --uses--> `OutputState`  [INFERRED]
+  CAPABILITIES.md → modules/zoe-music/services/music/outputs/base.py
+- `home-assistant` --uses--> `PlaybackState`  [INFERRED]
+  CAPABILITIES.md → modules/zoe-music/services/music/outputs/base.py
 
-## Communities (763 total, 215 thin omitted)
+## Communities (834 total, 292 thin omitted)
 
 ### Community 0 - "Community 0"
-Cohesion: 0.03
-Nodes (120): rate_limit(), Create a rate limiting dependency with Redis-based sliding window          Args:, Add to Playlist, Create Playlist, Get Liked Songs, Get Playlist Tracks, Get Similar Tracks, Playlist Endpoints (+112 more)
+Cohesion: 0.02
+Nodes (90): Main optimization function, Analyze a single database and return schema information, Main analysis function, check_home_directory(), get_category(), Determine where a file should go, Check /home/pi for violations, Run comprehensive audit (+82 more)
 
 ### Community 1 - "Community 1"
-Cohesion: 0.02
-Nodes (95): Main optimization function, Analyze a single database and return schema information, Main analysis function, check_home_directory(), get_category(), Determine where a file should go, Check /home/pi for violations, Run comprehensive audit (+87 more)
+Cohesion: 0.03
+Nodes (103): Add to Queue, Get session by ID with validation, Get current playback state from an AirPlay device, Get a specific device by ID, Get current playback state from a Chromecast, get_event_tracker(), Get the singleton event tracker instance., MediaController (+95 more)
 
 ### Community 2 - "Community 2"
-Cohesion: 0.04
-Nodes (73): Add to Queue, Clear Queue, Get Next Track, Get Queue, Queue Endpoints, Remove from Queue, Reorder Queue, Select Output Device (+65 more)
+Cohesion: 0.03
+Nodes (105): rate_limit(), Create a rate limiting dependency with Redis-based sliding window          Args:, Create Playlist, Get Liked Songs, Get Playlist Tracks, Get Similar Tracks, Playlist Endpoints, Remove from Playlist (+97 more)
 
 ### Community 3 - "Community 3"
-Cohesion: 0.03
-Nodes (96): homeassistant, homeassistant-mcp-bridge, Enum, Get all discovered AirPlay devices, Get current playback state from an AirPlay device, Get all discovered Chromecast devices, Get a specific device by ID, Get current playback state from a Chromecast (+88 more)
+Cohesion: 0.02
+Nodes (80): browse(), Browser automation endpoint - navigates websites and extracts data.          Use, Log startup information., startup_event(), AutomationTriggerRequest, DeviceControlRequest, ha_voice_turn(), ha_voice_wake() (+72 more)
 
 ### Community 4 - "Community 4"
-Cohesion: 0.02
-Nodes (107): "Code execution blocked", "Research taking too long", code:bash (# Check zoe-core logs), code:bash (# Check current mode), Intents Not Loading, Safety Mode Not Working, code:python (# In Python shell), code:bash (docker exec zoe-core python3 -c "from intent_system.executor) (+99 more)
+Cohesion: 0.07
+Nodes (73): Override to customise the prompt per-check., Local voice session WebSocket for voice.html.      Accepts text and binary (audi, websocket_voice(), _bash(), _build_memory_context(), _build_prompt(), _build_tools(), _chat_capability_shortcut() (+65 more)
 
 ### Community 5 - "Community 5"
 Cohesion: 0.04
-Nodes (96): demo_action_execution(), demo_complex_queries(), demo_memory_storage(), Demo: Action execution (lists, calendar, etc.), Send a chat message to Zoe, Demo: Complex queries requiring reasoning, Demo: P0-2 Confidence formatting, Verify that a fact was stored in memory (+88 more)
+Nodes (75): code:block7 (INFO: ✅ Loaded module: agent-zero (4 intents, 4 handlers)), ✅ TEST 1: Service Health, ✅ TEST 2: Service Status, ✅ TEST 3: Research Endpoint, ✅ TEST 4: Planning Endpoint, ✅ TEST 5: Analysis Endpoint, ✅ TEST 6: Comparison Endpoint, ✅ TEST 7: Intent System Integration (+67 more)
 
 ### Community 6 - "Community 6"
-Cohesion: 0.05
-Nodes (96): Override to customise the prompt per-check., Local voice session WebSocket for voice.html.      Accepts text and binary (audi, websocket_voice(), _background_memory_save(), _bash(), _build_memory_context(), _build_prompt(), _build_tools() (+88 more)
+Cohesion: 0.03
+Nodes (75): "Code execution blocked", "Research taking too long", code:bash (docker exec zoe-core python3 -c "from intent_system.executor), Handler Not Executing, code:bash (docker logs zoe-litellm 2>&1 | tail -50), Connection Refused, Service Won't Start, Slow Responses (+67 more)
 
 ### Community 7 - "Community 7"
-Cohesion: 0.02
-Nodes (65): browse(), Browser automation endpoint - navigates websites and extracts data.          Use, Log startup information., startup_event(), AutomationTriggerRequest, DeviceControlRequest, ha_voice_turn(), ha_voice_wake() (+57 more)
+Cohesion: 0.05
+Nodes (67): Send a chat message to Zoe, Send a chat message and validate response, get_db(), _build_hermes_payload(), _build_panel_intent_card(), cancel_latest_run(), chat(), chat_stream_generator() (+59 more)
 
 ### Community 8 - "Community 8"
-Cohesion: 0.04
-Nodes (57): ABC, Get Discover, Get Personal Radio, Recommendations Endpoints, get_affinity_engine(), Get the singleton affinity engine instance., get_auth_manager(), Get the singleton auth manager instance. (+49 more)
-
-### Community 9 - "Community 9"
 Cohesion: 0.05
 Nodes (34): CalendarExpert, HomeAssistantExpert, ImprovedBirthdayExpert, JournalExpert, ListExpert, MemoryExpert, PlanningExpert, Comprehensive Expert System Test Suite ====================================== Te (+26 more)
 
+### Community 9 - "Community 9"
+Cohesion: 0.04
+Nodes (65): activate_scene(), analyze_home_assistant(), get_automations(), get_entities(), get_entity(), get_lights(), get_scenes(), get_scripts() (+57 more)
+
 ### Community 10 - "Community 10"
-Cohesion: 0.03
-Nodes (61): a2a_task(), a2a_task_result(), a2a_task_stream(), _A2ATaskRequest, board_approve(), board_cancel(), board_review(), delegate_to_agent() (+53 more)
+Cohesion: 0.04
+Nodes (60): memory-consolidation, a2a_task(), a2a_task_result(), a2a_task_stream(), _A2ATaskRequest, board_approve(), board_cancel(), board_review() (+52 more)
 
 ### Community 11 - "Community 11"
-Cohesion: 0.06
-Nodes (15): Delete Playlist, Shuffle Queue, 2. Widget Lifecycle Methods, `init(element)`, `resize(newSize)`, `update()`, escapeHtml(), saveZoneEditor() (+7 more)
+Cohesion: 0.05
+Nodes (53): ABC, Get Discover, Get Personal Radio, Recommendations Endpoints, get_affinity_engine(), Get the singleton affinity engine instance., _check_memory_headroom(), Check if enough memory is available for ML components. (+45 more)
 
 ### Community 12 - "Community 12"
 Cohesion: 0.06
-Nodes (60): BaseModel, createGame(), roundConfigs, contactData, Record a reaction. Mutual thumbs-up → silent connection., speed_dating_react(), ChallengeAnswerCreate, ChallengeCreate (+52 more)
+Nodes (56): attachCardActions(), buildActionButtons(), buildMatchCard(), hideSDTimerOverlay(), hideSpeedDatingBanner(), loadMatches(), loadPendingConnections(), metPeople (+48 more)
 
 ### Community 13 - "Community 13"
-Cohesion: 0.04
-Nodes (57): Test P1-1: Validate behavioral pattern extraction, Test that pattern extraction is fast enough for nightly jobs, Test that all pattern types can be extracted, TestP11BehavioralMemoryImprovements, fresh_collection(), _install_mempalace_stubs(), Comprehensive MemPalace integration tests.  Tests: user isolation, upsert behavi, Install mempalace module stubs so zoe_agent doesn't require the real package. (+49 more)
+Cohesion: 0.05
+Nodes (50): BaseHTTPMiddleware, How Proactive Nudges Fire, PeopleBirthdayTrigger, PeopleHealthTrigger, person_health.calc_health_score(), Manually trigger the morning brief for the calling user.     Useful for testing, trigger_morning_brief(), check() (+42 more)
 
 ### Community 14 - "Community 14"
-Cohesion: 0.06
-Nodes (55): attachCardActions(), buildActionButtons(), buildMatchCard(), hideSDTimerOverlay(), hideSpeedDatingBanner(), loadMatches(), loadPendingConnections(), metPeople (+47 more)
-
-### Community 15 - "Community 15"
 Cohesion: 0.05
 Nodes (59): AuthResponse, get_current_user(), get_passcode_status(), get_user_profile(), guest_login(), InitialPasswordSetupRequest, login(), login_passcode() (+51 more)
 
+### Community 15 - "Community 15"
+Cohesion: 0.1
+Nodes (21): createGame(), roundConfigs, pickWinner(), submitCards(), WSMessage, _cancel_timer(), GameError, GameManager (+13 more)
+
 ### Community 16 - "Community 16"
 Cohesion: 0.07
-Nodes (57): post_install_component(), build_updates_snapshot(), _check_and_notify_zoe_release(), _check_docker_service(), _check_hermes(), _check_openclaw(), _check_zoe_data(), _docker_inspect() (+49 more)
+Nodes (53): boot(), btnJoin, code, codeError, doCheckin(), enterWelcomeScreen(), joinCodeInput, joinNameInput (+45 more)
 
 ### Community 17 - "Community 17"
-Cohesion: 0.04
-Nodes (45): Initialize Agent Zero client.                  Args:             base_url: Base, Initialize safety guardrails.                  Args:             mode: Safety mo, init(), Initialize the affinity engine.                  Args:             half_life_day, AirPlayDevice, AirPlayService, AirPlay Integration Service Discovers and controls AirPlay devices for music pla, Start discovering AirPlay devices (+37 more)
+Cohesion: 0.05
+Nodes (49): graphify_search, FileSystemEventHandler, get_peer_agent_card(), Return a live A2A v1.0 proxy card for a peer agent with dynamic skills[]., Admin-only: force-flush the skill discovery cache for a peer agent., reload_peer_skills(), _build_capabilities_md(), _build_compact() (+41 more)
 
 ### Community 18 - "Community 18"
-Cohesion: 0.05
-Nodes (34): Execute comprehensive test suite, Test RouteLLM classification, Test Enhanced MemAgent, Test RAG enhancements, Test full chat API endpoint with authentication, Get JWT token from zoe-auth service for authenticated requests, SystemTester, test_conversation() (+26 more)
+Cohesion: 0.07
+Nodes (54): BaseModel, note_create, note_update, reminder_create, reminder_update, transaction_create, contactData, Record a reaction. Mutual thumbs-up → silent connection. (+46 more)
 
 ### Community 19 - "Community 19"
 Cohesion: 0.05
-Nodes (48): FileSystemEventHandler, get_peer_agent_card(), Return a live A2A v1.0 proxy card for a peer agent with dynamic skills[]., Admin-only: force-flush the skill discovery cache for a peer agent., reload_peer_skills(), _build_capabilities_md(), _build_compact(), _build_federation_skills_md() (+40 more)
+Nodes (36): Check if Agent Zero is available.                  Returns:             True if, Analyze a target (file, system, configuration).                  Args:, analyze(), Analysis endpoint - analyzes files, configurations, systems.          Uses Agent, Analyze all files in root, AudioAnalyzer, Audio Analyzer ==============  Extracts audio features from music tracks using E, Analyze a track and extract audio features.                  Args:             t (+28 more)
 
 ### Community 20 - "Community 20"
-Cohesion: 0.05
-Nodes (35): Generate comprehensive audit report, Test that API endpoints are accessible, IntelligentSystemTester, Test manual model adaptation, Run comprehensive test of the intelligent system, Test the intelligent model management system, Test the enhanced chat endpoint, Test the performance monitoring endpoints (+27 more)
+Cohesion: 0.08
+Nodes (52): add_activity(), add_bucket_item(), add_gift_idea(), add_important_date(), add_relationship(), _archive_person_mempalace(), create_people_field(), create_person() (+44 more)
 
 ### Community 21 - "Community 21"
-Cohesion: 0.05
-Nodes (52): High Priority:, Low Priority:, Medium Priority:, Low Priority (Future Releases), Medium Priority (Next Sprint), ✅ 3. Performance Optimizations, code:bash (docker exec zoe-ollama ollama ps), 1. SSL Certificate Errors (+44 more)
+Cohesion: 0.07
+Nodes (51): post_install_component(), build_updates_snapshot(), _check_and_notify_zoe_release(), _check_docker_service(), _check_hermes(), _check_zoe_data(), _docker_inspect(), _dockerhub_digest() (+43 more)
 
 ### Community 22 - "Community 22"
-Cohesion: 0.04
-Nodes (50): Safety Tests, Unit Tests, Voice Tests, After Implementation (Current), Target State, code:python (# tests/unit/test_versioning.py), code:block2 (/api/v1/calendar/events), For Documentation (+42 more)
+Cohesion: 0.06
+Nodes (33): Generate comprehensive audit report, Test that API endpoints are accessible, IntelligentSystemTester, Test manual model adaptation, Run comprehensive test of the intelligent system, Test the intelligent model management system, Test the enhanced chat endpoint, Test the performance monitoring endpoints (+25 more)
 
 ### Community 23 - "Community 23"
 Cohesion: 0.06
-Nodes (47): _build_calendar_form_props(), _build_reminder_form_props(), _intent_action_form_payload(), Build a panel_show_action_form payload for intents that show an in-place overlay, HA full-setup shorthand intent and OpenClaw message expansion., test_detect_ha_full_setup(), test_execute_ha_full_setup_returns_none(), test_openclaw_user_message_expands_with_intent() (+39 more)
+Nodes (32): escalate_session(), Refresh current session expiration          Args:         current_session: Curre, Escalate passcode session to full session with password verification          Ar, Invalidate a specific session (user can only invalidate their own sessions), refresh_session(), Verify passcode for user                  Args:             user_id: User identi, EnhancedSessionManager, Enhanced session manager with multi-factor support (+24 more)
 
 ### Community 24 - "Community 24"
 Cohesion: 0.06
-Nodes (48): run_music_digest(), Manually trigger the LLM memory digest for a user (or the requesting user)., trigger_memory_digest(), _deep_sleep_pass(), _emotional_memory_pass(), _extract_concept_tags(), _extract_facts_with_gemma(), _extract_open_loops() (+40 more)
+Nodes (47): _build_calendar_form_props(), _build_reminder_form_props(), _intent_action_form_payload(), Build a panel_show_action_form payload for intents that show an in-place overlay, HA full-setup shorthand intent and OpenClaw message expansion., test_detect_ha_full_setup(), test_execute_ha_full_setup_returns_none(), test_openclaw_user_message_expands_with_intent() (+39 more)
 
 ### Community 25 - "Community 25"
-Cohesion: 0.08
-Nodes (47): add_activity(), add_bucket_item(), add_gift_idea(), add_important_date(), add_relationship(), _archive_person_mempalace(), create_person(), delete_person() (+39 more)
+Cohesion: 0.06
+Nodes (49): High Priority:, Low Priority:, Medium Priority:, Low Priority (Future Releases), Medium Priority (Next Sprint), ✅ 3. Performance Optimizations, code:bash (docker exec zoe-ollama ollama ps), 1. SSL Certificate Errors (+41 more)
 
 ### Community 26 - "Community 26"
-Cohesion: 0.07
-Nodes (45): Get user information (without sensitive data), hash_secret(), OIDC client registration and secret verification., Exact match only — no wildcards., Insert or update a client. Safe to call on every startup., upsert_client(), validate_redirect_uri(), verify_secret() (+37 more)
+Cohesion: 0.06
+Nodes (48): run_music_digest(), Manually trigger the LLM memory digest for a user (or the requesting user)., trigger_memory_digest(), _deep_sleep_pass(), _emotional_memory_pass(), _extract_concept_tags(), _extract_facts_with_gemma(), _extract_open_loops() (+40 more)
 
 ### Community 27 - "Community 27"
-Cohesion: 0.07
-Nodes (29): escalate_session(), Refresh current session expiration          Args:         current_session: Curre, Escalate passcode session to full session with password verification          Ar, Invalidate a specific session (user can only invalidate their own sessions), refresh_session(), EnhancedSessionManager, Enhanced session manager with multi-factor support, Authenticate user and create session                  Args:             request: (+21 more)
+Cohesion: 0.06
+Nodes (32): check_permission(), Check if current user has specific permission          Args:         permission:, AccessContext, PermissionResult, Role-Based Access Control (RBAC) System Advanced permission management with inhe, Role-Based Access Control Manager, Check if user has specific permission                  Args:             user_id, Check multiple permissions at once                  Args:             user_id: U (+24 more)
 
 ### Community 28 - "Community 28"
-Cohesion: 0.14
-Nodes (12): pickWinner(), submitCards(), _cancel_timer(), GameError, GameManager, get_game(), start_game(), ws_console() (+4 more)
+Cohesion: 0.05
+Nodes (47): 2. Start the Bridge Service, 3. Verify Services, 4. Environment Configuration, code:bash (cd /home/zoe/assistant/modules/agent-zero), code:bash (# Check both containers are running), code:bash (# Agent Zero Configuration), 🔑 Default Credentials, 🆕 First-Time Setup (New Installations) (+39 more)
 
 ### Community 29 - "Community 29"
 Cohesion: 0.06
-Nodes (37): analyze_login_patterns(), AuditLogger, log_authentication_attempt(), log_security_event(), RateLimiter, RateLimitRule, Security Features and Controls Rate limiting, audit logging, and advanced securi, Clear rate limit for identifier (admin function) (+29 more)
+Nodes (46): get_reports(), add_item(), create_list(), delete_item(), delete_list(), get_list(), get_list_types(), list_items() (+38 more)
 
 ### Community 30 - "Community 30"
-Cohesion: 0.08
-Nodes (33): Unit tests for person_extractor.py — pattern matching and process_text() logic., Integration-style tests that mock DB and MemPalace., Create a mock DB that returns person_id on SELECT., test_birthday_pattern_known_person_writes_date(), test_bucket_list_pattern_writes_bucket(), test_empty_text_returns_zero(), test_gift_pattern_known_person_writes_gift(), test_guest_returns_zero() (+25 more)
+Cohesion: 0.06
+Nodes (45): fresh_collection(), _install_mempalace_stubs(), Comprehensive MemPalace integration tests.  Tests: user isolation, upsert behavi, Install mempalace module stubs so zoe_agent doesn't require the real package., Reset the in-memory Chroma collection before each test.      Also resets the Mem, Writing for 'jason' must not appear when loading facts for 'family-admin'., Deleting a CRM entity should archive all scoped MemPalace facts for it., Writing for 'family-admin' must not appear when loading facts for 'jason'. (+37 more)
 
 ### Community 31 - "Community 31"
-Cohesion: 0.05
-Nodes (44): create_role(), get_audit_logs(), get_sync_data(), get_system_stats(), invalidate_session_admin(), list_all_sessions(), list_roles(), list_users() (+36 more)
+Cohesion: 0.07
+Nodes (25): Initialize Agent Zero client.                  Args:             base_url: Base, Initialize safety guardrails.                  Args:             mode: Safety mo, Select Output Device, MCPMusicStateManager, init(), Initialize the affinity engine.                  Args:             half_life_day, Initialize the AirPlay service, Initialize the audio analyzer with Essentia. (+17 more)
 
 ### Community 32 - "Community 32"
-Cohesion: 0.06
-Nodes (43): _broadcast_calendar_chat_prefill_ui(), _broadcast_calendar_ui(), _broadcast_shopping_chat_ui(), chatgpt_auth_status(), _extract_complete_sentences(), _get_kokoro_instance(), get_livekit_token(), _has_espeak_ng() (+35 more)
+Cohesion: 0.08
+Nodes (16): Clear Queue, Delete Playlist, Get Next Track, Get Queue, Queue Endpoints, Remove from Queue, Reorder Queue, Shuffle Queue (+8 more)
 
 ### Community 33 - "Community 33"
-Cohesion: 0.04
-Nodes (44): 1. Fastest Setup (2 minutes), 1. "Talk to Zoe" - Voice Chat Shortcut, 2. "Add to Zoe" - Quick Capture, 2. Complete Setup (5 minutes), 3. "Open Zoe Calendar" - Quick Access, 4. "Show Zoe Dashboard" - Status View, 5. Share from Other Apps, "Add Shopping Item" (+36 more)
+Cohesion: 0.06
+Nodes (37): analyze_login_patterns(), AuditLogger, log_authentication_attempt(), log_security_event(), RateLimiter, RateLimitRule, Security Features and Controls Rate limiting, audit logging, and advanced securi, Clear rate limit for identifier (admin function) (+29 more)
 
 ### Community 34 - "Community 34"
 Cohesion: 0.07
-Nodes (40): print_results(), Scan entire project and categorize all files., Check if path should be ignored., Categorize a file and determine if it's in the right location.          Returns:, scan_project(), should_ignore(), Print validation results.          Returns:         Exit code (0 if all files ex, check_root_md_limit() (+32 more)
+Nodes (44): Agent Zero Intent Patterns, Agent Zero Module for Zoe, Comparison to Music Module, Example: Direct HTTP Call, HTTP Endpoints (for Direct Integration), Agent Zero Research Skill, Agent Zero Comparison Skill, Agent Zero Planning Skill (+36 more)
 
 ### Community 35 - "Community 35"
 Cohesion: 0.06
-Nodes (27): Scan a single file for database references, Recursively scan directory for database references, Print formatted audit report, DatabaseValidator, Print validation report, Find all .db files in data directory, Check if file is in a backup/archive location, Validate database structure (+19 more)
+Nodes (43): _broadcast_calendar_chat_prefill_ui(), _broadcast_calendar_ui(), _broadcast_shopping_chat_ui(), chatgpt_auth_status(), _extract_complete_sentences(), _get_kokoro_instance(), get_livekit_token(), _has_espeak_ng() (+35 more)
 
 ### Community 36 - "Community 36"
-Cohesion: 0.05
-Nodes (41): 1. `thinking` ⚠️, 2. `tool_call` ⚠️, 3. `tool_result` ⚠️, 4. `progress` ⚠️, AG-UI Protocol Implementation Status, AG-UI Protocol Overview, Current Capabilities, Current Implementation (+33 more)
+Cohesion: 0.04
+Nodes (44): 1. Fastest Setup (2 minutes), 1. "Talk to Zoe" - Voice Chat Shortcut, 2. "Add to Zoe" - Quick Capture, 2. Complete Setup (5 minutes), 3. "Open Zoe Calendar" - Quick Access, 4. "Show Zoe Dashboard" - Status View, 5. Share from Other Apps, "Add Shopping Item" (+36 more)
 
 ### Community 37 - "Community 37"
-Cohesion: 0.08
-Nodes (37): Clean up Python cache, code:bash (find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/nu), cleanup_documentation_files(), cleanup_duplicate_files(), cleanup_ui_dist_files(), optimize_git(), Remove duplicate or redundant files, Remove redundant documentation files (+29 more)
+Cohesion: 0.07
+Nodes (40): print_results(), Scan entire project and categorize all files., Check if path should be ignored., Categorize a file and determine if it's in the right location.          Returns:, scan_project(), should_ignore(), Print validation results.          Returns:         Exit code (0 if all files ex, check_root_md_limit() (+32 more)
 
 ### Community 38 - "Community 38"
-Cohesion: 0.09
-Nodes (39): Agent Zero Intent Patterns, Agent Zero Module for Zoe, Comparison to Music Module, Agent Zero Research Skill, Agent Zero Comparison Skill, Agent Zero Planning Skill, Agent Zero Deep Research Skill, Agent Zero + Zoe Integration Summary (+31 more)
+Cohesion: 0.05
+Nodes (42): 1. **Add Person Modal - Missing Fields**, 2. **Edit Mode - No Backend Save**, 3. **Person Expert Integration**, **Add Person Modal** (Basic), Backend API Support, code:javascript (// Current code (lines 1315-1339)), code:html (<input id="personName">       ✅ Has), code:block3 (User edits fields → savePersonChanges() → Updates local JS o) (+34 more)
 
 ### Community 39 - "Community 39"
 Cohesion: 0.07
-Nodes (25): create_user(), Create new user (admin only)          Args:         request: User creation detai, change_password(), Change current user's password          Args:         request: Current and new p, AuthManager, Verify user password                  Args:             user_id: User identifier, Change user password                  Args:             user_id: User identifier, Reset user password (admin function)                  Args:             user_id: (+17 more)
+Nodes (27): create_user(), Create new user (admin only)          Args:         request: User creation detai, change_password(), Change current user's password          Args:         request: Current and new p, AuthManager, AuthValidationResult, Verify user password                  Args:             user_id: User identifier, Change user password                  Args:             user_id: User identifier (+19 more)
 
 ### Community 40 - "Community 40"
+Cohesion: 0.07
+Nodes (32): Change to Developer Mode, code:bash (# In .env), Developer Mode, Grandma Mode (Default), Agent Zero Safety Guardrails ============================  Provides safety contr, Safety modes for Agent Zero., SafetyMode, Enum (+24 more)
+
+### Community 41 - "Community 41"
+Cohesion: 0.05
+Nodes (38): Files Modified, Before Implementation, To Update (Future), Critical Service Files (Must Update), 📝 Files Requiring Updates, Total Files Needing Review: 95 files, 📊 Comparison: Before vs After, After Implementation (+30 more)
+
+### Community 42 - "Community 42"
+Cohesion: 0.09
+Nodes (35): evolution_proposal_action(), Act on an evolution proposal: approve|reject|defer.      On approve: creates a M, _fire_autopilot_job(), get_autopilot_triggers(), get_multica_autopilots(), _headers(), _is_configured(), multica_autopilot_sync.py — Syncs Multica autopilot schedules to APScheduler.  O (+27 more)
+
+### Community 43 - "Community 43"
+Cohesion: 0.06
+Nodes (38): home-assistant, homeassistant-mcp-bridge, Get all discovered AirPlay devices, Get all discovered Chromecast devices, get_airplay_output(), Discover available AirPlay devices., Refresh the device list., Get the singleton AirPlay output instance. (+30 more)
+
+### Community 44 - "Community 44"
+Cohesion: 0.08
+Nodes (37): Clean up Python cache, code:bash (find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/nu), cleanup_documentation_files(), cleanup_duplicate_files(), cleanup_ui_dist_files(), optimize_git(), Remove duplicate or redundant files, Remove redundant documentation files (+29 more)
+
+### Community 45 - "Community 45"
+Cohesion: 0.07
+Nodes (38): _agent_loop(), _build_room_handlers(), _collect_audio_stream(), _cooldown_watchdog(), _get_current_user_soft(), _handle_ptt_stop(), livekit_audio(), livekit_cancel() (+30 more)
+
+### Community 46 - "Community 46"
+Cohesion: 0.07
+Nodes (40): clear_all_device_caches(), clear_device_cache(), get_cached_users(), get_device_config(), get_device_status(), list_touch_panel_devices(), QuickSwitchRequest, Touch Panel API Endpoints Optimized endpoints for touch panel quick authenticati (+32 more)
+
+### Community 47 - "Community 47"
 Cohesion: 0.05
 Nodes (38): handle_agent_zero_analyze(), handle_agent_zero_compare(), handle_agent_zero_plan(), handle_agent_zero_research(), handle_music_discover(), handle_music_like(), handle_music_mood(), handle_music_now_playing() (+30 more)
 
-### Community 41 - "Community 41"
-Cohesion: 0.08
-Nodes (38): _bridge_post(), _ambient_capture_thread(), _api_post(), _barge_in_vad_thread(), _do_single_turn(), _espeak_local(), _follow_up_listen(), _get_silero_vad() (+30 more)
-
-### Community 42 - "Community 42"
-Cohesion: 0.07
-Nodes (37): clear_all_device_caches(), clear_device_cache(), get_cached_users(), get_device_config(), get_device_status(), list_touch_panel_devices(), QuickSwitchRequest, Touch Panel API Endpoints Optimized endpoints for touch panel quick authenticati (+29 more)
-
-### Community 43 - "Community 43"
+### Community 48 - "Community 48"
 Cohesion: 0.05
 Nodes (37): code:bash (open http://192.168.1.218:50001), Phase 1: Research Agent Zero API, Phase 3: Test with Agent Zero UI, Phase 6: Optimization, code:python (# services/zoe-core/main.py), code:python (# services/zoe-core/middleware/deprecation.py), code:python (from middleware.deprecation import DeprecationMiddleware), code:http (HTTP/1.1 200 OK) (+29 more)
 
-### Community 44 - "Community 44"
-Cohesion: 0.1
-Nodes (32): evolution_proposal_action(), Act on an evolution proposal: approve|reject|defer.      On approve: creates a M, _fire_autopilot_job(), get_autopilot_triggers(), get_multica_autopilots(), _headers(), _is_configured(), multica_autopilot_sync.py — Syncs Multica autopilot schedules to APScheduler.  O (+24 more)
-
-### Community 45 - "Community 45"
-Cohesion: 0.06
-Nodes (30): check_readme_links(), find_doc_references(), find_hardcoded_paths(), generate_report(), Check if README references are current, Generate audit report, Find all references to documentation files in code, Find hardcoded paths to documentation (+22 more)
-
-### Community 46 - "Community 46"
-Cohesion: 0.13
-Nodes (37): $(), addTeamToLobby(), buildTeamStatusRow(), clearSession(), clearTimers(), deckNamesForConfig(), displayRevealedCard(), enterGameOver() (+29 more)
-
-### Community 47 - "Community 47"
-Cohesion: 0.11
-Nodes (34): tryRestoreSession(), showScreen(), closeAndReconnect(), connectWebSocket(), dom, esc(), formatCardText(), isLightColor() (+26 more)
-
-### Community 48 - "Community 48"
-Cohesion: 0.07
-Nodes (25): disable_passcode(), Disable passcode for current user          Args:         current_session: Curren, AuthValidationResult, PasswordPolicy, Password security policy, Result of authentication validation, PasscodeManager, PasscodePolicy (+17 more)
-
 ### Community 49 - "Community 49"
-Cohesion: 0.09
-Nodes (34): Get a specific provider by type.                  Args:             provider_typ, _classify_proposal(), _db_exec(), _get(), _is_noise(), _parse_psql_output(), _patch(), _post() (+26 more)
+Cohesion: 0.05
+Nodes (37): create_role(), get_audit_logs(), get_sync_data(), get_system_stats(), invalidate_session_admin(), list_all_sessions(), list_roles(), PasscodeSetRequest (+29 more)
 
 ### Community 50 - "Community 50"
-Cohesion: 0.09
-Nodes (30): BaseHTTPMiddleware, How Proactive Nudges Fire, PeopleBirthdayTrigger, PeopleHealthTrigger, person_health.calc_health_score(), check(), What a trigger wants to send., TriggerResult (+22 more)
+Cohesion: 0.08
+Nodes (27): Get detailed status of Agent Zero service.          Returns:         Status info, status(), code:bash (# Edit config), Disable Module, migrate_self_entries(), Create self entries for users in the people table, _compute_compatibility(), Compute compatibility score and shared traits between two check-ins. (+19 more)
 
 ### Community 51 - "Community 51"
 Cohesion: 0.06
-Nodes (33): Zoe Code Execution with MCP - Implementation Summary, References, Adding New Widgets, code:javascript (// core/my-widget.js), Files Changed, Step 1: Create Widget Class, Step 2: Add to Manifest, Step 3: Import in HTML (+25 more)
+Nodes (30): check_readme_links(), find_doc_references(), find_hardcoded_paths(), generate_report(), Check if README references are current, Generate audit report, Find all references to documentation files in code, Find hardcoded paths to documentation (+22 more)
 
 ### Community 52 - "Community 52"
-Cohesion: 0.09
-Nodes (33): add_item(), create_list(), delete_item(), delete_list(), get_list(), get_list_types(), list_items(), list_lists() (+25 more)
+Cohesion: 0.06
+Nodes (38): Error Codes, Error Handling, zoe-capability-extender, zoe-page-builder, zoe-widget-builder, code:json ({"tool": "deep_web_research", "query": "cheapest Emu Export ), Escalate to OpenClaw instead when, Example Calls (+30 more)
 
 ### Community 53 - "Community 53"
-Cohesion: 0.1
-Nodes (30): get_capability_matrix(), get_my_capability_matrix(), reset_capability_matrix_defaults(), update_capability_matrix_role(), _validate_matrix_shape(), test_authenticated_allowed_for_mutation(), test_default_matrix_has_fixed_shape(), test_guest_blocked_for_mutation() (+22 more)
+Cohesion: 0.13
+Nodes (37): $(), addTeamToLobby(), buildTeamStatusRow(), clearSession(), clearTimers(), deckNamesForConfig(), displayRevealedCard(), enterGameOver() (+29 more)
 
 ### Community 54 - "Community 54"
-Cohesion: 0.13
-Nodes (33): _FakeIntent, Unit tests for `voice_scope.classify`.  Covers every branch of the classifier wi, test_empty_string_defaults_public(), test_empty_string_strict_mode(), test_intent_build_widget_is_user_scoped(), test_intent_calendar_show_is_public_household(), test_intent_ha_prefix_public(), test_intent_journal_create_is_user_scoped() (+25 more)
+Cohesion: 0.07
+Nodes (26): AirPlayDevice, AirPlayService, AirPlay Integration Service Discovers and controls AirPlay devices for music pla, Start discovering AirPlay devices, Connect to an AirPlay device, Play media on an AirPlay device                  Args:             device_id: Ta, Represents a discovered AirPlay device, Send a control command to an AirPlay device                  Args:             d (+18 more)
 
 ### Community 55 - "Community 55"
-Cohesion: 0.07
-Nodes (33): activate_scene(), analyze_home_assistant(), get_automations(), get_entities(), get_entity(), get_lights(), get_scenes(), get_scripts() (+25 more)
+Cohesion: 0.06
+Nodes (37): 1. Self-Contained Module Structure ✅, 2. Running Services ✅, 3. Loaded Intents ✅, code:block1 (User: "research smart light bulbs"), code:block8 (modules/agent-zero/), Module Structure, code:block1 (modules/agent-zero/), What We Built (+29 more)
 
 ### Community 56 - "Community 56"
 Cohesion: 0.06
-Nodes (21): Unit Tests for Retry Utility ============================  Tests the retry decor, Test no retry on excluded exception type., Test on_retry callback is called., Tests for the retry_async function., Tests for the RetryContext context manager., Tests for NETWORK_CONFIG preset., Test NETWORK_CONFIG retries on network errors., Tests for RetryConfig. (+13 more)
+Nodes (33): Key Findings, Overall Assessment: 🟢 **EXCELLENT** (with optimization opportunities), 🔗 External Resources, LiteLLM Gateway Integration - Architecture Document, 1. ✅ CRITICAL: All Files Deleted from Working Tree, 2. ✅ Archive Files Tracked in Git, 3. ✅ Incomplete .gitignore Rules, Added Exclusions: (+25 more)
 
 ### Community 57 - "Community 57"
-Cohesion: 0.06
-Nodes (33): ✅ 4. Widget Persistence - WORKING & ENHANCED, 3. Intelligence WebSocket, 1. Basic Widget Structure, AI-Generated Widgets, Browse Marketplace, Category Colors, code:javascript (/**), code:javascript (// ✅ GOOD - Use widget element) (+25 more)
+Cohesion: 0.08
+Nodes (33): Get user information (without sensitive data), hash_secret(), OIDC client registration and secret verification., Exact match only — no wildcards., Insert or update a client. Safe to call on every startup., upsert_client(), validate_redirect_uri(), verify_secret() (+25 more)
 
 ### Community 58 - "Community 58"
-Cohesion: 0.06
-Nodes (33): code:bash (scripts/setup/touchscreen/install_touchscreen.sh \), Current Architecture, Endpoints, Operational Docs, Touchscreen, Touchscreen (Raspberry Pi at `192.168.1.61`), Active Runtime Areas, Archived/Retired Runtime Trees (+25 more)
+Cohesion: 0.08
+Nodes (23): Sync password change to Home Assistant                  Args:             user_i, Sync password change to Matrix                  Args:             user_id: User, create_n8n_auth_config(), N8nIntegration, N8nUser, n8n SSO Integration Replace n8n's basic auth with Zoe's central authentication, Sync Zoe user to n8n                  Args:             user_id: Zoe user ID, Handle password change for n8n user                  Args:             user_id: (+15 more)
 
 ### Community 59 - "Community 59"
 Cohesion: 0.06
-Nodes (22): Check a single router file for authentication issues.     Returns list of (line_, check_file(), Check a single file for hardcoded database paths, check_api_endpoints(), check_router_expectations(), check_ui_pages(), Check database table schemas, Check what routers expect vs what database has (+14 more)
+Nodes (35): 📞 Support & Resources, code:block4 (/home/pi/fix_something.sh             ❌ WRONG), Scripts, Code References, Container Paths, ✅ Verification Complete, 🗄️ Database Status, Frontend Files (59 total) (+27 more)
 
 ### Community 60 - "Community 60"
 Cohesion: 0.06
-Nodes (8): Unit tests for person relationships feature.  Tests: - _REL_RE regex pattern mat, Test the _rel_lookup helper in people.py., Tier normalisation used in both UIs and people.py validation., Test _REL_RE patterns in person_extractor.py., Test RELATIONSHIP_TYPES constant from people.py., TestNormTier, TestRelationshipRegex, TestRelLookup
+Nodes (35): After Implementation (Current), Target State, code:block2 (/api/v1/calendar/events), For Documentation, For Zoe Team, 🏗️ Proposed Approach: URI Path Versioning, Version Support Policy, 📐 Versioning Rules (+27 more)
 
 ### Community 61 - "Community 61"
-Cohesion: 0.07
-Nodes (27): Check for overly large router files, Check for hardcoded command detection patterns, Check for duplicate router patterns, Check main.py for excessive imports, Check for TODO/FIXME/HACK comments, Cleanup Philosophy:, Instead of Deleting:, Red Flags: (+19 more)
+Cohesion: 0.1
+Nodes (7): 2. Widget Lifecycle Methods, `init(element)`, `resize(newSize)`, `update()`, formatTime(), MusicPlayerWidget, MusicSuggestionsWidget
 
 ### Community 62 - "Community 62"
-Cohesion: 0.06
-Nodes (33): Test Results After Fixes, API Test, code:sql (-- Each list should have correct type), code:bash (# Should return isolated lists), Database Test, Code Execution Migration Guide, code:python (# services/zoe-code-execution/), code:typescript (// servers/zoe-lists/add_to_list.ts) (+25 more)
+Cohesion: 0.1
+Nodes (30): get_capability_matrix(), get_my_capability_matrix(), reset_capability_matrix_defaults(), update_capability_matrix_role(), _validate_matrix_shape(), test_authenticated_allowed_for_mutation(), test_default_matrix_has_fixed_shape(), test_guest_blocked_for_mutation() (+22 more)
 
 ### Community 63 - "Community 63"
-Cohesion: 0.06
-Nodes (34): code:python (routing = await route_llm_router.route_query("add bread to s), code:python (result = await enhanced_mem_agent.enhanced_search("add bread), Enhanced MemAgent Test, RouteLLM Test, code:bash (# Test fixed GPU model), Verified Working, code:block5 (📡 AG-UI Event: session_start), Expected Console Output (+26 more)
+Cohesion: 0.13
+Nodes (33): _FakeIntent, Unit tests for `voice_scope.classify`.  Covers every branch of the classifier wi, test_empty_string_defaults_public(), test_empty_string_strict_mode(), test_intent_build_widget_is_user_scoped(), test_intent_calendar_show_is_public_household(), test_intent_ha_prefix_public(), test_intent_journal_create_is_user_scoped() (+25 more)
 
 ### Community 64 - "Community 64"
-Cohesion: 0.09
-Nodes (31): create_event(), delete_event(), get_event(), list_events(), list_today_events(), FastAPI router for calendar events. Mounted at prefix="/api/calendar" with tag ", Get a single event by ID., Create a new calendar event. (+23 more)
+Cohesion: 0.06
+Nodes (21): Unit Tests for Retry Utility ============================  Tests the retry decor, Test no retry on excluded exception type., Test on_retry callback is called., Tests for the retry_async function., Tests for the RetryContext context manager., Tests for NETWORK_CONFIG preset., Test NETWORK_CONFIG retries on network errors., Tests for RetryConfig. (+13 more)
 
 ### Community 65 - "Community 65"
-Cohesion: 0.09
-Nodes (32): Make HTTP request to Home Assistant API, activate_workflow(), analyze_n8n(), create_credential(), create_workflow(), deactivate_workflow(), delete_workflow(), execute_workflow() (+24 more)
+Cohesion: 0.06
+Nodes (8): Unit tests for person relationships feature.  Tests: - _REL_RE regex pattern mat, Test the _rel_lookup helper in people.py., Tier normalisation used in both UIs and people.py validation., Test _REL_RE patterns in person_extractor.py., Test RELATIONSHIP_TYPES constant from people.py., TestNormTier, TestRelationshipRegex, TestRelLookup
 
 ### Community 66 - "Community 66"
-Cohesion: 0.09
-Nodes (19): Analyze warmth on 1-10 scale, Build a comprehensive Samantha-level system prompt, Analyze overall Samantha-level intelligence, Analyze warmth level on 1-10 scale, Analyze intelligence level on 1-10 scale, Analyze tool usage effectiveness on 1-10 scale, Run final comprehensive Samantha-level intelligence test, Final comprehensive Samantha-level intelligence testing (+11 more)
+Cohesion: 0.08
+Nodes (33): get_plugins(), install_plugin_endpoint(), preview_skill_endpoint(), Update a workspace skill from ClawHub., Remove a workspace skill by deleting its directory., Return all plugins (installed + available) for the openclaw_manager component., Install an OpenClaw plugin., Remove an OpenClaw plugin. (+25 more)
 
 ### Community 67 - "Community 67"
 Cohesion: 0.06
-Nodes (32): get_homeassistant_areas(), get_n8n_user_info(), get_service_configurations(), get_user_matrix_rooms(), get_user_n8n_workflows(), handle_password_change_webhook(), handle_user_deactivation_webhook(), homeassistant_auth() (+24 more)
+Nodes (22): Check a single router file for authentication issues.     Returns list of (line_, check_file(), Check a single file for hardcoded database paths, check_api_endpoints(), check_router_expectations(), check_ui_pages(), Check database table schemas, Check what routers expect vs what database has (+14 more)
 
 ### Community 68 - "Community 68"
-Cohesion: 0.06
-Nodes (31): 1. ✅ LiteLLM (Universal LLM API), 2. ✅ RouteLLM (Intelligent Model Router), 3. ✅ MemAgent (Memory Agent), 4. ✅ Enhanced MemAgent (Multi-Expert Model), 5. ✅ LightRAG (Lightweight RAG System), 6. ✅ RAG Enhancements (Query Expansion, Reranking, Hybrid Search), Code Integration, code:block2 (Query: "add bread to shopping list") (+23 more)
+Cohesion: 0.07
+Nodes (27): Check for overly large router files, Check for hardcoded command detection patterns, Check for duplicate router patterns, Check main.py for excessive imports, Check for TODO/FIXME/HACK comments, Cleanup Philosophy:, Instead of Deleting:, Red Flags: (+19 more)
 
 ### Community 69 - "Community 69"
-Cohesion: 0.07
-Nodes (32): code:bash (# Message 1), Test 1: List Addition (After Fix 1), Test 2: Temporal Memory (After Fix 2), Test 3: Person Creation (After Fix 3), 🧪 Testing Plan, code:bash (# From zoe-core to music module), code:bash (# From zoe-core via MCP server to music), code:block12 (Platform detected: ARM architecture, assuming Pi5) (+24 more)
+Cohesion: 0.06
+Nodes (34): code:python (routing = await route_llm_router.route_query("add bread to s), code:python (result = await enhanced_mem_agent.enhanced_search("add bread), Enhanced MemAgent Test, RouteLLM Test, code:bash (# Test fixed GPU model), Verified Working, code:block5 (📡 AG-UI Event: session_start), Expected Console Output (+26 more)
 
 ### Community 70 - "Community 70"
-Cohesion: 0.07
-Nodes (21): AnalyzeRequest, BrowseRequest, CompareRequest, PlanRequest, Request model for browser automation endpoint., Request model for planning endpoint., Request model for analysis endpoint., Request model for comparison endpoint. (+13 more)
+Cohesion: 0.09
+Nodes (31): create_event(), delete_event(), get_event(), list_events(), list_today_events(), FastAPI router for calendar events. Mounted at prefix="/api/calendar" with tag ", Get a single event by ID., Create a new calendar event. (+23 more)
 
 ### Community 71 - "Community 71"
-Cohesion: 0.09
-Nodes (20): create_n8n_auth_config(), N8nIntegration, N8nUser, n8n SSO Integration Replace n8n's basic auth with Zoe's central authentication, Sync Zoe user to n8n                  Args:             user_id: Zoe user ID, Sync user permissions to n8n                  Args:             user_id: User ID, Create workflow-specific permissions in n8n                  Args:             w, n8n user representation (+12 more)
+Cohesion: 0.08
+Nodes (31): compose_message(), Message composer for the proactive engine.  Calls llama-server (same endpoint as, Given a trigger_type and a context dict, ask the LLM for a short message.     Re, _cleanup_expired_pending(), fire_notification(), _is_in_quiet_hours(), Proactive Engine — coordinates all trigger tiers.  Tier 1: APScheduler fires _fi, Internal: import push router and call send_push_to_user. (+23 more)
 
 ### Community 72 - "Community 72"
 Cohesion: 0.06
-Nodes (29): Key Findings, Overall Assessment: 🟢 **EXCELLENT** (with optimization opportunities), 1. LiteLLM Gateway Service, 3. Integration Points, code:python (# Streaming endpoint (line ~755)), 🔗 External Resources, LiteLLM Gateway Integration - Architecture Document, 1. Widget Manifest (`widget-manifest.json`) (+21 more)
+Nodes (32): get_homeassistant_areas(), get_n8n_user_info(), get_service_configurations(), get_user_matrix_rooms(), get_user_n8n_workflows(), handle_password_change_webhook(), handle_user_deactivation_webhook(), homeassistant_auth() (+24 more)
 
 ### Community 73 - "Community 73"
 Cohesion: 0.09
-Nodes (30): Effects, Visual Design, After Adding a Photo, Color Scheme, Large (8x12), Medium (4x8) - Default, Size Variations, Small (3x5) (+22 more)
+Nodes (31): _classify_proposal(), _db_exec(), _is_noise(), _parse_psql_output(), _patch(), _post(), _post_with_workspace(), Run SQL against the multica DB via docker exec. (+23 more)
 
 ### Community 74 - "Community 74"
-Cohesion: 0.1
-Nodes (32): Create Household, Delete Household, Get Household Details, Get My Households, Household Endpoints, Update Household, Get Playback State, Pause Playback (+24 more)
+Cohesion: 0.12
+Nodes (15): person_extractor.process_text(), routers/people.py, Get a specific provider by type.                  Args:             provider_typ, _get(), Return Atomic semantic hits as normalized records., MemoryRef, MemoryService - the sole read/write surface for Zoe memory.  This module is the, The sole read/write surface for Zoe memory. (+7 more)
 
 ### Community 75 - "Community 75"
-Cohesion: 0.1
-Nodes (29): Journal, Lists, Page-Specific Notes, Settings, create_memory_proposal(), export_user_memories(), forget_user(), get_memory_opt_out() (+21 more)
+Cohesion: 0.07
+Nodes (32): code:bash (# Message 1), Test 1: List Addition (After Fix 1), Test 2: Temporal Memory (After Fix 2), Test 3: Person Creation (After Fix 3), 🧪 Testing Plan, code:bash (# From zoe-core to music module), code:bash (# From zoe-core via MCP server to music), code:block12 (Platform detected: ARM architecture, assuming Pi5) (+24 more)
 
 ### Community 76 - "Community 76"
-Cohesion: 0.09
-Nodes (22): AgentZeroClient, _compute_agent_zero_api_key(), Agent Zero Client =================  Client for communicating with Agent Zero's, Get or create context ID for a user.                  Args:             user_id:, Extract URLs from text as sources.                  Args:             text: Text, Send a message to Agent Zero and get response.                  Uses the /api_me, Execute a research task via Agent Zero.                  Args:             query, Create a multi-step plan for a task.                  Args:             task: Ta (+14 more)
+Cohesion: 0.07
+Nodes (33): briefing, browser, dynamic-widgets, family-data, gh-issues, github, grocery-meal, ha-patterns (+25 more)
 
 ### Community 77 - "Community 77"
-Cohesion: 0.08
-Nodes (27): Before Implementation, Additional Optimizations, After Fix:, Before Fix:, Expected Performance, 📊 Comparison: Before vs After, After Implementation, 📈 Impact Summary (+19 more)
+Cohesion: 0.09
+Nodes (19): Analyze warmth on 1-10 scale, Build a comprehensive Samantha-level system prompt, Analyze overall Samantha-level intelligence, Analyze warmth level on 1-10 scale, Analyze intelligence level on 1-10 scale, Analyze tool usage effectiveness on 1-10 scale, Run final comprehensive Samantha-level intelligence test, Final comprehensive Samantha-level intelligence testing (+11 more)
 
 ### Community 78 - "Community 78"
 Cohesion: 0.07
-Nodes (29): Via HTTP (Direct), Via Voice/Chat, Test Commands Used, code:bash (# Research), Direct HTTP (for testing), How to Use, 1. Core Infrastructure ✅, 2. Intent Patterns ✅ (+21 more)
+Nodes (19): Save detailed report to JSON, Scan a single file for database references, Recursively scan directory for database references, Print formatted audit report, DatabaseValidator, Print validation report, Find all .db files in data directory, Check if file is in a backup/archive location (+11 more)
 
 ### Community 79 - "Community 79"
-Cohesion: 0.08
-Nodes (18): Clear the stream URL cache., Get cache statistics., CachedSession, CachedUser, Touch Panel Local Caching System Optimized for fast authentication on touch pane, Verify passcode using cached data (offline mode)                  Args:, Cached user information for touch panels, Cache session for offline use                  Args:             session_id: Ses (+10 more)
+Cohesion: 0.06
+Nodes (31): 1. Visual States, 2. Chat Interface, API Integration, code:block11 (WS /api/ws/intelligence), code:block2 (POST /api/chat/?user_id={user_id}&stream=true), code:javascript (// Lazy load only when needed), code:block4 (data: {"type": "token", "content": "token text"}), Load Time (+23 more)
 
 ### Community 80 - "Community 80"
-Cohesion: 0.11
-Nodes (17): Sync user to Matrix homeserver          Args:         request: Sync request, sync_user_to_matrix(), MatrixIntegration, Sync Zoe user to Matrix homeserver                  Args:             user_id: Z, Deactivate Matrix user                  Args:             username: Username to, Create Matrix room                  Args:             room_config: Room configur, Join user to Matrix room                  Args:             user_id: Zoe user ID, Get Matrix rooms for user                  Args:             user_id: Zoe user I (+9 more)
+Cohesion: 0.06
+Nodes (31): 1. Fix Response Format (Quick Win), 2. Implement Agent Zero Protocol (Main Task), 3. Test End-to-End, code:block1 (2026-01-25 08:51:27,321 - main - INFO - 🔍 Research request f), code:block10 (INFO - 🔍 Research request from user test: smart light bulbs), code:python (return {), code:block2 (Error: Tool execution failed: 404), code:block3 (2026-01-25 08:51:28,198 - main - INFO - 📋 Planning request f) (+23 more)
 
 ### Community 81 - "Community 81"
 Cohesion: 0.07
-Nodes (27): Current Limitations:, Test Commands:, Voice/Chat Testing (Manual), ✅ All Systems Active, Backend (chat.py), Backend Not Responding, Chat Page Configuration, Frontend (chat.html) (+19 more)
+Nodes (32): Combined Metrics, Context Retention Testing, Combined P1 Metrics, Decision Gate Results, P0-1: Context Validation, P0-2: Confidence Expression, P0-3: Temperature Adjustment, P0-4: Grounding Checks (+24 more)
 
 ### Community 82 - "Community 82"
 Cohesion: 0.07
-Nodes (26): 1. Graceful Degradation, 2. Resource Management, 3. Error Recovery, Enhancement Opportunities:, Fixes Applied for 100% System Reliability, GPU Optimization, Model Warmup Strategy, On Startup: (+18 more)
+Nodes (21): AnalyzeRequest, BrowseRequest, CompareRequest, PlanRequest, Request model for browser automation endpoint., Request model for planning endpoint., Request model for analysis endpoint., Request model for comparison endpoint. (+13 more)
 
 ### Community 83 - "Community 83"
-Cohesion: 0.08
-Nodes (29): Trigger Conditions, Prerequisites, 1. Understand and classify the request, 3. Implement minimally, 4. Test, 5. Confirm with user, code:python (# Add to the relevant pattern group — do NOT create a new if), code:python (@mcp_tool(name="tool_name", description="One-line descriptio) (+21 more)
+Cohesion: 0.06
+Nodes (31): ✅ 4. Widget Persistence - WORKING & ENHANCED, 3. Intelligence WebSocket, 1. Basic Widget Structure, AI-Generated Widgets, Browse Marketplace, Category Colors, code:javascript (/**), code:javascript (// ✅ GOOD - Use widget element) (+23 more)
 
 ### Community 84 - "Community 84"
-Cohesion: 0.08
-Nodes (28): Frontend Files (59 total), What Was Deleted, Critical Files Validation, File Deletion Protection, Junk File Pattern Detection, Project Structure Validation, Before ANY Cleanup Operation:, ✅ CLEANUP BEST PRACTICES (+20 more)
+Cohesion: 0.15
+Nodes (29): Test P0-3: Temperature Adjustment, Test classification performance., Test that Tier 0 (HassIL) meets <5ms target., Test batch classification performance., 🎉 Success!, Color, failure(), get_docker_logs() (+21 more)
 
 ### Community 85 - "Community 85"
-Cohesion: 0.1
-Nodes (18): Check if Agent Zero is available.                  Returns:             True if, EmbeddingService, Embedding Service =================  Generates audio and metadata embeddings for, Initialize projection layer for fused embeddings., Generate audio embedding from audio file using CLAP.                  Args:, Generate text embedding from track metadata.                  Args:, Generate fused embedding from audio and metadata embeddings.                  If, Create and cache all embeddings for a track.                  Args: (+10 more)
+Cohesion: 0.07
+Nodes (30): Via HTTP (Direct), Via Voice/Chat, Test Commands Used, code:bash (# Research), Direct HTTP (for testing), How to Use, 1. Dual FAB System, 2. Better Visual Feedback (+22 more)
 
 ### Community 86 - "Community 86"
-Cohesion: 0.08
-Nodes (26): create_pin_challenge(), get_panel_bindings(), load_device_tokens(), panel_public_info(), panel_status(), _pin_check_locked(), _pin_clear(), _pin_record_failure() (+18 more)
+Cohesion: 0.06
+Nodes (32): Root Cause Analysis, The 404 Error, Why LLM Took Over, code:python (# OLD CODE (services/mem-agent/enhanced_mem_agent_service.py), code:python (# Lines 26-38: Temporal memory imported), code:block5 (INFO:__main__:Enhanced search request: Create a person named), code:python (['list', 'calendar', 'memory', 'planning', 'journal', 'remin), code:python (# In chat endpoint, add:) (+24 more)
 
 ### Community 87 - "Community 87"
-Cohesion: 0.07
-Nodes (28): _broadcast_lets_talk_ui(), _broadcast_list_ui(), _broadcast_reminder_ui(), _broadcast_weather_ui(), _contains_decision_keyword(), _get_or_create_voice_session(), _handle_introduce_intent(), _load_voice_history() (+20 more)
+Cohesion: 0.09
+Nodes (22): AgentZeroClient, _compute_agent_zero_api_key(), Agent Zero Client =================  Client for communicating with Agent Zero's, Get or create context ID for a user.                  Args:             user_id:, Extract URLs from text as sources.                  Args:             text: Text, Send a message to Agent Zero and get response.                  Uses the /api_me, Execute a research task via Agent Zero.                  Args:             query, Create a multi-step plan for a task.                  Args:             task: Ta (+14 more)
 
 ### Community 88 - "Community 88"
-Cohesion: 0.08
-Nodes (27): _cleanup_rate_limit_storage(), get_client_info(), get_current_session(), get_session_id_from_bearer_token(), get_session_id_from_header(), _in_memory_rate_limit(), optional_session(), FastAPI Dependencies for Authentication Reusable dependencies for session valida (+19 more)
+Cohesion: 0.1
+Nodes (29): Lists, Page-Specific Notes, Settings, journal, create_memory_proposal(), export_user_memories(), forget_user(), get_memory_opt_out() (+21 more)
 
 ### Community 89 - "Community 89"
-Cohesion: 0.19
-Nodes (27): Test P0-3: Temperature Adjustment, Test classification performance., 🎉 Success!, Color, failure(), get_docker_logs(), log(), Test 1: Baseline with all features OFF (+19 more)
+Cohesion: 0.11
+Nodes (29): Request model for research endpoint., ResearchRequest, _build_research_package(), _capture_research_screenshot(), Capture a screenshot for research evidence using broker-backed browser control., Build research package and attach screenshot evidence when possible., build_package(), classify_query() (+21 more)
 
 ### Community 90 - "Community 90"
-Cohesion: 0.08
-Nodes (28): What Was Fixed, What Was Wrong, [0.0.1] - 2025-10-25 "Initial Release", [0.1.0] - 2025-11-16 "Jetson Optimization & Multi-Platform", Added, Changed, Fixed, Removed (+20 more)
+Cohesion: 0.1
+Nodes (28): Add to Playlist, MusicProvider, Abstract base class for music streaming providers.          All providers (YouTu, Like/save a track. Override if provider supports it., Add tracks to a playlist. Override if provider supports it., Save a track to user's library., Remove track from user's library., Add tracks to a playlist. (+20 more)
 
 ### Community 91 - "Community 91"
 Cohesion: 0.07
-Nodes (26): Agent Zero Integration - COMPLETE, Key Achievements, Next Steps (Optional), Status: Integration Successful!, Agent Zero Live Integration Test Report, code:block11 (zoe-network (bridge)), Docker Network:, Developer Experience (+18 more)
+Nodes (29): Next Steps (Optional), Auto-Discovery Process, code:mermaid (sequenceDiagram), How It Works, Intent Flow, code:block1 (1. Load ALL 20+ tool definitions into context (~2,000 tokens), code:block2 (1. Model writes TypeScript code:), New Pattern (Efficient): (+21 more)
 
 ### Community 92 - "Community 92"
-Cohesion: 0.12
-Nodes (28): code:block24 (docs/), docs/ Folder, Root Level (Max 10 Files), Decision Gates, Appendix: Historical Context, code:block1 (IF only 1 target fails AND it's non-critical:), code:block2 (IF 3 of 4 individual targets pass AND combined targets pass:), Decision Authority (+20 more)
+Cohesion: 0.07
+Nodes (29): 1. Validation Before Save, 2. Empty Layout Detection, 3. Advanced Protection Layer, 4. Loading with Recovery, code:javascript (// saveLayout() was blindly saving whatever it found:), code:javascript (const widgetType = widget.getAttribute('data-widget-type');), code:javascript (// PROTECTION: Don't save if no valid widgets), code:javascript (let layout = null;) (+21 more)
 
 ### Community 93 - "Community 93"
-Cohesion: 0.15
-Nodes (16): BaseHTTPRequestHandler, get_config(), Save OAuth token to database., _HealthHandler, Handle orb-tap activation from the touch UI (POST /activate)., _discover_zoe_server(), _get_local_subnet(), _get_mac() (+8 more)
+Cohesion: 0.07
+Nodes (26): Code Changes, code:python (# Determine list type and category), code:python (tenacity==8.2.3  # ✅ Added for retry logic), ✅ Fix Applied, 🎉 Impact, Test Score Improvement, What Now Works, Available MCP Tools (Not Communicated to LLM) (+18 more)
 
 ### Community 94 - "Community 94"
 Cohesion: 0.09
-Nodes (16): get_vector_index(), Get the vector index (Jetson only).          Returns None on Pi5 or if memory is, Vector Index =============  FAISS-based vector index for fast music similarity s, Load index and ID map from disk., Save index and ID map to disk., Add a track embedding to the index.                  Args:             track_id:, Search with similarity scores.                  Args:             query: 256-dim, Check if track is in the index. (+8 more)
+Nodes (19): RootCleaner, _FakeCursor, Minimal compatibility wrapper so person_extractor works with raw asyncpg., db_compat.py — asyncpg compatibility shim providing an aiosqlite-style cursor AP, Buffered cursor wrapping a list of asyncpg Records., Thin wrapper around asyncpg Connection providing aiosqlite-compatible execute AP, AsyncpgCompat, close_pool() (+11 more)
 
 ### Community 95 - "Community 95"
-Cohesion: 0.09
-Nodes (19): Analyze a target (file, system, configuration).                  Args:, analyze(), Analysis endpoint - analyzes files, configurations, systems.          Uses Agent, Analyze all files in root, RootCleaner, AudioAnalyzer, Audio Analyzer ==============  Extracts audio features from music tracks using E, Analyze a track and extract audio features.                  Args:             t (+11 more)
+Cohesion: 0.1
+Nodes (28): _bridge_post(), _api_post(), _do_single_turn(), _espeak_local(), _get_voice_encoder(), _identify_speaker_from_wav(), _is_junk_transcript(), _notify_wake_background() (+20 more)
 
 ### Community 96 - "Community 96"
-Cohesion: 0.11
-Nodes (21): quick_user_switch(), Touch panel authentication request, Quick user switching for touch panels          Args:         request: Quick swit, validateSession(), Background sync loop for HA integration, QuickAuthManager, QuickAuthResult, Quick user switching for touch panels                  Args:             current (+13 more)
+Cohesion: 0.08
+Nodes (18): Clear the stream URL cache., Get cache statistics., CachedSession, CachedUser, Touch Panel Local Caching System Optimized for fast authentication on touch pane, Verify passcode using cached data (offline mode)                  Args:, Cached user information for touch panels, Cache session for offline use                  Args:             session_id: Ses (+10 more)
 
 ### Community 97 - "Community 97"
-Cohesion: 0.07
-Nodes (16): Test that database schema is created correctly, Test embedding generation, Test embedding hash generation, Test cosine similarity calculation, Test adding memory with automatic embedding generation, Test entity context generation, Test relationship path generation, Test relationship boost calculation (+8 more)
+Cohesion: 0.08
+Nodes (17): Test P0-1: Measure actual latency improvements, Measure latency improvement for Tier 0 intents, Ensure data-fetching intents get context (no regression), Test memory keyword detection accuracy, TestP01ContextValidationImprovements, Tier 0 intents should have high confidence, Tier 0 intents should have 0.0 temperature, Factual queries should have low temperature (+9 more)
 
 ### Community 98 - "Community 98"
-Cohesion: 0.09
-Nodes (16): Test P0-1: Measure actual latency improvements, Measure latency improvement for Tier 0 intents, Ensure data-fetching intents get context (no regression), Test memory keyword detection accuracy, TestP01ContextValidationImprovements, Tier 0 intents should have 0.0 temperature, Factual queries should have low temperature, Conversational intents should have higher temperature (+8 more)
+Cohesion: 0.07
+Nodes (29): code:block1 (/home/zoe/assistant/data/zoe.db), code:bash (docker stop zoe-core zoe-auth), code:bash (cp /home/zoe/assistant/data/zoe.db /home/zoe/assistant/data/), code:bash (sqlite3 /home/zoe/assistant/data/zoe.db < /home/zoe/assistan), code:bash (docker start zoe-core zoe-auth), code:block2 (/home/zoe/assistant-clean/data/          # DELETED - DO NOT ), ✅ CORRECT Location (PRODUCTION), 📍 DATABASE LOCATION - SINGLE SOURCE OF TRUTH (+21 more)
 
 ### Community 99 - "Community 99"
-Cohesion: 0.08
-Nodes (24): Files Modified, To Update (Future), ✅ Fix Applied, 🎉 Impact, 📊 Results, Test Score Improvement, What Now Works, Conflicting Approaches (+16 more)
+Cohesion: 0.07
+Nodes (29): What To Remember, What Didn't Work, What Worked, Architecture Insights, What Went Right, What Went Wrong, code:bash (# Now when someone tries to commit bad code:), Prevention System: (+21 more)
 
 ### Community 100 - "Community 100"
-Cohesion: 0.07
-Nodes (26): System Restoration Log - October 19, 2025, 1. Enhanced Critical Files Protection, 2. Git Branch Protection, 3. Database Backups, ✅ Advanced Memory Systems (100% Intact), ✅ Agent & Orchestration (100% Intact), Commit Summary, ✅ Core Intelligence Systems (100% Intact) (+18 more)
+Cohesion: 0.12
+Nodes (27): get_openclaw_info(), post_openclaw_upgrade(), OpenClaw brain info: skills, cron, gateway, versions., Background: daily npm check, notify users, optional auto-upgrade., run_scheduled_openclaw_version_check(), clear_satisfied_update_notifications(), fetch_gateway_status(), fetch_npm_latest_version() (+19 more)
 
 ### Community 101 - "Community 101"
 Cohesion: 0.07
-Nodes (26): 1. Self-Contained Module Structure ✅, 2. Running Services ✅, 3. Loaded Intents ✅, code:block8 (modules/agent-zero/), Grandma Mode (Default), Module Structure, Agent Zero Safety Guardrails ============================  Provides safety contr, Safety modes for Agent Zero. (+18 more)
+Nodes (28): _broadcast_lets_talk_ui(), _broadcast_list_ui(), _broadcast_reminder_ui(), _broadcast_weather_ui(), _contains_decision_keyword(), _get_or_create_voice_session(), _handle_introduce_intent(), _load_voice_history() (+20 more)
 
 ### Community 102 - "Community 102"
-Cohesion: 0.12
-Nodes (21): Temporal Memory Integration, add_chat_turn(), close_chat_episode(), enhance_memory_search_with_temporal(), Get context from current and recent episodes, Close current episode, Integrates temporal memory with Zoe's chat system, Get active episode for user (+13 more)
+Cohesion: 0.07
+Nodes (27): For existing users (admin):, For Jason (or any new user):, 1. Authentication Testing, 2. Environment Variable Testing, 3. Cloudflared Profile Testing, 4. Test File Location Testing, code:bash (# Test unauthenticated access is blocked), code:bash (# Create .env with custom credentials) (+19 more)
 
 ### Community 103 - "Community 103"
+Cohesion: 0.15
+Nodes (16): BaseHTTPRequestHandler, get_config(), Save OAuth token to database., _HealthHandler, Handle orb-tap activation from the touch UI (POST /activate)., _discover_zoe_server(), _get_local_subnet(), _get_mac() (+8 more)
+
+### Community 104 - "Community 104"
+Cohesion: 0.09
+Nodes (16): get_vector_index(), Get the vector index (Jetson only).          Returns None on Pi5 or if memory is, Vector Index =============  FAISS-based vector index for fast music similarity s, Load index and ID map from disk., Save index and ID map to disk., Add a track embedding to the index.                  Args:             track_id:, Search with similarity scores.                  Args:             query: 256-dim, Check if track is in the index. (+8 more)
+
+### Community 105 - "Community 105"
+Cohesion: 0.08
+Nodes (25): Zoe Code Execution with MCP - Implementation Summary, 1. LiteLLM Gateway Service, 3. Integration Points, code:python (# Streaming endpoint (line ~755)), 1. Widget Manifest (`widget-manifest.json`), 2. WidgetManager (`widget-system.js`), 3. Dashboard Loaders, Adding New Widgets (+17 more)
+
+### Community 106 - "Community 106"
+Cohesion: 0.07
+Nodes (27): 1. Fixed the Database Query, 2. Created Default Lists, 3. Migrated Misplaced Items, 4. Updated Response Format, code:python (# Now correctly filters by list_type!), code:sql (INSERT INTO lists (id, user_id, list_type, list_category, na), code:sql (-- Move bucket items to proper bucket list), code:python (lists.append({) (+19 more)
+
+### Community 107 - "Community 107"
+Cohesion: 0.07
+Nodes (27): All Issues Resolved, Browser Console Output, code:block5 (🔑 Generated device ID: [32-char-hash]), Testing Completed, code:bash (# Root .md count), 1. Service Worker Check, 2. Offline Test, 3. Install Test (+19 more)
+
+### Community 108 - "Community 108"
+Cohesion: 0.09
+Nodes (24): Enter Edit Mode, For End Users, Rearrange Widgets, Reset Layout, Resize Widgets, Save & Exit, code:bash (# Quick compliance check), add_widgets() (+16 more)
+
+### Community 109 - "Community 109"
+Cohesion: 0.1
+Nodes (25): create_background_task(), get_pending_tasks(), Queue a long-running task for background execution.      Body: {"message": "find, Return completed background tasks not yet shown to the user., enqueue_background_task(), _ensure_table(), background_runner.py — Background task queue for Zoe.  Enables "fire and forget", Run a background task through Hermes' OpenAI-compatible API. (+17 more)
+
+### Community 110 - "Community 110"
 Cohesion: 0.14
 Nodes (24): Update Preferences, get_display_preferences(), Fetch the display preferences for a specific panel device.      Deliberately una, _row_to_prefs(), _fetch_openmeteo_current(), _fetch_openmeteo_forecast(), _fetch_owm_current(), _fetch_owm_forecast() (+16 more)
 
-### Community 104 - "Community 104"
+### Community 111 - "Community 111"
 Cohesion: 0.12
-Nodes (25): Request model for research endpoint., ResearchRequest, build_package(), classify_query(), _clean_html_text(), _decode_ddg_href(), default_source_for_query(), _extract_price_from_html_text() (+17 more)
+Nodes (19): quick_user_switch(), Quick user switching for touch panels          Args:         request: Quick swit, validateSession(), Background sync loop for HA integration, QuickAuthManager, QuickAuthResult, Quick Authentication for Touch Panels Optimized for fast user switching and offl, Quick user switching for touch panels                  Args:             current (+11 more)
 
-### Community 105 - "Community 105"
-Cohesion: 0.1
-Nodes (17): Apple Music Provider ====================  Integration with Apple Music using th, display_name(), ProviderType, Supported music provider types., supports_streaming(), get_provider_registry(), ProviderRegistry, Music Provider Registry =======================  Singleton registry that manages (+9 more)
-
-### Community 106 - "Community 106"
+### Community 112 - "Community 112"
 Cohesion: 0.11
 Nodes (13): DatabaseMigrator, Migrate people from zoe.db and memory.db, Create backup of all existing databases, Migrate calendar events from zoe.db, Migrate developer tasks from developer_tasks.db, Migrate lists and list items from zoe.db, Migrate conversations from zoe.db, Create the new unified database schema (+5 more)
 
-### Community 107 - "Community 107"
-Cohesion: 0.08
-Nodes (25): 📋 Affected Endpoints:, 📋 Affected Files:, 🔒 AUTHENTICATION & USER ISOLATION RULES - CRITICAL, code:python (def __init__(self, db_path: str = "/home/zoe/assistant/data/), code:python (# Use LiteLLMProvider (default)), code:bash (# Run before every commit), code:python (# WRONG: Hardcoded default user), ✅ CORRECT Pattern: (+17 more)
-
-### Community 108 - "Community 108"
-Cohesion: 0.08
-Nodes (26): 1. Changed Default Model, 2. Added CPU Models to Config, 3. Improved Error Handling, 4. Created Fixed GPU Model, 5. Updated Model Selection, ✅ 1. Reduced num_predict to 256, ✅ 2. Fixed Warmup Script, 1. Protocol Handling (+18 more)
-
-### Community 109 - "Community 109"
+### Community 113 - "Community 113"
 Cohesion: 0.08
 Nodes (22): 1. Code Execution Service (`services/zoe-code-execution/`), 2. Updated Chat Router (`services/zoe-core/routers/chat.py`), 3. Docker Configuration, 1. PWA Manifest (`/dist/manifest.json`), 2. Service Worker (`/dist/sw.js`), 3. Service Worker Registration (`/dist/js/sw-registration.js`), 4. App Icons (14 icons generated), 5. PWA Meta Tags (21 HTML files updated) (+14 more)
 
-### Community 110 - "Community 110"
-Cohesion: 0.08
-Nodes (26): code:typescript (import * as zoeCalendar from './servers/zoe-calendar';), Example 1: Simple Tool Call, Example 2: Filtering Data, Example 3: Multi-Tool Workflow, code:typescript (import * as zoeLists from './servers/zoe-lists';), Basic Chat Completion, code:bash (curl -X POST http://zoe-litellm:8001/v1/chat/completions \), Streaming Response (+18 more)
-
-### Community 111 - "Community 111"
-Cohesion: 0.08
-Nodes (25): code:javascript (// saveLayout() was blindly saving whatever it found:), Problem This Solves, 1. lists.html (5 locations), 2. chat.html (12 locations), 3. dashboard.html (1 location), Defense in Depth, Files Fixed, For existing users (admin): (+17 more)
-
-### Community 112 - "Community 112"
-Cohesion: 0.1
-Nodes (24): Exception, _enqueue_panel_tool(), _execute_tool(), _get_weather_default_location(), handle_tool(), _MissingUserId, _notify_ui(), MCP Server for zoe-data. Exposes family data tools that OpenClaw skills can call (+16 more)
-
-### Community 113 - "Community 113"
-Cohesion: 0.14
-Nodes (25): Health check endpoint.          Returns service health and Agent Zero availabili, health(), _get_active_player(), _ha_service(), _ma_available(), _ma_cmd(), _ma_play_media(), _ma_player_command() (+17 more)
-
 ### Community 114 - "Community 114"
 Cohesion: 0.08
-Nodes (23): For Production Use, Next Steps, Optional Enhancements, Chat Model Fix - GPU Allocation Error, Current Model Configuration, GPU Models, Key Insights from Gemma DevDay Repository, Primary Models (+15 more)
+Nodes (25): 1. ✅ Project Structure Validation, 2. ✅ Critical Files Validation, 3. ✅ File Deletion Protection, 4. ✅ Junk File Pattern Detection, 5. ✅ Database Path Enforcement, 6. ✅ Authentication Security Check, 7. ✅ CHANGELOG Validation (NEW!), 8. ✅ Large File Detection (NEW!) (+17 more)
 
 ### Community 115 - "Community 115"
 Cohesion: 0.08
-Nodes (24): Architecture Overview, code:bash (# Add database indexes), Commands Executed, MCP-Only Architecture for Zoe Modules, 1. Single Interface, 2. Module Self-Containment, 3. No REST Fallbacks, Automatic: Cache-Busting (+16 more)
+Nodes (26): 1. Changed Default Model, 2. Added CPU Models to Config, 3. Improved Error Handling, 4. Created Fixed GPU Model, 5. Updated Model Selection, ✅ 1. Reduced num_predict to 256, ✅ 2. Fixed Warmup Script, 1. Protocol Handling (+18 more)
 
 ### Community 116 - "Community 116"
 Cohesion: 0.08
-Nodes (24): ❌ NEVER DO, 1. **Automated Enforcement Tool** ✅, 2. **Pre-Commit Hook Integration** ✅, 3. **Documentation Updated** ✅, code:bash (python3 tools/audit/check_database_paths.py), 1. EXPLICIT Network Naming, 2. All Services Use Same Network, Check Current Networks (+16 more)
+Nodes (25): GPU Optimization, Performance Optimizations, Performance Improvement, 📊 Results, 1. Response Time Optimization, 2. Cost Optimization, code:javascript (// Pseudo-code routing logic), code:python (# After Agent Zero research) (+17 more)
 
 ### Community 117 - "Community 117"
-Cohesion: 0.08
-Nodes (24): 1. Automated Docker Monitoring & Cleanup, 2. Disk Space Monitoring, 3. Emergency Cleanup Script, 4. Backup Retention Policy, 5. Docker Prune Services (Fixed), Automated Schedule Summary, Check Current Status, code:bash (systemctl status docker-prune-daily.timer) (+16 more)
+Cohesion: 0.14
+Nodes (25): Health check endpoint.          Returns service health and Agent Zero availabili, health(), _get_active_player(), _ha_service(), _ma_available(), _ma_cmd(), _ma_play_media(), _ma_player_command() (+17 more)
 
 ### Community 118 - "Community 118"
-Cohesion: 0.08
-Nodes (25): code:bash (modules/zoe-music-mcp/), code:python (# services/zoe-core/services/music/__init__.py), code:bash (# Test 1: Module disabled (core still works)), code:bash (FROM: services/zoe-core/services/music/), code:python ("""Platform detection for music module."""), code:python (TOOLS = [), code:block5 (tools/), code:python (# tools/play_song.py) (+17 more)
+Cohesion: 0.11
+Nodes (24): Test that pattern extraction is fast enough for nightly jobs, Each extraction pattern must fire on its canonical example., Questions must not be extracted as memory facts., _fire_memory_capture must write facts to the correct user's wing., Writing same fact twice via _background_memory_save should not create duplicates, test_background_dedup(), test_fire_memory_capture_user_scoped(), test_pattern_extraction() (+16 more)
 
 ### Community 119 - "Community 119"
 Cohesion: 0.13
-Nodes (9): person_extractor.process_text(), routers/people.py, Return Atomic semantic hits as normalized records., MemoryRef, MemoryService - the sole read/write surface for Zoe memory.  This module is the, The sole read/write surface for Zoe memory., Opaque reference returned by MemoryService., Increment consolidation_count on the given memory IDs (called by deep-sleep pass (+1 more)
+Nodes (15): Sync user to Matrix homeserver          Args:         request: Sync request, sync_user_to_matrix(), MatrixIntegration, Sync Zoe user to Matrix homeserver                  Args:             user_id: Z, Deactivate Matrix user                  Args:             username: Username to, Join user to Matrix room                  Args:             user_id: Zoe user ID, Get Matrix rooms for user                  Args:             user_id: Zoe user I, Matrix homeserver SSO integration (+7 more)
 
 ### Community 120 - "Community 120"
-Cohesion: 0.12
-Nodes (23): install_plugin_endpoint(), preview_skill_endpoint(), Update a workspace skill from ClawHub., Install an OpenClaw plugin., Remove an OpenClaw plugin., Read SKILL.md and run automated security scan. Returns content + security verdic, remove_plugin_endpoint(), update_skill_endpoint() (+15 more)
+Cohesion: 0.08
+Nodes (24): code:bash (# Check for large files), Regular Audits, 1. Automated Docker Monitoring & Cleanup, 2. Disk Space Monitoring, 3. Emergency Cleanup Script, 4. Backup Retention Policy, 5. Docker Prune Services (Fixed), Automated Schedule Summary (+16 more)
 
 ### Community 121 - "Community 121"
-Cohesion: 0.09
-Nodes (22): code:block3 (DELETE /api/proactive/schedule/<scheduled_id>), create_schedule(), delete_schedule(), list_schedules(), Proactive Engine REST router.  Endpoints:   POST   /api/proactive/schedule, Manually trigger the morning brief for the calling user.     Useful for testing, Schedule a one-shot proactive nudge., List pending scheduled nudges for the calling user. (+14 more)
+Cohesion: 0.13
+Nodes (23): After Adding a Photo, What It Looks Like, Jetson Orin NX (8K Context, GPU), Platform Configuration, Raspberry Pi 5 (4K Context, CPU), After P0, Architecture Diagram: Memory & Hallucination Reduction, Before P0 (+15 more)
 
 ### Community 122 - "Community 122"
+Cohesion: 0.08
+Nodes (24): Check Task Status, Submit General Task, Submit Research Task, code:block1 (User speaks (1-3s of speech)), Latency Budget (Target: <4s end-to-end), Latency Targets, Services, Voice Pipeline Architecture (+16 more)
+
+### Community 123 - "Community 123"
+Cohesion: 0.09
+Nodes (24): code:python (from fastapi import APIRouter), Example Backend Implementation, 📋 Affected Endpoints:, 📋 Affected Files:, 🔒 AUTHENTICATION & USER ISOLATION RULES - CRITICAL, code:python (def __init__(self, db_path: str = "/home/zoe/assistant/data/), code:python (# Use LiteLLMProvider (default)), code:bash (# Run before every commit) (+16 more)
+
+### Community 124 - "Community 124"
+Cohesion: 0.08
+Nodes (23): For Production Use, Next Steps, Optional Enhancements, Chat Model Fix - GPU Allocation Error, Current Model Configuration, GPU Models, Key Insights from Gemma DevDay Repository, Primary Models (+15 more)
+
+### Community 125 - "Community 125"
+Cohesion: 0.08
+Nodes (23): Android:, Desktop:, 📱 How to Install Zoe, iOS:, 🎯 Phase 1 Goals - Status, Phase 2: Push Notifications, PWA Phase 1 Implementation - COMPLETE ✅, 🎨 Visual Identity (+15 more)
+
+### Community 126 - "Community 126"
+Cohesion: 0.09
+Nodes (23): Architecture Validation ✅, Summary, Tests Passed: 8/8 (100%), What Needs Implementation 🔨, Code Integration, code:block3 (User Query), Current Models (After Adding Gemma DevDay Models), Integration Flow (+15 more)
+
+### Community 127 - "Community 127"
+Cohesion: 0.08
+Nodes (24): Architecture Overview, code:bash (# Add database indexes), Commands Executed, MCP-Only Architecture for Zoe Modules, 1. Single Interface, 2. Module Self-Containment, 3. No REST Fallbacks, Automatic: Cache-Busting (+16 more)
+
+### Community 128 - "Community 128"
+Cohesion: 0.1
+Nodes (19): IntEnum, _AudioStream, _ConnState, _DataPacket, _Frame, _FrameEvent, make_audio_stream(), make_room() (+11 more)
+
+### Community 129 - "Community 129"
+Cohesion: 0.14
+Nodes (10): Connect, AiortcRoom, Drop-in replacement for livekit.rtc.Room using aiortc + WebSocket signalling., Decorator: @room.on("event_name"), Connect to a LiveKit room using WebSocket signalling + aiortc., Handle SDP re-offer from LiveKit server (subscriber PC)., Add an ICE candidate received from the server., Called when aiortc delivers an audio track — map to participant. (+2 more)
+
+### Community 130 - "Community 130"
 Cohesion: 0.11
 Nodes (14): HomeAssistantIntegration, initialize_ha_integration(), Sync user deletion to Home Assistant                  Args:             username, Authenticate user for Home Assistant (called by HA auth provider), Get Home Assistant areas for user assignment, Assign user to specific Home Assistant areas                  Args:, Sync all active Zoe users to Home Assistant                  Returns:, Sync user to HA person entity (+6 more)
 
-### Community 123 - "Community 123"
+### Community 131 - "Community 131"
+Cohesion: 0.09
+Nodes (23): get_client_info(), get_current_session(), get_session_id_from_bearer_token(), get_session_id_from_header(), optional_session(), FastAPI Dependencies for Authentication Reusable dependencies for session valida, Create a dependency that requires specific permission          Args:         per, Require full password-authenticated session (not passcode)          Returns: (+15 more)
+
+### Community 132 - "Community 132"
 Cohesion: 0.08
 Nodes (8): Unit Tests for Household System ===============================  Tests household, Test creating a household., Tests for DeviceBindingManager., Tests for HouseholdManager., Tests for FamilyMixGenerator., TestDeviceBindingManager, TestFamilyMixGenerator, TestHouseholdManager
 
-### Community 124 - "Community 124"
+### Community 133 - "Community 133"
 Cohesion: 0.11
 Nodes (13): Test lists, tasks, and projects with context, Test calendar and event management, Test people management and relationships, Test journal entries and notes, Test N8N workflow automation, Test developer tools and system management, Test voice and media capabilities, Test advanced orchestration and intelligence features (+5 more)
 
-### Community 125 - "Community 125"
-Cohesion: 0.09
-Nodes (22): Android:, Desktop:, 📱 How to Install Zoe, iOS:, 🎯 Phase 1 Goals - Status, Phase 2: Push Notifications, PWA Phase 1 Implementation - COMPLETE ✅, 🎨 Visual Identity (+14 more)
+### Community 134 - "Community 134"
+Cohesion: 0.1
+Nodes (23): Agent Zero Container, Bridge Container, code:block3 (Container ID: d6f0119dbecc), code:block4 (Container ID: 4e4a7f9824d5), code:block6 (✅ Module agent-zero loaded), Zoe Core Integration, code:python (# Current endpoints), 1. **Service Organization** (Low Priority) (+15 more)
 
-### Community 126 - "Community 126"
+### Community 135 - "Community 135"
+Cohesion: 0.08
+Nodes (23): Streaming Response, code:python (# ❌ FORBIDDEN), code:bash (# Automatic backup with timestamp), code:sql (-- ❌ FORBIDDEN without backup), code:bash (echo "$(date): Migration XYZ applied" >> /home/zoe/assistant), code:bash (chmod 644 /home/zoe/assistant/data/*.db), Rule 1: Database Path Enforcement, Rule 2: Automatic Backups Before Changes (+15 more)
+
+### Community 136 - "Community 136"
+Cohesion: 0.09
+Nodes (23): Memory & Hallucination Reduction Analysis for Zoe, 10. WHAT YOU'RE MISSING (Summary), 11. CLOSING THOUGHTS, 4. ADVANCED TECHNIQUES (P2 - Future Considerations), 5. PRIORITIZED IMPLEMENTATION ROADMAP, 7. CRITICAL SUCCESS FACTORS, 9. FINAL RECOMMENDATIONS, Analysis by Research Area (+15 more)
+
+### Community 137 - "Community 137"
+Cohesion: 0.1
+Nodes (24): ⚙️ Automated Enforcement, Monthly Structure Audit, Pre-Commit Checks (`tools/audit/enforce_structure.py`), 1. homeassistant-mcp (cronus42), 2. hass-mcp (voska), Alternative Approach: Use Community Implementations, Layer 2: Pre-Deletion Validation Script, code:python (#!/usr/bin/env python3) (+16 more)
+
+### Community 138 - "Community 138"
+Cohesion: 0.08
+Nodes (24): Action Plan Progress, 2. Chat Integration Diagnostics (PENDING), 3. Router Consolidation (PENDING), 🎯 Action Plan Progress Report, 📝 Additional Issues Discovered, Immediate (This Session), 🔄 In Progress Tasks, 💡 Key Learnings (+16 more)
+
+### Community 139 - "Community 139"
 Cohesion: 0.08
 Nodes (24): code:block39 (📄 Documentation → Root (if essential) or docs/{category}/), I Want To..., 🎯 Quick Reference, code:python (# Standard pattern for all LLM calls), By Purpose:, Check Graph Stats, Check Training Status, code:bash (curl "http://localhost:8000/api/chat/training-stats?user_id=) (+16 more)
 
-### Community 127 - "Community 127"
-Cohesion: 0.09
-Nodes (22): AI Capabilities Evolution, code:block11 (Browse modules:), code:block12 (Company builds internal modules:), code:block13 (Today's Zoe:), Community Marketplace, 🎯 Comparison to Other Systems, 🏗️ Complete Architecture, 📚 Documentation Index (+14 more)
+### Community 140 - "Community 140"
+Cohesion: 0.16
+Nodes (7): GameCardPool, get_deck(), list_decks(), BlackCard, Deck, DeckInfo, WhiteCard
 
-### Community 128 - "Community 128"
-Cohesion: 0.09
-Nodes (22): 🎯 Objective, 🔧 Service Health Fixes - Implementation Guide, 1. API Versioning - DEFERRED ✅, 2. Focus on Quick Wins ✅, 3. Router Consolidation - PLANNED ✅, 💡 Key Decisions Made, 1. **Navigation Bar Inconsistency**, 1. Unified Navigation (+14 more)
-
-### Community 129 - "Community 129"
-Cohesion: 0.12
-Nodes (23): code:json ("prohibited_patterns": [), Action Items (if FAIL), All Features Enabled, Day 22: P0 Validation Gate, Day 27: Behavioral Memory LLM Enhancement Decision, Day 38: P1 Validation Gate, Day 47: Final Deployment Status, Day 4: Memory Architecture Decision (+15 more)
-
-### Community 130 - "Community 130"
-Cohesion: 0.09
-Nodes (24): Change Tracking, code:bash (# See this week's changes), code:bash (# Initialize databases (new installations)), code:bash (# Structure compliance (12 checks)), 🛠️ Tools Now Available, CHANGELOG Generation, code:bash (# Initialize databases from schemas), code:bash (# Weekly change summary) (+16 more)
-
-### Community 131 - "Community 131"
-Cohesion: 0.09
-Nodes (23): code:python (# Add static file serving (see Backend section above)), code:javascript (// static/js/your-widget.js), code:block5 (1. User Opens UI (music.html, dashboard.html)), code:bash (mkdir -p static/{js,css,icons}), code:bash (cat > static/manifest.json <<EOF), 🚀 Creating a New Module with Widgets, 🚀 Example: Complete Calendar Module, 💻 Frontend: Widget Implementation (+15 more)
-
-### Community 132 - "Community 132"
-Cohesion: 0.09
-Nodes (24): Change to Developer Mode, Enabled Modules, code:bash (# In .env), Developer Mode, Files Created (9 total), code:yaml (enabled_modules:), code:bash (AGENT_ZERO_ENABLED=true), Configuration Verified (+16 more)
-
-### Community 133 - "Community 133"
-Cohesion: 0.13
-Nodes (22): get_openclaw_info(), _load_skills_and_cron(), post_openclaw_upgrade(), OpenClaw brain info: skills, cron, gateway, versions., Background: daily npm check, notify users, optional auto-upgrade., run_scheduled_openclaw_version_check(), clear_satisfied_update_notifications(), fetch_gateway_status() (+14 more)
-
-### Community 134 - "Community 134"
-Cohesion: 0.12
-Nodes (22): create_background_task(), get_pending_tasks(), Queue a long-running task for background execution.      Body: {"message": "find, Return completed background tasks not yet shown to the user., enqueue_background_task(), _ensure_table(), background_runner.py — Background task queue for Zoe.  Enables "fire and forget", Return completed-but-unseen tasks for a user, then mark them seen. (+14 more)
-
-### Community 135 - "Community 135"
-Cohesion: 0.09
-Nodes (20): Proactive adapters — thin wrappers that translate external service events into T, Features Added, More Overlay, get_capabilities(), Music Service Module ====================  Platform-aware music system with: - Y, Get music system capabilities for this platform.          Returns:         Dict, More Overlay Modal, Navigation Bar (+12 more)
-
-### Community 136 - "Community 136"
-Cohesion: 0.12
-Nodes (17): Save detailed report to JSON, benchmark(), HallucinationBenchmark, pytest_addoption(), Hallucination Benchmark Test Suite  This test suite measures hallucination rates, Calculate performance metrics from results, Save benchmark report to file, Fixture to provide benchmark instance (+9 more)
-
-### Community 137 - "Community 137"
-Cohesion: 0.09
-Nodes (20): Building Zoe Modules - Developer Guide, Module Intent Auto-Discovery System, Zoe Module Requirements - MANDATORY, code:yaml (module:), Example: Music Module, Getting Help, Module Categories, Module Manifest (Optional) (+12 more)
-
-### Community 138 - "Community 138"
-Cohesion: 0.13
-Nodes (17): Get detailed status of Agent Zero service.          Returns:         Status info, status(), code:bash (# Edit config), Disable Module, cli(), disable(), enable(), info() (+9 more)
-
-### Community 139 - "Community 139"
+### Community 141 - "Community 141"
 Cohesion: 0.21
 Nodes (12): Check if required directories and files exist, ModuleValidator, Check docker-compose.module.yml., Check main.py structure., Validates module structure and safety., Check requirements.txt., Check intents (optional)., Check naming conventions. (+4 more)
 
-### Community 140 - "Community 140"
-Cohesion: 0.09
-Nodes (23): All Issues Resolved, Browser Console Output, code:block5 (🔑 Generated device ID: [32-char-hash]), Testing Completed, code:bash (# Root .md count), 1. Service Worker Check, 2. Offline Test, 3. Install Test (+15 more)
-
-### Community 141 - "Community 141"
-Cohesion: 0.09
-Nodes (22): 🚨 BREAKING CHANGE POLICY, Breaking Changes Require:, ✅ CHECKLIST BEFORE COMMIT, CI/CD Checks (Automatic):, code:block2 (feat(intent): add ListShare intent for sharing lists), code:block4 ([ ] YAML syntax valid (ran validator)), 📝 COMMIT MESSAGE FORMAT, Every Handler Must Meet: (+14 more)
-
 ### Community 142 - "Community 142"
 Cohesion: 0.09
-Nodes (22): code:bash (git commit -m "feat(chat): Add voice command support"), code:bash (# Export updated schema), Conventional Commits (Required), Database Changes, 🔄 For Developers, code:bash (# Commits must follow conventional format), code:bash (# 1. Make schema changes in code), code:bash (# 1. Generate CHANGELOG) (+14 more)
+Nodes (22): check_no_archive_folders(), check_no_databases_in_git(), check_no_duplicate_configs(), check_no_root_tests(), check_no_temp_files(), check_no_venv_in_git(), check_required_docs(), check_root_md_files() (+14 more)
 
 ### Community 143 - "Community 143"
 Cohesion: 0.09
-Nodes (22): Post-Mortem: October 23, 2025 System Failure, 10:00 AM - Nginx Proxy Issues, 10:15 AM - Router 404 Errors, 11:30 AM - System Restored, 1. Hardcoded Database Paths, 2. Module-Level Database Initialization, 3. Orphaned Docker Containers, 4. Dashboard localStorage Corruption (+14 more)
+Nodes (16): Feature Improvement Testing Test each feature individually, measure impact, vali, Ensure we don't add qualifiers to already-qualified responses, Test P0-3: Validate temperature appropriateness, Test that temperature ranges are appropriate for intent types, Test that temperature adjusts based on context availability, Test P0-4: Validate grounding detection, Test P1-1: Validate behavioral pattern extraction, Test that all pattern types can be extracted (+8 more)
 
 ### Community 144 - "Community 144"
 Cohesion: 0.09
-Nodes (22): Agent Zero Not Responding, code:bash (# Check Agent Zero container), 📡 API Integration Details, code:javascript (async function searchMemories(query, userId) {), code:javascript (async function createPlan(task, userId) {), code:bash (# Check Zoe is running), code:bash (# Check skills directory), 💰 Cost Analysis (+14 more)
+Nodes (23): 1. **Schema Normalization** (Medium Priority), 2. **API Versioning Strategy** (Medium Priority), 2. **Service Standardization** (Medium Priority), 2. **Table Count Optimization** (Low Priority), 3. **API Documentation** (Low Priority), 3. **Data Directory Organization** (Low Priority), 3. **Performance Optimization Opportunities** (Medium Priority), 4. **Error Handling Consistency** (Medium Priority) (+15 more)
 
 ### Community 145 - "Community 145"
-Cohesion: 0.17
-Nodes (11): _AcpBridge, _build_env(), openclaw_acp(), openclaw_acp_stream(), ZoeAcpClient — Zoe as a first-class OpenClaw ACP channel.  Uses the Agent Client, Send a JSON-RPC request and return the result, passing through notifications., Create an ACP session (maps to the gateway session key). Returns session UUID., Send a prompt and return the full response text. (+3 more)
+Cohesion: 0.09
+Nodes (22): Files Created (9 total), Classification Speed, code:block10 (Query: "add bread to shopping list" (100 iterations)), code:block11 ("add bread to shopping list" → Database → Response), Coverage (To Be Measured), 🙏 Credits, End-to-End Execution, Files to Configure (+14 more)
 
 ### Community 146 - "Community 146"
-Cohesion: 0.13
-Nodes (16): delete_user(), Delete user (admin only)          Args:         user_id: User ID to delete, _build_metadata(), _idempotency_key(), _luhn_valid(), MemoryServiceError, Return (possibly-redacted-text, reject_reason_or_None)., Raised for operational failures. (+8 more)
+Cohesion: 0.09
+Nodes (23): 📁 File Structure, Decision Gates, Appendix: Historical Context, Decision Gate Checklist, During Gate, Escalation Process, Gate 1 (Day 5): Architecture Audit, Gate 2 (Day 22): P0 Validation (+15 more)
 
 ### Community 147 - "Community 147"
-Cohesion: 0.15
-Nodes (9): Connect, AiortcRoom, Drop-in replacement for livekit.rtc.Room using aiortc + WebSocket signalling., Decorator: @room.on("event_name"), Connect to a LiveKit room using WebSocket signalling + aiortc., Handle SDP re-offer from LiveKit server (subscriber PC)., Add an ICE candidate received from the server., Extract track SID → participant SID from SDP msid attributes.          LiveKit e (+1 more)
+Cohesion: 0.09
+Nodes (21): code:json (// Request current state), Common Error Codes, Error Responses, Get Available Devices, Get Device State, Library Sync Endpoints, Messages to Server, Output Device Endpoints (+13 more)
 
 ### Community 148 - "Community 148"
-Cohesion: 0.1
-Nodes (21): Create a notification., acknowledge_reminder(), create_reminder(), delete_reminder(), list_pending_notifications(), list_reminders(), list_today_reminders(), mark_notification_delivered() (+13 more)
+Cohesion: 0.09
+Nodes (23): Future Enhancements, Backend Sync (Planned), code:javascript (// TODO in lists-dashboard.js line 339), Enhanced Validation, Multi-Dashboard Support, 1. Hybrid Research Mode, 2. Proactive Agent Zero Summaries, 3. Multi-Agent Collaboration (+15 more)
 
 ### Community 149 - "Community 149"
-Cohesion: 0.1
-Nodes (21): create_entry(), delete_entry(), get_entry(), get_mood_stats(), get_prompts(), get_streak_stats(), list_entries(), list_on_this_day() (+13 more)
+Cohesion: 0.09
+Nodes (22): Allowed in Root, 🚀 Benefits of This System, code:block43 (✅ Essential docs (max 10)), 📊 Compliance Monitoring, 💾 Database Management (NEW in v2.4.0), ⚖️ Exceptions & Special Cases, For Maintenance, For New Developers (+14 more)
 
 ### Community 150 - "Community 150"
-Cohesion: 0.11
-Nodes (21): Register a Tier 2 slow-loop trigger., register_trigger(), _blocking_synthesize(), _load_pipeline(), _pcm_to_wav(), Convert a torch.FloatTensor of PCM samples to WAV bytes.      Uses struct.pack i, Run Kokoro inference synchronously (called inside run_in_executor).      Calls t, Async wrapper: runs blocking inference in thread pool under the lock. (+13 more)
+Cohesion: 0.09
+Nodes (22): 🚨 BREAKING CHANGE POLICY, Breaking Changes Require:, ✅ CHECKLIST BEFORE COMMIT, CI/CD Checks (Automatic):, code:block2 (feat(intent): add ListShare intent for sharing lists), code:block4 ([ ] YAML syntax valid (ran validator)), 📝 COMMIT MESSAGE FORMAT, Every Handler Must Meet: (+14 more)
 
 ### Community 151 - "Community 151"
 Cohesion: 0.09
-Nodes (20): Full Integration Test: People System =====================================  Test, Test address extraction, Test adding person with all fields via natural language, Test that Person Expert can extract ALL fields from natural language, Test phone number extraction with different formats, Test email extraction, Test birthday extraction, test_all_capabilities_present() (+12 more)
+Nodes (23): Agent Zero Docker Compose Module, 4.1 Update client.py, 4.2 Test Individual Methods, 4.3 Test via Voice, code:python (import websockets), code:bash (# Test research), Phase 4: Implement & Test, code:block1 ("Zoe, research smart light bulbs") (+15 more)
 
 ### Community 152 - "Community 152"
+Cohesion: 0.17
+Nodes (11): _AcpBridge, _build_env(), openclaw_acp(), openclaw_acp_stream(), ZoeAcpClient — Zoe as a first-class OpenClaw ACP channel.  Uses the Agent Client, Send a JSON-RPC request and return the result, passing through notifications., Create an ACP session (maps to the gateway session key). Returns session UUID., Send a prompt and return the full response text. (+3 more)
+
+### Community 153 - "Community 153"
+Cohesion: 0.1
+Nodes (21): create_entry(), delete_entry(), get_entry(), get_mood_stats(), get_prompts(), get_streak_stats(), list_entries(), list_on_this_day() (+13 more)
+
+### Community 154 - "Community 154"
+Cohesion: 0.12
+Nodes (13): disable_passcode(), Disable passcode for current user          Args:         current_session: Curren, PasscodeManager, Disable passcode for user                  Args:             user_id: User ident, Get passcode information for user (without hash), Reset failed attempts counter (admin function), Validate passcode against policy, Check if passcode is already used by another user (+5 more)
+
+### Community 155 - "Community 155"
+Cohesion: 0.1
+Nodes (20): load_device_tokens(), panel_public_info(), panel_status(), _pin_check_locked(), _pin_clear(), _pin_record_failure(), Panel device token authentication endpoints.  Pi voice daemons and kiosk softwar, Load all active device tokens from DB into the in-memory cache (call at startup) (+12 more)
+
+### Community 156 - "Community 156"
+Cohesion: 0.15
+Nodes (16): delete_user(), Delete user (admin only)          Args:         user_id: User ID to delete, _build_metadata(), _idempotency_key(), MemoryServiceError, Raised for operational failures., Store a fact. Returns None when silently dropped., Fast metadata-filter read for system prompt injection. (+8 more)
+
+### Community 157 - "Community 157"
+Cohesion: 0.17
+Nodes (22): code structure cleanup, Cursor MCP, Graphify Agent Instructions, Greptile PR loop, Hermes-First Delegation, Hermes Agent, OpenClaw Agent, Zoe's Personal Assistant Squad (+14 more)
+
+### Community 158 - "Community 158"
+Cohesion: 0.12
+Nodes (12): Execute comprehensive test suite, test_conversation(), Test if Zoe knows the user's name, Test if Zoe can recall stored facts, Test if new facts are extracted and stored, Test natural language calendar additions (Andrew's issue), Create a demo user with comprehensive profile, Test adding items to lists via natural language (+4 more)
+
+### Community 159 - "Community 159"
+Cohesion: 0.09
+Nodes (20): Full Integration Test: People System =====================================  Test, Test address extraction, Test adding person with all fields via natural language, Test that Person Expert can extract ALL fields from natural language, Test phone number extraction with different formats, Test email extraction, Test birthday extraction, test_all_capabilities_present() (+12 more)
+
+### Community 160 - "Community 160"
+Cohesion: 0.13
+Nodes (13): Test direct action execution, Run comprehensive optimization tests, ZoeOptimizationTester, Test MCP server integration, OptimizationResult, Test memory system optimization, Test MCP integration optimization, Test RouteLLM intelligence optimization (+5 more)
+
+### Community 161 - "Community 161"
+Cohesion: 0.09
+Nodes (21): 7 Layers of Protection:, Best Practices Enforced, code:block5 (/home/zoe/assistant/ (16 files - CLEAN!)), Deleted:, Documentation Reference, File Organization:, Files Moved During Organization, From docs/ to docs/governance/: (+13 more)
+
+### Community 162 - "Community 162"
+Cohesion: 0.09
+Nodes (22): Executive Summary: Memory & Hallucination Reduction for Zoe, Closing Thought, code:block1 (Before: [1000 conversation vectors]), code:python (# "add milk to shopping list" → Tier 0 intent), Expected Outcomes (After P0), Gap #1: No Behavioral Memory (Layer 1), Gap #2: No Pre-Response Validation, Gap #3: No Confidence Expression (+14 more)
+
+### Community 163 - "Community 163"
 Cohesion: 0.09
 Nodes (22): Phase 1: Basic Versioning (Week 1), Phase 2: Deprecation (Week 2), Phase 3: Client Migration (Months 1-6), Phase 4: Cleanup (Month 6), Phase 1: Setup (Day 1), Phase 2: Update Routers (Days 2-4), Phase 3: Documentation (Day 5), Phase 4: Testing (Day 6) (+14 more)
 
-### Community 153 - "Community 153"
-Cohesion: 0.11
-Nodes (21): code:block1 (I'm implementing [Feature Name] from Day [X] of the plan.), code:block10 (I'm evaluating the P0 Validation decision gate on Day 22.), code:block11 (I'm testing [Feature] integration with [System/Component].), code:block12 (I'm testing Context Validation integration with the chat rou), code:block2 (I'm implementing Context Validation from Day 8-10 of the pla), code:block3 (I'm debugging [Issue] in [Feature].), code:block4 (I'm debugging grounding checks not working in P0-4.), code:block5 (I'm validating [Phase] against the plan.) (+13 more)
-
-### Community 154 - "Community 154"
-Cohesion: 0.09
-Nodes (21): Database Breakdown, Databases Found: 19 total, Priority: Nice-to-Have, Available MCP Tools (Not Communicated to LLM), Code Evidence, code:python:640:644:services/zoe-core/routers/chat.py (# Check if this requires tool calls via MCP), code:python:12:120:services/zoe-core/prompt_templates.py (# AVAILABLE TOOLS), code:python:31:41:services/zoe-core/cross_agent_collaboration.py (class ExpertType(Enum):) (+13 more)
-
-### Community 155 - "Community 155"
-Cohesion: 0.09
-Nodes (21): ✅ All Tests Passed (8/8), Test Results Summary, code:block1 (# MCP TOOLS VIA CODE EXECUTION (Progressive Disclosure Patte), code:block3 ([Errno -2] Name or service not known), ✅ **Test 1: Code Execution Pattern in Context** - PASSED, ✅ **Test 2: Code Block Detection** - PASSED, ✅ **Test 3: Search Tools Function** - PASSED (After Fix), ⚠️ **Test 4: Code Execution Service** - NEEDS STARTUP (+13 more)
-
-### Community 156 - "Community 156"
-Cohesion: 0.09
-Nodes (21): Add Member, Add to Shared Playlist, Bind Device to User, Binding Types, Content Filters, Create Shared Playlist, Device Endpoints, Family Mix Endpoints (+13 more)
-
-### Community 157 - "Community 157"
+### Community 164 - "Community 164"
 Cohesion: 0.1
 Nodes (21): **1. Context Briefing**, code:markdown (## 🆕 This Week (Oct 14-18)), code:block16 (1. Immediately start coding), code:bash (# 1. Check context), code:block18 (@workspace Check recent changes), code:markdown (1. Read these files in order:), code:bash (./scripts/utilities/context_briefing.sh), code:bash (# Last week) (+13 more)
 
-### Community 158 - "Community 158"
+### Community 165 - "Community 165"
 Cohesion: 0.09
-Nodes (21): 🔍 Before Every Commit (Mandatory), Code Quality Metrics, code:bash (# Daily health check (30 seconds)), code:markdown (# Maintenance Log), code:bash (# 1. Run automated pre-commit hooks (already installed)), code:bash (# 1. Comprehensive Audit), 🎯 Daily Quality Checks (5 minutes), First Sunday of Month (+13 more)
+Nodes (21): 1. Graceful Degradation, 2. Resource Management, 3. Error Recovery, Fixes Applied for 100% System Reliability, Model Warmup Strategy, On Startup:, Response Time Targets:, System Reliability Improvements (+13 more)
 
-### Community 159 - "Community 159"
+### Community 166 - "Community 166"
+Cohesion: 0.09
+Nodes (20): 1. `thinking` ⚠️, 2. `tool_call` ⚠️, 3. `tool_result` ⚠️, 4. `progress` ⚠️, AG-UI Protocol Implementation Status, AG-UI Protocol Overview, Current Implementation, Frontend Implementation Status (+12 more)
+
+### Community 167 - "Community 167"
+Cohesion: 0.11
+Nodes (21): code:block1 (I'm implementing [Feature Name] from Day [X] of the plan.), code:block10 (I'm evaluating the P0 Validation decision gate on Day 22.), code:block11 (I'm testing [Feature] integration with [System/Component].), code:block12 (I'm testing Context Validation integration with the chat rou), code:block2 (I'm implementing Context Validation from Day 8-10 of the pla), code:block3 (I'm debugging [Issue] in [Feature].), code:block4 (I'm debugging grounding checks not working in P0-4.), code:block5 (I'm validating [Phase] against the plan.) (+13 more)
+
+### Community 168 - "Community 168"
+Cohesion: 0.09
+Nodes (21): Need Help?, 🔧 Advanced: Enable Full Training, After 3 Months:, Be Specific in Corrections, code:bash (# Install Unsloth (one-time)), Data Privacy, First Month:, First Week: (+13 more)
+
+### Community 169 - "Community 169"
+Cohesion: 0.09
+Nodes (21): Key Optimizations, References, 1. Async Generator Pattern, 2. Delta Calculation, 3. Server-Sent Events (SSE), 4. Request Tracking, Buffered Streaming (Ollama Old), Client Integration (+13 more)
+
+### Community 170 - "Community 170"
+Cohesion: 0.14
+Nodes (21): code:json ("prohibited_patterns": [), Action Items (if FAIL), Action Items (if rollback), Day 22: P0 Validation Gate, Day 27: Behavioral Memory LLM Enhancement Decision, Day 38: P1 Validation Gate, Day 42: Initial Deployment Review, Day 4: Memory Architecture Decision (+13 more)
+
+### Community 171 - "Community 171"
 Cohesion: 0.11
 Nodes (20): buildInterestChips(), buildValueChips(), computePersonality(), existing, initQuiz(), INTERESTS, nameInput, nextFromName() (+12 more)
 
-### Community 160 - "Community 160"
-Cohesion: 0.12
-Nodes (13): Create a person, run process_text → verify DB activity row AND MemPalace entry., recalc_and_save updates health_score in DB., Minimal compatibility wrapper so person_extractor works with raw asyncpg., test_health_score_recalc(), test_person_extractor_dual_fanout(), Thin wrapper around asyncpg Connection providing aiosqlite-compatible execute AP, AsyncpgCompat, _ExecResult (+5 more)
+### Community 172 - "Community 172"
+Cohesion: 0.09
+Nodes (21): code:bash (# Export updated schema), Database Changes, Music Module Migration Guide, API Changes, Backward Compatibility, code:bash (# Disable module), code:bash (# Start module alone), code:bash (# Enable in config) (+13 more)
 
-### Community 161 - "Community 161"
-Cohesion: 0.12
-Nodes (12): MusicEvent, MusicEventTracker, Music Event Tracker ====================  Captures listening behavior events for, Record a listening event.                  Args:             user_id: User ident, Track play start event., Track play end event.                  Automatically determines if this was a sk, Track explicit skip event., Track repeat play event. (+4 more)
+### Community 173 - "Community 173"
+Cohesion: 0.15
+Nodes (19): _ensure_db(), _ingest_to_mempalace(), LLM-based person fact extraction — complements regex person_extractor., Extract person facts via local LLM. Silently no-ops on error., _post_write_hooks(), process_text(), person_extractor.py — Extract person facts from conversation text.  Dual fan-out, Return DB UUID if a person with this name exists for user_id, else None. (+11 more)
 
-### Community 162 - "Community 162"
+### Community 174 - "Community 174"
 Cohesion: 0.12
 Nodes (20): _memory_digest_loop(), Wait until 3am, then run LLM digest for all active users daily., Start the nightly memory digest loop (if not disabled)., Manually trigger full nightly dreaming cycle including evolution notice (admin o, start_memory_digest_background(), trigger_run_digest(), _load_recent_misses(), _proposal_exists() (+12 more)
 
-### Community 163 - "Community 163"
-Cohesion: 0.13
-Nodes (20): _agent_loop(), _build_room_handlers(), _cooldown_watchdog(), _get_current_user_soft(), livekit_audio(), livekit_cancel(), _make_participant_state(), _mint_agent_token() (+12 more)
-
-### Community 164 - "Community 164"
-Cohesion: 0.12
-Nodes (19): compose_message(), Message composer for the proactive engine.  Calls llama-server (same endpoint as, Given a trigger_type and a context dict, ask the LLM for a short message.     Re, _cleanup_expired_pending(), fire_notification(), _is_in_quiet_hours(), Proactive Engine — coordinates all trigger tiers.  Tier 1: APScheduler fires _fi, Internal: import push router and call send_push_to_user. (+11 more)
-
-### Community 165 - "Community 165"
+### Community 175 - "Community 175"
 Cohesion: 0.1
-Nodes (20): check_no_archive_folders(), check_no_databases_in_git(), check_no_duplicate_configs(), check_no_root_tests(), check_no_temp_files(), check_no_venv_in_git(), check_required_docs(), check_schema_files_exist() (+12 more)
+Nodes (13): Test that database schema is created correctly, Test embedding generation, Test embedding hash generation, Test cosine similarity calculation, Test adding memory with automatic embedding generation, Test relationship path generation, Test relationship boost calculation, Test search result caching (+5 more)
 
-### Community 166 - "Community 166"
-Cohesion: 0.1
-Nodes (20): Allowed in Root, 🚀 Benefits of This System, code:block43 (✅ Essential docs (max 10)), 💾 Database Management (NEW in v2.4.0), ⚖️ Exceptions & Special Cases, For Maintenance, For New Developers, For Project (+12 more)
-
-### Community 167 - "Community 167"
-Cohesion: 0.1
-Nodes (20): 🔧 Advanced: Enable Full Training, After 3 Months:, Be Specific in Corrections, code:bash (# Install Unsloth (one-time)), Data Privacy, First Month:, First Week:, Give Quality Feedback (+12 more)
-
-### Community 168 - "Community 168"
-Cohesion: 0.1
-Nodes (20): Future Enhancements, Backend Sync (Planned), code:javascript (// TODO in lists-dashboard.js line 339), Enhanced Validation, Multi-Dashboard Support, code:javascript (// Custom event handlers), Extension Points, Planned Features (+12 more)
-
-### Community 169 - "Community 169"
-Cohesion: 0.1
-Nodes (20): **Add Person Modal** (Basic), Backend API Support, code:javascript (// Current code (lines 1315-1339)), code:javascript (function savePersonChanges(personId) {), code:html (<div class="modal-field">), code:javascript (body: JSON.stringify({), code:block9 (User: "Add Sarah, birthday January 15, phone 555-1234"), Current Integration Status (+12 more)
-
-### Community 170 - "Community 170"
-Cohesion: 0.1
-Nodes (21): Auto-Discovery Process, code:mermaid (sequenceDiagram), How It Works, Intent Flow, code:block1 (1. Load ALL 20+ tool definitions into context (~2,000 tokens), code:block2 (1. Model writes TypeScript code:), New Pattern (Efficient):, Old Pattern (Inefficient): (+13 more)
-
-### Community 171 - "Community 171"
+### Community 176 - "Community 176"
 Cohesion: 0.13
 Nodes (21): After (v2.0), Before (v1.0), Authentication (NEVER DELETE), 🔧 BACKEND CRITICAL FILES, code:block4 (services/zoe-ui/dist/components/), code:block9 (services/zoe-auth/), Components (NEVER DELETE), Core CSS (NEVER DELETE) (+13 more)
 
-### Community 172 - "Community 172"
-Cohesion: 0.1
-Nodes (21): 5. Restart Zoe Core (to load intents), code:bash (docker logs zoe-core | grep "agent-zero"), code:bash (docker restart zoe-core), "Intent not recognized", Console Warnings to Watch, Success Messages, 3. Restarted Service, code:bash (docker ps --filter "name=zoe-litellm" --format "table {{.Nam) (+13 more)
-
-### Community 173 - "Community 173"
-Cohesion: 0.1
-Nodes (21): Executive Summary: Memory & Hallucination Reduction for Zoe, Closing Thought, Expected Outcomes (After P0), Gap #1: No Behavioral Memory (Layer 1), Gap #2: No Pre-Response Validation, Gap #3: No Confidence Expression, Monday Morning: P0-2 Implementation, Next Actions (Start This Week) (+13 more)
-
-### Community 174 - "Community 174"
-Cohesion: 0.17
-Nodes (4): GameCardPool, list_decks(), BlackCard, WhiteCard
-
-### Community 175 - "Community 175"
-Cohesion: 0.12
-Nodes (18): chat_capabilities(), Load compact Zoe self-description from file; falls back to empty string., OpenClaw message context prefix (zoe-auth role → agent)., test_context_prefix_includes_user_role_and_name(), test_context_prefix_unknown_role_when_omitted(), chat_inject(), discover_openclaw_capabilities(), _load_zoe_self_compact() (+10 more)
-
-### Community 176 - "Community 176"
-Cohesion: 0.12
-Nodes (16): IntEnum, _AudioStream, _ConnState, _DataPacket, _Frame, _FrameEvent, make_audio_stream(), make_room() (+8 more)
-
 ### Community 177 - "Community 177"
-Cohesion: 0.18
-Nodes (4): Legacy single-dim circle values fall back gracefully., TestCalcHealthScore, calc_health_score(), Calculate a relationship health score in [0.0, 1.0].      Args:         last_con
+Cohesion: 0.1
+Nodes (20): 1. Pre-Commit Hook, 2. CI/CD Check, 3. Monthly Audit, code:bash (#!/bin/bash), code:yaml (# .github/workflows/structure-check.yml), code:bash (# Cron job: Run 1st of each month), 🔒 Enforcement Mechanisms, Pre-Commit Hook (+12 more)
 
 ### Community 178 - "Community 178"
-Cohesion: 0.14
-Nodes (19): get_matches(), get_quiz_question(), _make_quiz_question(), _parse_checkin(), Return a quiz question about the scanned person., Build a multiple-choice question from the scanned person's profile., intent_score(), intents_compatible() (+11 more)
+Cohesion: 0.1
+Nodes (19): 🎯 Architecture Improvements - Implementation Summary, 🔧 Prerequisites for Implementation, Recommended, Required, 📊 Risk Assessment, 1. **Load Page**, 2. **Add Person (All Fields)**, 3. **Click Person (Sidebar)** (+11 more)
 
 ### Community 179 - "Community 179"
 Cohesion: 0.1
-Nodes (20): 1. EXECUTIVE_SUMMARY.md (⭐ Start Here), 2. MEMORY_HALLUCINATION_ANALYSIS.md (📚 Comprehensive Reference), 3. IMPLEMENTATION_GUIDE_P0.md (🛠️ Step-by-Step Code), 4. ARCHITECTURE_DIAGRAM.md (🎨 Visual Guide), code:block1 (Week 1 (Nov 18-22): P0 Implementation), 📄 Document Guide, 📝 Document Maintenance, 📚 Documentation Overview (+12 more)
+Nodes (20): API Test, code:sql (-- Each list should have correct type), code:bash (# Should return isolated lists), Database Test, API Endpoint Health, code:bash (# Test critical API endpoints), Core Endpoints (Tested), Database Schema Status (+12 more)
 
 ### Community 180 - "Community 180"
 Cohesion: 0.1
-Nodes (19): 1. Visual States, Remaining Issues, 📷 Photo Upload, 💾 Smart Saving, ✍️ Title & Content, Core Authentication, Role-Based Access Control (RBAC), Security Features (+11 more)
+Nodes (19): 1. Enhanced MEM Agent ✅, 2. RAG System ✅, 3. Expert Orchestrator ✅, 4. Temporal Memory ✅, 5. Vector Search ✅, 6. Context Optimization ✅, ✅ Advanced Systems Integration, ✅ All Systems Operational (+11 more)
 
 ### Community 181 - "Community 181"
-Cohesion: 0.1
-Nodes (19): 1. **Reminders API 500 Error** (CRITICAL), 2. **WebSocket Connection Failed** (Non-Critical), code:block1 (GET https://zoe.local/api/reminders/ 500 (Internal Server Er), Issues Reported, code:block16 (WebSocket connection to 'wss://zoe.local/ws/intelligence' fa), code:python (from fastapi import WebSocket), code:javascript (// In initOrbChat() function, comment out:), Current Behavior (+11 more)
+Cohesion: 0.18
+Nodes (4): Legacy single-dim circle values fall back gracefully., TestCalcHealthScore, calc_health_score(), Calculate a relationship health score in [0.0, 1.0].      Args:         last_con
 
 ### Community 182 - "Community 182"
 Cohesion: 0.11
-Nodes (19): Project Governance & Cleanup - Implementation Summary, 🎯 Benefits Realized, code:block10 (Total: ~15MB (not counting .git)), code:bash (# 1. Clone repository), code:block9 (Total: 428MB), Documentation Organization, 📂 Files Moved (35+ files to archive), First-Time Setup (+11 more)
+Nodes (19): code:block3 (DELETE /api/proactive/schedule/<scheduled_id>), claim_pending(), Mark a pending notification as claimed and create a chat session seeded     with, claim_pending_endpoint(), create_schedule(), delete_schedule(), list_schedules(), Proactive Engine REST router.  Endpoints:   POST   /api/proactive/schedule (+11 more)
 
 ### Community 183 - "Community 183"
+Cohesion: 0.12
+Nodes (18): chat_capabilities(), chat_inject_background(), Fire-and-forget: inject a summary into the correct user's OpenClaw session., Optionally mirror an intent summary into OpenClaw for legacy debugging., OpenClaw message context prefix (zoe-auth role → agent)., test_context_prefix_includes_user_role_and_name(), test_context_prefix_unknown_role_when_omitted(), chat_inject() (+10 more)
+
+### Community 184 - "Community 184"
 Cohesion: 0.11
 Nodes (19): By Platform, code:python (def detect_hardware():), code:python (PRIMARY_MODELS = {), From Jetson to Pi, From Pi to Jetson, Future Platform Support, Hardware Detection, Migration Between Platforms (+11 more)
 
-### Community 184 - "Community 184"
-Cohesion: 0.1
-Nodes (20): 2. Start the Bridge Service, 3. Verify Services, 4. Environment Configuration, code:bash (cd /home/zoe/assistant/modules/agent-zero), code:bash (# Check both containers are running), code:bash (# Agent Zero Configuration), Manifest, Meta Tags (+12 more)
-
 ### Community 185 - "Community 185"
-Cohesion: 0.1
-Nodes (19): Memory & Hallucination Reduction Analysis for Zoe, 10. WHAT YOU'RE MISSING (Summary), 11. CLOSING THOUGHTS, 4. ADVANCED TECHNIQUES (P2 - Future Considerations), 5. PRIORITIZED IMPLEMENTATION ROADMAP, 9. FINAL RECOMMENDATIONS, Analysis by Research Area, Appendix: Architecture Decision Record (+11 more)
+Cohesion: 0.14
+Nodes (15): benchmark(), HallucinationBenchmark, pytest_addoption(), Hallucination Benchmark Test Suite  This test suite measures hallucination rates, Calculate performance metrics from results, Fixture to provide benchmark instance, Run baseline hallucination measurement          This test:     1. Loads 100 test, Measure latency by intent tier          This test measures:     - Tier 0 (determ (+7 more)
 
 ### Community 186 - "Community 186"
-Cohesion: 0.18
-Nodes (17): create_people_field(), list_people_fields(), update_people_field(), ack_ui_action(), bind_panel(), create_ui_action(), get_action_ledger(), get_pending_ui_actions() (+9 more)
+Cohesion: 0.1
+Nodes (19): 1. **Users Table** (CRITICAL), 2. **People Table**, 3. **Sessions Table**, After Migration, Before Migration, code:markdown (## 🗄️ DATABASE MANAGEMENT RULES), 🚨 Critical Duplicate Issues, 📚 Documentation Updates Needed (+11 more)
 
 ### Community 187 - "Community 187"
-Cohesion: 0.15
-Nodes (10): Tests for panel_* MCP tool definitions., test_panel_announce_exists(), test_panel_check_auth_exists(), test_panel_clear_exists(), test_panel_navigate_exists(), test_panel_request_auth_exists(), test_panel_set_mode_exists(), test_panel_show_fullscreen_exists() (+2 more)
+Cohesion: 0.11
+Nodes (20): code:bash (pytest tests/ -v --cov=routers), code:bash (# Generate endpoint inventory), code:python (# OLD (64 imports)), 🚀 Implementation Strategy, Phase 1: Preparation (Day 1), Phase 2: Consolidate High-Value Targets (Days 2-3), Phase 3: Update Imports (Day 4), Phase 4: Testing & Validation (Day 5) (+12 more)
 
 ### Community 188 - "Community 188"
-Cohesion: 0.11
-Nodes (18): 1. Critical Security Alerts, 2. Best Practices (From Community Guides), 3. Notable Community Forks, 5. Files to Track (Adopt-Patterns Strategy), 6. Decision Triggers (Re-evaluate Strategy), 7. Video Reference, 8. Summary: Updated Recommendations, 9. References (+10 more)
+Cohesion: 0.14
+Nodes (20): Quick-Start Implementation Guide: P0 Recommendations, code:block3 (High (0.90): "I've added milk to your shopping list! ✓"), P0-3: Confidence-Aware Uncertainty Expression, code:python ("""Intent validation module"""), code:bash (grep "SKIP context retrieval" /app/data/logs/zoe-core.log | ), code:python ("""), code:bash (grep "confidence_level" /app/data/logs/zoe-core.log | tail -), code:bash (cat /app/data/logs/behavioral_extraction.log) (+12 more)
 
 ### Community 189 - "Community 189"
-Cohesion: 0.15
-Nodes (11): Test direct action execution, Run comprehensive optimization tests, ZoeOptimizationTester, OptimizationResult, Test memory system optimization, Test RouteLLM intelligence optimization, Comprehensive system optimization for maximum potential, Run comprehensive system optimization (+3 more)
+Cohesion: 0.1
+Nodes (20): 1. EXECUTIVE_SUMMARY.md (⭐ Start Here), 2. MEMORY_HALLUCINATION_ANALYSIS.md (📚 Comprehensive Reference), 3. IMPLEMENTATION_GUIDE_P0.md (🛠️ Step-by-Step Code), 4. ARCHITECTURE_DIAGRAM.md (🎨 Visual Guide), code:block1 (Week 1 (Nov 18-22): P0 Implementation), 📄 Document Guide, 📝 Document Maintenance, 📚 Documentation Overview (+12 more)
 
 ### Community 190 - "Community 190"
-Cohesion: 0.16
-Nodes (14): _intent_name(), ir(), _load_intent_router(), Unit tests for intent_router.py — all A2A + Multica + Evolution intents.  These, Verify that intents used in the Multica board routing list exist., _setup_stubs(), _stub_module(), _stub_psycopg2() (+6 more)
+Cohesion: 0.11
+Nodes (18): Approved Root Files (9):, Architecture Documentation ✅, ✅ Compliance Summary, ✅ Documentation Location Status, Documentation & Rules Audit Report, 📝 Files Created This Session, Governance Documentation ✅, Guides Documentation ✅ (+10 more)
 
 ### Community 191 - "Community 191"
-Cohesion: 0.11
-Nodes (10): Test getting all user sessions, Test session expiration, Test session metadata handling, Test concurrent session handling, Test cases for SessionManager class, Test session creation, Test session retrieval, Test session activity update (+2 more)
+Cohesion: 0.1
+Nodes (19): Current Limitations:, Test Commands:, Voice/Chat Testing (Manual), Response Types, User Sends Message, Chat SSL Certificate Fix, ⚠️ May Fail (Non-Critical), code:block1 (sqlite3.OperationalError: no such table: users) (+11 more)
 
 ### Community 192 - "Community 192"
-Cohesion: 0.19
-Nodes (11): EnhancementTaskCreator, Create user feedback system task, Create cross-agent orchestration enhancement task, Create performance optimization task, Create enhancement tasks in the developer task system, Create comprehensive testing framework task, Create temporal memory system implementation task, Create architecture documentation task (+3 more)
+Cohesion: 0.11
+Nodes (20): What Was Fixed, What Was Wrong, [0.0.1] - 2025-10-25 "Initial Release", [0.1.0] - 2025-11-16 "Jetson Optimization & Multi-Platform", Added, Changed, Removed, Repository Consolidation (+12 more)
 
 ### Community 193 - "Community 193"
 Cohesion: 0.11
-Nodes (18): 1. `routers/music.py`, 2. `routers/chat.py`, 3. `routers/tool_registry.py`, code:block1 (services/music/), code:python (from services.music.context import get_music_context, format), code:python (from services.music.youtube_provider import YouTubeMusicProv), Core Services (26 files), ✅ Easy (Low Risk) (+10 more)
+Nodes (19): Project Governance & Cleanup - Implementation Summary, 🎯 Benefits Realized, code:block10 (Total: ~15MB (not counting .git)), code:bash (# 1. Clone repository), code:block9 (Total: 428MB), Documentation Organization, 📂 Files Moved (35+ files to archive), First-Time Setup (+11 more)
 
 ### Community 194 - "Community 194"
-Cohesion: 0.11
-Nodes (19): Agent Zero Docker Compose Module, Agent Zero Implementation Checklist, Current Status: Placeholder Implementation ✅, code:block2 (🔍 Agent Zero research capability for 'smart light bulbs' is ), code:bash (# Test bridge health), code:bash (# Edit .env), code:bash (# Stop Agent Zero module), Agent Zero Quick Start Guide (+11 more)
+Cohesion: 0.15
+Nodes (13): Unit tests for person_extractor.py — pattern matching and process_text() logic., Integration-style tests that mock DB and MemPalace., Create a mock DB that returns person_id on SELECT., test_birthday_pattern_known_person_writes_date(), test_bucket_list_pattern_writes_bucket(), test_empty_text_returns_zero(), test_gift_pattern_known_person_writes_gift(), test_guest_returns_zero() (+5 more)
 
 ### Community 195 - "Community 195"
-Cohesion: 0.13
-Nodes (17): Enter Edit Mode, For End Users, Rearrange Widgets, Reset Layout, Resize Widgets, Save & Exit, code:bash (# Quick compliance check), 📊 Compliance Monitoring (+9 more)
+Cohesion: 0.11
+Nodes (19): _mempalace_search(), Semantic search of this user's MemPalace facts via MemoryService.      Returns t, _cloak_search(), _ddg_search_sync(), _google_maps_local_search(), _parse_ddg_result_urls(), Search the web using DuckDuckGo (no API key needed)., Synchronous DuckDuckGo search using the duckduckgo-search library.      Returns (+11 more)
 
 ### Community 196 - "Community 196"
-Cohesion: 0.11
-Nodes (18): 1. Critical Tests (Must Pass), 2. Important Tests (Should Pass), 3. Optional Tests (Nice to Have), 🔄 CI/CD Integration, code:block1 (tests/), code:yaml (# .github/workflows/test.yml), Console Output, Critical Path (Must Pass for UI to Work) (+10 more)
+Cohesion: 0.15
+Nodes (10): Tests for panel_* MCP tool definitions., test_panel_announce_exists(), test_panel_check_auth_exists(), test_panel_clear_exists(), test_panel_navigate_exists(), test_panel_request_auth_exists(), test_panel_set_mode_exists(), test_panel_show_fullscreen_exists() (+2 more)
 
 ### Community 197 - "Community 197"
 Cohesion: 0.11
-Nodes (13): Feature Improvement Testing Test each feature individually, measure impact, vali, Ensure we don't add qualifiers to already-qualified responses, Test P0-3: Validate temperature appropriateness, Test that temperature ranges are appropriate for intent types, Test that temperature adjusts based on context availability, Test P0-4: Validate grounding detection, Test that all features can be imported without conflicts, Test P0-2: Validate confidence expression quality (+5 more)
+Nodes (18): 1. Critical Security Alerts, 2. Best Practices (From Community Guides), 3. Notable Community Forks, 5. Files to Track (Adopt-Patterns Strategy), 6. Decision Triggers (Re-evaluate Strategy), 7. Video Reference, 8. Summary: Updated Recommendations, 9. References (+10 more)
 
 ### Community 198 - "Community 198"
+Cohesion: 0.11
+Nodes (11): P0 Feature Validation Tests Tests all P0 features against targets, Low confidence (≥0.50) should add clear qualifier, Very low confidence (<0.50) should admit limitation, Test P0-4: Grounding Checks, Verify all features can be imported, Verify feature flags are properly configured, Test P0-2: Confidence Expression, High confidence (≥0.85) should have no qualifier (+3 more)
+
+### Community 199 - "Community 199"
 Cohesion: 0.15
 Nodes (10): DatabaseConsolidator, Merge sessions from sessions.db and auth.db, Verify that consolidation was successful, Run full consolidation, Check if table exists in database, Merge users from auth.db into zoe.db, DatabaseReferenceUpdater, Run the update process (+2 more)
 
-### Community 199 - "Community 199"
-Cohesion: 0.11
-Nodes (18): Code Flow Analysis, code:block1 (User: "My name is Alice"), code:block2 (User: "What is my name?"), code:python (self_info_patterns = [), Context, Files Involved, Issue 1: LLM Not Using Retrieved Facts, Issue 2: Auto-Injection for Retrieval Not Working (+10 more)
-
 ### Community 200 - "Community 200"
-Cohesion: 0.11
-Nodes (19): What To Remember, What Didn't Work, What Worked, Architecture Insights, What Went Right, What Went Wrong, code:bash (# Now when someone tries to commit bad code:), Prevention System: (+11 more)
+Cohesion: 0.16
+Nodes (14): _intent_name(), ir(), _load_intent_router(), Unit tests for intent_router.py — all A2A + Multica + Evolution intents.  These, Verify that intents used in the Multica board routing list exist., _setup_stubs(), _stub_module(), _stub_psycopg2() (+6 more)
 
 ### Community 201 - "Community 201"
-Cohesion: 0.14
-Nodes (18): Trade-offs, Changes Required, code:block1 ("play Beatles"), code:bash (# 1. Disable music intents (reversible)), code:yaml (# Comment out or remove MusicPlay intent), code:bash (# Backup first), Cons ❌, Decision Helper (+10 more)
+Cohesion: 0.11
+Nodes (10): Test getting all user sessions, Test session expiration, Test session statistics, Test session metadata handling, Test concurrent session handling, Test cases for SessionManager class, Test session creation, Test session retrieval (+2 more)
 
 ### Community 202 - "Community 202"
-Cohesion: 0.11
-Nodes (18): Automation, code:bash (# Add to cron for monthly evolution), Continuous Evolution, Cross-System Pattern Discovery, Data Archival Strategy, Evolution Cycle, Evolution Timeline, Infinite Learning Corpus (+10 more)
+Cohesion: 0.19
+Nodes (11): EnhancementTaskCreator, Create user feedback system task, Create cross-agent orchestration enhancement task, Create performance optimization task, Create enhancement tasks in the developer task system, Create comprehensive testing framework task, Create temporal memory system implementation task, Create architecture documentation task (+3 more)
 
 ### Community 203 - "Community 203"
 Cohesion: 0.11
-Nodes (19): Check Task Status, Submit General Task, Submit Research Task, GET `/api/widgets/available`, GET `/api/widgets/{widget_id}/info`, code:json ({"task": "Compare X vs Y", "context": "comparison context"}), Submit Comparison, Archive Management (+11 more)
+Nodes (19): 5. Restart Zoe Core (to load intents), code:bash (docker logs zoe-core | grep "agent-zero"), code:bash (docker restart zoe-core), "Intent not recognized", Console Warnings to Watch, Success Messages, 3. Restarted Service, code:bash (docker ps --filter "name=zoe-litellm" --format "table {{.Nam) (+11 more)
 
 ### Community 204 - "Community 204"
 Cohesion: 0.11
-Nodes (18): 1. ✅ Model Tests (6/7 Passing - 86%), 2. ✅ RouteLLM Classification (3/3 Passing - 100%), 3. ⚠️ Enhanced MemAgent (0/3 Passing - 0%), 4. ✅ RAG Enhancements (3/3 Passing - 100%), 5. ❌ Chat API (0/4 Passing - 0%), Action Prompts:, Complex Prompts:, Conversation Prompts: (+10 more)
+Nodes (18): Automation, code:bash (# Add to cron for monthly evolution), Continuous Evolution, Cross-System Pattern Discovery, Data Archival Strategy, Evolution Cycle, Evolution Timeline, Infinite Learning Corpus (+10 more)
 
 ### Community 205 - "Community 205"
 Cohesion: 0.11
-Nodes (18): Code References, code:bash (# Check containers still running), Container Paths, Migration Verification Report - /home/zoe/zoe → /home/zoe/assistant, Old Location Contents (/home/zoe/zoe), Post-Deletion Verification, ✅ Verification Complete, 🗄️ Database Status (+10 more)
+Nodes (18): System Restoration Log - October 19, 2025, ✅ Advanced Memory Systems (100% Intact), ✅ Agent & Orchestration (100% Intact), Commit Summary, ✅ Core Intelligence Systems (100% Intact), Developer Dashboard (29 files), Experimental/Broken Routers, Final Status: ✅ SYSTEM RESTORED (+10 more)
 
 ### Community 206 - "Community 206"
-Cohesion: 0.13
-Nodes (19): 1. `session_start` ✅, 2. `agent_state_delta` ✅, 3. `action` ✅, 4. `action_result` ✅, 5. `message_delta` ✅, 6. `session_end` ✅, 7. `action_cards` ✅ (Custom Extension), 8. `error` ✅ (+11 more)
+Cohesion: 0.19
+Nodes (19): code:block24 (docs/), docs/ Folder, Root Level (Max 10 Files), code:block1 (IF only 1 target fails AND it's non-critical:), code:block2 (IF 3 of 4 individual targets pass AND combined targets pass:), Decision Authority, Decision Tree (if FAIL), Documentation (+11 more)
 
 ### Community 207 - "Community 207"
 Cohesion: 0.11
-Nodes (18): Architecture: Four-Tier System, code:yaml (language: "en"), Evaluated Alternatives, Google Home / Alexa Architecture, HassIL Advantages, HassIL YAML Pattern, Migration Strategy, Pattern Example (+10 more)
+Nodes (17): Overview, 1. API Versioning - DEFERRED ✅, 2. Focus on Quick Wins ✅, 3. Router Consolidation - PLANNED ✅, 💡 Key Decisions Made, Technical Debt, code:block2 (SECURITY CONTEXT: This content is from an UNTRUSTED source.), LLM Enforcement (+9 more)
 
 ### Community 208 - "Community 208"
-Cohesion: 0.11
-Nodes (18): code:block1 (2026-01-25 08:51:27,321 - main - INFO - 🔍 Research request f), code:block2 (Error: Tool execution failed: 404), code:block3 (2026-01-25 08:51:28,198 - main - INFO - 📋 Planning request f), code:block4 (I'd love to help you plan your home automation setup. What k), code:block5 (2026-01-25 08:51:28,647 - main - INFO - 🔬 Analysis request f), code:block6 (<tool_call>), code:block7 (2026-01-25 08:51:29,409 - main - INFO - ⚖️ Comparison reques), code:block8 (Ah, a great topic! Both Zigbee and Z-Wave are popular wirele) (+10 more)
+Cohesion: 0.13
+Nodes (19): 1. `session_start` ✅, 2. `agent_state_delta` ✅, 3. `action` ✅, 4. `action_result` ✅, 5. `message_delta` ✅, 6. `session_end` ✅, 7. `action_cards` ✅ (Custom Extension), 8. `error` ✅ (+11 more)
 
 ### Community 209 - "Community 209"
-Cohesion: 0.13
-Nodes (18): code:bash (./stop-zoe.sh), code:bash (tail -f /tmp/zoe-auth.log), 🔑 Default Credentials, 🆕 First-Time Setup (New Installations), 🚀 How to Start Zoe, 🛑 How to Stop Zoe, 🐛 If Something's Wrong, To Commit These Changes: (+10 more)
+Cohesion: 0.11
+Nodes (18): Code Flow Analysis, code:block1 (User: "My name is Alice"), code:block2 (User: "What is my name?"), code:python (self_info_patterns = [), Context, Files Involved, Issue 1: LLM Not Using Retrieved Facts, Issue 2: Auto-Injection for Retrieval Not Working (+10 more)
 
 ### Community 210 - "Community 210"
+Cohesion: 0.11
+Nodes (18): 1. **gemma3n:e2b** ✅ (Modern efficient - recommended), 2. **gemma3n:e4b** ❌ (Multimodal - image, audio, video), 3. **gemma3:27b** ❌ (Large, very accurate), 4. **gemma2:2b** ❌ (Small, fast), Article Recommended Models, Configured but Not Installed:, Current Model Strategy, Current Setup (+10 more)
+
+### Community 211 - "Community 211"
+Cohesion: 0.11
+Nodes (18): 1. Critical Tests (Must Pass), 2. Important Tests (Should Pass), 3. Optional Tests (Nice to Have), 🔄 CI/CD Integration, code:block1 (tests/), code:yaml (# .github/workflows/test.yml), Console Output, Critical Path (Must Pass for UI to Work) (+10 more)
+
+### Community 212 - "Community 212"
+Cohesion: 0.11
+Nodes (18): Quality Maintenance Guide for Zoe AI Assistant, 🔍 Before Every Commit (Mandatory), code:bash (# Daily health check (30 seconds)), code:markdown (# Maintenance Log), code:bash (# 1. Run automated pre-commit hooks (already installed)), code:bash (# 1. Comprehensive Audit), 🎯 Daily Quality Checks (5 minutes), First Sunday of Month (+10 more)
+
+### Community 213 - "Community 213"
+Cohesion: 0.11
+Nodes (18): Features Added, More Overlay, Manage Contacts, Plan Gifts, Remember Details, Visualize Relationships, What You Can Do, More Overlay Modal (+10 more)
+
+### Community 214 - "Community 214"
 Cohesion: 0.16
 Nodes (15): DESIRE_LABELS, getMyCheckinId(), goDiscover(), INTENT_LABELS, load(), loadQuiz(), pathParts, renderCompatibility() (+7 more)
 
-### Community 211 - "Community 211"
-Cohesion: 0.12
-Nodes (19): 3. Resource Optimization, 1. homeassistant-mcp (cronus42), 2. hass-mcp (voska), Alternative Approach: Use Community Implementations, code:dockerfile (FROM python:3.11-slim), code:yaml (services:), docker-compose.module.yml Template, Dockerfile Template (+11 more)
+### Community 215 - "Community 215"
+Cohesion: 0.11
+Nodes (19): code:bash (git commit -m "feat(chat): Add voice command support"), Conventional Commits (Required), 🔄 For Developers, code:bash (# Commits must follow conventional format), code:bash (# 1. Make schema changes in code), code:bash (# 1. Generate CHANGELOG), Creating a Release, Database Schema Changes (+11 more)
 
-### Community 212 - "Community 212"
-Cohesion: 0.15
-Nodes (19): Quick-Start Implementation Guide: P0 Recommendations, code:block1 (Before: [1000 conversation vectors]), code:python (# "add milk to shopping list" → Tier 0 intent), code:block3 (High (0.90): "I've added milk to your shopping list! ✓"), P0-1: Behavioral Memory Extraction, P0-2: Intent-Aware Context Validation, P0-3: Confidence-Aware Uncertainty Expression, The 3 High-Impact Recommendations (P0) (+11 more)
+### Community 216 - "Community 216"
+Cohesion: 0.11
+Nodes (18): 1. `routers/music.py`, 2. `routers/chat.py`, 3. `routers/tool_registry.py`, code:block1 (services/music/), code:python (from services.music.context import get_music_context, format), code:python (from services.music.youtube_provider import YouTubeMusicProv), Core Services (26 files), ✅ Easy (Low Risk) (+10 more)
 
-### Community 213 - "Community 213"
-Cohesion: 0.15
-Nodes (12): BrowserActionPlan, BrowserBackendCapabilities, BrowserEvidence, build_cloak_executor(), build_openclaw_gateway_executor(), create_default_browser_broker(), Browser broker for Zoe multi-surface browser orchestration.  This module is inte, Provide side-by-side backend summary and current recommendation. (+4 more)
+### Community 217 - "Community 217"
+Cohesion: 0.14
+Nodes (18): Trade-offs, Changes Required, code:block1 ("play Beatles"), code:bash (# 1. Disable music intents (reversible)), code:yaml (# Comment out or remove MusicPlay intent), code:bash (# Backup first), Cons ❌, Decision Helper (+10 more)
 
-### Community 214 - "Community 214"
+### Community 218 - "Community 218"
+Cohesion: 0.11
+Nodes (19): Change Tracking, code:bash (# See this week's changes), code:bash (# Initialize databases (new installations)), code:bash (# Structure compliance (12 checks)), 🛠️ Tools Now Available, CHANGELOG Generation, code:bash (# Initialize databases from schemas), code:bash (# Weekly change summary) (+11 more)
+
+### Community 219 - "Community 219"
 Cohesion: 0.15
 Nodes (11): AffinityEngine, AffinityScore, Music Affinity Engine =====================  Calculates user preferences from li, Get affinity score for an artist.                  Aggregates affinity across al, Get user's top tracks by affinity score.                  Args:             user, Get aggregate listening statistics for a user.                  Returns:, Rank a list of tracks by user affinity.                  Args:             track, Affinity score with metadata (+3 more)
 
-### Community 215 - "Community 215"
+### Community 220 - "Community 220"
+Cohesion: 0.16
+Nodes (17): Exception, _enqueue_panel_tool(), _execute_tool(), _get_weather_default_location(), handle_tool(), _MissingUserId, _notify_ui(), MCP Server for zoe-data. Exposes family data tools that OpenClaw skills can call (+9 more)
+
+### Community 221 - "Community 221"
 Cohesion: 0.12
 Nodes (17): Ensure audio features table exists., Initialize music auth table., Ensure embeddings table exists., Ensure music_events table exists., Initialize music playback tables., init_db(), migrate_db(), Module-local SQLite database for Orbit. (+9 more)
 
-### Community 216 - "Community 216"
-Cohesion: 0.18
-Nodes (11): Generate random text for testing, Benchmark system initialization, Benchmark embedding generation performance, Benchmark migration performance, Benchmark search performance, Benchmark caching performance, Benchmark memory usage, Benchmark concurrent access performance (+3 more)
-
-### Community 217 - "Community 217"
-Cohesion: 0.12
-Nodes (11): test_session(), Test session statistics, Test cases for session API endpoints, Test session creation endpoint, Test session retrieval endpoint, Test session extension endpoint, Test session invalidation endpoint, Test get user sessions endpoint (+3 more)
-
-### Community 218 - "Community 218"
-Cohesion: 0.14
-Nodes (9): Get application log sizes, Get overall disk usage, Storage monitoring and safe optimization, SAFE: Run VACUUM on databases (reversible optimization)                  Args:, SAFE: Archive old application logs                  Args:             days_to_ke, Analyze storage usage - MONITORING ONLY, NO DELETION                  Returns:, Get Docker images usage, Get database file sizes (+1 more)
-
-### Community 219 - "Community 219"
-Cohesion: 0.12
-Nodes (18): code:yaml (zoe-auth:), code:yaml (zoe-litellm:), code:yaml (general_settings:), Fix 1: zoe-auth Health Check, Fix 2: zoe-litellm Health Check, 🔧 Recommended Fixes, 1. Network Configuration, 2. Security - NEVER Commit Secrets (+10 more)
-
-### Community 220 - "Community 220"
-Cohesion: 0.11
-Nodes (18): 1. Fixed the Database Query, 2. Created Default Lists, 3. Migrated Misplaced Items, 4. Updated Response Format, code:python (# Now correctly filters by list_type!), code:sql (INSERT INTO lists (id, user_id, list_type, list_category, na), code:sql (-- Move bucket items to proper bucket list), code:python (lists.append({) (+10 more)
-
-### Community 221 - "Community 221"
-Cohesion: 0.11
-Nodes (18): Services Running, Building a New Module, code:bash (# List available modules), code:block8 (✅ zoe-core         (orchestration, intents)), 🎮 How to Use the System, Managing Modules, code:bash (# Check status), code:bash (# 1. Copy template) (+10 more)
-
 ### Community 222 - "Community 222"
-Cohesion: 0.11
-Nodes (17): code:python (class SomeService:), code:bash (# Try to commit code with hardcoded path), code:bash (# Check current status), ✅ CORRECT:, Existing Violations (Non-Critical), Files Corrected:, How This Prevents Future Issues, Protection Layers: (+9 more)
+Cohesion: 0.12
+Nodes (17): _detect_preview_urls(), For builder intents, strip code fences from the chat bubble and     shorten the, TEXT_MESSAGE_* for assistant reply, then CUSTOM zoe.ui_* for generative UI., Return (widget_preview_url, page_preview_url) if found in text., If a builder run staged a preview but forgot to emit navigate/orb_prompt,     sy, _sanitize_builder_reply(), _stream_openclaw_assistant_ag(), _synthesize_builder_actions() (+9 more)
 
 ### Community 223 - "Community 223"
-Cohesion: 0.12
-Nodes (18): code:python (# routers/features/v2/calendar.py), code:python (from routers.features.v2 import calendar as calendar_v2), Phase 3: Version-Specific Routers, Discoverability, Feedback, Reliability, After (Standardized), Before (Inconsistent) (+10 more)
+Cohesion: 0.14
+Nodes (12): get_permission_checker(), Helper class for complex permission checking, Check if session has specific permission, Check if session has any of the listed permissions, Check if can access another user's resource, Get permission checker instance for current session, PermissionCheck, Result of permission verification (+4 more)
 
 ### Community 224 - "Community 224"
 Cohesion: 0.12
-Nodes (16): 📊 **Implementation Status**, 🧪 **Manual Testing via UI**, ✅ **TESTING COMPLETE - Implementation Verified**, ⚠️ **What Needs Action**, code:bash (docker-compose up -d zoe-code-execution), All Systems Test, Architecture Test, code:bash (python3 test_all_systems.py) (+8 more)
+Nodes (11): test_session(), Test cases for session API endpoints, Test session creation endpoint, Test session retrieval endpoint, Test session extension endpoint, Test session invalidation endpoint, Test get user sessions endpoint, Test retrieval of non-existent session (+3 more)
 
 ### Community 225 - "Community 225"
-Cohesion: 0.11
-Nodes (17): code:bash (git clone https://github.com/jason-easyazz/zoe-ai-assistant.), code:bash (docker compose up -d zoe-auth zoe-ui homeassistant homeassis), Raspberry Pi 5 (CPU), 1. Copy the Template, 2. Update Module Structure, 3. Define Your Tools, 4. Register with MCP Server, 5. Test Your Module (+9 more)
+Cohesion: 0.15
+Nodes (12): BrowserActionPlan, BrowserBackendCapabilities, BrowserEvidence, build_cloak_executor(), build_openclaw_gateway_executor(), create_default_browser_broker(), Browser broker for Zoe multi-surface browser orchestration.  This module is inte, Provide side-by-side backend summary and current recommendation. (+4 more)
 
 ### Community 226 - "Community 226"
-Cohesion: 0.12
-Nodes (18): code:python (# services/zoe-core/routers/chat.py), 2. HALLUCINATION REDUCTION TECHNIQUES, code:block11 (User: "Add milk to shopping list"), code:block12 (User: "What's my next Arduino project?"), code:block13 (User: "When did I last talk to Sarah?"), code:block14 (User: "What's my favorite color?"), code:python (# services/zoe-core/grounding_validator.py (NEW)), code:python (# services/zoe-core/behavioral_memory.py (NEW)) (+10 more)
+Cohesion: 0.18
+Nodes (11): Generate random text for testing, Benchmark system initialization, Benchmark embedding generation performance, Benchmark migration performance, Benchmark search performance, Benchmark caching performance, Benchmark memory usage, Benchmark concurrent access performance (+3 more)
 
 ### Community 227 - "Community 227"
-Cohesion: 0.11
-Nodes (17): Canonical backend decision, Endpoint compatibility matrix (current), Operational rule, Planned additions for provider sync operations, UI-consumed endpoints that remain primary, Calendar Sync Baseline, Canonical Runtime Configuration (Observed), Device Identity (+9 more)
+Cohesion: 0.14
+Nodes (9): Get application log sizes, Get overall disk usage, Storage monitoring and safe optimization, SAFE: Run VACUUM on databases (reversible optimization)                  Args:, SAFE: Archive old application logs                  Args:             days_to_ke, Analyze storage usage - MONITORING ONLY, NO DELETION                  Returns:, Get Docker images usage, Get database file sizes (+1 more)
 
 ### Community 228 - "Community 228"
 Cohesion: 0.12
-Nodes (17): Touch Panel Skill, Backend API, Browser visibility architecture, code:block1 (panel_navigate(url, panel_id)          → Load URL full-scree), code:bash (panel_ssh_exec("zoe-touch-pi", "systemctl status zoe-kiosk")), code:block3 (GET  /api/panels                           → list registered), code:python (panel_browser_screenshot(navigate_to="https://example.com", ), code:bash (# From Jetson repo root — deploy scripts/config to panel) (+9 more)
+Nodes (18): code:typescript (import * as zoeCalendar from './servers/zoe-calendar';), Example 1: Simple Tool Call, Example 2: Filtering Data, Example 3: Multi-Tool Workflow, code:typescript (import * as zoeLists from './servers/zoe-lists';), Basic Chat Completion, code:bash (curl -X POST http://zoe-litellm:8001/v1/chat/completions \), code:bash (# Find when user added milk to shopping) (+10 more)
 
 ### Community 229 - "Community 229"
-Cohesion: 0.18
-Nodes (17): Hermes Agent, OpenClaw Agent, Zoe's Personal Assistant Squad, Zoe Squad, Zoe Capabilities, Agent Architecture, Core Capabilities, escalate_to_hermes (+9 more)
+Cohesion: 0.11
+Nodes (18): Enabled Modules, code:yaml (enabled_modules:), code:block11 (zoe-network (bridge)), code:bash (AGENT_ZERO_ENABLED=true), Configuration Verified, Docker Network:, Environment Variables:, Modules Configuration: (+10 more)
 
 ### Community 230 - "Community 230"
-Cohesion: 0.19
-Nodes (16): _infer_event_category(), _call_with_tool(), _extract_calendar(), _extract_journal(), _extract_list_add(), _extract_note(), _extract_people(), _extract_reminder() (+8 more)
+Cohesion: 0.11
+Nodes (17): code:bash (# Check if service exists), code:block3 (IF all criteria met:), ❌ ABSOLUTE PROHIBITIONS, ALWAYS Ask Before Deleting:, 🛡️ CLEANUP SAFETY RULES - MANDATORY FOR ALL AI ASSISTANTS, code:block10 (Should I delete this file?), Immediate Actions:, 📞 INCIDENT RESPONSE (+9 more)
 
 ### Community 231 - "Community 231"
-Cohesion: 0.12
-Nodes (15): create_docs_folder(), create_project_status(), move_to_archive(), Create organized docs folder structure, Move old docs to archive, Create docs/README.md index, Create consolidated PROJECT_STATUS.md, create_docs_index() (+7 more)
+Cohesion: 0.11
+Nodes (17): Authentication Security Check, CHANGELOG Validation, Large File Detection, Secret/API Key Detection, code:bash (# Try to commit code with hardcoded path), code:bash (# Check current status), Existing Violations (Non-Critical), Files Corrected: (+9 more)
 
 ### Community 232 - "Community 232"
 Cohesion: 0.12
-Nodes (16): Chat / Voice Commands Reference, Circle Model, code:block1 (score = 0.6 × recency + 0.3 × frequency + birthday_boost), Developer Notes, entity_id consistency, Entity ID strategy, Health dot colours (UI), How Facts Are Extracted from Conversations (+8 more)
+Nodes (18): code:python (# services/zoe-core/routers/chat.py), 2. HALLUCINATION REDUCTION TECHNIQUES, code:block11 (User: "Add milk to shopping list"), code:block12 (User: "What's my next Arduino project?"), code:block13 (User: "When did I last talk to Sarah?"), code:block14 (User: "What's my favorite color?"), code:python (# services/zoe-core/grounding_validator.py (NEW)), code:python (# services/zoe-core/behavioral_memory.py (NEW)) (+10 more)
 
 ### Community 233 - "Community 233"
-Cohesion: 0.12
-Nodes (16): 1. **Users Table** (CRITICAL), 2. **People Table**, 3. **Sessions Table**, After Migration, Before Migration, code:markdown (## 🗄️ DATABASE MANAGEMENT RULES), 🚨 Critical Duplicate Issues, Critical Service Files (Must Update) (+8 more)
+Cohesion: 0.11
+Nodes (17): Action Prompts:, Complex Prompts:, Conversation Prompts:, ✅ Highly Effective Systems:, Memory Prompts:, Natural Language Prompt Testing, ⚠️ Needs Attention:, System Effectiveness Analysis (+9 more)
 
 ### Community 234 - "Community 234"
 Cohesion: 0.12
-Nodes (16): Usage, Voice/Chat Commands, Cleanup Commands, code:bash (# Before making changes), Daily Operations, Archive Structure, code:bash (# Make scripts executable and setup cron job), code:bash (# Tag unused files manually) (+8 more)
+Nodes (17): Safety Tests, Unit Tests, Voice Tests, code:python (# tests/unit/test_versioning.py), 🧪 Testing Strategy, Access Your Entries, Backend, Integration (+9 more)
 
 ### Community 235 - "Community 235"
-Cohesion: 0.13
-Nodes (17): Browser Automation → Moltbot, code:javascript (if (message.includes("remember") || message.includes("said a), code:javascript (if (message.includes("research") || message.includes("invest), code:javascript (if (message.includes("plan") || message.includes("roadmap") ), code:javascript (if (message.includes("analyze") || message.includes("review"), code:javascript (if (message.includes("compare") || message.includes("vs") ||), code:javascript (if (message.includes("book") || message.includes("find fligh), Comparisons → Agent Zero (+9 more)
+Cohesion: 0.12
+Nodes (18): code:python (# routers/features/v2/calendar.py), code:python (from routers.features.v2 import calendar as calendar_v2), Phase 3: Version-Specific Routers, Discoverability, Feedback, Reliability, After (Standardized), Before (Inconsistent) (+10 more)
 
 ### Community 236 - "Community 236"
-Cohesion: 0.12
-Nodes (17): Before Cleanup, Before ANY File Changes, Before Cleanup Operations, Before Committing, Clean up Mac metadata, code:bash (# 1. Validate current state), code:bash (find . -type f -size +10M -not -path "./.git/*"), code:bash (# 1. Create safety commit) (+9 more)
+Cohesion: 0.17
+Nodes (15): Temporal Memory Integration, add_chat_turn(), enhance_memory_search_with_temporal(), Get context from current and recent episodes, Integrates temporal memory with Zoe's chat system, Store conversation turn in episode, Start a new conversation episode, Enhance existing memory search with temporal context (+7 more)
 
 ### Community 237 - "Community 237"
-Cohesion: 0.12
-Nodes (15): Overview, Accessibility, Backup Information, CSS Added (~150 lines), JavaScript Added (~100 lines), Mobile Responsiveness, Navigation Hierarchy, Navigation Standardization Report (+7 more)
+Cohesion: 0.11
+Nodes (17): Canonical backend decision, Endpoint compatibility matrix (current), Operational rule, Planned additions for provider sync operations, UI-consumed endpoints that remain primary, Calendar Sync Baseline, Canonical Runtime Configuration (Observed), Device Identity (+9 more)
 
 ### Community 238 - "Community 238"
-Cohesion: 0.12
-Nodes (17): code:bash (docker stop zoe-core zoe-auth), code:bash (cp /home/zoe/assistant/data/zoe.db /home/zoe/assistant/data/), code:bash (sqlite3 /home/zoe/assistant/data/zoe.db < /home/zoe/assistan), code:bash (docker start zoe-core zoe-auth), If Users Are Lost, 1. Find When Deleted, 2. Restore from Git, 3. Restore Multiple Files (+9 more)
+Cohesion: 0.16
+Nodes (9): MusicEventTracker, Record a listening event.                  Args:             user_id: User ident, Track play start event., Track play end event.                  Automatically determines if this was a sk, Track explicit skip event., Track repeat play event., Track queue add event., Get the affinity weight for an event type. (+1 more)
 
 ### Community 239 - "Community 239"
-Cohesion: 0.12
-Nodes (17): Compliance Check, ✅ Manifest Compliance, ✅ Structure Compliance, Active Users, Database State (Post-Fix), Verification Results, code:block10 ($ python3 tools/reports/repo_health.py), Run All Structure Checks (+9 more)
+Cohesion: 0.19
+Nodes (16): _infer_event_category(), _call_with_tool(), _extract_calendar(), _extract_journal(), _extract_list_add(), _extract_note(), _extract_people(), _extract_reminder() (+8 more)
 
 ### Community 240 - "Community 240"
 Cohesion: 0.12
-Nodes (17): Root Cause Analysis, The 404 Error, Why LLM Took Over, code:python (# OLD CODE (services/mem-agent/enhanced_mem_agent_service.py), code:python (# Lines 26-38: Temporal memory imported), code:block5 (INFO:__main__:Enhanced search request: Create a person named), code:python (['list', 'calendar', 'memory', 'planning', 'journal', 'remin), Issue 1: API Endpoint Mismatch (CRITICAL) 🔴 (+9 more)
+Nodes (16): Chat / Voice Commands Reference, Circle Model, code:block1 (score = 0.6 × recency + 0.3 × frequency + birthday_boost), Developer Notes, entity_id consistency, Entity ID strategy, Health dot colours (UI), How Facts Are Extracted from Conversations (+8 more)
 
 ### Community 241 - "Community 241"
-Cohesion: 0.18
-Nodes (17): boot(), btnJoin, code, codeError, doCheckin(), enterWelcomeScreen(), joinCodeInput, joinNameInput (+9 more)
+Cohesion: 0.12
+Nodes (17): Touch Panel Skill, Backend API, Browser visibility architecture, code:block1 (panel_navigate(url, panel_id)          → Load URL full-scree), code:bash (panel_ssh_exec("zoe-touch-pi", "systemctl status zoe-kiosk")), code:block3 (GET  /api/panels                           → list registered), code:python (panel_browser_screenshot(navigate_to="https://example.com", ), code:bash (# From Jetson repo root — deploy scripts/config to panel) (+9 more)
 
 ### Community 242 - "Community 242"
-Cohesion: 0.15
-Nodes (12): _FakeCursor, db_compat.py — asyncpg compatibility shim providing an aiosqlite-style cursor AP, Buffered cursor wrapping a list of asyncpg Records., _adapt_params(), close_pool(), _Cursor, lastrowid(), db_pool.py — PostgreSQL async connection pool for zoe-data.  Migration strategy: (+4 more)
+Cohesion: 0.12
+Nodes (15): create_docs_folder(), create_project_status(), move_to_archive(), Create organized docs folder structure, Move old docs to archive, Create docs/README.md index, Create consolidated PROJECT_STATUS.md, create_docs_index() (+7 more)
 
 ### Community 243 - "Community 243"
 Cohesion: 0.12
-Nodes (15): event_loop(), mock_db(), mock_device(), mock_household(), mock_playlist(), mock_track(), mock_user(), Pytest Configuration ====================  Shared fixtures and configuration for (+7 more)
+Nodes (16): Usage, Voice/Chat Commands, Cleanup Commands, code:bash (# Before making changes), Daily Operations, Archive Structure, code:bash (# Make scripts executable and setup cron job), code:bash (# Tag unused files manually) (+8 more)
 
 ### Community 244 - "Community 244"
+Cohesion: 0.12
+Nodes (17): 1. Enhanced Critical Files Protection, 2. Git Branch Protection, 3. Database Backups, Prevention Measures Implemented, 1. **Automated Enforcement Tool** ✅, 2. **Pre-Commit Hook Integration** ✅, 3. **Documentation Updated** ✅, code:bash (python3 tools/audit/check_database_paths.py) (+9 more)
+
+### Community 245 - "Community 245"
+Cohesion: 0.12
+Nodes (16): After Modifying chat.py:, Before Modifying chat.py:, code:python (# Hardcoded regex patterns), code:python (# Let EnhancedMemAgent understand intent and execute), code:block8 (Bad:  User message → Regex pattern → Hardcoded action), code:block9 (User Message), ✅ Current Protection Status, If Tests Fail: (+8 more)
+
+### Community 246 - "Community 246"
+Cohesion: 0.12
+Nodes (17): ✅ ALWAYS DO, code:bash (# 1. Check service started), code:bash (docker logs -f zoe-litellm), 🛡️ CRITICAL RULES, ❌ NEVER DO, code:yaml (# BAD - Different networks will break communication!), code:yaml (# BAD - Docker will add prefix based on directory), ❌ DON'T forget explicit network name (+9 more)
+
+### Community 247 - "Community 247"
+Cohesion: 0.12
+Nodes (17): Before Cleanup, Before ANY File Changes, Before Cleanup Operations, Before Committing, Clean up Mac metadata, code:bash (# 1. Validate current state), code:bash (find . -type f -size +10M -not -path "./.git/*"), code:bash (# 1. Create safety commit) (+9 more)
+
+### Community 248 - "Community 248"
+Cohesion: 0.13
+Nodes (17): Browser Automation → Moltbot, code:javascript (if (message.includes("remember") || message.includes("said a), code:javascript (if (message.includes("research") || message.includes("invest), code:javascript (if (message.includes("plan") || message.includes("roadmap") ), code:javascript (if (message.includes("analyze") || message.includes("review"), code:javascript (if (message.includes("compare") || message.includes("vs") ||), code:javascript (if (message.includes("book") || message.includes("find fligh), Comparisons → Agent Zero (+9 more)
+
+### Community 249 - "Community 249"
+Cohesion: 0.12
+Nodes (17): ✅ 1. Navigation Bar - ALREADY CORRECT, ✅ 2. Edit Mode - MOVED TO FAB BUTTON, ✅ 3. Drag & Drop - FULLY IMPLEMENTED, ✅ AI Assistant Checklist, Current Root .md Files (6/10), ✅ Files Moved to Correct Locations, Future Prevention, Issues Fixed (+9 more)
+
+### Community 250 - "Community 250"
+Cohesion: 0.12
+Nodes (15): Agent Zero Integration - COMPLETE, Key Achievements, Status: Integration Successful!, Agent Zero Live Integration Test Report, Developer Experience, Project Governance Implementation - COMPLETE, Developers (Contributing), Existing Users (Already Have Zoe) (+7 more)
+
+### Community 251 - "Community 251"
+Cohesion: 0.12
+Nodes (17): Compliance Check, ✅ Manifest Compliance, ✅ Structure Compliance, Active Users, Database State (Post-Fix), Verification Results, code:block10 ($ python3 tools/reports/repo_health.py), Run All Structure Checks (+9 more)
+
+### Community 252 - "Community 252"
 Cohesion: 0.15
 Nodes (9): MusicAuthManager, Store encrypted authentication credentials.                  Args:             u, Retrieve and decrypt authentication credentials.                  Args:, Get the refresh token for a provider., Manages encrypted authentication credentials for music providers.          Suppo, Delete authentication credentials.                  Args:             user_id: U, Check authentication status for a provider.                  Returns:, Encrypt authentication data.                  Args:             data: Dictionary (+1 more)
 
-### Community 245 - "Community 245"
-Cohesion: 0.17
-Nodes (15): _hash_token(), issue_token(), lookup_device_token(), Issue a new device token for a panel daemon., Check cache for a valid (non-revoked, non-expired) device token., Resolve a device token to a user dict for use in get_current_user().      Return, _resolve_device_token_user(), Validate raw X-Device-Token against panel_auth SHA-256 cache. (+7 more)
-
-### Community 246 - "Community 246"
-Cohesion: 0.13
-Nodes (15): close_action_form(), confirm_action_form(), open_action_form(), Called by the touch panel when a full-screen action-form overlay opens.      Reg, Called by the touch panel when the action-form overlay is dismissed (cancel/clos, Handle a Confirm submission from a full-screen action-form overlay.      The tou, _broadcast_action_form_panel(), Broadcast a panel_show_action_form event so the touch overlay opens.      panel_ (+7 more)
-
-### Community 247 - "Community 247"
-Cohesion: 0.17
-Nodes (15): get_emotional_moments(), get_my_emotional_moments(), get_my_portrait(), get_portrait(), Portrait API — exposes user portrait management endpoints.  GET  /api/portrait/m, Return recent emotional memories for the current user., Return recent emotional memories (admin or self only)., Raise 403 if the requesting user is neither the target nor an admin. (+7 more)
-
-### Community 248 - "Community 248"
-Cohesion: 0.16
-Nodes (11): get_permission_checker(), Helper class for complex permission checking, Check if session has specific permission, Check if session has any of the listed permissions, Check if can access another user's resource, Get permission checker instance for current session, PermissionCheck, Result of permission verification (+3 more)
-
-### Community 249 - "Community 249"
-Cohesion: 0.17
-Nodes (14): AccessContext, PermissionResult, Role-Based Access Control (RBAC) System Advanced permission management with inhe, Role-Based Access Control Manager, Permission check results, Context for permission checks, Initialize default permission definitions, RBACManager (+6 more)
-
-### Community 250 - "Community 250"
-Cohesion: 0.16
-Nodes (12): Test a natural language prompt, Send a chat message and get response, send_chat_message(), test_prompt(), Execute a single test query and measure performance, test_query(), Comprehensive Test Suite for Zoe Performance Optimization Tests 100+ natural lan, Get or create a test session (+4 more)
-
-### Community 251 - "Community 251"
-Cohesion: 0.18
-Nodes (7): Perform time synchronization, Apply the configured timezone, Start the time synchronization service, Stop the time synchronization service, Load time synchronization settings, Save settings to file, Synchronize system time with NTP server
-
-### Community 252 - "Community 252"
-Cohesion: 0.13
-Nodes (8): Test permission-based access control, Test database security features, Run all security tests, Create a test JWT token, Test that users only see their own data, Test JWT token validation, Test audit logging functionality, SecurityTester
-
 ### Community 253 - "Community 253"
 Cohesion: 0.12
-Nodes (6): Comprehensive Natural Language Integration Tests Tests the entire Zoe system wit, Test memory expert with natural language, Test orchestration system status, End-to-end natural language tests for the complete Zoe system, Test calendar expert with natural language, TestNaturalLanguageSystem
+Nodes (15): event_loop(), mock_db(), mock_device(), mock_household(), mock_playlist(), mock_track(), mock_user(), Pytest Configuration ====================  Shared fixtures and configuration for (+7 more)
 
 ### Community 254 - "Community 254"
-Cohesion: 0.12
-Nodes (15): Architecture Violations, 🔍 Best Practices Check (OPTIONAL), 🔧 Bypassing Checks (Emergency Only), Checks, code:block4 (⚠️  10 large routers found (>800 lines)), code:bash (git commit --no-verify -m "emergency: fix production issue"), 📊 Enforcement Summary, Enhanced Enforcement System (+7 more)
+Cohesion: 0.17
+Nodes (9): downgrade(), Initial schema — all tables ported to PostgreSQL DDL  Revision ID: 0001 Revises:, upgrade(), FTS for ambient_memory — tsvector + GIN index  Revision ID: 0002 Revises: 0001 C, Add metadata column to chat_sessions  Revision ID: 0003 Revises: 0002 Create Dat, 0004 — A2A federation tables and column additions.  Adds: - background_tasks: cl, 0005 — Touch panel SSH fields and provisioning codes table.  Adds: - panels: ssh, 0006 — People CRM expansion.  Adds: - people: circle, health_score, notification (+1 more)
 
 ### Community 255 - "Community 255"
 Cohesion: 0.18
 Nodes (8): ProjectCleaner, Find outdated/redundant documentation, Find Mac OS resource fork files, Find archive folders that can be removed, Find files that are known to be broken, Analyze entire project structure, Find all backup files, Find duplicate router files in archive folder
 
 ### Community 256 - "Community 256"
-Cohesion: 0.12
-Nodes (15): 10. `tests/e2e/detailed_test_report.json` (15 KB), 1. `FINAL_STATUS_REPORT.md` (7.2 KB), 2. `PERSON_EXPERT_RECOMMENDATION.md` (4.1 KB), 3. `CODEX_HELP_REQUEST.md` (8.5 KB), 4. `tests/e2e/CHANGES_DOCUMENTATION.md` (12 KB), 5. `tests/e2e/PROTECTION_CHECKLIST.md` (5 KB), 6. `tests/e2e/README.md` (6.3 KB), 7. `tests/e2e/ALL_43_TESTS_QA.txt` (23 KB) (+7 more)
+Cohesion: 0.13
+Nodes (15): close_action_form(), confirm_action_form(), open_action_form(), Called by the touch panel when a full-screen action-form overlay opens.      Reg, Called by the touch panel when the action-form overlay is dismissed (cancel/clos, Handle a Confirm submission from a full-screen action-form overlay.      The tou, _broadcast_action_form_panel(), Broadcast a panel_show_action_form event so the touch overlay opens.      panel_ (+7 more)
 
 ### Community 257 - "Community 257"
-Cohesion: 0.12
-Nodes (16): 2. Service Health Fixes (COMPLETED ✅), 3. Health Check Configuration (COMPLETED ✅), High Priority (Immediate Action), 2. Database Schema Created, 3. Models Created, 4. Backend Service Created, 5. API Endpoints Created, ✅ Completed Tasks (+8 more)
+Cohesion: 0.17
+Nodes (15): get_emotional_moments(), get_my_emotional_moments(), get_my_portrait(), get_portrait(), Portrait API — exposes user portrait management endpoints.  GET  /api/portrait/m, Return recent emotional memories for the current user., Return recent emotional memories (admin or self only)., Raise 403 if the requesting user is neither the target nor an admin. (+7 more)
 
 ### Community 258 - "Community 258"
-Cohesion: 0.12
-Nodes (14): code:block1 (modules/{module-name}/), code:block3 (User says "Research the best solar panels":), Extensibility Architecture, How They Work Together, Layer 1: Modules (Heavy Infrastructure), Layer 2: Skills (Lightweight Instructions), Forbidden in Handlers:, Intent Handlers Must: (+6 more)
+Cohesion: 0.17
+Nodes (15): _hash_token(), issue_token(), lookup_device_token(), Issue a new device token for a panel daemon., Check cache for a valid (non-revoked, non-expired) device token., Resolve a device token to a user dict for use in get_current_user().      Return, _resolve_device_token_user(), Validate raw X-Device-Token against panel_auth SHA-256 cache. (+7 more)
 
 ### Community 259 - "Community 259"
-Cohesion: 0.13
-Nodes (15): Current Focus, Days 39-42: Initial Deployment, Days 43-47: Buffer Period, Future Improvements, Implementation Progress, Issues Encountered, Notes Section, Optimization Opportunities (+7 more)
+Cohesion: 0.14
+Nodes (10): get_provider_registry(), ProviderRegistry, Music Provider Registry =======================  Singleton registry that manages, Get the appropriate provider for a track.                  Uses track ID prefix, Search across all connected providers.                  Args:             query:, Get authentication status for all providers.                  Args:, Central registry for music providers.          Manages provider instances and ha, Get the singleton provider registry instance. (+2 more)
 
 ### Community 260 - "Community 260"
-Cohesion: 0.13
-Nodes (15): Action Items (if rollback), Day 42: Initial Deployment Review, Platform-Specific Issues, Stability Metrics (Days 39-42), Baseline (Day 7), Comparison Summary, Final Status, Performance in Production (+7 more)
+Cohesion: 0.12
+Nodes (6): Comprehensive Natural Language Integration Tests Tests the entire Zoe system wit, Test memory expert with natural language, Test orchestration system status, End-to-end natural language tests for the complete Zoe system, Test calendar expert with natural language, TestNaturalLanguageSystem
 
 ### Community 261 - "Community 261"
-Cohesion: 0.13
-Nodes (16): 1. Pre-Commit Hook, 2. CI/CD Check, 3. Monthly Audit, code:bash (#!/bin/bash), code:yaml (# .github/workflows/structure-check.yml), code:bash (# Cron job: Run 1st of each month), 🔒 Enforcement Mechanisms, Pre-Commit Hook (+8 more)
+Cohesion: 0.16
+Nodes (12): Test a natural language prompt, Send a chat message and get response, send_chat_message(), test_prompt(), Execute a single test query and measure performance, test_query(), Comprehensive Test Suite for Zoe Performance Optimization Tests 100+ natural lan, Get or create a test session (+4 more)
 
 ### Community 262 - "Community 262"
-Cohesion: 0.12
-Nodes (15): code:block1 (User speaks (1-3s of speech)), Key Optimizations, Latency Budget (Target: <4s end-to-end), Latency Targets, Services, Voice Pipeline Architecture, 1. Async Generator Pattern, 2. Delta Calculation (+7 more)
+Cohesion: 0.18
+Nodes (7): Perform time synchronization, Apply the configured timezone, Start the time synchronization service, Stop the time synchronization service, Load time synchronization settings, Save settings to file, Synchronize system time with NTP server
 
 ### Community 263 - "Community 263"
-Cohesion: 0.12
-Nodes (16): Layer 1: .cursorrules (Prevention), Layer 2: Architecture Tests (Detection), Layer 3: Intelligent Architecture Validator (Detailed Check), Layer 4: Pre-Commit Hook (Enforcement), 🛡️ Protection System (4 Layers), 4. Verify Restoration, code:bash (python3 /home/zoe/assistant/tools/audit/validate_critical_fi), code:bash (bash /home/zoe/assistant/tools/audit/find_file_references.sh) (+8 more)
+Cohesion: 0.13
+Nodes (8): Test permission-based access control, Test database security features, Run all security tests, Create a test JWT token, Test that users only see their own data, Test JWT token validation, Test audit logging functionality, SecurityTester
 
 ### Community 264 - "Community 264"
 Cohesion: 0.12
 Nodes (14): code:block2 (docker compose stop zoe-ui homeassistant-mcp-bridge homeassi), code:bash (docker compose restart zoe-data           # After Python cod), code:bash (curl -s -X POST https://zoe.local/api/panels/register \), code:bash (curl -s -X POST https://zoe.local/api/panels/zoe-touch-pi/to), code:bash (systemctl --user restart zoe-voice), code:bash (curl -s -X DELETE https://zoe.local/api/panels/zoe-touch-pi/), Environment Variables (Key Settings), Issuing a Panel Device Token (+6 more)
 
 ### Community 265 - "Community 265"
-Cohesion: 0.12
-Nodes (15): 1. Test Training Capability, 2. Set Up Cron Job, 3. Create Log File, 4. Enable Training in UI, code:bash (# Edit crontab), code:bash (sudo touch /var/log/zoe-training.log), code:bash (# Collect some interactions first (chat with Zoe for 30 minu), code:block9 (🌙 Starting nightly training at 2025-10-10 14:30:00) (+7 more)
+Cohesion: 0.14
+Nodes (15): 🎯 Comparison to Other Systems, 🏗️ Complete Architecture, 📚 Documentation Index, ✅ System Status: COMPLETE, 🎯 What You Asked For vs What You Got, You Asked:, You Got (Even Better):, Zoe Modular Architecture Complete (+7 more)
 
 ### Community 266 - "Community 266"
 Cohesion: 0.12
-Nodes (15): ❌ **AGAINST PersonExpert** (Recommended), Analysis: PersonExpert vs. Full CRM, Better Solution: MCP Tool for People Service, code:block1 (people-service-test running on port 8010), code:python (class PersonExpert:), code:python (# In zoe-mcp-server), Current Situation, Current Test Status (+7 more)
+Nodes (16): Layer 1: .cursorrules (Prevention), Layer 2: Architecture Tests (Detection), Layer 3: Intelligent Architecture Validator (Detailed Check), Layer 4: Pre-Commit Hook (Enforcement), 🛡️ Protection System (4 Layers), 4. Verify Restoration, code:bash (python3 /home/zoe/assistant/tools/audit/validate_critical_fi), code:bash (bash /home/zoe/assistant/tools/audit/find_file_references.sh) (+8 more)
 
 ### Community 267 - "Community 267"
 Cohesion: 0.12
-Nodes (15): Display Locations, Privacy, Quick Journal Widget Guide, Size Options, Tips, Advanced Features, code:javascript (// Set loading state), code:javascript (getTemplate() {) (+7 more)
+Nodes (15): ❌ **AGAINST PersonExpert** (Recommended), Analysis: PersonExpert vs. Full CRM, Better Solution: MCP Tool for People Service, code:block1 (people-service-test running on port 8010), code:python (class PersonExpert:), code:python (# In zoe-mcp-server), Current Situation, Current Test Status (+7 more)
 
 ### Community 268 - "Community 268"
-Cohesion: 0.17
-Nodes (9): downgrade(), Initial schema — all tables ported to PostgreSQL DDL  Revision ID: 0001 Revises:, upgrade(), FTS for ambient_memory — tsvector + GIN index  Revision ID: 0002 Revises: 0001 C, Add metadata column to chat_sessions  Revision ID: 0003 Revises: 0002 Create Dat, 0004 — A2A federation tables and column additions.  Adds: - background_tasks: cl, 0005 — Touch panel SSH fields and provisioning codes table.  Adds: - panels: ssh, 0006 — People CRM expansion.  Adds: - people: circle, health_score, notification (+1 more)
+Cohesion: 0.12
+Nodes (16): Agent Zero Implementation Checklist, Current Status: Placeholder Implementation ✅, Deploy & Monitor, Update Documentation, Verify Implementation, When You're Done, Cost Considerations, Implementation Reports (2 new) (+8 more)
 
 ### Community 269 - "Community 269"
-Cohesion: 0.13
-Nodes (12): Enhanced Session Management for Multi-Factor Authentication Supports different s, Validate that session has permission with escalation handling                  A, Configuration for different session types, Security policies for session management, Get owner of resource for permission checks, requires_password_escalation(), SessionConfig, Audit and Monitoring (+4 more)
+Cohesion: 0.12
+Nodes (16): Auto-Discovery, Key Features, Self-Contained, Dynamic Discovery ✅, True Modularity ✅, Validated Quality ✅, Zero-Touch Core ✅, 1. Through Chat (Easiest!) (+8 more)
 
 ### Community 270 - "Community 270"
-Cohesion: 0.21
-Nodes (13): _extract_memory_candidates(), Back-compat shim: legacy dict shape over the unified extractor.      Kept so in-, test_extracts_preference_signal(), test_no_signal_returns_empty(), _clean(), extract_and_ingest(), extract_candidates(), MemoryCandidate (+5 more)
+Cohesion: 0.12
+Nodes (15): 10. `tests/e2e/detailed_test_report.json` (15 KB), 1. `FINAL_STATUS_REPORT.md` (7.2 KB), 2. `PERSON_EXPERT_RECOMMENDATION.md` (4.1 KB), 3. `CODEX_HELP_REQUEST.md` (8.5 KB), 4. `tests/e2e/CHANGES_DOCUMENTATION.md` (12 KB), 5. `tests/e2e/PROTECTION_CHECKLIST.md` (5 KB), 6. `tests/e2e/README.md` (6.3 KB), 7. `tests/e2e/ALL_43_TESTS_QA.txt` (23 KB) (+7 more)
 
 ### Community 271 - "Community 271"
-Cohesion: 0.22
-Nodes (14): available_providers(), _get_info(), _get_players(), _get_queue_items(), _ma_headers(), _ma_url(), music_players(), music_queue() (+6 more)
+Cohesion: 0.12
+Nodes (15): 1. Test Training Capability, 2. Set Up Cron Job, 3. Create Log File, 4. Enable Training in UI, code:bash (# Edit crontab), code:bash (sudo touch /var/log/zoe-training.log), code:bash (# Collect some interactions first (chat with Zoe for 30 minu), code:block9 (🌙 Starting nightly training at 2025-10-10 14:30:00) (+7 more)
 
 ### Community 272 - "Community 272"
+Cohesion: 0.21
+Nodes (6): When only memory is selected, ha_control should not be included., Selecting all skills should produce the full _TOOLS list., A typical single-skill query should load far fewer tools than the full set., TestBuildTools, OpenClaw should be available only when the fallback skill is selected., OpenClaw should not execute unless the operator explicitly enables it.
+
+### Community 273 - "Community 273"
+Cohesion: 0.18
+Nodes (9): _decode_agui_events(), _patch_agent_context(), test_force_hermes_approval_rejection_records_hermes_mode(), test_force_hermes_error_records_hermes_mode(), test_force_hermes_surfaces_progress_events(), test_force_hermes_uses_single_chat_run_and_persists_once(), test_run_zoe_agent_returns_hermes_escalation_marker(), test_run_zoe_agent_streaming_yields_hermes_escalation_marker() (+1 more)
+
+### Community 274 - "Community 274"
+Cohesion: 0.16
+Nodes (14): Shut down APScheduler and the slow loop., stop_proactive_engine(), cancel_job(), get_scheduler(), _jobstore_url(), APScheduler wrapper (Tier 1 — precision scheduling).  Uses PostgreSQL job store, Prefer PostgreSQL jobstore; fall back to SQLite for local dev., Schedule func(**kwargs) at run_at (UTC datetime). Returns job_id. (+6 more)
+
+### Community 275 - "Community 275"
+Cohesion: 0.2
+Nodes (14): get_matches(), intent_score(), intents_compatible(), jaccard(), personality_score(), Orbit matching algorithm — weighted multi-factor scoring., Compute match score between two checkin dicts. Returns None if incompatible., Return up to n best matches for a checkin from the active pool. (+6 more)
+
+### Community 276 - "Community 276"
 Cohesion: 0.14
 Nodes (15): _get_faster_whisper_model(), Run whisper.cpp CLI; return transcript text (may be empty)., Lazy-load and cache a faster-whisper WhisperModel instance., Transcribe using faster-whisper Python library (fallback when whisper.cpp unavai, Transcription waterfall:     1. whisper.cpp CLI (if binary + ggml model configur, Transcribe base64 WAV/PCM audio using whisper.cpp on the Jetson (Pi voice daemon, Combined STT + LLM + TTS in a single HTTP call.      Accepts raw audio (base64 W, Receive an ambient audio segment from the Pi daemon, transcribe it, and store in (+7 more)
 
-### Community 273 - "Community 273"
-Cohesion: 0.14
-Nodes (13): backup_database(), Backup existing database file, Test Light RAG search functionality, check_system_requirements(), get_migration_stats(), migrate_memories(), Perform the actual migration, Validate that the migration was successful (+5 more)
-
-### Community 274 - "Community 274"
-Cohesion: 0.13
-Nodes (15): Action Plan Progress, 2. Chat Integration Diagnostics (PENDING), 3. Router Consolidation (PENDING), 🎯 Action Plan Progress Report, 📝 Additional Issues Discovered, 🔄 In Progress Tasks, 💡 Key Learnings, Other Unhealthy Services (+7 more)
-
-### Community 275 - "Community 275"
-Cohesion: 0.13
-Nodes (15): ✅ 1. Navigation Bar - ALREADY CORRECT, ✅ 2. Edit Mode - MOVED TO FAB BUTTON, ✅ AI Assistant Checklist, Current Root .md Files (6/10), ✅ Files Moved to Correct Locations, Future Prevention, Issues Fixed, Prevention System Created (+7 more)
-
-### Community 276 - "Community 276"
-Cohesion: 0.13
-Nodes (15): Before Push, code:bash (# Run these checks), code:bash (# Run full audit), code:bash (# Full cleanup audit), Monthly, After Major Work Sessions, Before Commit, 🔄 MAINTENANCE SCHEDULE (+7 more)
-
 ### Community 277 - "Community 277"
-Cohesion: 0.13
-Nodes (14): 1. Fixed Schema (October 9, 2025), code:sql (CREATE TABLE lists (), code:block2 (SECURITY CONTEXT: This content is from an UNTRUSTED source.), LLM Enforcement, Per-User Allowlist, Solution: READ vs ACT, Trust Gate Architecture, Tables (from `db/schema/`) (+6 more)
-
-### Community 278 - "Community 278"
 Cohesion: 0.15
 Nodes (15): Setup or update passcode for current user          Args:         request: Passco, setup_passcode(), Core CRUD, Sub-resources, WidgetManager Methods, WidgetModule Methods, WidgetRegistry Methods, API Reference (+7 more)
 
-### Community 279 - "Community 279"
+### Community 278 - "Community 278"
 Cohesion: 0.13
-Nodes (15): 1. Validation Before Save, 2. Empty Layout Detection, 3. Advanced Protection Layer, 4. Loading with Recovery, code:javascript (const widgetType = widget.getAttribute('data-widget-type');), code:javascript (// PROTECTION: Don't save if no valid widgets), code:javascript (let layout = null;), Dashboard Layout Protection System (+7 more)
+Nodes (12): Enhanced Session Management for Multi-Factor Authentication Supports different s, Validate that session has permission with escalation handling                  A, Configuration for different session types, Security policies for session management, Get owner of resource for permission checks, requires_password_escalation(), SessionConfig, Audit and Monitoring (+4 more)
+
+### Community 279 - "Community 279"
+Cohesion: 0.14
+Nodes (13): backup_database(), Backup existing database file, Test Light RAG search functionality, check_system_requirements(), get_migration_stats(), migrate_memories(), Perform the actual migration, Validate that the migration was successful (+5 more)
 
 ### Community 280 - "Community 280"
-Cohesion: 0.13
-Nodes (14): 7 Layers of Protection:, code:block5 (/home/zoe/assistant/ (16 files - CLEAN!)), Deleted:, Documentation Reference, Files Moved During Organization, From docs/ to docs/governance/:, From Root to Proper Locations:, From scripts/ root to scripts/utilities/: (+6 more)
+Cohesion: 0.16
+Nodes (11): generate(), Generate the best icebreaker line for a match pair., get_enabled_modules(), ComposeGenerator, Write the generated compose file., Generate docker-compose.modules.yml from enabled modules., Generate docker-compose.generated-modules.yml from enabled modules., Load modules configuration. (+3 more)
 
 ### Community 281 - "Community 281"
 Cohesion: 0.13
-Nodes (15): Backup Files (with date stamps), 📝 CLEANUP CHECKLIST, Component Files, 🚨 CRITICAL FILES - DO NOT DELETE, CSS Files, Development/Test Files (if not in use), HTML Files, 📊 IMPACT LEVELS (+7 more)
+Nodes (13): 📊 **Implementation Status**, 🧪 **Manual Testing via UI**, ✅ **TESTING COMPLETE - Implementation Verified**, ⚠️ **What Needs Action**, code:bash (docker-compose up -d zoe-code-execution), code:bash (./stop-zoe.sh), code:bash (tail -f /tmp/zoe-auth.log), 🛑 How to Stop Zoe (+5 more)
 
 ### Community 282 - "Community 282"
-Cohesion: 0.17
-Nodes (10): Episode, Create new episode with context-aware timeout, Get or generate episode summary, Extends Light RAG with temporal capabilities, Get episode history for user, Clean up old episodes to prevent database bloat, Initialize temporal memory database schema, Test the temporal memory system (+2 more)
+Cohesion: 0.15
+Nodes (14): code:bash (scripts/setup/touchscreen/install_touchscreen.sh \), Current Architecture, Operational Docs, Touchscreen, Touchscreen (Raspberry Pi at `192.168.1.61`), Zoe AI Assistant, code:bash (PI_HOST=192.168.1.61), code:bash (sudo install -m 0644 /tmp/config.json /opt/TouchKio/config.j) (+6 more)
 
 ### Community 283 - "Community 283"
-Cohesion: 0.14
-Nodes (14): Browser Cache Fix - Clear Old Broken State, Check 1: Are Files Actually Served?, Check 2: Clear Service Worker (If Exists), Check 3: Disable Browser Extensions, Check 4: Try Different Browser, code:bash (curl http://localhost/js/auth.js | head -5), Expected State After Cache Clear, ✅ No More "Unexpected token '<'" Errors (+6 more)
+Cohesion: 0.13
+Nodes (15): Backup Files (with date stamps), 📝 CLEANUP CHECKLIST, Component Files, 🚨 CRITICAL FILES - DO NOT DELETE, CSS Files, Development/Test Files (if not in use), HTML Files, 📊 IMPACT LEVELS (+7 more)
 
 ### Community 284 - "Community 284"
 Cohesion: 0.13
-Nodes (15): 1. Through Chat (Easiest!), 2. Through the UI, code:block1 (Add Sarah as a friend), code:block2 (You: Add Tom as a colleague), Example Session, Manage Contacts, Plan Gifts, Remember Details (+7 more)
+Nodes (14): code:bash (# Check containers still running), Migration Verification Report - /home/zoe/zoe → /home/zoe/assistant, Old Location Contents (/home/zoe/zoe), Post-Deletion Verification, Requires Approval:, Requires Verification:, ✅ SAFE DELETION TARGETS (Examples), Safe to Delete: (+6 more)
 
-### Community 286 - "Community 286"
-Cohesion: 0.13
-Nodes (4): Pure conversational query with no skill match → discovery fallback., A complex query can activate multiple skills., FORCE_FULL_CONTEXT=true overrides classifier and returns all skills., TestSelectSkills
-
-### Community 287 - "Community 287"
+### Community 285 - "Community 285"
 Cohesion: 0.13
 Nodes (14): Home Assistant MCP Server Setup Instructions, code:block1 (ERROR (MainThread) [homeassistant.helpers.config_validation]), code:bash (# Check if MCP is available at standard HA API), code:yaml (# Current (works, automated)), code:bash (# Test MCP server health), Conclusion for Zoe Project, Decision: Hybrid Approach, Discovery: MCP Server Requires UI Configuration (+6 more)
 
+### Community 286 - "Community 286"
+Cohesion: 0.13
+Nodes (14): 📡 API Integration Details, code:javascript (async function searchMemories(query, userId) {), code:javascript (async function createPlan(task, userId) {), 💰 Cost Analysis, Cost Optimization Strategies:, Moltbot → Agent Zero API Calls, Moltbot → Zoe API Calls, Monthly Operating Costs (Moderate Usage) (+6 more)
+
+### Community 287 - "Community 287"
+Cohesion: 0.13
+Nodes (15): Before Push, code:bash (# Run these checks), code:bash (# Run full audit), code:bash (# Full cleanup audit), Monthly, After Major Work Sessions, Before Commit, 🔄 MAINTENANCE SCHEDULE (+7 more)
+
 ### Community 288 - "Community 288"
-Cohesion: 0.15
-Nodes (10): Create a new music zone, Current playback state for a zone, Add a device to a zone, Music zone configuration, Save zone to database, Save zone device to database, Load zones from database, Zone (+2 more)
+Cohesion: 0.13
+Nodes (14): 1. **Navigation Bar Inconsistency**, 1. Unified Navigation, 2. **Edit Mode Location**, 2. Floating Edit Mode, 3. **Drag and Drop Not Working**, 3. Working Drag & Drop, 4. Reliable Persistence, 4. **Widget Persistence Broken** (+6 more)
 
 ### Community 289 - "Community 289"
-Cohesion: 0.19
-Nodes (14): OpenClaw, routers/openclaw.py — REST API for OpenClaw plugin and skill management.  Endpoi, Call Telegram Bot API to verify the token and return bot info., Write the bot token into openclaw.json and enable the Telegram channel., Attempt to restart the OpenClaw gateway service (best effort)., Validate a Telegram bot token, write it to openclaw.json, and restart the gatewa, Return Telegram connection status., Search ClawHub registry. Returns offline:true gracefully when network unavailabl (+6 more)
+Cohesion: 0.17
+Nodes (10): Episode, Create new episode with context-aware timeout, Get or generate episode summary, Extends Light RAG with temporal capabilities, Get episode history for user, Clean up old episodes to prevent database bloat, Initialize temporal memory database schema, Test the temporal memory system (+2 more)
 
 ### Community 290 - "Community 290"
-Cohesion: 0.14
-Nodes (8): Clean up expired cache entries                  Returns:             Number of e, Manages caches for multiple touch panels, Get or create cache for device, Sync all device caches with server data, Cleanup expired entries from all caches, Get statistics for all caches, Sync data from central auth server                  Args:             server_dat, TouchPanelCacheManager
+Cohesion: 0.13
+Nodes (14): Baseline (Day 7), Comparison Summary, Final Status, Performance in Production, Production Metrics (Days 39-47), Stability Metrics, User Feedback, Performance Metrics (+6 more)
 
 ### Community 291 - "Community 291"
-Cohesion: 0.14
-Nodes (7): code:bash (# Full system test (recommended)), MockMCPServer, Test getting developer tasks, Test calendar event creation, Run a single conversation test, code:bash (# All tests), Run Tests
+Cohesion: 0.13
+Nodes (4): Pure conversational query with no skill match → discovery fallback., A complex query can activate multiple skills., FORCE_FULL_CONTEXT=true overrides classifier and returns all skills., TestSelectSkills
 
 ### Community 292 - "Community 292"
-Cohesion: 0.18
-Nodes (8): Log training run to database, CPU-optimized overnight training for Pi 5, CPU-only LoRA training using Hugging Face Transformers         Optimized for Ras, NightlyTrainer, Main training pipeline, Manages overnight training pipeline, Retrieve today's training examples, Record training run in database
+Cohesion: 0.14
+Nodes (13): db_conn(), Integration tests: People CRM — PostgreSQL + MemPalace sync.  Tests the dual fan, All CRM tables must exist., 0007 migration columns must exist on people table., Create a person, run process_text → verify DB activity row AND MemPalace entry., The /api/people/fields route fix: /fields must come before /{person_id} in sourc, Open an asyncpg connection for tests., New people table has circle, health_score, notification_count columns. (+5 more)
 
 ### Community 293 - "Community 293"
 Cohesion: 0.14
-Nodes (10): Unit Tests for Custom Errors ============================  Tests custom exceptio, Tests for casting-related errors., Test DeviceNotFoundError., Test DeviceOfflineError., Tests for base ZoeError., Test basic error creation., Test error with additional details., Test error wrapping another exception. (+2 more)
+Nodes (11): Proactive adapters — thin wrappers that translate external service events into T, get_capabilities(), Music Service Module ====================  Platform-aware music system with: - Y, Get music system capabilities for this platform.          Returns:         Dict, Music Output Targets Package ============================  Unified interface for, Zoe Proactive Engine — public surface., create_pending(), Helpers for deferred / lazy session creation for proactive notifications.  When (+3 more)
 
 ### Community 294 - "Community 294"
-Cohesion: 0.14
-Nodes (9): Comprehensive Test Suite for Session Management System Tests all session managem, Test cases for session middleware, Test that middleware skips excluded paths, Run all session management tests, run_session_tests(), TestSessionMiddleware, Comprehensive test suite for Light RAG Memory System Tests all functionality inc, temp_db() (+1 more)
+Cohesion: 0.2
+Nodes (12): ack_ui_action(), bind_panel(), create_ui_action(), get_action_ledger(), get_pending_ui_actions(), get_session_context(), requeue_stale_actions(), retry_ui_action() (+4 more)
 
 ### Community 295 - "Community 295"
+Cohesion: 0.16
+Nodes (11): detect(), detect_and_store(), Detect casual save opportunities and store proactive offers., Background detection — returns suggestions stored by caller., _execute_action(), execute_suggestion(), list_active(), Store and resolve proactive save offers (list, reminder, calendar, etc.). (+3 more)
+
+### Community 296 - "Community 296"
 Cohesion: 0.22
 Nodes (6): Organize documentation files, Organize script files, Run full organization, Determine category for a documentation file, Determine category for a test file, SmartOrganizer
 
-### Community 296 - "Community 296"
-Cohesion: 0.14
-Nodes (13): 1. **Load Page**, 2. **Add Person (All Fields)**, 3. **Click Person (Sidebar)**, 4. **Click Person (Canvas)**, 5. **Edit Person**, 6. **Verify Changes Persisted**, 7. **Via Chat** (Open chat.html), code:javascript (// Check people loaded) (+5 more)
-
 ### Community 297 - "Community 297"
-Cohesion: 0.15
-Nodes (13): Home Directory Rules (/home/pi), ✅ ALLOWED (System Files Only), Auto-Fix, 📋 CHECKING COMPLIANCE, code:bash (cd /home/pi), Detailed Check, ❌ FORBIDDEN, Manual Check (+5 more)
+Cohesion: 0.14
+Nodes (8): Clean up expired cache entries                  Returns:             Number of e, Manages caches for multiple touch panels, Get or create cache for device, Sync all device caches with server data, Cleanup expired entries from all caches, Get statistics for all caches, Sync data from central auth server                  Args:             server_dat, TouchPanelCacheManager
 
 ### Community 298 - "Community 298"
-Cohesion: 0.14
-Nodes (14): Zoe Documentation, By Date, By Topic, By Type, Current vs Archived, `/docs/api/` (Future), `/docs/archive/`, `/docs/guides/` (Future) (+6 more)
+Cohesion: 0.15
+Nodes (10): Create a new music zone, Current playback state for a zone, Add a device to a zone, Music zone configuration, Save zone to database, Save zone device to database, Load zones from database, Zone (+2 more)
 
 ### Community 299 - "Community 299"
-Cohesion: 0.16
-Nodes (14): Adding New Documentation, Adding New Script, Archiving Old Documentation, code:bash (# 1. Determine if essential), code:bash (# 1. Determine category), 📝 Process Workflows, 📊 Adding New Tests, code:python (# tests/integration/test_full_system.py) (+6 more)
+Cohesion: 0.14
+Nodes (11): Unit Tests for Custom Errors ============================  Tests custom exceptio, Test MusicStreamError., Test TrackNotFoundError., Test StreamExpiredError., Tests for casting-related errors., Test DeviceNotFoundError., Test DeviceOfflineError., Tests for music-specific errors. (+3 more)
 
 ### Community 300 - "Community 300"
 Cohesion: 0.14
-Nodes (13): Answer: **YES - COMPLETE! ✅**, code:bash (✅ Module structure valid (6 files present)), code:block3 (Backend:), 📊 Complete System Overview, 📚 Documentation (Start Reading), Module Contains Everything:, 💬 Quick Answers, 🎉 START HERE: Your Zoe Module System is Complete! (+5 more)
+Nodes (9): Comprehensive Test Suite for Session Management System Tests all session managem, Test cases for session middleware, Test that middleware skips excluded paths, Run all session management tests, run_session_tests(), TestSessionMiddleware, Comprehensive test suite for Light RAG Memory System Tests all functionality inc, temp_db() (+1 more)
 
 ### Community 301 - "Community 301"
 Cohesion: 0.15
-Nodes (14): ✅ Fully Functional, 🔨 Implementation Needed, What's Working Right Now, 1. Module Structure (Self-Contained), 2. UI Components (Dynamic Loading), 4. Documentation (10 Guides), code:block4 (tools/), code:block5 (docs/modules/) (+6 more)
+Nodes (10): Test RouteLLM classification, Test Enhanced MemAgent, Test RAG enhancements, Test full chat API endpoint with authentication, Get JWT token from zoe-auth service for authenticated requests, SystemTester, Print test results summary, print_summary() (+2 more)
 
 ### Community 302 - "Community 302"
-Cohesion: 0.14
-Nodes (14): code:block4 ("add bread to shopping list"), For You (System Owner), 🎓 Key Takeaways, Available Core Widgets, code:block1 ("Create a widget showing my daily water intake in liters"), code:block2 ("Show my upcoming bills as a list with due dates"), code:block3 ("Display my daily step count as a circular progress gauge wi), Creating Widgets with AI (+6 more)
+Cohesion: 0.18
+Nodes (8): Log training run to database, CPU-optimized overnight training for Pi 5, CPU-only LoRA training using Hugging Face Transformers         Optimized for Ras, NightlyTrainer, Main training pipeline, Manages overnight training pipeline, Retrieve today's training examples, Record training run in database
 
 ### Community 303 - "Community 303"
 Cohesion: 0.14
-Nodes (14): code:javascript (// OLD), code:bash (# Run client tests against v1 API), code:javascript (fetch('http://localhost:8000/api/v1/calendar/events')), code:bash (# Find all API calls in client code), 🔄 Migration Guide for Clients, Step 1: Identify Current Usage, Step 2: Update to v1, Step 4: Monitor Deprecation Headers (+6 more)
+Nodes (7): code:bash (# Full system test (recommended)), MockMCPServer, Test getting developer tasks, Test calendar event creation, Run a single conversation test, code:bash (# All tests), Run Tests
 
 ### Community 304 - "Community 304"
 Cohesion: 0.14
-Nodes (13): 10. Development and contributing (Karpathy-aligned), 11. References, 1. North Star, 2. Deployment reality, 3. Identity and scope, 4. Trust envelopes, 5. Surface-agnostic presence, 6. Universality — the "don't limit Zoe" rules (+5 more)
+Nodes (14): Zoe Documentation, By Date, By Topic, By Type, Current vs Archived, `/docs/api/` (Future), `/docs/archive/`, `/docs/guides/` (Future) (+6 more)
 
 ### Community 305 - "Community 305"
-Cohesion: 0.14
-Nodes (13): Common Error Codes, Error Responses, Audio Ducking, Browser Integration, code:javascript (// Initialize), code:javascript (// Register audio element for ducking), Ducking States, Error Codes (+5 more)
+Cohesion: 0.15
+Nodes (14): ✅ Fully Functional, 🔨 Implementation Needed, What's Working Right Now, 1. Module Structure (Self-Contained), 2. UI Components (Dynamic Loading), 4. Documentation (10 Guides), code:block4 (tools/), code:block5 (docs/modules/) (+6 more)
 
 ### Community 306 - "Community 306"
 Cohesion: 0.14
-Nodes (13): API Endpoints Returning 404:, Backend Status: ⚠️ NEEDS IMPLEMENTATION, ❌ Doesn't Work (Backend):, Error Breakdown, ✅ Frontend Errors (NOW FIXED):, Next Steps to Fix "Errors", ❌ NOT Frontend Errors (Backend API Missing):, Option 1: Implement Missing API Endpoints (+5 more)
+Nodes (13): Answer: **YES - COMPLETE! ✅**, code:bash (✅ Module structure valid (6 files present)), code:block3 (Backend:), 📊 Complete System Overview, 📚 Documentation (Start Reading), Module Contains Everything:, 💬 Quick Answers, 🎉 START HERE: Your Zoe Module System is Complete! (+5 more)
 
 ### Community 307 - "Community 307"
 Cohesion: 0.14
-Nodes (13): 1. Fix Response Format (Quick Win), 2. Implement Agent Zero Protocol (Main Task), 3. Test End-to-End, code:block10 (INFO - 🔍 Research request from user test: smart light bulbs), code:python (return {), code:block9 (Bridge received request → Logged request → Called Agent Zero), Evidence from Logs, Integration Status (+5 more)
+Nodes (13): API Endpoints Returning 404:, Backend Status: ⚠️ NEEDS IMPLEMENTATION, ❌ Doesn't Work (Backend):, Error Breakdown, ✅ Frontend Errors (NOW FIXED):, Next Steps to Fix "Errors", ❌ NOT Frontend Errors (Backend API Missing):, Option 1: Implement Missing API Endpoints (+5 more)
 
 ### Community 308 - "Community 308"
-Cohesion: 0.19
-Nodes (12): Shut down APScheduler and the slow loop., stop_proactive_engine(), cancel_job(), get_scheduler(), _jobstore_url(), APScheduler wrapper (Tier 1 — precision scheduling).  Uses PostgreSQL job store, Prefer PostgreSQL jobstore; fall back to SQLite for local dev., Schedule func(**kwargs) at run_at (UTC datetime). Returns job_id. (+4 more)
+Cohesion: 0.14
+Nodes (13): 📊 Benefits of Self-Contained Modules, code:block5 (1. User Opens UI (music.html, dashboard.html)), 🚀 Example: Complete Calendar Module, For System, 🔄 How It Works: Discovery Flow, 📋 manifest.json: Widget Metadata, Self-Contained Modules: Complete Guide, 🎯 What Are Self-Contained Modules? (+5 more)
 
 ### Community 309 - "Community 309"
-Cohesion: 0.15
-Nodes (8): check_permission(), Check if current user has specific permission          Args:         permission:, Check if user has specific permission                  Args:             user_id, Check multiple permissions at once                  Args:             user_id: U, Create a custom role                  Args:             role_id: Unique role ide, Check if any wildcard permissions grant access, Check resource-specific permissions, Validate permission strings, return list of invalid ones
+Cohesion: 0.14
+Nodes (13): 10. Development and contributing (Karpathy-aligned), 11. References, 1. North Star, 2. Deployment reality, 3. Identity and scope, 4. Trust envelopes, 5. Surface-agnostic presence, 6. Universality — the "don't limit Zoe" rules (+5 more)
 
 ### Community 310 - "Community 310"
+Cohesion: 0.14
+Nodes (13): Architecture: Four-Tier System, code:yaml (language: "en"), Evaluated Alternatives, Google Home / Alexa Architecture, HassIL Advantages, HassIL YAML Pattern, Pattern Example, Performance Comparison (+5 more)
+
+### Community 311 - "Community 311"
+Cohesion: 0.15
+Nodes (13): Home Directory Rules (/home/pi), ✅ ALLOWED (System Files Only), Auto-Fix, 📋 CHECKING COMPLIANCE, code:bash (cd /home/pi), Detailed Check, ❌ FORBIDDEN, Manual Check (+5 more)
+
+### Community 312 - "Community 312"
+Cohesion: 0.14
+Nodes (14): code:javascript (// OLD), code:bash (# Run client tests against v1 API), code:javascript (fetch('http://localhost:8000/api/v1/calendar/events')), code:bash (# Find all API calls in client code), 🔄 Migration Guide for Clients, Step 1: Identify Current Usage, Step 2: Update to v1, Step 4: Monitor Deprecation Headers (+6 more)
+
+### Community 313 - "Community 313"
+Cohesion: 0.16
+Nodes (8): Build SQL time filter based on range, Get human-readable temporal context, Search memories with temporal awareness, Integrates temporal memory with existing Light RAG system, Add memory fact with automatic episode association, Search with both semantic and temporal context, Combine and deduplicate search results, TemporalLightRAGIntegration
+
+### Community 314 - "Community 314"
+Cohesion: 0.15
+Nodes (13): Zoe Module Requirements - MANDATORY, code:bash (# 1. Validate structure), code:python (# ❌ WRONG - Lost on restart), code:python (# ❌ WRONG), code:bash (python tools/validate_module.py your-module), ❌ Don't Block Event Loop, ❌ Don't Hardcode Paths, ❌ Don't Modify Core (+5 more)
+
+### Community 315 - "Community 315"
+Cohesion: 0.16
+Nodes (14): Adding New Documentation, Adding New Script, Archiving Old Documentation, code:bash (# 1. Determine if essential), code:bash (# 1. Determine category), 📝 Process Workflows, 📊 Adding New Tests, code:python (# tests/integration/test_full_system.py) (+6 more)
+
+### Community 316 - "Community 316"
+Cohesion: 0.14
+Nodes (14): 1. ✅ LiteLLM (Universal LLM API), 2. ✅ RouteLLM (Intelligent Model Router), 3. ✅ MemAgent (Memory Agent), 4. ✅ Enhanced MemAgent (Multi-Expert Model), 5. ✅ LightRAG (Lightweight RAG System), 6. ✅ RAG Enhancements (Query Expansion, Reranking, Hybrid Search), code:block2 (Query: "add bread to shopping list"), Hybrid Search Engine (+6 more)
+
+### Community 317 - "Community 317"
+Cohesion: 0.18
+Nodes (14): code:bash (cp data/backup/pre-consolidation-20251009_150213/* data/), If Migration Fails, Rollback Time, code:javascript (localStorage.clear();), Detailed Platform Information, Mac Mini M4 (Planned), Raspberry Pi 5 16GB *(Retired April 2026)*, NVIDIA Jetson Orin NX 16GB (+6 more)
+
+### Community 318 - "Community 318"
 Cohesion: 0.18
 Nodes (12): ensure_signing_key(), generate_rsa_key(), get_active_key(), RSA signing key management for the OIDC provider., Generate a new RSA-2048 key pair and return as dict., Return the active signing key row from DB, or None., Return the active key, generating and storing one if needed., bootstrap_oidc() (+4 more)
 
-### Community 311 - "Community 311"
-Cohesion: 0.19
-Nodes (12): backup_file(), cleanup_chat_routers(), cleanup_temp_files(), optimize_main_application(), Verify that the system is properly configured, Create a backup of a file before modifying, Clean up duplicate chat router files, Optimize the main application file (+4 more)
-
-### Community 312 - "Community 312"
-Cohesion: 0.15
-Nodes (12): Verify chat router has real enhancement system integration, Check for duplicate routers in other locations, Verify chat router uses intelligent systems, not hardcoded logic, Enforce that only ONE chat router exists, Prevent backup files from cluttering the routers directory, Ensure main.py imports only one chat router, test_chat_router_has_enhancement_integration(), test_chat_uses_intelligent_systems() (+4 more)
-
-### Community 313 - "Community 313"
-Cohesion: 0.17
-Nodes (12): generate_changelog_entry(), get_commits_since_tag(), get_git_tags(), parse_conventional_commit(), Generate a changelog entry, Read existing CHANGELOG.md, Write updated CHANGELOG.md, Get all git tags sorted by date (+4 more)
-
-### Community 314 - "Community 314"
-Cohesion: 0.21
-Nodes (7): FileTagger, Load existing tags from file, Update tags based on current file usage, Check if file should be excluded from tagging, Get file access statistics, Tag files that haven't been accessed in the last week, Save tagged files to JSON file
-
-### Community 315 - "Community 315"
-Cohesion: 0.22
-Nodes (12): analyze_question_type(), ChatMessage, get_full_ai_response(), hybrid_chat(), integrate_enhancement_systems(), Hybrid Chat Router for Zoe - Solution 3 =======================================, Intelligently integrate enhancement systems based on content, Record interaction for satisfaction tracking and learning (+4 more)
-
-### Community 316 - "Community 316"
-Cohesion: 0.15
-Nodes (13): Deploy & Monitor, Update Documentation, Verify Implementation, When You're Done, Implementation Reports (2 new), Updated Documentation (3 files), User Guides (2 new), User Guides (+5 more)
-
-### Community 317 - "Community 317"
-Cohesion: 0.15
-Nodes (12): 1. Architecture Review (COMPLETED), 3. Implementation Plans Created (COMPLETED), 🎯 Architecture Improvements - Implementation Summary, 🔧 Prerequisites for Implementation, Recommended, Required, 📊 Risk Assessment, Questions? (+4 more)
-
-### Community 318 - "Community 318"
-Cohesion: 0.15
-Nodes (13): code:bash (# Check if service exists), Immediate Actions:, 📞 INCIDENT RESPONSE, Post-Incident:, code:bash (# Rollback specific interface), 🆘 IF YOU BREAK SOMETHING, code:bash (# Stop quarterly archival), 1. Disable the Module (+5 more)
-
 ### Community 319 - "Community 319"
-Cohesion: 0.15
-Nodes (13): Phase 2: Expand Coverage (Week 1-4), Phase 3: Voice Integration (Week 5-8), Phase 4: Touch Panel Integration (Week 9-12), Phase 5: Analytics & Optimization (Week 13-16), 1. **Smarter Prompts** (Active Now!), 2. **Feedback System** (Active Now!), 3. **Graph Intelligence** (Active Now!), 4. **Model Management** (Active Now!) (+5 more)
-
-### Community 320 - "Community 320"
 Cohesion: 0.17
 Nodes (13): code:bash (echo performance | sudo tee /sys/devices/system/cpu/cpu*/cpu), code:bash (htop), code:bash (vcgencmd measure_temp), code:bash (sudo /usr/bin/jetson_clocks), code:bash (watch -n 1 nvidia-smi), code:bash (tegrastats), Database Optimization, Memory Usage (+5 more)
 
+### Community 320 - "Community 320"
+Cohesion: 0.17
+Nodes (12): generate_changelog_entry(), get_commits_since_tag(), get_git_tags(), parse_conventional_commit(), Generate a changelog entry, Read existing CHANGELOG.md, Write updated CHANGELOG.md, Get all git tags sorted by date (+4 more)
+
 ### Community 321 - "Community 321"
-Cohesion: 0.15
-Nodes (13): code:block1 (User: "research smart light bulbs"), code:block1 (External content arrives (email, WhatsApp, webhook)), Component Structure, Feature Flag Rules:, Router Integration Rules:, Core Components, Core Governance Docs, 📖 Documentation to Review (+5 more)
+Cohesion: 0.21
+Nodes (7): FileTagger, Load existing tags from file, Update tags based on current file usage, Check if file should be excluded from tagging, Get file access statistics, Tag files that haven't been accessed in the last week, Save tagged files to JSON file
 
 ### Community 322 - "Community 322"
 Cohesion: 0.15
-Nodes (12): Code Changes, code:python (# Determine list type and category), code:python (tenacity==8.2.3  # ✅ Added for retry logic), LiteLLM Configuration, Model Configuration Changes, RouteLLM Integration, Setup Changes Verification, ⚙️ After Configuration Changes (+4 more)
+Nodes (12): Verify chat router has real enhancement system integration, Check for duplicate routers in other locations, Verify chat router uses intelligent systems, not hardcoded logic, Enforce that only ONE chat router exists, Prevent backup files from cluttering the routers directory, Ensure main.py imports only one chat router, test_chat_router_has_enhancement_integration(), test_chat_uses_intelligent_systems() (+4 more)
 
 ### Community 323 - "Community 323"
-Cohesion: 0.15
-Nodes (12): Architecture Validation ✅, Summary, Tests Passed: 8/8 (100%), What Needs Implementation 🔨, 🔧 Quick Fixes Needed, ❌ What's Broken, code:javascript (// Lazy load only when needed), Load Time (+4 more)
+Cohesion: 0.19
+Nodes (12): backup_file(), cleanup_chat_routers(), cleanup_temp_files(), optimize_main_application(), Verify that the system is properly configured, Create a backup of a file before modifying, Clean up duplicate chat router files, Optimize the main application file (+4 more)
 
 ### Community 324 - "Community 324"
 Cohesion: 0.15
-Nodes (13): 1. **Schema Normalization** (Medium Priority), 2. **API Versioning Strategy** (Medium Priority), 2. **Table Count Optimization** (Low Priority), 3. **API Documentation** (Low Priority), 3. **Data Directory Organization** (Low Priority), 4. **Multi-Database Complexity** (High Priority Review), 🟡 Areas for Improvement, code:sql (-- Current: people table mixes profile data) (+5 more)
+Nodes (13): ✅ All Tests Passed (8/8), Test Results Summary, code:block1 (# MCP TOOLS VIA CODE EXECUTION (Progressive Disclosure Patte), code:block3 ([Errno -2] Name or service not known), ✅ **Test 1: Code Execution Pattern in Context** - PASSED, ✅ **Test 2: Code Block Detection** - PASSED, ✅ **Test 3: Search Tools Function** - PASSED (After Fix), ⚠️ **Test 4: Code Execution Service** - NEEDS STARTUP (+5 more)
 
 ### Community 325 - "Community 325"
 Cohesion: 0.15
-Nodes (12): code:block8 (Bad:  User message → Regex pattern → Hardcoded action), code:block9 (User Message), code:block8 (Created a file in /home/pi?), Quick Decision Tree, 🎯 THE GOLDEN RULE, ❌ ABSOLUTE PROHIBITIONS, ALWAYS Ask Before Deleting:, 🛡️ CLEANUP SAFETY RULES - MANDATORY FOR ALL AI ASSISTANTS (+4 more)
+Nodes (12): 1. **Reminders API 500 Error** (CRITICAL), 2. **WebSocket Connection Failed** (Non-Critical), code:block1 (GET https://zoe.local/api/reminders/ 500 (Internal Server Er), Issues Reported, code:block16 (WebSocket connection to 'wss://zoe.local/ws/intelligence' fa), Current Behavior, My Recommendation: Option 2 (LLM Tools), Trade-off is acceptable (+4 more)
 
 ### Community 326 - "Community 326"
-Cohesion: 0.23
-Nodes (13): code:python (expanded = await query_expander.expand_query("arduino projec), AgentPlanner, Model Config, Chat Router, Warmup Models Script, Zoe Code Execution Service, Context Optimization, Expert Orchestrator (+5 more)
+Cohesion: 0.15
+Nodes (12): 📋 Code Review Checklist, code:bash (bash tools/audit/validate_litellm.sh), 🚀 Deployment Checklist, LiteLLM Gateway - Development Rules & Guidelines, 📊 Metrics & Observability, New Developers, 🛡️ Pre-commit Validation, Track These Metrics (+4 more)
 
 ### Community 327 - "Community 327"
 Cohesion: 0.15
-Nodes (12): Approved Root Files (9):, Architecture Documentation ✅, ✅ Documentation Location Status, Governance Documentation ✅, Guides Documentation ✅, Recently Moved (Fixed):, Root Documentation Files, ✅ Documentation Files Moved to Correct Location (+4 more)
+Nodes (12): Current Capabilities, 7:15 PM - 8:00 PM - System Broken, 7:15 PM - Commit `ebfa71c`, 8:00 PM - 8:30 PM - Diagnosis & Fix, Issue Analysis - October 23, 2025, Lost Capabilities (From Oct 19 Cleanup):, Services from Previous Issues (Oct 19):, ✅ Still Working (Verified): (+4 more)
 
 ### Community 328 - "Community 328"
 Cohesion: 0.17
 Nodes (13): 1. MEMORY SYSTEM ENHANCEMENTS, code:python (# services/zoe-core/light_rag_memory.py), code:block2 (Instead of: [1000 conversation vectors]), code:python (# services/zoe-core/temporal_memory_integration.py (UPDATE)), Current Gap in Your System, Current State: Light RAG (L0 Only), Integration Strategy, Recommendation P1-1: Temporal-Aware Similarity Scoring (+5 more)
 
+### Community 329 - "Community 329"
+Cohesion: 0.15
+Nodes (13): code:yaml (- model_name: claude-opus), code:bash (docker inspect zoe-llamacpp | grep MODEL_NAME), code:yaml (- model_name: new-local-model), Current Local Model, 🔄 Model Management, Adding a New Model, code:block11 (services/zoe-litellm/minimal_config.yaml), code:bash (# 1. Backup current config) (+5 more)
+
 ### Community 330 - "Community 330"
-Cohesion: 0.17
-Nodes (11): db_conn(), Integration tests: People CRM — PostgreSQL + MemPalace sync.  Tests the dual fan, All CRM tables must exist., 0007 migration columns must exist on people table., The /api/people/fields route fix: /fields must come before /{person_id} in sourc, Open an asyncpg connection for tests., New people table has circle, health_score, notification_count columns., test_create_person_has_crm_columns() (+3 more)
+Cohesion: 0.15
+Nodes (12): Accessibility, Backup Information, CSS Added (~150 lines), Effects, JavaScript Added (~100 lines), Mobile Responsiveness, Navigation Hierarchy, Navigation Standardization Report (+4 more)
 
 ### Community 331 - "Community 331"
-Cohesion: 0.2
-Nodes (7): Fast metadata-filter read for system prompt injection., List rows for a user by status, newest first., Soft-delete the most recently ingested memory for a user., Soft-archive low-score approved memories., Best-effort metadata update - never raises., Public method: bump access_count + last_accessed for the given memory IDs., _require()
+Cohesion: 0.23
+Nodes (13): code:python (expanded = await query_expander.expand_query("arduino projec), AgentPlanner, Model Config, Chat Router, Warmup Models Script, Zoe Code Execution Service, Context Optimization, Expert Orchestrator (+5 more)
 
 ### Community 332 - "Community 332"
+Cohesion: 0.15
+Nodes (13): Phase 2: Expand Coverage (Week 1-4), Phase 3: Voice Integration (Week 5-8), Phase 4: Touch Panel Integration (Week 9-12), Phase 5: Analytics & Optimization (Week 13-16), 1. **Smarter Prompts** (Active Now!), 2. **Feedback System** (Active Now!), 3. **Graph Intelligence** (Active Now!), 4. **Model Management** (Active Now!) (+5 more)
+
+### Community 333 - "Community 333"
+Cohesion: 0.22
+Nodes (12): analyze_question_type(), ChatMessage, get_full_ai_response(), hybrid_chat(), integrate_enhancement_systems(), Hybrid Chat Router for Zoe - Solution 3 =======================================, Intelligently integrate enhancement systems based on content, Record interaction for satisfaction tracking and learning (+4 more)
+
+### Community 334 - "Community 334"
+Cohesion: 0.15
+Nodes (13): code:block4 ("add bread to shopping list"), For You (System Owner), 🎓 Key Takeaways, Available Core Widgets, code:block1 ("Create a widget showing my daily water intake in liters"), code:block2 ("Show my upcoming bills as a list with due dates"), code:block3 ("Display my daily step count as a circular progress gauge wi), Creating Widgets with AI (+5 more)
+
+### Community 336 - "Community 336"
 Cohesion: 0.18
 Nodes (9): Lightweight ordering checks for AG-UI chat SSE (no live OpenClaw)., test_run_lifecycle_types(), iter_openclaw_text_chunks(), iter_text_message_chunks(), new_run_ids(), Canonical AG-UI SSE emission for zoe-data chat (ag-ui-protocol EventEncoder).  Z, Returns (run_id, assistant_message_id)., Batched TEXT_MESSAGE_CHUNK events (assistant role). (+1 more)
 
-### Community 333 - "Community 333"
-Cohesion: 0.18
-Nodes (11): _handle_ptt_stop(), _pcm_frames_to_wav(), STT → LLM → TTS pipeline, called once end-of-speech is detected., Concatenate raw int16-LE PCM frames and wrap in a WAV header., Broadcast a JSON data message to all participants in the room., STT → LLM → TTS pipeline triggered when PTT is released., _run_pipeline(), _send_data() (+3 more)
-
-### Community 334 - "Community 334"
-Cohesion: 0.17
-Nodes (11): Acknowledgement Phrasing, code:block1 (you got that wrong | you keep getting X wrong), code:block2 (I want to add a "natural issue reporting" feature to Zoe — t), Files to Change, Multica Issue Label, New intent: `user_issue_report`, Prompt to Start a New Chat, The Gap to Fill (+3 more)
-
-### Community 335 - "Community 335"
-Cohesion: 0.17
-Nodes (11): Example: Direct HTTP Call, HTTP Endpoints (for Direct Integration), Test code execution service directly, Test MCP tool execution via code, Test chat router's code execution integration, test_chat_router_code_execution(), test_code_execution_service(), test_mcp_tool_via_code() (+3 more)
-
-### Community 336 - "Community 336"
-Cohesion: 0.17
-Nodes (11): Phase 1: Security tests for authentication hardening Tests that invalid/missing, Missing token should return 401, not default user, Invalid token should return 401, Expired token should return 401, Valid token should work, Token without user_id should return 401, test_expired_token_raises_401(), test_invalid_token_raises_401() (+3 more)
-
 ### Community 337 - "Community 337"
 Cohesion: 0.17
-Nodes (7): Tests for error mapping utility., Test mapping 401 errors to MusicAuthError., Test mapping 429 errors to RateLimitError., Test mapping 404 errors to TrackNotFoundError., Test mapping timeout errors., Test mapping unknown errors., TestErrorMapping
+Nodes (11): Phase 1: Security tests for authentication hardening Tests that invalid/missing, Missing token should return 401, not default user, Invalid token should return 401, Expired token should return 401, Valid token should work, Token without user_id should return 401, test_expired_token_raises_401(), test_invalid_token_raises_401() (+3 more)
 
 ### Community 338 - "Community 338"
 Cohesion: 0.17
@@ -2134,7 +2208,7 @@ Nodes (7): Test personality summary generation, Tests for user profile creation 
 
 ### Community 339 - "Community 339"
 Cohesion: 0.17
-Nodes (10): test_simple_greeting(), classifier(), Intent Classification Tests ===========================  Tests for HassIL-based, Test greeting intents., Test basic greeting patterns., Test queries that should NOT match any intent., Complex queries should return None (fall back to LLM)., Initialize classifier with test intents. (+2 more)
+Nodes (7): Tests for error mapping utility., Test mapping 401 errors to MusicAuthError., Test mapping 429 errors to RateLimitError., Test mapping 404 errors to TrackNotFoundError., Test mapping timeout errors., Test mapping unknown errors., TestErrorMapping
 
 ### Community 340 - "Community 340"
 Cohesion: 0.17
@@ -2142,311 +2216,307 @@ Nodes (7): Test list-related intent classification., Test basic 'add to shopping
 
 ### Community 341 - "Community 341"
 Cohesion: 0.17
-Nodes (9): check_root_md_files(), Max 10 .md files in root, migrate_self_entries(), Create self entries for users in the people table, _compute_compatibility(), Compute compatibility score and shared traits between two check-ins., Get all registered providers., list() (+1 more)
+Nodes (10): test_simple_greeting(), classifier(), Intent Classification Tests ===========================  Tests for HassIL-based, Test greeting intents., Test basic greeting patterns., Test queries that should NOT match any intent., Complex queries should return None (fall back to LLM)., Initialize classifier with test intents. (+2 more)
 
 ### Community 342 - "Community 342"
 Cohesion: 0.17
-Nodes (11): 🎉 Action Plan Completion Summary, code:block3 (zoe-auth                   ✅ Up and HEALTHY), ✅ Completion Checklist, 📊 Current Service Status, For Next Session, 📝 Handoff Notes, 🎯 Mission Accomplished, Phase 2: Chat Integration (Future) (+3 more)
+Nodes (6): Set default model for Zoe, Deploy a specific adapter as current, Show current configuration, Manage Ollama models and LoRA adapters, List all LoRA adapters, Pull/download a model from Ollama registry
 
 ### Community 343 - "Community 343"
-Cohesion: 0.18
-Nodes (12): Files Modified (21 HTML files), New Files Created (11), 📁 Files Created/Modified, Modified Files, New Files, code:yaml (zoe-core:), code:python (# Added module intent integration at startup), Removed Files (+4 more)
-
-### Community 344 - "Community 344"
-Cohesion: 0.17
-Nodes (12): code:block1 (/home/zoe/assistant/data/zoe.db), code:block2 (/home/zoe/assistant-clean/data/          # DELETED - DO NOT ), ✅ CORRECT Location (PRODUCTION), 📍 DATABASE LOCATION - SINGLE SOURCE OF TRUTH, 🚫 FORBIDDEN ACTIONS, 🚨 INCIDENT REPORT, NEVER Do These Without Explicit User Approval, ❌ NEVER Use These Locations (+4 more)
-
-### Community 345 - "Community 345"
-Cohesion: 0.17
-Nodes (12): ✅ 3. Drag & Drop - FULLY IMPLEMENTED, code:javascript (// Emit event from widget), code:javascript (// Listen to global widget events), Emitting Events, Global Events, Widget Communication, 🎨 Advanced Widget Features, code:javascript (class StatefulWidget {) (+4 more)
-
-### Community 346 - "Community 346"
-Cohesion: 0.18
-Nodes (12): Component Architecture, Orb Features, Zoe Orb Implementation, Step 1: Create Backup, code:bash (cp /home/zoe/assistant/services/zoe-ui/dist/components/zoe-o), code:html (<!-- At end of body -->), code:bash (# Clear browser cache or add version query), Component Loading (+4 more)
-
-### Community 347 - "Community 347"
-Cohesion: 0.17
-Nodes (12): code:bash (cd modules/agent-zero), code:bash (# Health check), code:bash (docker compose -f docker-compose.module.yml up --build -d), Run Bridge Standalone, Test Endpoints, Step 1: Copy Template, 1. Build the module, code:bash (docker compose -f modules/zoe-music/docker-compose.module.ym) (+4 more)
-
-### Community 348 - "Community 348"
-Cohesion: 0.17
-Nodes (12): code:block3 (IF all criteria met:), code:block10 (Should I delete this file?), code:block1 (IF light_rag_accuracy >= 80%: → Option D (Status Quo)), code:block1 (Is there a location / "near me" in the query?), code:json ({"tool": "deep_web_research", "query": "cheapest Emu Export ), Decision Tree, Escalate to OpenClaw instead when, Example Calls (+4 more)
-
-### Community 349 - "Community 349"
-Cohesion: 0.17
-Nodes (12): ✅ ALWAYS DO, code:bash (# 1. Check service started), code:bash (docker logs -f zoe-litellm), 🛡️ CRITICAL RULES, code:bash (# 1. Check resource usage), code:bash (# 1. Check LiteLLM models available), code:bash (# 1. Check git history), 🚨 Emergency Procedures (+4 more)
-
-### Community 350 - "Community 350"
-Cohesion: 0.17
-Nodes (11): code:python (raise HTTPException(status_code=404, detail="Not found")), code:python (# tests/unit/test_error_handling.py), code:python (return {"error": "Not found", "status": 404}), code:python (return JSONResponse(status_code=404, content={"detail": "Not), code:python (# services/zoe-core/models/errors.py), 🔍 Current State Problems, Inconsistent Error Formats, 🏗️ Proposed Standard (+3 more)
-
-### Community 351 - "Community 351"
-Cohesion: 0.17
-Nodes (11): Music Preferences, Update Music Preferences, Get Available Devices, Get Device State, Get Music Preferences, Library Sync Endpoints, Output Device Endpoints, Preferences Endpoints (+3 more)
-
-### Community 352 - "Community 352"
-Cohesion: 0.2
-Nodes (7): Build SQL time filter based on range, Get human-readable temporal context, Search memories with temporal awareness, Integrates temporal memory with existing Light RAG system, Search with both semantic and temporal context, Combine and deduplicate search results, TemporalLightRAGIntegration
-
-### Community 353 - "Community 353"
-Cohesion: 0.17
-Nodes (11): After Modifying chat.py:, Before Modifying chat.py:, code:python (# Hardcoded regex patterns), code:python (# Let EnhancedMemAgent understand intent and execute), ✅ Current Protection Status, If Tests Fail:, 🛡️ Preventing Hardcoded Logic - Architecture Protection System, 📋 Preventing The Mistake - Checklist (+3 more)
-
-### Community 354 - "Community 354"
-Cohesion: 0.18
-Nodes (11): After: HassIL-First Architecture, Before: LLM-First Architecture, code:block1 (User: "add bread to shopping list"), The Problem, code:block6 (routers/), code:block7 (/app/data/zoe.db           # Via ./data:/app/data), code:markdown (### BEFORE DELETING ANY FILE:), Emergency Recovery Plan (+3 more)
-
-### Community 355 - "Community 355"
-Cohesion: 0.17
-Nodes (11): 1. Enhanced MEM Agent ✅, 2. RAG System ✅, 3. Expert Orchestrator ✅, 4. Temporal Memory ✅, 5. Vector Search ✅, 6. Context Optimization ✅, ✅ Advanced Systems Integration, ✅ All Systems Operational (+3 more)
-
-### Community 356 - "Community 356"
-Cohesion: 0.17
-Nodes (11): ✅ Configuration Complete, 📁 File Structure, Platform-Specific Docker Compose Overrides, code:block3 (docker-compose.yml              # Base config (works on both), Jetson (GPU), Model Selection, Path Structure, Pi (CPU) (+3 more)
-
-### Community 357 - "Community 357"
 Cohesion: 0.17
 Nodes (9): After Consolidation, 📊 Expected Outcomes, Violations Prevented (Estimate), Performance Impact, api_health_check(), Zoe Core Service - Enhanced Main Application with Enhancement Systems ==========, API health check endpoint (for frontend compatibility), Prometheus metrics endpoint (+1 more)
 
-### Community 358 - "Community 358"
+### Community 344 - "Community 344"
+Cohesion: 0.18
+Nodes (12): Files Modified (21 HTML files), New Files Created (11), 📁 Files Created/Modified, Modified Files, New Files, code:yaml (zoe-core:), code:python (# Added module intent integration at startup), Removed Files (+4 more)
+
+### Community 345 - "Community 345"
+Cohesion: 0.17
+Nodes (12): Services Running, Building a New Module, code:bash (# List available modules), code:block8 (✅ zoe-core         (orchestration, intents)), 🎮 How to Use the System, Managing Modules, code:bash (# Check status), code:bash (# 1. Copy template) (+4 more)
+
+### Community 346 - "Community 346"
+Cohesion: 0.17
+Nodes (12): code:bash (cd modules/agent-zero), code:bash (# Health check), code:bash (docker compose -f docker-compose.module.yml up --build -d), Run Bridge Standalone, Test Endpoints, Step 1: Copy Template, 1. Build the module, code:bash (docker compose -f modules/zoe-music/docker-compose.module.ym) (+4 more)
+
+### Community 347 - "Community 347"
+Cohesion: 0.17
+Nodes (12): code:python (# Add static file serving (see Backend section above)), code:javascript (// static/js/your-widget.js), code:bash (mkdir -p static/{js,css,icons}), code:bash (cat > static/manifest.json <<EOF), 🚀 Creating a New Module with Widgets, 💻 Frontend: Widget Implementation, Step 2: Create Static Directory, Step 3: Create Manifest (+4 more)
+
+### Community 348 - "Community 348"
 Cohesion: 0.17
 Nodes (12): 6. ANSWERS TO YOUR SPECIFIC QUESTIONS, code:python (def get_temperature_for_intent(intent: ZoeIntent) -> float:), code:python (intent_task = intent_classifier.classify(message)), Context Assembly Questions, GraphRAG vs Vector RAG Questions, Hallucination Prevention Questions, Intent System Integration Questions, Memory System Enhancement Questions (+4 more)
 
-### Community 359 - "Community 359"
+### Community 349 - "Community 349"
 Cohesion: 0.17
 Nodes (5): get_intelligence_settings(), Stub routers for frontend endpoints that don't have full implementations yet. Re, Persist intelligence/proactive feature settings for the current user., Return intelligence/proactive feature settings for the current user., save_intelligence_settings()
 
-### Community 360 - "Community 360"
-Cohesion: 0.22
-Nodes (7): A2AClient, get_a2a_client(), A2A v1.0 client — Zoe calling peer agents.  Provides discover/submit_task/poll_t, Call a specific skill on a peer agent and return the result text., Async A2A v1.0 client., Submit a task to a peer A2A agent.          Returns the peer's response dict (co, Poll the status of a previously submitted A2A task.
+### Community 350 - "Community 350"
+Cohesion: 0.17
+Nodes (12): Display Locations, Size Options, Advanced Features, code:javascript (// Set loading state), code:javascript (getTemplate() {), Using WidgetModule Helper Methods, Answers to Your Top 10 Questions, Hallucination Reduction (+4 more)
 
-### Community 361 - "Community 361"
+### Community 351 - "Community 351"
+Cohesion: 0.21
+Nodes (11): Additional Optimizations, After Fix:, Before Fix:, Expected Performance, code:bash (GET /api/lists/shopping → Returns 64 lists (all types!)), code:bash (GET /api/lists/shopping → Returns 1 list (shopping only)), Verification Tests, code:bash (curl 'http://localhost:8000/api/reminders/?user_id=default') (+3 more)
+
+### Community 352 - "Community 352"
+Cohesion: 0.18
+Nodes (12): Component Architecture, Orb Features, Zoe Orb Implementation, Step 1: Create Backup, code:bash (cp /home/zoe/assistant/services/zoe-ui/dist/components/zoe-o), code:html (<!-- At end of body -->), code:bash (# Clear browser cache or add version query), Component Loading (+4 more)
+
+### Community 353 - "Community 353"
+Cohesion: 0.18
+Nodes (11): After: HassIL-First Architecture, Before: LLM-First Architecture, code:block1 (User: "add bread to shopping list"), The Problem, code:block6 (routers/), code:block7 (/app/data/zoe.db           # Via ./data:/app/data), code:markdown (### BEFORE DELETING ANY FILE:), Emergency Recovery Plan (+3 more)
+
+### Community 354 - "Community 354"
+Cohesion: 0.17
+Nodes (12): ❌ WRONG Patterns (FORBIDDEN):, 1. Direct LLM Service Calls, 2. Hardcoded Model Logic, 3. Multiple Inference Endpoints, 4. Inline Model Configuration, 5. Custom Auth/Retry Logic, code:python (# ❌ WRONG - Direct llamacpp call), code:python (# ❌ WRONG - Hardcoded model routing) (+4 more)
+
+### Community 355 - "Community 355"
+Cohesion: 0.17
+Nodes (11): code:python (raise HTTPException(status_code=404, detail="Not found")), code:python (# tests/unit/test_error_handling.py), code:python (return {"error": "Not found", "status": 404}), code:python (return JSONResponse(status_code=404, content={"detail": "Not), code:python (# services/zoe-core/models/errors.py), 🔍 Current State Problems, Inconsistent Error Formats, 🏗️ Proposed Standard (+3 more)
+
+### Community 356 - "Community 356"
+Cohesion: 0.18
+Nodes (12): 1. Network Configuration, 2. Security - NEVER Commit Secrets, 3. Code Execution Safety, 4. Required Files, 5. Health Endpoints, code:yaml (# docker-compose.module.yml), code:python (# ✅ CORRECT), code:python (eval(user_input)      # ❌ NEVER) (+4 more)
+
+### Community 357 - "Community 357"
+Cohesion: 0.17
+Nodes (11): 🎉 Action Plan Completion Summary, code:block3 (zoe-auth                   ✅ Up and HEALTHY), ✅ Completion Checklist, 📊 Current Service Status, For Next Session, 📝 Handoff Notes, 🎯 Mission Accomplished, Phase 2: Chat Integration (Future) (+3 more)
+
+### Community 358 - "Community 358"
 Cohesion: 0.25
 Nodes (9): test_assistant_prefix_stripped(), test_code_block_not_in_title(), test_derive_strips_markdown(), test_derive_truncates_words(), test_weak_titles(), derive_session_title(), Derive short, human-readable chat session titles from message content., Turn the first line / opening of a message into a sidebar-friendly title.     St (+1 more)
 
-### Community 362 - "Community 362"
-Cohesion: 0.22
-Nodes (11): _bridge_get(), list_entities(), Home Assistant direct control endpoint.  Allows the touch panel to control HA en, Accept any authenticated caller (session user or device token)., Return entity list from the HA bridge, optionally filtered by domain/area., Get current state of a single HA entity., Call a HA service directly from the touch panel.      Body:       { "entity_id":, _require_caller() (+3 more)
-
-### Community 363 - "Community 363"
-Cohesion: 0.18
-Nodes (11): 1. **Add Person Modal - Missing Fields**, 2. **Edit Mode - No Backend Save**, 3. **Person Expert Integration**, code:html (<input id="personName">       ✅ Has), code:block3 (User edits fields → savePersonChanges() → Updates local JS o), code:block4 (User edits fields → savePersonChanges() → API PUT request → ), Evolution notice (nightly), Evolution proposals review (intent: `evolution_proposals_review`) (+3 more)
-
-### Community 364 - "Community 364"
-Cohesion: 0.18
-Nodes (6): Get user's current role, Get all permissions for a role, including inherited ones, Get sorted list of all effective permissions for user, Get user permissions with caching, Get cached permissions for user, Cache permissions for user
-
-### Community 365 - "Community 365"
-Cohesion: 0.18
-Nodes (10): check_module_structure(), Check if a file exists, Check if a module has required classes, Verify all enhancement systems, verify_enhancements(), check_file_exists(), check_for_dangerous_patterns(), Check for dangerous file patterns that indicate backups/duplicates.          Ret (+2 more)
-
-### Community 366 - "Community 366"
-Cohesion: 0.22
-Nodes (3): In-memory session state and WebSocket fan-out for Orbit., Send a message to all players in a session., code:javascript (const session = window.zoeAuth?.getCurrentSession();)
-
-### Community 367 - "Community 367"
+### Community 359 - "Community 359"
 Cohesion: 0.24
 Nodes (10): analyze_markdown_files(), analyze_shell_scripts(), analyze_test_files(), display_plan(), execute_cleanup(), Create a cleanup plan, Display the cleanup plan, Analyze all .md files in root (+2 more)
 
+### Community 360 - "Community 360"
+Cohesion: 0.22
+Nodes (11): _bridge_get(), list_entities(), Home Assistant direct control endpoint.  Allows the touch panel to control HA en, Accept any authenticated caller (session user or device token)., Return entity list from the HA bridge, optionally filtered by domain/area., Get current state of a single HA entity., Call a HA service directly from the touch panel.      Body:       { "entity_id":, _require_caller() (+3 more)
+
+### Community 361 - "Community 361"
+Cohesion: 0.18
+Nodes (9): Search, Search for k most similar tracks.                  Args:             query: 256-, Search YouTube Music.                  Search works without authentication using, Return mock results when not authenticated., _luhn_valid(), Return (possibly-redacted-text, reject_reason_or_None)., Best-effort metadata update - never raises., Public method: bump access_count + last_accessed for the given memory IDs. (+1 more)
+
+### Community 363 - "Community 363"
+Cohesion: 0.22
+Nodes (3): In-memory session state and WebSocket fan-out for Orbit., Send a message to all players in a session., code:javascript (const session = window.zoeAuth?.getCurrentSession();)
+
+### Community 364 - "Community 364"
+Cohesion: 0.18
+Nodes (11): zoe-ui, cloudflared, multica-backend, multica-web, zoe-auth, zoe-database, zoe-auth requirements.txt, zoe-capability-extender SKILL.md (+3 more)
+
+### Community 365 - "Community 365"
+Cohesion: 0.24
+Nodes (7): PromptTestResult, PromptTestSuite, Real-world prompt testing for Zoe capabilities, Execute a single prompt test, Analyze if response meets success criteria, Calculate score based on success analysis, Extract actions executed from response data
+
+### Community 366 - "Community 366"
+Cohesion: 0.22
+Nodes (5): Run a conversation and display full Q&A, run_conversation_test(), Check if response meets expectations, Run a full conversation and track results, Try to resolve an ambiguous utterance relative to the last intent.         Retur
+
+### Community 367 - "Community 367"
+Cohesion: 0.18
+Nodes (10): check_module_structure(), Check if a file exists, Check if a module has required classes, Verify all enhancement systems, verify_enhancements(), check_file_exists(), check_for_dangerous_patterns(), Check for dangerous file patterns that indicate backups/duplicates.          Ret (+2 more)
+
 ### Community 368 - "Community 368"
-Cohesion: 0.18
-Nodes (10): 1. Dual FAB System, 2. Better Visual Feedback, 3. Developer Tools, ✅ Acceptance Criteria - ALL MET, Backup Created, 🔍 Known Limitations, Lines of Code, 🎨 New Features Added (+2 more)
-
-### Community 369 - "Community 369"
-Cohesion: 0.18
-Nodes (11): code:block10 (✅ ALLOWED:), code:block11 (✅ ALLOWED:), code:block12 (✅ ALLOWED in root OR tools/:), code:block13 (❌ NEVER COMMIT:), code:block9 (✅ ALLOWED in root:), Rule 1: Documentation, Rule 2: Test Files, Rule 3: Scripts (+3 more)
-
-### Community 370 - "Community 370"
-Cohesion: 0.18
-Nodes (11): code:block17 (├─ Is it essential documentation?), code:block18 (├─ Is it test_architecture.py?), code:block19 (├─ What's its purpose?), code:block20 (├─ Is it reusable automation?), code:block21 (└─ Delete it. Use .gitignore to prevent commit.), 🔍 Decision Tree: Where Does This File Go?, Is it a Markdown file?, Is it a Python tool? (+3 more)
-
-### Community 371 - "Community 371"
-Cohesion: 0.18
-Nodes (6): Low confidence (≥0.50) should add clear qualifier, Very low confidence (<0.50) should admit limitation, Tier 0 intents should have high confidence, Test P0-2: Confidence Expression, High confidence (≥0.85) should have no qualifier, Medium confidence (≥0.70) should add soft qualifier
-
-### Community 372 - "Community 372"
-Cohesion: 0.18
-Nodes (11): 2.1 Connection & Authentication, 2.2 Research Method, 2.3 Planning Method, 2.4 Analysis Method, 2.5 Comparison Method, code:python (async def connect(self) -> bool:), code:python (async def research(self, query: str, depth: str = "thorough"), code:python (async def plan(self, task: str) -> Dict[str, Any]:) (+3 more)
-
-### Community 373 - "Community 373"
-Cohesion: 0.18
-Nodes (11): Combined Metrics, Decision Gate Results, P0-1: Context Validation, P0-2: Confidence Expression, P0-3: Temperature Adjustment, P0-4: Grounding Checks, P0 Results (Day 22), P0-2: Confidence Expression (Days 11-13) (+3 more)
-
-### Community 374 - "Community 374"
-Cohesion: 0.18
-Nodes (11): code:bash (docker logs zoe-code-execution --tail 50), code:bash (docker logs zoe-core --tail 100 | grep -i "code\|tool\|mcp"), code:bash (docker ps | grep -E "(zoe-code-execution|zoe-mcp-server|zoe-), code:bash (curl -X POST http://localhost:8010/execute \), Check MCP Connection, Check Widget Discovery, Check Widget Loading, code:javascript (// Open browser console) (+3 more)
-
-### Community 375 - "Community 375"
-Cohesion: 0.18
-Nodes (11): 1. Always Use LiteLLMProvider, 2. Use Model Aliases, 3. Include Master Key, 4. Handle Streaming Properly, 5. Test Configuration Changes, code:python (# ✅ CORRECT - Validation before deployment), code:python (from llm_provider import get_llm_provider), code:python (# ✅ CORRECT - Semantic aliases from config) (+3 more)
-
-### Community 376 - "Community 376"
-Cohesion: 0.18
-Nodes (11): code:bash (# Check if Agent Zero is responding), Log Files, Useful Commands, code:bash (# Bridge logs), Check Gateway Status, code:bash (# Service health), code:bash (# Test gateway directly), Debug Request Issues (+3 more)
-
-### Community 377 - "Community 377"
-Cohesion: 0.18
-Nodes (11): code:bash (# 1. Verify systems running), code:bash (# Install with one-liner (requires sudo)), code:bash (# 1. Copy skills to Moltbot workspace), code:bash (# WhatsApp), code:bash (# Test 1: Direct Zoe API), 🚀 Deployment Sequence, Phase 1: Pre-Installation (5 min), Phase 2: Install Moltbot (10-15 min) (+3 more)
-
-### Community 378 - "Community 378"
-Cohesion: 0.18
-Nodes (11): code:block7 (INFO: ✅ Loaded module: agent-zero (4 intents, 4 handlers)), ✅ TEST 1: Service Health, ✅ TEST 2: Service Status, ✅ TEST 3: Research Endpoint, ✅ TEST 4: Planning Endpoint, ✅ TEST 5: Analysis Endpoint, ✅ TEST 6: Comparison Endpoint, ✅ TEST 7: Intent System Integration (+3 more)
-
-### Community 379 - "Community 379"
-Cohesion: 0.18
-Nodes (11): 2. EnhancedMemAgentClient, 4. AgentPlanner / ExpertOrchestrator, 5. MCP Server, code:python (mem_agent = MemAgentClient()), code:python (enhanced_mem_agent = EnhancedMemAgentClient()), code:python (provider, model = route_llm.classify_query(message, context)), code:python (orchestrator = ExpertOrchestrator()), 🧠 Your Intelligent Architecture (What To Use) (+3 more)
-
-### Community 380 - "Community 380"
-Cohesion: 0.18
-Nodes (10): Backend/UI Changes Applied, Baseline (Collected), Hardening Implemented on Pi, Important Routing Finding (Fixed in Runtime Config), Operational Status, Real Panel Action-Loop Verification, Retry Behavior Verification, Scope Completed (+2 more)
-
-### Community 381 - "Community 381"
 Cohesion: 0.18
 Nodes (11): Backup / Rollback, Before `.env` token changes, Before HA config edits (automated by OpenClaw), code:bash (cp assistant/homeassistant/configuration.yaml \), code:bash (cp assistant/.env assistant/.env.bak.$(date +%Y%m%d)), code:bash (cp assistant/.env.bak.YYYYMMDD assistant/.env), code:bash (sqlite3 assistant/services/zoe-data/zoe.db ".backup /tmp/zoe), code:bash (# Stop zoe-data first) (+3 more)
 
+### Community 369 - "Community 369"
+Cohesion: 0.18
+Nodes (11): 1. Always Use LiteLLMProvider, 2. Use Model Aliases, 3. Include Master Key, 4. Handle Streaming Properly, 5. Test Configuration Changes, code:python (# ✅ CORRECT - Validation before deployment), code:python (from llm_provider import get_llm_provider), code:python (# ✅ CORRECT - Semantic aliases from config) (+3 more)
+
+### Community 370 - "Community 370"
+Cohesion: 0.18
+Nodes (11): code:bash (docker logs zoe-code-execution --tail 50), code:bash (docker logs zoe-core --tail 100 | grep -i "code\|tool\|mcp"), code:bash (docker ps | grep -E "(zoe-code-execution|zoe-mcp-server|zoe-), code:bash (curl -X POST http://localhost:8010/execute \), Check MCP Connection, Check Widget Discovery, Check Widget Loading, code:javascript (// Open browser console) (+3 more)
+
+### Community 371 - "Community 371"
+Cohesion: 0.18
+Nodes (11): code:bash (# Check if Agent Zero is responding), Log Files, Useful Commands, code:bash (# Bridge logs), Check Gateway Status, code:bash (# Service health), code:bash (# Test gateway directly), Debug Request Issues (+3 more)
+
+### Community 372 - "Community 372"
+Cohesion: 0.18
+Nodes (11): code:bash (# 1. Verify systems running), code:bash (# Install with one-liner (requires sudo)), code:bash (# 1. Copy skills to Moltbot workspace), code:bash (# WhatsApp), code:bash (# Test 1: Direct Zoe API), 🚀 Deployment Sequence, Phase 1: Pre-Installation (5 min), Phase 2: Install Moltbot (10-15 min) (+3 more)
+
+### Community 373 - "Community 373"
+Cohesion: 0.18
+Nodes (11): code:block17 (├─ Is it essential documentation?), code:block18 (├─ Is it test_architecture.py?), code:block19 (├─ What's its purpose?), code:block20 (├─ Is it reusable automation?), code:block21 (└─ Delete it. Use .gitignore to prevent commit.), 🔍 Decision Tree: Where Does This File Go?, Is it a Markdown file?, Is it a Python tool? (+3 more)
+
+### Community 374 - "Community 374"
+Cohesion: 0.18
+Nodes (11): code:block10 (✅ ALLOWED:), code:block11 (✅ ALLOWED:), code:block12 (✅ ALLOWED in root OR tools/:), code:block13 (❌ NEVER COMMIT:), code:block9 (✅ ALLOWED in root:), Rule 1: Documentation, Rule 2: Test Files, Rule 3: Scripts (+3 more)
+
+### Community 375 - "Community 375"
+Cohesion: 0.18
+Nodes (11): 2.1 Connection & Authentication, 2.2 Research Method, 2.3 Planning Method, 2.4 Analysis Method, 2.5 Comparison Method, code:python (async def connect(self) -> bool:), code:python (async def research(self, query: str, depth: str = "thorough"), code:python (async def plan(self, task: str) -> Dict[str, Any]:) (+3 more)
+
+### Community 376 - "Community 376"
+Cohesion: 0.18
+Nodes (11): 2. EnhancedMemAgentClient, 4. AgentPlanner / ExpertOrchestrator, 5. MCP Server, code:python (mem_agent = MemAgentClient()), code:python (enhanced_mem_agent = EnhancedMemAgentClient()), code:python (provider, model = route_llm.classify_query(message, context)), code:python (orchestrator = ExpertOrchestrator()), 🧠 Your Intelligent Architecture (What To Use) (+3 more)
+
+### Community 377 - "Community 377"
+Cohesion: 0.18
+Nodes (10): Backend/UI Changes Applied, Baseline (Collected), Hardening Implemented on Pi, Important Routing Finding (Fixed in Runtime Config), Operational Status, Real Panel Action-Loop Verification, Retry Behavior Verification, Scope Completed (+2 more)
+
+### Community 378 - "Community 378"
+Cohesion: 0.18
+Nodes (11): Automated CHANGELOG, code:block45 (feat(chat): Add auto-discovery router system), code:bash (# Generate CHANGELOG for new version), code:bash (# See last week's changes), Conventional Commits (ENFORCED), 🔄 Git Commit Standards (NEW in v2.4.0), Weekly Change Summaries, Commit Message Validation (+3 more)
+
+### Community 379 - "Community 379"
+Cohesion: 0.22
+Nodes (7): A2AClient, get_a2a_client(), A2A v1.0 client — Zoe calling peer agents.  Provides discover/submit_task/poll_t, Call a specific skill on a peer agent and return the result text., Async A2A v1.0 client., Submit a task to a peer A2A agent.          Returns the peer's response dict (co, Poll the status of a previously submitted A2A task.
+
+### Community 380 - "Community 380"
+Cohesion: 0.22
+Nodes (8): recalc_and_save updates health_score in DB., test_health_score_recalc(), Proactive trigger: birthday 7-day lookahead.  Fires once daily at 8am for contac, _next_occurrence(), person_health.py — Relationship health scoring.  Health score = weighted combina, Return the next calendar occurrence of (month, day) on or after ref (default: to, Recalculate health_score for one person and persist it to the DB.      Args:, recalc_and_save()
+
+### Community 381 - "Community 381"
+Cohesion: 0.24
+Nodes (9): create_note(), delete_note(), list_notes(), FastAPI router for notes. Mounted at prefix="/api/notes" with tag "notes"., Update an existing note., Write a note-derived fact to MemPalace through MemoryService.      `db` is kept, List notes with optional category filter. Returns {notes: [...], count}., _store_note_memory() (+1 more)
+
 ### Community 382 - "Community 382"
-Cohesion: 0.2
-Nodes (11): code:bash (pytest tests/ -v --cov=routers), code:bash (# Generate endpoint inventory), code:python (# OLD (64 imports)), 🚀 Implementation Strategy, Phase 1: Preparation (Day 1), Phase 2: Consolidate High-Value Targets (Days 2-3), Phase 3: Update Imports (Day 4), Phase 4: Testing & Validation (Day 5) (+3 more)
+Cohesion: 0.22
+Nodes (9): _blocking_synthesize(), _load_pipeline(), _pcm_to_wav(), Convert a torch.FloatTensor of PCM samples to WAV bytes.      Uses struct.pack i, Run Kokoro inference synchronously (called inside run_in_executor).      Calls t, Async wrapper: runs blocking inference in thread pool under the lock., Load and return the Kokoro pipeline (blocking; run once in thread pool)., _run_synthesis() (+1 more)
 
 ### Community 383 - "Community 383"
-Cohesion: 0.27
-Nodes (4): When only memory is selected, ha_control should not be included., Selecting all skills should produce the full _TOOLS list., A typical single-skill query should load far fewer tools than the full set., TestBuildTools
-
-### Community 384 - "Community 384"
 Cohesion: 0.2
 Nodes (9): _build_agent_team_prompt(), get_agent_info(), load_agent_registry(), zoe_agent_registry.py — Agent registry loader for zoe_agent.py.  Loads agents_re, Load agents_registry.yml. Returns empty dict on failure (agent still works)., Generate AGENT TEAM routing guidance from registry data.      Returns an empty s, Build a tool description from registry skills, falling back to static text., Return the registry entry for a named agent, or empty dict. (+1 more)
 
-### Community 385 - "Community 385"
-Cohesion: 0.2
-Nodes (10): get_skills(), install_skill_endpoint(), Install a skill (allowlist-gated). Returns 403 if not in allowlist., Return workspace-installed + eligible bundled skills for the skills_manager comp, install_skill(), list_skills(), Return True if a skill may be installed.      Bundled skills are always allowed, Return workspace-installed skills + eligible bundled skills.      Workspace skil (+2 more)
+### Community 384 - "Community 384"
+Cohesion: 0.24
+Nodes (10): _ambient_capture_thread(), _barge_in_vad_thread(), _follow_up_listen(), _get_silero_vad(), Load Silero VAD model lazily — ~1MB, loads in <200ms on Pi., Return max speech probability across 512-sample windows in the chunk., Background thread: runs Silero VAD during TTS playback to detect barge-in., Background thread: always-on VAD captures room speech for ambient memory.      R (+2 more)
 
-### Community 386 - "Community 386"
+### Community 385 - "Community 385"
 Cohesion: 0.27
 Nodes (8): Fail-closed default: no X-Session-ID → guest role.  Old behaviour (promote unaut, Unset env → guest. Fail-closed is the new default., Explicit ZOE_UNAUTHENTICATED_ROLE=guest still resolves to guest., Legacy LAN deployments can flip ZOE_UNAUTHENTICATED_ROLE=family-admin to     res, _reload_auth(), test_family_admin_opt_in_still_possible(), test_no_session_defaults_to_guest(), test_no_session_guest_when_env_set()
 
+### Community 386 - "Community 386"
+Cohesion: 0.2
+Nodes (9): Widget System Quick Start Guide, Zoe Authentication Service, Adding New Services, code:python (# sso/new_service.py), code:python (# api/sso.py), code:python (# main.py startup), Contributing, SSO Integration Guide (+1 more)
+
 ### Community 387 - "Community 387"
+Cohesion: 0.2
+Nodes (10): get_skills(), install_skill_endpoint(), Install a skill (allowlist-gated). Returns 403 if not in allowlist., Return workspace-installed + eligible bundled skills for the skills_manager comp, install_skill(), list_skills(), Return True if a skill may be installed.      Bundled skills are always allowed, Return workspace-installed skills + eligible bundled skills.      Workspace skil (+2 more)
+
+### Community 388 - "Community 388"
+Cohesion: 0.2
+Nodes (9): Test required directories exist, Test model manager CLI, Test if Unsloth is installed, Test that all required modules can be imported, Test training database is set up correctly, test_database(), test_directories(), test_imports() (+1 more)
+
+### Community 389 - "Community 389"
 Cohesion: 0.27
 Nodes (5): HTMLSyntaxValidator, Check for unterminated quotes in JavaScript, Check for basic JavaScript syntax errors, Validate a single HTML file, Validate all HTML files in the directory
 
-### Community 389 - "Community 389"
-Cohesion: 0.2
-Nodes (10): 1. ✅ Project Structure Validation, 2. ✅ Critical Files Validation, 3. ✅ File Deletion Protection, 4. ✅ Junk File Pattern Detection, 5. ✅ Database Path Enforcement, 6. ✅ Authentication Security Check, 7. ✅ CHANGELOG Validation (NEW!), 8. ✅ Large File Detection (NEW!) (+2 more)
-
 ### Community 390 - "Community 390"
 Cohesion: 0.2
-Nodes (10): code:python (from routers import push), code:bash (docker exec zoe-core pip install -r /app/requirements.txt), 🎯 Next Steps to Complete Phase 2, Step 1: Run Database Migration (5 min), Step 2: Register Push Router (5 min), Step 3: Install Dependencies (5 min), Step 4: Create Frontend Handler (30 min), Step 5: Add Notification Settings (30 min) (+2 more)
+Nodes (9): Test code execution service directly, Test MCP tool execution via code, Test chat router's code execution integration, test_chat_router_code_execution(), test_code_execution_service(), test_mcp_tool_via_code(), Test 2: Music Search (Standalone), code:bash (curl -X POST http://localhost:8100/tools/search \) (+1 more)
 
 ### Community 391 - "Community 391"
 Cohesion: 0.2
-Nodes (9): code:bash (# 1. Apply database migration), 🔧 Commands to Complete Phase 2, 🐛 Known Issues to Address, 🔔 Phase 2: Push Notifications (In Progress), 📊 Progress Summary, 🚀 Ready to Complete?, 🎉 What Works After Phase 2, PWA Phase 2 Implementation Progress (+1 more)
+Nodes (10): Code Execution Testing Summary, ⚠️ Issues to Watch For:, 🧪 Manual Testing Instructions, ✅ Success Indicators:, Test 1: Simple List Addition, Test 2: Calendar Event, Test 3: Multi-Step Operation, Test 4: Capability Question (+2 more)
 
 ### Community 392 - "Community 392"
 Cohesion: 0.2
-Nodes (6): P0 Feature Validation Tests Tests all P0 features against targets, Test P0-4: Grounding Checks, Verify all features can be imported, Verify feature flags are properly configured, test_all_features_importable(), test_feature_flags_status()
+Nodes (10): code:javascript (// Emit event from widget), code:javascript (// Listen to global widget events), Emitting Events, Global Events, Widget Communication, 🎨 Advanced Widget Features, code:javascript (class StatefulWidget {), code:javascript (class RealtimeWidget {) (+2 more)
 
 ### Community 393 - "Community 393"
 Cohesion: 0.2
-Nodes (10): 0. Code Execution Pattern (CRITICAL), code:python (# ❌ ISSUE: Loading ALL tool definitions upfront), code:python (# User: "Get all my events and add them to a list"), code:block3 (servers/), code:typescript (// Agent writes code instead of direct tool calls), 🔴 **Critical Action Required**, ❌ **Current Implementation: Direct Tool Calls**, 📈 **Expected Benefits** (+2 more)
+Nodes (10): Implementation Timeline, Month 2+ (P2 - Future Considerations), Week 1 (P0 - Days 1-6), Week 2 (P0 - Testing & Iteration), Week 3-4 (P1 - Optional Enhancements), 8. NEXT ACTIONS (Start This Week), Day 1-2: Implement P0-2 (Intent-Aware Context Validation), Day 3: Implement P0-3 (Confidence-Aware Uncertainty) (+2 more)
 
 ### Community 394 - "Community 394"
-Cohesion: 0.22
-Nodes (10): Context Retention Testing, Combined P1 Metrics, P1-1: Behavioral Memory, P1-2: Platform Optimization, P1-3: Integration Optimization, P1-4: Memory Enhancement, P1 Results (Day 38), P1-1: Behavioral Memory L1 (Days 23-29) - TIMEBOXED (+2 more)
+Cohesion: 0.2
+Nodes (10): 2. Service Health Fixes (COMPLETED ✅), 3. Health Check Configuration (COMPLETED ✅), 2. Database Schema Created, 3. Models Created, 4. Backend Service Created, 5. API Endpoints Created, ✅ Completed Tasks, Dependencies Added (+2 more)
 
 ### Community 395 - "Community 395"
 Cohesion: 0.2
-Nodes (10): Code Execution Testing Summary, ⚠️ Issues to Watch For:, 🧪 Manual Testing Instructions, ✅ Success Indicators:, Test 1: Simple List Addition, Test 2: Calendar Event, Test 3: Multi-Step Operation, Test 4: Capability Question (+2 more)
+Nodes (10): Step 1: Run Database Migration (5 min), Complete Audit Results, Update - Final Fix Count (Oct 19, 2025), User Impact, Verification Command, Check Last Backup, Check User Count, code:bash (sqlite3 /home/zoe/assistant/data/zoe.db "SELECT COUNT(*) FRO) (+2 more)
 
 ### Community 396 - "Community 396"
-Cohesion: 0.2
-Nodes (10): code:block10 ([500ms thinking]), code:block11 (❌ No intent match (too complex phrasing)), code:block12 (✅ LLM: "60s song, 'let it be' → Beatles"), code:block13 (Intent: MusicPlay (only handles first part)), code:block14 (LLM: "User wants jazz but with energy preference"), code:block9 ([Instant]), Example 1: "Play some Beatles", Example 2: "Find that song from the 60s, you know, the one that goes 'let it be'" (+2 more)
-
-### Community 397 - "Community 397"
-Cohesion: 0.2
-Nodes (10): 📞 Support & Resources, code:block1 (/home/pi/test_something.py  ❌ WRONG), code:block2 (/home/pi/STATUS_REPORT.md           ❌ WRONG), code:block3 (/home/pi/nginx.conf        ❌ WRONG), code:block4 (/home/pi/fix_something.sh             ❌ WRONG), Config Files, Scripts, Status Reports & Summaries (+2 more)
-
-### Community 398 - "Community 398"
 Cohesion: 0.22
 Nodes (9): Adding New Files, code:bash (# Run all validators), File Limits, Maintenance, Manifest System Documentation, Test Validators, Update Manifest, Cleanup Operations (+1 more)
 
+### Community 397 - "Community 397"
+Cohesion: 0.2
+Nodes (9): Layer 2: Skills (Lightweight Instructions), Forbidden in Handlers:, Intent Handlers Must:, code:yaml (---), Module-Shipped Skills, Security Rules, Skill Locations, SKILL.md Format (+1 more)
+
+### Community 398 - "Community 398"
+Cohesion: 0.2
+Nodes (9): Building Zoe Modules - Developer Guide, code:yaml (module:), Example: Music Module, Getting Help, Module Categories, Module Manifest (Optional), Port Assignment, Submitting Modules (+1 more)
+
 ### Community 399 - "Community 399"
 Cohesion: 0.2
-Nodes (10): code:json (// Playback state change), code:json (// Request current state), Messages to Server, Ducking Update, Interrupt Event, Messages from Server, Pong, State Update (+2 more)
+Nodes (10): 0. Code Execution Pattern (CRITICAL), code:python (# ❌ ISSUE: Loading ALL tool definitions upfront), code:python (# User: "Get all my events and add them to a list"), code:block3 (servers/), code:typescript (// Agent writes code instead of direct tool calls), 🔴 **Critical Action Required**, ❌ **Current Implementation: Direct Tool Calls**, 📈 **Expected Benefits** (+2 more)
 
-### Community 401 - "Community 401"
+### Community 400 - "Community 400"
 Cohesion: 0.24
 Nodes (5): Unit tests for the Pi Agent skills classifier and tool builder.  Tests _select_s, _llm_call must accept tool_choice kwarg defaulting to 'auto'., Verify a selection of the weather cue strings would match typical messages., TestChatCapabilityShortcutExists, TestLlmCallSignature
 
-### Community 402 - "Community 402"
+### Community 401 - "Community 401"
 Cohesion: 0.2
 Nodes (6): Verify the inputs to the _first_turn_choice expression are correct.      We can', Pure weather query (no 'today' crossover) → should produce 'required'., today' triggers calendar+weather (7 tools > 6) → should produce 'auto'., Discovery fallback → real_skills is empty → should produce 'auto'., When all skills match, tool count exceeds 5 → should produce 'auto'., TestFirstTurnChoiceLogic
 
 ### Community 403 - "Community 403"
 Cohesion: 0.2
-Nodes (10): Implementation Timeline, Month 2+ (P2 - Future Considerations), Week 1 (P0 - Days 1-6), Week 2 (P0 - Testing & Iteration), Week 3-4 (P1 - Optional Enhancements), 8. NEXT ACTIONS (Start This Week), Day 1-2: Implement P0-2 (Intent-Aware Context Validation), Day 3: Implement P0-3 (Confidence-Aware Uncertainty) (+2 more)
+Nodes (10): code:block10 ([500ms thinking]), code:block11 (❌ No intent match (too complex phrasing)), code:block12 (✅ LLM: "60s song, 'let it be' → Beatles"), code:block13 (Intent: MusicPlay (only handles first part)), code:block14 (LLM: "User wants jazz but with energy preference"), code:block9 ([Instant]), Example 1: "Play some Beatles", Example 2: "Find that song from the 60s, you know, the one that goes 'let it be'" (+2 more)
 
-### Community 404 - "Community 404"
+### Community 405 - "Community 405"
+Cohesion: 0.39
+Nodes (6): _fake_get_db(), _FakeDb, test_save_chat_message_only_touches_existing_strong_title(), test_save_chat_message_updates_weak_session_title(), test_load_todays_messages_uses_postgres_timestamp_cast(), test_run_digest_for_all_active_users_uses_postgres_timestamp_cast()
+
+### Community 406 - "Community 406"
+Cohesion: 0.36
+Nodes (3): TestParseBirthday, _parse_birthday(), Return (month, day, year) from a birthday string, any values may be None.
+
+### Community 407 - "Community 407"
 Cohesion: 0.28
 Nodes (8): _call_llm_for_portrait(), User Portrait: synthesized narrative understanding of each person.  A portrait i, Call the local LLM to generate a portrait. Returns the portrait text or ''., Upsert the portrait into the user_portraits table., Run portrait synthesis for all users who have approved memories.      Called as, Synthesize a fresh user portrait from MemPalace memories and journal entries., run_portrait_synthesis(), _save_portrait()
 
-### Community 405 - "Community 405"
-Cohesion: 0.22
-Nodes (9): _compute_resemblyzer_embedding(), _cosine_similarity(), Identify speaker from a WAV audio sample by comparing to enrolled profiles., Compute a 256-dim resemblyzer voice embedding from a WAV file.      Returns raw, Cosine similarity between two float32 byte blobs., Enroll a speaker voice profile using a WAV audio sample.      Request: { "audio_, Identify speaker by comparing to enrolled profiles.      Accepts two request for, voice_enroll() (+1 more)
-
-### Community 406 - "Community 406"
-Cohesion: 0.22
-Nodes (8): parse_json_fields(), get_connection_icebreaker(), Orbit icebreaker engine — rule cascade, strongest signal wins., Shorter icebreaker for the QR scan connect page., get_pending_connections(), Get all pending connection requests for a user., Accept or decline a pending connection request., respond_to_connection()
-
-### Community 407 - "Community 407"
-Cohesion: 0.22
-Nodes (6): User Profile Schema Tests ========================= Tests for the compatibility, Tests for interest categories, Test creating an interest, Test creating a life goal, TestInterestCategory, TestLifeGoal
-
 ### Community 408 - "Community 408"
 Cohesion: 0.22
-Nodes (3): Real Conversation Quality Tests Tests actual multi-message conversations with co, Test real conversations with context retention and usefulness, Test response quality metrics
+Nodes (9): agent_card(), _build_agent_card(), A2A agent identity card.     Returns Zoe's public capability advertisement follo, Build an A2A v1.0 compliant agent card for Zoe., A2A v1.0 agent identity card — public capability advertisement., a2a_well_known(), internal_broadcast(), A2A v1.0 agent discovery — served inline to avoid redirect caching issues. (+1 more)
 
 ### Community 409 - "Community 409"
-Cohesion: 0.22
-Nodes (9): code:python (# OLD), code:block6 (modules/zoe-music-mcp/), code:python (# modules/zoe-music-mcp/services/platform.py), code:python (# Already handled via DATABASE_PATH environment variable), code:python (# MCP tools receive user_id in requests), Extraction Strategy, Phase 1: Create Module Structure, Phase 2: Handle Dependencies (+1 more)
+Cohesion: 0.25
+Nodes (9): _compute_resemblyzer_embedding(), _cosine_similarity(), Identify speaker from a WAV audio sample by comparing to enrolled profiles., Compute a 256-dim resemblyzer voice embedding from a WAV file.      Returns raw, Cosine similarity between two float32 byte blobs., Enroll a speaker voice profile using a WAV audio sample.      Request: { "audio_, Identify speaker by comparing to enrolled profiles.      Accepts two request for, voice_enroll() (+1 more)
 
 ### Community 410 - "Community 410"
 Cohesion: 0.22
-Nodes (9): 🧪 Browser Console Testing, Check Manifest, Check Service Worker Status, code:javascript (// Run in browser console), code:javascript (// Check notification permission), code:javascript (// Verify manifest loaded), code:javascript (// List what's cached), Test Push Notification Permission (+1 more)
+Nodes (8): ✅ All Systems Active, Backend (chat.py), Backend Not Responding, Chat Page Configuration, Frontend (chat.html), Potential Issues, System Integration, Model Not Found
 
 ### Community 411 - "Community 411"
 Cohesion: 0.22
-Nodes (8): Project Governance Implementation - COMPLETE, Developers (Contributing), Existing Users (Already Have Zoe), Key Documents, Key Tools, New Users (Installing Zoe), 📖 Reference, 🎓 What Changed for Users
+Nodes (8): code:bash (./svc.sh install), code:block2 (XDG_RUNTIME_DIR=/run/user/1000), code:bash (loginctl enable-linger zoe), GitHub Secrets, One-time installation (run as the `zoe` user on the Jetson), Required: user session bus access, Self-hosted GitHub Actions Runner — Jetson Orin Setup, Verifying a deployment
 
 ### Community 412 - "Community 412"
 Cohesion: 0.22
-Nodes (9): Immediate (This Session), Medium Term (Future), Short Term (Next Session), Medium Term (Next Month), 🎯 Recommended Implementation Order, Short Term (Next 2 Weeks), Immediate (This Week), 🚦 Next Actions (+1 more)
+Nodes (6): User Profile Schema Tests ========================= Tests for the compatibility, Tests for interest categories, Test creating an interest, Test creating a life goal, TestInterestCategory, TestLifeGoal
 
 ### Community 413 - "Community 413"
 Cohesion: 0.22
-Nodes (9): 2. Hardcoded Model Logic, 3. Multiple Inference Endpoints, 4. Inline Model Configuration, 5. Custom Auth/Retry Logic, code:python (# ❌ WRONG - Hardcoded model routing), code:python (# ❌ WRONG - Multiple endpoints), code:python (# ❌ WRONG - Model config in code), code:python (# ❌ WRONG - Custom retry logic) (+1 more)
+Nodes (3): Real Conversation Quality Tests Tests actual multi-message conversations with co, Test real conversations with context retention and usefulness, Test response quality metrics
 
 ### Community 414 - "Community 414"
 Cohesion: 0.22
-Nodes (9): 1. **chat.html**, 2. **dashboard.html**, 3. **journal.html**, 4. **calendar.html**, 5. **memories.html**, 6. **workflows.html**, 7. **settings.html**, Changes Made (+1 more)
+Nodes (8): code:bash (# View current tags), code:bash (# System overview), code:bash (# Enable music), Enable/Disable Modules, Module Management Commands, Project Statistics, Zoe Module System - Implementation Complete, Check Status
 
 ### Community 415 - "Community 415"
 Cohesion: 0.22
-Nodes (8): code:bash (./svc.sh install), code:block2 (XDG_RUNTIME_DIR=/run/user/1000), code:bash (loginctl enable-linger zoe), GitHub Secrets, One-time installation (run as the `zoe` user on the Jetson), Required: user session bus access, Self-hosted GitHub Actions Runner — Jetson Orin Setup, Verifying a deployment
+Nodes (9): code:block10 (✅ Intent Auto-Discovery: Scans modules/*/intents/), code:block9 (✅ Backend: 28 Python files), Discovery Systems, Music Module, Current System State, ❌ Failed Routers (Need Analysis), 📊 Frontend Status, ✅ Working Routers (68 registered) (+1 more)
 
 ### Community 416 - "Community 416"
 Cohesion: 0.22
-Nodes (9): code:bash (# Automatic backup with timestamp), code:sql (-- ❌ FORBIDDEN without backup), code:bash (echo "$(date): Migration XYZ applied" >> /home/zoe/assistant), code:bash (chmod 644 /home/zoe/assistant/data/*.db), Rule 2: Automatic Backups Before Changes, Rule 3: User Data Protection, Rule 4: Migration Logging, Rule 5: Database File Permissions (+1 more)
+Nodes (8): code:block2 (GET /shopping → [List 123, List 60, List 61, ...]), Comprehensive Restoration Analysis, Database Path Clarification, Files Still Missing/Broken, Missing WebSocket/Intelligence Endpoints, Next Steps (Structured Approach), SQL Schema Issues, What Happened
 
 ### Community 417 - "Community 417"
 Cohesion: 0.22
-Nodes (9): 1. Hybrid Research Mode, 2. Proactive Agent Zero Summaries, 3. Multi-Agent Collaboration, 4. Cost Controls, code:python (async def smart_research(query, user_id):), code:yaml (# In Moltbot cron), code:python (# Example: Home automation planning), code:python (# Monthly budget enforcement) (+1 more)
+Nodes (9): Escalation Path, During Implementation, For Architectural Questions, For "Why" Questions, 📞 Support & Questions, code:bash (# Check for long-running transactions), code:bash (# Clear permission cache), code:bash (# Check rate limit status) (+1 more)
 
 ### Community 418 - "Community 418"
 Cohesion: 0.22
-Nodes (9): Escalation Path, During Implementation, For Architectural Questions, For "Why" Questions, 📞 Support & Questions, code:bash (# Check for long-running transactions), code:bash (# Clear permission cache), code:bash (# Check rate limit status) (+1 more)
+Nodes (9): code:python (# MCP server discovers music tools), code:bash (# Start full system with module), Phase 4: Integration & Testing (60 minutes), Step 4.1: Test Module Standalone (20 minutes), Step 4.2: Register with zoe-mcp-server (15 minutes), Step 4.3: Test AI Control (15 minutes), Step 4.4: Update chat.py Context (10 minutes), code:bash (# Build and start module) (+1 more)
 
 ### Community 419 - "Community 419"
 Cohesion: 0.22
-Nodes (8): 📋 Code Review Checklist, code:bash (bash tools/audit/validate_litellm.sh), LiteLLM Gateway - Development Rules & Guidelines, 📊 Metrics & Observability, New Developers, 🛡️ Pre-commit Validation, Track These Metrics, 🎓 Training Resources
+Nodes (8): code:bash (# 1. Apply database migration), 🔧 Commands to Complete Phase 2, 🐛 Known Issues to Address, 🔔 Phase 2: Push Notifications (In Progress), 📊 Progress Summary, 🚀 Ready to Complete?, 🎉 What Works After Phase 2, PWA Phase 2 Implementation Progress
 
 ### Community 420 - "Community 420"
 Cohesion: 0.22
@@ -2454,15 +2524,15 @@ Nodes (9): 7-Layer Prevention System, code:bash (# Check if any critical files a
 
 ### Community 421 - "Community 421"
 Cohesion: 0.22
-Nodes (9): Automated CHANGELOG, code:block45 (feat(chat): Add auto-discovery router system), code:bash (# Generate CHANGELOG for new version), code:bash (# See last week's changes), Conventional Commits (ENFORCED), 🔄 Git Commit Standards (NEW in v2.4.0), Weekly Change Summaries, code:block1 (type(scope): description) (+1 more)
+Nodes (9): 1. Hardcoded Database Paths, 2. Module-Level Database Initialization, 3. Orphaned Docker Containers, 4. Dashboard localStorage Corruption, code:python (# ❌ WRONG - Breaks in Docker), code:python (# ✅ CORRECT - Works everywhere), code:python (# ❌ WRONG - Runs before env vars loaded), code:python (# ✅ CORRECT - Lazy initialization) (+1 more)
 
 ### Community 422 - "Community 422"
-Cohesion: 0.22
-Nodes (9): code:block10 (✅ Intent Auto-Discovery: Scans modules/*/intents/), code:block9 (✅ Backend: 28 Python files), Discovery Systems, Music Module, Current System State, ❌ Failed Routers (Need Analysis), 📊 Frontend Status, ✅ Working Routers (68 registered) (+1 more)
+Cohesion: 0.25
+Nodes (8): Browser Cache Fix - Clear Old Broken State, Expected State After Cache Clear, ✅ No More "Unexpected token '<'" Errors, ✅ Pages Styled Correctly, Prevention, ⚠️ Still See API 404 Errors (This is Normal), What You Should See After Clearing Cache, Why This Happened
 
 ### Community 423 - "Community 423"
 Cohesion: 0.22
-Nodes (8): code:block2 (GET /shopping → [List 123, List 60, List 61, ...]), Comprehensive Restoration Analysis, Database Path Clarification, Files Still Missing/Broken, Missing WebSocket/Intelligence Endpoints, Next Steps (Structured Approach), SQL Schema Issues, What Happened
+Nodes (9): 🧪 Browser Console Testing, Check Manifest, Check Service Worker Status, code:javascript (// Run in browser console), code:javascript (// Check notification permission), code:javascript (// Verify manifest loaded), code:javascript (// List what's cached), Test Push Notification Permission (+1 more)
 
 ### Community 424 - "Community 424"
 Cohesion: 0.22
@@ -2470,79 +2540,79 @@ Nodes (4): _PI_SOUL_STATIC must not contain any day/time strings (KV cache stabi
 
 ### Community 425 - "Community 425"
 Cohesion: 0.22
-Nodes (9): code:python (# MCP server discovers music tools), code:bash (# Start full system with module), Phase 4: Integration & Testing (60 minutes), Step 4.1: Test Module Standalone (20 minutes), Step 4.2: Register with zoe-mcp-server (15 minutes), Step 4.3: Test AI Control (15 minutes), Step 4.4: Update chat.py Context (10 minutes), code:bash (# Build and start module) (+1 more)
+Nodes (9): code:python (# OLD), code:block6 (modules/zoe-music-mcp/), code:python (# modules/zoe-music-mcp/services/platform.py), code:python (# Already handled via DATABASE_PATH environment variable), code:python (# MCP tools receive user_id in requests), Extraction Strategy, Phase 1: Create Module Structure, Phase 2: Handle Dependencies (+1 more)
 
 ### Community 426 - "Community 426"
 Cohesion: 0.25
-Nodes (5): PushBroadcaster, Client reconnection catch-up. For now, just send current sequence., WebSocket push broadcaster for real-time UI updates.      Clients subscribe to a, Subscribe a panel WebSocket to both 'all' (global) and its own panel channel., Send an event only to the named panel's dedicated channel.          Falls back t
+Nodes (7): app_settings(), prometheus_metrics(), Public settings consumed by frontend widgets (e.g. music widget HA deep-link)., Prometheus scrape endpoint.      Exposes counters/gauges from `memory_metrics.RE, Prometheus metrics for Zoe memory + self-learning.  Exposed via `/metrics` on th, Best-effort refresh of per-user MemPalace size gauge.      Called by the `/metri, snapshot_collection_sizes()
 
 ### Community 427 - "Community 427"
 Cohesion: 0.25
-Nodes (7): _geocode(), _parse_md_table(), zoe_ui_components.py — Automatic AG-UI component extraction from agent response, Parse a markdown table into a list of dicts keyed by header., Convert parsed table rows into price_table component row format., Geocode an address using Nominatim (free, no API key)., _table_to_price_rows()
+Nodes (7): WebSocket push endpoint.      Clients may connect with ?panel_id=<id> to subscri, websocket_push(), Performance Targets, Tier 1: Intent Router (< 1.5s), Tier 2: OpenClaw + GPT-4o-mini (5-30s), Visibility & Security, Zoe Test Plan
 
 ### Community 428 - "Community 428"
+Cohesion: 0.36
+Nodes (6): test_high_risk_requires_confirmation(), test_low_risk_read_only(), test_whatsapp_detection(), classify_request(), is_whatsapp_connect_request(), RiskDecision
+
+### Community 429 - "Community 429"
 Cohesion: 0.32
 Nodes (7): _get_vapid_keys(), get_vapid_public_key(), Web Push Notifications via VAPID. Generates VAPID keys on first run, stores subs, Send a push notification to all of a user's subscriptions.      ``message`` is a, send_push_to_user(), subscribe(), unsubscribe()
 
-### Community 429 - "Community 429"
-Cohesion: 0.25
-Nodes (8): Audit: Zoe Agent, code:block1 (I want to work on improving Zoe Agent — Zoe's on-device LLM ), Honest Weaknesses, Prioritised Improvements (impact order), Prompt to start improvement plan in a new chat, What was already fixed in this session (May 18 2026), What Zoe Agent Does, Zoe Agent Improvement Brief
-
 ### Community 430 - "Community 430"
 Cohesion: 0.25
-Nodes (7): claim_pending(), create_pending(), Helpers for deferred / lazy session creation for proactive notifications.  When, Insert a proactive_pending row and return its id.     The push notification's de, Mark a pending notification as claimed and create a chat session seeded     with, claim_pending_endpoint(), Claim a pending proactive notification (called when user taps push).     Creates
+Nodes (8): code:block14 (1. Kokoro PyTorch sidecar  :10201  af_sky  GPU  ~150–400ms w), code:bash (# Check service state), code:bash (# Restart the sidecar), If the voice sounds wrong (British accent instead of natural), Jetson-specific CUDA fixes (both documented in `kokoro_sidecar.py`), Primary voice: Kokoro PyTorch sidecar, TTS Voice Stack (Jetson Orin NX), Verifying the voice is working
 
 ### Community 431 - "Community 431"
 Cohesion: 0.25
-Nodes (8): get_compat_db(), Async context manager yielding AsyncpgCompat wrapping a pooled connection., Run the evening wind-down trigger for all active users., Run the evolution weekly digest trigger for all active users., Run the reminder scan to auto-schedule upcoming reminders into APScheduler., _run_evening_winddown(), _run_evolution_weekly_digest(), _run_reminder_scan()
+Nodes (7): PasswordPolicy, Password security policy, PasscodePolicy, PasscodeValidationResult, Passcode Authentication System Secure handling of 4-8 digit PIN codes with advan, Result of passcode validation, Passcode security policy configuration
 
 ### Community 432 - "Community 432"
 Cohesion: 0.29
-Nodes (6): Proactive trigger: birthday 7-day lookahead.  Fires once daily at 8am for contac, _next_occurrence(), person_health.py — Relationship health scoring.  Health score = weighted combina, Return the next calendar occurrence of (month, day) on or after ref (default: to, Recalculate health_score for one person and persist it to the DB.      Args:, recalc_and_save()
+Nodes (7): format_music_for_prompt(), get_music_context(), Music Context Provider ======================  Provides music context for Zoe's, Format music context for inclusion in system prompt.          Returns a concise, Get comprehensive music context for user.          Returns:         Dict with:, MCP Tool: music.get_context          Get music context for chat prompt (replaces, tool_get_context()
 
 ### Community 433 - "Community 433"
 Cohesion: 0.25
-Nodes (7): app_settings(), prometheus_metrics(), Public settings consumed by frontend widgets (e.g. music widget HA deep-link)., Prometheus scrape endpoint.      Exposes counters/gauges from `memory_metrics.RE, Prometheus metrics for Zoe memory + self-learning.  Exposed via `/metrics` on th, Best-effort refresh of per-user MemPalace size gauge.      Called by the `/metri, snapshot_collection_sizes()
-
-### Community 434 - "Community 434"
-Cohesion: 0.29
-Nodes (7): format_music_for_prompt(), get_music_context(), Music Context Provider ======================  Provides music context for Zoe's, Format music context for inclusion in system prompt.          Returns a concise, Get comprehensive music context for user.          Returns:         Dict with:, MCP Tool: music.get_context          Get music context for chat prompt (replaces, tool_get_context()
+Nodes (5): Test safeguards and error handling, Verify all features are disabled by default (safety), Test that features fail gracefully when disabled, Test that platform configs are valid, TestFeatureSafeguards
 
 ### Community 435 - "Community 435"
 Cohesion: 0.25
-Nodes (7): WebSocket push endpoint.      Clients may connect with ?panel_id=<id> to subscri, websocket_push(), Performance Targets, Tier 1: Intent Router (< 1.5s), Tier 2: OpenClaw + GPT-4o-mini (5-30s), Visibility & Security, Zoe Test Plan
+Nodes (5): Tests for base ZoeError., Test basic error creation., Test error with additional details., Test error wrapping another exception., TestZoeError
 
 ### Community 436 - "Community 436"
-Cohesion: 0.29
-Nodes (6): Apply Enhanced Lists System migration, check_migration_applied(), create_migration_table(), Check if this migration has already been applied, Create schema_migrations table if it doesn't exist, Apply Project Lists migration
+Cohesion: 0.25
+Nodes (8): Audit: Zoe Agent, code:block1 (I want to work on improving Zoe Agent — Zoe's on-device LLM ), Honest Weaknesses, Prioritised Improvements (impact order), Prompt to start improvement plan in a new chat, What was already fixed in this session (May 18 2026), What Zoe Agent Does, Zoe Agent Improvement Brief
 
 ### Community 437 - "Community 437"
 Cohesion: 0.32
 Nodes (7): get_pg_tables(), migrate_table(), _parse_datetime(), migrate_sqlite_to_postgres.py — Phase 5: Copy all data from SQLite → PostgreSQL., Convert a sqlite3.Row to a tuple suitable for asyncpg INSERT., Migrate one table. Returns (rows_read, rows_inserted)., sqlite_row_to_pg()
 
 ### Community 438 - "Community 438"
+Cohesion: 0.29
+Nodes (6): Apply Enhanced Lists System migration, check_migration_applied(), create_migration_table(), Check if this migration has already been applied, Create schema_migrations table if it doesn't exist, Apply Project Lists migration
+
+### Community 439 - "Community 439"
 Cohesion: 0.25
-Nodes (6): Test MusicStreamError., Test TrackNotFoundError., Test StreamExpiredError., Tests for music-specific errors., Test MusicProviderError., TestMusicErrors
+Nodes (8): Database Breakdown, Databases Found: 19 total, Current State Analysis, Question: Does the LLM know what it can do?, ❌ What the LLM DOESN'T KNOW:, ✅ What the LLM KNOWS:, code:block1 (routers/), Total Routers: 64 files (27,247 lines of code)
 
 ### Community 440 - "Community 440"
 Cohesion: 0.25
-Nodes (8): code:python (import sqlite3), code:sql (-- db/schema/your_feature.sql), Database Access, code:python (from model_config import detect_hardware  # Jetson vs Pi det), code:python (DB_PATH = os.getenv("DATABASE_PATH", "/app/data/zoe.db")), External Dependencies, Standard Library Only, zoe-core Imports
+Nodes (8): 1. **Router Proliferation** (High Priority), 1. **Service Communication Patterns** (Medium Priority), 2. **Service Health Issues** (High Priority), code:bash (# Check logs), code:plaintext (routers/), Current Services (11 Containers), 🟡 Improvements, 🏢 Service Architecture Review
 
 ### Community 441 - "Community 441"
 Cohesion: 0.25
-Nodes (8): 2. Logging, 4. User Isolation, code:python (logger.info(f"✅ your_action: param={request.param}, user_id=), code:python (cursor.execute("SELECT * FROM data WHERE user_id = ?", (user), 7. MCP Tool Naming, code:python (# ✅ CORRECT - User isolated), code:python (import logging), 🟡 STRONGLY RECOMMENDED
+Nodes (8): 10. Notification Settings UI (30 min), 11. Calendar Integration (20 min), 12. Task Integration (20 min), 6. Database Migration (10 min), 7. Register Router (5 min), 8. Install Dependencies (5 min), 9. Frontend Notification Handler (30 min), 🚧 Remaining Tasks
 
 ### Community 442 - "Community 442"
 Cohesion: 0.25
-Nodes (8): code:python (# Replace placeholder methods with actual Agent Zero API cal), Next Steps for Full Implementation, Phase 1: Implement Agent Zero Client, Phase 2: Test with Real Agent Zero, Phase 3: Error Handling, Phase 4: UI Integration (Optional), code:python (try:), 3. Handle Stream Errors Gracefully
+Nodes (8): code:python (from routers import push), code:bash (docker exec zoe-core pip install -r /app/requirements.txt), 🎯 Next Steps to Complete Phase 2, Step 2: Register Push Router (5 min), Step 3: Install Dependencies (5 min), Step 4: Create Frontend Handler (30 min), Step 5: Add Notification Settings (30 min), Step 6: Test Everything (15 min)
 
 ### Community 443 - "Community 443"
 Cohesion: 0.25
-Nodes (8): 2. Chat Interface, API Integration, code:block11 (WS /api/ws/intelligence), code:python (from fastapi import APIRouter), code:block2 (POST /api/chat/?user_id={user_id}&stream=true), code:block4 (data: {"type": "token", "content": "token text"}), Example Backend Implementation, Required Backend Endpoints
+Nodes (6): code:bash (docker exec zoe-core env | grep DATABASE_PATH), code:bash (ls -lh /home/zoe/assistant/data/zoe.db), check_database(), Send a message to the API and return the response, Query the database directly, test_api()
 
 ### Community 444 - "Community 444"
 Cohesion: 0.25
-Nodes (8): code:yaml (# services/zoe-core/intent_system/intents/en/myintent.yaml), code:python (# services/zoe-core/intent_system/handlers/my_handlers.py), code:python (# In intent_executor.py _register_builtin_handlers()), code:python (intent = classifier.classify("do something with test")), Adding New Intent:, Modifying Existing Intent:, Removing Intent:, ✅ REQUIRED PROCESS FOR CHANGES
+Nodes (8): Agent Zero Not Responding, code:bash (# Check Agent Zero container), code:bash (# Check Zoe is running), code:bash (# Check skills directory), Issue: Agent Zero Slow/Timeout, Issue: Moltbot Can't Reach Zoe, Issue: Skills Not Loading in Moltbot, 🐛 Troubleshooting Guide
 
 ### Community 445 - "Community 445"
 Cohesion: 0.29
@@ -2550,371 +2620,343 @@ Nodes (8): Resources, Your Files, code:block14 (✅ GOOD:), code:block15 (✅ GO
 
 ### Community 446 - "Community 446"
 Cohesion: 0.25
-Nodes (8): Complete Audit Results, Update - Final Fix Count (Oct 19, 2025), User Impact, Verification Command, Check Last Backup, Check User Count, code:bash (sqlite3 /home/zoe/assistant/data/zoe.db "SELECT COUNT(*) FRO), code:bash (ls -lt /home/zoe/assistant/data/backups/ | head -5)
+Nodes (8): code:block1 (Ctrl + Shift + R), code:block2 (Ctrl + F5), code:block3 (Cmd + Shift + R), Method 1: Hard Refresh (Try This First), Method 2: Clear Specific Site Data (If Hard Refresh Doesn't Work), Method 3: Clear All Browser Cache (Nuclear Option), Method 4: Use Incognito/Private Window, The Solution: Hard Refresh + Clear Cache
 
 ### Community 447 - "Community 447"
 Cohesion: 0.25
-Nodes (6): code:bash (docker exec zoe-core env | grep DATABASE_PATH), code:bash (ls -lh /home/zoe/assistant/data/zoe.db), check_database(), Send a message to the API and return the response, Query the database directly, test_api()
+Nodes (8): 1. ✅ Model Tests (6/7 Passing - 86%), 2. ✅ RouteLLM Classification (3/3 Passing - 100%), 3. ⚠️ Enhanced MemAgent (0/3 Passing - 0%), 4. ✅ RAG Enhancements (3/3 Passing - 100%), 5. ❌ Chat API (0/4 Passing - 0%), Detailed Results, Failed Models:, Working Models:
 
 ### Community 448 - "Community 448"
 Cohesion: 0.25
-Nodes (8): 10. Notification Settings UI (30 min), 11. Calendar Integration (20 min), 12. Task Integration (20 min), 6. Database Migration (10 min), 7. Register Router (5 min), 8. Install Dependencies (5 min), 9. Frontend Notification Handler (30 min), 🚧 Remaining Tasks
+Nodes (8): code:yaml (# services/zoe-core/intent_system/intents/en/myintent.yaml), code:python (# services/zoe-core/intent_system/handlers/my_handlers.py), code:python (# In intent_executor.py _register_builtin_handlers()), code:python (intent = classifier.classify("do something with test")), Adding New Intent:, Modifying Existing Intent:, Removing Intent:, ✅ REQUIRED PROCESS FOR CHANGES
 
 ### Community 449 - "Community 449"
 Cohesion: 0.25
-Nodes (5): Test safeguards and error handling, Verify all features are disabled by default (safety), Test that features fail gracefully when disabled, Test that platform configs are valid, TestFeatureSafeguards
+Nodes (8): code:python (# Replace placeholder methods with actual Agent Zero API cal), Next Steps for Full Implementation, Phase 1: Implement Agent Zero Client, Phase 2: Test with Real Agent Zero, Phase 3: Error Handling, Phase 4: UI Integration (Optional), code:python (try:), 3. Handle Stream Errors Gracefully
 
 ### Community 450 - "Community 450"
 Cohesion: 0.25
-Nodes (8): 4.1 Update client.py, 4.2 Test Individual Methods, 4.3 Test via Voice, code:python (import websockets), code:bash (# Test research), Phase 4: Implement & Test, code:block1 ("Zoe, research smart light bulbs"), Try It Now
+Nodes (8): **BEFORE Starting Any New Work**, code:bash (# Step 1: Read recent changes (CRITICAL)), code:bash (# Check if tool/feature already exists), code:bash (# 1. Update RECENT_CHANGES.md), **DURING Work**, 📋 Standard Workflow for Cursor/AI, After Making Changes, code:bash (# 1. Make your changes to AI/LLM code)
 
 ### Community 451 - "Community 451"
 Cohesion: 0.25
-Nodes (8): code:block14 (1. Kokoro PyTorch sidecar  :10201  af_sky  GPU  ~150–400ms w), code:bash (# Check service state), code:bash (# Restart the sidecar), If the voice sounds wrong (British accent instead of natural), Jetson-specific CUDA fixes (both documented in `kokoro_sidecar.py`), Primary voice: Kokoro PyTorch sidecar, TTS Voice Stack (Jetson Orin NX), Verifying the voice is working
-
-### Community 452 - "Community 452"
-Cohesion: 0.25
-Nodes (8): code:yaml (- model_name: claude-opus), code:bash (docker inspect zoe-llamacpp | grep MODEL_NAME), code:yaml (- model_name: new-local-model), Current Local Model, 🔄 Model Management, Adding a New Model, code:yaml (- model_name: my-new-model), code:yaml (- model_name: gpt-4-turbo)
+Nodes (8): 2. Logging, 4. User Isolation, code:python (logger.info(f"✅ your_action: param={request.param}, user_id=), code:python (cursor.execute("SELECT * FROM data WHERE user_id = ?", (user), 7. MCP Tool Naming, code:python (# ✅ CORRECT - User isolated), code:python (import logging), 🟡 STRONGLY RECOMMENDED
 
 ### Community 453 - "Community 453"
 Cohesion: 0.25
-Nodes (7): ✅ Best Practices Being Followed, 🗄️ Database Architecture Review, 📊 Database Schema Quality Score, 📊 Folder Structure Quality Score, 📁 Folder Structure Review, 📈 Overall Architecture Score, 🏗️ Zoe Architecture Review - Complete Analysis
+Nodes (8): code:bash (# Rollback specific interface), code:bash (# Stop quarterly archival), 1. Disable the Module, 2. Restart Without Module, 3. Old Code Still Works, Rollback Procedure, code:bash ($ python tools/zoe_module.py disable zoe-music), Test 6: Enable/Disable Cycle
 
 ### Community 454 - "Community 454"
 Cohesion: 0.25
-Nodes (8): 1. **Service Organization** (Low Priority), 📊 API Architecture Quality Score, 🔌 API Architecture Review, code:bash (✅ Required Docs: All present), code:plaintext (zoe/), code:plaintext (services/), code:python (# Excellent separation of concerns), ✅ Strengths
+Nodes (8): code:python (import sqlite3), code:sql (-- db/schema/your_feature.sql), Database Access, code:python (from model_config import detect_hardware  # Jetson vs Pi det), code:python (DB_PATH = os.getenv("DATABASE_PATH", "/app/data/zoe.db")), External Dependencies, Standard Library Only, zoe-core Imports
 
 ### Community 455 - "Community 455"
-Cohesion: 0.25
-Nodes (8): Agent Zero Container, Bridge Container, code:block3 (Container ID: d6f0119dbecc), code:block4 (Container ID: 4e4a7f9824d5), code:block6 (✅ Module agent-zero loaded), Zoe Core Integration, code:python (# Current endpoints), 📊 CURRENT STATE
-
-### Community 456 - "Community 456"
-Cohesion: 0.25
-Nodes (8): 1. **Router Proliferation** (High Priority), 1. **Service Communication Patterns** (Medium Priority), 2. **Service Health Issues** (High Priority), code:bash (# Check logs), code:plaintext (routers/), Current Services (11 Containers), 🟡 Improvements, 🏢 Service Architecture Review
-
-### Community 457 - "Community 457"
-Cohesion: 0.25
-Nodes (8): code:block1 (Ctrl + Shift + R), code:block2 (Ctrl + F5), code:block3 (Cmd + Shift + R), Method 1: Hard Refresh (Try This First), Method 2: Clear Specific Site Data (If Hard Refresh Doesn't Work), Method 3: Clear All Browser Cache (Nuclear Option), Method 4: Use Incognito/Private Window, The Solution: Hard Refresh + Clear Cache
-
-### Community 458 - "Community 458"
-Cohesion: 0.25
-Nodes (8): **BEFORE Starting Any New Work**, code:bash (# Step 1: Read recent changes (CRITICAL)), code:bash (# Check if tool/feature already exists), code:bash (# 1. Update RECENT_CHANGES.md), **DURING Work**, 📋 Standard Workflow for Cursor/AI, After Making Changes, code:bash (# 1. Make your changes to AI/LLM code)
-
-### Community 459 - "Community 459"
-Cohesion: 0.25
-Nodes (8): 📋 Fix Implementation Status, 📊 Progress Tracker, Problem Statement, Chat Integration Diagnosis & Fixes, After: True Token Streaming, Before: Buffered Streaming, code:block1 (User speaks → STT (300ms) → LLM generates full response (2s)), code:block2 (User speaks → STT (300ms) → First token (200ms) → Streaming )
-
-### Community 461 - "Community 461"
-Cohesion: 0.29
-Nodes (8): ⚙️ Automated Enforcement, Monthly Structure Audit, Pre-Commit Checks (`tools/audit/enforce_structure.py`), Layer 2: Pre-Deletion Validation Script, code:python (#!/usr/bin/env python3), Phase 5: Module Management (45 minutes), Step 5.1: Create Module CLI (30 minutes), Step 5.2: Create Compose Generator (15 minutes)
-
-### Community 462 - "Community 462"
-Cohesion: 0.33
-Nodes (4): Simple database wrapper that avoids locking issues, Context manager support, Skip migration - database already compatible, SimpleAuthDatabase
-
-### Community 463 - "Community 463"
-Cohesion: 0.29
-Nodes (7): _collect_audio_stream(), _on_pipeline_done(), Background task: read AudioStream frames and buffer them during active PTT., Background task: run energy VAD on incoming audio frames.      Maintains per-par, Called when the pipeline task finishes — move to COOLDOWN., Compute RMS energy of a raw int16-LE PCM frame., _rms()
-
-### Community 464 - "Community 464"
-Cohesion: 0.29
-Nodes (3): Assign role to user                  Args:             user_id: User to assign r, Log role change for audit, Invalidate cache for specific user
-
-### Community 465 - "Community 465"
-Cohesion: 0.29
-Nodes (6): analyze_query_performance(), optimize_memory_db(), optimize_zoe_db(), Analyze query plans to verify index usage, Add indexes to zoe.db for better performance, Add indexes to memory.db for better temporal memory performance
-
-### Community 466 - "Community 466"
-Cohesion: 0.29
-Nodes (6): convert_params_to_positional(), convert_question_marks(), Convert tuple literal like (a, b, c) to positional args a, b, c., Convert ? in SQL string literals to $1, $2, etc., Convert ? placeholders in SQL string literals., transform_sql_strings()
-
-### Community 468 - "Community 468"
-Cohesion: 0.29
-Nodes (6): Tests for compatibility calculation functions, Test values alignment calculation, Test personality compatibility calculation, Test interest overlap calculation, Test that empty profiles return neutral scores, TestCompatibilityCalculations
-
-### Community 469 - "Community 469"
-Cohesion: 0.29
-Nodes (6): Tests for error class hierarchy., Test music errors inherit from ZoeError., Test casting errors inherit from ZoeError., Test household errors inherit from ZoeError., Test catching all ZoeError subclasses., TestErrorInheritance
-
-### Community 470 - "Community 470"
-Cohesion: 0.29
-Nodes (5): Test Home Assistant integration, Test turn off patterns., Test Home Assistant control intents., Test turn on patterns., TestHomeAssistantIntents
-
-### Community 471 - "Community 471"
-Cohesion: 0.33
-Nodes (7): code:python (# ❌ WRONG - Lost on restart), code:python (# ❌ WRONG), ❌ Don't Block Event Loop, ❌ Don't Hardcode Paths, ❌ Don't Modify Core, ❌ Don't Share State, 🚫 What NOT to Do
-
-### Community 472 - "Community 472"
 Cohesion: 0.29
 Nodes (6): create_synapse_auth_provider(), MatrixUser, Matrix (Synapse/Dendrite) SSO Integration Authentication provider for Matrix hom, Matrix user representation, Create Synapse authentication provider module, Initialize Matrix integration
 
-### Community 473 - "Community 473"
+### Community 456 - "Community 456"
 Cohesion: 0.29
-Nodes (7): code:bash (# Move remaining docs), code:bash (# Create tools structure), code:bash (# Run enforcement), 🔄 Migration Path (One-Time), Step 1: Move Remaining Files, Step 2: Install Enforcement, Step 3: Verify
+Nodes (7): list_users(), Get all active sessions for a specific user (admin only)          Args:, List all users (admin only)          Args:         active_only: Filter to active, get_user_sessions(), Get all active sessions for current user          Args:         current_session:, List users (admin function)                  Args:             requested_by: Use, Get all active sessions for user
 
-### Community 474 - "Community 474"
+### Community 457 - "Community 457"
 Cohesion: 0.29
-Nodes (7): Adding Mock Data, code:python (# At top of test_full_system.py), code:python (# tests/fixtures/test_data.json), code:python (import json), 🔧 Customizing Tests, Test Configuration, Using Fixtures
+Nodes (6): analyze_query_performance(), optimize_memory_db(), optimize_zoe_db(), Analyze query plans to verify index usage, Add indexes to zoe.db for better performance, Add indexes to memory.db for better temporal memory performance
 
-### Community 475 - "Community 475"
+### Community 458 - "Community 458"
+Cohesion: 0.33
+Nodes (4): Simple database wrapper that avoids locking issues, Context manager support, Skip migration - database already compatible, SimpleAuthDatabase
+
+### Community 460 - "Community 460"
 Cohesion: 0.29
-Nodes (7): After AI/LLM Changes, Before Deployment, Before Major Changes, code:bash (- [ ] Run full system test: `python3 tests/integration/test_), code:bash (- [ ] Test chat API specifically), code:bash (- [ ] Full system test passes ✅), 📋 Test Checklist Template
+Nodes (6): Tests for compatibility calculation functions, Test values alignment calculation, Test personality compatibility calculation, Test interest overlap calculation, Test that empty profiles return neutral scores, TestCompatibilityCalculations
 
-### Community 476 - "Community 476"
+### Community 461 - "Community 461"
 Cohesion: 0.29
-Nodes (7): 1. Pre-Commit Hook (ACTIVE), 2. Automatic Backup Script, 3. Database Integrity Check, 4. User Count Monitor, 🔧 AUTOMATED SAFEGUARDS, code:bash (0 2 * * * /home/zoe/assistant/scripts/maintenance/check_db_i), code:bash (0 */6 * * * /home/zoe/assistant/scripts/maintenance/auto_bac)
+Nodes (6): Tests for error class hierarchy., Test music errors inherit from ZoeError., Test casting errors inherit from ZoeError., Test household errors inherit from ZoeError., Test catching all ZoeError subclasses., TestErrorInheritance
 
-### Community 477 - "Community 477"
+### Community 462 - "Community 462"
 Cohesion: 0.29
-Nodes (6): Allowed API Hosts, code:block1 (localhost, 127.0.0.1, zoe-core, zoe-auth, zoe-n8n,), Reporting Issues, Security Policy for Skills, Self-Created Skills (Phase 8), Self-Created Widgets (Phase 8)
+Nodes (5): Test Home Assistant integration, Test turn off patterns., Test Home Assistant control intents., Test turn on patterns., TestHomeAssistantIntents
 
-### Community 478 - "Community 478"
+### Community 463 - "Community 463"
 Cohesion: 0.29
-Nodes (6): code:bash (# Enable (default)), Chat Commands, Feature Flags, OpenClaw Terminal Chat Rollout, Smoke Checklist, Staged Enablement
+Nodes (6): convert_params_to_positional(), convert_question_marks(), Convert tuple literal like (a, b, c) to positional args a, b, c., Convert ? in SQL string literals to $1, $2, etc., Convert ? placeholders in SQL string literals., transform_sql_strings()
 
-### Community 479 - "Community 479"
-Cohesion: 0.29
-Nodes (7): code:bash (# Disable module), code:bash (# Start module alone), code:bash (# Enable module), Test 1: Module Enabled, Test 2: Module Disabled, Test 3: Standalone Module, Testing Guide
-
-### Community 480 - "Community 480"
-Cohesion: 0.43
-Nodes (7): Detailed Platform Information, Mac Mini M4 (Planned), Raspberry Pi 5 16GB *(Retired April 2026)*, NVIDIA Jetson Orin NX 16GB, Raspberry Pi 5 16GB, 3. Start the module, code:bash (docker compose -f docker-compose.yml \)
-
-### Community 481 - "Community 481"
+### Community 464 - "Community 464"
 Cohesion: 0.29
 Nodes (7): 🎯 Consolidation Strategy, **TWO-DATABASE ARCHITECTURE** (Recommended), ✅ Builds on Your Solid Foundation, ✅ Focus on User-Facing Impact, ✅ Incremental Implementation, ✅ Respects Your Constraints, Why This Approach Works
 
-### Community 482 - "Community 482"
+### Community 465 - "Community 465"
 Cohesion: 0.29
-Nodes (7): 📋 Migration Steps, Phase 1: Preparation ✅ COMPLETED, Phase 2: Schema Updates (PENDING), Phase 3: Data Migration (PENDING), Phase 4: Code Updates (PENDING), Phase 5: Protection Mechanisms (PENDING), Phase 6: Testing & Verification (PENDING)
+Nodes (7): Endpoints, Claim a pending notification (called by UI on tap), code:block1 (POST /api/proactive/schedule), code:block2 (GET /api/proactive/schedule), code:block4 (POST /api/proactive/pending/<pending_id>), List pending scheduled nudges, Schedule a one-shot nudge
 
-### Community 483 - "Community 483"
+### Community 466 - "Community 466"
 Cohesion: 0.29
-Nodes (7): code:bash (cp data/backup/pre-consolidation-20251009_150213/* data/), If Migration Fails, Rollback Time, code:javascript (localStorage.clear();), code:bash (docker stop zoe-music-mcp), code:yaml (# config/modules.yaml), Rollback Plan
+Nodes (7): AI Capabilities Evolution, code:block11 (Browse modules:), code:block12 (Company builds internal modules:), code:block13 (Today's Zoe:), Community Marketplace, Enterprise Integrations, 🚀 What's Possible in the Future
 
-### Community 484 - "Community 484"
+### Community 467 - "Community 467"
+Cohesion: 0.29
+Nodes (7): 1. Pre-Commit Hook (ACTIVE), 2. Automatic Backup Script, 3. Database Integrity Check, 4. User Count Monitor, 🔧 AUTOMATED SAFEGUARDS, code:bash (0 2 * * * /home/zoe/assistant/scripts/maintenance/check_db_i), code:bash (0 */6 * * * /home/zoe/assistant/scripts/maintenance/auto_bac)
+
+### Community 468 - "Community 468"
+Cohesion: 0.29
+Nodes (7): code:python (from fastapi import WebSocket), code:javascript (// In initOrbChat() function, comment out:), Option 1: Implement WebSocket Endpoint, Option 2: Disable WebSocket Connection, Option 3: Leave As-Is (Recommended), WebSocket Error Resolution, 🔧 Backend: Serving Static Files
+
+### Community 469 - "Community 469"
 Cohesion: 0.29
 Nodes (7): 1. Document the Reason, 2. Add TODO Comments, 3. Create Tracking Task, 4. Time-box the Fix, 🚨 Breaking Changes Protocol, code:python (# TODO: TECH DEBT - Direct LLM call bypassing gateway), code:markdown (## TECH DEBT: Direct LLM Call in module_name.py)
 
-### Community 485 - "Community 485"
+### Community 470 - "Community 470"
+Cohesion: 0.29
+Nodes (7): 3. Resource Optimization, 3. PLATFORM OPTIMIZATION, code:python (# Same limits for both Jetson and Pi), code:python (# services/zoe-core/context_budget_manager.py (NEW)), code:yaml (# docker-compose.yml (UPDATE)), Recommendation P1-3: Dynamic Context Budget Management, Research Finding #6: Platform-Aware Context Budgets
+
+### Community 471 - "Community 471"
+Cohesion: 0.29
+Nodes (7): code:bash (modules/zoe-music-mcp/), code:bash (FROM: services/zoe-core/services/music/), code:python ("""Platform detection for music module."""), Phase 1: Foundation (30 minutes), Step 1.1: Create Module Directory Structure ✅ NEXT, Step 1.2: Copy Music Services (15 minutes), Step 1.3: Create Platform Helper (10 minutes)
+
+### Community 472 - "Community 472"
 Cohesion: 0.38
 Nodes (7): code:block25 (tests/), code:block26 (scripts/), 📋 Governance Rules, Script File Rules, Structure, Test File Rules, Tool File Rules
 
-### Community 486 - "Community 486"
+### Community 473 - "Community 473"
+Cohesion: 0.29
+Nodes (6): code:block1 (modules/{module-name}/), code:block3 (User says "Research the best solar panels":), Extensibility Architecture, How They Work Together, Layer 1: Modules (Heavy Infrastructure), Security
+
+### Community 474 - "Community 474"
+Cohesion: 0.29
+Nodes (7): code:bash (# Move remaining docs), code:bash (# Create tools structure), code:bash (# Run enforcement), 🔄 Migration Path (One-Time), Step 1: Move Remaining Files, Step 2: Install Enforcement, Step 3: Verify
+
+### Community 475 - "Community 475"
 Cohesion: 0.29
 Nodes (6): AG-UI chat protocol for Zoe (zoe-data + `chat.html`), Contract checklist (manual / tests), Decision (Option 1), Persistence (serialization groundwork), Spike: `clawg-ui` (@contextableai/clawg-ui), Wire format: legacy Zoe vs canonical AG-UI
 
-### Community 487 - "Community 487"
+### Community 476 - "Community 476"
+Cohesion: 0.33
+Nodes (5): close_chat_episode(), Close current episode, Get active episode for user, Get active episode for user, create new one if needed, Close an episode and optionally generate summary
+
+### Community 477 - "Community 477"
 Cohesion: 0.29
 Nodes (6): Disallowed autonomous actions, Mandatory approval gates, OpenClaw Calendar Orchestration Guide, Purpose, Safety workflow, Supported operator commands
 
-### Community 488 - "Community 488"
+### Community 478 - "Community 478"
 Cohesion: 0.29
 Nodes (7): **1. Does It Already Exist?**, **2. Will It Conflict?**, **3. Does Documentation Cover It?**, code:bash (# Search codebase), code:bash (# See active work), code:bash (# Search all documentation), 🚨 Critical Checks Before Creating New Features
 
-### Community 489 - "Community 489"
+### Community 479 - "Community 479"
 Cohesion: 0.29
-Nodes (7): code:python (# In chat endpoint, add:), code:python (# services/mem-agent/person_expert.py), 🔧 Detailed Fix Plan, Fix 1: API Endpoints (COMPLETED ✅), Fix 2: Integrate Temporal Memory (TO DO), Fix 3: Add Person Creation Expert (TO DO), Fix 4: Optimize Response Times (TO DO)
+Nodes (7): Adding Mock Data, code:python (# At top of test_full_system.py), code:python (# tests/fixtures/test_data.json), code:python (import json), 🔧 Customizing Tests, Test Configuration, Using Fixtures
 
-### Community 490 - "Community 490"
+### Community 480 - "Community 480"
 Cohesion: 0.29
-Nodes (7): multica-backend, multica-web, zoe-auth, zoe-database, zoe-auth requirements.txt, zoe-capability-extender SKILL.md, zoe-data requirements.txt
+Nodes (7): After AI/LLM Changes, Before Deployment, Before Major Changes, code:bash (- [ ] Run full system test: `python3 tests/integration/test_), code:bash (- [ ] Test chat API specifically), code:bash (- [ ] Full system test passes ✅), 📋 Test Checklist Template
 
-### Community 491 - "Community 491"
+### Community 481 - "Community 481"
+Cohesion: 0.29
+Nodes (6): code:bash (# Enable (default)), Chat Commands, Feature Flags, OpenClaw Terminal Chat Rollout, Smoke Checklist, Staged Enablement
+
+### Community 482 - "Community 482"
 Cohesion: 0.33
-Nodes (4): Called when aiortc delivers an audio track — map to participant., Wraps an aiortc MediaStreamTrack received from a remote participant., Await the next AudioFrame from the underlying aiortc track., _RemoteAudioTrack
+Nodes (6): _chatgpt_connect_flow(), Write ChatGPT OAuth tokens to Hermes auth store (~/.hermes/auth.json)., Restart hermes-agent systemd user service so it picks up the new token., Full OpenAI Codex device-code OAuth flow, streamed as AG-UI events.      Phases, _restart_hermes(), _write_hermes_codex_token()
 
-### Community 492 - "Community 492"
+### Community 483 - "Community 483"
 Cohesion: 0.33
-Nodes (6): get_plugins(), Return all plugins (installed + available) for the openclaw_manager component., _installed_plugins_from_config(), list_plugins(), Read installed plugins from openclaw.json without shelling out., Return a merged list of installed + known-available plugins.
+Nodes (6): _build_voice_tools(), _hermes_available(), _openclaw_execution_enabled(), Build the compact voice tool list while respecting Hermes health., OpenClaw is present but not an active executor unless the operator opts in., Return True if Hermes should be offered as an escalation target.      Checks run
 
-### Community 493 - "Community 493"
+### Community 484 - "Community 484"
 Cohesion: 0.33
-Nodes (5): build_run_at(), _parse_due_time(), Tier 2 trigger: reminder table scanner.  Reads the `reminders` table every slow-, Parse a due_time string into (hour, minute) in 24-hour format.      Handles form, Build a UTC datetime for when the reminder should fire.      The reminder times
+Nodes (6): General Questions, Issue: Behavioral extraction returns 0 patterns, Issue: Confidence always shows as 0.5, Issue: Context still being fetched for Tier 0 intents, Issue: Patterns not showing in system prompt, 🆘 Troubleshooting Quick Reference
 
-### Community 494 - "Community 494"
+### Community 485 - "Community 485"
+Cohesion: 0.33
+Nodes (3): Create Matrix room                  Args:             room_config: Room configur, Resolve room alias to room ID, Call Matrix Client-Server API
+
+### Community 486 - "Community 486"
 Cohesion: 0.47
 Nodes (4): _init_auth_tables(), Current-contract API tests for zoe-auth., test_login_requires_initial_password_setup_marker(), test_profiles_endpoint_returns_non_system_users()
 
-### Community 495 - "Community 495"
-Cohesion: 0.4
-Nodes (4): add_user_id_extraction(), fix_router(), Fix a single router file, Add user_id = session.user_id after each function with AuthenticatedSession
-
-### Community 496 - "Community 496"
+### Community 487 - "Community 487"
 Cohesion: 0.33
 Nodes (4): Tests for personality traits, Test default trait values, Test that traits stay within bounds, TestPersonalityTraits
 
-### Community 497 - "Community 497"
-Cohesion: 0.33
-Nodes (5): Test converting error to dictionary., Tests for values priority, Test default value priorities, Test conversion to dictionary, TestValuesPriority
-
-### Community 498 - "Community 498"
+### Community 488 - "Community 488"
 Cohesion: 0.33
 Nodes (4): Tests for compatibility analysis, Test creating compatibility analysis, Test compatibility level descriptions, Test dimension breakdown
 
-### Community 499 - "Community 499"
+### Community 489 - "Community 489"
 Cohesion: 0.33
-Nodes (6): Authentication Security Check, CHANGELOG Validation, Commit Message Validation, Large File Detection, Secret/API Key Detection, Git Hook: `commit-msg`
+Nodes (5): Test converting error to dictionary., Tests for values priority, Test default value priorities, Test conversion to dictionary, TestValuesPriority
 
-### Community 500 - "Community 500"
+### Community 490 - "Community 490"
+Cohesion: 0.4
+Nodes (4): add_user_id_extraction(), fix_router(), Fix a single router file, Add user_id = session.user_id after each function with AuthenticatedSession
+
+### Community 491 - "Community 491"
+Cohesion: 0.33
+Nodes (5): Active Runtime Areas, Archived/Retired Runtime Trees, Device/Deployment Setup, Repository Layout, Rule of Thumb
+
+### Community 492 - "Community 492"
 Cohesion: 0.33
 Nodes (6): code:bash (# Test individual checks), Automated Testing, code:bash (# 1. Build module), code:python (# tests/test_widgets.py), Manual Testing, 🧪 Testing Your Module
 
-### Community 501 - "Community 501"
+### Community 493 - "Community 493"
 Cohesion: 0.33
-Nodes (6): 1. Prepare Widget, 2. Submit via API, 3. Widget Review, code:javascript (const response = await fetch('/api/widgets/marketplace', {), code:bash (curl -X POST http://localhost:8000/api/widgets/marketplace \), Publishing to Marketplace
+Nodes (6): code:python (TOOLS = [), code:block5 (tools/), code:python (# tools/play_song.py), Phase 2: MCP Tool Definition (45 minutes), Step 2.1: Define Core MCP Tools (20 minutes), Step 2.2: Implement Tool Handlers (25 minutes)
 
-### Community 502 - "Community 502"
+### Community 494 - "Community 494"
 Cohesion: 0.33
-Nodes (5): Calendar Sync Migration and Rollback Playbook, Incident triage quick map, Phase rollout, Preflight checklist, Rollback strategy
+Nodes (6): code:python (# services/zoe-core/services/music/__init__.py), code:bash (# Test 1: Module disabled (core still works)), Phase 7: Cleanup & Finalization (30 minutes), Step 7.1: Deprecate Old Code (10 minutes), Step 7.2: Create Migration Guide (10 minutes), Step 7.3: Final Testing (10 minutes)
 
-### Community 503 - "Community 503"
+### Community 495 - "Community 495"
+Cohesion: 0.33
+Nodes (6): 1. Architecture Review (COMPLETED), 3. Implementation Plans Created (COMPLETED), ✅ Completed, Current Implementation Status, 📊 Expected Impact (When Enabled), 🔄 Ready for Testing
+
+### Community 496 - "Community 496"
+Cohesion: 0.33
+Nodes (6): High Priority (Immediate Action), 1. Database Performance Optimization ✅, 2. Service Health Fixes ✅, 3. Comprehensive Documentation Created ✅, code:sql (✅ CREATE INDEX idx_events_user_date ON events(user_id, start), ✅ What Was Completed
+
+### Community 497 - "Community 497"
+Cohesion: 0.33
+Nodes (6): Check 1: Are Files Actually Served?, Check 2: Clear Service Worker (If Exists), Check 3: Disable Browser Extensions, Check 4: Try Different Browser, code:bash (curl http://localhost/js/auth.js | head -5), Still Not Working?
+
+### Community 498 - "Community 498"
 Cohesion: 0.33
 Nodes (6): code:python (# This is what you DON'T want to maintain:), Custom ML Model, Pure LLM, Rasa NLU, Regex Patterns, Why Not Other Solutions?
 
-### Community 504 - "Community 504"
+### Community 499 - "Community 499"
 Cohesion: 0.33
-Nodes (6): code:bash (grep "SKIP context retrieval" /app/data/logs/zoe-core.log | ), code:bash (grep "confidence_level" /app/data/logs/zoe-core.log | tail -), code:bash (cat /app/data/logs/behavioral_extraction.log), Daily Checks (Week 1), Verification & Monitoring, Week 1 Metrics
+Nodes (5): Calendar Sync Migration and Rollback Playbook, Incident triage quick map, Phase rollout, Preflight checklist, Rollback strategy
 
-### Community 505 - "Community 505"
+### Community 500 - "Community 500"
+Cohesion: 0.33
+Nodes (5): Module Intent Auto-Discovery System, Module System Validation, Next Module Candidates, Regression Testing, Music Module Test Results
+
+### Community 502 - "Community 502"
+Cohesion: 0.5
+Nodes (4): _extract_memory_candidates(), Back-compat shim: legacy dict shape over the unified extractor.      Kept so in-, test_extracts_preference_signal(), test_no_signal_returns_empty()
+
+### Community 503 - "Community 503"
+Cohesion: 0.4
+Nodes (5): _broadcast_intent_nav(), _intent_card_data(), Broadcast UI actions to the touch panel when an intent is detected.      For act, Build show_card data payload from intent slots for Google Home-style card., Instantly broadcast panel_navigate + panel_open_form + show_card when intent is
+
+### Community 504 - "Community 504"
 Cohesion: 0.4
 Nodes (3): _FakeCollection, _match_where(), Minimal Chroma collection stub backed by a plain dict.
 
 ### Community 506 - "Community 506"
 Cohesion: 0.4
-Nodes (5): agent_card(), _build_agent_card(), A2A agent identity card.     Returns Zoe's public capability advertisement follo, Build an A2A v1.0 compliant agent card for Zoe., A2A v1.0 agent identity card — public capability advertisement.
+Nodes (4): Restart llama.cpp container with new model, Test a model through Zoe's chat API with conversation history, switch_model(), test_model_via_api()
 
 ### Community 507 - "Community 507"
 Cohesion: 0.4
-Nodes (4): Search, Search for k most similar tracks.                  Args:             query: 256-, Search YouTube Music.                  Search works without authentication using, Return mock results when not authenticated.
-
-### Community 509 - "Community 509"
-Cohesion: 0.4
-Nodes (4): Restart llama.cpp container with new model, Test a model through Zoe's chat API with conversation history, switch_model(), test_model_via_api()
-
-### Community 511 - "Community 511"
-Cohesion: 0.4
-Nodes (5): 1. Always Use Streaming for Voice, code:python (# ✅ GOOD), 📝 Test Development Guidelines, Test Naming Convention, Writing Good Tests
-
-### Community 512 - "Community 512"
-Cohesion: 0.4
-Nodes (5): Adding New Test Module, code:python (# tests/integration/test_new_feature.py), code:python (# In test_full_system.py), 🎨 Extending the Framework, Integrating with Main Suite
-
-### Community 513 - "Community 513"
-Cohesion: 0.4
-Nodes (5): code:python (def test_chat_api(self):), 🚨 Critical: Chat API Test, What It Tests, When Chat Test Fails, Why It's Most Important
-
-### Community 514 - "Community 514"
-Cohesion: 0.4
 Nodes (4): Flags, People + Memory Rollout Flags, Rollback, Suggested rollout stages
 
-### Community 515 - "Community 515"
-Cohesion: 0.4
-Nodes (5): 1. Clean Git History (Requires Force Push), 2. Consider Git LFS for Future Large Files, code:bash (# WARNING: This rewrites history and requires force push), code:bash (git lfs install), Optional Future Actions
-
-### Community 516 - "Community 516"
+### Community 508 - "Community 508"
 Cohesion: 0.4
 Nodes (5): code:block1 (I want you to do a deep browser-based QA test of Zoe's inten), code:block2 (Or check the log at: http://localhost/api/system/logs (if th), Intent System Browser Test — New Chat Prompt, Paste this into a new Cursor chat:, Intent System Browser Test Prompt
 
-### Community 517 - "Community 517"
-Cohesion: 0.4
-Nodes (5): code:block11 (services/zoe-litellm/minimal_config.yaml), code:bash (# 1. Backup current config), 🔧 Configuration Management, File Location, Safe Configuration Updates
-
-### Community 518 - "Community 518"
-Cohesion: 0.4
-Nodes (5): Gate 1 (Day 5): Architecture Audit, Gate 2 (Day 22): P0 Validation, Gate 3 (Day 38): P1 Validation, Gate 4 (Day 42): Deployment Stability, Gate Metrics Summary
-
-### Community 519 - "Community 519"
+### Community 509 - "Community 509"
 Cohesion: 0.4
 Nodes (4): Auditability, Data protection policy, Scope governance, Token and secret handling
 
-### Community 521 - "Community 521"
-Cohesion: 0.5
-Nodes (4): _panel_session_trust_window_s(), Seconds that an active panel session is trusted for voice scope gating., Resolve panel user only when the panel session heartbeat is fresh enough     to, _resolve_recent_panel_session_user()
+### Community 510 - "Community 510"
+Cohesion: 0.4
+Nodes (5): Migration Strategy, Phase 1: Add Intent Layer (Week 1-2), Phase 2: Integrate Chat (Week 3), Phase 3: Optimize Patterns (Week 4-8), Phase 4: Expand to Voice & Touch (Week 9-12)
 
-### Community 523 - "Community 523"
+### Community 511 - "Community 511"
+Cohesion: 0.4
+Nodes (5): 1. Clean Git History (Requires Force Push), 2. Consider Git LFS for Future Large Files, code:bash (# WARNING: This rewrites history and requires force push), code:bash (git lfs install), Optional Future Actions
+
+### Community 512 - "Community 512"
+Cohesion: 0.4
+Nodes (5): code:python (def test_chat_api(self):), 🚨 Critical: Chat API Test, What It Tests, When Chat Test Fails, Why It's Most Important
+
+### Community 513 - "Community 513"
+Cohesion: 0.4
+Nodes (5): 1. Always Use Streaming for Voice, code:python (# ✅ GOOD), 📝 Test Development Guidelines, Test Naming Convention, Writing Good Tests
+
+### Community 514 - "Community 514"
 Cohesion: 0.5
 Nodes (4): FastAPI App, ZoeException, global_exception_handler(), Global exception handler for unhandled errors
 
-### Community 524 - "Community 524"
+### Community 515 - "Community 515"
+Cohesion: 0.5
+Nodes (4): _panel_session_trust_window_s(), Seconds that an active panel session is trusted for voice scope gating., Resolve panel user only when the panel session heartbeat is fresh enough     to, _resolve_recent_panel_session_user()
+
+### Community 518 - "Community 518"
+Cohesion: 0.5
+Nodes (4): _cleanup_rate_limit_storage(), _in_memory_rate_limit(), Fallback in-memory rate limiting (not suitable for production multi-instance), Clean up old rate limit entries
+
+### Community 522 - "Community 522"
+Cohesion: 0.5
+Nodes (3): MusicEvent, Music Event Tracker ====================  Captures listening behavior events for, A music listening event
+
+### Community 523 - "Community 523"
 Cohesion: 0.5
 Nodes (3): get_test_people(), Test Memories Endpoint ======================  A simple endpoint to test memorie, Get people from memories without authentication (for testing)
 
-### Community 525 - "Community 525"
+### Community 524 - "Community 524"
 Cohesion: 0.5
 Nodes (3): Final verification with real-world scenarios, final_verification(), Final verification of all enhancement systems
 
+### Community 525 - "Community 525"
+Cohesion: 0.5
+Nodes (4): Large (8x12), Medium (4x8) - Default, Size Variations, Small (3x5)
+
 ### Community 527 - "Community 527"
-Cohesion: 0.5
-Nodes (3): Sync password change to Home Assistant                  Args:             user_i, Sync password change to Matrix                  Args:             user_id: User, Handle password change for n8n user                  Args:             user_id:
-
-### Community 528 - "Community 528"
-Cohesion: 0.5
-Nodes (4): 🚀 Deployment Checklist, Before Deploying to Production, code:bash (# API Keys (CRITICAL - NEVER commit these)), Production Environment Variables Required
-
-### Community 529 - "Community 529"
-Cohesion: 0.5
-Nodes (4): Expected Production Performance, Performance Characteristics, Resource Usage, Response Times (Placeholder)
-
-### Community 530 - "Community 530"
-Cohesion: 0.5
-Nodes (4): 3. **Performance Optimization Opportunities** (Medium Priority), code:sql (-- Add composite indexes for common queries), code:sql (-- Instead of: WHERE json_extract(metadata, '$.priority') = ), code:sql (CREATE TABLE conversations_archive AS SELECT * FROM conversa)
-
-### Community 531 - "Community 531"
-Cohesion: 0.5
-Nodes (4): cloudflared, zoe-ui, zoe-page-builder SKILL.md, zoe-widget-builder SKILL.md
-
-### Community 533 - "Community 533"
-Cohesion: 1.0
-Nodes (3): Remove a workspace skill by deleting its directory., remove_skill_endpoint(), remove_skill()
-
-### Community 546 - "Community 546"
 Cohesion: 0.67
 Nodes (3): code:bash (docker logs zoe-core --tail 50 | grep -i intent), code:block13 (INFO:intent_system.executors.intent_executor:Registered 5 in), Intent System Not Loading
 
-### Community 547 - "Community 547"
+### Community 528 - "Community 528"
 Cohesion: 0.67
 Nodes (3): code:bash (sudo systemctl status cron), code:bash (/home/zoe/assistant/scripts/train/nightly_training.sh), Cron Not Running
 
-### Community 548 - "Community 548"
+### Community 529 - "Community 529"
+Cohesion: 0.67
+Nodes (3): Chat Not Working, code:bash (curl -X POST http://localhost:8000/api/chat/?stream=true), code:javascript (console.log(window.zoeAuth?.getCurrentSession());)
+
+### Community 530 - "Community 530"
 Cohesion: 0.67
 Nodes (3): "Agent Zero is unavailable", code:bash (docker logs zoe-agent0), code:bash (docker logs agent-zero-bridge)
 
-### Community 549 - "Community 549"
+### Community 531 - "Community 531"
 Cohesion: 0.67
-Nodes (3): 2. **Service Standardization** (Medium Priority), code:plaintext (# Some services have:), code:plaintext (service-template/)
+Nodes (3): code:javascript (console.log(document.getElementById('zoeOrb'));), code:bash (curl http://localhost/components/zoe-orb.html), Orb Not Appearing
 
-### Community 550 - "Community 550"
+### Community 532 - "Community 532"
 Cohesion: 0.67
-Nodes (3): 4. **Error Handling Consistency** (Medium Priority), code:python (# Some routers), code:python (# Create error handler middleware)
+Nodes (3): get_panel_bindings(), Return the current user bindings for a panel (admin view)., Replace the user bindings for a panel.      Payload:       {         "default_us
 
-### Community 551 - "Community 551"
+### Community 533 - "Community 533"
+Cohesion: 0.67
+Nodes (3): create_pin_challenge(), Create a PIN auth challenge for a high-privilege panel action.     Returns a cha, Internal version — callable from voice_tts without HTTP context.
+
+### Community 545 - "Community 545"
 Cohesion: 0.67
 Nodes (3): Journal Widget JavaScript, MyCustomWidget JavaScript Widget, MyWidget JavaScript Widget
 
-### Community 552 - "Community 552"
+### Community 546 - "Community 546"
 Cohesion: 0.67
 Nodes (3): HassIL Classifier, Intent Executor, Lists Handlers
 
 ## Knowledge Gaps
-- **4938 isolated node(s):** `Orbit matching algorithm — weighted multi-factor scoring.`, `Jaccard with intensity weighting — shared high-intensity items score higher.`, `Score personality compatibility using per-trait similarity/complementarity.`, `Compute match score between two checkin dicts. Returns None if incompatible.`, `Return up to n best matches for a checkin from the active pool.` (+4933 more)
+- **5042 isolated node(s):** `Orbit matching algorithm — weighted multi-factor scoring.`, `Jaccard with intensity weighting — shared high-intensity items score higher.`, `Score personality compatibility using per-trait similarity/complementarity.`, `Compute match score between two checkin dicts. Returns None if incompatible.`, `Return up to n best matches for a checkin from the active pool.` (+5037 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **215 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
+- **292 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `init()` connect `Community 17` to `Community 0`, `Community 1`, `Community 2`, `Community 3`, `Community 8`, `Community 520`, `Community 11`, `Community 18`, `Community 19`, `Community 20`, `Community 27`, `Community 28`, `Community 29`, `Community 35`, `Community 39`, `Community 44`, `Community 45`, `Community 47`, `Community 48`, `Community 50`, `Community 55`, `Community 59`, `Community 61`, `Community 65`, `Community 66`, `Community 70`, `Community 71`, `Community 76`, `Community 79`, `Community 80`, `Community 85`, `Community 94`, `Community 95`, `Community 96`, `Community 98`, `Community 101`, `Community 102`, `Community 105`, `Community 106`, `Community 119`, `Community 122`, `Community 124`, `Community 136`, `Community 138`, `Community 139`, `Community 145`, `Community 147`, `Community 160`, `Community 161`, `Community 174`, `Community 176`, `Community 189`, `Community 192`, `Community 198`, `Community 213`, `Community 214`, `Community 215`, `Community 216`, `Community 218`, `Community 242`, `Community 244`, `Community 248`, `Community 249`, `Community 250`, `Community 251`, `Community 252`, `Community 255`, `Community 282`, `Community 285`, `Community 288`, `Community 290`, `Community 291`, `Community 292`, `Community 295`, `Community 314`, `Community 333`, `Community 341`, `Community 352`, `Community 360`, `Community 366`, `Community 387`, `Community 426`, `Community 462`, `Community 467`, `Community 491`, `Community 505`?**
-  _High betweenness centrality (0.315) - this node is a cross-community bridge._
-- **Why does `main()` connect `Community 1` to `Community 2`, `Community 387`, `Community 5`, `Community 134`, `Community 136`, `Community 138`, `Community 139`, `Community 273`, `Community 18`, `Community 20`, `Community 24`, `Community 34`, `Community 35`, `Community 292`, `Community 37`, `Community 291`, `Community 41`, `Community 45`, `Community 49`, `Community 436`, `Community 437`, `Community 311`, `Community 312`, `Community 313`, `Community 314`, `Community 59`, `Community 189`, `Community 319`, `Community 192`, `Community 66`, `Community 335`, `Community 466`, `Community 341`, `Community 87`, `Community 215`, `Community 216`, `Community 89`, `Community 93`, `Community 365`, `Community 495`, `Community 124`, `Community 242`, `Community 250`, `Community 251`, `Community 252`, `Community 509`, `Community 127`?**
-  _High betweenness centrality (0.131) - this node is a cross-community bridge._
-- **Why does `Troubleshooting` connect `Community 4` to `Community 264`, `Community 265`, `Community 142`, `Community 144`, `Community 415`, `Community 33`, `Community 418`, `Community 546`, `Community 548`, `Community 547`, `Community 38`, `Community 167`, `Community 168`, `Community 172`, `Community 183`, `Community 57`, `Community 58`, `Community 323`, `Community 72`, `Community 78`, `Community 81`, `Community 212`, `Community 219`, `Community 356`, `Community 228`, `Community 234`, `Community 236`, `Community 116`, `Community 117`, `Community 125`, `Community 126`, `Community 127`?**
-  _High betweenness centrality (0.071) - this node is a cross-community bridge._
+- **Why does `init()` connect `Community 31` to `Community 0`, `Community 1`, `Community 2`, `Community 519`, `Community 9`, `Community 11`, `Community 13`, `Community 15`, `Community 16`, `Community 17`, `Community 19`, `Community 22`, `Community 23`, `Community 27`, `Community 32`, `Community 33`, `Community 39`, `Community 40`, `Community 42`, `Community 43`, `Community 45`, `Community 50`, `Community 51`, `Community 54`, `Community 58`, `Community 61`, `Community 67`, `Community 68`, `Community 74`, `Community 77`, `Community 78`, `Community 82`, `Community 87`, `Community 94`, `Community 96`, `Community 97`, `Community 104`, `Community 111`, `Community 112`, `Community 119`, `Community 128`, `Community 129`, `Community 130`, `Community 133`, `Community 140`, `Community 141`, `Community 152`, `Community 154`, `Community 158`, `Community 160`, `Community 185`, `Community 199`, `Community 202`, `Community 219`, `Community 221`, `Community 223`, `Community 225`, `Community 226`, `Community 227`, `Community 236`, `Community 238`, `Community 252`, `Community 255`, `Community 259`, `Community 261`, `Community 262`, `Community 263`, `Community 280`, `Community 289`, `Community 296`, `Community 297`, `Community 298`, `Community 301`, `Community 302`, `Community 303`, `Community 313`, `Community 321`, `Community 342`, `Community 363`, `Community 365`, `Community 366`, `Community 379`, `Community 389`, `Community 405`, `Community 431`, `Community 458`, `Community 459`, `Community 504`?**
+  _High betweenness centrality (0.330) - this node is a cross-community bridge._
+- **Why does `main()` connect `Community 0` to `Community 1`, `Community 388`, `Community 261`, `Community 262`, `Community 389`, `Community 263`, `Community 390`, `Community 133`, `Community 141`, `Community 22`, `Community 279`, `Community 280`, `Community 26`, `Community 158`, `Community 160`, `Community 37`, `Community 44`, `Community 301`, `Community 302`, `Community 303`, `Community 50`, `Community 51`, `Community 437`, `Community 438`, `Community 320`, `Community 321`, `Community 322`, `Community 323`, `Community 67`, `Community 73`, `Community 202`, `Community 332`, `Community 77`, `Community 78`, `Community 463`, `Community 84`, `Community 342`, `Community 221`, `Community 94`, `Community 95`, `Community 226`, `Community 101`, `Community 103`, `Community 490`, `Community 109`, `Community 365`, `Community 366`, `Community 367`, `Community 506`?**
+  _High betweenness centrality (0.125) - this node is a cross-community bridge._
+- **Why does `Troubleshooting` connect `Community 6` to `Community 386`, `Community 264`, `Community 265`, `Community 139`, `Community 527`, `Community 271`, `Community 145`, `Community 530`, `Community 531`, `Community 529`, `Community 528`, `Community 410`, `Community 411`, `Community 417`, `Community 34`, `Community 36`, `Community 552`, `Community 553`, `Community 169`, `Community 555`, `Community 556`, `Community 172`, `Community 558`, `Community 559`, `Community 560`, `Community 561`, `Community 177`, `Community 557`, `Community 180`, `Community 184`, `Community 56`, `Community 444`, `Community 188`, `Community 203`, `Community 168`, `Community 79`, `Community 83`, `Community 356`, `Community 484`, `Community 554`, `Community 241`, `Community 243`, `Community 247`, `Community 120`, `Community 125`?**
+  _High betweenness centrality (0.074) - this node is a cross-community bridge._
 - **Are the 4 inferred relationships involving `main()` (e.g. with `init_pool()` and `close_pool()`) actually correct?**
   _`main()` has 4 INFERRED edges - model-reasoned connections that need verification._
 - **Are the 87 inferred relationships involving `require_feature_access()` (e.g. with `create_reminder()` and `list_reminders()`) actually correct?**
   _`require_feature_access()` has 87 INFERRED edges - model-reasoned connections that need verification._
 - **What connects `Orbit matching algorithm — weighted multi-factor scoring.`, `Jaccard with intensity weighting — shared high-intensity items score higher.`, `Score personality compatibility using per-trait similarity/complementarity.` to the rest of the system?**
-  _4938 weakly-connected nodes found - possible documentation gaps or missing edges._
+  _5042 weakly-connected nodes found - possible documentation gaps or missing edges._
 - **Should `Community 0` be split into smaller, more focused modules?**
-  _Cohesion score 0.03 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.02 - nodes in this community are weakly interconnected._

--- a/scripts/maintenance/greploop_guard.py
+++ b/scripts/maintenance/greploop_guard.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Operator CLI for Zoe's bounded Greploop guard."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "services" / "zoe-data"))
+
+from greploop_guard import GuardError, read_guard_state, run_guard_once  # noqa: E402
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run one Zoe Greploop guard iteration.")
+    parser.add_argument("--task-id", help="Zoe engineering_tasks id")
+    parser.add_argument("--pr", type=int, help="Read guard state for a PR number")
+    parser.add_argument("--once", action="store_true", help="Run one bounded guard iteration")
+    parser.add_argument("--packet-only", action="store_true", help="Build packet and stop before model execution")
+    parser.add_argument("--state", action="store_true", help="Print file-backed guard state")
+    args = parser.parse_args()
+
+    try:
+        if args.state:
+            if not args.pr:
+                parser.error("--state requires --pr")
+            print(json.dumps(read_guard_state(args.pr), indent=2, sort_keys=True))
+            return 0
+        if not args.task_id:
+            parser.error("--task-id is required for --once/--packet-only")
+        if not (args.once or args.packet_only):
+            parser.error("choose --once or --packet-only")
+        result = asyncio.run(run_guard_once(args.task_id, packet_only=args.packet_only))
+        print(json.dumps(result, indent=2, sort_keys=True))
+        return 0 if result.get("ok") else 2
+    except GuardError as exc:
+        print(json.dumps({"ok": False, "error": str(exc)}, indent=2, sort_keys=True))
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/maintenance/refresh_graphify.sh
+++ b/scripts/maintenance/refresh_graphify.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="${ZOE_ASSISTANT_ROOT:-/home/zoe/assistant}"
+GRAPHIFY_BIN="${GRAPHIFY_BIN:-/home/zoe/.local/share/uv/tools/graphifyy/bin/graphify}"
+MODE="${1:-}"
+LOCK_FILE="${TMPDIR:-/tmp}/zoe-graphify-refresh.lock"
+
+log() {
+  printf '[graphify-refresh] %s\n' "$*"
+}
+
+cd "$ROOT"
+
+exec 9>"$LOCK_FILE"
+if ! flock -n 9; then
+  log "another refresh is already running; exiting"
+  exit 0
+fi
+
+if [[ ! -x "$GRAPHIFY_BIN" ]]; then
+  log "graphify executable not found: $GRAPHIFY_BIN"
+  exit 1
+fi
+
+if [[ ! -f graphify-out/GRAPH_REPORT.md ]]; then
+  log "missing graphify-out/GRAPH_REPORT.md"
+  exit 1
+fi
+
+if [[ "${GRAPHIFY_ALLOW_DIRTY:-0}" != "1" ]]; then
+  dirty_source="$(git status --porcelain --untracked-files=no -- . ':(exclude)graphify-out' || true)"
+  if [[ -n "$dirty_source" ]]; then
+    log "source tree has tracked changes outside graphify-out; commit or stash before refreshing"
+    exit 2
+  fi
+fi
+
+current_head="$(git rev-parse --short=8 HEAD)"
+built_head="$(python3 - <<'PY'
+from pathlib import Path
+import re
+
+report = Path("graphify-out/GRAPH_REPORT.md").read_text(encoding="utf-8", errors="ignore")
+match = re.search(r"Built from commit:\s*`?([0-9a-fA-F]{7,40})`?", report)
+print(match.group(1)[:8] if match else "")
+PY
+)"
+
+report_age_seconds="$(python3 - <<'PY'
+from pathlib import Path
+import time
+
+path = Path("graphify-out/GRAPH_REPORT.md")
+print(int(time.time() - path.stat().st_mtime))
+PY
+)"
+
+should_refresh=0
+if [[ "$MODE" == "--force" ]]; then
+  should_refresh=1
+elif [[ -z "$built_head" || "$built_head" != "$current_head" ]]; then
+  should_refresh=1
+elif [[ "$MODE" == "--daily" && "$report_age_seconds" -ge 86400 ]]; then
+  should_refresh=1
+fi
+
+if [[ "$should_refresh" != "1" ]]; then
+  log "graph is current for $current_head; no refresh needed"
+  exit 0
+fi
+
+if [[ -z "${OPENAI_API_KEY:-}" && -f .env ]]; then
+  OPENAI_API_KEY="$(python3 - <<'PY'
+from pathlib import Path
+
+for line in Path(".env").read_text(encoding="utf-8", errors="ignore").splitlines():
+    if not line or line.lstrip().startswith("#") or "=" not in line:
+        continue
+    key, value = line.split("=", 1)
+    if key.strip() == "OPENAI_API_KEY":
+        value = value.strip().strip('"').strip("'")
+        print(value)
+        break
+PY
+)"
+fi
+
+if [[ -z "${OPENAI_API_KEY:-}" ]]; then
+  log "OPENAI_API_KEY is required; set it in the environment or .env"
+  exit 1
+fi
+export OPENAI_API_KEY
+
+log "refreshing graphify graph for $current_head"
+"$GRAPHIFY_BIN" extract . --backend openai
+"$GRAPHIFY_BIN" cluster-only . --no-viz
+log "graphify refresh complete"

--- a/scripts/setup/jetson/zoe-graphify-refresh.service
+++ b/scripts/setup/jetson/zoe-graphify-refresh.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Refresh Zoe Graphify knowledge graph
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+WorkingDirectory=/home/zoe/assistant
+ExecStart=/home/zoe/assistant/scripts/maintenance/refresh_graphify.sh --daily
+StandardOutput=journal
+StandardError=journal
+TimeoutStartSec=7200

--- a/scripts/setup/jetson/zoe-graphify-refresh.timer
+++ b/scripts/setup/jetson/zoe-graphify-refresh.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Daily Zoe Graphify refresh
+
+[Timer]
+OnCalendar=*-*-* 04:30:00
+Persistent=true
+RandomizedDelaySec=30min
+Unit=zoe-graphify-refresh.service
+
+[Install]
+WantedBy=timers.target

--- a/services/zoe-data/background_runner.py
+++ b/services/zoe-data/background_runner.py
@@ -22,6 +22,17 @@ import httpx
 
 logger = logging.getLogger(__name__)
 
+_HERMES_API_KEY = os.environ.get("HERMES_API_KEY") or os.environ.get("API_SERVER_KEY") or ""
+
+
+def _hermes_headers(*, session_id: str | None = None) -> dict[str, str]:
+    headers: dict[str, str] = {}
+    if _HERMES_API_KEY:
+        headers["Authorization"] = f"Bearer {_HERMES_API_KEY}"
+    if session_id:
+        headers["X-Hermes-Session-Id"] = session_id
+    return headers
+
 # Running task futures keyed by task id (to avoid duplicate runs)
 _running: dict[int, asyncio.Task] = {}
 
@@ -222,7 +233,11 @@ async def _run_hermes_background_task(task: str, *, user_id: str, task_id: int) 
         "stream": False,
     }
     async with httpx.AsyncClient(timeout=timeout_s) as client:
-        resp = await client.post(f"{api_url}/v1/chat/completions", json=payload)
+        resp = await client.post(
+            f"{api_url}/v1/chat/completions",
+            json=payload,
+            headers=_hermes_headers(session_id=f"background-task-{task_id}"),
+        )
         resp.raise_for_status()
         data = resp.json()
     return (

--- a/services/zoe-data/greploop_guard.py
+++ b/services/zoe-data/greploop_guard.py
@@ -22,6 +22,7 @@ from typing import Any
 
 DEFAULT_REPO = os.environ.get("ZOE_GITHUB_REPO", "jason-easyazz/zoe-ai-assistant")
 DEFAULT_BASE_BRANCH = os.environ.get("ZOE_GITHUB_DEFAULT_BRANCH", "main")
+REPO_ROOT = Path(os.environ.get("ZOE_ASSISTANT_ROOT", Path(__file__).resolve().parents[2]))
 STATE_ROOT = Path(os.environ.get("ZOE_PR_GUARD_STATE_DIR", "/home/zoe/assistant/.cursor/tmp/pr_guard"))
 LOCK_TTL_SECONDS = int(os.environ.get("ZOE_PR_GUARD_LOCK_TTL_SECONDS", "1800"))
 MAX_ITERATIONS = int(os.environ.get("ZOE_PR_GUARD_MAX_ITERATIONS", "5"))
@@ -158,7 +159,7 @@ def acquire_lock(pr_number: int):
 
 
 def _run_git(args: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(["git", *args], cwd="/home/zoe/assistant", text=True, capture_output=True, check=check)
+    return subprocess.run(["git", *args], cwd=REPO_ROOT, text=True, capture_output=True, check=check)
 
 
 def _local_head_sha() -> str | None:
@@ -331,7 +332,7 @@ async def _run_cheap_agent(packet: GuardPacket, *, task_id: str | None = None) -
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
-            cwd="/home/zoe/assistant",
+            cwd=REPO_ROOT,
         )
         stdout, stderr = await proc.communicate(payload.encode())
         output = (stdout + stderr).decode(errors="replace")[:MAX_OUTPUT_CHARS]

--- a/services/zoe-data/greploop_guard.py
+++ b/services/zoe-data/greploop_guard.py
@@ -1,0 +1,412 @@
+"""Bounded Greptile PR guard for cheap-model repair packets.
+
+The guard keeps deterministic state outside model context. Cheap models get one
+validated packet at a time; Hermes remains the escalation path for broad or risky
+work.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import os
+import re
+import subprocess
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+DEFAULT_REPO = os.environ.get("ZOE_GITHUB_REPO", "jason-easyazz/zoe-ai-assistant")
+DEFAULT_BASE_BRANCH = os.environ.get("ZOE_GITHUB_DEFAULT_BRANCH", "main")
+STATE_ROOT = Path(os.environ.get("ZOE_PR_GUARD_STATE_DIR", "/home/zoe/assistant/.cursor/tmp/pr_guard"))
+LOCK_TTL_SECONDS = int(os.environ.get("ZOE_PR_GUARD_LOCK_TTL_SECONDS", "1800"))
+MAX_ITERATIONS = int(os.environ.get("ZOE_PR_GUARD_MAX_ITERATIONS", "5"))
+NO_PROGRESS_LIMIT = int(os.environ.get("ZOE_PR_GUARD_NO_PROGRESS_LIMIT", "3"))
+SAME_ERROR_LIMIT = int(os.environ.get("ZOE_PR_GUARD_SAME_ERROR_LIMIT", "3"))
+MAX_COST_USD = float(os.environ.get("ZOE_PR_GUARD_MAX_COST_USD", "0.25"))
+MAX_OUTPUT_CHARS = int(os.environ.get("ZOE_PR_GUARD_MAX_OUTPUT_CHARS", "12000"))
+
+FORBIDDEN_ACTIONS = [
+    "merge_pr",
+    "force_push",
+    "manual_deploy",
+    "delete_branch",
+    "amend_commit",
+    "bypass_hooks",
+]
+ALLOWED_TASK_TYPES = {"FIX_GREPTILE_FINDING", "FIX_CI_FAILURE", "SUMMARIZE_BLOCKER"}
+HIGH_RISK_PREFIXES = (
+    ".github/workflows/",
+    "services/zoe-data/alembic/",
+    "services/zoe-data/auth.py",
+    "services/zoe-data/database.py",
+    "services/zoe-data/routers/chat.py",
+    "docker-compose",
+)
+SECRET_RE = re.compile(
+    r"(?i)(api[_-]?key|token|secret|password|authorization|bearer)\s*[:=]\s*['\"]?[^'\"\s]+"
+)
+BEARER_RE = re.compile(r"(?i)(authorization\s*:\s*bearer)\s+[^'\"\s]+")
+
+
+class GuardError(RuntimeError):
+    pass
+
+
+@dataclass
+class GuardPacket:
+    task_type: str
+    pr: int
+    head_sha: str | None
+    base_branch: str
+    allowed_files: list[str]
+    max_files: int
+    max_changed_lines: int
+    issue_text: str
+    commands_to_run: list[str]
+    success_condition: str
+    stop_condition: str
+    forbidden_actions: list[str]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "task_type": self.task_type,
+            "pr": self.pr,
+            "head_sha": self.head_sha,
+            "base_branch": self.base_branch,
+            "allowed_files": self.allowed_files,
+            "max_files": self.max_files,
+            "max_changed_lines": self.max_changed_lines,
+            "issue_text": self.issue_text,
+            "commands_to_run": self.commands_to_run,
+            "success_condition": self.success_condition,
+            "stop_condition": self.stop_condition,
+            "forbidden_actions": self.forbidden_actions,
+        }
+
+
+def redact(value: Any) -> Any:
+    if isinstance(value, str):
+        value = BEARER_RE.sub(lambda m: f"{m.group(1)} <redacted>", value)
+        return SECRET_RE.sub(lambda m: f"{m.group(1)}=<redacted>", value)
+    if isinstance(value, list):
+        return [redact(item) for item in value]
+    if isinstance(value, dict):
+        return {key: redact(item) for key, item in value.items()}
+    return value
+
+
+def _state_dir(pr_number: int) -> Path:
+    return STATE_ROOT / f"pr-{int(pr_number)}"
+
+
+def _json_path(pr_number: int, name: str) -> Path:
+    return _state_dir(pr_number) / name
+
+
+def _write_json(pr_number: int, name: str, payload: dict[str, Any]) -> None:
+    path = _json_path(pr_number, name)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(redact(payload), indent=2, sort_keys=True) + "\n")
+
+
+def read_guard_state(pr_number: int) -> dict[str, Any]:
+    path = _json_path(pr_number, "status.json")
+    if not path.exists():
+        return {"pr": int(pr_number), "state": "MISSING"}
+    return json.loads(path.read_text())
+
+
+def _append_progress(pr_number: int, line: str) -> None:
+    path = _json_path(pr_number, "progress.md")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(f"- {time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())} {redact(line)}\n")
+
+
+def _record_guardrail(pr_number: int, line: str) -> None:
+    path = _json_path(pr_number, "guardrails.md")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(f"- {time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())} {redact(line)}\n")
+
+
+@contextmanager
+def acquire_lock(pr_number: int):
+    path = _json_path(pr_number, "lock")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    now = time.time()
+    if path.exists():
+        try:
+            existing = json.loads(path.read_text())
+        except Exception:
+            existing = {}
+        created = float(existing.get("created_at") or 0)
+        if now - created < LOCK_TTL_SECONDS:
+            raise GuardError(f"guard already running for PR #{pr_number}")
+        path.unlink(missing_ok=True)
+    payload = {"pid": os.getpid(), "created_at": now, "owner": "zoe-greploop-guard"}
+    path.write_text(json.dumps(payload, indent=2) + "\n")
+    try:
+        yield
+    finally:
+        path.unlink(missing_ok=True)
+
+
+def _run_git(args: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(["git", *args], cwd="/home/zoe/assistant", text=True, capture_output=True, check=check)
+
+
+def _local_head_sha() -> str | None:
+    try:
+        return _run_git(["rev-parse", "HEAD"]).stdout.strip()
+    except Exception:
+        return None
+
+
+def _diff_files() -> list[str]:
+    proc = _run_git(["diff", "--name-only"], check=False)
+    return [line.strip() for line in proc.stdout.splitlines() if line.strip()]
+
+
+def _diff_changed_lines() -> int:
+    proc = _run_git(["diff", "--numstat"], check=False)
+    total = 0
+    for line in proc.stdout.splitlines():
+        parts = line.split()
+        if len(parts) >= 2:
+            for value in parts[:2]:
+                if value.isdigit():
+                    total += int(value)
+    return total
+
+
+def validate_packet(packet: GuardPacket) -> None:
+    if packet.task_type not in ALLOWED_TASK_TYPES:
+        raise GuardError(f"unsupported task_type: {packet.task_type}")
+    if not packet.pr or not packet.issue_text.strip():
+        raise GuardError("BLOCKED_MISSING_CONTEXT: pr and issue_text are required")
+    if not packet.allowed_files:
+        raise GuardError("BLOCKED_MISSING_CONTEXT: allowed_files is required")
+    if len(packet.allowed_files) > packet.max_files:
+        raise GuardError("packet exceeds max_files")
+    for action in FORBIDDEN_ACTIONS:
+        if action not in packet.forbidden_actions:
+            raise GuardError(f"packet missing forbidden action: {action}")
+
+
+def _finding_hash(finding: dict[str, Any]) -> str:
+    raw = f"{finding.get('id')}|{finding.get('file_path')}|{finding.get('body')}"
+    return hashlib.sha256(raw.encode()).hexdigest()[:16]
+
+
+def _packet_for_finding(pr_number: int, status: dict[str, Any], finding: dict[str, Any]) -> GuardPacket:
+    allowed_file = finding.get("file_path") or ""
+    if not allowed_file:
+        raise GuardError("BLOCKED_MISSING_CONTEXT: finding has no file path")
+    packet = GuardPacket(
+        task_type="FIX_GREPTILE_FINDING",
+        pr=int(pr_number),
+        head_sha=status.get("headSha") or _local_head_sha(),
+        base_branch=DEFAULT_BASE_BRANCH,
+        allowed_files=[allowed_file],
+        max_files=1,
+        max_changed_lines=120,
+        issue_text=str(finding.get("body") or "")[:4000],
+        commands_to_run=[
+            "python3 tools/audit/validate_structure.py",
+            "python3 tools/audit/validate_critical_files.py",
+            "git diff --check",
+        ],
+        success_condition="Focused fix is applied, local checks pass, and Greptile can be re-run on the current head.",
+        stop_condition="Stop if files outside allowed_files are required, the finding is ambiguous, or a forbidden action is needed.",
+        forbidden_actions=FORBIDDEN_ACTIONS,
+    )
+    validate_packet(packet)
+    return packet
+
+
+def analyze_result(packet: GuardPacket, result_text: str) -> dict[str, Any]:
+    changed = _diff_files()
+    changed_lines = _diff_changed_lines()
+    outside = [path for path in changed if path not in set(packet.allowed_files)]
+    forbidden = [action for action in packet.forbidden_actions if action.replace("_", " ") in result_text.lower()]
+    if outside or len(changed) > packet.max_files or changed_lines > packet.max_changed_lines or forbidden:
+        return {
+            "classification": "REJECTED",
+            "changed_files": changed,
+            "changed_lines": changed_lines,
+            "outside_allowlist": outside,
+            "forbidden_actions": forbidden,
+        }
+    if "BLOCKED" in result_text.upper():
+        return {"classification": "BLOCKED", "changed_files": changed, "changed_lines": changed_lines}
+    return {"classification": "APPLIED", "changed_files": changed, "changed_lines": changed_lines}
+
+
+def _load_status(pr_number: int) -> dict[str, Any]:
+    state = read_guard_state(pr_number)
+    if state.get("state") == "MISSING":
+        return {
+            "pr": int(pr_number),
+            "iteration": 0,
+            "no_progress_count": 0,
+            "same_error_count": 0,
+            "last_progress_key": "",
+            "last_error_hash": "",
+        }
+    return state
+
+
+def _update_circuit_breakers(pr_number: int, state: dict[str, Any], progress_key: str, error: str | None = None) -> str | None:
+    state["iteration"] = int(state.get("iteration") or 0) + 1
+    if state["iteration"] > MAX_ITERATIONS:
+        return "BLOCKED_MAX_ITERATIONS"
+    if progress_key == state.get("last_progress_key"):
+        state["no_progress_count"] = int(state.get("no_progress_count") or 0) + 1
+    else:
+        state["no_progress_count"] = 0
+    state["last_progress_key"] = progress_key
+    if state["no_progress_count"] >= NO_PROGRESS_LIMIT:
+        return "BLOCKED_NO_PROGRESS"
+    if error:
+        error_hash = hashlib.sha256(error.encode()).hexdigest()[:16]
+        if error_hash == state.get("last_error_hash"):
+            state["same_error_count"] = int(state.get("same_error_count") or 0) + 1
+        else:
+            state["same_error_count"] = 1
+        state["last_error_hash"] = error_hash
+        if state["same_error_count"] >= SAME_ERROR_LIMIT:
+            return "BLOCKED_REPEATED_ERROR"
+    _write_json(pr_number, "status.json", state)
+    return None
+
+
+async def _record_cost_event(task_id: str | None, estimated_cost_usd: float) -> None:
+    if estimated_cost_usd <= 0:
+        return
+    try:
+        from db_pool import get_db_ctx
+        import uuid
+
+        async with get_db_ctx() as db:
+            await db.execute(
+                """INSERT INTO agent_cost_events
+                   (id, agent_name, model, task_id, user_id, input_tokens, output_tokens, estimated_cost_usd, ts)
+                   VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)""",
+                uuid.uuid4().hex,
+                "greploop_guard",
+                os.environ.get("ZOE_CHEAP_PR_AGENT_MODEL", "cheap-pr-agent"),
+                task_id,
+                "system",
+                0,
+                0,
+                estimated_cost_usd,
+                time.time(),
+            )
+    except Exception:
+        return
+
+
+async def _run_cheap_agent(packet: GuardPacket, *, task_id: str | None = None) -> tuple[str, str]:
+    cmd = os.environ.get("ZOE_CHEAP_PR_AGENT_CMD")
+    url = os.environ.get("ZOE_CHEAP_PR_AGENT_URL")
+    if not cmd and not url:
+        return "BLOCKED_CHEAP_RUNNER_NOT_CONFIGURED", ""
+    estimated_cost = float(os.environ.get("ZOE_CHEAP_PR_AGENT_ESTIMATED_COST_USD", "0"))
+    if estimated_cost > MAX_COST_USD:
+        return "BLOCKED_BUDGET_EXCEEDED", f"estimated_cost_usd={estimated_cost} max_cost_usd={MAX_COST_USD}"
+    payload = json.dumps(packet.to_dict())
+    start = time.time()
+    if cmd:
+        proc = await asyncio.create_subprocess_shell(
+            cmd,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            cwd="/home/zoe/assistant",
+        )
+        stdout, stderr = await proc.communicate(payload.encode())
+        output = (stdout + stderr).decode(errors="replace")[:MAX_OUTPUT_CHARS]
+        status = "OK" if proc.returncode == 0 else f"BLOCKED_CHEAP_RUNNER_EXIT_{proc.returncode}"
+    else:
+        import httpx
+
+        async with httpx.AsyncClient(timeout=300) as client:
+            resp = await client.post(url or "", json=packet.to_dict())
+            output = resp.text[:MAX_OUTPUT_CHARS]
+            status = "OK" if resp.status_code < 400 else f"BLOCKED_CHEAP_RUNNER_HTTP_{resp.status_code}"
+    elapsed = time.time() - start
+    await _record_cost_event(task_id, estimated_cost)
+    return status, f"elapsed={elapsed:.1f}s estimated_cost_usd={estimated_cost}\n{output}"
+
+
+async def run_guard_once(task_id: str, *, packet_only: bool = False) -> dict[str, Any]:
+    from engineering_workflow import get_engineering_task, update_greptile_state
+    from greptile_client import DEFAULT_REPO, get_pr_status, list_pr_comments, trigger_review
+
+    task = await get_engineering_task(task_id)
+    if not task:
+        raise GuardError(f"engineering task not found: {task_id}")
+    pr_number = task.get("pr_number")
+    if not pr_number:
+        raise GuardError("engineering task has no PR number")
+    pr_number = int(pr_number)
+    with acquire_lock(pr_number):
+        state = _load_status(pr_number)
+        status = await get_pr_status(repo=DEFAULT_REPO, pr_number=pr_number, default_branch=DEFAULT_BASE_BRANCH)
+        comments = await list_pr_comments(repo=DEFAULT_REPO, pr_number=pr_number, default_branch=DEFAULT_BASE_BRANCH)
+        findings = comments.get("findings") or []
+        progress_key = f"{status.get('headSha')}:{status.get('confidenceScore')}:{len(findings)}"
+        blocked = _update_circuit_breakers(pr_number, state, progress_key)
+        if blocked:
+            state["terminal_state"] = blocked
+            _write_json(pr_number, "status.json", state)
+            _record_guardrail(pr_number, blocked)
+            return {"ok": False, "state": blocked, "status": state}
+        await update_greptile_state(
+            task_id,
+            greptile_status=status.get("reviewCompleteness") or "reviewed",
+            confidence=status.get("confidenceScore"),
+            unaddressed_count=len(findings),
+        )
+        if status.get("reviewIsRunning"):
+            state["terminal_state"] = "WAITING_GREPTILE"
+            _write_json(pr_number, "status.json", state)
+            return {"ok": True, "state": "WAITING_GREPTILE", "greptile": status}
+        if (status.get("confidenceScore") or 0) >= int(task.get("target_confidence") or 5) and not findings:
+            state["terminal_state"] = "READY_TO_MERGE"
+            _write_json(pr_number, "status.json", state)
+            return {"ok": True, "state": "READY_TO_MERGE", "greptile": status}
+        if not findings:
+            triggered = await trigger_review(repo=DEFAULT_REPO, pr_number=pr_number, default_branch=DEFAULT_BASE_BRANCH)
+            state["terminal_state"] = "WAITING_GREPTILE"
+            _write_json(pr_number, "status.json", {**state, "triggered_review": triggered})
+            return {"ok": True, "state": "WAITING_GREPTILE", "triggered_review": triggered}
+        finding = findings[0]
+        if any(str(finding.get("file_path") or "").startswith(prefix) for prefix in HIGH_RISK_PREFIXES):
+            state["terminal_state"] = "ESCALATE_HERMES"
+            _write_json(pr_number, "status.json", state)
+            return {"ok": False, "state": "ESCALATE_HERMES", "finding": finding}
+        packet = _packet_for_finding(pr_number, status, finding)
+        _write_json(pr_number, "last_packet.json", packet.to_dict())
+        _append_progress(pr_number, f"packet {_finding_hash(finding)} for {finding.get('file_path')}")
+        if packet_only:
+            state["terminal_state"] = "PACKET_READY"
+            _write_json(pr_number, "status.json", state)
+            return {"ok": True, "state": "PACKET_READY", "packet": packet.to_dict()}
+        runner_status, runner_output = await _run_cheap_agent(packet, task_id=task_id)
+        analysis = analyze_result(packet, runner_output)
+        result = {"runner_status": runner_status, "analysis": analysis, "output": runner_output[:MAX_OUTPUT_CHARS]}
+        _write_json(pr_number, "last_result.json", result)
+        if runner_status != "OK" or analysis["classification"] != "APPLIED":
+            state["terminal_state"] = analysis.get("classification") if runner_status == "OK" else runner_status
+            _write_json(pr_number, "status.json", state)
+            return {"ok": False, "state": state["terminal_state"], "result": result}
+        triggered = await trigger_review(repo=DEFAULT_REPO, pr_number=pr_number, default_branch=DEFAULT_BASE_BRANCH)
+        state["terminal_state"] = "WAITING_GREPTILE"
+        _write_json(pr_number, "status.json", {**state, "triggered_review": triggered})
+        return {"ok": True, "state": "WAITING_GREPTILE", "result": result, "triggered_review": triggered}

--- a/services/zoe-data/greploop_guard.py
+++ b/services/zoe-data/greploop_guard.py
@@ -12,6 +12,7 @@ import hashlib
 import json
 import os
 import re
+import shlex
 import subprocess
 import time
 from contextlib import contextmanager
@@ -322,8 +323,11 @@ async def _run_cheap_agent(packet: GuardPacket, *, task_id: str | None = None) -
     payload = json.dumps(packet.to_dict())
     start = time.time()
     if cmd:
-        proc = await asyncio.create_subprocess_shell(
-            cmd,
+        argv = shlex.split(cmd)
+        if not argv:
+            return "BLOCKED_CHEAP_RUNNER_NOT_CONFIGURED", "empty ZOE_CHEAP_PR_AGENT_CMD"
+        proc = await asyncio.create_subprocess_exec(
+            *argv,
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,

--- a/services/zoe-data/greploop_guard.py
+++ b/services/zoe-data/greploop_guard.py
@@ -169,20 +169,33 @@ def _local_head_sha() -> str | None:
         return None
 
 
-def _diff_files() -> list[str]:
-    proc = _run_git(["diff", "--name-only"], check=False)
-    return [line.strip() for line in proc.stdout.splitlines() if line.strip()]
+def _diff_files(base_sha: str | None = None) -> list[str]:
+    paths: list[str] = []
+    commands = [["diff", "--name-only"]]
+    if base_sha:
+        commands.insert(0, ["diff", "--name-only", f"{base_sha}..HEAD"])
+    for args in commands:
+        proc = _run_git(args, check=False)
+        for line in proc.stdout.splitlines():
+            path = line.strip()
+            if path and path not in paths:
+                paths.append(path)
+    return paths
 
 
-def _diff_changed_lines() -> int:
-    proc = _run_git(["diff", "--numstat"], check=False)
+def _diff_changed_lines(base_sha: str | None = None) -> int:
     total = 0
-    for line in proc.stdout.splitlines():
-        parts = line.split()
-        if len(parts) >= 2:
-            for value in parts[:2]:
-                if value.isdigit():
-                    total += int(value)
+    commands = [["diff", "--numstat"]]
+    if base_sha:
+        commands.insert(0, ["diff", "--numstat", f"{base_sha}..HEAD"])
+    for args in commands:
+        proc = _run_git(args, check=False)
+        for line in proc.stdout.splitlines():
+            parts = line.split()
+            if len(parts) >= 2:
+                for value in parts[:2]:
+                    if value.isdigit():
+                        total += int(value)
     return total
 
 
@@ -231,9 +244,9 @@ def _packet_for_finding(pr_number: int, status: dict[str, Any], finding: dict[st
     return packet
 
 
-def analyze_result(packet: GuardPacket, result_text: str) -> dict[str, Any]:
-    changed = _diff_files()
-    changed_lines = _diff_changed_lines()
+def analyze_result(packet: GuardPacket, result_text: str, *, pre_run_sha: str | None = None) -> dict[str, Any]:
+    changed = _diff_files(pre_run_sha)
+    changed_lines = _diff_changed_lines(pre_run_sha)
     outside = [path for path in changed if path not in set(packet.allowed_files)]
     forbidden = [action for action in packet.forbidden_actions if action.replace("_", " ") in result_text.lower()]
     if outside or len(changed) > packet.max_files or changed_lines > packet.max_changed_lines or forbidden:
@@ -403,8 +416,9 @@ async def run_guard_once(task_id: str, *, packet_only: bool = False) -> dict[str
             state["terminal_state"] = "PACKET_READY"
             _write_json(pr_number, "status.json", state)
             return {"ok": True, "state": "PACKET_READY", "packet": packet.to_dict()}
+        pre_run_sha = _local_head_sha()
         runner_status, runner_output = await _run_cheap_agent(packet, task_id=task_id)
-        analysis = analyze_result(packet, runner_output)
+        analysis = analyze_result(packet, runner_output, pre_run_sha=pre_run_sha)
         result = {"runner_status": runner_status, "analysis": analysis, "output": runner_output[:MAX_OUTPUT_CHARS]}
         _write_json(pr_number, "last_result.json", result)
         if runner_status != "OK" or analysis["classification"] != "APPLIED":

--- a/services/zoe-data/greptile_client.py
+++ b/services/zoe-data/greptile_client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 from pathlib import Path
 from typing import Any
 
@@ -18,6 +19,67 @@ DEFAULT_REPO = os.environ.get("ZOE_GITHUB_REPO", "jason-easyazz/zoe-ai-assistant
 
 class GreptileAuthError(RuntimeError):
     """Raised when Greptile credentials are unavailable."""
+
+
+_CONFIDENCE_RE = re.compile(r"(?:Confidence\s+Score|confidence)\s*:?\s*([0-5])\s*/\s*5", re.I)
+
+
+def parse_confidence_score(*sources: Any) -> int | None:
+    """Return the first Greptile confidence score found in nested text-like data."""
+    stack = list(sources)
+    while stack:
+        item = stack.pop(0)
+        if item is None:
+            continue
+        if isinstance(item, str):
+            match = _CONFIDENCE_RE.search(item)
+            if match:
+                return int(match.group(1))
+            continue
+        if isinstance(item, dict):
+            direct = item.get("confidenceScore") or item.get("confidence_score")
+            if isinstance(direct, int) and 0 <= direct <= 5:
+                return direct
+            stack.extend(item.values())
+            continue
+        if isinstance(item, list):
+            stack.extend(item)
+    return None
+
+
+def normalize_pr_comment(comment: dict[str, Any]) -> dict[str, Any]:
+    """Normalize Greptile/GitHub comment fields for guard packets."""
+    body = comment.get("body") or comment.get("text") or comment.get("content") or ""
+    path = comment.get("filePath") or comment.get("path") or comment.get("file") or ""
+    line = comment.get("line") or comment.get("startLine") or comment.get("originalLine")
+    return {
+        "id": str(comment.get("id") or comment.get("commentId") or comment.get("nodeId") or ""),
+        "file_path": path,
+        "line": line,
+        "body": body,
+        "suggested_code": comment.get("suggestedCode") or comment.get("suggestion"),
+        "has_suggestion": bool(comment.get("hasSuggestion") or comment.get("suggestedCode")),
+        "addressed": bool(comment.get("addressed", False)),
+        "raw": comment,
+    }
+
+
+def normalize_pr_comments(comments: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [normalize_pr_comment(comment) for comment in comments]
+
+
+def review_is_running(status: dict[str, Any]) -> bool:
+    """Best-effort Greptile running-state check from MCP/GitHub shaped payloads."""
+    candidates = [
+        status.get("reviewCompleteness"),
+        status.get("state"),
+        status.get("status"),
+        status.get("conclusion"),
+    ]
+    for review in status.get("codeReviews") or []:
+        if isinstance(review, dict):
+            candidates.extend([review.get("status"), review.get("state"), review.get("conclusion")])
+    return any(str(value).lower() in {"running", "queued", "pending", "in_progress", "in-progress"} for value in candidates if value)
 
 
 def _load_api_key() -> str:
@@ -75,12 +137,13 @@ async def get_pr_status(
     mr = data.get("mergeRequest") or data
     analysis = mr.get("reviewAnalysis") or {}
     body = mr.get("description") or ""
-    confidence = None
-    import re
-
-    match = re.search(r"Confidence Score:\s*(\d)/5", body, re.I)
-    if match:
-        confidence = int(match.group(1))
+    confidence = parse_confidence_score(body, mr, analysis, mr.get("codeReviews") or [])
+    head_sha = (
+        mr.get("headSha")
+        or mr.get("headSHA")
+        or (mr.get("headRef") or {}).get("oid")
+        or (mr.get("head") or {}).get("sha")
+    )
     return {
         "repo": repo,
         "prNumber": pr,
@@ -91,6 +154,8 @@ async def get_pr_status(
         "hasNewCommitsSinceReview": analysis.get("hasNewCommitsSinceReview"),
         "lastReviewDate": analysis.get("lastReviewDate"),
         "confidenceScore": confidence,
+        "headSha": head_sha,
+        "reviewIsRunning": review_is_running({**mr, **analysis}),
         "codeReviews": mr.get("codeReviews") or [],
     }
 
@@ -110,7 +175,13 @@ async def list_pr_comments(
         params["addressed"] = False
     data = await _mcp_call("list_merge_request_comments", params)
     comments = data.get("comments") or []
-    return {"repo": repo, "prNumber": pr, "total": len(comments), "comments": comments}
+    return {
+        "repo": repo,
+        "prNumber": pr,
+        "total": len(comments),
+        "comments": comments,
+        "findings": normalize_pr_comments(comments),
+    }
 
 
 async def trigger_review(

--- a/services/zoe-data/memory_digest.py
+++ b/services/zoe-data/memory_digest.py
@@ -23,6 +23,7 @@ import httpx
 logger = logging.getLogger(__name__)
 
 _GEMMA_URL = os.environ.get("GEMMA_SERVER_URL", "http://127.0.0.1:11434")
+_ZOE_TIMEZONE = os.environ.get("ZOE_TIMEZONE", "Australia/Perth")
 
 _EXTRACTION_PROMPT = """\
 You are extracting personal facts from a chat transcript. Only extract facts the user explicitly stated about themselves, their family, preferences, or life. Do NOT infer, assume, or add anything not stated directly.
@@ -417,11 +418,12 @@ async def _load_todays_messages(user_id: str, db=None) -> str:
             JOIN chat_sessions cs ON cm.session_id = cs.id
             WHERE cs.user_id = ?
               AND cm.role = 'user'
-              AND cm.created_at::timestamptz::date = CURRENT_DATE
+              AND (cm.created_at::timestamptz AT TIME ZONE ?)::date =
+                  (now() AT TIME ZONE ?)::date
             ORDER BY cm.created_at ASC
             LIMIT 200
             """,
-            (user_id,),
+            (user_id, _ZOE_TIMEZONE, _ZOE_TIMEZONE),
         )
         rows = await rows.fetchall()
         if not rows:
@@ -706,8 +708,10 @@ async def run_digest_for_all_active_users(db=None) -> list[dict]:
             FROM chat_messages cm
             JOIN chat_sessions cs ON cm.session_id = cs.id
             WHERE cm.role = 'user'
-              AND cm.created_at::timestamptz::date = CURRENT_DATE
+              AND (cm.created_at::timestamptz AT TIME ZONE ?)::date =
+                  (now() AT TIME ZONE ?)::date
             """,
+            (_ZOE_TIMEZONE, _ZOE_TIMEZONE),
         )
         rows = await rows.fetchall()
         user_ids = [row[0] for row in rows if row[0]]

--- a/services/zoe-data/memory_digest.py
+++ b/services/zoe-data/memory_digest.py
@@ -417,7 +417,7 @@ async def _load_todays_messages(user_id: str, db=None) -> str:
             JOIN chat_sessions cs ON cm.session_id = cs.id
             WHERE cs.user_id = ?
               AND cm.role = 'user'
-              AND DATE(cm.created_at) = DATE('now', 'localtime')
+              AND cm.created_at::timestamptz::date = CURRENT_DATE
             ORDER BY cm.created_at ASC
             LIMIT 200
             """,
@@ -706,7 +706,7 @@ async def run_digest_for_all_active_users(db=None) -> list[dict]:
             FROM chat_messages cm
             JOIN chat_sessions cs ON cm.session_id = cs.id
             WHERE cm.role = 'user'
-              AND DATE(cm.created_at) = DATE('now', 'localtime')
+              AND cm.created_at::timestamptz::date = CURRENT_DATE
             """,
         )
         rows = await rows.fetchall()

--- a/services/zoe-data/proactive/triggers/openclaw_trigger.py
+++ b/services/zoe-data/proactive/triggers/openclaw_trigger.py
@@ -19,7 +19,17 @@ from proactive.triggers.base import ProactiveTrigger, TriggerResult
 log = logging.getLogger(__name__)
 
 _HERMES_URL = os.environ.get("HERMES_API_URL", "http://127.0.0.1:8642/v1/chat/completions")
+_HERMES_API_KEY = os.environ.get("HERMES_API_KEY") or os.environ.get("API_SERVER_KEY") or ""
 _TIMEOUT = 30.0
+
+
+def _hermes_headers(*, session_id: str | None = None) -> dict[str, str]:
+    headers: dict[str, str] = {}
+    if _HERMES_API_KEY:
+        headers["Authorization"] = f"Bearer {_HERMES_API_KEY}"
+    if session_id:
+        headers["X-Hermes-Session-Id"] = session_id
+    return headers
 
 
 class OpenClawTrigger(ProactiveTrigger):
@@ -52,6 +62,7 @@ class OpenClawTrigger(ProactiveTrigger):
             async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
                 r = await client.post(
                     _HERMES_URL,
+                    headers=_hermes_headers(session_id=f"proactive-trigger:{self.trigger_type}"),
                     json={
                         "model": os.environ.get("HERMES_MODEL", "hermes"),
                         "messages": [

--- a/services/zoe-data/routers/chat.py
+++ b/services/zoe-data/routers/chat.py
@@ -878,15 +878,35 @@ async def _save_chat_message(session_id: str, role: str, content: str) -> None:
     the server owns the transcript. Zoe Agent reads this table for conversation
     history on the next turn, enabling proper follow-on context.
     """
-    if not content or not content.strip():
+    clean_content = (content or "").strip()
+    if not clean_content:
         return
     try:
         async for db in get_db():
             await db.execute(
                 "INSERT INTO chat_messages (id, session_id, role, content) "
                 "VALUES (?, ?, ?, ?) ON CONFLICT DO NOTHING",
-                (uuid.uuid4().hex, session_id, role, content.strip()),
+                (uuid.uuid4().hex, session_id, role, clean_content),
             )
+            title_row = await db.execute_fetchall(
+                "SELECT title FROM chat_sessions WHERE id = ?",
+                (session_id,),
+            )
+            if title_row:
+                current_title = dict(title_row[0]).get("title") or "New Chat"
+                new_title = None
+                if title_is_weak(current_title):
+                    new_title = derive_session_title(clean_content)
+                if new_title:
+                    await db.execute(
+                        "UPDATE chat_sessions SET updated_at = NOW()::text, title = ? WHERE id = ?",
+                        (new_title, session_id),
+                    )
+                else:
+                    await db.execute(
+                        "UPDATE chat_sessions SET updated_at = NOW()::text WHERE id = ?",
+                        (session_id,),
+                    )
             await db.commit()
             break
     except Exception as _sme:
@@ -1606,12 +1626,14 @@ async def chat_stream_generator(
                     response_text=followup,
                     metadata={"task_class": task_class, "missing_constraints": missing},
                 )
+                await _save_chat_message(session_id, "assistant", followup)
                 return
         if "what can you do right now" in lc or lc in {"/capabilities", "capabilities", "tools"}:
             try:
                 caps_text = Path("/home/zoe/assistant/CAPABILITIES.md").read_text()[:12000]
             except Exception:
                 caps_text = "Hermes is the active escalation agent. Zoe tools include calendar, lists, reminders, memory, Graphify, Multica, and CloakBrowser."
+            capabilities_text = f"Hermes/Zoe capabilities:\n\n{caps_text}"
             yield emit(
                 TextMessageStartEvent(
                     type=EventType.TEXT_MESSAGE_START,
@@ -1619,11 +1641,12 @@ async def chat_stream_generator(
                     role="assistant",
                 )
             )
-            async for line in iter_text_message_chunks(enc, recorder, assistant_message_id, f"Hermes/Zoe capabilities:\n\n{caps_text}"):
+            async for line in iter_text_message_chunks(enc, recorder, assistant_message_id, capabilities_text):
                 yield line
             yield emit(TextMessageEndEvent(type=EventType.TEXT_MESSAGE_END, message_id=assistant_message_id))
             yield emit(RunFinishedEvent(type=EventType.RUN_FINISHED, thread_id=session_id, run_id=run_id))
-            await _record_run_state(run_id, session_id, user_id, mode="chat", status="completed", request_text=message, response_text="capabilities")
+            await _record_run_state(run_id, session_id, user_id, mode="chat", status="completed", request_text=message, response_text=capabilities_text)
+            await _save_chat_message(session_id, "assistant", capabilities_text)
             return
 
         if _WHATSAPP_FLOW_ENABLED and is_whatsapp_connect_request(message_for_processing):
@@ -2798,6 +2821,7 @@ async def chat(request: Request, user: dict = Depends(get_current_user), stream:
             missing = missing_brief_fields(message_for_processing)
             if missing:
                 followup = _research_followup_prompt(missing)
+                asyncio.ensure_future(_save_chat_message(session_id, "assistant", followup))
                 return {
                     "response": followup,
                     "session_id": session_id,
@@ -2816,7 +2840,9 @@ async def chat(request: Request, user: dict = Depends(get_current_user), stream:
                 caps_text = Path("/home/zoe/assistant/CAPABILITIES.md").read_text()[:12000]
             except Exception:
                 caps_text = "Hermes is the active escalation agent. Zoe tools include calendar, lists, reminders, memory, Graphify, Multica, and CloakBrowser."
-            return {"response": "Hermes/Zoe capabilities:\n\n" + caps_text, "session_id": session_id}
+            capabilities_text = "Hermes/Zoe capabilities:\n\n" + caps_text
+            asyncio.ensure_future(_save_chat_message(session_id, "assistant", capabilities_text))
+            return {"response": capabilities_text, "session_id": session_id}
 
         use_intent_fast_path = (not force_openclaw) and _ALL_TOOLS_ENABLED
         if task_class == "research":

--- a/services/zoe-data/routers/chat.py
+++ b/services/zoe-data/routers/chat.py
@@ -888,29 +888,35 @@ async def _save_chat_message(session_id: str, role: str, content: str) -> None:
                 "VALUES (?, ?, ?, ?) ON CONFLICT DO NOTHING",
                 (uuid.uuid4().hex, session_id, role, clean_content),
             )
-            title_row = await db.execute_fetchall(
-                "SELECT title FROM chat_sessions WHERE id = ?",
-                (session_id,),
-            )
-            if title_row:
-                current_title = dict(title_row[0]).get("title") or "New Chat"
-                new_title = None
-                if title_is_weak(current_title):
-                    new_title = derive_session_title(clean_content)
-                if new_title:
-                    await db.execute(
-                        "UPDATE chat_sessions SET updated_at = NOW()::text, title = ? WHERE id = ?",
-                        (new_title, session_id),
-                    )
-                else:
-                    await db.execute(
-                        "UPDATE chat_sessions SET updated_at = NOW()::text WHERE id = ?",
-                        (session_id,),
-                    )
+            await _touch_chat_session(db, session_id=session_id, content=clean_content)
             await db.commit()
             break
     except Exception as _sme:
         logger.debug("_save_chat_message failed (non-fatal): %s", _sme)
+
+
+async def _touch_chat_session(db, *, session_id: str, content: str, user_id: str | None = None) -> None:
+    """Refresh session recency and promote weak titles from the saved turn."""
+    where = "id = ? AND user_id = ?" if user_id else "id = ?"
+    params = (session_id, user_id) if user_id else (session_id,)
+    title_row = await db.execute_fetchall(
+        f"SELECT title FROM chat_sessions WHERE {where}",
+        params,
+    )
+    if not title_row:
+        return
+    current_title = dict(title_row[0]).get("title") or "New Chat"
+    new_title = derive_session_title(content) if content.strip() and title_is_weak(current_title) else None
+    if new_title:
+        await db.execute(
+            f"UPDATE chat_sessions SET updated_at = NOW()::text, title = ? WHERE {where}",
+            (new_title, *params),
+        )
+    else:
+        await db.execute(
+            f"UPDATE chat_sessions SET updated_at = NOW()::text WHERE {where}",
+            params,
+        )
 
 
 INTENT_LABELS = {
@@ -3082,37 +3088,12 @@ async def save_message(session_id: str, request: Request, user: dict = Depends(g
         if not owner:
             await db.commit()
             return {"status": "error", "message": "Session not found"}
-        title_row = await db.execute_fetchall(
-            "SELECT title FROM chat_sessions WHERE id = ? AND user_id = ?",
-            (session_id, user_id),
-        )
-        current_title = dict(title_row[0])["title"] if title_row else "New Chat"
-
         await db.execute(
             "INSERT INTO chat_messages (id, session_id, role, content, metadata) VALUES (?, ?, ?, ?, ?)",
             (msg_id, session_id, role, content, metadata),
         )
 
-        new_title = None
-        if role == "user" and content.strip():
-            candidate = derive_session_title(content)
-            if title_is_weak(current_title):
-                new_title = candidate
-        elif role == "assistant" and content.strip():
-            if title_is_weak(current_title):
-                new_title = derive_session_title(content)
-
-        if new_title:
-            await db.execute(
-                """UPDATE chat_sessions SET updated_at = NOW()::text, title = ?
-                   WHERE id = ? AND user_id = ?""",
-                (new_title, session_id, user_id),
-            )
-        else:
-            await db.execute(
-                "UPDATE chat_sessions SET updated_at = NOW()::text WHERE id = ? AND user_id = ?",
-                (session_id, user_id),
-            )
+        await _touch_chat_session(db, session_id=session_id, user_id=user_id, content=content)
         await db.commit()
     return {"status": "ok", "id": msg_id}
 

--- a/services/zoe-data/routers/chat.py
+++ b/services/zoe-data/routers/chat.py
@@ -2821,7 +2821,7 @@ async def chat(request: Request, user: dict = Depends(get_current_user), stream:
             missing = missing_brief_fields(message_for_processing)
             if missing:
                 followup = _research_followup_prompt(missing)
-                asyncio.ensure_future(_save_chat_message(session_id, "assistant", followup))
+                await _save_chat_message(session_id, "assistant", followup)
                 return {
                     "response": followup,
                     "session_id": session_id,
@@ -2841,7 +2841,7 @@ async def chat(request: Request, user: dict = Depends(get_current_user), stream:
             except Exception:
                 caps_text = "Hermes is the active escalation agent. Zoe tools include calendar, lists, reminders, memory, Graphify, Multica, and CloakBrowser."
             capabilities_text = "Hermes/Zoe capabilities:\n\n" + caps_text
-            asyncio.ensure_future(_save_chat_message(session_id, "assistant", capabilities_text))
+            await _save_chat_message(session_id, "assistant", capabilities_text)
             return {"response": capabilities_text, "session_id": session_id}
 
         use_intent_fast_path = (not force_openclaw) and _ALL_TOOLS_ENABLED
@@ -2876,7 +2876,7 @@ async def chat(request: Request, user: dict = Depends(get_current_user), stream:
                     chat_inject_background(message_for_processing, result, intent.name, user_id, session_id)
                 )
                 asyncio.ensure_future(_persist_memory_candidates(user_id, session_id, message_for_processing, result))
-                asyncio.ensure_future(_save_chat_message(session_id, "assistant", result))
+                await _save_chat_message(session_id, "assistant", result)
                 return {"response": result, "session_id": session_id}
         if _WHATSAPP_FLOW_ENABLED and is_whatsapp_connect_request(message_for_processing):
             message_for_processing = (
@@ -2991,7 +2991,7 @@ async def chat(request: Request, user: dict = Depends(get_current_user), stream:
             asyncio.ensure_future(_queue_ui_actions_background(actions, user_id, session_id))
         asyncio.ensure_future(_persist_memory_candidates(user_id, session_id, message_for_processing, response_text))
         if response_text:
-            asyncio.ensure_future(_save_chat_message(session_id, "assistant", response_text))
+            await _save_chat_message(session_id, "assistant", response_text)
         return resp
 
 

--- a/services/zoe-data/routers/chat.py
+++ b/services/zoe-data/routers/chat.py
@@ -2409,6 +2409,11 @@ async def chat_stream_generator(
 
 _HERMES_API_URL = os.environ.get("HERMES_API_URL", "http://127.0.0.1:8642")
 _HERMES_MODEL   = os.environ.get("HERMES_MODEL", "hermes-agent")
+_HERMES_API_KEY = (
+    os.environ.get("HERMES_API_KEY")
+    or os.environ.get("API_SERVER_KEY")
+    or ""
+)
 
 _ZOE_SOUL_HERMES = (
     "You are Zoe — a warm, curious, genuinely present AI companion. "
@@ -2497,6 +2502,15 @@ def _hermes_progress_events(event_name: str, payload) -> list:
     ]
 
 
+def _hermes_request_headers(*, session_id: str | None = None) -> dict[str, str]:
+    headers: dict[str, str] = {}
+    if _HERMES_API_KEY:
+        headers["Authorization"] = f"Bearer {_HERMES_API_KEY}"
+    if session_id:
+        headers["X-Hermes-Session-Id"] = session_id
+    return headers
+
+
 async def _iter_hermes_stream_events(
     message: str,
     session_id: str,
@@ -2524,8 +2538,10 @@ async def _iter_hermes_stream_events(
             async with session.post(
                 f"{_HERMES_API_URL}/v1/chat/completions",
                 json=payload,
+                headers=_hermes_request_headers(session_id=session_id),
                 timeout=aiohttp.ClientTimeout(total=120),
             ) as resp:
+                resp.raise_for_status()
                 sse_event = ""
                 async for raw_line in resp.content:
                     line = raw_line.decode("utf-8", errors="replace").strip()
@@ -2651,8 +2667,10 @@ async def _hermes_completion(
         async with _hses.post(
             f"{_HERMES_API_URL}/v1/chat/completions",
             json=payload,
+            headers=_hermes_request_headers(),
             timeout=aiohttp.ClientTimeout(total=120),
         ) as _hr:
+            _hr.raise_for_status()
             _hj = await _hr.json()
     return _hj.get("choices", [{}])[0].get("message", {}).get("content", "") or "(no response)"
 

--- a/services/zoe-data/routers/system.py
+++ b/services/zoe-data/routers/system.py
@@ -717,6 +717,10 @@ class _EngineeringTaskCancelRequest(BaseModel):
     reason: str = "cancelled by operator"
 
 
+class _EngineeringGuardRunRequest(BaseModel):
+    packet_only: bool = False
+
+
 @_agent_card_router.post("/tasks")
 async def a2a_task(body: _A2ATaskRequest, user: dict = Depends(get_a2a_caller)):
     """
@@ -895,6 +899,44 @@ async def check_engineering_workflow_greptile(task_id: str, user: dict = Depends
     try:
         return {"ok": True, "task": await check_greptile_for_task(task_id)}
     except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@_agent_card_router.get("/engineering/tasks/{task_id}/guard")
+async def get_engineering_workflow_guard(task_id: str, user: dict = Depends(require_admin)):
+    from engineering_workflow import get_engineering_task
+    from greploop_guard import read_guard_state
+
+    task = await get_engineering_task(task_id)
+    if not task:
+        raise HTTPException(status_code=404, detail="Engineering task not found")
+    pr_number = task.get("pr_number")
+    if not pr_number:
+        return {"ok": False, "state": "NO_PR", "task": task}
+    return {"ok": True, "state": read_guard_state(int(pr_number)), "task": task}
+
+
+@_agent_card_router.post("/engineering/tasks/{task_id}/guard/once")
+async def run_engineering_workflow_guard_once(
+    task_id: str,
+    body: _EngineeringGuardRunRequest | None = None,
+    user: dict = Depends(require_admin),
+):
+    from greploop_guard import GuardError, run_guard_once
+
+    try:
+        return await run_guard_once(task_id, packet_only=bool(body.packet_only if body else False))
+    except GuardError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@_agent_card_router.post("/engineering/tasks/{task_id}/guard/packet")
+async def build_engineering_workflow_guard_packet(task_id: str, user: dict = Depends(require_admin)):
+    from greploop_guard import GuardError, run_guard_once
+
+    try:
+        return await run_guard_once(task_id, packet_only=True)
+    except GuardError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 

--- a/services/zoe-data/tests/test_chat_persistence_contract.py
+++ b/services/zoe-data/tests/test_chat_persistence_contract.py
@@ -1,0 +1,57 @@
+import pytest
+
+from routers import chat as chat_router
+
+
+class _FakeDb:
+    def __init__(self, title="New Chat"):
+        self.title = title
+        self.executed = []
+
+    async def execute(self, sql, params=()):
+        self.executed.append((sql, params))
+
+    async def execute_fetchall(self, sql, params=()):
+        self.executed.append((sql, params))
+        if "SELECT title FROM chat_sessions" in sql:
+            return [{"title": self.title}]
+        return []
+
+    async def commit(self):
+        self.executed.append(("COMMIT", ()))
+
+
+def _fake_get_db(db):
+    async def _gen():
+        yield db
+
+    return _gen
+
+
+@pytest.mark.asyncio
+async def test_save_chat_message_updates_weak_session_title(monkeypatch):
+    db = _FakeDb(title="New Chat")
+    monkeypatch.setattr(chat_router, "get_db", _fake_get_db(db))
+
+    await chat_router._save_chat_message("session-1", "user", "  plan the lake trip  ")
+
+    insert = db.executed[0]
+    assert "INSERT INTO chat_messages" in insert[0]
+    assert insert[1][1:] == ("session-1", "user", "plan the lake trip")
+
+    title_updates = [params for sql, params in db.executed if "title = ?" in sql]
+    assert title_updates
+    assert title_updates[0][0] != "New Chat"
+    assert title_updates[0][1] == "session-1"
+
+
+@pytest.mark.asyncio
+async def test_save_chat_message_only_touches_existing_strong_title(monkeypatch):
+    db = _FakeDb(title="Trip Planning")
+    monkeypatch.setattr(chat_router, "get_db", _fake_get_db(db))
+
+    await chat_router._save_chat_message("session-1", "assistant", "Sounds good")
+
+    assert any("INSERT INTO chat_messages" in sql for sql, _ in db.executed)
+    assert not any("title = ?" in sql for sql, _ in db.executed)
+    assert any("UPDATE chat_sessions SET updated_at" in sql for sql, _ in db.executed)

--- a/services/zoe-data/tests/test_greploop_guard.py
+++ b/services/zoe-data/tests/test_greploop_guard.py
@@ -86,3 +86,14 @@ async def test_cheap_runner_blocks_before_budget_exceeded(monkeypatch):
 
     assert status == "BLOCKED_BUDGET_EXCEEDED"
     assert "max_cost_usd=1.0" in output
+
+
+@pytest.mark.asyncio
+async def test_cheap_runner_command_does_not_expand_shell_metacharacters(monkeypatch):
+    monkeypatch.setenv("ZOE_CHEAP_PR_AGENT_CMD", "python3 -c 'import sys; sys.stdin.read(); print(\"$HOME\")'")
+    monkeypatch.setenv("ZOE_CHEAP_PR_AGENT_ESTIMATED_COST_USD", "0")
+
+    status, output = await greploop_guard._run_cheap_agent(_packet())
+
+    assert status == "OK"
+    assert "$HOME" in output

--- a/services/zoe-data/tests/test_greploop_guard.py
+++ b/services/zoe-data/tests/test_greploop_guard.py
@@ -41,8 +41,8 @@ def test_redact_removes_secret_like_values():
 
 
 def test_analyze_result_rejects_files_outside_allowlist(monkeypatch):
-    monkeypatch.setattr(greploop_guard, "_diff_files", lambda: ["services/zoe-data/other.py"])
-    monkeypatch.setattr(greploop_guard, "_diff_changed_lines", lambda: 5)
+    monkeypatch.setattr(greploop_guard, "_diff_files", lambda base_sha=None: ["services/zoe-data/other.py"])
+    monkeypatch.setattr(greploop_guard, "_diff_changed_lines", lambda base_sha=None: 5)
 
     result = greploop_guard.analyze_result(_packet(), "done")
 
@@ -51,12 +51,32 @@ def test_analyze_result_rejects_files_outside_allowlist(monkeypatch):
 
 
 def test_analyze_result_accepts_focused_diff(monkeypatch):
-    monkeypatch.setattr(greploop_guard, "_diff_files", lambda: ["services/zoe-data/example.py"])
-    monkeypatch.setattr(greploop_guard, "_diff_changed_lines", lambda: 5)
+    monkeypatch.setattr(greploop_guard, "_diff_files", lambda base_sha=None: ["services/zoe-data/example.py"])
+    monkeypatch.setattr(greploop_guard, "_diff_changed_lines", lambda base_sha=None: 5)
 
     result = greploop_guard.analyze_result(_packet(), "TESTS=git diff --check")
 
     assert result["classification"] == "APPLIED"
+
+
+def test_analyze_result_checks_committed_diff_from_pre_run_sha(monkeypatch):
+    seen = {}
+
+    def fake_diff_files(base_sha=None):
+        seen["files_base_sha"] = base_sha
+        return ["services/zoe-data/other.py"]
+
+    def fake_diff_changed_lines(base_sha=None):
+        seen["lines_base_sha"] = base_sha
+        return 5
+
+    monkeypatch.setattr(greploop_guard, "_diff_files", fake_diff_files)
+    monkeypatch.setattr(greploop_guard, "_diff_changed_lines", fake_diff_changed_lines)
+
+    result = greploop_guard.analyze_result(_packet(), "done", pre_run_sha="before-sha")
+
+    assert result["classification"] == "REJECTED"
+    assert seen == {"files_base_sha": "before-sha", "lines_base_sha": "before-sha"}
 
 
 def test_lock_prevents_duplicate_runs(tmp_path, monkeypatch):

--- a/services/zoe-data/tests/test_greploop_guard.py
+++ b/services/zoe-data/tests/test_greploop_guard.py
@@ -1,0 +1,88 @@
+import json
+
+import pytest
+
+import greploop_guard
+
+
+def _packet(**overrides):
+    data = {
+        "task_type": "FIX_GREPTILE_FINDING",
+        "pr": 66,
+        "head_sha": "abc123",
+        "base_branch": "main",
+        "allowed_files": ["services/zoe-data/example.py"],
+        "max_files": 1,
+        "max_changed_lines": 50,
+        "issue_text": "Fix the narrow bug",
+        "commands_to_run": ["git diff --check"],
+        "success_condition": "focused fix",
+        "stop_condition": "stop on ambiguity",
+        "forbidden_actions": greploop_guard.FORBIDDEN_ACTIONS,
+    }
+    data.update(overrides)
+    return greploop_guard.GuardPacket(**data)
+
+
+def test_validate_packet_rejects_broad_missing_context():
+    packet = _packet(issue_text="")
+
+    with pytest.raises(greploop_guard.GuardError, match="BLOCKED_MISSING_CONTEXT"):
+        greploop_guard.validate_packet(packet)
+
+
+def test_redact_removes_secret_like_values():
+    payload = {"message": "Authorization: Bearer abc123", "nested": ["api_key=secret-value"]}
+
+    redacted = greploop_guard.redact(payload)
+
+    assert "abc123" not in json.dumps(redacted)
+    assert "secret-value" not in json.dumps(redacted)
+
+
+def test_analyze_result_rejects_files_outside_allowlist(monkeypatch):
+    monkeypatch.setattr(greploop_guard, "_diff_files", lambda: ["services/zoe-data/other.py"])
+    monkeypatch.setattr(greploop_guard, "_diff_changed_lines", lambda: 5)
+
+    result = greploop_guard.analyze_result(_packet(), "done")
+
+    assert result["classification"] == "REJECTED"
+    assert result["outside_allowlist"] == ["services/zoe-data/other.py"]
+
+
+def test_analyze_result_accepts_focused_diff(monkeypatch):
+    monkeypatch.setattr(greploop_guard, "_diff_files", lambda: ["services/zoe-data/example.py"])
+    monkeypatch.setattr(greploop_guard, "_diff_changed_lines", lambda: 5)
+
+    result = greploop_guard.analyze_result(_packet(), "TESTS=git diff --check")
+
+    assert result["classification"] == "APPLIED"
+
+
+def test_lock_prevents_duplicate_runs(tmp_path, monkeypatch):
+    monkeypatch.setattr(greploop_guard, "STATE_ROOT", tmp_path)
+
+    with greploop_guard.acquire_lock(66):
+        with pytest.raises(greploop_guard.GuardError, match="already running"):
+            with greploop_guard.acquire_lock(66):
+                pass
+
+
+def test_write_json_redacts_state(tmp_path, monkeypatch):
+    monkeypatch.setattr(greploop_guard, "STATE_ROOT", tmp_path)
+
+    greploop_guard._write_json(66, "status.json", {"token": "token=abc123"})
+
+    assert "abc123" not in (tmp_path / "pr-66" / "status.json").read_text()
+
+
+@pytest.mark.asyncio
+async def test_cheap_runner_blocks_before_budget_exceeded(monkeypatch):
+    monkeypatch.setenv("ZOE_CHEAP_PR_AGENT_CMD", "false")
+    monkeypatch.setenv("ZOE_CHEAP_PR_AGENT_ESTIMATED_COST_USD", "99")
+    monkeypatch.setattr(greploop_guard, "MAX_COST_USD", 1.0)
+
+    status, output = await greploop_guard._run_cheap_agent(_packet())
+
+    assert status == "BLOCKED_BUDGET_EXCEEDED"
+    assert "max_cost_usd=1.0" in output

--- a/services/zoe-data/tests/test_greptile_client.py
+++ b/services/zoe-data/tests/test_greptile_client.py
@@ -1,0 +1,36 @@
+import greptile_client
+
+
+def test_parse_confidence_score_from_nested_sources():
+    payload = {
+        "description": "No score here",
+        "codeReviews": [{"body": "Confidence Score: 4/5\nLooks close"}],
+    }
+
+    assert greptile_client.parse_confidence_score(payload) == 4
+
+
+def test_parse_confidence_score_prefers_direct_numeric_value():
+    assert greptile_client.parse_confidence_score({"confidenceScore": 5}) == 5
+
+
+def test_normalize_pr_comment_maps_common_fields():
+    comment = {
+        "id": 123,
+        "filePath": "services/zoe-data/example.py",
+        "line": 42,
+        "body": "Fix this",
+        "suggestedCode": "pass",
+    }
+
+    normalized = greptile_client.normalize_pr_comment(comment)
+
+    assert normalized["id"] == "123"
+    assert normalized["file_path"] == "services/zoe-data/example.py"
+    assert normalized["line"] == 42
+    assert normalized["has_suggestion"] is True
+
+
+def test_review_is_running_detects_pending_states():
+    assert greptile_client.review_is_running({"reviewCompleteness": "in_progress"}) is True
+    assert greptile_client.review_is_running({"reviewCompleteness": "reviewed"}) is False

--- a/services/zoe-data/tests/test_memory_digest_postgres_sql.py
+++ b/services/zoe-data/tests/test_memory_digest_postgres_sql.py
@@ -28,7 +28,9 @@ async def test_load_todays_messages_uses_postgres_timestamp_cast():
     text = await memory_digest._load_todays_messages("user-1", db=db)
 
     assert text == "I like quiet mornings\nI prefer tea"
-    assert "cm.created_at::timestamptz::date = CURRENT_DATE" in db.sql[0]
+    assert "(cm.created_at::timestamptz AT TIME ZONE ?)::date" in db.sql[0]
+    assert "(now() AT TIME ZONE ?)::date" in db.sql[0]
+    assert "CURRENT_DATE" not in db.sql[0]
     assert "DATE('now'" not in db.sql[0]
 
 
@@ -47,5 +49,7 @@ async def test_run_digest_for_all_active_users_uses_postgres_timestamp_cast(monk
 
     assert [item["user_id"] for item in results] == ["user-1", "user-2"]
     assert seen == ["user-1", "user-2"]
-    assert "cm.created_at::timestamptz::date = CURRENT_DATE" in db.sql[0]
+    assert "(cm.created_at::timestamptz AT TIME ZONE ?)::date" in db.sql[0]
+    assert "(now() AT TIME ZONE ?)::date" in db.sql[0]
+    assert "CURRENT_DATE" not in db.sql[0]
     assert "DATE('now'" not in db.sql[0]

--- a/services/zoe-data/tests/test_memory_digest_postgres_sql.py
+++ b/services/zoe-data/tests/test_memory_digest_postgres_sql.py
@@ -1,0 +1,51 @@
+import pytest
+
+import memory_digest
+
+
+class _Cursor:
+    def __init__(self, rows):
+        self._rows = rows
+
+    async def fetchall(self):
+        return self._rows
+
+
+class _FakeDb:
+    def __init__(self, rows):
+        self.rows = rows
+        self.sql = []
+
+    async def execute(self, sql, params=()):
+        self.sql.append(sql)
+        return _Cursor(self.rows)
+
+
+@pytest.mark.asyncio
+async def test_load_todays_messages_uses_postgres_timestamp_cast():
+    db = _FakeDb([("I like quiet mornings",), ("I prefer tea",)])
+
+    text = await memory_digest._load_todays_messages("user-1", db=db)
+
+    assert text == "I like quiet mornings\nI prefer tea"
+    assert "cm.created_at::timestamptz::date = CURRENT_DATE" in db.sql[0]
+    assert "DATE('now'" not in db.sql[0]
+
+
+@pytest.mark.asyncio
+async def test_run_digest_for_all_active_users_uses_postgres_timestamp_cast(monkeypatch):
+    db = _FakeDb([("user-1",), ("user-2",)])
+    seen = []
+
+    async def fake_run_memory_digest(user_id, db=None):
+        seen.append(user_id)
+        return {"user_id": user_id, "stored": 0}
+
+    monkeypatch.setattr(memory_digest, "run_memory_digest", fake_run_memory_digest)
+
+    results = await memory_digest.run_digest_for_all_active_users(db=db)
+
+    assert [item["user_id"] for item in results] == ["user-1", "user-2"]
+    assert seen == ["user-1", "user-2"]
+    assert "cm.created_at::timestamptz::date = CURRENT_DATE" in db.sql[0]
+    assert "DATE('now'" not in db.sql[0]

--- a/services/zoe-ui/dist/chat.html
+++ b/services/zoe-ui/dist/chat.html
@@ -4170,7 +4170,7 @@
                     } else {
                         contentEl.innerHTML = 'Sorry, I encountered an error. Please try again.';
                     }
-                    if (currentSessionId && stream.text) {
+                    if (currentSessionId) {
                         loadSessions().catch((err) => console.warn('sessions reload:', err));
                     }
                 }

--- a/services/zoe-ui/dist/chat.html
+++ b/services/zoe-ui/dist/chat.html
@@ -3271,10 +3271,7 @@
                 const stopBtn = document.getElementById('stopStreamBtn');
                 if (stopBtn) { stopBtn.classList.remove('visible'); stopBtn.disabled = false; }
                 streamAbortController = null;
-                if (currentSessionId && stream.text) {
-                    saveMessageToSession('user', ctx.originalMessage);
-                    saveMessageToSession('assistant', stream.text);
-                }
+                loadSessions().catch((err) => console.warn('sessions reload:', err));
                 return;
             }
             if (t === 'RUN_ERROR') {
@@ -3400,10 +3397,7 @@
                         group.insertBefore(badge, ctx.traceDisclosureEl || ctx.toolTraceEl || contentEl);
                     }
                 }
-                if (currentSessionId && stream.text) {
-                    saveMessageToSession('user', ctx.originalMessage);
-                    saveMessageToSession('assistant', stream.text);
-                }
+                loadSessions().catch((err) => console.warn('sessions reload:', err));
                 return;
             }
             if (t === 'error') {
@@ -4152,9 +4146,8 @@
                         contentEl.innerHTML = renderMarkdown(stream.text);
                         enhanceCodeBlocks(contentEl);
                     }
-                    if (currentSessionId && stream.text) {
-                        saveMessageToSession('user', originalMessage);
-                        saveMessageToSession('assistant', stream.text);
+                    if (currentSessionId) {
+                        loadSessions().catch((err) => console.warn('sessions reload:', err));
                     }
                     streamCtx.finalized = true;
                 }
@@ -4166,9 +4159,8 @@
                     } else {
                         contentEl.innerHTML = '<span style="color:#64748b;">Generation stopped.</span>';
                     }
-                    if (currentSessionId && stream.text) {
-                        saveMessageToSession('user', originalMessage);
-                        saveMessageToSession('assistant', stream.text);
+                    if (currentSessionId) {
+                        loadSessions().catch((err) => console.warn('sessions reload:', err));
                     }
                 } else {
                     console.error('Chat error:', error);
@@ -4179,8 +4171,7 @@
                         contentEl.innerHTML = 'Sorry, I encountered an error. Please try again.';
                     }
                     if (currentSessionId && stream.text) {
-                        saveMessageToSession('user', originalMessage);
-                        saveMessageToSession('assistant', stream.text);
+                        loadSessions().catch((err) => console.warn('sessions reload:', err));
                     }
                 }
             } finally {

--- a/services/zoe-ui/dist/js/touch-ui-executor.js
+++ b/services/zoe-ui/dist/js/touch-ui-executor.js
@@ -1333,7 +1333,19 @@ body.light-mode #zvo-header { border-bottom-color: rgba(0,0,0,0.07); }
         state.processing = true;
         try {
             const res = await api(`/api/ui/actions/pending?panel_id=${encodeURIComponent(state.panelId)}&limit=10`);
-            if (!res.ok) return;
+            if (!res.ok) {
+                if (res.status === 401 || res.status === 403) {
+                    if (state.pollTimer) {
+                        clearInterval(state.pollTimer);
+                        state.pollTimer = null;
+                    }
+                    if ('serviceWorker' in navigator && navigator.serviceWorker.controller) {
+                        navigator.serviceWorker.controller.postMessage({ type: 'STOP_PANEL_POLL' });
+                    }
+                    console.warn(`Touch action polling stopped after auth failure: HTTP ${res.status}`);
+                }
+                return;
+            }
             const data = await res.json();
             const actions = Array.isArray(data.actions) ? data.actions : [];
             for (const action of actions) {

--- a/services/zoe-ui/dist/sw.js
+++ b/services/zoe-ui/dist/sw.js
@@ -8,7 +8,7 @@
 importScripts('https://storage.googleapis.com/workbox-cdn/releases/7.0.0/workbox-sw.js');
 
 // Zoe UI Version 4.17.3 - public modules (with or without trailing path segment)
-const SW_VERSION = '4.63.7'; // backend-owned chat saves and touch poll auth stop
+const SW_VERSION = '4.63.8'; // refresh chat sidebar on zero-token stream errors
 const CACHE_NAME = `zoe-ui-v${SW_VERSION}`;
 
 // Verify Workbox loaded

--- a/services/zoe-ui/dist/sw.js
+++ b/services/zoe-ui/dist/sw.js
@@ -8,7 +8,7 @@
 importScripts('https://storage.googleapis.com/workbox-cdn/releases/7.0.0/workbox-sw.js');
 
 // Zoe UI Version 4.17.3 - public modules (with or without trailing path segment)
-const SW_VERSION = '4.63.6'; // tighten Hermes progress trace handling
+const SW_VERSION = '4.63.7'; // backend-owned chat saves and touch poll auth stop
 const CACHE_NAME = `zoe-ui-v${SW_VERSION}`;
 
 // Verify Workbox loaded
@@ -407,7 +407,11 @@ async function _panelFetch(path) {
     const headers = { 'Content-Type': 'application/json' };
     if (_panelSessionId) headers['X-Session-ID'] = _panelSessionId;
     const resp = await fetch(path, { headers, credentials: 'include' });
-    if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+    if (!resp.ok) {
+        const err = new Error(`HTTP ${resp.status}`);
+        err.status = resp.status;
+        throw err;
+    }
     return resp.json();
 }
 
@@ -482,7 +486,12 @@ async function _panelPoll() {
                 // Don't ack — let the page executor do it to avoid double-ack.
             }
         }
-    } catch (_) {
+    } catch (err) {
+        if (err && (err.status === 401 || err.status === 403)) {
+            _stopPanelPoll();
+            console.warn(`🎛️ SW panel executor stopped after auth failure: HTTP ${err.status}`);
+            return;
+        }
         // Silently retry — network may be unavailable.
     }
 }

--- a/services/zoe-ui/dist/touch/chat.html
+++ b/services/zoe-ui/dist/touch/chat.html
@@ -3582,7 +3582,7 @@
                     } else {
                         contentEl.innerHTML = 'Sorry, I encountered an error. Please try again.';
                     }
-                    if (currentSessionId && stream.text) {
+                    if (currentSessionId) {
                         loadSessions().catch((err) => console.warn('sessions reload:', err));
                     }
                 }

--- a/services/zoe-ui/dist/touch/chat.html
+++ b/services/zoe-ui/dist/touch/chat.html
@@ -2824,10 +2824,7 @@
                 const stopBtn = document.getElementById('stopStreamBtn');
                 if (stopBtn) { stopBtn.classList.remove('visible'); stopBtn.disabled = false; }
                 streamAbortController = null;
-                if (currentSessionId && stream.text) {
-                    saveMessageToSession('user', ctx.originalMessage);
-                    saveMessageToSession('assistant', stream.text);
-                }
+                loadSessions().catch((err) => console.warn('sessions reload:', err));
                 return;
             }
             if (t === 'RUN_ERROR') {
@@ -2940,10 +2937,7 @@
                         group.insertBefore(badge, ctx.traceDisclosureEl || ctx.toolTraceEl || contentEl);
                     }
                 }
-                if (currentSessionId && stream.text) {
-                    saveMessageToSession('user', ctx.originalMessage);
-                    saveMessageToSession('assistant', stream.text);
-                }
+                loadSessions().catch((err) => console.warn('sessions reload:', err));
                 return;
             }
             if (t === 'error') {
@@ -3564,9 +3558,8 @@
                         contentEl.innerHTML = renderMarkdown(stream.text);
                         enhanceCodeBlocks(contentEl);
                     }
-                    if (currentSessionId && stream.text) {
-                        saveMessageToSession('user', originalMessage);
-                        saveMessageToSession('assistant', stream.text);
+                    if (currentSessionId) {
+                        loadSessions().catch((err) => console.warn('sessions reload:', err));
                     }
                     streamCtx.finalized = true;
                 }
@@ -3578,9 +3571,8 @@
                     } else {
                         contentEl.innerHTML = '<span style="color:#64748b;">Generation stopped.</span>';
                     }
-                    if (currentSessionId && stream.text) {
-                        saveMessageToSession('user', originalMessage);
-                        saveMessageToSession('assistant', stream.text);
+                    if (currentSessionId) {
+                        loadSessions().catch((err) => console.warn('sessions reload:', err));
                     }
                 } else {
                     console.error('Chat error:', error);
@@ -3591,8 +3583,7 @@
                         contentEl.innerHTML = 'Sorry, I encountered an error. Please try again.';
                     }
                     if (currentSessionId && stream.text) {
-                        saveMessageToSession('user', originalMessage);
-                        saveMessageToSession('assistant', stream.text);
+                        loadSessions().catch((err) => console.warn('sessions reload:', err));
                     }
                 }
             } finally {

--- a/services/zoe-ui/nginx.conf
+++ b/services/zoe-ui/nginx.conf
@@ -252,6 +252,7 @@ server {
         proxy_set_header   Host $host;
     }
 
+    # Requires zoe-ui extra_hosts host.docker.internal:host-gateway (see docker-compose.yml).
     location /multica-api/ {
         proxy_pass http://host.docker.internal:8080/;
         proxy_set_header Host $http_host;
@@ -545,6 +546,7 @@ server {
         proxy_set_header   Host $host;
     }
 
+    # Requires zoe-ui extra_hosts host.docker.internal:host-gateway (see docker-compose.yml).
     location /multica-api/ {
         proxy_pass http://host.docker.internal:8080/;
         proxy_set_header Host $http_host;

--- a/services/zoe-ui/nginx.conf
+++ b/services/zoe-ui/nginx.conf
@@ -253,7 +253,7 @@ server {
     }
 
     location /multica-api/ {
-        proxy_pass http://multica-backend:8080/;
+        proxy_pass http://host.docker.internal:8080/;
         proxy_set_header Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -282,13 +282,13 @@ server {
     # ^~ prevents the ~* \.(js|css)$ regex location from intercepting these requests.
     # Next.js embeds root-relative /_next/ paths in its HTML when no basePath is configured.
     location ^~ /_next/ {
-        proxy_pass        http://multica-web:3000/_next/;
+        proxy_pass        http://host.docker.internal:3000/_next/;
         proxy_http_version 1.1;
         proxy_set_header   Host        $host;
     }
 
     location /multica/ {
-        proxy_pass        http://multica-web:3000/;
+        proxy_pass        http://host.docker.internal:3000/;
         proxy_http_version 1.1;
         proxy_set_header   Upgrade     $http_upgrade;
         proxy_set_header   Connection  $connection_upgrade;
@@ -546,7 +546,7 @@ server {
     }
 
     location /multica-api/ {
-        proxy_pass http://multica-backend:8080/;
+        proxy_pass http://host.docker.internal:8080/;
         proxy_set_header Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -575,13 +575,13 @@ server {
     # ^~ prevents the ~* \.(js|css)$ regex location from intercepting these requests.
     # Next.js embeds root-relative /_next/ paths in its HTML when no basePath is configured.
     location ^~ /_next/ {
-        proxy_pass        http://multica-web:3000/_next/;
+        proxy_pass        http://host.docker.internal:3000/_next/;
         proxy_http_version 1.1;
         proxy_set_header   Host        $host;
     }
 
     location /multica/ {
-        proxy_pass        http://multica-web:3000/;
+        proxy_pass        http://host.docker.internal:3000/;
         proxy_http_version 1.1;
         proxy_set_header   Upgrade     $http_upgrade;
         proxy_set_header   Connection  $connection_upgrade;


### PR DESCRIPTION
## Summary
- Add Zoe's integrated Greploop guard with file-backed state, packet-only cheap-model handoff, result analysis, locks, budget checks, and circuit breakers.
- Strengthen Greptile parsing and expose admin/CLI guard entry points for engineering tasks.
- Align agent workflow docs, session bootstrap, Greptile rules, Hermes request headers, Graphify refresh automation, and CI-safe tests around bounded PR repair.

## Test plan
- `python3 tools/audit/validate_structure.py`
- `python3 tools/audit/validate_critical_files.py`
- `python3 -m py_compile services/zoe-data/greploop_guard.py services/zoe-data/greptile_client.py services/zoe-data/engineering_workflow.py services/zoe-data/routers/system.py`
- `PYTHONPATH=services/zoe-data python3 -m pytest services/zoe-data/tests/test_greptile_client.py services/zoe-data/tests/test_greploop_guard.py services/zoe-data/tests/test_engineering_workflow.py -q`
- `git diff --check`

## Notes
- Cheap model execution is opt-in via `ZOE_CHEAP_PR_AGENT_CMD` or `ZOE_CHEAP_PR_AGENT_URL`; otherwise the guard stops safely after writing a packet.
- Graphify timer files are included but not installed/enabled by this PR.