### PR TITLE
fix(multica): Hermes board pipeline, blocked retry, and recovery scripts

### DIFF
--- a/docs/guides/MULTICA_HERMES_PR_LOOP.md
+++ b/docs/guides/MULTICA_HERMES_PR_LOOP.md
@@ -7,8 +7,10 @@ This workflow lets Zoe track engineering work from a Multica issue through Herme
 - `ZOE_MULTICA=true`
 - `MULTICA_BASE_URL`, `MULTICA_API_TOKEN`, and `MULTICA_WORKSPACE_ID`
 - `MULTICA_WEBHOOK_SECRET` for any webhook path that starts Hermes
-- `HERMES_MULTICA_AGENT_ID` set to the Hermes agent ID in Multica
+- `HERMES_MULTICA_AGENT_ID` set to the Hermes agent ID in Multica (or rely on [`agents_registry.yml`](../../services/zoe-data/agents_registry.yml))
+- `HERMES_API_KEY` or `API_SERVER_KEY` matching the Hermes gateway (`runtime_env.bootstrap_runtime_env()` loads service `.env`)
 - Hermes running on `HERMES_API_URL` or `http://127.0.0.1:8642`
+- Run `python3 scripts/maintenance/sync_hermes_env_from_zoe.py` once so `~/.hermes/.env` includes `MULTICA_*` for Hermes MCP subprocesses
 - GitHub auth available to Hermes through `gh` or `GITHUB_TOKEN`
 - Greptile auth through `GREPTILE_API_KEY` or `~/.config/zoe/greptile.env`
 
@@ -52,11 +54,44 @@ Expected state changes after approval/start:
 - `ready_for_human` when Greptile reports target confidence and no actionable findings.
 - `blocked` if Hermes reports `BLOCKER=...` or completes without a PR URL.
 
+## Board recovery rollout
+
+After deploying this PR on the Zoe host:
+
+1. `systemctl --user daemon-reload && systemctl --user restart zoe-data.service`
+2. `python3 scripts/maintenance/sync_hermes_env_from_zoe.py`
+3. `curl -sf -H "Authorization: Bearer $HERMES_API_KEY" http://127.0.0.1:8642/v1/models`
+4. Retry blocked workflows (Hermes HTTP 401 only):
+
+   ```bash
+   python3 scripts/maintenance/retry_blocked_engineering.py --dry-run --bucket http401
+   python3 scripts/maintenance/retry_blocked_engineering.py --limit 5 --bucket http401
+   ```
+
+5. Reassign open Self-Improvement issues:
+
+   ```bash
+   python3 scripts/maintenance/multica_reassign_open_to_hermes.py --dry-run
+   python3 scripts/maintenance/multica_reassign_open_to_hermes.py --execute
+   ```
+
+6. **Dispatcher:** Hermes cron `hourly-zoe-board-dispatch` (script `dispatch-hermes-board.sh`, 1 issue/hour) or manual:
+
+   ```bash
+   python3 scripts/maintenance/dispatch_hermes_board_batch.py --dry-run --limit 1
+   ```
+
+**Do not** run batch dispatch while many `background_tasks` are already `running`. Keep `ZOE_BOARD_REVIEW_AUTOPILOT_ENABLED=false`.
+
+**Still blocked after retry:** ~16 workflows with `dirty_tree` blockers need a clean git working tree before retry (`--bucket dirty_tree` is list-only).
+
+**Operator cron (outside repo):** disable Board Fix Progress Watcher; ensure Graphify refresh script path is valid under `~/.hermes/scripts/`.
+
 ## Local Verification
 
 ```bash
-python3 -m pytest services/zoe-data/tests/test_engineering_workflow.py -q
-python3 -m py_compile services/zoe-data/engineering_workflow.py services/zoe-data/greptile_client.py
+python3 -m pytest services/zoe-data/tests/test_engineering_workflow.py services/zoe-data/tests/test_multica_client.py services/zoe-data/tests/test_runtime_env.py -q
+python3 -m py_compile services/zoe-data/engineering_workflow.py services/zoe-data/multica_client.py services/zoe-data/runtime_env.py
 python3 tools/audit/validate_structure.py
 python3 tools/audit/validate_critical_files.py
 ```

