### PR TITLE
fix(memory_service): narrow broad except Exception to ImportError on metrics import

### DIFF
--- a/services/zoe-data/memory_service.py
+++ b/services/zoe-data/memory_service.py
@@ -48,7 +48,8 @@ try:
         memory_pii_reject_count,
     )
     _METRICS_OK = True
-except Exception:  # pragma: no cover
+except ImportError:  # pragma: no cover
+    # memory_metrics is an optional instrumentation module; silently degrade.
     _METRICS_OK = False
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary

`memory_service.py` was using `except Exception` on the optional `memory_metrics` import block. This silently masks any non-missing-module error (SyntaxError, AttributeError) inside the module by setting `_METRICS_OK = False` with no log output.

## Fix
Changed to `except ImportError` — only the expected missing-module case degrades gracefully; all other exceptions propagate.

## Validation
- `python3 -m py_compile services/zoe-data/memory_service.py` ✅
- Memory test suite (37 tests): ✅ passed
- Full test suite: 273 passed ✅
- `python3 tools/audit/validate_structure.py` ✅

## Multica
Issue: `13304fd6-0949-473a-96fe-3f22b9270313`