### PR TITLE
feat(kanban): add engineering mode runtimes

### DIFF
--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -118,7 +118,6 @@ def _engineering_mode(issue: dict | None = None) -> str:
     issue = issue or {}
     raw = (
         issue.get("engineering_mode")
-        or issue.get("mode")
         or (issue.get("metadata") or {}).get("engineering_mode")
         or os.environ.get("ZOE_ENGINEERING_MODE")
         or "interactive"
@@ -174,10 +173,10 @@ class KanbanAdapter:
         except json.JSONDecodeError as exc:
             raise KanbanCLIError(f"non-JSON output from kanban {args[0]}: {exc}: {stdout[:200]}")
 
-    def _build_body(self, phase: str, issue: dict, identifier: str) -> str:
+    def _build_body(self, phase: str, issue: dict, identifier: str, *, mode: str | None = None) -> str:
         title = issue.get("title") or identifier
         description = issue.get("description") or ""
-        mode = _engineering_mode(issue)
+        mode = mode or _engineering_mode(issue)
         mode_note = (
             "Engineering mode: overnight. Prioritize free/reliable local or OpenRouter-low-cost routes;"
             " latency is secondary to evidence quality.\n"
@@ -290,7 +289,7 @@ class KanbanAdapter:
     async def dispatch(self, issue: dict) -> dict:
         """Create (idempotently) the implement->verify->review->closeout chain for a Multica issue.
 
-        Returns {ok, external_ref, chain:{phase:task_id}, created:[phases]}.
+        Returns {ok, external_ref, chain:{phase:task_id}, created:[phases], mode}.
         """
         issue_id = str(issue.get("id") or "").strip()
         if not issue_id:
@@ -318,7 +317,7 @@ class KanbanAdapter:
                 "--created-by",
                 "zoe-bridge",
                 "--body",
-                self._build_body(phase, issue, identifier),
+                self._build_body(phase, issue, identifier, mode=mode),
                 "--json",
             ]
             for skill in skills:

--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -108,7 +108,30 @@ def _greptile_mcp_bin() -> str:
     return os.path.expanduser("~/bin/greptile-mcp.py")
 
 
-def _max_runtime() -> str:
+def _engineering_mode(issue: dict | None = None) -> str:
+    """Resolve the engineering execution mode for a Kanban chain.
+
+    Interactive is the default for user-visible work. Overnight mode allows
+    slower, cheaper runs by extending worker runtime and making the cost
+    preference explicit in every worker prompt.
+    """
+    issue = issue or {}
+    raw = (
+        issue.get("engineering_mode")
+        or issue.get("mode")
+        or (issue.get("metadata") or {}).get("engineering_mode")
+        or os.environ.get("ZOE_ENGINEERING_MODE")
+        or "interactive"
+    )
+    mode = str(raw).strip().lower()
+    if mode in {"overnight", "background", "self_evolution", "self-evolution"}:
+        return "overnight"
+    return "interactive"
+
+
+def _max_runtime(mode: str = "interactive") -> str:
+    if mode == "overnight":
+        return os.environ.get("ZOE_KANBAN_OVERNIGHT_MAX_RUNTIME", "6h")
     return os.environ.get("ZOE_KANBAN_MAX_RUNTIME", "45m")
 
 
@@ -154,6 +177,13 @@ class KanbanAdapter:
     def _build_body(self, phase: str, issue: dict, identifier: str) -> str:
         title = issue.get("title") or identifier
         description = issue.get("description") or ""
+        mode = _engineering_mode(issue)
+        mode_note = (
+            "Engineering mode: overnight. Prioritize free/reliable local or OpenRouter-low-cost routes;"
+            " latency is secondary to evidence quality.\n"
+            if mode == "overnight"
+            else "Engineering mode: interactive. Keep user-visible latency and review size tight.\n"
+        )
         # `zoe-ref:` is a machine marker that lets poll() correlate this task back
         # to its Multica issue + phase. The live `hermes kanban list --json` output
         # does NOT expose the idempotency key, so the body (which it does expose) is
@@ -165,6 +195,7 @@ class KanbanAdapter:
         common = (
             f"Multica issue: {identifier} (id {issue_id})\n"
             f"zoe-ref: multica:{issue_id}:{phase}\n"
+            f"{mode_note}"
             f"Repo: {_repo_root()}  |  Base branch: main  |  Workspace: git worktree\n\n"
             f"Title: {title}\n\n{description}\n\n"
         )
@@ -271,6 +302,7 @@ class KanbanAdapter:
         chain: dict[str, str] = {}
         created: list[str] = []
         parent: str | None = None
+        mode = _engineering_mode(issue)
         for phase, assignee, skills in _CHAIN:
             args = [
                 "create",
@@ -282,7 +314,7 @@ class KanbanAdapter:
                 "--idempotency-key",
                 f"{external_ref}:{phase}",
                 "--max-runtime",
-                _max_runtime(),
+                _max_runtime(mode),
                 "--created-by",
                 "zoe-bridge",
                 "--body",
@@ -305,7 +337,7 @@ class KanbanAdapter:
         logger.info(
             "kanban_adapter: dispatched %s -> chain=%s (new=%s)", identifier, chain, created
         )
-        return {"ok": True, "external_ref": external_ref, "chain": chain, "created": created}
+        return {"ok": True, "external_ref": external_ref, "chain": chain, "created": created, "mode": mode}
 
     def _title(self, phase: str, identifier: str, issue: dict) -> str:
         base = issue.get("title") or identifier

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -79,6 +79,7 @@ async def test_dispatch_overnight_mode_extends_runtime(monkeypatch):
 @pytest.mark.asyncio
 async def test_dispatch_interactive_mode_uses_default_runtime(monkeypatch):
     monkeypatch.setenv("ZOE_KANBAN_MAX_RUNTIME", "30m")
+    monkeypatch.delenv("ZOE_ENGINEERING_MODE", raising=False)
     a = _FakeAdapter()
     await a.dispatch({"id": "uuid-fast", "identifier": "ZOE-FAST", "title": "Immediate work"})
 
@@ -86,6 +87,29 @@ async def test_dispatch_interactive_mode_uses_default_runtime(monkeypatch):
     assert creates[0][creates[0].index("--max-runtime") + 1] == "30m"
     body = creates[0][creates[0].index("--body") + 1]
     assert "Engineering mode: interactive" in body
+
+
+@pytest.mark.asyncio
+async def test_dispatch_overnight_mode_from_metadata(monkeypatch):
+    monkeypatch.setenv("ZOE_KANBAN_OVERNIGHT_MAX_RUNTIME", "7h")
+    a = _FakeAdapter()
+    result = await a.dispatch(
+        {"id": "uuid-meta", "identifier": "ZOE-META", "title": "Background work", "metadata": {"engineering_mode": "overnight"}}
+    )
+    creates = [c for c in a.calls if c[0] == "create"]
+    assert result["mode"] == "overnight"
+    assert creates[0][creates[0].index("--max-runtime") + 1] == "7h"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_overnight_mode_from_env(monkeypatch):
+    monkeypatch.setenv("ZOE_ENGINEERING_MODE", "self_evolution")
+    monkeypatch.setenv("ZOE_KANBAN_OVERNIGHT_MAX_RUNTIME", "9h")
+    a = _FakeAdapter()
+    result = await a.dispatch({"id": "uuid-env", "identifier": "ZOE-ENV", "title": "Env work"})
+    creates = [c for c in a.calls if c[0] == "create"]
+    assert result["mode"] == "overnight"
+    assert creates[0][creates[0].index("--max-runtime") + 1] == "9h"
 
 
 @pytest.mark.asyncio

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -52,6 +52,40 @@ async def test_dispatch_creates_three_linked_phases():
         "multica:uuid-1:review",
         "multica:uuid-1:closeout",
     ]
+    assert result["mode"] == "interactive"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_overnight_mode_extends_runtime(monkeypatch):
+    monkeypatch.setenv("ZOE_KANBAN_OVERNIGHT_MAX_RUNTIME", "8h")
+    a = _FakeAdapter()
+    result = await a.dispatch(
+        {
+            "id": "uuid-night",
+            "identifier": "ZOE-NIGHT",
+            "title": "Slow cheap work",
+            "engineering_mode": "overnight",
+        }
+    )
+
+    creates = [c for c in a.calls if c[0] == "create"]
+    runtimes = [c[c.index("--max-runtime") + 1] for c in creates]
+    body = creates[0][creates[0].index("--body") + 1]
+    assert result["mode"] == "overnight"
+    assert runtimes == ["8h", "8h", "8h", "8h"]
+    assert "latency is secondary" in body
+
+
+@pytest.mark.asyncio
+async def test_dispatch_interactive_mode_uses_default_runtime(monkeypatch):
+    monkeypatch.setenv("ZOE_KANBAN_MAX_RUNTIME", "30m")
+    a = _FakeAdapter()
+    await a.dispatch({"id": "uuid-fast", "identifier": "ZOE-FAST", "title": "Immediate work"})
+
+    creates = [c for c in a.calls if c[0] == "create"]
+    assert creates[0][creates[0].index("--max-runtime") + 1] == "30m"
+    body = creates[0][creates[0].index("--body") + 1]
+    assert "Engineering mode: interactive" in body
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Add `interactive` and `overnight` engineering mode resolution for Kanban chains.
- Keep interactive as the default while allowing issue/env-driven overnight mode with longer runtime windows.
- Include the mode in worker prompts so cost/latency expectations are explicit.

## Test plan
- `python3 -m pytest services/zoe-data/tests/test_kanban_adapter.py -q`
- `python3 -m py_compile services/zoe-data/executors/kanban_adapter.py`
- `python3 tools/audit/validate_structure.py`
- `python3 tools/audit/validate_critical_files.py`

Made with [Cursor](https://cursor.com)