### PR TITLE
fix(hermes): document cost-controlled routing

### DIFF
--- a/docs/guides/HERMES_OPTIMIZATION_PLAYBOOK.md
+++ b/docs/guides/HERMES_OPTIMIZATION_PLAYBOOK.md
@@ -119,6 +119,27 @@ and whether it can run the engineering loop. Output any remaining config diff an
 
 Restart after edits: `systemctl --user restart hermes-agent.service`.
 
+### 0.7 Cost-control routing refresh (2026-06-01)
+
+Routing was tightened to match the board-cost policy:
+
+- Main Hermes (`~/.hermes/config.yaml`) now uses `openai-codex / gpt-5.4` as primary.
+- Main fallback is now a single controlled path: `openrouter / openrouter/free`.
+- Main fallback entries for direct `gemini` and `openai-api` were removed from the fallback chain.
+- Planner profile now uses `openrouter` directly (`anthropic/claude-sonnet-4.6`) instead of `provider: auto`.
+- Kanban worker profiles (`zoe-planner`, `zoe-coder`, `zoe-reviewer`) now keep fallback chains OpenRouter-only:
+  - `anthropic/claude-sonnet-4.6`
+  - `google/gemini-2.5-flash`
+  - `openrouter/free`
+- Root background auxiliaries were moved away from direct Gemini/OpenAI and `provider: auto` to `provider: openrouter` with `openrouter/free` where they are text-only (`web_extract`, `compression`, title/session/search/triage/curator/approval/MCP helpers, etc.) to avoid background calls silently routing to Codex or paid direct APIs.
+- Specialized non-engineering slots such as vision/TTS remain separate and are not part of the Kanban cost-control route.
+
+Verification run after apply:
+
+- `systemctl --user restart hermes-agent.service`
+- `hermes doctor` (profiles + connectivity)
+- `curl http://127.0.0.1:8642/health`
+
 ---
 
 ## Phase A — Give Hermes the why (DONE)

--- a/docs/guides/HERMES_OPTIMIZATION_PLAYBOOK.md
+++ b/docs/guides/HERMES_OPTIMIZATION_PLAYBOOK.md
@@ -48,20 +48,14 @@ dead fallback chain plus unauthenticated health probes. Five fixes, all applied:
 ### 0.1 Rebuilt the fallback chain with healthy providers
 
 `~/.hermes/config.yaml` now uses an ordered chain of providers that have working
-creds and real models (dropped `openrouter/free` and exhausted Anthropic):
+creds and real models. The original outage fix used Sonnet/Gemini/OpenAI API
+fallbacks, but the Phase 0.7 cost-control refresh superseded that chain. The
+live fallback chain is now intentionally:
 
 ```yaml
 fallback_providers:
-# Codex (primary) emits encrypted reasoning blobs in history; OpenAI Chat
-# Completions rejects them ("Encrypted content is not supported"), so the
-# proven-compatible OpenRouter/Sonnet hop goes first. gemini next (cheap),
-# openai-api last (only succeeds when history did not originate from Codex).
 - provider: openrouter
-  model: anthropic/claude-sonnet-4.6
-- provider: gemini
-  model: gemini-2.5-flash
-- provider: openai-api
-  model: gpt-4.1
+  model: openrouter/free
 ```
 
 `model.default` stays `openai-codex / gpt-5.4` (strongest; resets ~daily) — the
@@ -138,7 +132,7 @@ Verification run after apply:
 
 - `systemctl --user restart hermes-agent.service`
 - `hermes doctor` (profiles + connectivity)
-- `curl http://127.0.0.1:8642/health`
+- `curl -sf http://127.0.0.1:8642/health`
 
 ---
 
@@ -406,7 +400,7 @@ Masterclass", and the DigitalOcean deploy guide — mapped to Zoe:
 - `hermes doctor` clean; `systemctl --user status hermes-agent.service` active.
 - Auth'd probe: `curl -s -H "Authorization: Bearer $HERMES_API_KEY" 127.0.0.1:8642/v1/models` → 200.
 - **Failover proof**: with Codex exhausted, a `/v1/chat/completions` call
