### PR TITLE
fix(system_updates): wrap bare open() in with-statement (ZOE-5321/ZOE-5337)

### DIFF
--- a/services/zoe-data/system_updates.py
+++ b/services/zoe-data/system_updates.py
@@ -64,7 +64,8 @@ def invalidate_cache() -> None:
 def _read_local_version() -> str:
     """Read the installed Zoe platform version from the VERSION file."""
     try:
-        return open(VERSION_FILE, encoding="utf-8").read().strip()
+        with open(VERSION_FILE, encoding="utf-8") as fh:
+            return fh.read().strip()
     except OSError:
         return "dev"
 


### PR DESCRIPTION
## Summary
Fixes ZOE-5321 and ZOE-5337: `_read_local_version()` in `system_updates.py` used
a bare `open()` call without a context manager. If an exception occurred during
`.read()` or `.strip()`, the file descriptor would not be closed until GC ran,
potentially leaking file handles over time (especially relevant on resource-constrained
hardware like the Zoe Jetson host).

## Change
- **Before:** `return open(VERSION_FILE, encoding="utf-8").read().strip()`
- **After:** `with open(VERSION_FILE, encoding="utf-8") as fh: return fh.read().strip()`

## Tests
- Existing system_update test suite passes (3/3)
- Module imports and `_read_local_version()` executes correctly
- No logic change; pure resource management fix

## Issues closed
- ZOE-5321: Resource Leak: Unclosed file handle in `system_updates.py`
- ZOE-5337: `system_updates.py` uses bare `open()` for version file