### PR TITLE
fix(zoe-data): Hermes auth headers + GEPA density metric docs

### DIFF
--- a/docs/guides/HERMES_OPTIMIZATION_PLAYBOOK.md
+++ b/docs/guides/HERMES_OPTIMIZATION_PLAYBOOK.md
@@ -249,13 +249,19 @@ instructional clarity, not real tool-use success, and the judge rewards longer/m
 complete answers — so GEPA reliably pads skills. The +20% growth gate is therefore
 essential, not cosmetic. Measured first runs (budget 80, ~$0.85 each):
 
-- `github-greptile-loop`: baseline 0.954 → 0.930 (−0.024), +72% growth → **rejected**.
-- `zoe-engineering`: baseline 0.779 → 0.970 (+0.191) but +79% growth → **rejected**.
+- `github-greptile-loop`: baseline 0.954 → 0.930 (−0.024 raw), +72% growth → **rejected**.
+- `zoe-engineering`: baseline 0.779 → 0.970 (+0.191 raw) but +79% growth → **rejected**
+  (including a subtly wrong “put every endpoint in chat.py” rule).
 
 Both correctly produced no merge. Treat positive holdout delta AND passing constraints as
-*necessary, not sufficient* — a human reviews every diff. To get a mergeable gain, fold
-concision into the signal (harder length penalty / instruct GEPA to preserve size), not
-just the post-gate.
+*necessary, not sufficient* — a human reviews every diff.
+
+**Density-adjusted metric (wired in `zoe_evolve.py`).** GEPA now optimizes
+`quality × (baseline_chars / current_chars)` instead of raw judge score alone, and
+feeds GEPA reflection text when the skill body grows. Holdout reports both raw and
+density scores; the weekly loop queues on **density** improvement only. Example on the
+`zoe-engineering` run above: raw +0.191 would have become density **−0.258** — GEPA would
+not treat bloat as a win.
 
 **Eval data / privacy.** Default and only path in the driver is `--eval-source synthetic`.
 Upstream's `sessiondb` mode would mine `~/.claude/history.jsonl`,

--- a/services/zoe-data/background_runner.py
+++ b/services/zoe-data/background_runner.py
@@ -20,18 +20,13 @@ from datetime import datetime, timezone
 
 import httpx
 
-logger = logging.getLogger(__name__)
+from hermes_http import hermes_auth_headers
 
-_HERMES_API_KEY = os.environ.get("HERMES_API_KEY") or os.environ.get("API_SERVER_KEY") or ""
+logger = logging.getLogger(__name__)
 
 
 def _hermes_headers(*, session_id: str | None = None) -> dict[str, str]:
-    headers: dict[str, str] = {}
-    if _HERMES_API_KEY:
-        headers["Authorization"] = f"Bearer {_HERMES_API_KEY}"
-    if session_id:
-        headers["X-Hermes-Session-Id"] = session_id
-    return headers
+    return hermes_auth_headers(session_id=session_id)
 
 # Running task futures keyed by task id (to avoid duplicate runs)
 _running: dict[int, asyncio.Task] = {}

--- a/services/zoe-data/hermes_http.py
+++ b/services/zoe-data/hermes_http.py
@@ -1,0 +1,23 @@
+"""Shared Hermes gateway HTTP helpers (auth headers for :8642 /v1/*)."""
+
+from __future__ import annotations
+
+import os
+
+
+def hermes_api_key() -> str:
+    return (
+        os.environ.get("HERMES_API_KEY")
+        or os.environ.get("API_SERVER_KEY")
+        or ""
+    ).strip()
+
+
+def hermes_auth_headers(*, session_id: str | None = None) -> dict[str, str]:
+    headers: dict[str, str] = {}
+    key = hermes_api_key()
+    if key:
+        headers["Authorization"] = f"Bearer {key}"
+    if session_id:
+        headers["X-Hermes-Session-Id"] = session_id
+    return headers

--- a/services/zoe-data/proactive/triggers/openclaw_trigger.py
+++ b/services/zoe-data/proactive/triggers/openclaw_trigger.py
@@ -18,18 +18,14 @@ from proactive.triggers.base import ProactiveTrigger, TriggerResult
 
 log = logging.getLogger(__name__)
 
+from hermes_http import hermes_auth_headers
+
 _HERMES_URL = os.environ.get("HERMES_API_URL", "http://127.0.0.1:8642/v1/chat/completions")
-_HERMES_API_KEY = os.environ.get("HERMES_API_KEY") or os.environ.get("API_SERVER_KEY") or ""
 _TIMEOUT = 30.0
 
 
 def _hermes_headers(*, session_id: str | None = None) -> dict[str, str]:
