### PR TITLE
feat(kanban): add verify gate phase

### DIFF
--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -209,6 +209,9 @@ class KanbanAdapter:
                 "- Start with `kanban_show` to read the implementer handoff and PR_URL.\n"
                 "- Do not redesign or refactor. Run the declared tests and the minimum extra checks needed"
                 " for the touched surface.\n"
+                "- Always run and record `python3 tools/audit/validate_structure.py` and"
+                " `python3 tools/audit/validate_critical_files.py` in VALIDATORS unless the task"
+                " is explicitly audit-only with no code/config changes.\n"
                 "- Required evidence in your final `kanban_complete` metadata: TESTS, VALIDATORS,"
                 " PR_URL, and a pass/fail summary. Include exact commands and outcomes.\n"
                 "- If tests fail, evidence is missing, the PR is absent for a code task, or the task needs"
@@ -352,6 +355,10 @@ class KanbanAdapter:
                 break
 
         closeout = phases.get("closeout", {})
+        # Format invariant: new chains are created serially as implement->verify->review->closeout.
+        # If `verify` is absent, the row set is either a legacy 3-phase chain or a partial
+        # new chain that failed before verify; both are safe to evaluate against the legacy
+        # required set so re-dispatch can backfill only genuinely missing phases.
         expected = set(tuple(p for p, _, _ in _CHAIN) if "verify" in phases else _LEGACY_CHAIN_PHASES)
         missing = expected - set(phases)
         if (closeout.get("status") or "") in _TERMINAL_KANBAN_STATUSES:

--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -11,6 +11,7 @@ surface-agnostic.
 Worker profiles + pinned skills encode Zoe's agentic-engineering loop:
   - implement (zoe-coder):  zoe-engineering, zoe-graphify, source-code-context,
                             code-structure-cleanup  (graph-first, opensrc, lean)
+  - verify    (zoe-reviewer): zoe-engineering           (tests/evidence gate)
   - review    (zoe-reviewer): zoe-engineering           (verification gate)
   - closeout  (zoe-planner):  github-greptile-loop      (grep-loop, merge, Multica done)
 """
@@ -37,9 +38,11 @@ _CHAIN = (
         "zoe-coder",
         ("zoe-engineering", "zoe-graphify", "source-code-context", "code-structure-cleanup"),
     ),
+    ("verify", "zoe-reviewer", ("zoe-engineering",)),
     ("review", "zoe-reviewer", ("zoe-engineering",)),
     ("closeout", "zoe-planner", ("github-greptile-loop",)),
 )
+_LEGACY_CHAIN_PHASES = ("implement", "review", "closeout")
 
 _ACTIVE_KANBAN_STATUSES = {"triage", "todo", "ready", "running", "blocked"}
 _TERMINAL_KANBAN_STATUSES = {"done", "archived"}
@@ -200,14 +203,26 @@ class KanbanAdapter:
                 "PR_URL=<url or blank>\nBLOCKER=<reason or blank>\nTESTS=<checks run>\nSUMMARY=<short>\n"
                 "Changed files + branch/worktree details for the reviewer."
             )
+        if phase == "verify":
+            return common + (
+                "You are verify (zoe-reviewer). This is the objective test/evidence gate before review.\n"
+                "- Start with `kanban_show` to read the implementer handoff and PR_URL.\n"
+                "- Do not redesign or refactor. Run the declared tests and the minimum extra checks needed"
+                " for the touched surface.\n"
+                "- Required evidence in your final `kanban_complete` metadata: TESTS, VALIDATORS,"
+                " PR_URL, and a pass/fail summary. Include exact commands and outcomes.\n"
+                "- If tests fail, evidence is missing, the PR is absent for a code task, or the task needs"
+                " product clarification, call `kanban_block` with BLOCKER= and the failing output.\n"
+                "- TERMINAL PROTOCOL: end with `kanban_complete` or `kanban_block` (no silent exit)."
+            )
         if phase == "review":
             return common + (
-                "You are the reviewer (zoe-reviewer). Verification-first — a task is not done until verified.\n"
+                "You are the reviewer (zoe-reviewer). Review the diff, scope, and verify-phase evidence.\n"
                 "- Confirm the change is small and in scope. Audit-only / doc-only handoffs with blank PR_URL"
                 " need a short verification note, then `kanban_complete` — do not re-implement or burn turns"
                 " re-exploring the tree.\n"
-                "- Run `validate_structure.py`, `validate_critical_files.py`, focused tests,"
-                " and live `/health` + `/api/system/status` when code changed.\n"
+                "- Do not approve if verify-phase evidence is missing, stale, or inconsistent with the diff."
+                " Block with a concrete reason instead.\n"
                 "- TERMINAL PROTOCOL: end with `kanban_complete` or `kanban_block` (no silent exit).\n"
                 "- Do NOT approve if verification or the Greptile gate is unavailable; set the task blocked"
                 " with an explicit reason instead.\n"
@@ -242,7 +257,7 @@ class KanbanAdapter:
         )
 
     async def dispatch(self, issue: dict) -> dict:
-        """Create (idempotently) the implement->review->closeout chain for a Multica issue.
+        """Create (idempotently) the implement->verify->review->closeout chain for a Multica issue.
 
         Returns {ok, external_ref, chain:{phase:task_id}, created:[phases]}.
         """
