### PR TITLE
fix(kanban): correlate poll() via zoe-ref body marker, not idempotency_key

### DIFF
--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -44,6 +44,26 @@ _CHAIN = (
 _ACTIVE_KANBAN_STATUSES = {"triage", "todo", "ready", "running", "blocked"}
 _TERMINAL_KANBAN_STATUSES = {"done", "archived"}
 
+# Matches the `zoe-ref: multica:{id}:{phase}` marker the adapter writes into each
+# task body at dispatch. Anchored to the start of a line so it never collides with
+# prose elsewhere in the body.
+_REF_MARKER_RE = re.compile(r"^zoe-ref:\s*(\S+)", re.MULTILINE)
+
+
+def _row_ref_key(row: dict) -> str:
+    """Correlate a Kanban list row back to its ``multica:{id}:{phase}`` ref.
+
+    The live ``hermes kanban list --json`` output does NOT expose the idempotency
+    key, so poll() cannot filter on it. We parse the ``zoe-ref:`` marker the adapter
+    writes into the task body instead. A top-level ``idempotency_key`` field is
+    preferred when present so this stays correct if a future CLI exposes it.
+    """
+    key = (row or {}).get("idempotency_key") or ""
+    if key:
+        return key
+    match = _REF_MARKER_RE.search((row or {}).get("body") or "")
+    return match.group(1) if match else ""
+
 
 def _hermes_bin() -> str:
     """Locate the hermes CLI; honour HERMES_BIN override."""
@@ -117,8 +137,14 @@ class KanbanAdapter:
     def _build_body(self, phase: str, issue: dict, identifier: str) -> str:
         title = issue.get("title") or identifier
         description = issue.get("description") or ""
+        # `zoe-ref:` is a machine marker that lets poll() correlate this task back
+        # to its Multica issue + phase. The live `hermes kanban list --json` output
+        # does NOT expose the idempotency key, so the body (which it does expose) is
+        # the durable correlation channel. Keep the value identical to the
+        # --idempotency-key so both stay in lockstep: multica:{id}:{phase}.
         common = (
             f"Multica issue: {identifier} (id {issue.get('id')})\n"
+            f"zoe-ref: multica:{issue.get('id')}:{phase}\n"
             f"Repo: {_repo_root()}  |  Base branch: main  |  Workspace: git worktree\n\n"
             f"Title: {title}\n\n{description}\n\n"
         )
@@ -226,16 +252,17 @@ class KanbanAdapter:
         idempotent ``dispatch`` can backfill the missing phases, rather than
         leaving the chain wedged in ``running`` forever.
         """
-        # `hermes kanban list` has no idempotency-prefix filter flag, so we pull
-        # the board once and filter by prefix in Python. This is O(board size)
-        # per candidate; acceptable while the board is small. Revisit (push the
-        # filter into the CLI) if the board grows large enough to matter.
+        # `hermes kanban list` has no idempotency-prefix filter flag (and does not
+        # even surface the idempotency key), so we pull the board once and correlate
+        # each row via _row_ref_key (the `zoe-ref:` body marker) in Python. This is
+        # O(board size) per candidate; acceptable while the board is small. Revisit
+        # (push the filter into the CLI) if the board grows large enough to matter.
         tasks = await self._run(["list", "--json"], expect_json=True)
         rows = tasks if isinstance(tasks, list) else (tasks or {}).get("tasks", [])
         prefix = f"{external_ref}:"
         phases: dict[str, dict] = {}
         for row in rows:
-            key = (row or {}).get("idempotency_key") or ""
+            key = _row_ref_key(row)
             if key.startswith(prefix):
                 phases[key[len(prefix):]] = row
         if not phases:

--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -140,11 +140,14 @@ class KanbanAdapter:
         # `zoe-ref:` is a machine marker that lets poll() correlate this task back
         # to its Multica issue + phase. The live `hermes kanban list --json` output
         # does NOT expose the idempotency key, so the body (which it does expose) is
-        # the durable correlation channel. Keep the value identical to the
-        # --idempotency-key so both stay in lockstep: multica:{id}:{phase}.
+        # the durable correlation channel. Strip the id the same way dispatch() does
+        # so the marker stays byte-identical to the --idempotency-key (otherwise a
+        # whitespace-padded id would desync the marker from external_ref and poll()
+        # would never match): multica:{id}:{phase}.
+        issue_id = str(issue.get("id") or "").strip()
         common = (
-            f"Multica issue: {identifier} (id {issue.get('id')})\n"
-            f"zoe-ref: multica:{issue.get('id')}:{phase}\n"
+            f"Multica issue: {identifier} (id {issue_id})\n"
+            f"zoe-ref: multica:{issue_id}:{phase}\n"
             f"Repo: {_repo_root()}  |  Base branch: main  |  Workspace: git worktree\n\n"
             f"Title: {title}\n\n{description}\n\n"
         )

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -49,6 +49,18 @@ async def test_dispatch_creates_three_linked_phases():
 
 
 @pytest.mark.asyncio
+async def test_dispatch_writes_zoe_ref_marker_into_body():
+    # poll() correlates on the `zoe-ref:` body marker because the live
+    # `hermes kanban list --json` output does not expose the idempotency key.
+    a = _FakeAdapter()
+    await a.dispatch({"id": "uuid-7", "identifier": "ZOE-7", "title": "t"})
+    creates = [c for c in a.calls if c[0] == "create"]
+    for phase, create in zip(("implement", "review", "closeout"), creates):
+        body = create[create.index("--body") + 1]
+        assert f"zoe-ref: multica:uuid-7:{phase}" in body
+
+
+@pytest.mark.asyncio
 async def test_dispatch_pins_expected_skills():
     a = _FakeAdapter()
     await a.dispatch({"id": "u", "identifier": "ZOE-1", "title": "t"})
@@ -101,6 +113,56 @@ async def test_poll_partial_chain_is_redispatchable():
     out = await a.poll("multica:u")
     assert out["found"] is True
     assert out["status"] == "partial"
+
+
+def _row(phase, status, **extra):
+    """A Kanban list row shaped like the real CLI: body marker, NO idempotency_key."""
+    return {
+        "id": f"t_{phase}",
+        "body": f"Multica issue: ZOE-9 (id uuid-9)\nzoe-ref: multica:uuid-9:{phase}\nTitle: x",
+        "status": status,
+        **extra,
+    }
+
+
+@pytest.mark.asyncio
+async def test_poll_correlates_via_body_marker_when_no_idempotency_key():
+    # Regression: live `hermes kanban list --json` rows have no idempotency_key,
+    # so correlation must fall back to the `zoe-ref:` body marker — otherwise the
+    # in_progress->done auto-advance never fires.
+    rows = [
+        _row("implement", "done"),
+        _row("review", "done"),
+        _row("closeout", "done"),
+    ]
+    a = _FakeAdapter(list_rows=rows)
+    out = await a.poll("multica:uuid-9")
+    assert out["found"] is True
+    assert out["status"] == "done"
+    assert out["phases"] == {"implement": "done", "review": "done", "closeout": "done"}
+
+
+@pytest.mark.asyncio
+async def test_poll_body_marker_blocked_detected():
+    rows = [
+        _row("implement", "blocked", block_reason="dirty tree"),
+        _row("review", "todo"),
+        _row("closeout", "todo"),
+    ]
+    a = _FakeAdapter(list_rows=rows)
+    out = await a.poll("multica:uuid-9")
+    assert out["status"] == "blocked"
+    assert "dirty tree" in out["blocker"]
+
+
+@pytest.mark.asyncio
+async def test_poll_ignores_rows_without_marker():
+    # Foreign tasks (other dispatchers) carry neither marker nor matching key.
+    rows = [{"id": "t_x", "body": "some unrelated task body", "status": "running"}]
+    a = _FakeAdapter(list_rows=rows)
+    out = await a.poll("multica:uuid-9")
+    assert out["found"] is False
+    assert out["status"] == "not_found"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- **Root cause (Finding 2):** `KanbanAdapter.poll()` correlated Kanban tasks back to a Multica issue by filtering `hermes kanban list --json` rows on `idempotency_key` — a field the live CLI output does **not** expose (confirmed: 0/159 rows carry it; `show --json` also omits it). So `poll_ref("multica:{id}")` always returned `not_found`, and the Zoe-side auto-advance of a Multica issue `in_progress -> done` (in `main.py`'s multica poll loop) never fired. Completion relied solely on the closeout worker updating Multica directly.
- **Fix (smallest correct, no external-CLI dependency):** dispatch now writes a stable `zoe-ref: multica:{id}:{phase}` marker into each task **body** (the body *is* exposed by `list --json`), and `poll()` correlates rows on that marker via a new `_row_ref_key()` helper. The marker value is kept identical to the `--idempotency-key` so they stay in lockstep. A top-level `idempotency_key` is still preferred when present, so this remains correct if a future CLI exposes it.
- Product policy stays in the adapter; change is surgical (no `_v2`/`_new`/backup files), touching only `kanban_adapter.py` + its tests.

## Files
- `services/zoe-data/executors/kanban_adapter.py` — add `zoe-ref:` body marker at dispatch; `_row_ref_key()` + marker-based correlation in `poll()`.
- `services/zoe-data/tests/test_kanban_adapter.py` — new tests for correlation via body marker (done/blocked/no-marker) using real-CLI-shaped rows, and assert dispatch writes the marker per phase.

## Test plan
- [x] `pytest tests/test_kanban_adapter.py tests/test_executor_registry.py tests/test_multica_webhook_emitter.py` → 18 passed
- [x] `tools/audit/validate_critical_files.py` → passed (43/43)
- [x] `tools/audit/validate_structure.py` → only pre-existing orphans under the untracked `wt-t_52c496d1/` worktree; unrelated to this change

Made with [Cursor](https://cursor.com)