### PR TITLE
feat(executor): Multica->Kanban executor seam (agnostic dispatch)

### DIFF
--- a/scripts/maintenance/sync_multica_to_kanban.py
+++ b/scripts/maintenance/sync_multica_to_kanban.py
@@ -72,17 +72,26 @@ async def run(args: argparse.Namespace) -> int:
         if not issue_id:
             continue
 
-        existing = await poll_ref(f"multica:{issue_id}")
-        if existing.get("found") and existing.get("status") in ("running", "blocked"):
-            print(f"SKIP {ident}: chain exists status={existing['status']}")
+        # Isolate each candidate: a Kanban CLI failure (missing hermes binary,
+        # non-zero exit) on one issue must not abort the whole batch and skip
+        # the remaining candidates. Mirrors the outer try/except that guards
+        # board_approve and the Multica webhook handler.
+        try:
+            existing = await poll_ref(f"multica:{issue_id}")
+            if existing.get("found") and existing.get("status") in ("running", "blocked"):
+                print(f"SKIP {ident}: chain exists status={existing['status']}")
+                continue
+
+            if args.dry_run:
+                print(f"DRY-RUN would dispatch {ident}: {(issue.get('title') or '')[:60]}")
+                dispatched += 1
+                continue
+
+            result = await dispatch_issue(issue)
+        except Exception as exc:  # noqa: BLE001 - one bad candidate must not abort the batch
+            print(f"ERROR {ident}: dispatch failed: {exc}", file=sys.stderr)
             continue
 
-        if args.dry_run:
-            print(f"DRY-RUN would dispatch {ident}: {(issue.get('title') or '')[:60]}")
-            dispatched += 1
-            continue
-
-        result = await dispatch_issue(issue)
         if not result.get("ok"):
             print(f"SKIP {ident}: {result.get('reason')}")
             continue

