### PR TITLE
docs(agent): add spike metrics playbook

### DIFF
--- a/docs/guides/AGENT_SPIKE_PLAYBOOK.md
+++ b/docs/guides/AGENT_SPIKE_PLAYBOOK.md
@@ -31,7 +31,7 @@ Generate a packet before each spike:
 ```bash
 python3 scripts/maintenance/agent_spike_metrics.py forge \
   --task "verify local model tool-call rescue on a small Zoe PR" \
-  --output .zoe/tmp/forge-spike.json
+  --output /tmp/zoe-agent-spikes/forge-spike.json
 ```
 
 The packet records availability, cost policy, required evidence, and suggested

--- a/docs/guides/AGENT_SPIKE_PLAYBOOK.md
+++ b/docs/guides/AGENT_SPIKE_PLAYBOOK.md
@@ -1,0 +1,47 @@
+# Agent Spike Playbook
+
+Use this for Forge, Caveman, Babysitter, and local-model/Spark simulation work.
+These are evaluation tracks, not production dependencies.
+
+## Guardrails
+
+- Native Zoe evidence gates come first. Spikes should prove whether an outside
+  pattern helps Zoe; they should not replace Zoe's orchestrator.
+- Tools before tokens: every packet must record Graphify/opensrc/Greptile/
+  validators used before any paid model escalation.
+- Overnight mode can be slow. Prefer free/local reliability over latency for
+  self-evolution tasks.
+- Do not install Forge, Caveman, or Babysitter into production services from a
+  spike PR. Keep caches outside the repo and report the exact command/version.
+
+## Candidates
+
+- Forge: evaluate local-model tool-call reliability, retries, and rescue parsing.
+- Caveman: evaluate token compression only; it must not become an authority for
+  requirements or code review.
+- Babysitter: borrow process-as-code, event journal, breakpoint, and resume
+  patterns; do not make it Zoe's runtime orchestrator.
+- Local model: simulate Spark-fit overnight work and compare pass rate, latency,
+  and evidence quality against OpenRouter routes.
+
+## Metrics Packet
+
+Generate a packet before each spike:
+
+```bash
+python3 scripts/maintenance/agent_spike_metrics.py forge \
+  --task "verify local model tool-call rescue on a small Zoe PR" \
+  --output .zoe/tmp/forge-spike.json
+```
+
+The packet records availability, cost policy, required evidence, and suggested
+commands. Attach the resulting JSON to the PR or Multica issue summary.
+
+## Pass Criteria
+
+- The spike has a real Zoe task or replay, not a toy prompt.
+- The packet includes pass/fail, commands run, cost/locality observation, gotchas,
+  and a recommendation.
+- If the candidate increases cost, complexity, or dependency gravity without a
+  measurable reliability gain, close it as "do not adopt."
+

--- a/scripts/maintenance/agent_spike_metrics.py
+++ b/scripts/maintenance/agent_spike_metrics.py
@@ -50,7 +50,9 @@ def tool_available(candidate: str) -> bool:
         "caveman": "caveman",
         "babysitter": "babysitter",
         "local-model": "llama-server",
-    }[candidate]
+    }.get(candidate)
+    if command is None:
+        return False
     return shutil.which(command) is not None
 
 

