### PR TITLE
feat(hermes): add model profile settings controls

### DIFF
--- a/services/zoe-data/hermes_model_profiles.py
+++ b/services/zoe-data/hermes_model_profiles.py
@@ -347,6 +347,7 @@ def rollback_profiles(backup_dir_value: str | None, *, actor: str) -> dict[str, 
     audit = {
         "timestamp": datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ"),
         "actor": actor,
+        "status": "rolled_back",
         "rollback_dir": str(selected),
         "restored": restored,
     }

--- a/services/zoe-data/hermes_model_profiles.py
+++ b/services/zoe-data/hermes_model_profiles.py
@@ -44,6 +44,12 @@ def rollback_dir() -> Path:
     return hermes_home() / "rollback" / "model-profiles"
 
 
+def _append_audit(record: dict[str, Any]) -> None:
+    audit_path().parent.mkdir(parents=True, exist_ok=True)
+    with audit_path().open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(record, sort_keys=True) + "\n")
+
+
 def _profile_path(profile: str) -> Path:
     if profile not in PROFILE_PATHS:
         raise ValueError(f"Unknown profile: {profile}")
@@ -245,12 +251,35 @@ def apply_profiles(
     ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
     backup_root = rollback_dir() / ts
     backup_root.mkdir(parents=True, exist_ok=True)
-    for profile in diff["profiles"]:
-        path = _profile_path(profile["name"])
-        backup_path = backup_root / profile["name"] / path.name
-        backup_path.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(path, backup_path)
-        _dump_yaml(path, _apply_to_yaml(_load_yaml(path), profile))
+    written: list[str] = []
+    try:
+        for profile in diff["profiles"]:
+            path = _profile_path(profile["name"])
+            backup_path = backup_root / profile["name"] / path.name
+            backup_path.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(path, backup_path)
+            _dump_yaml(path, _apply_to_yaml(_load_yaml(path), profile))
+            written.append(profile["name"])
+    except Exception as exc:
+        restored: list[str] = []
+        for profile_name in written:
+            backup_file = backup_root / profile_name / _profile_path(profile_name).name
+            if backup_file.exists():
+                shutil.copy2(backup_file, _profile_path(profile_name))
+                restored.append(profile_name)
+        _append_audit(
+            {
+                "timestamp": ts,
+                "actor": actor,
+                "status": "failed",
+                "error": str(exc),
+                "profiles": [p["name"] for p in diff["profiles"]],
+                "written": written,
+                "restored": restored,
+                "backup_dir": str(backup_root),
+            }
+        )
+        raise
 
     restart_result = None
     if restart:
@@ -269,14 +298,13 @@ def apply_profiles(
     audit = {
         "timestamp": ts,
         "actor": actor,
+        "status": "applied",
         "profiles": [p["name"] for p in diff["profiles"]],
         "restart": restart,
         "force_restart": force_restart,
         "backup_dir": str(backup_root),
     }
-    audit_path().parent.mkdir(parents=True, exist_ok=True)
-    with audit_path().open("a", encoding="utf-8") as fh:
-        fh.write(json.dumps(audit, sort_keys=True) + "\n")
+    _append_audit(audit)
     return {**diff, "backup_dir": str(backup_root), "restart": restart_result}
 
 
@@ -289,7 +317,7 @@ def rollback_profiles(backup_dir_value: str | None, *, actor: str) -> dict[str, 
         if not backups:
             raise ValueError("No rollback backups found")
         selected = backups[-1].resolve()
-    if root not in selected.parents and selected != root:
+    if root not in selected.parents:
         raise ValueError("Rollback path escapes Hermes rollback directory")
 
     restored = []
@@ -309,8 +337,6 @@ def rollback_profiles(backup_dir_value: str | None, *, actor: str) -> dict[str, 
         "rollback_dir": str(selected),
         "restored": restored,
     }
-    audit_path().parent.mkdir(parents=True, exist_ok=True)
-    with audit_path().open("a", encoding="utf-8") as fh:
-        fh.write(json.dumps(audit, sort_keys=True) + "\n")
+    _append_audit(audit)
     return {"ok": True, "rollback_dir": str(selected), "restored": restored}
 

--- a/services/zoe-data/hermes_model_profiles.py
+++ b/services/zoe-data/hermes_model_profiles.py
@@ -394,17 +394,23 @@ def apply_profiles(
 
     restart_result = None
     if restart:
-        restarted = subprocess.run(
-            ["systemctl", "--user", "restart", "hermes-agent.service"],
-            check=False,
-            text=True,
-            capture_output=True,
-            timeout=30,
-        )
-        restart_result = {
-            "returncode": restarted.returncode,
-            "stderr": restarted.stderr[-4000:],
-        }
+        try:
+            restarted = subprocess.run(
+                ["systemctl", "--user", "restart", "hermes-agent.service"],
+                check=False,
+                text=True,
+                capture_output=True,
+                timeout=30,
+            )
+            restart_result = {
+                "returncode": restarted.returncode,
+                "stderr": restarted.stderr[-4000:],
+            }
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            restart_result = {
+                "returncode": -1,
+                "stderr": f"hermes-agent.service restart failed after profiles applied: {exc}",
+            }
 
     audit = {
         "timestamp": ts,
@@ -414,6 +420,7 @@ def apply_profiles(
         "restart": restart,
         "force_restart": force_restart,
         "backup_dir": str(backup_root),
+        "restart_result": restart_result,
     }
     audit_warning = None
     try:

--- a/services/zoe-data/hermes_model_profiles.py
+++ b/services/zoe-data/hermes_model_profiles.py
@@ -226,8 +226,8 @@ def count_running_workers() -> int:
             capture_output=True,
             timeout=5,
         )
-    except (OSError, subprocess.TimeoutExpired):
-        return 0
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise OSError("Unable to determine running Kanban workers") from exc
     return len([line for line in result.stdout.splitlines() if "work kanban task" in line])
 
 
@@ -244,9 +244,10 @@ def apply_profiles(
         raise ValueError("No profiles supplied and no draft exists")
     diff = build_diff(selected, confirm_paid_auto=confirm_paid_auto)
 
-    running_workers = count_running_workers()
-    if restart and running_workers and not force_restart:
-        raise RuntimeError(f"{running_workers} Kanban worker(s) running; retry after drain or force restart")
+    if restart and not force_restart:
+        running_workers = count_running_workers()
+        if running_workers:
+            raise RuntimeError(f"{running_workers} Kanban worker(s) running; retry after drain or force restart")
 
     ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
     backup_root = rollback_dir() / ts

--- a/services/zoe-data/hermes_model_profiles.py
+++ b/services/zoe-data/hermes_model_profiles.py
@@ -321,13 +321,26 @@ def rollback_profiles(backup_dir_value: str | None, *, actor: str) -> dict[str, 
         raise ValueError("Rollback path escapes Hermes rollback directory")
 
     restored = []
-    for profile_name in PROFILE_PATHS:
-        backup_file = selected / profile_name / _profile_path(profile_name).name
-        if not backup_file.exists():
-            continue
-        target = _profile_path(profile_name)
-        shutil.copy2(backup_file, target)
-        restored.append(profile_name)
+    try:
+        for profile_name in PROFILE_PATHS:
+            backup_file = selected / profile_name / _profile_path(profile_name).name
+            if not backup_file.exists():
+                continue
+            target = _profile_path(profile_name)
+            shutil.copy2(backup_file, target)
+            restored.append(profile_name)
+    except Exception as exc:
+        _append_audit(
+            {
+                "timestamp": datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ"),
+                "actor": actor,
+                "status": "rollback_failed",
+                "error": str(exc),
+                "rollback_dir": str(selected),
+                "restored": restored,
+            }
+        )
+        raise
     if not restored:
         raise ValueError("Selected rollback backup contains no known profile configs")
 

--- a/services/zoe-data/hermes_model_profiles.py
+++ b/services/zoe-data/hermes_model_profiles.py
@@ -1,0 +1,316 @@
+"""Host-scoped Hermes model profile management.
+
+This module intentionally exposes structured profile fields instead of a raw
+YAML editor. Hermes config lives outside the repo under ``~/.hermes``.
+"""
+
+from __future__ import annotations
+
+import difflib
+import json
+import os
+import shutil
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+PROFILE_PATHS = {
+    "main": "config.yaml",
+    "zoe-planner": "profiles/zoe-planner/config.yaml",
+    "zoe-coder": "profiles/zoe-coder/config.yaml",
+    "zoe-reviewer": "profiles/zoe-reviewer/config.yaml",
+}
+
+ALLOWED_PROVIDERS = {"openai-codex", "openrouter", "local"}
+PAID_OPENROUTER_MODEL = "openrouter/auto"
+
+
+def hermes_home() -> Path:
+    return Path(os.environ.get("HERMES_HOME", "~/.hermes")).expanduser().resolve()
+
+
+def draft_path() -> Path:
+    return hermes_home() / "model-profile-draft.json"
+
+
+def audit_path() -> Path:
+    return hermes_home() / "model-profile-audit.jsonl"
+
+
+def rollback_dir() -> Path:
+    return hermes_home() / "rollback" / "model-profiles"
+
+
+def _profile_path(profile: str) -> Path:
+    if profile not in PROFILE_PATHS:
+        raise ValueError(f"Unknown profile: {profile}")
+    root = hermes_home()
+    path = (root / PROFILE_PATHS[profile]).resolve()
+    if root not in path.parents and path != root:
+        raise ValueError("Profile path escapes HERMES_HOME")
+    return path
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise FileNotFoundError(str(path))
+    data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    if not isinstance(data, dict):
+        raise ValueError(f"Expected YAML mapping in {path}")
+    return data
+
+
+def _dump_yaml(path: Path, data: dict[str, Any]) -> None:
+    text = yaml.safe_dump(data, sort_keys=False, allow_unicode=False)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(text, encoding="utf-8")
+    tmp.replace(path)
+
+
+def _profile_from_yaml(name: str, data: dict[str, Any]) -> dict[str, Any]:
+    model = data.get("model") if isinstance(data.get("model"), dict) else {}
+    fallbacks = data.get("fallback_providers")
+    if not isinstance(fallbacks, list):
+        fallbacks = []
+    normalized_fallbacks = []
+    for item in fallbacks:
+        if isinstance(item, dict):
+            normalized_fallbacks.append(
+                {
+                    "provider": str(item.get("provider") or ""),
+                    "model": str(item.get("model") or ""),
+                }
+            )
+    return {
+        "name": name,
+        "path": str(_profile_path(name)),
+        "provider": str(model.get("provider") or ""),
+        "model": str(model.get("default") or ""),
+        "context_length": model.get("context_length"),
+        "fallbacks": normalized_fallbacks,
+    }
+
+
+def list_profiles() -> list[dict[str, Any]]:
+    profiles = []
+    for name in PROFILE_PATHS:
+        path = _profile_path(name)
+        profiles.append(_profile_from_yaml(name, _load_yaml(path)))
+    return profiles
+
+
+def _validate_entry(entry: dict[str, Any], *, profile_name: str) -> dict[str, Any]:
+    allowed_keys = {"name", "provider", "model", "fallbacks", "context_length"}
+    forbidden = sorted(set(entry) - allowed_keys)
+    if forbidden:
+        raise ValueError(f"{profile_name}: unsupported fields: {', '.join(forbidden)}")
+
+    provider = str(entry.get("provider") or "").strip()
+    model = str(entry.get("model") or "").strip()
+    if provider not in ALLOWED_PROVIDERS:
+        raise ValueError(f"{profile_name}: provider must be one of {sorted(ALLOWED_PROVIDERS)}")
+    if not model:
+        raise ValueError(f"{profile_name}: model is required")
+
+    fallbacks = entry.get("fallbacks") or []
+    if not isinstance(fallbacks, list):
+        raise ValueError(f"{profile_name}: fallbacks must be a list")
+    clean_fallbacks = []
+    for idx, fallback in enumerate(fallbacks):
+        if not isinstance(fallback, dict):
+            raise ValueError(f"{profile_name}: fallback {idx} must be an object")
+        fp = str(fallback.get("provider") or "").strip()
+        fm = str(fallback.get("model") or "").strip()
+        if fp not in ALLOWED_PROVIDERS:
+            raise ValueError(f"{profile_name}: fallback {idx} provider is not allowed")
+        if not fm:
+            raise ValueError(f"{profile_name}: fallback {idx} model is required")
+        clean_fallbacks.append({"provider": fp, "model": fm})
+
+    result = {
+        "name": profile_name,
+        "provider": provider,
+        "model": model,
+        "fallbacks": clean_fallbacks,
+    }
+    if entry.get("context_length") is not None:
+        result["context_length"] = int(entry["context_length"])
+    return result
+
+
+def validate_profiles(profiles: list[dict[str, Any]], *, confirm_paid_auto: bool = False) -> dict[str, Any]:
+    seen = set()
+    clean = []
+    paid_auto = []
+    for entry in profiles:
+        if not isinstance(entry, dict):
+            raise ValueError("Each profile must be an object")
+        name = str(entry.get("name") or "").strip()
+        if name not in PROFILE_PATHS:
+            raise ValueError(f"Unknown profile: {name}")
+        if name in seen:
+            raise ValueError(f"Duplicate profile: {name}")
+        seen.add(name)
+        clean_entry = _validate_entry(entry, profile_name=name)
+        all_models = [clean_entry["model"], *[f["model"] for f in clean_entry["fallbacks"]]]
+        if PAID_OPENROUTER_MODEL in all_models:
+            paid_auto.append(name)
+        clean.append(clean_entry)
+
+    if paid_auto and not confirm_paid_auto:
+        raise ValueError(f"OpenRouter Auto requires confirmation for: {', '.join(paid_auto)}")
+    return {"profiles": clean, "paid_auto_profiles": paid_auto}
+
+
+def _apply_to_yaml(data: dict[str, Any], profile: dict[str, Any]) -> dict[str, Any]:
+    model = data.setdefault("model", {})
+    if not isinstance(model, dict):
+        raise ValueError(f"{profile['name']}: model section must be a mapping")
+    model["provider"] = profile["provider"]
+    model["default"] = profile["model"]
+    if "context_length" in profile:
+        model["context_length"] = profile["context_length"]
+    data["fallback_providers"] = [
+        {"provider": f["provider"], "model": f["model"]} for f in profile["fallbacks"]
+    ]
+    return data
+
+
+def _diff_for_profile(profile: dict[str, Any]) -> str:
+    path = _profile_path(profile["name"])
+    old = path.read_text(encoding="utf-8").splitlines(keepends=True)
+    new_data = _apply_to_yaml(_load_yaml(path), profile)
+    new = yaml.safe_dump(new_data, sort_keys=False, allow_unicode=False).splitlines(keepends=True)
+    return "".join(difflib.unified_diff(old, new, fromfile=str(path), tofile=str(path)))
+
+
+def build_diff(profiles: list[dict[str, Any]], *, confirm_paid_auto: bool = False) -> dict[str, Any]:
+    validated = validate_profiles(profiles, confirm_paid_auto=confirm_paid_auto)
+    diffs = {p["name"]: _diff_for_profile(p) for p in validated["profiles"]}
+    return {**validated, "diffs": diffs}
+
+
+def save_draft(profiles: list[dict[str, Any]], *, confirm_paid_auto: bool = False) -> dict[str, Any]:
+    diff = build_diff(profiles, confirm_paid_auto=confirm_paid_auto)
+    path = draft_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(diff["profiles"], indent=2), encoding="utf-8")
+    return diff
+
+
+def load_draft() -> list[dict[str, Any]] | None:
+    path = draft_path()
+    if not path.exists():
+        return None
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, list):
+        raise ValueError("Draft must contain a profile list")
+    return data
+
+
+def count_running_workers() -> int:
+    try:
+        result = subprocess.run(
+            ["pgrep", "-af", "hermes .*work kanban task"],
+            check=False,
+            text=True,
+            capture_output=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return 0
+    return len([line for line in result.stdout.splitlines() if "work kanban task" in line])
+
+
+def apply_profiles(
+    profiles: list[dict[str, Any]] | None,
+    *,
+    actor: str,
+    confirm_paid_auto: bool = False,
+    restart: bool = False,
+    force_restart: bool = False,
+) -> dict[str, Any]:
+    selected = profiles if profiles is not None else load_draft()
+    if selected is None:
+        raise ValueError("No profiles supplied and no draft exists")
+    diff = build_diff(selected, confirm_paid_auto=confirm_paid_auto)
+
+    running_workers = count_running_workers()
+    if restart and running_workers and not force_restart:
+        raise RuntimeError(f"{running_workers} Kanban worker(s) running; retry after drain or force restart")
+
+    ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    backup_root = rollback_dir() / ts
+    backup_root.mkdir(parents=True, exist_ok=True)
+    for profile in diff["profiles"]:
+        path = _profile_path(profile["name"])
+        backup_path = backup_root / profile["name"] / path.name
+        backup_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(path, backup_path)
+        _dump_yaml(path, _apply_to_yaml(_load_yaml(path), profile))
+
+    restart_result = None
+    if restart:
+        restarted = subprocess.run(
+            ["systemctl", "--user", "restart", "hermes-agent.service"],
+            check=False,
+            text=True,
+            capture_output=True,
+            timeout=30,
+        )
+        restart_result = {
+            "returncode": restarted.returncode,
+            "stderr": restarted.stderr[-4000:],
+        }
+
+    audit = {
+        "timestamp": ts,
+        "actor": actor,
+        "profiles": [p["name"] for p in diff["profiles"]],
+        "restart": restart,
+        "force_restart": force_restart,
+        "backup_dir": str(backup_root),
+    }
+    audit_path().parent.mkdir(parents=True, exist_ok=True)
+    with audit_path().open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(audit, sort_keys=True) + "\n")
+    return {**diff, "backup_dir": str(backup_root), "restart": restart_result}
+
+
+def rollback_profiles(backup_dir_value: str | None, *, actor: str) -> dict[str, Any]:
+    root = rollback_dir().resolve()
+    if backup_dir_value:
+        selected = Path(backup_dir_value).expanduser().resolve()
+    else:
+        backups = sorted([p for p in root.iterdir() if p.is_dir()]) if root.exists() else []
+        if not backups:
+            raise ValueError("No rollback backups found")
+        selected = backups[-1].resolve()
+    if root not in selected.parents and selected != root:
+        raise ValueError("Rollback path escapes Hermes rollback directory")
+
+    restored = []
+    for profile_name in PROFILE_PATHS:
+        backup_file = selected / profile_name / _profile_path(profile_name).name
+        if not backup_file.exists():
+            continue
+        target = _profile_path(profile_name)
+        shutil.copy2(backup_file, target)
+        restored.append(profile_name)
+    if not restored:
+        raise ValueError("Selected rollback backup contains no known profile configs")
+
+    audit = {
+        "timestamp": datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ"),
+        "actor": actor,
+        "rollback_dir": str(selected),
+        "restored": restored,
+    }
+    audit_path().parent.mkdir(parents=True, exist_ok=True)
+    with audit_path().open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(audit, sort_keys=True) + "\n")
+    return {"ok": True, "rollback_dir": str(selected), "restored": restored}
+

--- a/services/zoe-data/hermes_model_profiles.py
+++ b/services/zoe-data/hermes_model_profiles.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import difflib
 import json
 import os
+import re
 import shutil
 import subprocess
 from datetime import datetime, timezone
@@ -69,8 +70,118 @@ def _load_yaml(path: Path) -> dict[str, Any]:
     return data
 
 
-def _dump_yaml(path: Path, data: dict[str, Any]) -> None:
-    text = yaml.safe_dump(data, sort_keys=False, allow_unicode=False)
+def _yaml_scalar(value: Any) -> str:
+    dumped = yaml.safe_dump(value, default_flow_style=True, allow_unicode=False, sort_keys=False)
+    return "\n".join(line for line in dumped.splitlines() if line != "...").strip()
+
+
+def _format_yaml_list(items: list[dict[str, Any]]) -> list[str]:
+    dumped = yaml.safe_dump(items, sort_keys=False, allow_unicode=False)
+    return dumped.rstrip("\n").splitlines()
+
+
+def _split_inline_comment(value: str) -> tuple[str, str]:
+    match = re.search(r"\s+#", value)
+    if not match:
+        return value.rstrip(), ""
+    return value[: match.start()].rstrip(), value[match.start() :]
+
+
+def _find_top_level_section(lines: list[str], key: str) -> tuple[int, int] | None:
+    start = None
+    for idx, line in enumerate(lines):
+        if re.match(rf"^{re.escape(key)}:(?:\s.*)?$", line):
+            start = idx
+            break
+    if start is None:
+        return None
+
+    end = len(lines)
+    for idx in range(start + 1, len(lines)):
+        line = lines[idx]
+        if re.match(r"^[^\s#-][^:]*:", line):
+            end = idx
+            break
+    return start, end
+
+
+def _replace_nested_scalar(lines: list[str], section: tuple[int, int], key: str, value: Any) -> bool:
+    start, end = section
+    for idx in range(start + 1, end):
+        match = re.match(r"^(\s+)" + re.escape(key) + r":(.*)$", lines[idx])
+        if not match:
+            continue
+        _, comment = _split_inline_comment(match.group(2))
+        lines[idx] = f"{match.group(1)}{key}: {_yaml_scalar(value)}{comment}"
+        return True
+    return False
+
+
+def _apply_to_yaml_text(text: str, profile: dict[str, Any]) -> str:
+    loaded = yaml.safe_load(text) or {}
+    if not isinstance(loaded, dict):
+        raise ValueError(f"Expected YAML mapping for {profile['name']}")
+    data = _apply_to_yaml(loaded, profile)
+
+    lines = text.splitlines()
+    model_section = _find_top_level_section(lines, "model")
+    if model_section is None:
+        lines.extend(
+            [
+                "model:",
+                f"  provider: {_yaml_scalar(profile['provider'])}",
+                f"  default: {_yaml_scalar(profile['model'])}",
+            ]
+        )
+    else:
+        model_value = lines[model_section[0]].split(":", 1)[1]
+        if model_value.strip() and not model_value.lstrip().startswith("#"):
+            lines[model_section[0]] = "model:"
+        insert_at = model_section[1]
+        if not _replace_nested_scalar(lines, model_section, "provider", profile["provider"]):
+            lines.insert(insert_at, f"  provider: {_yaml_scalar(profile['provider'])}")
+            insert_at += 1
+            model_section = (model_section[0], model_section[1] + 1)
+        if not _replace_nested_scalar(lines, model_section, "default", profile["model"]):
+            lines.insert(insert_at, f"  default: {_yaml_scalar(profile['model'])}")
+            insert_at += 1
+            model_section = (model_section[0], model_section[1] + 1)
+        if "context_length" in profile and not _replace_nested_scalar(
+            lines, model_section, "context_length", profile["context_length"]
+        ):
+            lines.insert(insert_at, f"  context_length: {_yaml_scalar(profile['context_length'])}")
+
+    fallback_section = _find_top_level_section(lines, "fallback_providers")
+    fallback_comment = ""
+    fallback_preserved_comments: list[str] = []
+    if fallback_section is None:
+        if lines and lines[-1] != "":
+            lines.append("")
+    else:
+        _, fallback_comment = _split_inline_comment(lines[fallback_section[0]].split(":", 1)[1])
+        fallback_preserved_comments = [
+            line
+            for line in lines[fallback_section[0] + 1 : fallback_section[1]]
+            if line.lstrip().startswith("#")
+        ]
+
+    if data["fallback_providers"]:
+        fallback_lines = [f"fallback_providers:{fallback_comment}"]
+        fallback_lines.extend(fallback_preserved_comments)
+        fallback_lines.extend(f"  {line}" for line in _format_yaml_list(data["fallback_providers"]))
+    else:
+        fallback_lines = [f"fallback_providers: []{fallback_comment}"]
+
+    if fallback_section is None:
+        lines.extend(fallback_lines)
+    else:
+        lines[fallback_section[0] : fallback_section[1]] = fallback_lines
+
+    return "\n".join(lines) + ("\n" if text.endswith("\n") else "")
+
+
+def _dump_yaml(path: Path, profile: dict[str, Any]) -> None:
+    text = _apply_to_yaml_text(path.read_text(encoding="utf-8"), profile)
     tmp = path.with_suffix(path.suffix + ".tmp")
     tmp.write_text(text, encoding="utf-8")
     tmp.replace(path)
@@ -188,8 +299,7 @@ def _apply_to_yaml(data: dict[str, Any], profile: dict[str, Any]) -> dict[str, A
 def _diff_for_profile(profile: dict[str, Any]) -> str:
     path = _profile_path(profile["name"])
     old = path.read_text(encoding="utf-8").splitlines(keepends=True)
-    new_data = _apply_to_yaml(_load_yaml(path), profile)
-    new = yaml.safe_dump(new_data, sort_keys=False, allow_unicode=False).splitlines(keepends=True)
+    new = _apply_to_yaml_text(path.read_text(encoding="utf-8"), profile).splitlines(keepends=True)
     return "".join(difflib.unified_diff(old, new, fromfile=str(path), tofile=str(path)))
 
 
@@ -259,7 +369,7 @@ def apply_profiles(
             backup_path = backup_root / profile["name"] / path.name
             backup_path.parent.mkdir(parents=True, exist_ok=True)
             shutil.copy2(path, backup_path)
-            _dump_yaml(path, _apply_to_yaml(_load_yaml(path), profile))
+            _dump_yaml(path, profile)
             written.append(profile["name"])
     except Exception as exc:
         restored: list[str] = []
@@ -305,8 +415,12 @@ def apply_profiles(
         "force_restart": force_restart,
         "backup_dir": str(backup_root),
     }
-    _append_audit(audit)
-    return {**diff, "backup_dir": str(backup_root), "restart": restart_result}
+    audit_warning = None
+    try:
+        _append_audit(audit)
+    except OSError as exc:
+        audit_warning = f"Profiles applied, but audit append failed: {exc}"
+    return {**diff, "backup_dir": str(backup_root), "restart": restart_result, "audit_warning": audit_warning}
 
 
 def rollback_profiles(backup_dir_value: str | None, *, actor: str) -> dict[str, Any]:

--- a/services/zoe-data/hermes_model_profiles.py
+++ b/services/zoe-data/hermes_model_profiles.py
@@ -51,6 +51,14 @@ def _append_audit(record: dict[str, Any]) -> None:
         fh.write(json.dumps(record, sort_keys=True) + "\n")
 
 
+def _append_audit_best_effort(record: dict[str, Any]) -> str | None:
+    try:
+        _append_audit(record)
+    except OSError as exc:
+        return str(exc)
+    return None
+
+
 def _profile_path(profile: str) -> Path:
     if profile not in PROFILE_PATHS:
         raise ValueError(f"Unknown profile: {profile}")
@@ -373,12 +381,16 @@ def apply_profiles(
             written.append(profile["name"])
     except Exception as exc:
         restored: list[str] = []
+        restore_errors: list[dict[str, str]] = []
         for profile_name in written:
-            backup_file = backup_root / profile_name / _profile_path(profile_name).name
-            if backup_file.exists():
-                shutil.copy2(backup_file, _profile_path(profile_name))
-                restored.append(profile_name)
-        _append_audit(
+            try:
+                backup_file = backup_root / profile_name / _profile_path(profile_name).name
+                if backup_file.exists():
+                    shutil.copy2(backup_file, _profile_path(profile_name))
+                    restored.append(profile_name)
+            except Exception as restore_exc:
+                restore_errors.append({"profile": profile_name, "error": str(restore_exc)})
+        _append_audit_best_effort(
             {
                 "timestamp": ts,
                 "actor": actor,
@@ -387,6 +399,7 @@ def apply_profiles(
                 "profiles": [p["name"] for p in diff["profiles"]],
                 "written": written,
                 "restored": restored,
+                "restore_errors": restore_errors,
                 "backup_dir": str(backup_root),
             }
         )
@@ -423,10 +436,9 @@ def apply_profiles(
         "restart_result": restart_result,
     }
     audit_warning = None
-    try:
-        _append_audit(audit)
-    except OSError as exc:
-        audit_warning = f"Profiles applied, but audit append failed: {exc}"
+    audit_error = _append_audit_best_effort(audit)
+    if audit_error:
+        audit_warning = f"Profiles applied, but audit append failed: {audit_error}"
     return {**diff, "backup_dir": str(backup_root), "restart": restart_result, "audit_warning": audit_warning}
 
 
@@ -452,7 +464,7 @@ def rollback_profiles(backup_dir_value: str | None, *, actor: str) -> dict[str, 
             shutil.copy2(backup_file, target)
             restored.append(profile_name)
     except Exception as exc:
-        _append_audit(
+        _append_audit_best_effort(
             {
                 "timestamp": datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ"),
                 "actor": actor,
@@ -464,6 +476,16 @@ def rollback_profiles(backup_dir_value: str | None, *, actor: str) -> dict[str, 
         )
         raise
     if not restored:
+        _append_audit_best_effort(
+            {
+                "timestamp": datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ"),
+                "actor": actor,
+                "status": "rollback_failed",
+                "error": "no known profile configs in backup",
+                "rollback_dir": str(selected),
+                "restored": [],
+            }
+        )
         raise ValueError("Selected rollback backup contains no known profile configs")
 
     audit = {
@@ -473,6 +495,7 @@ def rollback_profiles(backup_dir_value: str | None, *, actor: str) -> dict[str, 
         "rollback_dir": str(selected),
         "restored": restored,
     }
-    _append_audit(audit)
-    return {"ok": True, "rollback_dir": str(selected), "restored": restored}
+    audit_error = _append_audit_best_effort(audit)
+    audit_warning = f"Rollback succeeded, but audit append failed: {audit_error}" if audit_error else None
+    return {"ok": True, "rollback_dir": str(selected), "restored": restored, "audit_warning": audit_warning}
 

--- a/services/zoe-data/routers/system.py
+++ b/services/zoe-data/routers/system.py
@@ -229,7 +229,12 @@ class HermesProfilesRollbackRequest(BaseModel):
 
 
 def _hermes_profile_error(exc: Exception) -> HTTPException:
-    status = 409 if isinstance(exc, RuntimeError) else 400
+    if isinstance(exc, RuntimeError):
+        status = 409
+    elif isinstance(exc, OSError):
+        status = 503
+    else:
+        status = 400
     return HTTPException(status_code=status, detail=str(exc))
 
 
@@ -250,10 +255,11 @@ async def get_hermes_model_profiles(user: dict = Depends(require_admin)):
 
     try:
         draft = load_draft()
-    except Exception:
-        draft = None
+        profiles = list_profiles()
+    except (ValueError, TypeError, OSError) as exc:
+        raise _hermes_profile_error(exc) from exc
     return {
-        "profiles": list_profiles(),
+        "profiles": profiles,
         "draft": draft,
         "running_workers": count_running_workers(),
     }
@@ -268,7 +274,7 @@ async def put_hermes_model_profiles_draft(
 
     try:
         return save_draft(body.profiles, confirm_paid_auto=body.confirm_paid_auto)
-    except (ValueError, TypeError) as exc:
+    except (ValueError, TypeError, OSError) as exc:
         raise _hermes_profile_error(exc) from exc
 
 
@@ -281,7 +287,7 @@ async def post_hermes_model_profiles_validate(
 
     try:
         return build_diff(body.profiles, confirm_paid_auto=body.confirm_paid_auto)
-    except (ValueError, TypeError) as exc:
+    except (ValueError, TypeError, OSError) as exc:
         raise _hermes_profile_error(exc) from exc
 
 
@@ -301,7 +307,7 @@ async def post_hermes_model_profiles_apply(
             restart=body.restart,
             force_restart=body.force_restart,
         )
-    except (RuntimeError, ValueError, TypeError) as exc:
+    except (RuntimeError, ValueError, TypeError, OSError) as exc:
         raise _hermes_profile_error(exc) from exc
 
 
@@ -315,7 +321,7 @@ async def post_hermes_model_profiles_rollback(
     actor = str(user.get("user_id") or user.get("username") or "unknown")
     try:
         return rollback_profiles(body.backup_dir, actor=actor)
-    except (ValueError, TypeError) as exc:
+    except (ValueError, TypeError, OSError) as exc:
         raise _hermes_profile_error(exc) from exc
 
 

--- a/services/zoe-data/routers/system.py
+++ b/services/zoe-data/routers/system.py
@@ -4,7 +4,7 @@ import json
 import logging
 import os
 import re
-from typing import Optional
+from typing import Any, Optional
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel
@@ -210,6 +210,113 @@ def _load_skills_and_cron():
 
 
 _DEFAULT_OPENCLAW_PREFS = {"openclaw_auto_update": "notify"}
+
+
+class HermesProfilesRequest(BaseModel):
+    profiles: list[dict[str, Any]]
+    confirm_paid_auto: bool = False
+
+
+class HermesProfilesApplyRequest(BaseModel):
+    profiles: list[dict[str, Any]] | None = None
+    confirm_paid_auto: bool = False
+    restart: bool = False
+    force_restart: bool = False
+
+
+class HermesProfilesRollbackRequest(BaseModel):
+    backup_dir: str | None = None
+
+
+def _hermes_profile_error(exc: Exception) -> HTTPException:
+    status = 409 if isinstance(exc, RuntimeError) else 400
+    return HTTPException(status_code=status, detail=str(exc))
+
+
+@router.get("/hermes/model-profiles/status")
+async def get_hermes_model_profiles_status(user: dict = Depends(require_admin)):
+    from hermes_model_profiles import count_running_workers, draft_path
+
+    return {
+        "ok": True,
+        "running_workers": count_running_workers(),
+        "draft_exists": draft_path().exists(),
+    }
+
+
+@router.get("/hermes/model-profiles")
+async def get_hermes_model_profiles(user: dict = Depends(require_admin)):
+    from hermes_model_profiles import count_running_workers, list_profiles, load_draft
+
+    try:
+        draft = load_draft()
+    except Exception:
+        draft = None
+    return {
+        "profiles": list_profiles(),
+        "draft": draft,
+        "running_workers": count_running_workers(),
+    }
+
+
+@router.put("/hermes/model-profiles/draft")
+async def put_hermes_model_profiles_draft(
+    body: HermesProfilesRequest,
+    user: dict = Depends(require_admin),
+):
+    from hermes_model_profiles import save_draft
+
+    try:
+        return save_draft(body.profiles, confirm_paid_auto=body.confirm_paid_auto)
+    except (ValueError, TypeError) as exc:
+        raise _hermes_profile_error(exc) from exc
+
+
+@router.post("/hermes/model-profiles/validate")
+async def post_hermes_model_profiles_validate(
+    body: HermesProfilesRequest,
+    user: dict = Depends(require_admin),
+):
+    from hermes_model_profiles import build_diff
+
+    try:
+        return build_diff(body.profiles, confirm_paid_auto=body.confirm_paid_auto)
+    except (ValueError, TypeError) as exc:
+        raise _hermes_profile_error(exc) from exc
+
+
+@router.post("/hermes/model-profiles/apply")
+async def post_hermes_model_profiles_apply(
+    body: HermesProfilesApplyRequest,
+    user: dict = Depends(require_admin),
+):
+    from hermes_model_profiles import apply_profiles
+
+    actor = str(user.get("user_id") or user.get("username") or "unknown")
+    try:
+        return apply_profiles(
+            body.profiles,
+            actor=actor,
+            confirm_paid_auto=body.confirm_paid_auto,
+            restart=body.restart,
+            force_restart=body.force_restart,
+        )
+    except (RuntimeError, ValueError, TypeError) as exc:
+        raise _hermes_profile_error(exc) from exc
+
+
+@router.post("/hermes/model-profiles/rollback")
+async def post_hermes_model_profiles_rollback(
+    body: HermesProfilesRollbackRequest,
+    user: dict = Depends(require_admin),
+):
+    from hermes_model_profiles import rollback_profiles
+
+    actor = str(user.get("user_id") or user.get("username") or "unknown")
+    try:
+        return rollback_profiles(body.backup_dir, actor=actor)
+    except (ValueError, TypeError) as exc:
+        raise _hermes_profile_error(exc) from exc
 
 
 @router.get("/openclaw/preferences")

--- a/services/zoe-data/routers/system.py
+++ b/services/zoe-data/routers/system.py
@@ -242,11 +242,14 @@ def _hermes_profile_error(exc: Exception) -> HTTPException:
 async def get_hermes_model_profiles_status(user: dict = Depends(require_admin)):
     from hermes_model_profiles import count_running_workers, draft_path
 
-    return {
-        "ok": True,
-        "running_workers": count_running_workers(),
-        "draft_exists": draft_path().exists(),
-    }
+    try:
+        return {
+            "ok": True,
+            "running_workers": count_running_workers(),
+            "draft_exists": draft_path().exists(),
+        }
+    except OSError as exc:
+        raise _hermes_profile_error(exc) from exc
 
 
 @router.get("/hermes/model-profiles")
@@ -256,12 +259,13 @@ async def get_hermes_model_profiles(user: dict = Depends(require_admin)):
     try:
         draft = load_draft()
         profiles = list_profiles()
+        running_workers = count_running_workers()
     except (ValueError, TypeError, OSError) as exc:
         raise _hermes_profile_error(exc) from exc
     return {
         "profiles": profiles,
         "draft": draft,
-        "running_workers": count_running_workers(),
+        "running_workers": running_workers,
     }
 
 

--- a/services/zoe-data/tests/test_hermes_model_profiles.py
+++ b/services/zoe-data/tests/test_hermes_model_profiles.py
@@ -1,4 +1,5 @@
 import json
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -93,6 +94,23 @@ def test_restart_apply_blocks_when_workers_are_running(hermes_home, monkeypatch)
             actor="tester",
             restart=True,
         )
+
+
+def test_restart_apply_fails_closed_when_worker_count_times_out(hermes_home, monkeypatch):
+    def timeout_run(*args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd="pgrep", timeout=5)
+
+    monkeypatch.setattr(hmp.subprocess, "run", timeout_run)
+
+    with pytest.raises(OSError, match="Unable to determine"):
+        hmp.apply_profiles(
+            [{"name": "main", "provider": "openrouter", "model": "changed/model", "fallbacks": []}],
+            actor="tester",
+            restart=True,
+        )
+
+    data = yaml.safe_load((hermes_home / "config.yaml").read_text(encoding="utf-8"))
+    assert data["model"]["default"] == "openrouter/free"
 
 
 def test_rollback_restores_latest_backup(hermes_home, monkeypatch):

--- a/services/zoe-data/tests/test_hermes_model_profiles.py
+++ b/services/zoe-data/tests/test_hermes_model_profiles.py
@@ -109,6 +109,8 @@ def test_rollback_restores_latest_backup(hermes_home, monkeypatch):
     data = yaml.safe_load((hermes_home / "config.yaml").read_text(encoding="utf-8"))
     assert restored["restored"] == ["main"]
     assert data["model"]["default"] == "openrouter/free"
+    audit = json.loads((hermes_home / "model-profile-audit.jsonl").read_text(encoding="utf-8").splitlines()[-1])
+    assert audit["status"] == "rolled_back"
 
 
 def test_apply_failure_writes_failed_audit_and_restores_written_profiles(hermes_home, monkeypatch):

--- a/services/zoe-data/tests/test_hermes_model_profiles.py
+++ b/services/zoe-data/tests/test_hermes_model_profiles.py
@@ -85,6 +85,72 @@ def test_apply_profiles_writes_atomically_and_keeps_other_yaml(hermes_home, monk
     assert json.loads(audit.splitlines()[-1])["actor"] == "tester"
 
 
+def test_apply_profiles_preserves_unrelated_yaml_comments(hermes_home, monkeypatch):
+    monkeypatch.setattr(hmp, "count_running_workers", lambda: 0)
+    config = hermes_home / "profiles/zoe-coder/config.yaml"
+    config.write_text(
+        """# operator notes stay
+model: # model selection
+  # provider rationale
+  provider: openrouter # keep provider note
+  default: openrouter/free # keep default note
+  context_length: 128000
+
+fallback_providers: # failover order
+  # fallback rationale
+  - provider: openrouter
+    model: openrouter/free
+
+kept:
+  # unrelated nested note
+  value: true
+""",
+        encoding="utf-8",
+    )
+
+    hmp.apply_profiles(
+        [
+            {
+                "name": "zoe-coder",
+                "provider": "openai-codex",
+                "model": "gpt-5.5-medium",
+                "fallbacks": [{"provider": "openrouter", "model": "openrouter/auto"}],
+            }
+        ],
+        actor="tester",
+        confirm_paid_auto=True,
+    )
+
+    text = config.read_text(encoding="utf-8")
+    assert "# operator notes stay" in text
+    assert "# provider rationale" in text
+    assert "provider: openai-codex # keep provider note" in text
+    assert "default: gpt-5.5-medium # keep default note" in text
+    assert "fallback_providers: # failover order" in text
+    assert "# fallback rationale" in text
+    assert "# unrelated nested note" in text
+    parsed = yaml.safe_load(text)
+    assert parsed["fallback_providers"] == [{"provider": "openrouter", "model": "openrouter/auto"}]
+
+
+def test_apply_profiles_returns_audit_warning_after_successful_write(hermes_home, monkeypatch):
+    monkeypatch.setattr(hmp, "count_running_workers", lambda: 0)
+
+    def fail_audit(record):
+        raise OSError("audit read-only")
+
+    monkeypatch.setattr(hmp, "_append_audit", fail_audit)
+
+    result = hmp.apply_profiles(
+        [{"name": "main", "provider": "openrouter", "model": "changed/model", "fallbacks": []}],
+        actor="tester",
+    )
+
+    data = yaml.safe_load((hermes_home / "config.yaml").read_text(encoding="utf-8"))
+    assert data["model"]["default"] == "changed/model"
+    assert result["audit_warning"] == "Profiles applied, but audit append failed: audit read-only"
+
+
 def test_restart_apply_blocks_when_workers_are_running(hermes_home, monkeypatch):
     monkeypatch.setattr(hmp, "count_running_workers", lambda: 2)
 

--- a/services/zoe-data/tests/test_hermes_model_profiles.py
+++ b/services/zoe-data/tests/test_hermes_model_profiles.py
@@ -147,3 +147,23 @@ def test_rollback_rejects_rollback_root(hermes_home):
     with pytest.raises(ValueError, match="escapes"):
         hmp.rollback_profiles(str(root), actor="tester")
 
+
+def test_rollback_failure_writes_failed_audit(hermes_home, monkeypatch):
+    monkeypatch.setattr(hmp, "count_running_workers", lambda: 0)
+    result = hmp.apply_profiles(
+        [{"name": "main", "provider": "openrouter", "model": "changed/model", "fallbacks": []}],
+        actor="tester",
+    )
+
+    def fail_copy(src, dst):
+        raise OSError("restore failed")
+
+    monkeypatch.setattr(hmp.shutil, "copy2", fail_copy)
+
+    with pytest.raises(OSError, match="restore failed"):
+        hmp.rollback_profiles(result["backup_dir"], actor="tester")
+
+    audit = json.loads((hermes_home / "model-profile-audit.jsonl").read_text(encoding="utf-8").splitlines()[-1])
+    assert audit["status"] == "rollback_failed"
+    assert audit["rollback_dir"] == result["backup_dir"]
+

--- a/services/zoe-data/tests/test_hermes_model_profiles.py
+++ b/services/zoe-data/tests/test_hermes_model_profiles.py
@@ -110,3 +110,40 @@ def test_rollback_restores_latest_backup(hermes_home, monkeypatch):
     assert restored["restored"] == ["main"]
     assert data["model"]["default"] == "openrouter/free"
 
+
+def test_apply_failure_writes_failed_audit_and_restores_written_profiles(hermes_home, monkeypatch):
+    monkeypatch.setattr(hmp, "count_running_workers", lambda: 0)
+    original_dump = hmp._dump_yaml
+    calls = {"count": 0}
+
+    def flaky_dump(path, data):
+        calls["count"] += 1
+        if calls["count"] == 2:
+            raise OSError("disk full")
+        return original_dump(path, data)
+
+    monkeypatch.setattr(hmp, "_dump_yaml", flaky_dump)
+
+    with pytest.raises(OSError, match="disk full"):
+        hmp.apply_profiles(
+            [
+                {"name": "main", "provider": "openrouter", "model": "changed/main", "fallbacks": []},
+                {"name": "zoe-coder", "provider": "openrouter", "model": "changed/coder", "fallbacks": []},
+            ],
+            actor="tester",
+        )
+
+    main = yaml.safe_load((hermes_home / "config.yaml").read_text(encoding="utf-8"))
+    audit = json.loads((hermes_home / "model-profile-audit.jsonl").read_text(encoding="utf-8").splitlines()[-1])
+    assert main["model"]["default"] == "openrouter/free"
+    assert audit["status"] == "failed"
+    assert audit["restored"] == ["main"]
+
+
+def test_rollback_rejects_rollback_root(hermes_home):
+    root = hmp.rollback_dir()
+    root.mkdir(parents=True)
+
+    with pytest.raises(ValueError, match="escapes"):
+        hmp.rollback_profiles(str(root), actor="tester")
+

--- a/services/zoe-data/tests/test_hermes_model_profiles.py
+++ b/services/zoe-data/tests/test_hermes_model_profiles.py
@@ -248,6 +248,59 @@ def test_apply_failure_writes_failed_audit_and_restores_written_profiles(hermes_
     assert audit["restored"] == ["main"]
 
 
+def test_apply_failure_preserves_original_error_when_audit_fails(hermes_home, monkeypatch):
+    monkeypatch.setattr(hmp, "count_running_workers", lambda: 0)
+
+    def fail_dump(path, profile):
+        raise OSError("disk full")
+
+    def fail_audit(record):
+        raise OSError("audit read-only")
+
+    monkeypatch.setattr(hmp, "_dump_yaml", fail_dump)
+    monkeypatch.setattr(hmp, "_append_audit", fail_audit)
+
+    with pytest.raises(OSError, match="disk full"):
+        hmp.apply_profiles(
+            [{"name": "main", "provider": "openrouter", "model": "changed/main", "fallbacks": []}],
+            actor="tester",
+        )
+
+
+def test_apply_failure_preserves_original_error_when_restore_fails(hermes_home, monkeypatch):
+    monkeypatch.setattr(hmp, "count_running_workers", lambda: 0)
+    original_dump = hmp._dump_yaml
+    original_copy = hmp.shutil.copy2
+    calls = {"count": 0}
+
+    def flaky_dump(path, profile):
+        calls["count"] += 1
+        if calls["count"] == 2:
+            raise OSError("disk full")
+        return original_dump(path, profile)
+
+    def flaky_copy(src, dst):
+        if "rollback/model-profiles" in str(src):
+            raise OSError("restore failed")
+        return original_copy(src, dst)
+
+    monkeypatch.setattr(hmp, "_dump_yaml", flaky_dump)
+    monkeypatch.setattr(hmp.shutil, "copy2", flaky_copy)
+
+    with pytest.raises(OSError, match="disk full"):
+        hmp.apply_profiles(
+            [
+                {"name": "main", "provider": "openrouter", "model": "changed/main", "fallbacks": []},
+                {"name": "zoe-coder", "provider": "openrouter", "model": "changed/coder", "fallbacks": []},
+            ],
+            actor="tester",
+        )
+
+    audit = json.loads((hermes_home / "model-profile-audit.jsonl").read_text(encoding="utf-8").splitlines()[-1])
+    assert audit["status"] == "failed"
+    assert audit["restore_errors"] == [{"profile": "main", "error": "restore failed"}]
+
+
 def test_rollback_rejects_rollback_root(hermes_home):
     root = hmp.rollback_dir()
     root.mkdir(parents=True)
@@ -274,4 +327,24 @@ def test_rollback_failure_writes_failed_audit(hermes_home, monkeypatch):
     audit = json.loads((hermes_home / "model-profile-audit.jsonl").read_text(encoding="utf-8").splitlines()[-1])
     assert audit["status"] == "rollback_failed"
     assert audit["rollback_dir"] == result["backup_dir"]
+
+
+def test_rollback_failure_preserves_original_error_when_audit_fails(hermes_home, monkeypatch):
+    monkeypatch.setattr(hmp, "count_running_workers", lambda: 0)
+    result = hmp.apply_profiles(
+        [{"name": "main", "provider": "openrouter", "model": "changed/model", "fallbacks": []}],
+        actor="tester",
+    )
+
+    def fail_copy(src, dst):
+        raise OSError("restore failed")
+
+    def fail_audit(record):
+        raise OSError("audit read-only")
+
+    monkeypatch.setattr(hmp.shutil, "copy2", fail_copy)
+    monkeypatch.setattr(hmp, "_append_audit", fail_audit)
+
+    with pytest.raises(OSError, match="restore failed"):
+        hmp.rollback_profiles(result["backup_dir"], actor="tester")
 

--- a/services/zoe-data/tests/test_hermes_model_profiles.py
+++ b/services/zoe-data/tests/test_hermes_model_profiles.py
@@ -1,0 +1,112 @@
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+import hermes_model_profiles as hmp
+
+
+def _write_config(path: Path, provider: str = "openrouter", model: str = "openrouter/free") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        yaml.safe_dump(
+            {
+                "model": {"provider": provider, "default": model, "context_length": 128000},
+                "fallback_providers": [{"provider": "openrouter", "model": "openrouter/free"}],
+                "kept": {"value": True},
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+
+@pytest.fixture()
+def hermes_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    for rel in hmp.PROFILE_PATHS.values():
+        _write_config(tmp_path / rel)
+    return tmp_path
+
+
+def test_list_profiles_reads_existing_host_configs(hermes_home):
+    profiles = hmp.list_profiles()
+
+    assert [p["name"] for p in profiles] == ["main", "zoe-planner", "zoe-coder", "zoe-reviewer"]
+    assert profiles[0]["provider"] == "openrouter"
+    assert profiles[0]["fallbacks"] == [{"provider": "openrouter", "model": "openrouter/free"}]
+
+
+def test_validate_rejects_raw_secret_or_unknown_fields(hermes_home):
+    with pytest.raises(ValueError, match="unsupported fields"):
+        hmp.validate_profiles(
+            [
+                {
+                    "name": "main",
+                    "provider": "openrouter",
+                    "model": "openrouter/free",
+                    "api_key": "secret",
+                }
+            ]
+        )
+
+
+def test_openrouter_auto_requires_confirmation(hermes_home):
+    payload = [{"name": "main", "provider": "openrouter", "model": "openrouter/auto", "fallbacks": []}]
+
+    with pytest.raises(ValueError, match="requires confirmation"):
+        hmp.validate_profiles(payload)
+
+    assert hmp.validate_profiles(payload, confirm_paid_auto=True)["paid_auto_profiles"] == ["main"]
+
+
+def test_apply_profiles_writes_atomically_and_keeps_other_yaml(hermes_home, monkeypatch):
+    monkeypatch.setattr(hmp, "count_running_workers", lambda: 0)
+
+    result = hmp.apply_profiles(
+        [
+            {
+                "name": "zoe-coder",
+                "provider": "openrouter",
+                "model": "deepseek/deepseek-chat-v3.1",
+                "fallbacks": [{"provider": "openrouter", "model": "openrouter/free"}],
+            }
+        ],
+        actor="tester",
+    )
+
+    updated = yaml.safe_load((hermes_home / "profiles/zoe-coder/config.yaml").read_text(encoding="utf-8"))
+    assert updated["model"]["default"] == "deepseek/deepseek-chat-v3.1"
+    assert updated["kept"] == {"value": True}
+    assert Path(result["backup_dir"]).exists()
+    audit = (hermes_home / "model-profile-audit.jsonl").read_text(encoding="utf-8")
+    assert json.loads(audit.splitlines()[-1])["actor"] == "tester"
+
+
+def test_restart_apply_blocks_when_workers_are_running(hermes_home, monkeypatch):
+    monkeypatch.setattr(hmp, "count_running_workers", lambda: 2)
+
+    with pytest.raises(RuntimeError, match="worker"):
+        hmp.apply_profiles(
+            [{"name": "main", "provider": "openrouter", "model": "openrouter/free", "fallbacks": []}],
+            actor="tester",
+            restart=True,
+        )
+
+
+def test_rollback_restores_latest_backup(hermes_home, monkeypatch):
+    monkeypatch.setattr(hmp, "count_running_workers", lambda: 0)
+    result = hmp.apply_profiles(
+        [{"name": "main", "provider": "openrouter", "model": "changed/model", "fallbacks": []}],
+        actor="tester",
+    )
+
+    data = yaml.safe_load((hermes_home / "config.yaml").read_text(encoding="utf-8"))
+    assert data["model"]["default"] == "changed/model"
+
+    restored = hmp.rollback_profiles(result["backup_dir"], actor="tester")
+    data = yaml.safe_load((hermes_home / "config.yaml").read_text(encoding="utf-8"))
+    assert restored["restored"] == ["main"]
+    assert data["model"]["default"] == "openrouter/free"
+

--- a/services/zoe-data/tests/test_hermes_model_profiles.py
+++ b/services/zoe-data/tests/test_hermes_model_profiles.py
@@ -179,6 +179,28 @@ def test_restart_apply_fails_closed_when_worker_count_times_out(hermes_home, mon
     assert data["model"]["default"] == "openrouter/free"
 
 
+def test_restart_timeout_is_reported_after_successful_apply(hermes_home, monkeypatch):
+    monkeypatch.setattr(hmp, "count_running_workers", lambda: 0)
+
+    def timeout_restart(*args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd="systemctl", timeout=30)
+
+    monkeypatch.setattr(hmp.subprocess, "run", timeout_restart)
+
+    result = hmp.apply_profiles(
+        [{"name": "main", "provider": "openrouter", "model": "changed/model", "fallbacks": []}],
+        actor="tester",
+        restart=True,
+    )
+
+    data = yaml.safe_load((hermes_home / "config.yaml").read_text(encoding="utf-8"))
+    audit = json.loads((hermes_home / "model-profile-audit.jsonl").read_text(encoding="utf-8").splitlines()[-1])
+    assert data["model"]["default"] == "changed/model"
+    assert result["restart"]["returncode"] == -1
+    assert "timed out" in result["restart"]["stderr"]
+    assert audit["restart_result"]["returncode"] == -1
+
+
 def test_rollback_restores_latest_backup(hermes_home, monkeypatch):
     monkeypatch.setattr(hmp, "count_running_workers", lambda: 0)
     result = hmp.apply_profiles(

--- a/services/zoe-ui/dist/settings.html
+++ b/services/zoe-ui/dist/settings.html
@@ -1796,13 +1796,17 @@ async function applyHermesProfiles(forceRestart) {
     if (paidAuto && !confirm('OpenRouter Auto can spend real money. Continue?')) return;
     const restart = !!forceRestart;
     if (restart && !confirm('Restart Hermes now? This can interrupt running workers.')) return;
-    await apiCall('POST', '/api/system/hermes/model-profiles/apply', {
+    const data = await apiCall('POST', '/api/system/hermes/model-profiles/apply', {
       profiles,
       confirm_paid_auto: paidAuto,
       restart,
       force_restart: false,
     });
-    toast('Hermes profiles applied', 'success');
+    if (data.restart && data.restart.returncode !== 0) {
+      toast('Profiles applied, but Hermes restart failed: ' + (data.restart.stderr || 'unknown error'), 'error');
+    } else {
+      toast(restart ? 'Hermes profiles applied and restart requested' : 'Hermes profiles applied', 'success');
+    }
     loadHermesModelProfiles();
   } catch (e) {
     toast(e.message, 'error');

--- a/services/zoe-ui/dist/settings.html
+++ b/services/zoe-ui/dist/settings.html
@@ -600,6 +600,7 @@ const NAV = [
   { group: 'Admin', admin: true, items: [
     { id: 'users',      icon: '👥', label: 'Users' },
     { id: 'system',     icon: '⚙️', label: 'System' },
+    { id: 'ai-models',  icon: '🧭', label: 'AI Models' },
   ]},
 ];
 
@@ -914,6 +915,17 @@ function buildSections() {
     <div class="card" id="system-info-card"><div class="empty"><span class="spinner"></span></div></div>
   </div>
 
+  <!-- Admin: AI Models -->
+  <div class="section" id="sec-ai-models">
+    <div class="section-title">AI Models</div>
+    <div class="section-desc">Admin: host-scoped Hermes model profile routing. API keys are never edited here.</div>
+    <div class="card" id="ai-models-card"><div class="empty"><span class="spinner"></span></div></div>
+    <div class="card">
+      <div class="card-header">Pending diff</div>
+      <pre id="ai-models-diff" style="white-space:pre-wrap;overflow:auto;max-height:320px;padding:14px 18px;margin:0;color:var(--text2);font-size:12px;"></pre>
+    </div>
+  </div>
+
   <!-- Music -->
   <div class="section" id="sec-music">
     <div class="section-title">Music</div>
@@ -1013,6 +1025,7 @@ const sectionLoaders = {
   openclaw:       loadOpenClaw,
   users:          loadUsers,
   system:         loadSystemInfo,
+  'ai-models':    loadHermesModelProfiles,
   theme:          loadTheme,
   music:          loadMusicStatus,
   evolution:      loadEvolutionProposals,
@@ -1675,6 +1688,135 @@ async function loadSystemInfo() {
       </div>`).join('');
   } catch (e) {
     card.innerHTML = `<div class="empty">Failed to load: ${e.message}</div>`;
+  }
+}
+
+/* ── Admin: AI Models ─────────────────────────────────────── */
+let hermesProfiles = [];
+
+function parseFallbacks(value) {
+  return (value || '').split('\n').map(line => line.trim()).filter(Boolean).map(line => {
+    const idx = line.indexOf(':');
+    if (idx <= 0) throw new Error('Fallbacks must use provider:model, one per line');
+    return { provider: line.slice(0, idx).trim(), model: line.slice(idx + 1).trim() };
+  });
+}
+
+function collectHermesProfiles() {
+  return hermesProfiles.map(p => ({
+    name: p.name,
+    provider: document.getElementById(`hm-provider-${p.name}`)?.value.trim() || '',
+    model: document.getElementById(`hm-model-${p.name}`)?.value.trim() || '',
+    context_length: p.context_length || undefined,
+    fallbacks: parseFallbacks(document.getElementById(`hm-fallbacks-${p.name}`)?.value || ''),
+  }));
+}
+
+function renderHermesProfiles(data) {
+  hermesProfiles = data.profiles || [];
+  const card = document.getElementById('ai-models-card');
+  if (!hermesProfiles.length) {
+    card.innerHTML = '<div class="empty">No Hermes profiles found</div>';
+    return;
+  }
+  const running = data.running_workers || 0;
+  card.innerHTML = `
+    <div class="row">
+      <div class="row-info">
+        <div class="row-label">Hermes profile state</div>
+        <div class="row-sub">${running} Kanban worker(s) running. Use Apply After Drain unless urgent.</div>
+      </div>
+    </div>
+    ${hermesProfiles.map(p => `
+      <div class="card-header">${escHtml(p.name)}</div>
+      <div class="field">
+        <label>Provider</label>
+        <input id="hm-provider-${p.name}" value="${escHtml(p.provider)}" placeholder="openrouter">
+      </div>
+      <div class="field">
+        <label>Model</label>
+        <input id="hm-model-${p.name}" value="${escHtml(p.model)}" placeholder="provider/model">
+      </div>
+      <div class="field">
+        <label>Fallbacks (provider:model, one per line)</label>
+        <textarea id="hm-fallbacks-${p.name}" rows="4">${escHtml((p.fallbacks || []).map(f => `${f.provider}:${f.model}`).join('\n'))}</textarea>
+        <div class="field-hint">Allowed providers: openai-codex, openrouter, local. API keys are not accepted here.</div>
+      </div>
+    `).join('')}
+    <div style="padding:14px 18px;display:flex;gap:10px;flex-wrap:wrap;">
+      <button class="btn btn-ghost" onclick="validateHermesProfiles()">Validate</button>
+      <button class="btn btn-primary" onclick="saveHermesProfileDraft()">Save Draft</button>
+      <button class="btn btn-primary" onclick="applyHermesProfiles(false)">Apply After Drain</button>
+      <button class="btn btn-danger" onclick="applyHermesProfiles(true)">Apply Now + Restart</button>
+      <button class="btn btn-ghost" onclick="rollbackHermesProfiles()">Roll Back Latest</button>
+    </div>
+  `;
+}
+
+async function loadHermesModelProfiles() {
+  const card = document.getElementById('ai-models-card');
+  const diffEl = document.getElementById('ai-models-diff');
+  if (diffEl) diffEl.textContent = '';
+  try {
+    const data = await apiCall('GET', '/api/system/hermes/model-profiles');
+    renderHermesProfiles(data);
+  } catch (e) {
+    card.innerHTML = `<div class="empty">Failed to load Hermes profiles: ${escHtml(e.message)}</div>`;
+  }
+}
+
+async function validateHermesProfiles() {
+  try {
+    const profiles = collectHermesProfiles();
+    const confirm_paid_auto = profiles.some(p => [p.model, ...p.fallbacks.map(f => f.model)].includes('openrouter/auto'));
+    const data = await apiCall('POST', '/api/system/hermes/model-profiles/validate', { profiles, confirm_paid_auto });
+    document.getElementById('ai-models-diff').textContent = Object.values(data.diffs || {}).join('\n');
+    toast('Hermes profiles validated', 'success');
+  } catch (e) {
+    toast(e.message, 'error');
+  }
+}
+
+async function saveHermesProfileDraft() {
+  try {
+    const profiles = collectHermesProfiles();
+    const confirm_paid_auto = profiles.some(p => [p.model, ...p.fallbacks.map(f => f.model)].includes('openrouter/auto'));
+    const data = await apiCall('PUT', '/api/system/hermes/model-profiles/draft', { profiles, confirm_paid_auto });
+    document.getElementById('ai-models-diff').textContent = Object.values(data.diffs || {}).join('\n');
+    toast('Draft saved', 'success');
+  } catch (e) {
+    toast(e.message, 'error');
+  }
+}
+
+async function applyHermesProfiles(forceRestart) {
+  try {
+    const profiles = collectHermesProfiles();
+    const paidAuto = profiles.some(p => [p.model, ...p.fallbacks.map(f => f.model)].includes('openrouter/auto'));
+    if (paidAuto && !confirm('OpenRouter Auto can spend real money. Continue?')) return;
+    const restart = !!forceRestart;
+    if (restart && !confirm('Restart Hermes now? This can interrupt running workers.')) return;
+    await apiCall('POST', '/api/system/hermes/model-profiles/apply', {
+      profiles,
+      confirm_paid_auto: paidAuto,
+      restart,
+      force_restart: restart,
+    });
+    toast('Hermes profiles applied', 'success');
+    loadHermesModelProfiles();
+  } catch (e) {
+    toast(e.message, 'error');
+  }
+}
+
+async function rollbackHermesProfiles() {
+  if (!confirm('Roll back to latest Hermes profile backup?')) return;
+  try {
+    await apiCall('POST', '/api/system/hermes/model-profiles/rollback', {});
+    toast('Rollback complete', 'success');
+    loadHermesModelProfiles();
+  } catch (e) {
+    toast(e.message, 'error');
   }
 }
 

--- a/services/zoe-ui/dist/settings.html
+++ b/services/zoe-ui/dist/settings.html
@@ -1747,7 +1747,7 @@ function renderHermesProfiles(data) {
       <button class="btn btn-ghost" onclick="validateHermesProfiles()">Validate</button>
       <button class="btn btn-primary" onclick="saveHermesProfileDraft()">Save Draft</button>
       <button class="btn btn-primary" onclick="applyHermesProfiles(false)">Apply After Drain</button>
-      <button class="btn btn-danger" onclick="applyHermesProfiles(true)">Apply Now + Restart</button>
+      <button class="btn btn-danger" onclick="applyHermesProfiles(true)">Apply + Restart After Drain</button>
       <button class="btn btn-ghost" onclick="rollbackHermesProfiles()">Roll Back Latest</button>
     </div>
   `;
@@ -1800,7 +1800,7 @@ async function applyHermesProfiles(forceRestart) {
       profiles,
       confirm_paid_auto: paidAuto,
       restart,
-      force_restart: restart,
+      force_restart: false,
     });
     toast('Hermes profiles applied', 'success');
     loadHermesModelProfiles();

--- a/services/zoe-ui/dist/settings.html
+++ b/services/zoe-ui/dist/settings.html
@@ -1795,7 +1795,7 @@ async function applyHermesProfiles(forceRestart) {
     const paidAuto = profiles.some(p => [p.model, ...p.fallbacks.map(f => f.model)].includes('openrouter/auto'));
     if (paidAuto && !confirm('OpenRouter Auto can spend real money. Continue?')) return;
     const restart = !!forceRestart;
-    if (restart && !confirm('Restart Hermes now? This can interrupt running workers.')) return;
+    if (restart && !confirm('Restart Hermes after applying profiles? This will fail if Kanban workers are still running.')) return;
     const data = await apiCall('POST', '/api/system/hermes/model-profiles/apply', {
       profiles,
       confirm_paid_auto: paidAuto,


### PR DESCRIPTION
## Summary
- Add guarded admin endpoints for existing Hermes model profiles: status, validate, draft, apply, and rollback.
- Add a settings page AI Models section that edits provider/model/fallback fields without exposing raw YAML or secrets.
- Add atomic YAML writes, rollback backups, audit JSONL, OpenRouter Auto confirmation, and restart blocking when Kanban workers are running.

## Test plan
- `python3 -m pytest services/zoe-data/tests/test_hermes_model_profiles.py -q`
- `python3 -m pytest services/zoe-data/tests/test_hermes_routing.py::test_system_delegate_to_hermes_queues_background_task -q`
- `python3 -m py_compile services/zoe-data/hermes_model_profiles.py services/zoe-data/routers/system.py`
- `node --check` against extracted `settings.html` script
- `python3 tools/audit/validate_structure.py`
- `python3 tools/audit/validate_critical_files.py`

Made with [Cursor](https://cursor.com)