### PR TITLE
Fix kanban worker GitHub auth (spawn env bridge)

### DIFF
--- a/docs/guides/KANBAN_GITHUB_AUTH.md
+++ b/docs/guides/KANBAN_GITHUB_AUTH.md
@@ -1,0 +1,61 @@
+# Kanban worker GitHub authentication
+
+Hermes kanban workers (`zoe-coder`, `zoe-reviewer`, `zoe-planner`) run terminal commands in a **profile-isolated** subprocess environment. Terminal tooling sets `HOME` to `{HERMES_HOME}/profiles/<profile>/home/`, which does **not** contain the operator's `gh` login state under `~/.config/gh/`.
+
+Symptoms when auth is missing:
+
+- `gh auth status` → "You are not logged into any GitHub hosts"
+- `git push -u origin HEAD` → exit 128 (HTTPS credential failure)
+- Worker handoff: `BLOCKER=Missing GitHub authentication`
+
+The host shell may be fully authenticated (`gh auth status` as the operator user) while workers still fail — that is expected without the bridge below.
+
+## Fix (Hermes spawn)
+
+Kanban dispatch injects the operator config directory into each worker spawn:
+
+```text
+XDG_CONFIG_HOME=${HOME}/.config   # gateway operator HOME, not profile HOME
+```
+
+Implemented in `~/.hermes/hermes-agent/hermes_cli/kanban_db.py` (`_inject_operator_github_config_env`, called from `_default_spawn`).
+
+After updating Hermes, restart the gateway:
+
+```bash
+systemctl --user restart hermes-agent.service
+```
+
+## Verify (no live dispatch)
+
+From the Zoe repo:
+
+```bash
+bash scripts/maintenance/verify_kanban_github_auth.sh zoe-coder
+```
+
+Optional second argument: path to an existing kanban worktree for `git push --dry-run`.
+
+## Operator prerequisites
+
+1. **Host `gh` login** (one-time, operator user):
+
+   ```bash
+   gh auth login
+   gh auth status
+   ```
+
+2. **Do not rely on `GH_TOKEN` in worker terminals.** Hermes intentionally blocks `GH_TOKEN` / `GITHUB_TOKEN` from terminal/execute_code child env (provider credential scrubbing). Use `gh auth login` on the host instead.
+
+3. **Non-standard HOME layouts:** if the gateway runs under a service user whose `HOME` is not where `gh` credentials live, set in `~/.config/systemd/user/hermes-agent.service` (or a drop-in):
+
+   ```ini
+   Environment=HERMES_OPERATOR_HOME=/path/to/operator/home
+   ```
+
+   Spawn derives `XDG_CONFIG_HOME=${HERMES_OPERATOR_HOME}/.config`. No secrets in unit files required when host `gh auth login` is used.
+
+## Related
+
+- Kanban adapter push/PR instructions: `services/zoe-data/executors/kanban_adapter.py`
+- Git credential helper in repo: `credential.helper = !gh auth git-credential` (works once `gh` sees the operator config via `XDG_CONFIG_HOME`)

--- a/docs/guides/KANBAN_GITHUB_AUTH.md
+++ b/docs/guides/KANBAN_GITHUB_AUTH.md
@@ -1,6 +1,6 @@
 # Kanban worker GitHub authentication
 
-Hermes kanban workers (`zoe-coder`, `zoe-reviewer`, `zoe-planner`) run terminal commands in a **profile-isolated** subprocess environment. Terminal tooling sets `HOME` to `{HERMES_HOME}/profiles/<profile>/home/`, which does **not** contain the operator's `gh` login state under `~/.config/gh/`.
+Hermes kanban workers (`zoe-coder`, `zoe-reviewer`, `zoe-planner`) run terminal commands in a **profile-isolated** subprocess environment. Terminal tooling sets worker `HOME` to `{HERMES_ROOT}/profiles/<profile>/home/` (where `HERMES_ROOT` is typically `~/.hermes`) and worker `HERMES_HOME` to the profile directory. That isolated `HOME` does **not** contain the operator's `gh` login state under `~/.config/gh/`.
 
 Symptoms when auth is missing:
 