--- a/scripts/maintenance/agent_spike_metrics.py
+++ b/scripts/maintenance/agent_spike_metrics.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Create repeatable metrics packets for local-agent spike evaluations.
+
+The script is intentionally non-installing: it records availability and the test
+plan for Forge, Caveman, Babysitter, or local-model experiments without making
+those projects production dependencies.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import platform
+import shutil
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+CANDIDATES = {
+    "forge": {
+        "role": "local model reliability middleware",
+        "cost_policy": "Only use after native evidence gates exist; prefer local/free models.",
+        "signals": ["tool-call recovery rate", "retry count", "invalid JSON repairs", "wall time"],
+        "commands": ["python3 -m pytest services/zoe-data/tests/test_pipeline_evidence.py -q"],
+    },
+    "caveman": {
+        "role": "token compression experiment",
+        "cost_policy": "Use only to reduce agent output/context tokens; never as authority.",
+        "signals": ["input tokens", "output tokens", "compression ratio", "lost requirements"],
+        "commands": ["python3 tools/audit/validate_structure.py"],
+    },
+    "babysitter": {
+        "role": "workflow/event-journal design reference",
+        "cost_policy": "Borrow process patterns; do not install as Zoe's production orchestrator.",
+        "signals": ["resume fidelity", "breakpoint quality", "event journal completeness"],
+        "commands": ["python3 -m pytest services/zoe-data/tests/test_kanban_adapter.py -q"],
+    },
+    "local-model": {
+        "role": "Spark-fit overnight model simulation",
+        "cost_policy": "Prefer local/free overnight execution; latency is secondary.",
+        "signals": ["pass rate", "tokens/sec", "first token latency", "cost", "evidence completeness"],
+        "commands": ["curl -sf http://127.0.0.1:11434/health"],
+    },
+}
+
+
+def tool_available(candidate: str) -> bool:
+    command = {
+        "forge": "forge",
+        "caveman": "caveman",
+        "babysitter": "babysitter",
+        "local-model": "llama-server",
+    }[candidate]
+    return shutil.which(command) is not None
+
+
+def build_packet(candidate: str, *, task: str, pr_url: str | None = None) -> dict[str, Any]:
+    if candidate not in CANDIDATES:
+        raise ValueError(f"unknown candidate: {candidate}")
+    spec = CANDIDATES[candidate]
+    return {
+        "schema_version": 1,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "candidate": candidate,
+        "task": task,
+        "pr_url": pr_url,
+        "host": {
+            "platform": platform.platform(),
+            "machine": platform.machine(),
+            "python": platform.python_version(),
+        },
+        "available": tool_available(candidate),
+        "role": spec["role"],
+        "cost_policy": spec["cost_policy"],
+        "signals": spec["signals"],
+        "commands": spec["commands"],
+        "required_evidence": [
+            "commands_run",
+            "pass_fail_result",
+            "cost_or_locality_observation",
+            "gotchas",
+            "recommendation",
+        ],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("candidate", choices=sorted(CANDIDATES))
+    parser.add_argument("--task", required=True, help="Task or scenario being evaluated")
+    parser.add_argument("--pr-url", default=None, help="Related PR URL, if any")
+    parser.add_argument("--output", type=Path, default=None, help="Optional JSON output path")
+    args = parser.parse_args()
+
+    packet = build_packet(args.candidate, task=args.task, pr_url=args.pr_url)
+    text = json.dumps(packet, indent=2, sort_keys=True)
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(text + "\n", encoding="utf-8")
+    else:
+        print(text)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/services/zoe-data/tests/test_agent_spike_metrics.py
+++ b/services/zoe-data/tests/test_agent_spike_metrics.py
@@ -7,8 +7,9 @@ import pytest
 def _load_module():
     path = Path(__file__).resolve().parents[3] / "scripts/maintenance/agent_spike_metrics.py"
     spec = importlib.util.spec_from_file_location("agent_spike_metrics", path)
-    module = importlib.util.module_from_spec(spec)
+    assert spec is not None, f"Could not locate module at {path}"
     assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
 

--- a/services/zoe-data/tests/test_agent_spike_metrics.py
+++ b/services/zoe-data/tests/test_agent_spike_metrics.py
@@ -1,0 +1,36 @@
+import importlib.util
+from pathlib import Path
+
+
+def _load_module():
+    path = Path(__file__).resolve().parents[3] / "scripts/maintenance/agent_spike_metrics.py"
+    spec = importlib.util.spec_from_file_location("agent_spike_metrics", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_build_packet_contains_cost_policy_and_required_evidence(monkeypatch):
+    module = _load_module()
+    monkeypatch.setattr(module, "tool_available", lambda candidate: candidate == "caveman")
+
+    packet = module.build_packet("caveman", task="compress a Greptile repair packet", pr_url="https://x/pull/1")
+
+    assert packet["candidate"] == "caveman"
+    assert packet["available"] is True
+    assert "token compression" in packet["role"]
+    assert "cost_policy" in packet
+    assert "gotchas" in packet["required_evidence"]
+
+
+def test_unknown_candidate_is_rejected():
+    module = _load_module()
+
+    try:
+        module.build_packet("unknown", task="x")
+    except ValueError as exc:
+        assert "unknown candidate" in str(exc)
+    else:
+        raise AssertionError("expected ValueError")
+

--- a/services/zoe-data/tests/test_agent_spike_metrics.py
+++ b/services/zoe-data/tests/test_agent_spike_metrics.py
@@ -1,6 +1,8 @@
 import importlib.util
 from pathlib import Path
 
+import pytest
+
 
 def _load_module():
     path = Path(__file__).resolve().parents[3] / "scripts/maintenance/agent_spike_metrics.py"
@@ -27,10 +29,6 @@ def test_build_packet_contains_cost_policy_and_required_evidence(monkeypatch):
 def test_unknown_candidate_is_rejected():
     module = _load_module()
 
-    try:
+    with pytest.raises(ValueError, match="unknown candidate"):
         module.build_packet("unknown", task="x")
-    except ValueError as exc:
-        assert "unknown candidate" in str(exc)
-    else:
-        raise AssertionError("expected ValueError")
 


### PR DESCRIPTION
## Summary
- Add a spike playbook for Forge, Caveman, Babysitter, and local-model/Spark simulation experiments.
- Add a non-installing metrics packet generator that records availability, cost policy, required evidence, and suggested commands.
- Add tests for packet shape and candidate validation.

## Test plan
- `python3 -m pytest services/zoe-data/tests/test_agent_spike_metrics.py -q`
- `python3 -m py_compile scripts/maintenance/agent_spike_metrics.py`
- `python3 scripts/maintenance/agent_spike_metrics.py caveman --task "compress a Greptile repair packet"`
- `python3 tools/audit/validate_structure.py`
- `python3 tools/audit/validate_critical_files.py`

Made with [Cursor](https://cursor.com)