@@ -298,6 +313,8 @@ class KanbanAdapter:
             return f"{identifier}: {base}"[:140]
         if phase == "review":
             return f"Review {identifier}"[:140]
+        if phase == "verify":
+            return f"Verify {identifier}"[:140]
         return f"Closeout {identifier}"[:140]
 
     async def poll(self, external_ref: str) -> dict:
@@ -335,11 +352,13 @@ class KanbanAdapter:
                 break
 
         closeout = phases.get("closeout", {})
+        expected = set(tuple(p for p, _, _ in _CHAIN) if "verify" in phases else _LEGACY_CHAIN_PHASES)
+        missing = expected - set(phases)
         if (closeout.get("status") or "") in _TERMINAL_KANBAN_STATUSES:
             agg = "done"
         elif blocker:
             agg = "blocked"
-        elif len(phases) < len(_CHAIN):
+        elif missing:
             # Some phases never got created (e.g. CLI error mid-chain). Report
             # "partial" so the sync path re-dispatches and idempotently backfills
             # the missing phases instead of skipping it as "running" forever.
@@ -358,7 +377,7 @@ class KanbanAdapter:
     async def _extract_pr_url(self, phases: dict[str, dict]) -> str | None:
         """Pull a PR URL from the implement/closeout task summaries or comments."""
         pattern = re.compile(r"https://github\.com/[^/\s]+/[^/\s]+/pull/\d+")
-        for phase in ("closeout", "implement", "review"):
+        for phase in ("closeout", "implement", "verify", "review"):
             row = phases.get(phase)
             if not row:
                 continue

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -31,7 +31,7 @@ class _FakeAdapter(ka.KanbanAdapter):
 
 
 @pytest.mark.asyncio
-async def test_dispatch_creates_three_linked_phases():
+async def test_dispatch_creates_four_linked_phases():
     a = _FakeAdapter()
     issue = {"id": "uuid-1", "identifier": "ZOE-9", "title": "Fix thing", "description": "do it"}
     result = await a.dispatch(issue)
@@ -90,6 +90,19 @@ async def test_verify_body_requires_evidence_gate():
     assert "objective test/evidence gate" in body
     assert "TESTS" in body
     assert "VALIDATORS" in body
+    assert "validate_structure.py" in body
+    assert "validate_critical_files.py" in body
+
+
+@pytest.mark.asyncio
+async def test_review_body_requires_verify_evidence():
+    body = ka.KanbanAdapter()._build_body(
+        "review",
+        {"id": "uuid-1", "identifier": "ZOE-9", "title": "Fix thing", "description": ""},
+        "ZOE-9",
+    )
+    assert "verify-phase evidence" in body
+    assert "Block" in body or "block" in body
 
 
 @pytest.mark.asyncio
@@ -215,6 +228,18 @@ async def test_poll_partial_chain_via_body_marker_is_redispatchable():
     rows = [
         _row("implement", "done"),
         _row("review", "running"),
+    ]
+    a = _FakeAdapter(list_rows=rows)
+    out = await a.poll("multica:uuid-9")
+    assert out["found"] is True
+    assert out["status"] == "partial"
+
+
+@pytest.mark.asyncio
+async def test_poll_current_partial_chain_with_verify_is_redispatchable():
+    rows = [
+        _row("implement", "done"),
+        _row("verify", "running"),
     ]
     a = _FakeAdapter(list_rows=rows)
     out = await a.poll("multica:uuid-9")

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -37,15 +37,21 @@ async def test_dispatch_creates_three_linked_phases():
     result = await a.dispatch(issue)
     assert result["ok"] is True
     assert result["external_ref"] == "multica:uuid-1"