--- a/scripts/maintenance/verify_kanban_github_auth.sh
+++ b/scripts/maintenance/verify_kanban_github_auth.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Simulate Hermes kanban worker subprocess auth (profile HOME isolation + XDG bridge).
+# Exit 0 when gh auth and git push --dry-run succeed in the worker-equivalent env.
+set -euo pipefail
+
+OPERATOR_HOME="${HERMES_OPERATOR_HOME:-${HOME:-/home/zoe}}"
+OPERATOR_CONFIG="${XDG_CONFIG_HOME:-${OPERATOR_HOME}/.config}"
+PROFILE="${1:-zoe-coder}"
+PROFILE_HOME="${HERMES_HOME:-${OPERATOR_HOME}/.hermes/profiles/${PROFILE}}/home"
+WORKTREE="${2:-${OPERATOR_HOME}/.worktrees/t_407dd148}"
+
+if [[ ! -d "${PROFILE_HOME}" ]]; then
+  echo "ERROR: profile home missing: ${PROFILE_HOME}" >&2
+  exit 1
+fi
+
+export HOME="${PROFILE_HOME}"
+export XDG_CONFIG_HOME="${OPERATOR_CONFIG}"
+export HERMES_HOME="${HERMES_HOME:-${OPERATOR_HOME}/.hermes/profiles/${PROFILE}}"
+export PATH="${OPERATOR_HOME}/.local/bin:${OPERATOR_HOME}/bin:/usr/local/bin:/usr/bin:/bin"
+
+echo "=== Worker-sim env ==="
+echo "HOME=${HOME}"
+echo "XDG_CONFIG_HOME=${XDG_CONFIG_HOME}"
+echo "HERMES_HOME=${HERMES_HOME}"
+echo
+
+echo "=== gh auth status ==="
+gh auth status
+echo
+
+if [[ -d "${WORKTREE}/.git" || -f "${WORKTREE}/.git" ]]; then
+  echo "=== git push --dry-run (${WORKTREE}) ==="
+  git -C "${WORKTREE}" push --dry-run origin HEAD
+else
+  echo "SKIP: worktree not found at ${WORKTREE} (gh auth check above is sufficient)"
+fi
+
+echo
+echo "OK: kanban worker GitHub auth simulation passed"

--- a/scripts/maintenance/verify_kanban_github_auth.sh
+++ b/scripts/maintenance/verify_kanban_github_auth.sh
@@ -6,8 +6,15 @@ set -euo pipefail
 OPERATOR_HOME="${HERMES_OPERATOR_HOME:-${HOME:-/home/zoe}}"
 OPERATOR_CONFIG="${XDG_CONFIG_HOME:-${OPERATOR_HOME}/.config}"
 PROFILE="${1:-zoe-coder}"
-PROFILE_HOME="${HERMES_HOME:-${OPERATOR_HOME}/.hermes/profiles/${PROFILE}}/home"
-WORKTREE="${2:-${OPERATOR_HOME}/.worktrees/t_407dd148}"
+# HERMES_HOME in worker spawn is profile-scoped; HERMES_ROOT is the hermes tree root (~/.hermes).
+HERMES_ROOT="${HERMES_ROOT:-${OPERATOR_HOME}/.hermes}"
+if [[ -n "${HERMES_HOME:-}" && -d "${HERMES_HOME}/profiles/${PROFILE}/home" ]]; then
+  HERMES_ROOT="${HERMES_HOME}"
+elif [[ -n "${HERMES_HOME:-}" && -d "${HERMES_HOME}/home" ]]; then
+  HERMES_ROOT="$(dirname "${HERMES_HOME}")"
+fi
+PROFILE_HOME="${HERMES_ROOT}/profiles/${PROFILE}/home"
+WORKTREE="${2:-}"
 
 if [[ ! -d "${PROFILE_HOME}" ]]; then
   echo "ERROR: profile home missing: ${PROFILE_HOME}" >&2
@@ -16,7 +23,7 @@ fi
 
 export HOME="${PROFILE_HOME}"
 export XDG_CONFIG_HOME="${OPERATOR_CONFIG}"
