### PR TITLE
fix(push): add missing user_id param to broadcast()

### DIFF
--- a/services/zoe-data/push.py
+++ b/services/zoe-data/push.py
@@ -69,11 +69,22 @@ class PushBroadcaster:
                 self._connections["all"].discard(websocket)
         self._ws_users.pop(websocket, None)
 
-    async def broadcast(self, channel: str, event_type: str, data: dict) -> int:
+    async def broadcast(
+        self,
+        channel: str,
+        event_type: str,
+        data: dict,
+        user_id: str | None = None,
+    ) -> int:
         """Broadcast to all subscribers on a channel.
 
-        Returns the number of subscribers that received the message successfully.
-        Returns 0 if the channel has no connections or all sends failed.
+        Pass ``user_id`` to restrict delivery to connections owned by that
+        user.  Connections without an associated user (panels, anonymous) are
+        always included so that global events still reach them.
+
+        Returns the number of subscribers that received the message
+        successfully.  Returns 0 if the channel has no connections or all
+        sends failed.
         """
         self._sequence += 1
         message = {

--- a/services/zoe-data/tests/test_push_broadcast_user_id.py
+++ b/services/zoe-data/tests/test_push_broadcast_user_id.py
@@ -15,11 +15,10 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 from push import PushBroadcaster
 
 
-def _make_ws(user_id=None):
-    """Return a mock WebSocket with pre-registered user_id."""
+def _make_ws():
+    """Return a mock WebSocket; user_id mapping is tracked in broadcaster state."""
     ws = MagicMock()
     ws.send_json = AsyncMock()
-    ws._mock_user_id = user_id
     return ws
 
 

--- a/services/zoe-data/tests/test_push_broadcast_user_id.py
+++ b/services/zoe-data/tests/test_push_broadcast_user_id.py
@@ -1,0 +1,102 @@
+"""Unit tests for PushBroadcaster.broadcast() user_id scoping.
+
+Regression test for: push.py broadcast() missing user_id parameter.
+The method signature previously omitted user_id, causing TypeError on every
+scoped WS notification (reminders, notes, journal, lists, calendar, people,
+transactions).
+"""
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+import pytest
+
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from push import PushBroadcaster
+
+
+def _make_ws(user_id=None):
+    """Return a mock WebSocket with pre-registered user_id."""
+    ws = MagicMock()
+    ws.send_json = AsyncMock()
+    ws._mock_user_id = user_id
+    return ws
+
+
+@pytest.fixture
+def bc():
+    return PushBroadcaster()
+
+
+async def _connect(bc, ws, channel="test", user_id=None):
+    ws.accept = AsyncMock()
+    ws.send_json = AsyncMock()
+    await bc.connect(ws, channel=channel, user_id=user_id)
+    # reset the send_json call count after the connect ack
+    ws.send_json.reset_mock()
+
+
+# ── signature ────────────────────────────────────────────────────────────────
+
+def test_broadcast_accepts_user_id_kwarg():
+    """broadcast() must accept user_id as an optional keyword argument."""
+    import inspect
+    sig = inspect.signature(PushBroadcaster.broadcast)
+    assert "user_id" in sig.parameters, (
+        "broadcast() is missing user_id parameter — caller TypeError regression"
+    )
+    assert sig.parameters["user_id"].default is None
+
+
+# ── scoped delivery ───────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_broadcast_global_reaches_all(bc):
+    """Without user_id, broadcast reaches every connection on the channel."""
+    ws_a = _make_ws()
+    ws_b = _make_ws()
+    await _connect(bc, ws_a, channel="ch", user_id="u1")
+    await _connect(bc, ws_b, channel="ch", user_id="u2")
+
+    delivered = await bc.broadcast("ch", "evt", {}, user_id=None)
+    assert delivered == 2
+    ws_a.send_json.assert_awaited_once()
+    ws_b.send_json.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_broadcast_scoped_only_reaches_owner(bc):
+    """With user_id set, only connections for that user receive the message."""
+    ws_a = _make_ws()
+    ws_b = _make_ws()
+    await _connect(bc, ws_a, channel="ch", user_id="u1")
+    await _connect(bc, ws_b, channel="ch", user_id="u2")
+
+    delivered = await bc.broadcast("ch", "evt", {}, user_id="u1")
+    assert delivered == 1
+    ws_a.send_json.assert_awaited_once()
+    ws_b.send_json.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_broadcast_scoped_includes_anon_connections(bc):
+    """Connections with no user (panels/anonymous) always receive scoped broadcasts."""
+    ws_owner = _make_ws()
+    ws_anon = _make_ws()
+    ws_other = _make_ws()
+    await _connect(bc, ws_owner, channel="ch", user_id="u1")
+    await _connect(bc, ws_anon, channel="ch", user_id=None)
+    await _connect(bc, ws_other, channel="ch", user_id="u2")
+
+    delivered = await bc.broadcast("ch", "evt", {}, user_id="u1")
+    assert delivered == 2  # owner + anon
+    ws_owner.send_json.assert_awaited_once()
+    ws_anon.send_json.assert_awaited_once()
+    ws_other.send_json.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_broadcast_empty_channel_returns_zero(bc):
+    """broadcast() on an empty or missing channel returns 0."""
+    result = await bc.broadcast("nonexistent", "evt", {}, user_id="u1")
+    assert result == 0


### PR DESCRIPTION
## Summary

**Bug:** `PushBroadcaster.broadcast()` in `services/zoe-data/push.py` was missing `user_id: str | None = None` from its signature. 25+ callers across reminders, notes, journal, lists, calendar, people, and transactions all passed `user_id=user_id` as a keyword argument, causing a `TypeError` on every scoped WebSocket notification. The filtering guard on line 93 also referenced the name `user_id` without it being in scope.

**Impact:** Every real-time WS push for user-owned data (notes, reminders, calendar, journal, lists, people, transactions) silently failed or raised an unhandled exception. User-scoped delivery (data isolation via WS) was completely broken.

## Change

- Add `user_id: str | None = None` to `broadcast()` (one-line signature fix)
- Expand docstring to document scoped vs global delivery semantics

## Tests Added

`services/zoe-data/tests/test_push_broadcast_user_id.py` — 5 regression tests:
- `test_broadcast_accepts_user_id_kwarg` — signature guard
- `test_broadcast_global_reaches_all` — no user_id → all connections
- `test_broadcast_scoped_only_reaches_owner` — user_id scopes delivery
- `test_broadcast_scoped_includes_anon_connections` — panels/anon always included
- `test_broadcast_empty_channel_returns_zero`

All 5 pass. 272 pre-existing tests pass. 1 pre-existing unrelated failure unchanged.

## Multica
Issue: 742a7853-4fb7-4cf4-bee8-171e32b3c582