-    assert set(result["chain"]) == {"implement", "review", "closeout"}
+    assert set(result["chain"]) == {"implement", "verify", "review", "closeout"}
     creates = [c for c in a.calls if c[0] == "create"]
-    assert len(creates) == 3
-    # review + closeout must be linked to a parent
+    assert len(creates) == 4
+    # verify + review + closeout must be linked to a parent
     assert "--parent" in creates[1]
     assert "--parent" in creates[2]
+    assert "--parent" in creates[3]
     # idempotency keys are phase-scoped
     keys = [c[c.index("--idempotency-key") + 1] for c in creates]
-    assert keys == ["multica:uuid-1:implement", "multica:uuid-1:review", "multica:uuid-1:closeout"]
+    assert keys == [
+        "multica:uuid-1:implement",
+        "multica:uuid-1:verify",
+        "multica:uuid-1:review",
+        "multica:uuid-1:closeout",
+    ]
 
 
 @pytest.mark.asyncio
@@ -55,7 +61,7 @@ async def test_dispatch_writes_zoe_ref_marker_into_body():
     a = _FakeAdapter()
     await a.dispatch({"id": "uuid-7", "identifier": "ZOE-7", "title": "t"})
     creates = [c for c in a.calls if c[0] == "create"]
-    for phase, create in zip(("implement", "review", "closeout"), creates):
+    for phase, create in zip(("implement", "verify", "review", "closeout"), creates):
         body = create[create.index("--body") + 1]
         assert f"zoe-ref: multica:uuid-7:{phase}" in body
 
@@ -75,13 +81,27 @@ async def test_closeout_body_instructs_merge_when_ready():
 
 
 @pytest.mark.asyncio
+async def test_verify_body_requires_evidence_gate():
+    body = ka.KanbanAdapter()._build_body(
+        "verify",
+        {"id": "uuid-1", "identifier": "ZOE-9", "title": "Fix thing", "description": ""},
+        "ZOE-9",
+    )
+    assert "objective test/evidence gate" in body
+    assert "TESTS" in body
+    assert "VALIDATORS" in body
+
+
+@pytest.mark.asyncio
 async def test_dispatch_pins_expected_skills():
     a = _FakeAdapter()
     await a.dispatch({"id": "u", "identifier": "ZOE-1", "title": "t"})
     creates = [c for c in a.calls if c[0] == "create"]
     impl_skills = [creates[0][i + 1] for i, v in enumerate(creates[0]) if v == "--skill"]
-    closeout_skills = [creates[2][i + 1] for i, v in enumerate(creates[2]) if v == "--skill"]
+    verify_skills = [creates[1][i + 1] for i, v in enumerate(creates[1]) if v == "--skill"]
+    closeout_skills = [creates[3][i + 1] for i, v in enumerate(creates[3]) if v == "--skill"]
     assert "zoe-graphify" in impl_skills and "code-structure-cleanup" in impl_skills
+    assert "zoe-engineering" in verify_skills
     assert "github-greptile-loop" in closeout_skills
 
 
@@ -154,6 +174,21 @@ async def test_poll_correlates_via_body_marker_when_no_idempotency_key():
     assert out["found"] is True
     assert out["status"] == "done"
     assert out["phases"] == {"implement": "done", "review": "done", "closeout": "done"}
+
+
+@pytest.mark.asyncio
+async def test_poll_current_chain_includes_verify_phase():
+    rows = [
+        _row("implement", "done"),
+        _row("verify", "done"),
+        _row("review", "running"),
+        _row("closeout", "todo"),
+    ]
+    a = _FakeAdapter(list_rows=rows)
+    out = await a.poll("multica:uuid-9")
+    assert out["found"] is True
+    assert out["status"] == "running"
+    assert out["phases"]["verify"] == "done"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Add a `verify` Kanban phase between implement and review.
- Give verify a focused evidence/test prompt and keep review focused on diff/scope/evidence assessment.
- Preserve legacy three-phase chain polling so in-flight v1 tasks without `verify` do not become permanently partial.

## Test plan
- `python3 -m pytest services/zoe-data/tests/test_kanban_adapter.py services/zoe-data/tests/test_pipeline_evidence.py -q`
- `python3 -m py_compile services/zoe-data/executors/kanban_adapter.py services/zoe-data/pipeline_evidence.py`
- `python3 tools/audit/validate_structure.py`
- `python3 tools/audit/validate_critical_files.py`

Made with [Cursor](https://cursor.com)