### PR TITLE
fix: people relationship visibility, field-schema admin gate, kiosk sessionStorage, orb history scoping

### DIFF
--- a/services/zoe-data/routers/people.py
+++ b/services/zoe-data/routers/people.py
@@ -448,7 +448,8 @@ async def update_people_field(
 
 @router.delete("/fields/{field_key}", dependencies=[Depends(require_admin)])
 async def delete_field_schema(field_key: str, db=Depends(get_db)):
-    await db.execute("DELETE FROM people_field_schema WHERE field_key = $1", field_key)
+    await db.execute("DELETE FROM people_field_definitions WHERE field_key = ?", (field_key,))
+    await db.commit()
     return {"deleted": True}
 
 

--- a/services/zoe-data/routers/people.py
+++ b/services/zoe-data/routers/people.py
@@ -17,7 +17,7 @@ from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 
-from auth import get_current_user
+from auth import get_current_user, require_admin
 from database import get_db
 from guest_policy import require_feature_access
 from models import (
@@ -389,6 +389,7 @@ async def list_people_fields(
 async def create_people_field(
     body: PeopleFieldDefinitionCreate,
     user: dict = Depends(get_current_user),
+    _admin: dict = Depends(require_admin),
     db=Depends(get_db),
 ):
     await require_feature_access(db, user, feature="people", action="manage_fields")
@@ -414,6 +415,7 @@ async def update_people_field(
     field_key: str,
     body: PeopleFieldDefinitionUpdate,
     user: dict = Depends(get_current_user),
+    _admin: dict = Depends(require_admin),
     db=Depends(get_db),
 ):
     await require_feature_access(db, user, feature="people", action="manage_fields")
@@ -912,6 +914,18 @@ async def add_relationship(
             if not row:
                 raise HTTPException(status_code=404, detail=f"Person '{name}' not found. Use create_partial=true to create a stub.")
             other_id = dict(row)["id"]
+    else:
+        # Verify person B is owned by this user or is family-visible
+        async with db.execute(
+            "SELECT user_id, visibility FROM people WHERE id = ? AND deleted = 0",
+            (other_id,),
+        ) as cur:
+            person_b_row = await cur.fetchone()
+        if not person_b_row:
+            raise HTTPException(status_code=404, detail="Linked person not found")
+        person_b = dict(person_b_row)
+        if person_b["user_id"] != user_id and person_b.get("visibility") != "family":
+            raise HTTPException(status_code=403, detail="You do not have permission to link to that person")
 
     # Prevent self-link
     if other_id == person_id:

--- a/services/zoe-data/routers/people.py
+++ b/services/zoe-data/routers/people.py
@@ -447,9 +447,12 @@ async def update_people_field(
 
 
 @router.delete("/fields/{field_key}", dependencies=[Depends(require_admin)])
-async def delete_field_schema(field_key: str, db=Depends(get_db)):
-    await db.execute("DELETE FROM people_field_definitions WHERE field_key = ?", (field_key,))
+async def delete_field_schema(field_key: str, user: dict = Depends(get_current_user), db=Depends(get_db)):
+    await require_feature_access(db, user, feature="people", action="manage_fields")
+    cursor = await db.execute("DELETE FROM people_field_definitions WHERE field_key = ?", (field_key,))
     await db.commit()
+    if cursor.rowcount == 0:
+        raise HTTPException(status_code=404, detail="Field definition not found")
     return {"deleted": True}
 
 

--- a/services/zoe-data/routers/people.py
+++ b/services/zoe-data/routers/people.py
@@ -446,6 +446,12 @@ async def update_people_field(
     return {"ok": True, "updated": True}
 
 
+@router.delete("/fields/{field_key}", dependencies=[Depends(require_admin)])
+async def delete_field_schema(field_key: str, db=Depends(get_db)):
+    await db.execute("DELETE FROM people_field_schema WHERE field_key = $1", field_key)
+    return {"deleted": True}
+
+
 # ── /{person_id} routes (must come AFTER /fields) ─────────────────────────────
 
 @router.get("/{person_id}")

--- a/services/zoe-ui/dist/js/auth.js
+++ b/services/zoe-ui/dist/js/auth.js
@@ -211,6 +211,9 @@
 
         setSession(null);
 
+        // Notify other modules (e.g. orb chat) so they can clear user-scoped state.
+        try { document.dispatchEvent(new CustomEvent('zoe:logout', { detail: { user_id: current && current.user_id } })); } catch(_){}
+
         const currentPath = window.location.pathname;
         const redirectUrl = currentPath.startsWith('/touch/') ? '/touch/index.html' : '/index.html';
 
@@ -227,12 +230,16 @@
     async function enforceAuth() {
         const currentPath = window.location.pathname;
         const search = window.location.search || '';
-        // Persist kiosk mode in localStorage so navigations within the touch UI
+        // Persist kiosk mode in sessionStorage so navigations within the touch UI
         // don't lose it (voice commands navigate to /touch/calendar.html etc. without query params).
+        // sessionStorage is tab-scoped and cleared when the browser tab closes, preventing
+        // the kiosk bypass from bleeding into non-kiosk sessions.
+        // Also clear any stale localStorage kiosk key left by older code.
+        try { localStorage.removeItem('zoe_kiosk'); } catch(_){}
         if (currentPath.startsWith('/touch/') && search.includes('kiosk=1')) {
-            try { localStorage.setItem('zoe_kiosk', '1'); } catch(_){}
+            try { sessionStorage.setItem('zoe_kiosk', '1'); } catch(_){}
         }
-        const kioskStored = currentPath.startsWith('/touch/') && (function(){ try { return localStorage.getItem('zoe_kiosk') === '1'; } catch(_){ return false; } })();
+        const kioskStored = currentPath.startsWith('/touch/') && (function(){ try { return sessionStorage.getItem('zoe_kiosk') === '1'; } catch(_){ return false; } })();
         const isKioskMode = kioskStored || (currentPath.startsWith('/touch/') && search.includes('kiosk=1'));
         const isPublicGameModule =
             currentPath === '/modules/qd' ||

--- a/services/zoe-ui/dist/js/auth.js
+++ b/services/zoe-ui/dist/js/auth.js
@@ -212,7 +212,8 @@
         setSession(null);
 
         // Notify other modules (e.g. orb chat) so they can clear user-scoped state.
-        try { document.dispatchEvent(new CustomEvent('zoe:logout', { detail: { user_id: current && current.user_id } })); } catch(_){}
+        const _logoutUid = current && (current.user_id || (current.user_info && current.user_info.user_id)) || null;
+        try { document.dispatchEvent(new CustomEvent('zoe:logout', { detail: { user_id: _logoutUid } })); } catch(_){}
 
         const currentPath = window.location.pathname;
         const redirectUrl = currentPath.startsWith('/touch/') ? '/touch/index.html' : '/index.html';

--- a/services/zoe-ui/dist/js/widgets/core/zoe-orb.js
+++ b/services/zoe-ui/dist/js/widgets/core/zoe-orb.js
@@ -65,11 +65,31 @@ class ZoeOrbWidget extends WidgetModule {
         // Stable session ID for this widget — persists across page loads so the
         // Hermes agent pool entry survives navigation and the user always gets
         // a warm response after the first message.
-        this._sessionId = localStorage.getItem('orbWidgetSessionId');
+        // The key is scoped by user ID to prevent chat history bleeding across accounts.
+        const _orbWidgetKey = () => {
+            try {
+                const s = window.zoeAuth ? window.zoeAuth.getCurrentSession() : null;
+                const uid = s && (s.user_id || (s.user_info && s.user_info.user_id));
+                if (uid && uid !== 'guest') return 'orbWidgetSessionId_' + uid;
+            } catch (_) {}
+            return 'orbWidgetSessionId';
+        };
+        this._getOrbWidgetKey = _orbWidgetKey;
+        this._sessionId = localStorage.getItem(_orbWidgetKey());
         if (!this._sessionId) {
             this._sessionId = 'orb-widget-' + Math.random().toString(36).slice(2, 10);
-            localStorage.setItem('orbWidgetSessionId', this._sessionId);
+            localStorage.setItem(_orbWidgetKey(), this._sessionId);
         }
+        // Clear this widget's session on logout.
+        document.addEventListener('zoe:logout', (e) => {
+            try {
+                const uid = e && e.detail && e.detail.user_id;
+                const key = uid && uid !== 'guest' ? 'orbWidgetSessionId_' + uid : 'orbWidgetSessionId';
+                localStorage.removeItem(key);
+                localStorage.removeItem('orbWidgetSessionId');
+            } catch (_) {}
+            this._sessionId = null;
+        });
 
         // Pre-warming via /api/chat/warm/{sid} was a zoe-core optimization
         // and is not served by zoe-data. Skip the warm-up call entirely so

--- a/services/zoe-ui/dist/js/widgets/core/zoe-orb.js
+++ b/services/zoe-ui/dist/js/widgets/core/zoe-orb.js
@@ -81,7 +81,7 @@ class ZoeOrbWidget extends WidgetModule {
             localStorage.setItem(_orbWidgetKey(), this._sessionId);
         }
         // Clear this widget's session on logout.
-        document.addEventListener('zoe:logout', (e) => {
+        this._logoutHandler = (e) => {
             try {
                 const uid = e && e.detail && e.detail.user_id;
                 const key = uid && uid !== 'guest' ? 'orbWidgetSessionId_' + uid : 'orbWidgetSessionId';
@@ -89,7 +89,8 @@ class ZoeOrbWidget extends WidgetModule {
                 localStorage.removeItem('orbWidgetSessionId');
             } catch (_) {}
             this._sessionId = null;
-        });
+        };
+        document.addEventListener('zoe:logout', this._logoutHandler);
 
         // Pre-warming via /api/chat/warm/{sid} was a zoe-core optimization
         // and is not served by zoe-data. Skip the warm-up call entirely so
@@ -489,6 +490,10 @@ class ZoeOrbWidget extends WidgetModule {
     }
     
     destroy() {
+        if (this._logoutHandler) {
+            document.removeEventListener('zoe:logout', this._logoutHandler);
+            this._logoutHandler = null;
+        }
         this.stopVoice();
         this.stopSpeaking();
         if (window.zoeWidgets) {

--- a/services/zoe-ui/dist/js/zoe-orb.js
+++ b/services/zoe-ui/dist/js/zoe-orb.js
@@ -10,7 +10,33 @@ let intelligenceWS = null;
 let wsRetries = 0;
 const MAX_WS_RETRIES = 2;
 let orbWebSocket = null;
-let orbSessionId = localStorage.getItem('orbSessionId') || null;
+
+/**
+ * Returns the localStorage key for the orb session, scoped by user ID to
+ * prevent chat history from bleeding across accounts.
+ */
+function getOrbStorageKey() {
+    try {
+        const session = window.zoeAuth ? window.zoeAuth.getCurrentSession() : null;
+        const uid = session && (session.user_id || (session.user_info && session.user_info.user_id));
+        if (uid && uid !== 'guest') return 'orbSessionId_' + uid;
+    } catch (_) {}
+    return 'orbSessionId';
+}
+
+let orbSessionId = localStorage.getItem(getOrbStorageKey()) || null;
+
+// Clear orb history when the user logs out.
+document.addEventListener('zoe:logout', function(e) {
+    try {
+        const uid = e && e.detail && e.detail.user_id;
+        const key = uid && uid !== 'guest' ? 'orbSessionId_' + uid : 'orbSessionId';
+        localStorage.removeItem(key);
+        // Also clear legacy unscoped key.
+        localStorage.removeItem('orbSessionId');
+    } catch (_) {}
+    orbSessionId = null;
+});
 
 /**
  * Initialize Orb Chat functionality
@@ -185,7 +211,7 @@ async function sendOrbMessage() {
 
         if (response && response.session_id) {
             orbSessionId = response.session_id;
-            localStorage.setItem('orbSessionId', orbSessionId);
+            localStorage.setItem(getOrbStorageKey(), orbSessionId);
         }
 
         if (response && response.response) {

--- a/services/zoe-ui/dist/js/zoe-orb.js
+++ b/services/zoe-ui/dist/js/zoe-orb.js
@@ -26,6 +26,16 @@ function getOrbStorageKey() {
 
 let orbSessionId = localStorage.getItem(getOrbStorageKey()) || null;
 
+// Lazily re-read the scoped key when auth may not have been ready at parse time.
+function _getOrbSessionId() {
+    if (orbSessionId) return orbSessionId;
+    // Try re-reading with the now-resolved user scope (auth may have loaded since parse).
+    const storedKey = getOrbStorageKey();
+    const stored = localStorage.getItem(storedKey);
+    if (stored) { orbSessionId = stored; }
+    return orbSessionId;
+}
+
 // Clear orb history when the user logs out.
 document.addEventListener('zoe:logout', function(e) {
     try {
@@ -77,11 +87,11 @@ function initOrbChat() {
     console.log('✅ Zoe orb initialized');
     
     // Pre-warm Hermes session for this orb so the first message is fast.
-    if (orbSessionId) {
+    if (_getOrbSessionId()) {
         var session = window.zoeAuth ? window.zoeAuth.getCurrentSession() : null;
         var warmHeaders = { 'Content-Type': 'application/json' };
         if (session && session.session_id) warmHeaders['X-Session-ID'] = session.session_id;
-        fetch('/api/chat/warm/' + encodeURIComponent(orbSessionId), {
+        fetch('/api/chat/warm/' + encodeURIComponent(_getOrbSessionId()), {
             method: 'POST', headers: warmHeaders
         }).catch(function() {});
     }
@@ -185,7 +195,7 @@ async function sendOrbMessage() {
             mode: 'orb_chat',
             page_context: { page: currentPage, url: location.pathname }
         };
-        if (orbSessionId) chatPayload.session_id = orbSessionId;
+        if (_getOrbSessionId()) chatPayload.session_id = _getOrbSessionId();
 
         var response;
         if (typeof apiRequest === 'function') {


### PR DESCRIPTION
## Security fixes

### ZOE-a95d2818 — People relationship visibility
**File:** `services/zoe-data/routers/people.py`
When `other_person_id` is supplied directly, the endpoint now fetches person B and raises **HTTP 403** if `person_b.user_id != current_user` and `person_b.visibility != 'family'`. Prevents users from linking arbitrary person IDs they don't own.

### ZOE-c6dfb266 — Field-schema management gated to admins
**File:** `services/zoe-data/routers/people.py`
Added `Depends(require_admin)` to the field-schema **create**, **update**, and **delete** endpoints. Non-admin users receive 403.

### ZOE-6868b97c — Kiosk auth bypass: sessionStorage instead of localStorage
**File:** `services/zoe-ui/dist/js/auth.js`
- Switched `zoe_kiosk` flag from `localStorage` → `sessionStorage` (tab-scoped, cleared on tab close).
- Added `localStorage.removeItem('zoe_kiosk')` on every `enforceAuth()` call to wipe stale keys from previous versions.

### ZOE-ebc18550 — Orb chat history scoped per user, cleared on logout
**Files:** `services/zoe-ui/dist/js/zoe-orb.js`, `services/zoe-ui/dist/js/widgets/core/zoe-orb.js`, `services/zoe-ui/dist/js/auth.js`
- Orb session IDs now stored under user-scoped keys: `orbSessionId_{user_id}` / `orbWidgetSessionId_{user_id}`.
- `auth.js` logout function now dispatches a `zoe:logout` DOM event with `user_id` in detail.
- Both orb files listen for `zoe:logout` and clear the user-scoped storage key (plus legacy unscoped key) and null out the in-memory session reference.