### PR TITLE
feat(kanban): merge PR in closeout when Greptile and CI are green

### DIFF
--- a/docs/guides/MULTICA_HERMES_PR_LOOP.md
+++ b/docs/guides/MULTICA_HERMES_PR_LOOP.md
@@ -20,7 +20,7 @@ This workflow lets Zoe track engineering work from a Multica issue through Herme
 1. A user, API caller, authenticated Multica webhook (`issue.assigned`), board approval, or the Zoe poll bridge creates a Hermes Kanban chain (implement → review → closeout) on DeepSeek worker profiles.
 2. `zoe-coder` implements on a worktree, opens a small PR, and hands off with `PR_URL=`, `BLOCKER=`, `TESTS=`, `SUMMARY=`.
 3. `zoe-reviewer` runs verification-first checks (structure validators, focused tests, live health).
-4. `zoe-planner` closeout runs the Greptile grep loop (`github-greptile-loop`) and updates the Multica issue when merge-ready.
+4. `zoe-planner` closeout runs the Greptile grep loop (`github-greptile-loop`), squash-merges when Greptile + CI are green (`greploop_guard.py --merge-when-ready`), then updates the Multica issue to done with merge SHA.
 5. The Zoe poll loop advances Multica `in_progress` issues to `done` when the Kanban chain completes.
 
 ### Webhooks (how Multica talks to Zoe)
@@ -66,7 +66,7 @@ Expected Kanban chain progression (per Multica issue):
 
 - `implement` (`zoe-coder`) — small PR opened on a worktree.
 - `review` (`zoe-reviewer`) — verification-first checks; blocks merge if they fail.
-- `closeout` (`zoe-planner`) — Greptile grep loop, then Multica issue set to `done`.
+- `closeout` (`zoe-planner`) — Greptile grep loop, squash merge when ready, then Multica issue set to `done`.
 - The Zoe poll loop advances the Multica issue to `done` when the chain completes.
 
 ## Board rollout

--- a/scripts/maintenance/greploop_guard.py
+++ b/scripts/maintenance/greploop_guard.py
@@ -12,15 +12,40 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT / "services" / "zoe-data"))
 
