### PR TITLE
fix(multica): reflect real runtime liveness into Multica registry

### DIFF
--- a/scripts/maintenance/multica_runtime_heartbeat.py
+++ b/scripts/maintenance/multica_runtime_heartbeat.py
@@ -133,9 +133,17 @@ def _update_runtime(provider: str, online: bool) -> tuple[bool, str]:
     ]
     try:
         res = subprocess.run(cmd, input=sql, capture_output=True, text=True, timeout=15)
-        if res.returncode == 0:
-            return True, res.stdout.strip()
-        return False, (res.stderr or res.stdout).strip()
+        if res.returncode != 0:
+            return False, (res.stderr or res.stdout).strip()
+        out = res.stdout.strip()
+        # psql prints the command tag "UPDATE <n>". A zero count means the
+        # WHERE clause matched no row — i.e. this provider/workspace pair has
+        # no seeded runtime to refresh. Surface that as a failure rather than
+        # reporting a phantom success, so a misconfigured provider name or
+        # workspace id is visible instead of silently no-op'ing forever.
+        if "UPDATE 0" in out:
+            return False, f"no runtime row matched (workspace={WORKSPACE_ID}, provider={provider})"
+        return True, out
     except Exception as exc:  # pragma: no cover - defensive
         return False, str(exc)
 

