### PR TITLE
feat(kanban): add evidence pipeline state contract

### DIFF
--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -1,7 +1,7 @@
 """Hermes Kanban executor adapter.
 
 Turns a Multica issue into a durable implement -> review -> closeout chain on
-the Hermes Kanban board, where cheap DeepSeek worker profiles do the work. All
+the Hermes Kanban board, where OpenRouter-routed worker profiles do the work. All
 Kanban-specific behaviour lives here so it never leaks into Zoe core.
 
 Boundary: this shells the ``hermes kanban`` CLI (same SQLite DB the in-gateway

--- a/services/zoe-data/pipeline_evidence.py
+++ b/services/zoe-data/pipeline_evidence.py
@@ -102,7 +102,14 @@ def transition(state: PipelineState, outcome: TransitionOutcome, *, reason: str 
     elif outcome == "block":
         next_phase = state.phase
         next_status = "blocked"
-    elif outcome in {"request_changes", "verification_failed"}:
+    elif outcome == "request_changes":
+        if state.phase != "review":
+            raise ValueError("request_changes is only valid from review")
+        next_phase = "implement"
+        next_status = "todo"
+    elif outcome == "verification_failed":
+        if state.phase != "verify":
+            raise ValueError("verification_failed is only valid from verify")
         next_phase = "implement"
         next_status = "todo"
     elif outcome == "merge_blocked":

--- a/services/zoe-data/pipeline_evidence.py
+++ b/services/zoe-data/pipeline_evidence.py
@@ -106,6 +106,8 @@ def transition(state: PipelineState, outcome: TransitionOutcome, *, reason: str 
         next_phase = "implement"
         next_status = "todo"
     elif outcome == "merge_blocked":
+        if state.phase != "closeout":
+            raise ValueError("merge_blocked is only valid from closeout")
         next_phase = "closeout"
         next_status = "blocked"
     elif outcome == "complete":

--- a/services/zoe-data/pipeline_evidence.py
+++ b/services/zoe-data/pipeline_evidence.py
@@ -1,0 +1,133 @@
+"""Evidence-gated engineering pipeline state.
+
+This is intentionally independent of the live Kanban adapter for now. Phase 2
+defines the contract; the verify-phase integration can adopt it in a smaller PR.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field, field_validator
+
+PipelinePhase = Literal["implement", "verify", "review", "closeout", "retro"]
+PipelineStatus = Literal["todo", "running", "blocked", "done"]
+EvidenceKind = Literal["tool", "test", "validator", "pr", "greptile", "human", "log"]
+TransitionOutcome = Literal[
+    "start",
+    "complete",
+    "block",
+    "request_changes",
+    "verification_failed",
+    "merge_blocked",
+]
+
+PHASE_ORDER: tuple[PipelinePhase, ...] = ("implement", "verify", "review", "closeout", "retro")
+
+_REQUIRED_EVIDENCE: dict[PipelinePhase, set[EvidenceKind]] = {
+    "implement": {"tool"},
+    "verify": {"test", "validator"},
+    "review": {"human"},
+    "closeout": {"greptile"},
+    "retro": {"log"},
+}
+
+
+class EvidenceItem(BaseModel):
+    kind: EvidenceKind
+    summary: str = Field(min_length=1, max_length=500)
+    command: str | None = Field(default=None, max_length=500)
+    artifact: str | None = Field(default=None, max_length=1000)
+    passed: bool | None = None
+    created_at: str = Field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("metadata")
+    @classmethod
+    def _no_secret_metadata(cls, value: dict[str, Any]) -> dict[str, Any]:
+        forbidden = {"api_key", "token", "password", "secret"}
+        leaked = sorted(k for k in value if k.lower() in forbidden)
+        if leaked:
+            raise ValueError(f"Evidence metadata may not contain secret fields: {', '.join(leaked)}")
+        return value
+
+
+class TransitionRecord(BaseModel):
+    from_phase: PipelinePhase
+    to_phase: PipelinePhase
+    outcome: TransitionOutcome
+    at: str = Field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+    reason: str | None = None
+
+
+class PipelineState(BaseModel):
+    schema_version: int = 1
+    task_ref: str
+    phase: PipelinePhase = "implement"
+    status: PipelineStatus = "todo"
+    attempts: dict[PipelinePhase, int] = Field(default_factory=dict)
+    evidence: list[EvidenceItem] = Field(default_factory=list)
+    history: list[TransitionRecord] = Field(default_factory=list)
+
+    @field_validator("task_ref")
+    @classmethod
+    def _task_ref_required(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("task_ref is required")
+        return value.strip()
+
+
+def evidence_kinds(state: PipelineState) -> set[EvidenceKind]:
+    return {item.kind for item in state.evidence if item.passed is not False}
+
+
+def missing_required_evidence(state: PipelineState, phase: PipelinePhase | None = None) -> set[EvidenceKind]:
+    selected = phase or state.phase
+    return _REQUIRED_EVIDENCE.get(selected, set()) - evidence_kinds(state)
+
+
+def can_complete_phase(state: PipelineState) -> bool:
+    return not missing_required_evidence(state)
+
+
+def with_evidence(state: PipelineState, *items: EvidenceItem) -> PipelineState:
+    return state.model_copy(update={"evidence": [*state.evidence, *items]})
+
+
+def transition(state: PipelineState, outcome: TransitionOutcome, *, reason: str | None = None) -> PipelineState:
+    if outcome == "start":
+        next_phase = state.phase
+        next_status: PipelineStatus = "running"
+    elif outcome == "block":
+        next_phase = state.phase
+        next_status = "blocked"
+    elif outcome in {"request_changes", "verification_failed"}:
+        next_phase = "implement"
+        next_status = "todo"
+    elif outcome == "merge_blocked":
+        next_phase = "closeout"
+        next_status = "blocked"
+    elif outcome == "complete":
+        if not can_complete_phase(state):
+            missing = ", ".join(sorted(missing_required_evidence(state)))
+            raise ValueError(f"{state.phase} is missing required evidence: {missing}")
+        current_idx = PHASE_ORDER.index(state.phase)
+        if current_idx == len(PHASE_ORDER) - 1:
+            next_phase = state.phase
+            next_status = "done"
+        else:
+            next_phase = PHASE_ORDER[current_idx + 1]
+            next_status = "todo"
+    else:
+        raise ValueError(f"Unsupported outcome: {outcome}")
+
+    attempts = dict(state.attempts)
+    if next_status == "running":
+        attempts[state.phase] = attempts.get(state.phase, 0) + 1
+    history = [
+        *state.history,
+        TransitionRecord(from_phase=state.phase, to_phase=next_phase, outcome=outcome, reason=reason),
+    ]
+    return state.model_copy(update={"phase": next_phase, "status": next_status, "attempts": attempts, "history": history})
+

--- a/services/zoe-data/pipeline_evidence.py
+++ b/services/zoe-data/pipeline_evidence.py
@@ -46,8 +46,8 @@ class EvidenceItem(BaseModel):
     @field_validator("metadata")
     @classmethod
     def _no_secret_metadata(cls, value: dict[str, Any]) -> dict[str, Any]:
-        forbidden = {"api_key", "token", "password", "secret"}
-        leaked = sorted(k for k in value if k.lower() in forbidden)
+        forbidden = {"api_key", "token", "password", "secret", "bearer", "credential", "auth"}
+        leaked = sorted(k for k in value if any(marker in k.lower() for marker in forbidden))
         if leaked:
             raise ValueError(f"Evidence metadata may not contain secret fields: {', '.join(leaked)}")
         return value
@@ -79,7 +79,7 @@ class PipelineState(BaseModel):
 
 
 def evidence_kinds(state: PipelineState) -> set[EvidenceKind]:
-    return {item.kind for item in state.evidence if item.passed is not False}
+    return {item.kind for item in state.evidence if item.passed is True}
 
 
 def missing_required_evidence(state: PipelineState, phase: PipelinePhase | None = None) -> set[EvidenceKind]:
@@ -129,5 +129,8 @@ def transition(state: PipelineState, outcome: TransitionOutcome, *, reason: str 
         *state.history,
         TransitionRecord(from_phase=state.phase, to_phase=next_phase, outcome=outcome, reason=reason),
     ]
-    return state.model_copy(update={"phase": next_phase, "status": next_status, "attempts": attempts, "history": history})
+    evidence = [] if outcome in {"request_changes", "verification_failed"} else state.evidence
+    return state.model_copy(
+        update={"phase": next_phase, "status": next_status, "attempts": attempts, "evidence": evidence, "history": history}
+    )
 

--- a/services/zoe-data/tests/test_pipeline_evidence.py
+++ b/services/zoe-data/tests/test_pipeline_evidence.py
@@ -74,6 +74,21 @@ def test_review_change_request_loops_to_implement():
     assert next_state.history[-1].reason == "missing rollback test"
 
 
+def test_loop_back_outcomes_are_phase_scoped():
+    with pytest.raises(ValueError, match="request_changes is only valid from review"):
+        transition(PipelineState(task_ref="multica:1", phase="verify"), "request_changes")
+
+    with pytest.raises(ValueError, match="verification_failed is only valid from verify"):
+        transition(PipelineState(task_ref="multica:1", phase="closeout"), "verification_failed")
+
+    state = PipelineState(task_ref="multica:1", phase="verify", status="running")
+    next_state = transition(state, "verification_failed", reason="pytest failed")
+
+    assert next_state.phase == "implement"
+    assert next_state.status == "todo"
+    assert next_state.history[-1].reason == "pytest failed"
+
+
 def test_start_records_attempts_per_phase():
     state = PipelineState(task_ref="multica:1")
 

--- a/services/zoe-data/tests/test_pipeline_evidence.py
+++ b/services/zoe-data/tests/test_pipeline_evidence.py
@@ -84,6 +84,39 @@ def test_start_records_attempts_per_phase():
     assert state.attempts["implement"] == 2
 
 
+def test_block_preserves_phase_and_evidence_until_restarted():
+    state = PipelineState(task_ref="multica:1", phase="verify", status="running")
+    state = with_evidence(state, EvidenceItem(kind="test", summary="pytest passed", passed=True))
+
+    blocked = transition(state, "block", reason="validator unavailable")
+    restarted = transition(blocked, "start")
+
+    assert blocked.phase == "verify"
+    assert blocked.status == "blocked"
+    assert blocked.evidence == state.evidence
+    assert restarted.phase == "verify"
+    assert restarted.status == "running"
+    assert restarted.attempts["verify"] == 1
+
+
+def test_merge_blocked_is_closeout_only_and_can_restart():
+    state = PipelineState(task_ref="multica:1", phase="closeout", status="running")
+    state = with_evidence(state, EvidenceItem(kind="greptile", summary="review passed", passed=True))
+
+    blocked = transition(state, "merge_blocked", reason="branch policy")
+    restarted = transition(blocked, "start")
+
+    assert blocked.phase == "closeout"
+    assert blocked.status == "blocked"
+    assert blocked.evidence == state.evidence
+    assert restarted.phase == "closeout"
+    assert restarted.status == "running"
+    assert restarted.attempts["closeout"] == 1
+
+    with pytest.raises(ValueError, match="only valid from closeout"):
+        transition(PipelineState(task_ref="multica:1", phase="retro"), "merge_blocked")
+
+
 def test_retro_complete_marks_pipeline_done():
     state = PipelineState(task_ref="multica:1", phase="retro")
     state = with_evidence(state, EvidenceItem(kind="log", summary="retro captured", passed=True))

--- a/services/zoe-data/tests/test_pipeline_evidence.py
+++ b/services/zoe-data/tests/test_pipeline_evidence.py
@@ -1,0 +1,81 @@
+import pytest
+
+from pipeline_evidence import (
+    EvidenceItem,
+    PipelineState,
+    can_complete_phase,
+    missing_required_evidence,
+    transition,
+    with_evidence,
+)
+
+
+def test_evidence_metadata_rejects_secret_fields():
+    with pytest.raises(ValueError, match="secret fields"):
+        EvidenceItem(kind="tool", summary="used graphify", metadata={"token": "abc"})
+
+
+def test_implement_requires_tool_evidence_before_complete():
+    state = PipelineState(task_ref="multica:1")
+
+    assert can_complete_phase(state) is False
+    assert missing_required_evidence(state) == {"tool"}
+    with pytest.raises(ValueError, match="missing required evidence"):
+        transition(state, "complete")
+
+    state = with_evidence(state, EvidenceItem(kind="tool", summary="graphify query ran", passed=True))
+    next_state = transition(state, "complete")
+
+    assert next_state.phase == "verify"
+    assert next_state.status == "todo"
+
+
+def test_verify_requires_test_and_validator_evidence():
+    state = PipelineState(task_ref="multica:1", phase="verify", status="running")
+    state = with_evidence(state, EvidenceItem(kind="test", summary="pytest passed", passed=True))
+
+    assert missing_required_evidence(state) == {"validator"}
+
+    state = with_evidence(state, EvidenceItem(kind="validator", summary="validate_structure passed", passed=True))
+    assert transition(state, "complete").phase == "review"
+
+
+def test_failed_evidence_does_not_satisfy_gate():
+    state = PipelineState(task_ref="multica:1", phase="verify")
+    state = with_evidence(
+        state,
+        EvidenceItem(kind="test", summary="pytest failed", passed=False),
+        EvidenceItem(kind="validator", summary="validator passed", passed=True),
+    )
+
+    assert missing_required_evidence(state) == {"test"}
+
+
+def test_review_change_request_loops_to_implement():
+    state = PipelineState(task_ref="multica:1", phase="review", status="running")
+    next_state = transition(state, "request_changes", reason="missing rollback test")
+
+    assert next_state.phase == "implement"
+    assert next_state.status == "todo"
+    assert next_state.history[-1].reason == "missing rollback test"
+
+
+def test_start_records_attempts_per_phase():
+    state = PipelineState(task_ref="multica:1")
+
+    state = transition(state, "start")
+    state = transition(state, "start")
+
+    assert state.status == "running"
+    assert state.attempts["implement"] == 2
+
+
+def test_retro_complete_marks_pipeline_done():
+    state = PipelineState(task_ref="multica:1", phase="retro")
+    state = with_evidence(state, EvidenceItem(kind="log", summary="retro captured", passed=True))
+
+    done = transition(state, "complete")
+
+    assert done.phase == "retro"
+    assert done.status == "done"
+

--- a/services/zoe-data/tests/test_pipeline_evidence.py
+++ b/services/zoe-data/tests/test_pipeline_evidence.py
@@ -12,7 +12,7 @@ from pipeline_evidence import (
 
 def test_evidence_metadata_rejects_secret_fields():
     with pytest.raises(ValueError, match="secret fields"):
-        EvidenceItem(kind="tool", summary="used graphify", metadata={"token": "abc"})
+        EvidenceItem(kind="tool", summary="used graphify", metadata={"access_token": "abc"})
 
 
 def test_implement_requires_tool_evidence_before_complete():
@@ -51,12 +51,26 @@ def test_failed_evidence_does_not_satisfy_gate():
     assert missing_required_evidence(state) == {"test"}
 
 
+def test_indeterminate_evidence_does_not_satisfy_gate():
+    state = PipelineState(task_ref="multica:1", phase="verify")
+    state = with_evidence(
+        state,
+        EvidenceItem(kind="test", summary="pytest command recorded"),
+        EvidenceItem(kind="validator", summary="validator passed", passed=True),
+    )
+
+    assert missing_required_evidence(state) == {"test"}
+
+
 def test_review_change_request_loops_to_implement():
     state = PipelineState(task_ref="multica:1", phase="review", status="running")
+    state = with_evidence(state, EvidenceItem(kind="tool", summary="old implementation evidence", passed=True))
     next_state = transition(state, "request_changes", reason="missing rollback test")
 
     assert next_state.phase == "implement"
     assert next_state.status == "todo"
+    assert next_state.evidence == []
+    assert can_complete_phase(next_state) is False
     assert next_state.history[-1].reason == "missing rollback test"
 
 


### PR DESCRIPTION
## Summary
- Add a standalone evidence-gated engineering pipeline state contract.
- Define required evidence by phase, deterministic transition outcomes, and loop paths for verification/review failures.
- Update stale Kanban adapter wording from DeepSeek-specific to OpenRouter-routed worker profiles.

## Test plan
- `python3 -m pytest services/zoe-data/tests/test_pipeline_evidence.py services/zoe-data/tests/test_kanban_adapter.py -q`
- `python3 -m py_compile services/zoe-data/pipeline_evidence.py services/zoe-data/executors/kanban_adapter.py`
- `python3 tools/audit/validate_structure.py`
- `python3 tools/audit/validate_critical_files.py`

Made with [Cursor](https://cursor.com)