-export HERMES_HOME="${HERMES_HOME:-${OPERATOR_HOME}/.hermes/profiles/${PROFILE}}"
+export HERMES_HOME="${HERMES_ROOT}/profiles/${PROFILE}"
 export PATH="${OPERATOR_HOME}/.local/bin:${OPERATOR_HOME}/bin:/usr/local/bin:/usr/bin:/bin"
 
 echo "=== Worker-sim env ==="
@@ -33,7 +40,7 @@ if [[ -d "${WORKTREE}/.git" || -f "${WORKTREE}/.git" ]]; then
   echo "=== git push --dry-run (${WORKTREE}) ==="
   git -C "${WORKTREE}" push --dry-run origin HEAD
 else
-  echo "SKIP: worktree not found at ${WORKTREE} (gh auth check above is sufficient)"
+  echo "SKIP: no worktree path (pass as 2nd arg for git push --dry-run); gh auth check above is sufficient"
 fi
 
 echo

--- a/scripts/maintenance/verify_kanban_github_auth.sh
+++ b/scripts/maintenance/verify_kanban_github_auth.sh
@@ -8,12 +8,16 @@ OPERATOR_CONFIG="${XDG_CONFIG_HOME:-${OPERATOR_HOME}/.config}"
 PROFILE="${1:-zoe-coder}"
 # HERMES_HOME in worker spawn is profile-scoped; HERMES_ROOT is the hermes tree root (~/.hermes).
 HERMES_ROOT="${HERMES_ROOT:-${OPERATOR_HOME}/.hermes}"
+PROFILE_HOME=""
 if [[ -n "${HERMES_HOME:-}" && -d "${HERMES_HOME}/profiles/${PROFILE}/home" ]]; then
   HERMES_ROOT="${HERMES_HOME}"
 elif [[ -n "${HERMES_HOME:-}" && -d "${HERMES_HOME}/home" ]]; then
-  HERMES_ROOT="$(dirname "${HERMES_HOME}")"
+  PROFILE_HOME="${HERMES_HOME}/home"
+  HERMES_ROOT="$(dirname "$(dirname "${HERMES_HOME}")")"
 fi
-PROFILE_HOME="${HERMES_ROOT}/profiles/${PROFILE}/home"
+if [[ -z "${PROFILE_HOME}" ]]; then
+  PROFILE_HOME="${HERMES_ROOT}/profiles/${PROFILE}/home"
+fi
 WORKTREE="${2:-}"
 
 if [[ ! -d "${PROFILE_HOME}" ]]; then

--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -223,6 +223,7 @@ class KanbanAdapter:
         if not issue_id:
             return {"ok": False, "reason": "issue has no id"}
         identifier = issue.get("identifier") or issue.get("title") or issue_id
+        # external_ref prefix for idempotency keys; full key is "multica:{issue_id}:{phase}" (multica:{id}:<phase>).
         external_ref = f"multica:{issue_id}"
 
         chain: dict[str, str] = {}


### PR DESCRIPTION
## Summary
- Documents root cause: Hermes kanban workers run with profile-isolated `HOME` (`~/.hermes/profiles/<profile>/home/`) so `gh` cannot see operator credentials at `~/.config/gh/`.
- Hermes-side fix applied locally: `_default_spawn` now injects `XDG_CONFIG_HOME=${HOME}/.config` from the gateway operator (see `~/.hermes/hermes-agent/hermes_cli/kanban_db.py`); `hermes-agent.service` restarted on host.
- Adds operator guide and `scripts/maintenance/verify_kanban_github_auth.sh` to dry-run `gh auth status` + `git push --dry-run` in worker-equivalent env without enabling dispatch.

## Test plan
- [x] `bash scripts/maintenance/verify_kanban_github_auth.sh zoe-coder /home/zoe/.worktrees/t_407dd148` — gh auth OK, push dry-run OK
- [x] Hermes unit test `TestWorkerSpawnEnv::test_default_spawn_sets_env_vars` passes after spawn patch
- [ ] Greptile review
- [ ] Merge + no zoe-data redeploy needed (docs/script only; runtime fix is Hermes spawn)


Made with [Cursor](https://cursor.com)