--- a/scripts/maintenance/sync_multica_to_kanban.py
+++ b/scripts/maintenance/sync_multica_to_kanban.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Sync Hermes-assigned Multica issues into Hermes Kanban chains (cheap DeepSeek).
+
+Replaces the old engineering_workflow/background_runner (Sonnet) dispatch path.
+For each Hermes-assigned ``todo`` Multica issue without an active Kanban chain,
+create an implement->review->closeout chain via the executor registry, then set
+the Multica issue to ``in_progress``.
+
+Idempotent: chains are keyed ``multica:{issue_id}:<phase>`` so re-runs are safe.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "services" / "zoe-data"))
+
+
+def _load_dotenv() -> None:
+    for path in (
+        ROOT / "services" / "zoe-data" / ".env",
+        ROOT / ".env",
+        Path.home() / ".hermes" / ".env",
+    ):
+        if not path.is_file():
+            continue
+        for line in path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, val = line.split("=", 1)
+            os.environ.setdefault(key.strip(), val.strip().strip('"').strip("'"))
+
+
+async def run(args: argparse.Namespace) -> int:
+    from runtime_env import bootstrap_runtime_env
+
+    bootstrap_runtime_env()
+    from executor_registry import dispatch_issue, poll_ref
+    from multica_client import get_engineering_multica_agent_id, get_multica_client
+
+    hermes_id = get_engineering_multica_agent_id()
+    client = get_multica_client()
+    if not client.is_configured():
+        print("Multica not configured in Zoe env", file=sys.stderr)
+        return 1
+
+    candidates: list[dict] = []
+    for issue in await client.list_issues(status="todo") or []:
+        if str(issue.get("assignee_id") or "") != str(hermes_id):
+            continue
+        title = (issue.get("title") or issue.get("identifier") or "")
+        if title.lower().startswith("autopilot:"):
+            continue
+        candidates.append(issue)
+
+    if not candidates:
+        print("No Hermes-assigned todo issues to dispatch")
+        return 0
+
+    print(f"Found {len(candidates)} Hermes-assigned todo issue(s)")
+    dispatched = 0
+    for issue in candidates:
+        if dispatched >= args.limit:
+            break
+        issue_id = str(issue.get("id") or "")
+        ident = issue.get("identifier") or issue_id
+        if not issue_id:
+            continue
+
+        existing = await poll_ref(f"multica:{issue_id}")
+        if existing.get("found") and existing.get("status") in ("running", "blocked"):
+            print(f"SKIP {ident}: chain exists status={existing['status']}")
+            continue
+
+        if args.dry_run:
+            print(f"DRY-RUN would dispatch {ident}: {(issue.get('title') or '')[:60]}")
+            dispatched += 1
+            continue
+
+        result = await dispatch_issue(issue)
+        if not result.get("ok"):
+            print(f"SKIP {ident}: {result.get('reason')}")
+            continue
+        try:
+            await client.update_issue(issue_id, status="in_progress")
+        except Exception as exc:  # noqa: BLE001 - best-effort status sync
+            print(f"WARN {ident}: could not set in_progress: {exc}", file=sys.stderr)
+        print(f"OK {ident} -> chain {result.get('chain')} (new={result.get('created')})")
+        dispatched += 1
+
+    print(f"Dispatched {dispatched} (limit={args.limit})")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument(
+        "--limit", type=int, default=1, help="Max new chains per run (default 1; respect kanban.max_in_progress)"
+    )
+    args = parser.parse_args()
+    _load_dotenv()
+    return asyncio.run(run(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/zoe-data/executor_registry.py
+++ b/services/zoe-data/executor_registry.py
@@ -34,6 +34,10 @@ def _adapter_for_assignee(assignee_id: str | None) -> Any | None:
 
 async def dispatch_issue(issue: dict) -> dict:
     """Dispatch a Multica issue to its executor. No-op result when unrouted."""
+    title = (issue.get("title") or issue.get("identifier") or "").strip()
+    if title.lower().startswith("autopilot:"):
+        # Autopilot wrapper issues are tracker artifacts, never engineering work.
+        return {"ok": False, "reason": "autopilot wrapper issue", "skipped": True}
     adapter = _adapter_for_assignee(issue.get("assignee_id"))
     if adapter is None:
         return {"ok": False, "reason": "no executor adapter for assignee", "skipped": True}

--- a/services/zoe-data/executor_registry.py
+++ b/services/zoe-data/executor_registry.py
@@ -1,0 +1,47 @@
+"""Executor adapter registry — routes Multica issues to a backend by assignee.
+
+Multica is the agnostic source of truth. Which executor runs an issue is
+selected by the issue's ``assignee_id`` here, so adding a new backend
+(OpenClaw, Codex, Cursor, ...) is a single new adapter + one mapping entry —
+no change to Zoe core. Today only the Hermes Kanban adapter is implemented.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from executors.kanban_adapter import KanbanAdapter
+
+logger = logging.getLogger(__name__)
+
+_kanban = KanbanAdapter()
+
+
+def _adapter_for_assignee(assignee_id: str | None) -> Any | None:
+    """Return the executor adapter for a Multica assignee, or None to skip.
+
+    Hermes (the engineering agent) -> Kanban adapter. Any other assignee
+    (OpenClaw fallback, unassigned, future agents without an adapter) returns
+    None so Zoe does not auto-dispatch it.
+    """
+    from multica_client import get_engineering_multica_agent_id  # type: ignore[import]
+
+    hermes_id = get_engineering_multica_agent_id()
+    if assignee_id and str(assignee_id) == str(hermes_id):
+        return _kanban
+    return None
+
+
+async def dispatch_issue(issue: dict) -> dict:
+    """Dispatch a Multica issue to its executor. No-op result when unrouted."""
+    adapter = _adapter_for_assignee(issue.get("assignee_id"))
+    if adapter is None:
+        return {"ok": False, "reason": "no executor adapter for assignee", "skipped": True}
+    return await adapter.dispatch(issue)
+
+
+async def poll_ref(external_ref: str, *, backend: str = "kanban") -> dict:
+    """Poll an external reference for its aggregate status."""
+    if backend == "kanban":
+        return await _kanban.poll(external_ref)
+    return {"found": False, "status": "not_found", "reason": f"unknown backend {backend}"}

--- a/services/zoe-data/executors/__init__.py
+++ b/services/zoe-data/executors/__init__.py
@@ -1,0 +1,10 @@
+"""Executor adapters for Multica-dispatched work.
+
+Multica is the agnostic source of truth for issues; each executor adapter
+knows how to run an issue on a specific backend (Hermes Kanban today;
+OpenClaw / Codex / Cursor are future drop-ins). Adapters implement a tiny
+contract so Zoe core stays backend-agnostic:
+
+    dispatch(issue) -> dict   # start work, return an external reference
+    poll(external_ref) -> dict  # report {status, pr_url, blocker}
+"""

--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -1,0 +1,268 @@
+"""Hermes Kanban executor adapter.
+
+Turns a Multica issue into a durable implement -> review -> closeout chain on
+the Hermes Kanban board, where cheap DeepSeek worker profiles do the work. All
+Kanban-specific behaviour lives here so it never leaks into Zoe core.
+
+Boundary: this shells the ``hermes kanban`` CLI (same SQLite DB the in-gateway
+dispatcher reads) rather than importing Hermes internals — keeping Zoe
+surface-agnostic.
+
+Worker profiles + pinned skills encode Zoe's agentic-engineering loop:
+  - implement (zoe-coder):  zoe-engineering, zoe-graphify, source-code-context,
+                            code-structure-cleanup  (graph-first, opensrc, lean)
+  - review    (zoe-reviewer): zoe-engineering           (verification gate)
+  - closeout  (zoe-planner):  github-greptile-loop      (grep-loop until merge-ready)
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import shutil
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+NAME = "kanban"
+
+# Phases of the per-issue chain, in order. Each maps to a worker profile and the
+# skills it must load. Keys double as the idempotency-key suffix (multica:{id}:<phase>).
+_CHAIN = (
+    (
+        "implement",
+        "zoe-coder",
+        ("zoe-engineering", "zoe-graphify", "source-code-context", "code-structure-cleanup"),
+    ),
+    ("review", "zoe-reviewer", ("zoe-engineering",)),
+    ("closeout", "zoe-planner", ("github-greptile-loop",)),
+)
+
+_ACTIVE_KANBAN_STATUSES = {"triage", "todo", "ready", "running", "blocked"}
+_TERMINAL_KANBAN_STATUSES = {"done", "archived"}
+
+
+def _hermes_bin() -> str:
+    """Locate the hermes CLI; honour HERMES_BIN override."""
+    override = os.environ.get("HERMES_BIN", "").strip()
+    if override:
+        return override
+    found = shutil.which("hermes")
+    if found:
+        return found
+    candidate = os.path.expanduser("~/.local/bin/hermes")
+    return candidate
+
+
+def _repo_root() -> str:
+    return os.environ.get("ZOE_REPO_ROOT", "/home/zoe/assistant")
+
+
+def _board() -> str:
+    return os.environ.get("ZOE_KANBAN_BOARD", "default")
+
+
+def _max_runtime() -> str:
+    return os.environ.get("ZOE_KANBAN_MAX_RUNTIME", "45m")
+
+
+class KanbanCLIError(RuntimeError):
+    """Raised when a hermes kanban CLI call fails."""
+
+
+class KanbanAdapter:
+    """Executor adapter backed by the Hermes Kanban board."""
+
+    name = NAME
+
+    async def _run(self, args: list[str], *, expect_json: bool = False) -> Any:
+        cmd = [_hermes_bin(), "kanban", "--board", _board(), *args]
+        env = dict(os.environ)
+        env.setdefault("HERMES_KANBAN_BOARD", _board())
+        proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            cwd=_repo_root(),
+            env=env,
+        )
+        out, err = await proc.communicate()
+        stdout = (out or b"").decode("utf-8", errors="replace").strip()
+        stderr = (err or b"").decode("utf-8", errors="replace").strip()
+        if proc.returncode != 0:
+            raise KanbanCLIError(
+                f"`hermes kanban {' '.join(args)}` exited {proc.returncode}: {stderr or stdout}"
+            )
+        if not expect_json:
+            return stdout
+        try:
+            return json.loads(stdout) if stdout else {}
+        except json.JSONDecodeError as exc:
+            raise KanbanCLIError(f"non-JSON output from kanban {args[0]}: {exc}: {stdout[:200]}")
+
+    def _build_body(self, phase: str, issue: dict, identifier: str) -> str:
+        title = issue.get("title") or identifier
+        description = issue.get("description") or ""
+        common = (
+            f"Multica issue: {identifier} (id {issue.get('id')})\n"
+            f"Repo: {_repo_root()}  |  Base branch: main  |  Workspace: git worktree\n\n"
+            f"Title: {title}\n\n{description}\n\n"
+        )
+        if phase == "implement":
+            return common + (
+                "You are the implementer (zoe-coder).\n"
+                "- Read the charter + graphify map first (graphify query/path/explain over raw grep).\n"
+                "- Use opensrc for any third-party library source before guessing APIs.\n"
+                "- Make the smallest reviewable change; do NOT rewrite existing functions into bloat;"
+                " reuse service-layer helpers.\n"
+                "- Validate: `python3 tools/audit/validate_structure.py` and focused tests for touched modules.\n"
+                "- Create a feature branch, commit verified changes, push, and open a small PR (do not merge).\n"
+                "- Stop and report BLOCKER=... for dirty tree, missing auth/secrets, destructive ops,"
+                " DB/docker changes needing approval, or ambiguous product decisions.\n\n"
+                "Final kanban handoff MUST include:\n"
+                "PR_URL=<url or blank>\nBLOCKER=<reason or blank>\nTESTS=<checks run>\nSUMMARY=<short>\n"
+                "Changed files + branch/worktree details for the reviewer."
+            )
+        if phase == "review":
+            return common + (
+                "You are the reviewer (zoe-reviewer). Verification-first — a task is not done until verified.\n"
+                "- Confirm the change is small and in scope.\n"
+                "- Run `validate_structure.py`, `validate_critical_files.py`, focused tests,"
+                " and live `/health` + `/api/system/status`.\n"
+                "- Do NOT approve if verification or the Greptile gate is unavailable; set the task blocked"
+                " with an explicit reason instead.\n"
+                "- Record findings (pass/fail/concern) and a merge-readiness verdict in your handoff."
+            )
+        # closeout
+        return common + (
+            "You are closeout (zoe-planner, orchestration only).\n"
+            "- Confirm the small PR exists; run the Greptile grep loop"
+            " (github-greptile-loop / greploop_guard.py --packet-only, <=3 rounds, target confidence 5).\n"
+            "- Only when CI is green, Greptile is clear, and the reviewer approved: update the Multica issue"
+            " to done with PR link + summary. Otherwise leave it in_progress/blocked with the reason.\n"
+            "Final handoff MUST include:\nPR_URL=<url>\nGREPTILE=<status>\nMULTICA=<updated? done/blocked>\nSUMMARY=<short>"
+        )
+
+    async def dispatch(self, issue: dict) -> dict:
+        """Create (idempotently) the implement->review->closeout chain for a Multica issue.
+
+        Returns {ok, external_ref, chain:{phase:task_id}, created:[phases]}.
+        """
+        issue_id = str(issue.get("id") or "").strip()
+        if not issue_id:
+            return {"ok": False, "reason": "issue has no id"}
+        identifier = issue.get("identifier") or issue.get("title") or issue_id
+        external_ref = f"multica:{issue_id}"
+
+        chain: dict[str, str] = {}
+        created: list[str] = []
+        parent: str | None = None
+        for phase, assignee, skills in _CHAIN:
+            args = [
+                "create",
+                self._title(phase, identifier, issue),
+                "--assignee",
+                assignee,
+                "--workspace",
+                "worktree",
+                "--idempotency-key",
+                f"{external_ref}:{phase}",
+                "--max-runtime",
+                _max_runtime(),
+                "--created-by",
+                "zoe-bridge",
+                "--body",
+                self._build_body(phase, issue, identifier),
+                "--json",
+            ]
+            for skill in skills:
+                args += ["--skill", skill]
+            if parent:
+                args += ["--parent", parent]
+            result = await self._run(args, expect_json=True)
+            task_id = (result or {}).get("id") or (result or {}).get("task", {}).get("id")
+            if not task_id:
+                raise KanbanCLIError(f"create returned no id for phase={phase}: {result}")
+            chain[phase] = task_id
+            if not (result or {}).get("deduplicated"):
+                created.append(phase)
+            parent = task_id
+
+        logger.info(
+            "kanban_adapter: dispatched %s -> chain=%s (new=%s)", identifier, chain, created
+        )
+        return {"ok": True, "external_ref": external_ref, "chain": chain, "created": created}
+
+    def _title(self, phase: str, identifier: str, issue: dict) -> str:
+        base = issue.get("title") or identifier
+        if phase == "implement":
+            return f"{identifier}: {base}"[:140]
+        if phase == "review":
+            return f"Review {identifier}"[:140]
+        return f"Closeout {identifier}"[:140]
+
+    async def poll(self, external_ref: str) -> dict:
+        """Report aggregate state of a chain by idempotency-key prefix.
+
+        Returns {found, status, phases:{phase:status}, pr_url, blocker}.
+        status is one of: running | blocked | done | not_found.
+        """
+        tasks = await self._run(["list", "--json"], expect_json=True)
+        rows = tasks if isinstance(tasks, list) else (tasks or {}).get("tasks", [])
+        prefix = f"{external_ref}:"
+        phases: dict[str, dict] = {}
+        for row in rows:
+            key = (row or {}).get("idempotency_key") or ""
+            if key.startswith(prefix):
+                phases[key[len(prefix):]] = row
+        if not phases:
+            return {"found": False, "status": "not_found", "phases": {}, "pr_url": None, "blocker": None}
+
+        statuses = {p: (r.get("status") or "") for p, r in phases.items()}
+        blocker = None
+        for p, r in phases.items():
+            if (r.get("status") or "") == "blocked":
+                blocker = r.get("block_reason") or f"{p} blocked"
+                break
+
+        closeout = phases.get("closeout", {})
+        if (closeout.get("status") or "") in _TERMINAL_KANBAN_STATUSES:
+            agg = "done"
+        elif blocker:
+            agg = "blocked"
+        else:
+            agg = "running"
+
+        return {
+            "found": True,
+            "status": agg,
+            "phases": statuses,
+            "pr_url": await self._extract_pr_url(phases),
+            "blocker": blocker,
+        }
+
+    async def _extract_pr_url(self, phases: dict[str, dict]) -> str | None:
+        """Pull a PR URL from the implement/closeout task summaries or comments."""
+        import re
+
+        pattern = re.compile(r"https://github\.com/[^/\s]+/[^/\s]+/pull/\d+")
+        for phase in ("closeout", "implement", "review"):
+            row = phases.get(phase)
+            if not row:
+                continue
+            task_id = row.get("id")
+            if not task_id:
+                continue
+            try:
+                detail = await self._run(["show", task_id, "--json"], expect_json=True)
+            except KanbanCLIError:
+                continue
+            haystacks = [json.dumps(detail.get("latest_summary") or "")]
+            for c in detail.get("comments", []) or []:
+                haystacks.append(str(c.get("body") or c.get("text") or ""))
+            for h in haystacks:
+                m = pattern.search(h)
+                if m:
+                    return m.group(0)
+        return None

--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -22,6 +22,7 @@ import logging
 import os
 import re
 import shutil
+from pathlib import Path
 from typing import Any
 
 logger = logging.getLogger(__name__)
@@ -57,7 +58,13 @@ def _hermes_bin() -> str:
 
 
 def _repo_root() -> str:
-    return os.environ.get("ZOE_REPO_ROOT", "/home/zoe/assistant")
+    env = os.environ.get("ZOE_REPO_ROOT", "").strip()
+    if env:
+        return env
+    # Derive the repo root from this file's location so non-standard deployments
+    # (different user/install path) work without ZOE_REPO_ROOT set:
+    # services/zoe-data/executors/kanban_adapter.py -> repo root is 3 levels up.
+    return str(Path(__file__).resolve().parents[3])
 
 
 def _board() -> str:
@@ -81,13 +88,18 @@ class KanbanAdapter:
         cmd = [_hermes_bin(), "kanban", "--board", _board(), *args]
         env = dict(os.environ)
         env.setdefault("HERMES_KANBAN_BOARD", _board())
-        proc = await asyncio.create_subprocess_exec(
-            *cmd,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            cwd=_repo_root(),
-            env=env,
-        )
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                cwd=_repo_root(),
+                env=env,
+            )
+        except OSError as exc:
+            raise KanbanCLIError(
+                f"`hermes kanban {' '.join(args)}` could not start: {exc}"
+            ) from exc
         out, err = await proc.communicate()
         stdout = (out or b"").decode("utf-8", errors="replace").strip()
         stderr = (err or b"").decode("utf-8", errors="replace").strip()