-    headers: dict[str, str] = {}
-    if _HERMES_API_KEY:
-        headers["Authorization"] = f"Bearer {_HERMES_API_KEY}"
-    if session_id:
-        headers["X-Hermes-Session-Id"] = session_id
-    return headers
+    return hermes_auth_headers(session_id=session_id)
 
 
 class OpenClawTrigger(ProactiveTrigger):

--- a/services/zoe-data/routers/system.py
+++ b/services/zoe-data/routers/system.py
@@ -1445,6 +1445,9 @@ async def _hermes_review_proposal(proposal: dict) -> tuple[bool, str]:
         f"Description: {proposal.get('description', '')}\n\n"
         f"Evidence: {proposal.get('evidence', '')}"
     )
+    from hermes_http import hermes_auth_headers
+
+    headers = {"Content-Type": "application/json", **hermes_auth_headers()}
     async with httpx.AsyncClient(timeout=90) as client:
         async with client.stream(
             "POST",
@@ -1454,7 +1457,7 @@ async def _hermes_review_proposal(proposal: dict) -> tuple[bool, str]:
                 "messages": [{"role": "user", "content": prompt}],
                 "stream": True,
             },
-            headers={"Content-Type": "application/json"},
+            headers=headers,
         ) as resp:
             resp.raise_for_status()
             content = ""

--- a/services/zoe-data/routers/system.py
+++ b/services/zoe-data/routers/system.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel
 
 from auth import get_current_user, require_admin, get_a2a_caller
 from database import get_db
+from hermes_http import hermes_auth_headers
 from openclaw_maintenance import (
     fetch_gateway_status,
     fetch_npm_latest_version,
@@ -1445,8 +1446,6 @@ async def _hermes_review_proposal(proposal: dict) -> tuple[bool, str]:
         f"Description: {proposal.get('description', '')}\n\n"
         f"Evidence: {proposal.get('evidence', '')}"
     )
-    from hermes_http import hermes_auth_headers
-
     headers = {"Content-Type": "application/json", **hermes_auth_headers()}
     async with httpx.AsyncClient(timeout=90) as client:
         async with client.stream(

--- a/services/zoe-data/routers/voice_tts.py
+++ b/services/zoe-data/routers/voice_tts.py
@@ -17,6 +17,7 @@ from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request, R
 from fastapi.responses import StreamingResponse
 from auth import get_current_user
 from database import get_db
+from hermes_http import hermes_auth_headers
 
 logger = logging.getLogger(__name__)
 
@@ -1775,8 +1776,6 @@ async def _run_hermes_voice_escalation(prompt: str, session_id: str, user_id: st
         "stream": False,
     }
     timeout_s = float(os.environ.get("ZOE_VOICE_HERMES_TIMEOUT_S", "45"))
-    from hermes_http import hermes_auth_headers
-
     async with httpx.AsyncClient(timeout=timeout_s) as client:
         resp = await client.post(
             hermes_url,

--- a/services/zoe-data/routers/voice_tts.py
+++ b/services/zoe-data/routers/voice_tts.py
@@ -1775,8 +1775,14 @@ async def _run_hermes_voice_escalation(prompt: str, session_id: str, user_id: st
         "stream": False,
     }
     timeout_s = float(os.environ.get("ZOE_VOICE_HERMES_TIMEOUT_S", "45"))
+    from hermes_http import hermes_auth_headers
+
     async with httpx.AsyncClient(timeout=timeout_s) as client:
-        resp = await client.post(hermes_url, json=payload)
+        resp = await client.post(
+            hermes_url,
+            json=payload,
+            headers=hermes_auth_headers(session_id=session_id),
+        )
         resp.raise_for_status()
         data = resp.json()
     return (data.get("choices") or [{}])[0].get("message", {}).get("content", "").strip()


### PR DESCRIPTION
## Summary
- Add `services/zoe-data/hermes_http.py` as the single source for Hermes gateway auth (`HERMES_API_KEY` / `API_SERVER_KEY`, optional `X-Hermes-Session-Id`).
- Wire all zoe-data Hermes callers through it: background runner, voice TTS escalation, system proposal review, and proactive OpenClaw trigger — fixing unauthenticated requests that returned 401.
- Document the density-adjusted GEPA metric in the Hermes optimization playbook (`quality × baseline_chars / current_chars`) so skill evolution cannot treat bloated variants as wins.

## Test plan
- [ ] `python3 tools/audit/validate_structure.py`
- [ ] `python3 tools/audit/validate_critical_files.py`
- [ ] Restart `zoe-data` and confirm voice Hermes escalation / background Hermes tasks no longer 401
- [ ] `curl -H "Authorization: Bearer $HERMES_API_KEY" http://127.0.0.1:8642/health` still OK from watchdog scripts


Made with [Cursor](https://cursor.com)