-  completes on a healthy fallback (Sonnet 4.6 via OpenRouter), not `openrouter/free`.
+  completes on the controlled fallback (`openrouter/free`).
 - `zoe-watchdog.sh` reports hermes-agent UP (no false "not responding" push);
   `hermes-keepwarm.sh` returns HTTP 200.
 - Hourly cron tick completes on a healthy provider (no `HTTP 400 credit balance too low`).

--- a/docs/guides/MULTICA_HERMES_PR_LOOP.md
+++ b/docs/guides/MULTICA_HERMES_PR_LOOP.md
@@ -17,7 +17,7 @@ This workflow lets Zoe track engineering work from a Multica issue through Herme
 
 ## Flow
 
-1. A user, API caller, authenticated Multica webhook (`issue.assigned`), board approval, or the Zoe poll bridge creates a Hermes Kanban chain (implement → review → closeout) on DeepSeek worker profiles.
+1. A user, API caller, authenticated Multica webhook (`issue.assigned`), board approval, or the Zoe poll bridge creates a Hermes Kanban chain (implement → review → closeout) on OpenRouter-routed worker profiles.
 2. `zoe-coder` implements on a worktree, opens a small PR, and hands off with `PR_URL=`, `BLOCKER=`, `TESTS=`, `SUMMARY=`.
 3. `zoe-reviewer` runs verification-first checks (structure validators, focused tests, live health).
 4. `zoe-planner` closeout runs the Greptile grep loop (`github-greptile-loop`), squash-merges when Greptile + CI are green (`greploop_guard.py --merge-when-ready`), then updates the Multica issue to done with merge SHA.

--- a/docs/guides/MULTICA_HERMES_PR_LOOP.md
+++ b/docs/guides/MULTICA_HERMES_PR_LOOP.md
@@ -23,6 +23,19 @@ This workflow lets Zoe track engineering work from a Multica issue through Herme
 4. `zoe-planner` closeout runs the Greptile grep loop (`github-greptile-loop`), squash-merges when Greptile + CI are green (`greploop_guard.py --merge-when-ready`), then updates the Multica issue to done with merge SHA.
 5. The Zoe poll loop advances Multica `in_progress` issues to `done` when the Kanban chain completes.
 
+## Model Routing Policy (Phase 0 cost control)
+
+Worker-chain routing is intentionally different from main chat routing:
+
+- **Main Hermes** (`~/.hermes/config.yaml`):
+  - Primary: `openai-codex / gpt-5.4`
+  - Fallback: `openrouter / openrouter/free`
+- **Kanban workers** (`zoe-planner`, `zoe-coder`, `zoe-reviewer`):
+  - Primary/fallbacks are OpenRouter-only (no direct `gemini` or `openai-api` provider entries)
+  - Current fallback order: `anthropic/claude-sonnet-4.6` → `google/gemini-2.5-flash` → `openrouter/free`
+
+This keeps board execution off Codex usage while preserving a deterministic low-cost fallback path.
+
 ### Webhooks (how Multica talks to Zoe)
 
 Zoe exposes `POST /api/agent/board/webhook` for `issue.assigned`, `issue.status_changed`, and `issue.created`.


### PR DESCRIPTION
## Summary
- Document the applied Phase 0 Hermes cost-control routing policy.
- Clarify that main Hermes uses Codex with controlled OpenRouter/free fallback while Kanban workers stay OpenRouter-only.
- Record verification commands used after the host config change.

## Test plan
- `python3 tools/audit/validate_structure.py`
- `python3 tools/audit/validate_critical_files.py`
- `systemctl --user restart hermes-agent.service`
- `curl -sf http://127.0.0.1:8642/health`
- `hermes doctor`

Made with [Cursor](https://cursor.com)