--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -20,6 +20,7 @@ import asyncio
 import json
 import logging
 import os
+import re
 import shutil
 from typing import Any
 
@@ -208,6 +209,10 @@ class KanbanAdapter:
         Returns {found, status, phases:{phase:status}, pr_url, blocker}.
         status is one of: running | blocked | done | not_found.
         """
+        # `hermes kanban list` has no idempotency-prefix filter flag, so we pull
+        # the board once and filter by prefix in Python. This is O(board size)
+        # per candidate; acceptable while the board is small. Revisit (push the
+        # filter into the CLI) if the board grows large enough to matter.
         tasks = await self._run(["list", "--json"], expect_json=True)
         rows = tasks if isinstance(tasks, list) else (tasks or {}).get("tasks", [])
         prefix = f"{external_ref}:"
@@ -244,8 +249,6 @@ class KanbanAdapter:
 
     async def _extract_pr_url(self, phases: dict[str, dict]) -> str | None:
         """Pull a PR URL from the implement/closeout task summaries or comments."""
-        import re
-
         pattern = re.compile(r"https://github\.com/[^/\s]+/[^/\s]+/pull/\d+")
         for phase in ("closeout", "implement", "review"):
             row = phases.get(phase)

--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -219,7 +219,12 @@ class KanbanAdapter:
         """Report aggregate state of a chain by idempotency-key prefix.
 
         Returns {found, status, phases:{phase:status}, pr_url, blocker}.