--- a/scripts/maintenance/multica_runtime_heartbeat.py
+++ b/scripts/maintenance/multica_runtime_heartbeat.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""multica_runtime_heartbeat.py — Reflect real local liveness into Multica's runtime registry.
+
+Why this exists
+---------------
+Multica's runtime registry (``agent_runtime`` rows) is normally fed by a Multica
+*daemon* that registers and then heartbeats over the daemon-authenticated API.
+Multica's sweeper flips an ``online`` row to ``offline`` once its ``last_seen_at``
+goes stale (``staleThresholdSeconds`` = 150s server-side).
+
+Zoe does NOT run a Multica daemon — the Zoe<->Multica pipeline talks to the
+*issues* REST API (executor_registry -> kanban_adapter), not the daemon/runtime
+protocol. The three Zoe runtime rows (openclaw-gateway, hermes-agent, Zoe Home
+Server) were seeded directly into the Multica DB by
+``scripts/setup/populate_multica.py`` with ``daemon_id = NULL``, so nothing ever
+heartbeats them and they permanently read "offline".
+
+This script closes that gap *honestly*: it probes the actual local processes and
+writes the truthful status (``online`` iff the process is really up) plus a fresh
+``last_seen_at`` directly into the Multica DB — the same channel
+``populate_multica.py`` already uses for these exact rows (POST /api/runtimes is
+405; PATCH only edits timezone/visibility). It is intended to run on a short
+systemd timer (< 150s cadence) so live runtimes stay online and dead ones flip
+offline within one tick.
+
+This is a cosmetic registry reflector. The Hermes Kanban execution pipeline does
+NOT depend on these rows; it exists so the Multica board shows reality.
+
+Usage
+-----
+    python3 scripts/maintenance/multica_runtime_heartbeat.py            # apply
+    python3 scripts/maintenance/multica_runtime_heartbeat.py --dry-run  # report only
+
+Env (read from .env, overridable by real env):
+    MULTICA_WORKSPACE_ID   workspace whose runtimes to refresh (required)
+    MULTICA_DB_CONTAINER   docker container running Multica's Postgres (default: zoe-database)
+    MULTICA_DB_USER        Postgres user (default: zoe)
+    MULTICA_DB_NAME        Postgres db   (default: multica)
+    ZOE_HEALTH_URL         Zoe health endpoint (default: http://localhost:8000/health)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import urllib.request
+from collections.abc import Callable
+from pathlib import Path
+
+_ENV_PATH = Path(__file__).resolve().parents[2] / ".env"
+
+
+def _load_env() -> dict[str, str]:
+    env: dict[str, str] = {}
+    if _ENV_PATH.exists():
+        for line in _ENV_PATH.read_text().splitlines():
+            line = line.strip()
+            if line and not line.startswith("#") and "=" in line:
+                k, _, v = line.partition("=")
+                env[k.strip()] = v.strip()
+    env.update(os.environ)
+    return env
+
+
+_ENV = _load_env()
+WORKSPACE_ID = _ENV.get("MULTICA_WORKSPACE_ID", "").strip()
+DB_CONTAINER = _ENV.get("MULTICA_DB_CONTAINER", "zoe-database").strip()
+DB_USER = _ENV.get("MULTICA_DB_USER", "zoe").strip()
+DB_NAME = _ENV.get("MULTICA_DB_NAME", "multica").strip()
+HEALTH_URL = _ENV.get("ZOE_HEALTH_URL", "http://localhost:8000/health").strip()
+
+
+def _proc_alive(pattern: str) -> bool:
+    """True if a process whose full command line matches ``pattern`` is running.
+
+    ``pgrep`` excludes its own PID, so the pattern appearing in this script's
+    arguments does not self-match.
+    """
+    try:
+        res = subprocess.run(
+            ["pgrep", "-f", pattern],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        return res.returncode == 0 and bool(res.stdout.strip())
+    except Exception:
+        return False
+
+
+def _zoe_alive() -> bool:
+    """True if the Zoe host API reports healthy."""
+    try:
+        with urllib.request.urlopen(HEALTH_URL, timeout=5) as resp:
+            if resp.status != 200:
+                return False
+            data = json.loads(resp.read().decode("utf-8", errors="replace") or "{}")
+            return str(data.get("status", "")).lower() == "ok"
+    except Exception:
+        return False
+
+
+# provider -> (human label, liveness probe). Keyed by the agent_runtime.provider
+# column so we update exactly the seeded Zoe rows and nothing else.
+_RUNTIMES: tuple[tuple[str, str, Callable[[], bool]], ...] = (
+    ("zoe", "Zoe Home Server", _zoe_alive),
+    ("hermes", "hermes-agent", lambda: _proc_alive("hermes gateway run")),
+    ("openclaw_gateway", "openclaw-gateway", lambda: _proc_alive("openclaw/dist/index.js gateway")),
+)
+
+
+def _update_runtime(provider: str, online: bool) -> tuple[bool, str]:
+    """Set status (+ bump last_seen_at when online) for one provider's row."""
+    status = "online" if online else "offline"
+    sql = (
+        "UPDATE agent_runtime "
+        "SET status = :'st', "
+        "    last_seen_at = CASE WHEN :'st' = 'online' THEN now() ELSE last_seen_at END, "
+        "    updated_at = now() "
+        "WHERE workspace_id = :'ws'::uuid AND provider = :'provider';"
+    )
+    # SQL is piped on stdin (not -c) so psql performs :'var' interpolation,
+    # which quotes/escapes each value safely server-side.
+    cmd = [
+        "docker", "exec", "-i", DB_CONTAINER,
+        "psql", "-U", DB_USER, "-d", DB_NAME,
+        "-v", "ON_ERROR_STOP=1",
+        "-v", f"ws={WORKSPACE_ID}",
+        "-v", f"provider={provider}",
+        "-v", f"st={status}",
+    ]
+    try:
+        res = subprocess.run(cmd, input=sql, capture_output=True, text=True, timeout=15)
+        if res.returncode == 0:
+            return True, res.stdout.strip()
+        return False, (res.stderr or res.stdout).strip()
+    except Exception as exc:  # pragma: no cover - defensive
+        return False, str(exc)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dry-run", action="store_true",
+        help="probe liveness and print intended status, but do not write to the DB",
+    )
+    args = parser.parse_args()
+
+    if not WORKSPACE_ID:
+        print("ERROR: MULTICA_WORKSPACE_ID not set (.env or env)", file=sys.stderr)
+        return 2
+
+    any_error = False
+    for provider, label, probe in _RUNTIMES:
+        online = bool(probe())
+        status = "online" if online else "offline"
+        if args.dry_run:
+            print(f"[dry-run] {label} ({provider}) -> {status}")
+            continue
+        ok, detail = _update_runtime(provider, online)
+        if ok:
+            print(f"{label} ({provider}) -> {status}")
+        else:
+            any_error = True
+            print(f"{label} ({provider}) -> {status} FAILED: {detail}", file=sys.stderr)
+
+    return 1 if any_error else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/setup/jetson/zoe-multica-heartbeat.service
+++ b/scripts/setup/jetson/zoe-multica-heartbeat.service
@@ -1,7 +1,10 @@
 [Unit]
 Description=Reflect Zoe runtime liveness into the Multica runtime registry
-After=network-online.target docker.service
-Wants=network-online.target
+# Installed as a `systemctl --user` unit. System-scope ordering targets
+# (docker.service, network-online.target) are not resolvable from the user
+# manager, so we deliberately omit them: the script fails gracefully if the
+# Multica DB container or Zoe API is briefly unavailable and the 60s timer
+# simply retries on the next tick.
 
 [Service]
 Type=oneshot

--- a/scripts/setup/jetson/zoe-multica-heartbeat.service
+++ b/scripts/setup/jetson/zoe-multica-heartbeat.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Reflect Zoe runtime liveness into the Multica runtime registry
+After=network-online.target docker.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+WorkingDirectory=/home/zoe/assistant
+ExecStart=/usr/bin/python3 /home/zoe/assistant/scripts/maintenance/multica_runtime_heartbeat.py
+StandardOutput=journal
+StandardError=journal
+TimeoutStartSec=60

--- a/scripts/setup/jetson/zoe-multica-heartbeat.timer
+++ b/scripts/setup/jetson/zoe-multica-heartbeat.timer
@@ -1,0 +1,13 @@
+[Unit]
+Description=Periodic Zoe->Multica runtime heartbeat (keeps live runtimes online)
+
+[Timer]
+# Cadence must stay below Multica's 150s stale threshold so live runtimes are
+# never falsely swept offline between beats (60s beat + <=30s sweep < 150s).
+OnBootSec=60s
+OnUnitActiveSec=60s
+AccuracySec=10s
+Unit=zoe-multica-heartbeat.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary
- The three Zoe runtime rows in Multica (`openclaw-gateway`, `hermes-agent`, `Zoe Home Server`) were seeded directly into Multica's DB with `daemon_id = NULL`. Multica's runtime registry is **daemon-fed** (heartbeat via daemon auth; the server sweeper flips `online`→`offline` after a 150s stale window). Zoe talks to Multica's **issues REST API** (executor_registry → kanban_adapter), not the daemon/runtime protocol, so nothing ever heartbeats those rows and they permanently read **offline** even while the gateways are up.
- The supported workspace APIs cannot fix this: `POST /api/runtimes` is 405 and `PATCH /api/runtimes/{id}` only edits `timezone`/`visibility` (status/last_seen are daemon-only). A real daemon would also create *duplicate* rows (upsert conflict key is `workspace_id, daemon_id, provider`; the seeds have `daemon_id NULL`).
- This adds a small, reversible **liveness reflector**: `scripts/maintenance/multica_runtime_heartbeat.py` probes the actual local processes (zoe `/health`, hermes gateway, openclaw gateway) and writes the **truthful** status + fresh `last_seen_at` via the same `docker exec … psql` channel `scripts/setup/populate_multica.py` already uses for these exact rows. SQL values are passed through psql `:'var'` interpolation (server-side quoting), scoped by `workspace_id` + `provider`.
- A user systemd timer (`zoe-multica-heartbeat.timer`, templates under `scripts/setup/jetson/`) beats every 60s — comfortably under the 150s sweeper window — so live runtimes stay `online` and dead ones flip `offline` within one tick.

This is a **cosmetic registry reflector**; the Hermes Kanban execution pipeline does not depend on these rows.

## Test plan
- [x] `--dry-run` reports `online` for all three while gateways/health are up.
- [x] Live run flips all three rows to `online` with fresh `last_seen_at` (verified via `GET /api/runtimes`).
- [x] systemd timer installed (`systemctl --user`), fires every 60s, service exits 0.
- [ ] Confirm runtimes remain `online` past the 150s sweeper window (timer keeps them fresh).
- [ ] Kill a gateway → row flips `offline` within one tick (manual spot-check optional).

Made with [Cursor](https://cursor.com)