-from greploop_guard import GuardError, read_guard_state, run_guard_once  # noqa: E402
+from greploop_guard import (  # noqa: E402
+    GuardError,
+    merge_pr_when_ready,
+    read_guard_state,
+    run_guard_once,
+)
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Run one Zoe Greploop guard iteration.")
+    parser = argparse.ArgumentParser(
+        description="Run one Zoe Greploop guard iteration or merge when ready.",
+        epilog=(
+            "Modes: --packet-only emits one cheap-model repair packet (no merge). "
+            "--once runs one guard iteration (fix packet or wait for Greptile). "
+            "--merge-when-ready squash-merges via `gh pr merge --squash` only when "
+            "Greptile confidence is met, comments are addressed, and CI is green "
+            "(never --admin, never force). Combine --once --merge-when-ready to "
+            "iterate once then merge if ready."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
     parser.add_argument("--pr", type=int, help="PR number to guard")
     parser.add_argument("--target-confidence", type=int, default=5, help="Greptile confidence to clear merge")
     parser.add_argument("--once", action="store_true", help="Run one bounded guard iteration")
-    parser.add_argument("--packet-only", action="store_true", help="Build packet and stop before model execution")
+    parser.add_argument(
+        "--packet-only",
+        action="store_true",
+        help="Build packet and stop before model execution (Cursor/cheap runners)",
+    )
+    parser.add_argument(
+        "--merge-when-ready",
+        action="store_true",
+        help="Squash-merge when READY (Greptile clear + CI green); optional after --once",
+    )
     parser.add_argument("--state", action="store_true", help="Print file-backed guard state")
     args = parser.parse_args()
 
@@ -30,12 +55,28 @@ def main() -> int:
         if args.state:
             print(json.dumps(read_guard_state(args.pr), indent=2, sort_keys=True))
             return 0
-        if not (args.once or args.packet_only):
-            parser.error("choose --once or --packet-only")
-        result = asyncio.run(
-            run_guard_once(args.pr, packet_only=args.packet_only, target_confidence=args.target_confidence)
-        )
-        print(json.dumps(result, indent=2, sort_keys=True))
+        if args.packet_only and args.merge_when_ready:
+            parser.error("--merge-when-ready is incompatible with --packet-only")
+        if not (args.once or args.packet_only or args.merge_when_ready):
+            parser.error("choose --once, --packet-only, and/or --merge-when-ready")
+        result: dict
+        if args.once or args.packet_only:
+            result = asyncio.run(
+                run_guard_once(
+                    args.pr,
+                    packet_only=args.packet_only,
+                    target_confidence=args.target_confidence,
+                )
+            )
+            print(json.dumps(result, indent=2, sort_keys=True))
+            if not result.get("ok") and not args.merge_when_ready:
+                return 2
+        if args.merge_when_ready:
+            merge_result = asyncio.run(
+                merge_pr_when_ready(args.pr, target_confidence=args.target_confidence)
+            )
+            print(json.dumps(merge_result, indent=2, sort_keys=True))
+            return 0 if merge_result.get("ok") else 2
         return 0 if result.get("ok") else 2
     except GuardError as exc:
         print(json.dumps({"ok": False, "error": str(exc)}, indent=2, sort_keys=True))

--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -12,7 +12,7 @@ Worker profiles + pinned skills encode Zoe's agentic-engineering loop:
   - implement (zoe-coder):  zoe-engineering, zoe-graphify, source-code-context,
                             code-structure-cleanup  (graph-first, opensrc, lean)
   - review    (zoe-reviewer): zoe-engineering           (verification gate)
-  - closeout  (zoe-planner):  github-greptile-loop      (grep-loop until merge-ready)
+  - closeout  (zoe-planner):  github-greptile-loop      (grep-loop, merge, Multica done)
 """
 from __future__ import annotations
 
@@ -203,15 +203,25 @@ class KanbanAdapter:
             "You are closeout (zoe-planner, orchestration only).\n"
             "- Read the implementer's PR_URL handoff and extract the PR number N (the trailing /pull/N)."
             " If no PR was pushed/opened, leave the issue blocked with that reason — do NOT open one yourself.\n"
-            "- Drive the Greptile grep loop with the pinned github-greptile-loop skill, using EXACTLY"
-            " (the guard REQUIRES --pr N; <=3 rounds, target confidence 5):\n"
-            "    python3 scripts/maintenance/greploop_guard.py --pr N --packet-only\n"
+            "- Address every substantive Greptile finding (fix_now or won't_fix with reason). Do not stop at"
+            " merge-ready — merge when gates pass.\n"
+            "- Drive the Greptile grep loop with the pinned github-greptile-loop skill (guard REQUIRES --pr N;"
+            " <=5 rounds, target confidence 5). Each round:\n"
+            "    python3 scripts/maintenance/greploop_guard.py --pr N --once\n"
+            "  Apply fixes yourself when the guard returns ESCALATE_HERMES or PACKET_READY; use --packet-only"
+            " only to hand off to a cheap Cursor runner.\n"
             "  Re-trigger review when needed via"
             f" `{_greptile_mcp_bin()} trigger-review jason-easyazz/zoe-ai-assistant N`"
             " (operator-local binary; override with GREPTILE_MCP_BIN).\n"
-            "- Only when CI is green, Greptile is clear, and the reviewer approved: update the Multica issue"
-            " to done with PR link + summary. Otherwise leave it in_progress/blocked with the reason.\n"
-            "Final handoff MUST include:\nPR_URL=<url>\nGREPTILE=<status>\nMULTICA=<updated? done/blocked>\nSUMMARY=<short>"
+            "- When Greptile is clear (confidence 5/5, no unaddressed findings) and CI is green, squash-merge"
+            " via normal GitHub (never --admin, never force, never --no-verify):\n"
+            "    python3 scripts/maintenance/greploop_guard.py --pr N --merge-when-ready\n"
+            "  Or one iteration then merge: --once --merge-when-ready\n"
+            "  If branch protection blocks merge, leave the issue blocked with the gh error — do not admin-merge.\n"
+            "- After a successful merge: update the Multica issue to done with PR_URL, merge SHA, GREPTILE status,"
+            " and summary. If merge did not happen, leave in_progress/blocked with the blocker.\n"
+            "Final handoff MUST include:\nPR_URL=<url>\nMERGE_SHA=<sha or blank>\nGREPTILE=<status>\n"
+            "MULTICA=<updated? done/blocked>\nSUMMARY=<short>"
         )
 
     async def dispatch(self, issue: dict) -> dict:

--- a/services/zoe-data/greploop_guard.py
+++ b/services/zoe-data/greploop_guard.py
@@ -31,6 +31,7 @@ SAME_ERROR_LIMIT = int(os.environ.get("ZOE_PR_GUARD_SAME_ERROR_LIMIT", "3"))
 MAX_COST_USD = float(os.environ.get("ZOE_PR_GUARD_MAX_COST_USD", "0.25"))
 MAX_OUTPUT_CHARS = int(os.environ.get("ZOE_PR_GUARD_MAX_OUTPUT_CHARS", "12000"))
 
+# Cheap-model repair packets must never merge or bypass hooks; use merge_pr_when_ready().
 FORBIDDEN_ACTIONS = [
     "merge_pr",
     "force_push",
@@ -39,6 +40,7 @@ FORBIDDEN_ACTIONS = [
     "amend_commit",
     "bypass_hooks",
 ]
+_CI_OK_CONCLUSIONS = frozenset({"SUCCESS", "NEUTRAL", "SKIPPED"})
 ALLOWED_TASK_TYPES = {"FIX_GREPTILE_FINDING", "FIX_CI_FAILURE", "SUMMARIZE_BLOCKER"}
 HIGH_RISK_PREFIXES = (
     ".github/workflows/",
@@ -360,6 +362,192 @@ async def _run_cheap_agent(packet: GuardPacket, *, task_id: str | None = None) -
     elapsed = time.time() - start
     await _record_cost_event(task_id, estimated_cost)
     return status, f"elapsed={elapsed:.1f}s estimated_cost_usd={estimated_cost}\n{output}"
+
+
+def _run_gh(args: list[str], *, repo: str = DEFAULT_REPO, check: bool = False) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["gh", *args, "--repo", repo],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=check,
+    )
+
+
+def _parse_gh_json(proc: subprocess.CompletedProcess[str]) -> dict[str, Any]:
+    if proc.returncode != 0:
+        raise GuardError((proc.stderr or proc.stdout or "gh command failed").strip())
+    try:
+        return json.loads(proc.stdout or "{}")
+    except json.JSONDecodeError as exc:
+        raise GuardError(f"gh returned non-JSON: {exc}") from exc
+
+
+def _ci_status_from_rollup(rollup: list[dict[str, Any]]) -> dict[str, Any]:
+    pending: list[str] = []
+    failures: list[str] = []
+    for check in rollup or []:
+        if not isinstance(check, dict):
+            continue
+        name = str(check.get("name") or "check")
+        status = str(check.get("status") or "").upper()
+        conclusion = str(check.get("conclusion") or "").upper()
+        if status in {"IN_PROGRESS", "PENDING", "QUEUED"}:
+            pending.append(name)
+            continue
+        if status == "COMPLETED" and conclusion:
+            if conclusion not in _CI_OK_CONCLUSIONS:
+                failures.append(f"{name}:{conclusion}")
+        elif status and status not in {"COMPLETED"}:
+            pending.append(name)
+    if pending:
+        return {"ok": False, "reason": "CI_PENDING", "pending": pending, "failures": failures}
+    if failures:
+        return {"ok": False, "reason": "CI_FAILED", "failures": failures, "pending": pending}
+    return {"ok": True, "pending": pending, "failures": failures}
+
+
+def _gh_mergeable_state(pr_number: int, *, repo: str = DEFAULT_REPO) -> dict[str, Any]:
+    proc = _run_gh(
+        [
+            "pr",
+            "view",
+            str(int(pr_number)),
+            "--json",
+            "mergeable,mergeStateStatus,state,statusCheckRollup",
+        ],
+        repo=repo,
+    )
+    if proc.returncode != 0:
+        return {"ok": False, "reason": "GH_PR_VIEW_FAILED", "detail": (proc.stderr or proc.stdout or "").strip()}
+    data = _parse_gh_json(proc)
+    if str(data.get("state") or "").upper() == "MERGED":
+        return {"ok": True, "already_merged": True, "mergeStateStatus": data.get("mergeStateStatus")}
+    mergeable = data.get("mergeable")
+    merge_state = str(data.get("mergeStateStatus") or "").upper()
+    if mergeable is False or merge_state in {"DIRTY", "UNSTABLE", "BEHIND", "BLOCKED"}:
+        return {
+            "ok": False,
+            "reason": "GH_NOT_MERGEABLE",
+            "mergeable": mergeable,
+            "mergeStateStatus": data.get("mergeStateStatus"),
+        }
+    ci = _ci_status_from_rollup(data.get("statusCheckRollup") or [])
+    if not ci.get("ok"):
+        return {**ci, "mergeStateStatus": data.get("mergeStateStatus")}
+    return {"ok": True, "mergeStateStatus": data.get("mergeStateStatus"), "ci": ci}
+
+
+async def assess_merge_readiness(
+    pr_number: int,
+    *,
+    target_confidence: int = 5,
+    repo: str = DEFAULT_REPO,
+    default_branch: str = DEFAULT_BASE_BRANCH,
+) -> dict[str, Any]:
+    """Return whether a PR is safe to squash-merge via normal gh (no admin/force)."""
+    from greptile_client import get_pr_status, list_pr_comments
+
+    pr_number = int(pr_number)
+    status = await get_pr_status(repo=repo, pr_number=pr_number, default_branch=default_branch)
+    comments = await list_pr_comments(repo=repo, pr_number=pr_number, default_branch=default_branch)
+    findings = comments.get("findings") or []
+    blockers: list[str] = []
+    if status.get("reviewIsRunning"):
+        blockers.append("GREPTILE_REVIEW_RUNNING")
+    if findings:
+        blockers.append(f"GREPTILE_UNADDRESSED:{len(findings)}")
+    confidence = int(status.get("confidenceScore") or 0)
+    if confidence < int(target_confidence):
+        blockers.append(f"GREPTILE_CONFIDENCE:{confidence}<{target_confidence}")
+    gh_state = _gh_mergeable_state(pr_number, repo=repo)
+    if not gh_state.get("ok"):
+        blockers.append(str(gh_state.get("reason") or "GH_NOT_READY"))
+    return {
+        "ready": not blockers,
+        "blockers": blockers,
+        "greptile": status,
+        "unaddressed_count": len(findings),
+        "gh": gh_state,
+        "target_confidence": int(target_confidence),
+    }
+
+
+async def merge_pr_when_ready(
+    pr_number: int,
+    *,
+    target_confidence: int = 5,
+    repo: str = DEFAULT_REPO,
+    default_branch: str = DEFAULT_BASE_BRANCH,
+) -> dict[str, Any]:
+    """Squash-merge via `gh pr merge` when Greptile + CI are clear. Never uses admin or force."""
+    pr_number = int(pr_number)
+    with acquire_lock(pr_number):
+        assessment = await assess_merge_readiness(
+            pr_number,
+            target_confidence=target_confidence,
+            repo=repo,
+            default_branch=default_branch,
+        )
+        state = _load_status(pr_number)
+        if not assessment["ready"]:
+            state["terminal_state"] = "BLOCKED_NOT_READY"
+            state["merge_blockers"] = assessment["blockers"]
+            _write_json(pr_number, "status.json", state)
+            _record_guardrail(pr_number, f"merge blocked: {assessment['blockers']}")
+            return {
+                "ok": False,
+                "state": "BLOCKED_NOT_READY",
+                "blockers": assessment["blockers"],
+                "assessment": assessment,
+            }
+        gh_state = assessment.get("gh") or {}
+        if gh_state.get("already_merged"):
+            proc = _run_gh(
+                ["pr", "view", str(pr_number), "--json", "mergeCommit,url,state"],
+                repo=repo,
+            )
+            merged = _parse_gh_json(proc) if proc.returncode == 0 else {}
+            state["terminal_state"] = "MERGED"
+            _write_json(pr_number, "status.json", state)
+            return {
+                "ok": True,
+                "state": "MERGED",
+                "already_merged": True,
+                "merge_commit": (merged.get("mergeCommit") or {}).get("oid"),
+                "pr_url": merged.get("url"),
+            }
+        proc = _run_gh(["pr", "merge", str(pr_number), "--squash"], repo=repo)
+        if proc.returncode != 0:
+            detail = (proc.stderr or proc.stdout or "").strip()
+            state["terminal_state"] = "BLOCKED_MERGE_FAILED"
+            state["merge_error"] = detail[:2000]
+            _write_json(pr_number, "status.json", state)
+            _record_guardrail(pr_number, f"gh pr merge failed: {detail[:500]}")
+            return {
+                "ok": False,
+                "state": "BLOCKED_MERGE_FAILED",
+                "error": detail,
+                "assessment": assessment,
+            }
+        view = _run_gh(
+            ["pr", "view", str(pr_number), "--json", "mergeCommit,url,state,mergedAt"],
+            repo=repo,
+        )
+        merged = _parse_gh_json(view) if view.returncode == 0 else {}
+        state["terminal_state"] = "MERGED"
+        state["merge_commit"] = (merged.get("mergeCommit") or {}).get("oid")
+        state["pr_url"] = merged.get("url")
+        _write_json(pr_number, "status.json", state)
+        _append_progress(pr_number, f"merged squash {state.get('merge_commit') or ''}".strip())
+        return {
+            "ok": True,
+            "state": "MERGED",
+            "merge_commit": state.get("merge_commit"),
+            "pr_url": merged.get("url"),
+            "merged_at": merged.get("mergedAt"),
+            "assessment": assessment,
+        }
 
 
 async def run_guard_once(

--- a/services/zoe-data/greploop_guard.py
+++ b/services/zoe-data/greploop_guard.py
@@ -383,10 +383,15 @@ def _parse_gh_json(proc: subprocess.CompletedProcess[str]) -> dict[str, Any]:
         raise GuardError(f"gh returned non-JSON: {exc}") from exc
 
 
+_BLOCKED_MERGE_STATE_STATUSES = frozenset({"DIRTY", "UNSTABLE", "BEHIND", "BLOCKED", "UNKNOWN"})
+
+
 def _ci_status_from_rollup(rollup: list[dict[str, Any]]) -> dict[str, Any]:
+    if not rollup:
+        return {"ok": False, "reason": "CI_NO_CHECKS", "pending": [], "failures": []}
     pending: list[str] = []
     failures: list[str] = []
-    for check in rollup or []:
+    for check in rollup:
         if not isinstance(check, dict):
             continue
         name = str(check.get("name") or "check")
@@ -423,9 +428,9 @@ def _gh_mergeable_state(pr_number: int, *, repo: str = DEFAULT_REPO) -> dict[str
     data = _parse_gh_json(proc)
     if str(data.get("state") or "").upper() == "MERGED":
         return {"ok": True, "already_merged": True, "mergeStateStatus": data.get("mergeStateStatus")}
-    mergeable = data.get("mergeable")
+    mergeable = str(data.get("mergeable") or "").upper()
     merge_state = str(data.get("mergeStateStatus") or "").upper()
-    if mergeable is False or merge_state in {"DIRTY", "UNSTABLE", "BEHIND", "BLOCKED"}:
+    if mergeable != "MERGEABLE" or merge_state in _BLOCKED_MERGE_STATE_STATUSES:
         return {
             "ok": False,
             "reason": "GH_NOT_MERGEABLE",

--- a/services/zoe-data/tests/test_greploop_guard.py
+++ b/services/zoe-data/tests/test_greploop_guard.py
@@ -130,6 +130,69 @@ def test_ci_status_from_rollup_accepts_success():
     assert greploop_guard._ci_status_from_rollup(rollup)["ok"] is True
 
 
+def test_ci_status_from_rollup_rejects_empty_rollup():
+    out = greploop_guard._ci_status_from_rollup([])
+
+    assert out["ok"] is False
+    assert out["reason"] == "CI_NO_CHECKS"
+
+
+def test_gh_mergeable_state_blocks_non_mergeable_and_unknown_state(monkeypatch):
+    def fake_run_gh(args, *, repo=greploop_guard.DEFAULT_REPO, check=False):
+        return type(
+            "P",
+            (),
+            {
+                "returncode": 0,
+                "stdout": json.dumps(
+                    {
+                        "state": "OPEN",
+                        "mergeable": "MERGEABLE",
+                        "mergeStateStatus": "UNKNOWN",
+                        "statusCheckRollup": [
+                            {"name": "validate", "status": "COMPLETED", "conclusion": "SUCCESS"},
+                        ],
+                    }
+                ),
+                "stderr": "",
+            },
+        )()
+
+    monkeypatch.setattr(greploop_guard, "_run_gh", fake_run_gh)
+
+    out = greploop_guard._gh_mergeable_state(66)
+
+    assert out["ok"] is False
+    assert out["reason"] == "GH_NOT_MERGEABLE"
+
+
+def test_gh_mergeable_state_blocks_conflicting_mergeable(monkeypatch):
+    def fake_run_gh(args, *, repo=greploop_guard.DEFAULT_REPO, check=False):
+        return type(
+            "P",
+            (),
+            {
+                "returncode": 0,
+                "stdout": json.dumps(
+                    {
+                        "state": "OPEN",
+                        "mergeable": "CONFLICTING",
+                        "mergeStateStatus": "DIRTY",
+                        "statusCheckRollup": [],
+                    }
+                ),
+                "stderr": "",
+            },
+        )()
+
+    monkeypatch.setattr(greploop_guard, "_run_gh", fake_run_gh)
+
+    out = greploop_guard._gh_mergeable_state(66)
+
+    assert out["ok"] is False
+    assert out["reason"] == "GH_NOT_MERGEABLE"
+
+
 @pytest.mark.asyncio
 async def test_assess_merge_readiness_blocks_low_confidence(monkeypatch):
     async def fake_status(**_kwargs):

--- a/services/zoe-data/tests/test_greploop_guard.py
+++ b/services/zoe-data/tests/test_greploop_guard.py
@@ -108,6 +108,89 @@ async def test_cheap_runner_blocks_before_budget_exceeded(monkeypatch):
     assert "max_cost_usd=1.0" in output
 
 
+def test_ci_status_from_rollup_flags_pending_and_failed():
+    rollup = [
+        {"name": "validate", "status": "IN_PROGRESS", "conclusion": ""},
+        {"name": "Greptile Review", "status": "COMPLETED", "conclusion": "FAILURE"},
+    ]
+
+    out = greploop_guard._ci_status_from_rollup(rollup)
+
+    assert out["ok"] is False
+    assert out["reason"] == "CI_PENDING"
+    assert "validate" in out["pending"]
+
+
+def test_ci_status_from_rollup_accepts_success():
+    rollup = [
+        {"name": "validate", "status": "COMPLETED", "conclusion": "SUCCESS"},
+        {"name": "Greptile Review", "status": "COMPLETED", "conclusion": "SUCCESS"},
+    ]
+
+    assert greploop_guard._ci_status_from_rollup(rollup)["ok"] is True
+
+
+@pytest.mark.asyncio
+async def test_assess_merge_readiness_blocks_low_confidence(monkeypatch):
+    async def fake_status(**_kwargs):
+        return {"confidenceScore": 3, "reviewIsRunning": False, "headSha": "abc"}
+
+    async def fake_comments(**_kwargs):
+        return {"findings": []}
+
+    monkeypatch.setattr("greptile_client.get_pr_status", fake_status)
+    monkeypatch.setattr("greptile_client.list_pr_comments", fake_comments)
+    monkeypatch.setattr(
+        greploop_guard,
+        "_gh_mergeable_state",
+        lambda pr, repo=greploop_guard.DEFAULT_REPO: {"ok": True},
+    )
+
+    out = await greploop_guard.assess_merge_readiness(66, target_confidence=5)
+
+    assert out["ready"] is False
+    assert any("GREPTILE_CONFIDENCE" in b for b in out["blockers"])
+
+
+@pytest.mark.asyncio
+async def test_merge_pr_when_ready_merges_when_assessment_passes(tmp_path, monkeypatch):
+    async def fake_assess(_pr_number, **_kwargs):
+        return {"ready": True, "blockers": [], "greptile": {}, "gh": {"ok": True}}
+
+    calls: list[list[str]] = []
+
+    def fake_run_gh(args, *, repo=greploop_guard.DEFAULT_REPO, check=False):
+        calls.append(list(args))
+        if args[:2] == ["pr", "merge"]:
+            return type("P", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+        return type(
+            "P",
+            (),
+            {
+                "returncode": 0,
+                "stdout": json.dumps(
+                    {
+                        "mergeCommit": {"oid": "deadbeef"},
+                        "url": "https://github.com/o/r/pull/66",
+                        "state": "MERGED",
+                    }
+                ),
+                "stderr": "",
+            },
+        )()
+
+    monkeypatch.setattr(greploop_guard, "STATE_ROOT", tmp_path)
+    monkeypatch.setattr(greploop_guard, "assess_merge_readiness", fake_assess)
+    monkeypatch.setattr(greploop_guard, "_run_gh", fake_run_gh)
+
+    out = await greploop_guard.merge_pr_when_ready(66)
+
+    assert out["ok"] is True
+    assert out["state"] == "MERGED"
+    assert out["merge_commit"] == "deadbeef"
+    assert ["pr", "merge", "66", "--squash"] in calls
+
+
 @pytest.mark.asyncio
 async def test_cheap_runner_command_does_not_expand_shell_metacharacters(monkeypatch):
     monkeypatch.setenv("ZOE_CHEAP_PR_AGENT_CMD", "python3 -c 'import sys; sys.stdin.read(); print(\"$HOME\")'")

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -61,6 +61,20 @@ async def test_dispatch_writes_zoe_ref_marker_into_body():
 
 
 @pytest.mark.asyncio
+async def test_closeout_body_instructs_merge_when_ready():
+    body = ka.KanbanAdapter()._build_body(
+        "closeout",
+        {"id": "uuid-1", "identifier": "ZOE-9", "title": "Fix thing", "description": ""},
+        "ZOE-9",
+    )
+    assert "greploop_guard.py --pr N --once" in body
+    assert "--merge-when-ready" in body
+    assert "MERGE_SHA=" in body
+    assert "--packet-only" in body
+    assert "never --admin" in body
+
+
+@pytest.mark.asyncio
 async def test_dispatch_pins_expected_skills():
     a = _FakeAdapter()
     await a.dispatch({"id": "u", "identifier": "ZOE-1", "title": "t"})


### PR DESCRIPTION
## Summary
- Add `greploop_guard.py --merge-when-ready` (and `--once --merge-when-ready`) to squash-merge via normal `gh pr merge --squash` when Greptile confidence is met, comments are cleared, and CI is green — never admin/force.
- Update Kanban closeout instructions to loop `--once` until clear, then merge; handoff includes `MERGE_SHA`.
- Align `github-greptile-loop` Hermes skill and Multica PR loop doc.

## Test plan
- [x] `pytest services/zoe-data/tests/test_greploop_guard.py services/zoe-data/tests/test_kanban_adapter.py` (26 passed)
- [x] `python3 tools/audit/validate_structure.py`
- [ ] After merge: `systemctl --user restart zoe-data.service` (closeout body loaded at runtime)

## Operator notes
- In-flight closeout tasks created before deploy still have the old prompt; re-queue closeout or run manually after deploy.
- PR #116: closeout `t_c55c7197` finished with old instructions (Multica done, PR still open). After deploy: `python3 scripts/maintenance/greploop_guard.py --pr 116 --merge-when-ready` when gates pass.


Made with [Cursor](https://cursor.com)