### PR TITLE
fix(test): patch _BOARD_REVIEW_AUTOPILOT_ENABLED in board-review skip test

### DIFF
--- a/services/zoe-data/tests/test_engineering_workflow.py
+++ b/services/zoe-data/tests/test_engineering_workflow.py
@@ -281,6 +281,10 @@ async def test_cancel_engineering_task_does_not_overwrite_done_workflow(monkeypa
 async def test_run_board_review_skips_autopilot_wrapper_issues(monkeypatch):
     calls = []
 
+    # Enable autopilot board review for this test (disabled by default; Hermes
+    # cron owns normal dispatch, but the test must exercise the skip logic).
+    monkeypatch.setattr(multica_autopilot_sync, "_BOARD_REVIEW_AUTOPILOT_ENABLED", True)
+
     class FakeClient:
         def is_configured(self):
             return True


### PR DESCRIPTION
## Summary

The test `test_run_board_review_skips_autopilot_wrapper_issues` was failing with `assert 0 == 1` because `_run_board_review()` returns early when `_BOARD_REVIEW_AUTOPILOT_ENABLED` is `False` (the production default — Hermes cron owns normal dispatch).

The test never patched this flag, so the skip-autopilot-wrapper logic was never reached.

## Fix
Added `monkeypatch.setattr(multica_autopilot_sync, '_BOARD_REVIEW_AUTOPILOT_ENABLED', True)` at the start of the test.

## Validation
- `pytest services/zoe-data/tests/test_engineering_workflow.py::test_run_board_review_skips_autopilot_wrapper_issues` ✅ PASSED
- Full test suite: 273 passed ✅
- `python3 tools/audit/validate_structure.py` ✅ PASSED

## Related
- ZOE-5281 already fixed in PR #101 (broadcast user_id param)
- This is a follow-up scan finding