--- a/scripts/maintenance/dispatch_hermes_board_batch.py
+++ b/scripts/maintenance/dispatch_hermes_board_batch.py
@@ -100,7 +100,7 @@ async def run(args: argparse.Namespace) -> int:
                 continue
 
             workflow = await create_and_start_engineering_task(
-                user_id="family-admin",
+                user_id=os.environ.get("ZOE_DISPATCH_USER", "family-admin"),
                 title=title,
                 task=(
                     f"Work this Hermes-assigned Multica issue.\n\n"

--- a/scripts/maintenance/dispatch_hermes_board_batch.py
+++ b/scripts/maintenance/dispatch_hermes_board_batch.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Start engineering workflows for Hermes-assigned Multica todos (controlled batch)."""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "services" / "zoe-data"))
+
+
+def _load_dotenv() -> None:
+    for path in (
+        ROOT / "services" / "zoe-data" / ".env",
+        ROOT / ".env",
+        Path.home() / ".hermes" / ".env",
+    ):
+        if not path.is_file():
+            continue
+        for line in path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, val = line.split("=", 1)
+            os.environ.setdefault(key.strip(), val.strip().strip('"').strip("'"))
+
+
+async def run(args: argparse.Namespace) -> int:
+    from runtime_env import bootstrap_runtime_env
+
+    bootstrap_runtime_env()
+    from db_pool import close_pool, get_db_ctx, init_pool
+    from engineering_workflow import create_and_start_engineering_task
+    from multica_client import get_engineering_multica_agent_id, get_multica_client
+
+    try:
+        await init_pool()
+    except Exception as exc:
+        print(f"Database pool initialisation failed: {exc}", file=sys.stderr)
+        return 1
+
+    hermes_id = get_engineering_multica_agent_id()
+    client = get_multica_client()
+    if not client.is_configured():
+        print("Multica not configured in Zoe env", file=sys.stderr)
+        return 1
+
+    try:
+        candidates: list[dict] = []
+        for status in ("todo", "in_progress"):
+            for issue in await client.list_issues(status=status) or []:
+                if str(issue.get("assignee_id") or "") != hermes_id:
+                    continue
+                title = issue.get("title") or issue.get("identifier") or ""
+                if title.lower().startswith("autopilot:"):
+                    continue
+                candidates.append(issue)
+
+        if not candidates:
+            print("No Hermes-assigned open issues to dispatch")
+            return 0
+
+        print(f"Found {len(candidates)} Hermes-assigned open issue(s)")
+        dispatched = 0
+        for issue in candidates:
+            if dispatched >= args.limit:
+                break
+            issue_id = str(issue.get("id") or "")
+            if not issue_id:
+                continue
+            async with get_db_ctx() as db:
+                existing = await db.fetchrow(
+                    """SELECT id, phase FROM engineering_tasks
+                       WHERE multica_issue_id=$1 AND phase NOT IN ('done', 'cancelled')
+                       ORDER BY updated_at DESC LIMIT 1""",
+                    issue_id,
+                )
+            if existing and existing.get("phase") in (
+                "queued",
+                "hermes_running",
+                "pr_open",
+                "greptile_wait",
+                "fixing",
+                "blocked",
+                "ready_for_human",
+            ):
+                ident = issue.get("identifier") or issue_id
+                print(f"SKIP {ident}: workflow {existing['id']} phase={existing['phase']}")
+                continue
+
+            title = issue.get("title") or issue.get("identifier") or "Multica engineering task"
+            description = issue.get("description") or ""
+            ident = issue.get("identifier") or issue_id
+            if args.dry_run:
+                print(f"DRY-RUN would dispatch {ident}: {title[:60]}")
+                dispatched += 1
+                continue
+
+            workflow = await create_and_start_engineering_task(
+                user_id="family-admin",
+                title=title,
+                task=(
+                    f"Work this Hermes-assigned Multica issue.\n\n"
+                    f"Title: {title}\n\n{description}"
+                ),
+                source="board_dispatch_batch",
+                source_id=issue_id,
+                multica_issue_id=issue_id,
+                idempotency_key=f"multica:{issue_id}",
+            )
+            print(f"OK {ident} -> workflow {workflow.get('id')} phase={workflow.get('phase')}")
+            dispatched += 1
+
+        print(f"Dispatched {dispatched} (limit={args.limit})")
+        return 0
+    finally:
+        await close_pool()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--limit", type=int, default=1, help="Max new workflows per run (default 1)")
+    args = parser.parse_args()
+    _load_dotenv()
+    return asyncio.run(run(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/maintenance/multica_reassign_open_to_hermes.py
+++ b/scripts/maintenance/multica_reassign_open_to_hermes.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Reassign open Multica issues from Self-Improvement Agent to Hermes."""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "services" / "zoe-data"))
+
+OPEN_STATUSES = ("todo", "in_progress", "in_review")
+
+
+def _load_dotenv() -> None:
+    for path in (
+        ROOT / "services" / "zoe-data" / ".env",
+        ROOT / ".env",
+        Path.home() / ".hermes" / ".env",
+    ):
+        if not path.is_file():
+            continue
+        for line in path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, val = line.split("=", 1)
+            os.environ.setdefault(key.strip(), val.strip().strip('"').strip("'"))
+
+
+async def run(args: argparse.Namespace) -> int:
+    from multica_client import (
+        get_engineering_multica_agent_id,
+        get_multica_client,
+        get_self_improvement_multica_agent_id,
+    )
+
+    client = get_multica_client()
+    if not client.is_configured():
+        print("Multica not configured", file=sys.stderr)
+        return 1
+
+    from_id = get_self_improvement_multica_agent_id()
+    to_id = get_engineering_multica_agent_id()
+    secret = os.environ.get("MULTICA_WEBHOOK_SECRET", "").strip()
+    if secret:
+        print(
+            "WARNING: MULTICA_WEBHOOK_SECRET is set — mass reassignment may trigger "
+            "webhook dispatch if Multica sends issue.assigned events."
+        )
+    else:
+        print("Preflight: MULTICA_WEBHOOK_SECRET unset — webhook auto-dispatch likely off")
+
+    print(f"From assignee: {from_id}")
+    print(f"To assignee:   {to_id}")
+
+    targets: list[dict] = []
+    for status in OPEN_STATUSES:
+        issues = await client.list_issues(status=status)
+        for issue in issues or []:
+            if str(issue.get("assignee_id") or "") != from_id:
+                continue
+            targets.append(issue)
+
+    if args.max:
+        targets = targets[: args.max]
+
+    print(f"Would reassign {len(targets)} issue(s) across {OPEN_STATUSES}")
+    for issue in targets[:20]:
+        ident = issue.get("identifier") or issue.get("id")
+        print(f"  - {ident}: {issue.get('title', '')[:60]}")
+    if len(targets) > 20:
+        print(f"  ... and {len(targets) - 20} more")
+
+    if args.dry_run or not args.execute:
+        if not args.execute:
+            print("Dry-run (pass --execute to apply)")
+        return 0
+
+    updated = 0
+    for issue in targets:
+        issue_id = str(issue.get("id") or "")
+        if not issue_id:
+            continue
+        result = await client.update_issue(
+            issue_id,
+            assignee_id=to_id,
+            assignee_type="agent",
+        )
+        if result.get("error"):
+            print(f"FAIL {issue.get('identifier') or issue_id}: {result['error']}", file=sys.stderr)
+        else:
+            updated += 1
+            print(f"OK {issue.get('identifier') or issue_id}")
+        if args.sleep_ms > 0:
+            await asyncio.sleep(args.sleep_ms / 1000.0)
+
+    print(f"Reassigned {updated}/{len(targets)}")
+    return 0 if updated == len(targets) else 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dry-run", action="store_true", help="List targets only")
+    parser.add_argument("--execute", action="store_true", help="Apply reassignments")
+    parser.add_argument("--max", type=int, default=0, help="Pilot cap (0 = all)")
+    parser.add_argument("--sleep-ms", type=int, default=200, help="Delay between updates")
+    args = parser.parse_args()
+    if args.execute and args.dry_run:
+        print("Use either --dry-run or --execute, not both", file=sys.stderr)
+        return 2
+    if not args.execute:
+        args.dry_run = True
+    _load_dotenv()
+    return asyncio.run(run(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/maintenance/retry_blocked_engineering.py
+++ b/scripts/maintenance/retry_blocked_engineering.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Retry blocked engineering_tasks workflows (401 bucket by default)."""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "services" / "zoe-data"))
+
+
+def _load_dotenv() -> None:
+    for path in (
+        ROOT / "services" / "zoe-data" / ".env",
+        ROOT / ".env",
+        Path.home() / ".hermes" / ".env",
+    ):
+        if not path.is_file():
+            continue
+        for line in path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, val = line.split("=", 1)
+            os.environ.setdefault(key.strip(), val.strip().strip('"').strip("'"))
+
+
+def _bucket_match(blocker: str | None, bucket: str) -> bool:
+    text = (blocker or "").lower()
+    if bucket == "http401":
+        return (
+            "401 unauthorized" in text
+            or "client error '401" in text
+            or ("401" in text and "127.0.0.1:8642" in text)
+        )
+    if bucket == "multica_auth":
+        return (
+            "multica not configured" in text
+            or "missing auth to multica" in text
+            or "multica board access is unavailable" in text
+        )
+    if bucket == "dirty_tree":
+        return "dirty" in text and "tree" in text
+    if bucket == "401":
+        # Legacy alias: Hermes HTTP 401 only (not Multica MCP auth).
+        return _bucket_match(blocker, "http401")
+    return True
+
+
+async def run(args: argparse.Namespace) -> int:
+    from runtime_env import bootstrap_runtime_env
+
+    bootstrap_runtime_env()
+    from db_pool import close_pool, get_db_ctx, init_pool
+    from engineering_workflow import retry_engineering_task
+
+    try:
+        await init_pool()
+    except Exception as exc:
+        print(f"Database pool initialisation failed: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        if args.bucket == "dirty_tree" and not args.force:
+            print(
+                "dirty_tree bucket: list-only (use --force to attempt retry after cleaning repo)"
+            )
+            list_only = True
+        else:
+            list_only = False
+
+        async with get_db_ctx() as db:
+            rows = await db.fetch(
+                """SELECT id, multica_issue_id, blocker_reason, phase
+                   FROM engineering_tasks
+                   WHERE phase = 'blocked'
+                   ORDER BY updated_at ASC"""
+            )
+
+        selected = []
+        for row in rows:
+            record = dict(row)
+            blocker = record.get("blocker_reason")
+            if not _bucket_match(blocker, args.bucket):
+                continue
+            selected.append(record)
+
+        if not selected:
+            print(f"No blocked workflows match bucket={args.bucket!r}")
+            return 0
+
+        print(f"Found {len(selected)} blocked workflow(s) for bucket={args.bucket!r}")
+        preview = selected[: args.limit] if args.limit else selected
+        for row in preview:
+            wid = row["id"]
+            ref = row.get("multica_issue_id") or "(no multica)"
+            blocker = (row.get("blocker_reason") or "")[:120]
+            print(f"  - {wid} multica={ref} blocker={blocker!r}")
+
+        if list_only:
+            return 0
+
+        to_run = selected[: args.limit] if args.limit else selected
+        if args.dry_run:
+            print(f"Dry-run: would retry {len(to_run)} workflow(s)")
+            return 0
+
+        ok = 0
+        for row in to_run:
+            wid = row["id"]
+            try:
+                updated = await retry_engineering_task(wid)
+                phase = updated.get("phase")
+                bt = updated.get("background_task_id")
+                print(f"OK {wid} -> phase={phase} background_task_id={bt}")
+                ok += 1
+            except Exception as exc:
+                print(f"FAIL {wid}: {exc}", file=sys.stderr)
+        print(f"Retried {ok}/{len(to_run)}")
+        return 0 if ok == len(to_run) else 1
+    finally:
+        await close_pool()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dry-run", action="store_true", help="Print targets only")
+    parser.add_argument("--limit", type=int, default=5, help="Max workflows to retry")
+    parser.add_argument(
+        "--bucket",
+        choices=("http401", "401", "dirty_tree", "multica_auth", "all"),
+        default="http401",
+        help="Filter bucket: http401, multica_auth, dirty_tree, all (401=http401 alias)",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Allow retry for dirty_tree (not recommended)",
+    )
+    args = parser.parse_args()
+    _load_dotenv()
+    return asyncio.run(run(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/maintenance/sync_hermes_env_from_zoe.py
+++ b/scripts/maintenance/sync_hermes_env_from_zoe.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Copy Zoe Multica/Hermes keys into ~/.hermes/.env when missing."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+ZOE_ENV = ROOT / "services" / "zoe-data" / ".env"
+HERMES_ENV = Path.home() / ".hermes" / ".env"
+
+SYNC_KEYS = (
+    "MULTICA_BASE_URL",
+    "MULTICA_API_TOKEN",
+    "MULTICA_WORKSPACE_ID",
+    "HERMES_API_KEY",
+    "API_SERVER_KEY",
+    "GITHUB_TOKEN",
+)
+
+
+def _parse_env(path: Path) -> dict[str, str]:
+    out: dict[str, str] = {}
+    if not path.is_file():
+        return out
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        key = key.strip()
+        if key:
+            out[key] = value.strip().strip('"').strip("'")
+    return out
+
+
+def main() -> int:
+    source = _parse_env(ZOE_ENV)
+    if not source:
+        print(f"No env at {ZOE_ENV}", file=sys.stderr)
+        return 1
+
+    existing_lines: list[str] = []
+    existing_keys: set[str] = set()
+    if HERMES_ENV.is_file():
+        for raw in HERMES_ENV.read_text(encoding="utf-8").splitlines():
+            existing_lines.append(raw)
+            line = raw.strip()
+            if line and not line.startswith("#") and "=" in line:
+                existing_keys.add(line.split("=", 1)[0].strip())
+
+    appended = []
+    for key in SYNC_KEYS:
+        value = source.get(key, "").strip()
+        if not value or key in existing_keys:
+            continue
+        appended.append(f"{key}={value}")
+        existing_keys.add(key)
+
+    if not appended:
+        print("Hermes .env already has required keys (nothing to add)")
+        return 0
+
+    HERMES_ENV.parent.mkdir(parents=True, exist_ok=True)
+    body = "\n".join(existing_lines)
+    if body and not body.endswith("\n"):
+        body += "\n"
+    body += "\n# Synced from Zoe zoe-data .env by sync_hermes_env_from_zoe.py\n"
+    body += "\n".join(appended) + "\n"
+    HERMES_ENV.write_text(body, encoding="utf-8")
+    print(f"Added {len(appended)} key(s) to {HERMES_ENV}: {', '.join(k.split('=')[0] for k in appended)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/zoe-data/engineering_workflow.py
+++ b/services/zoe-data/engineering_workflow.py
@@ -22,7 +22,7 @@ ACTIVE_PHASES = {
     "greptile_wait",
     "fixing",
 }
-TERMINAL_PHASES = {"ready_for_human", "done", "blocked", "cancelled"}
+NON_RETRYABLE_PHASES = {"done", "cancelled"}
 
 
 def _now() -> str:
@@ -89,6 +89,14 @@ async def create_engineering_task(
     if not task:
         raise ValueError("task is required")
     title = (title or task.splitlines()[0])[:160]
+    # Reject autopilot wrapper issues early so they never enter the engineering
+    # queue.  These are Multica tracker rows created by _fire_autopilot_job and
+    # have titles like "Autopilot: Board Review" — they carry no actionable
+    # engineering task and dispatching them causes recursive noise.
+    if title.lower().startswith("autopilot:"):
+        raise ValueError(
+            f"Autopilot wrapper issues must not be dispatched as engineering tasks: {title!r}"
+        )
     now = _now()
 
     async with get_db_ctx() as db:
@@ -102,10 +110,9 @@ async def create_engineering_task(
         if multica_issue_id:
             existing = await db.fetchrow(
                 """SELECT * FROM engineering_tasks
-                   WHERE multica_issue_id=$1 AND phase = ANY($2::text[])
+                   WHERE multica_issue_id=$1 AND phase NOT IN ('done', 'cancelled')
                    ORDER BY updated_at DESC LIMIT 1""",
                 multica_issue_id,
-                list(ACTIVE_PHASES),
             )
             if existing:
                 return dict(existing)
@@ -399,7 +406,7 @@ async def retry_engineering_task(task_id: str) -> dict[str, Any]:
     task = await get_engineering_task(task_id)
     if not task:
         raise ValueError(f"engineering task not found: {task_id}")
-    if task.get("phase") in TERMINAL_PHASES:
+    if task.get("phase") in NON_RETRYABLE_PHASES:
         return task
     round_count = int(task.get("round_count") or 0)
     max_rounds = int(task.get("max_rounds") or 5)

--- a/services/zoe-data/engineering_workflow.py
+++ b/services/zoe-data/engineering_workflow.py
@@ -22,7 +22,7 @@ ACTIVE_PHASES = {
     "greptile_wait",
     "fixing",
 }
-NON_RETRYABLE_PHASES = {"done", "cancelled"}
+NON_RETRYABLE_PHASES = {"ready_for_human", "done", "cancelled"}
 
 
 def _now() -> str:

--- a/services/zoe-data/hermes_http.py
+++ b/services/zoe-data/hermes_http.py
@@ -4,8 +4,11 @@ from __future__ import annotations
 
 import os
 
+from runtime_env import bootstrap_runtime_env
+
 
 def hermes_api_key() -> str:
+    bootstrap_runtime_env()
     return (
         os.environ.get("HERMES_API_KEY")
         or os.environ.get("API_SERVER_KEY")

--- a/services/zoe-data/main.py
+++ b/services/zoe-data/main.py
@@ -172,6 +172,19 @@ async def _runtime_health_refresh_loop() -> None:
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     global _openclaw_bg_task, _digest_bg_task, _zoe_update_bg_task, _consolidation_bg_task, _runtime_health_task
+    try:
+        from runtime_env import bootstrap_runtime_env  # type: ignore[import]
+        from hermes_http import hermes_api_key  # type: ignore[import]
+
+        bootstrap_runtime_env()
+        if not hermes_api_key():
+            logger.error(
+                "HERMES_API_KEY/API_SERVER_KEY missing after bootstrap — "
+                "engineering/Hermes background tasks may fail with 401"
+            )
+    except Exception as _env_exc:
+        logger.warning("runtime_env bootstrap (non-fatal): %s", _env_exc)
+
     logger.info("Initializing zoe-data database...")
     await init_db()
     logger.info("Database initialized. zoe-data is ready.")

--- a/services/zoe-data/mcp_server.py
+++ b/services/zoe-data/mcp_server.py
@@ -12,6 +12,10 @@ import httpx
 from datetime import date, datetime, timedelta
 import os
 
+from runtime_env import bootstrap_runtime_env
+
+bootstrap_runtime_env()
+
 OPENWEATHERMAP_API_KEY = os.environ.get("OPENWEATHERMAP_API_KEY", "")
 _BROADCAST_URL = "http://127.0.0.1:8000/api/internal/broadcast"
 _OPENCLAW_GW = os.environ.get("ZOE_OPENCLAW_GW", "http://127.0.0.1:18789")

--- a/services/zoe-data/multica_autopilot_sync.py
+++ b/services/zoe-data/multica_autopilot_sync.py
@@ -24,10 +24,10 @@ _MULTICA_API_TOKEN = os.environ.get("MULTICA_API_TOKEN", "")
 _MULTICA_WORKSPACE_ID = os.environ.get("MULTICA_WORKSPACE_ID", "")
 _TIMEOUT = 10.0
 _HEALTH_CHECK_TIMEOUT_S = float(os.environ.get("ZOE_HEALTH_CHECK_TIMEOUT_S", "120"))
-_HERMES_AGENT_ID = os.environ.get(
-    "HERMES_MULTICA_AGENT_ID",
-    "019ae0a7-62f1-47fe-9d46-75fd0ae5d570",
-)
+def _hermes_agent_id() -> str:
+    from multica_client import get_engineering_multica_agent_id  # type: ignore[import]
+
+    return get_engineering_multica_agent_id()
 _TZ = os.environ.get("ZOE_TIMEZONE", "Australia/Perth")
 
 # Default false: do not create a Multica tracker issue on every cron fire.
@@ -275,7 +275,7 @@ async def _run_platform_health_check() -> None:
                     f"```\n{tail}\n```"
                 ),
                 priority="high",
-                assignee_id=_HERMES_AGENT_ID,
+                assignee_id=_hermes_agent_id(),
                 assignee_type="agent",
             )
         except Exception as exc:
@@ -311,7 +311,7 @@ async def _run_board_review() -> None:
                 issue_id = str(issue.get("id") or "")
                 if not issue_id:
                     continue
-                if str(issue.get("assignee_id") or "") != _HERMES_AGENT_ID:
+                if str(issue.get("assignee_id") or "") != _hermes_agent_id():
                     continue
                 title = issue.get("title") or issue.get("identifier") or "Multica engineering task"
                 if title.lower().startswith("autopilot:"):

--- a/services/zoe-data/multica_client.py
+++ b/services/zoe-data/multica_client.py
@@ -21,6 +21,36 @@ import httpx
 logger = logging.getLogger(__name__)
 
 _TIMEOUT = 10.0
+_DEFAULT_HERMES_MULTICA_AGENT_ID = "019ae0a7-62f1-47fe-9d46-75fd0ae5d570"
+_SELF_IMPROVEMENT_MULTICA_AGENT_ID = "ee8596da-3a08-4e10-98e8-d058e57ea3ff"
+_cached_engineering_agent_id: str | None = None
+
+
+def get_engineering_multica_agent_id() -> str:
+    """Return the Multica agent UUID used for board engineering dispatch (Hermes)."""
+    global _cached_engineering_agent_id
+    env_id = os.environ.get("HERMES_MULTICA_AGENT_ID", "").strip()
+    if env_id:
+        return env_id
+    if _cached_engineering_agent_id:
+        return _cached_engineering_agent_id
+    try:
+        from zoe_agent_registry import load_agent_registry
+
+        registry = load_agent_registry()
+        hermes = (registry.get("agents") or {}).get("hermes") or {}
+        reg_id = str(hermes.get("multica_agent_id") or "").strip()
+        if reg_id:
+            _cached_engineering_agent_id = reg_id
+            return reg_id
+    except Exception as exc:
+        logger.debug("get_engineering_multica_agent_id: registry lookup failed: %s", exc)
+    return _DEFAULT_HERMES_MULTICA_AGENT_ID
+
+
+def get_self_improvement_multica_agent_id() -> str:
+    """Legacy Self-Improvement Agent UUID (reassign scripts filter from this)."""
+    return _SELF_IMPROVEMENT_MULTICA_AGENT_ID
 
 
 def _multica_env_key() -> tuple[str, str, str]:
@@ -220,7 +250,8 @@ async def sync_evolution_proposal_to_multica(
         logger.debug("Multica not configured — skipping sync_evolution_proposal")
         return None
 
-    agent_id, project_id = await _lookup_evolution_resources(client)
+    _agent_id, project_id = await _lookup_evolution_resources(client)
+    hermes_id = get_engineering_multica_agent_id()
 
     full_desc = description
     if evidence:
@@ -231,10 +262,9 @@ async def sync_evolution_proposal_to_multica(
         "description": full_desc,
         "status": "backlog",
         "priority": "medium",
+        "assignee_id": hermes_id,
+        "assignee_type": "agent",
     }
-    if agent_id:
-        payload["assignee_id"] = agent_id
-        payload["assignee_type"] = "agent"
     if project_id:
         payload["project_id"] = project_id
 

--- a/services/zoe-data/routers/system.py
+++ b/services/zoe-data/routers/system.py
@@ -1251,10 +1251,14 @@ async def board_approve(task_id: str, user: dict = Depends(require_admin)):
         client = MULClient()
         if not client.is_configured():
             return {"ok": False, "reason": "Multica not configured — route via Hermes manually"}
+        from multica_client import get_engineering_multica_agent_id  # type: ignore[import]
+
         issue = await client.create_issue(
             title=f"Task: {task_id}",
             description=f"Approved via Zoe chat. Task ID: {task_id}",
             priority="medium",
+            assignee_id=get_engineering_multica_agent_id(),
+            assignee_type="agent",
         )
         issue_id = issue.get("id") if isinstance(issue, dict) else None
         workflow = None
@@ -1353,8 +1357,9 @@ async def multica_webhook(request: Request):
                 "Multica webhook: %s issue=%s assignee=%s",
                 event, issue.get("identifier"), issue.get("assignee_id"),
             )
-            from multica_autopilot_sync import _HERMES_AGENT_ID as hermes_agent_id  # type: ignore[import]
-            if str(issue.get("assignee_id") or "") == hermes_agent_id:
+            from multica_client import get_engineering_multica_agent_id  # type: ignore[import]
+
+            if str(issue.get("assignee_id") or "") == get_engineering_multica_agent_id():
                 if not _multica_webhook_dispatch_allowed(request):
                     logger.warning(
                         "Multica webhook: skipped Hermes dispatch for issue=%s; webhook dispatch auth missing",

--- a/services/zoe-data/runtime_env.py
+++ b/services/zoe-data/runtime_env.py
@@ -7,15 +7,17 @@ from pathlib import Path
 
 _ENV_BOOTSTRAPPED = False
 
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
 # Order matters: service .env first, then repo root, then Hermes home.
 _ENV_FILES = (
-    "/home/zoe/assistant/services/zoe-data/.env",
-    "/home/zoe/assistant/.env",
-    "/home/zoe/.hermes/.env",
+    _REPO_ROOT / "services" / "zoe-data" / ".env",
+    _REPO_ROOT / ".env",
+    Path.home() / ".hermes" / ".env",
 )
 
 # Keys MCP/background workers need when spawned without systemd EnvironmentFile.
-_BOOTSTRAP_KEYS = (
+_BOOTSTRAP_KEYS = frozenset({
     "HERMES_API_KEY",
     "API_SERVER_KEY",
     "HERMES_API_URL",
@@ -24,11 +26,11 @@ _BOOTSTRAP_KEYS = (
     "MULTICA_WORKSPACE_ID",
     "POSTGRES_URL",
     "ZOE_INTERNAL_TOKEN",
-)
+})
 
 
 def bootstrap_runtime_env() -> None:
-    """Populate missing env vars from known Zoe/Hermes .env files."""
+    """Populate missing bootstrap keys from known Zoe/Hermes .env files."""
     global _ENV_BOOTSTRAPPED
     if _ENV_BOOTSTRAPPED:
         return
@@ -45,7 +47,7 @@ def bootstrap_runtime_env() -> None:
                     continue
                 key, value = line.split("=", 1)
                 key = key.strip()
-                if not key or key in os.environ:
+                if not key or key not in _BOOTSTRAP_KEYS or key in os.environ:
                     continue
                 os.environ[key] = value.strip().strip('"').strip("'")
         except OSError:

--- a/services/zoe-data/runtime_env.py
+++ b/services/zoe-data/runtime_env.py
@@ -1,0 +1,52 @@
+"""Load Zoe runtime secrets into os.environ for subprocess MCP workers."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+_ENV_BOOTSTRAPPED = False
+
+# Order matters: service .env first, then repo root, then Hermes home.
+_ENV_FILES = (
+    "/home/zoe/assistant/services/zoe-data/.env",
+    "/home/zoe/assistant/.env",
+    "/home/zoe/.hermes/.env",
+)
+
+# Keys MCP/background workers need when spawned without systemd EnvironmentFile.
+_BOOTSTRAP_KEYS = (
+    "HERMES_API_KEY",
+    "API_SERVER_KEY",
+    "HERMES_API_URL",
+    "MULTICA_BASE_URL",
+    "MULTICA_API_TOKEN",
+    "MULTICA_WORKSPACE_ID",
+    "POSTGRES_URL",
+    "ZOE_INTERNAL_TOKEN",
+)
+
+
+def bootstrap_runtime_env() -> None:
+    """Populate missing env vars from known Zoe/Hermes .env files."""
+    global _ENV_BOOTSTRAPPED
+    if _ENV_BOOTSTRAPPED:
+        return
+    _ENV_BOOTSTRAPPED = True
+
+    for path in _ENV_FILES:
+        env_path = Path(path)
+        if not env_path.is_file():
+            continue
+        try:
+            for raw in env_path.read_text(encoding="utf-8").splitlines():
+                line = raw.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                key, value = line.split("=", 1)
+                key = key.strip()
+                if not key or key in os.environ:
+                    continue
+                os.environ[key] = value.strip().strip('"').strip("'")
+        except OSError:
+            continue

--- a/services/zoe-data/tests/test_engineering_workflow.py
+++ b/services/zoe-data/tests/test_engineering_workflow.py
@@ -6,6 +6,8 @@ import pytest
 import engineering_workflow
 import multica_autopilot_sync
 
+_HERMES_TEST_AGENT_ID = "019ae0a7-62f1-47fe-9d46-75fd0ae5d570"
+
 
 def test_build_hermes_prompt_requires_pr_contract():
     prompt = engineering_workflow.build_hermes_prompt(
@@ -278,6 +280,88 @@ async def test_cancel_engineering_task_does_not_overwrite_done_workflow(monkeypa
 
 
 @pytest.mark.asyncio
+async def test_create_engineering_task_rejects_autopilot_wrapper_title():
+    with pytest.raises(ValueError, match="Autopilot wrapper"):
+        await engineering_workflow.create_engineering_task(
+            user_id="family-admin",
+            task="noop",
+            title="Autopilot: Board Review",
+        )
+
+
+@pytest.mark.asyncio
+async def test_retry_engineering_task_reopens_blocked(monkeypatch):
+    workflow = {
+        "id": "wf-blocked",
+        "phase": "blocked",
+        "round_count": 1,
+        "max_rounds": 5,
+        "blocker_reason": "401 Unauthorized",
+    }
+    started = {"id": "wf-blocked", "phase": "hermes_running", "background_task_id": 88}
+
+    class FakeDB:
+        async def execute(self, sql, *args):
+            assert "phase='queued'" in sql
+
+    class FakeCtx:
+        async def __aenter__(self):
+            return FakeDB()
+
+        async def __aexit__(self, *_):
+            return None
+
+    async def fake_get(task_id):
+        return workflow
+
+    async def fake_start(task_id):
+        return started
+
+    monkeypatch.setitem(sys.modules, "db_pool", types.SimpleNamespace(get_db_ctx=lambda: FakeCtx()))
+    monkeypatch.setattr(engineering_workflow, "get_engineering_task", fake_get)
+    monkeypatch.setattr(engineering_workflow, "start_engineering_task", fake_start)
+
+    updated = await engineering_workflow.retry_engineering_task("wf-blocked")
+
+    assert updated["phase"] == "hermes_running"
+
+
+@pytest.mark.asyncio
+async def test_create_engineering_task_dedupes_blocked_multica_issue(monkeypatch):
+    existing = {
+        "id": "wf-existing",
+        "phase": "blocked",
+        "multica_issue_id": "mc-99",
+        "task": "old",
+    }
+
+    class FakeDB:
+        async def fetchrow(self, sql, *args):
+            if "multica_issue_id=$1" in sql:
+                assert "phase NOT IN ('done', 'cancelled')" in sql
+                return existing
+            raise AssertionError(f"unexpected query: {sql}")
+
+    class FakeCtx:
+        async def __aenter__(self):
+            return FakeDB()
+
+        async def __aexit__(self, *_):
+            return None
+
+    monkeypatch.setitem(sys.modules, "db_pool", types.SimpleNamespace(get_db_ctx=lambda: FakeCtx()))
+
+    row = await engineering_workflow.create_engineering_task(
+        user_id="family-admin",
+        task="new attempt",
+        multica_issue_id="mc-99",
+    )
+
+    assert row["id"] == "wf-existing"
+    assert row["phase"] == "blocked"
+
+
+@pytest.mark.asyncio
 async def test_run_board_review_skips_autopilot_wrapper_issues(monkeypatch):
     calls = []
 
@@ -294,19 +378,19 @@ async def test_run_board_review_skips_autopilot_wrapper_issues(monkeypatch):
                 {
                     "id": "issue-autopilot",
                     "title": "Autopilot: Board Review",
-                    "assignee_id": multica_autopilot_sync._HERMES_AGENT_ID,
+                    "assignee_id": _HERMES_TEST_AGENT_ID,
                     "description": "Scheduled autopilot run for: Board Review",
                 },
                 {
                     "id": "issue-autopilot-upper",
                     "title": "AUTOPILOT: Daily Sync",
-                    "assignee_id": multica_autopilot_sync._HERMES_AGENT_ID,
+                    "assignee_id": _HERMES_TEST_AGENT_ID,
                     "description": "Scheduled autopilot run for: Daily Sync",
                 },
                 {
                     "id": "issue-real",
                     "title": "Fix board review recursion",
-                    "assignee_id": multica_autopilot_sync._HERMES_AGENT_ID,
+                    "assignee_id": _HERMES_TEST_AGENT_ID,
                     "description": "Investigate board review loop",
                 },
             ] if status == "todo" else []
@@ -317,7 +401,10 @@ async def test_run_board_review_skips_autopilot_wrapper_issues(monkeypatch):
     monkeypatch.setitem(
         sys.modules,
         "multica_client",
-        types.SimpleNamespace(get_multica_client=lambda: FakeClient()),
+        types.SimpleNamespace(
+            get_multica_client=lambda: FakeClient(),
+            get_engineering_multica_agent_id=lambda: _HERMES_TEST_AGENT_ID,
+        ),
     )
     monkeypatch.setitem(
         sys.modules,

--- a/services/zoe-data/tests/test_multica_client.py
+++ b/services/zoe-data/tests/test_multica_client.py
@@ -6,6 +6,18 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 import multica_client
 
 
+def test_get_engineering_multica_agent_id_prefers_env(monkeypatch):
+    monkeypatch.setenv("HERMES_MULTICA_AGENT_ID", "env-hermes-id")
+    multica_client._cached_engineering_agent_id = None
+    assert multica_client.get_engineering_multica_agent_id() == "env-hermes-id"
+
+
+def test_get_engineering_multica_agent_id_falls_back_to_registry(monkeypatch):
+    monkeypatch.delenv("HERMES_MULTICA_AGENT_ID", raising=False)
+    multica_client._cached_engineering_agent_id = None
+    assert multica_client.get_engineering_multica_agent_id() == "019ae0a7-62f1-47fe-9d46-75fd0ae5d570"
+
+
 def test_mul_client_reads_env_at_instantiation(monkeypatch):
     monkeypatch.setenv("MULTICA_BASE_URL", "https://multica.example/")
     monkeypatch.setenv("MULTICA_API_TOKEN", "token-1")

--- a/services/zoe-data/tests/test_multica_client.py
+++ b/services/zoe-data/tests/test_multica_client.py
@@ -12,7 +12,7 @@ def test_get_engineering_multica_agent_id_prefers_env(monkeypatch):
     assert multica_client.get_engineering_multica_agent_id() == "env-hermes-id"
 
 
-def test_get_engineering_multica_agent_id_falls_back_to_registry(monkeypatch):
+def test_get_engineering_multica_agent_id_falls_back_to_default(monkeypatch):
     monkeypatch.delenv("HERMES_MULTICA_AGENT_ID", raising=False)
     multica_client._cached_engineering_agent_id = None
     assert multica_client.get_engineering_multica_agent_id() == "019ae0a7-62f1-47fe-9d46-75fd0ae5d570"

--- a/services/zoe-data/tests/test_runtime_env.py
+++ b/services/zoe-data/tests/test_runtime_env.py
@@ -1,0 +1,16 @@
+import os
+
+import runtime_env
+
+
+def test_bootstrap_runtime_env_loads_hermes_key_from_service_env(monkeypatch, tmp_path):
+    env_file = tmp_path / "zoe-data.env"
+    env_file.write_text("HERMES_API_KEY=test-bootstrap-key\n", encoding="utf-8")
+    monkeypatch.setattr(runtime_env, "_ENV_FILES", (str(env_file),))
+    monkeypatch.delenv("HERMES_API_KEY", raising=False)
+    monkeypatch.delenv("API_SERVER_KEY", raising=False)
+    runtime_env._ENV_BOOTSTRAPPED = False
+
+    runtime_env.bootstrap_runtime_env()
+
+    assert os.environ.get("HERMES_API_KEY") == "test-bootstrap-key"

--- a/services/zoe-data/tests/test_runtime_env.py
+++ b/services/zoe-data/tests/test_runtime_env.py
@@ -14,3 +14,20 @@ def test_bootstrap_runtime_env_loads_hermes_key_from_service_env(monkeypatch, tm
     runtime_env.bootstrap_runtime_env()
 
     assert os.environ.get("HERMES_API_KEY") == "test-bootstrap-key"
+
+
+def test_bootstrap_runtime_env_skips_non_bootstrap_keys(monkeypatch, tmp_path):
+    env_file = tmp_path / "zoe-data.env"
+    env_file.write_text(
+        "HERMES_API_KEY=test-bootstrap-key\nDEBUG=true\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(runtime_env, "_ENV_FILES", (str(env_file),))
+    monkeypatch.delenv("HERMES_API_KEY", raising=False)
+    monkeypatch.delenv("DEBUG", raising=False)
+    runtime_env._ENV_BOOTSTRAPPED = False
+
+    runtime_env.bootstrap_runtime_env()
+
+    assert os.environ.get("HERMES_API_KEY") == "test-bootstrap-key"
+    assert "DEBUG" not in os.environ


### PR DESCRIPTION
## Summary

- **Hermes as board assignee:** `get_engineering_multica_agent_id()` (env → registry → default) wired through evolution sync, board approve, webhook, and autopilot paths.
- **Engineering workflow fixes:** `blocked` workflows are retryable again; dedupe on `multica_issue_id` includes non-terminal phases (prevents duplicate rows after reassignment).
- **Auth bootstrap:** `runtime_env.py` loads Zoe/Hermes `.env` for MCP and background Hermes calls; startup warns if API key is missing.
- **Autopilot guard:** reject `Autopilot:*` titles in `create_engineering_task` (complements board-review skip logic).
- **Maintenance scripts:** `retry_blocked_engineering.py`, `multica_reassign_open_to_hermes.py`, `dispatch_hermes_board_batch.py`, `sync_hermes_env_from_zoe.py`.
- **Docs:** [`docs/guides/MULTICA_HERMES_PR_LOOP.md`](docs/guides/MULTICA_HERMES_PR_LOOP.md) rollout and hazards.

## Host state (already applied on Jetson — not in this PR)

Operator steps were run on the live host before this PR:

- Reassigned **83** open Multica issues from Self-Improvement Agent → Hermes
- Retried **10** blocked workflows (5 Multica-auth + 5 HTTP-401) → `hermes_running` (background tasks 67–76)
- Synced `MULTICA_*` into `~/.hermes/.env`; Hermes cron `hourly-zoe-board-dispatch` enabled; Board Fix Watcher disabled

**Do not merge and immediately run `dispatch_hermes_board_batch.py --execute`** while many background tasks are still `running`.

## Post-merge operator checklist

1. `systemctl --user restart zoe-data.service`
2. `python3 scripts/maintenance/sync_hermes_env_from_zoe.py` (if not already done)
3. Retry remaining **http401** blockers only: `retry_blocked_engineering.py --limit 5 --bucket http401`
4. Hourly dispatch via Hermes cron (`dispatch-hermes-board.sh`, limit 1/hour) or manual dry-run first

## Still blocked (~20 workflows) — out of scope for code

| Bucket | ~count | Action |
|--------|--------|--------|
| **dirty_tree** | ~16 | Clean repo / remove `wt-*` worktrees; do **not** auto-retry (`--bucket dirty_tree` is list-only) |
| **multica_auth** | remainder | Should improve after `sync_hermes_env_from_zoe.py` + restart |
| Other | few | Manual triage |

## Test plan

- [x] `pytest services/zoe-data/tests/test_engineering_workflow.py services/zoe-data/tests/test_multica_client.py services/zoe-data/tests/test_runtime_env.py`
- [x] Pre-commit `validate_structure.py` / `validate_critical_files.py`
- [ ] After deploy: `curl -sf http://127.0.0.1:8000/health`
- [ ] After deploy: Hermes `GET /v1/models` with bearer succeeds
- [ ] `retry_blocked_engineering.py --dry-run --bucket http401` shows only HTTP-401 rows
- [ ] `dispatch_hermes_board_batch.py --dry-run --limit 1` skips issues with active workflows

## Out of scope

- `~/bin/zoe-tools-mcp.py` Multica env loading (operator host file; sync script covers Hermes `.env`)
- Completing 83 board todos in one PR
- Dirty-tree / worktree cleanup PR


Made with [Cursor](https://cursor.com)