-        status is one of: running | blocked | done | not_found.
+        status is one of: running | blocked | done | partial | not_found.
+
+        ``partial`` means some but not all chain phases exist (e.g. a CLI error
+        interrupted chain creation). Callers treat it as re-dispatchable so the
+        idempotent ``dispatch`` can backfill the missing phases, rather than
+        leaving the chain wedged in ``running`` forever.
         """
         # `hermes kanban list` has no idempotency-prefix filter flag, so we pull
         # the board once and filter by prefix in Python. This is O(board size)
@@ -248,6 +253,11 @@ class KanbanAdapter:
             agg = "done"
         elif blocker:
             agg = "blocked"
+        elif len(phases) < len(_CHAIN):
+            # Some phases never got created (e.g. CLI error mid-chain). Report
+            # "partial" so the sync path re-dispatches and idempotently backfills
+            # the missing phases instead of skipping it as "running" forever.
+            agg = "partial"
         else:
             agg = "running"
 

--- a/services/zoe-data/routers/system.py
+++ b/services/zoe-data/routers/system.py
@@ -1244,14 +1244,14 @@ async def get_agent_board():
 
 @_agent_card_router.post("/board/approve")
 async def board_approve(task_id: str, user: dict = Depends(require_admin)):
-    """Create a Multica board issue for agent execution (Hermes by default)."""
+    """Create a Hermes-assigned Multica issue and dispatch it via the executor seam."""
     try:
-        from multica_client import MULClient  # type: ignore[import]
-        from engineering_workflow import create_and_start_engineering_task  # type: ignore[import]
+        from multica_client import MULClient, get_engineering_multica_agent_id  # type: ignore[import]
+        from executor_registry import dispatch_issue  # type: ignore[import]
+
         client = MULClient()
         if not client.is_configured():
             return {"ok": False, "reason": "Multica not configured — route via Hermes manually"}
-        from multica_client import get_engineering_multica_agent_id  # type: ignore[import]
 
         issue = await client.create_issue(
             title=f"Task: {task_id}",
@@ -1261,18 +1261,10 @@ async def board_approve(task_id: str, user: dict = Depends(require_admin)):
             assignee_type="agent",
         )
         issue_id = issue.get("id") if isinstance(issue, dict) else None
-        workflow = None
+        dispatch = None
         if issue_id:
-            workflow = await create_and_start_engineering_task(
-                user_id=user.get("user_id", "admin"),
-                title=f"Task: {task_id}",
-                task=f"Implement approved Zoe board task `{task_id}`. Open a PR and run Greptile review.",
-                source="board_approve",
-                source_id=task_id,
-                multica_issue_id=issue_id,
-                idempotency_key=f"board_approve:{task_id}",
-            )
-        return {"ok": True, "issue": issue, "engineering_task": workflow}
+            dispatch = await dispatch_issue(issue)
+        return {"ok": True, "issue": issue, "dispatch": dispatch}
     except Exception as exc:
         return {"ok": False, "reason": str(exc)}
 
@@ -1367,20 +1359,11 @@ async def multica_webhook(request: Request):
                     )
                     return {"ok": True, "dispatched": False, "reason": "dispatch auth required"}
                 try:
-                    from engineering_workflow import create_and_start_engineering_task  # type: ignore[import]
-                    issue_id = str(issue.get("id") or "")
-                    title = issue.get("title") or issue.get("identifier") or "Multica engineering task"
-                    description = issue.get("description") or ""
-                    if issue_id:
-                        await create_and_start_engineering_task(
-                            user_id="family-admin",
-                            title=title,
-                            task=f"Work this Hermes-assigned Multica issue.\n\nTitle: {title}\n\n{description}",
-                            source="multica_webhook",
-                            source_id=issue_id,
-                            multica_issue_id=issue_id,
-                            idempotency_key=f"multica:{issue_id}",
-                        )
+                    from executor_registry import dispatch_issue  # type: ignore[import]
+
+                    if str(issue.get("id") or ""):
+                        result = await dispatch_issue(issue)
+                        return {"ok": True, "dispatched": bool(result.get("ok")), "dispatch": result}
                 except Exception as dispatch_exc:
                     logger.warning("Multica webhook: Hermes dispatch failed: %s", dispatch_exc)
 

--- a/services/zoe-data/tests/test_executor_registry.py
+++ b/services/zoe-data/tests/test_executor_registry.py
@@ -35,6 +35,16 @@ async def test_skips_unassigned(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_skips_autopilot_wrapper_titles(monkeypatch):
+    monkeypatch.setenv("HERMES_MULTICA_AGENT_ID", "hermes-xyz")
+    out = await reg.dispatch_issue(
+        {"id": "4", "assignee_id": "hermes-xyz", "title": "Autopilot: Platform Health Check"}
+    )
+    assert out["ok"] is False
+    assert out.get("skipped") is True
+
+
+@pytest.mark.asyncio
 async def test_poll_unknown_backend():
     out = await reg.poll_ref("multica:1", backend="nope")
     assert out["found"] is False

--- a/services/zoe-data/tests/test_executor_registry.py
+++ b/services/zoe-data/tests/test_executor_registry.py
@@ -1,0 +1,40 @@
+"""Tests for the executor adapter registry routing."""
+import pytest
+
+import executor_registry as reg
+
+
+@pytest.mark.asyncio
+async def test_routes_hermes_assignee_to_kanban(monkeypatch):
+    monkeypatch.setenv("HERMES_MULTICA_AGENT_ID", "hermes-xyz")
+    captured = {}
+
+    async def _fake_dispatch(issue):
+        captured["issue"] = issue
+        return {"ok": True, "external_ref": "multica:1", "chain": {}, "created": []}
+
+    monkeypatch.setattr(reg._kanban, "dispatch", _fake_dispatch)
+    out = await reg.dispatch_issue({"id": "1", "assignee_id": "hermes-xyz", "title": "t"})
+    assert out["ok"] is True
+    assert captured["issue"]["id"] == "1"
+
+
+@pytest.mark.asyncio
+async def test_skips_non_hermes_assignee(monkeypatch):
+    monkeypatch.setenv("HERMES_MULTICA_AGENT_ID", "hermes-xyz")
+    out = await reg.dispatch_issue({"id": "2", "assignee_id": "someone-else", "title": "t"})
+    assert out["ok"] is False
+    assert out.get("skipped") is True
+
+
+@pytest.mark.asyncio
+async def test_skips_unassigned(monkeypatch):
+    monkeypatch.setenv("HERMES_MULTICA_AGENT_ID", "hermes-xyz")
+    out = await reg.dispatch_issue({"id": "3", "assignee_id": None, "title": "t"})
+    assert out["ok"] is False
+
+
+@pytest.mark.asyncio
+async def test_poll_unknown_backend():
+    out = await reg.poll_ref("multica:1", backend="nope")
+    assert out["found"] is False

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -89,6 +89,21 @@ async def test_poll_blocked_detected():
 
 
 @pytest.mark.asyncio
+async def test_poll_partial_chain_is_redispatchable():
+    # closeout phase never got created (e.g. CLI error mid-chain): must report
+    # "partial" (not "running") so the sync path re-dispatches instead of
+    # skipping the wedged chain forever.
+    rows = [
+        {"id": "t_i", "idempotency_key": "multica:u:implement", "status": "done"},
+        {"id": "t_r", "idempotency_key": "multica:u:review", "status": "running"},
+    ]
+    a = _FakeAdapter(list_rows=rows)
+    out = await a.poll("multica:u")
+    assert out["found"] is True
+    assert out["status"] == "partial"
+
+
+@pytest.mark.asyncio
 async def test_poll_done_and_pr_extracted():
     rows = [
         {"id": "t_i", "idempotency_key": "multica:u:implement", "status": "done"},

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -1,0 +1,107 @@
+"""Tests for the Hermes Kanban executor adapter (CLI mocked)."""
+import json
+
+import pytest
+
+import executors.kanban_adapter as ka
+
+
+class _FakeAdapter(ka.KanbanAdapter):
+    """KanbanAdapter with the CLI replaced by a scripted recorder."""
+
+    def __init__(self, list_rows=None, show_map=None):
+        self.calls = []
+        self._list_rows = list_rows or []
+        self._show_map = show_map or {}
+        self._create_seq = 0
+
+    async def _run(self, args, *, expect_json=False):
+        self.calls.append(args)
+        verb = args[0]
+        if verb == "create":
+            self._create_seq += 1
+            # idempotency-key arg lets us derive a stable id per phase
+            key = args[args.index("--idempotency-key") + 1]
+            return {"id": f"t_{key.split(':')[-1]}", "deduplicated": False}
+        if verb == "list":
+            return self._list_rows
+        if verb == "show":
+            return self._show_map.get(args[1], {"comments": [], "latest_summary": ""})
+        return ""
+
+
+@pytest.mark.asyncio
+async def test_dispatch_creates_three_linked_phases():
+    a = _FakeAdapter()
+    issue = {"id": "uuid-1", "identifier": "ZOE-9", "title": "Fix thing", "description": "do it"}
+    result = await a.dispatch(issue)
+    assert result["ok"] is True
+    assert result["external_ref"] == "multica:uuid-1"
+    assert set(result["chain"]) == {"implement", "review", "closeout"}
+    creates = [c for c in a.calls if c[0] == "create"]
+    assert len(creates) == 3
+    # review + closeout must be linked to a parent
+    assert "--parent" in creates[1]
+    assert "--parent" in creates[2]
+    # idempotency keys are phase-scoped
+    keys = [c[c.index("--idempotency-key") + 1] for c in creates]
+    assert keys == ["multica:uuid-1:implement", "multica:uuid-1:review", "multica:uuid-1:closeout"]
+
+
+@pytest.mark.asyncio
+async def test_dispatch_pins_expected_skills():
+    a = _FakeAdapter()
+    await a.dispatch({"id": "u", "identifier": "ZOE-1", "title": "t"})
+    creates = [c for c in a.calls if c[0] == "create"]
+    impl_skills = [creates[0][i + 1] for i, v in enumerate(creates[0]) if v == "--skill"]
+    closeout_skills = [creates[2][i + 1] for i, v in enumerate(creates[2]) if v == "--skill"]
+    assert "zoe-graphify" in impl_skills and "code-structure-cleanup" in impl_skills
+    assert "github-greptile-loop" in closeout_skills
+
+
+@pytest.mark.asyncio
+async def test_dispatch_requires_issue_id():
+    a = _FakeAdapter()
+    result = await a.dispatch({"identifier": "ZOE-2"})
+    assert result["ok"] is False
+
+
+@pytest.mark.asyncio
+async def test_poll_not_found():
+    a = _FakeAdapter(list_rows=[{"id": "t_x", "idempotency_key": "other:1:implement"}])
+    out = await a.poll("multica:uuid-1")
+    assert out["found"] is False
+    assert out["status"] == "not_found"
+
+
+@pytest.mark.asyncio
+async def test_poll_blocked_detected():
+    rows = [
+        {"id": "t_i", "idempotency_key": "multica:u:implement", "status": "blocked", "block_reason": "dirty tree"},
+        {"id": "t_r", "idempotency_key": "multica:u:review", "status": "todo"},
+        {"id": "t_c", "idempotency_key": "multica:u:closeout", "status": "todo"},
+    ]
+    a = _FakeAdapter(list_rows=rows)
+    out = await a.poll("multica:u")
+    assert out["found"] is True
+    assert out["status"] == "blocked"
+    assert "dirty tree" in out["blocker"]
+
+
+@pytest.mark.asyncio
+async def test_poll_done_and_pr_extracted():
+    rows = [
+        {"id": "t_i", "idempotency_key": "multica:u:implement", "status": "done"},
+        {"id": "t_r", "idempotency_key": "multica:u:review", "status": "done"},
+        {"id": "t_c", "idempotency_key": "multica:u:closeout", "status": "done"},
+    ]
+    show = {
+        "t_c": {
+            "latest_summary": "",
+            "comments": [{"body": "Merged via https://github.com/o/r/pull/42 — done"}],
+        }
+    }
+    a = _FakeAdapter(list_rows=rows, show_map=show)
+    out = await a.poll("multica:u")
+    assert out["status"] == "done"
+    assert out["pr_url"] == "https://github.com/o/r/pull/42"


### PR DESCRIPTION
## Summary

PR **1 of 3** in a sequential stack that consolidates Multica → Kanban execution. This is the foundation the next two PRs build on.

- Introduces `executor_registry` + `KanbanAdapter` (`services/zoe-data/executors/kanban_adapter.py`): runs the implement → review → closeout chain on DeepSeek profiles, with idempotency keys `multica:{id}:<phase>` and pinned `agentic-engineering` skills.
- Routes `POST /board/approve` and the Multica `issue.assigned` webhook through the executor seam (`executor_registry.dispatch_issue`) instead of the Sonnet `background_runner` engineering-task path, guarding against dispatching `Autopilot:*` wrapper issues.
- Adds `scripts/maintenance/sync_multica_to_kanban.py` (hourly Hermes cron entrypoint) and unit tests (`test_executor_registry.py`, `test_kanban_adapter.py`).

## Stack context

- **PR 1 (this):** executor seam + adapter + dispatch rewiring.
- PR 2: retire `engineering_tasks` (DB migration 0010, Multica as source of truth).
- PR 3: wire board webhooks for Hermes Kanban dispatch.

Each PR is gated on Greptile review before the next is prepared.

## Verification

- `py_compile`: executor_registry, executors/__init__, executors/kanban_adapter, routers/system, scripts/maintenance/sync_multica_to_kanban — all OK.
- `pytest tests/test_kanban_adapter.py tests/test_executor_registry.py` — 11 passed.
- `validate_critical_files.py` — passed (43/43).
- Self-contained: `sync_multica_to_kanban.py` imports `executor_registry` only (`dispatch_issue`, `poll_ref`); no references to `engineering_tasks` removal or `multica_webhook_emitter` (those belong to PR 2/PR 3).

## Test plan

- [ ] CI `validate` green
- [ ] Greptile review clear