### PR TITLE
feat(kanban): wire pipeline evidence to adapter poll/dispatch

### DIFF
--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -339,6 +339,12 @@ class KanbanAdapter:
         logger.info(
             "kanban_adapter: dispatched %s -> chain=%s (new=%s)", identifier, chain, created
         )
+        try:
+            from pipeline_store import bootstrap_state
+
+            bootstrap_state(external_ref, start_phase="implement")
+        except Exception as exc:
+            logger.debug("kanban_adapter: pipeline bootstrap skipped for %s: %s", external_ref, exc)
         return {"ok": True, "external_ref": external_ref, "chain": chain, "created": created, "mode": mode}
 
     def _title(self, phase: str, identifier: str, issue: dict) -> str:
@@ -404,12 +410,30 @@ class KanbanAdapter:
         else:
             agg = "running"
 
+        pipeline_info: dict = {"tracked": False}
+        try:
+            from pipeline_store import pipeline_summary, sync_pipeline_from_chain
+
+            async def _fetch_detail(task_id: str) -> dict:
+                return await self._run(["show", task_id, "--json"], expect_json=True)
+
+            start_phase = "scout" if "scout" in phases else "implement"
+            state = await sync_pipeline_from_chain(
+                external_ref, phases, _fetch_detail, start_phase=start_phase  # type: ignore[arg-type]
+            )
+            pipeline_info = pipeline_summary(state)
+            if pipeline_info.get("missing_evidence") and agg == "running":
+                pipeline_info["gate"] = "evidence_required"
+        except Exception as exc:
+            logger.debug("kanban_adapter: pipeline sync skipped for %s: %s", external_ref, exc)
+
         return {
             "found": True,
             "status": agg,
             "phases": statuses,
             "pr_url": await self._extract_pr_url(phases),
             "blocker": blocker,
+            "pipeline": pipeline_info,
         }
 
     async def _extract_pr_url(self, phases: dict[str, dict]) -> str | None:

--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -342,7 +342,7 @@ class KanbanAdapter:
         try:
             from pipeline_store import bootstrap_state
 
-            bootstrap_state(external_ref, start_phase="implement")
+            await bootstrap_state(external_ref, start_phase="implement")
         except Exception as exc:
             logger.debug("kanban_adapter: pipeline bootstrap skipped for %s: %s", external_ref, exc)
         return {"ok": True, "external_ref": external_ref, "chain": chain, "created": created, "mode": mode}

--- a/services/zoe-data/pipeline_evidence.py
+++ b/services/zoe-data/pipeline_evidence.py
@@ -11,7 +11,7 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, Field, field_validator
 
-PipelinePhase = Literal["implement", "verify", "review", "closeout", "retro"]
+PipelinePhase = Literal["scout", "implement", "verify", "review", "closeout", "retro"]
 PipelineStatus = Literal["todo", "running", "blocked", "done"]
 EvidenceKind = Literal["tool", "test", "validator", "pr", "greptile", "human", "log"]
 TransitionOutcome = Literal[
@@ -23,9 +23,17 @@ TransitionOutcome = Literal[
     "merge_blocked",
 ]
 
-PHASE_ORDER: tuple[PipelinePhase, ...] = ("implement", "verify", "review", "closeout", "retro")
+PHASE_ORDER: tuple[PipelinePhase, ...] = (
+    "scout",
+    "implement",
+    "verify",
+    "review",
+    "closeout",
+    "retro",
+)
 
 _REQUIRED_EVIDENCE: dict[PipelinePhase, set[EvidenceKind]] = {
+    "scout": {"tool"},
     "implement": {"tool"},
     "verify": {"test", "validator"},
     "review": {"human"},

--- a/services/zoe-data/pipeline_handoff.py
+++ b/services/zoe-data/pipeline_handoff.py
@@ -1,0 +1,142 @@
+"""Parse Kanban worker handoffs into pipeline evidence items."""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+from pipeline_evidence import EvidenceItem, EvidenceKind, PipelinePhase
+
+_KV_RE = re.compile(r"^([A-Z_]+)=(.*)$", re.MULTILINE)
+_TOOL_NAMES = (
+    "graphify",
+    "opensrc",
+    "multica",
+    "greptile",
+    "greploop",
+    "validator",
+    "pytest",
+    "zoe-engineering",
+    "zoe-graphify",
+    "source-code-context",
+    "github-greptile-loop",
+)
+
+
+def _haystacks(detail: dict[str, Any]) -> list[str]:
+    parts: list[str] = []
+    summary = detail.get("latest_summary")
+    if summary:
+        parts.append(summary if isinstance(summary, str) else json.dumps(summary))
+    for comment in detail.get("comments") or []:
+        body = comment.get("body") or comment.get("text") or ""
+        if body:
+            parts.append(str(body))
+    metadata = detail.get("metadata") or {}
+    if metadata:
+        parts.append(json.dumps(metadata))
+    return parts
+
+
+def _parse_kv_fields(text: str) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for match in _KV_RE.finditer(text or ""):
+        key, value = match.group(1), match.group(2).strip()
+        if value:
+            out[key] = value
+    return out
+
+
+def _tool_summary(raw: str) -> str:
+    cleaned = raw.strip()
+    return cleaned[:500] if cleaned else "tools recorded in handoff"
+
+
+def evidence_from_handoff(phase: PipelinePhase, detail: dict[str, Any]) -> list[EvidenceItem]:
+    """Best-effort extraction of structured evidence from a Kanban task show payload."""
+    fields: dict[str, str] = {}
+    for chunk in _haystacks(detail):
+        fields.update(_parse_kv_fields(chunk))
+
+    items: list[EvidenceItem] = []
+
+    tools_raw = fields.get("TOOLS_USED") or fields.get("TOOLS") or ""
+    if tools_raw:
+        items.append(EvidenceItem(kind="tool", summary=_tool_summary(tools_raw), passed=True))
+    elif phase == "scout":
+        for chunk in _haystacks(detail):
+            lowered = chunk.lower()
+            if any(name in lowered for name in _TOOL_NAMES):
+                items.append(EvidenceItem(kind="tool", summary="context tools referenced in scout handoff", passed=True))
+                break
+
+    tests_raw = fields.get("TESTS") or ""
+    if tests_raw and phase in {"implement", "verify"}:
+        passed = "fail" not in tests_raw.lower()
+        items.append(EvidenceItem(kind="test", summary=tests_raw[:500], passed=passed))
+
+    validators_raw = fields.get("VALIDATORS") or ""
+    if validators_raw and phase in {"implement", "verify"}:
+        passed = "fail" not in validators_raw.lower()
+        items.append(
+            EvidenceItem(kind="validator", summary=validators_raw[:500], passed=passed)
+        )
+
+    if phase == "review":
+        review_note = fields.get("SUMMARY") or fields.get("REVIEW") or ""
+        if review_note:
+            items.append(EvidenceItem(kind="human", summary=review_note[:500], passed=True))
+
+    greptile_raw = fields.get("GREPTILE") or ""
+    if greptile_raw and phase == "closeout":
+        passed = "fail" not in greptile_raw.lower() and "block" not in greptile_raw.lower()
+        items.append(EvidenceItem(kind="greptile", summary=greptile_raw[:500], passed=passed))
+
+    retro_raw = fields.get("RETRO") or fields.get("LEARNINGS") or fields.get("SUMMARY") or ""
+    if retro_raw and phase == "retro":
+        items.append(EvidenceItem(kind="log", summary=retro_raw[:500], passed=True))
+
+    pr_url = fields.get("PR_URL") or ""
+    if pr_url and phase in {"implement", "verify", "closeout"}:
+        items.append(EvidenceItem(kind="pr", summary=pr_url[:500], artifact=pr_url, passed=True))
+
+    if phase == "implement" and not any(i.kind == "tool" for i in items):
+        for chunk in _haystacks(detail):
+            lowered = chunk.lower()
+            if any(name in lowered for name in _TOOL_NAMES):
+                items.append(
+                    EvidenceItem(kind="tool", summary="implementation referenced engineering tools", passed=True)
+                )
+                break
+
+    return items
+
+
+def infer_outcome(phase: PipelinePhase, row_status: str, detail: dict[str, Any]) -> str | None:
+    """Map a terminal Kanban row to a pipeline transition outcome when inferrable."""
+    status = (row_status or "").lower()
+    if status == "blocked":
+        if phase == "verify":
+            return "verification_failed"
+        if phase == "review":
+            return "request_changes"
+        if phase == "closeout":
+            return "merge_blocked"
+        return "block"
+    if status not in {"done", "archived"}:
+        return None
+
+    fields: dict[str, str] = {}
+    for chunk in _haystacks(detail):
+        fields.update(_parse_kv_fields(chunk))
+    blocker = fields.get("BLOCKER") or ""
+    if blocker:
+        if phase == "verify":
+            return "verification_failed"
+        if phase == "review":
+            return "request_changes"
+        if phase == "closeout":
+            return "merge_blocked"
+        return "block"
+    return "complete"

--- a/services/zoe-data/pipeline_handoff.py
+++ b/services/zoe-data/pipeline_handoff.py
@@ -6,7 +6,7 @@ import json
 import re
 from typing import Any
 
-from pipeline_evidence import EvidenceItem, EvidenceKind, PipelinePhase
+from pipeline_evidence import EvidenceItem, PipelinePhase
 
 _KV_RE = re.compile(r"^([A-Z_]+)=(.*)$", re.MULTILINE)
 _TOOL_NAMES = (

--- a/services/zoe-data/pipeline_store.py
+++ b/services/zoe-data/pipeline_store.py
@@ -2,16 +2,18 @@
 
 from __future__ import annotations
 
+import asyncio
+import fcntl
 import json
 import os
 import threading
+from functools import partial
 from pathlib import Path
 from typing import Any, Awaitable, Callable
 
 from pipeline_evidence import (
     PipelinePhase,
     PipelineState,
-    TransitionOutcome,
     can_complete_phase,
     missing_required_evidence,
     transition,
@@ -38,7 +40,11 @@ def append_record(record: dict[str, Any]) -> None:
     with _LOCK:
         _ensure_parent(path)
         with path.open("a", encoding="utf-8") as handle:
-            handle.write(json.dumps(record, sort_keys=True) + "\n")
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+            try:
+                handle.write(json.dumps(record, sort_keys=True) + "\n")
+            finally:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
 
 
 def load_latest_state(task_ref: str) -> PipelineState | None:
@@ -47,7 +53,13 @@ def load_latest_state(task_ref: str) -> PipelineState | None:
         return None
     latest: PipelineState | None = None
     with _LOCK:
-        for line in path.read_text(encoding="utf-8").splitlines():
+        with path.open("r", encoding="utf-8") as handle:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_SH)
+            try:
+                lines = handle.read().splitlines()
+            finally:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+        for line in lines:
             if not line.strip():
                 continue
             try:
@@ -61,8 +73,13 @@ def load_latest_state(task_ref: str) -> PipelineState | None:
     return latest
 
 
+async def _run_io(func, *args):
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(None, func, *args)
+
+
 def save_state(state: PipelineState, *, event: str, extra: dict[str, Any] | None = None) -> PipelineState:
-    record = {
+    record: dict[str, Any] = {
         "event": event,
         "task_ref": state.task_ref,
         "phase": state.phase,
@@ -70,17 +87,18 @@ def save_state(state: PipelineState, *, event: str, extra: dict[str, Any] | None
         "state": state.model_dump(),
     }
     if extra:
-        record.update(extra)
+        record["meta"] = extra
     append_record(record)
     return state
 
 
-def bootstrap_state(task_ref: str, *, start_phase: PipelinePhase = "implement") -> PipelineState:
-    existing = load_latest_state(task_ref)
+async def bootstrap_state(task_ref: str, *, start_phase: PipelinePhase = "implement") -> PipelineState:
+    existing = await _run_io(load_latest_state, task_ref)
     if existing:
         return existing
     state = PipelineState(task_ref=task_ref, phase=start_phase)
-    return save_state(state, event="bootstrap")
+    await _run_io(partial(save_state, state, event="bootstrap"))
+    return state
 
 
 def pipeline_summary(state: PipelineState | None) -> dict[str, Any]:
@@ -107,7 +125,7 @@ async def sync_pipeline_from_chain(
     """Advance pipeline state from terminal Kanban phase rows and parsed handoffs."""
     from pipeline_handoff import evidence_from_handoff, infer_outcome
 
-    state = bootstrap_state(task_ref, start_phase=start_phase)
+    state = await bootstrap_state(task_ref, start_phase=start_phase)
     if state.status == "done":
         return state
 
@@ -135,23 +153,40 @@ async def sync_pipeline_from_chain(
             continue
 
         if outcome == "complete" and not can_complete_phase(state):
-            save_state(
-                state,
-                event="gate_blocked",
-                extra={
-                    "phase": phase,
-                    "missing": sorted(missing_required_evidence(state)),
-                },
+            await _run_io(
+                partial(
+                    save_state,
+                    state,
+                    event="gate_blocked",
+                    extra={
+                        "row_phase": phase,
+                        "missing": sorted(missing_required_evidence(state)),
+                    },
+                )
             )
             return state
 
         try:
             state = transition(state, outcome)  # type: ignore[arg-type]
         except ValueError as exc:
-            save_state(state, event="transition_rejected", extra={"phase": phase, "reason": str(exc)})
+            await _run_io(
+                partial(
+                    save_state,
+                    state,
+                    event="transition_rejected",
+                    extra={"row_phase": phase, "reason": str(exc)},
+                )
+            )
             return state
 
-        save_state(state, event="transition", extra={"outcome": outcome, "from_phase": phase})
+        await _run_io(
+            partial(
+                save_state,
+                state,
+                event="transition",
+                extra={"outcome": outcome, "from_phase": phase},
+            )
+        )
         if state.status in {"blocked", "done"}:
             break
 

--- a/services/zoe-data/pipeline_store.py
+++ b/services/zoe-data/pipeline_store.py
@@ -1,0 +1,158 @@
+"""JSONL persistence for engineering pipeline runs."""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+from pathlib import Path
+from typing import Any, Awaitable, Callable
+
+from pipeline_evidence import (
+    PipelinePhase,
+    PipelineState,
+    TransitionOutcome,
+    can_complete_phase,
+    missing_required_evidence,
+    transition,
+    with_evidence,
+)
+
+_LOCK = threading.Lock()
+_TERMINAL = {"done", "archived", "blocked"}
+
+
+def store_path() -> Path:
+    override = os.environ.get("ZOE_PIPELINE_STORE_PATH", "").strip()
+    if override:
+        return Path(override)
+    return Path(os.path.expanduser("~/.zoe/engineering_pipeline_runs.jsonl"))
+
+
+def _ensure_parent(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+
+def append_record(record: dict[str, Any]) -> None:
+    path = store_path()
+    with _LOCK:
+        _ensure_parent(path)
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(record, sort_keys=True) + "\n")
+
+
+def load_latest_state(task_ref: str) -> PipelineState | None:
+    path = store_path()
+    if not path.exists():
+        return None
+    latest: PipelineState | None = None
+    with _LOCK:
+        for line in path.read_text(encoding="utf-8").splitlines():
+            if not line.strip():
+                continue
+            try:
+                payload = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if payload.get("task_ref") != task_ref:
+                continue
+            if "state" in payload:
+                latest = PipelineState.model_validate(payload["state"])
+    return latest
+
+
+def save_state(state: PipelineState, *, event: str, extra: dict[str, Any] | None = None) -> PipelineState:
+    record = {
+        "event": event,
+        "task_ref": state.task_ref,
+        "phase": state.phase,
+        "status": state.status,
+        "state": state.model_dump(),
+    }
+    if extra:
+        record.update(extra)
+    append_record(record)
+    return state
+
+
+def bootstrap_state(task_ref: str, *, start_phase: PipelinePhase = "implement") -> PipelineState:
+    existing = load_latest_state(task_ref)
+    if existing:
+        return existing
+    state = PipelineState(task_ref=task_ref, phase=start_phase)
+    return save_state(state, event="bootstrap")
+
+
+def pipeline_summary(state: PipelineState | None) -> dict[str, Any]:
+    if not state:
+        return {"tracked": False}
+    missing = sorted(missing_required_evidence(state))
+    return {
+        "tracked": True,
+        "phase": state.phase,
+        "status": state.status,
+        "evidence_ok": can_complete_phase(state) if state.status == "running" else True,
+        "missing_evidence": missing,
+        "attempts": dict(state.attempts),
+    }
+
+
+async def sync_pipeline_from_chain(
+    task_ref: str,
+    phases: dict[str, dict],
+    fetch_detail: Callable[[str], Awaitable[dict[str, Any]]],
+    *,
+    start_phase: PipelinePhase = "implement",
+) -> PipelineState:
+    """Advance pipeline state from terminal Kanban phase rows and parsed handoffs."""
+    from pipeline_handoff import evidence_from_handoff, infer_outcome
+
+    state = bootstrap_state(task_ref, start_phase=start_phase)
+    if state.status == "done":
+        return state
+
+    for phase in ("scout", "implement", "verify", "review", "closeout", "retro"):
+        row = phases.get(phase)
+        if not row:
+            continue
+        row_status = (row.get("status") or "").lower()
+        if row_status not in _TERMINAL:
+            continue
+
+        task_id = row.get("id")
+        detail: dict[str, Any] = {}
+        if task_id:
+            detail = await fetch_detail(task_id)
+
+        if phase != state.phase:
+            continue
+
+        for item in evidence_from_handoff(phase, detail):  # type: ignore[arg-type]
+            state = with_evidence(state, item)
+
+        outcome = infer_outcome(phase, row_status, detail)  # type: ignore[arg-type]
+        if not outcome:
+            continue
+
+        if outcome == "complete" and not can_complete_phase(state):
+            save_state(
+                state,
+                event="gate_blocked",
+                extra={
+                    "phase": phase,
+                    "missing": sorted(missing_required_evidence(state)),
+                },
+            )
+            return state
+
+        try:
+            state = transition(state, outcome)  # type: ignore[arg-type]
+        except ValueError as exc:
+            save_state(state, event="transition_rejected", extra={"phase": phase, "reason": str(exc)})
+            return state
+
+        save_state(state, event="transition", extra={"outcome": outcome, "from_phase": phase})
+        if state.status in {"blocked", "done"}:
+            break
+
+    return state

--- a/services/zoe-data/tests/test_pipeline_evidence.py
+++ b/services/zoe-data/tests/test_pipeline_evidence.py
@@ -16,7 +16,7 @@ def test_evidence_metadata_rejects_secret_fields():
 
 
 def test_implement_requires_tool_evidence_before_complete():
-    state = PipelineState(task_ref="multica:1")
+    state = PipelineState(task_ref="multica:1", phase="implement")
 
     assert can_complete_phase(state) is False
     assert missing_required_evidence(state) == {"tool"}
@@ -90,7 +90,7 @@ def test_loop_back_outcomes_are_phase_scoped():
 
 
 def test_start_records_attempts_per_phase():
-    state = PipelineState(task_ref="multica:1")
+    state = PipelineState(task_ref="multica:1", phase="implement")
 
     state = transition(state, "start")
     state = transition(state, "start")
@@ -130,6 +130,14 @@ def test_merge_blocked_is_closeout_only_and_can_restart():
 
     with pytest.raises(ValueError, match="only valid from closeout"):
         transition(PipelineState(task_ref="multica:1", phase="retro"), "merge_blocked")
+
+
+def test_scout_requires_tool_evidence_before_complete():
+    state = PipelineState(task_ref="multica:1", phase="scout")
+    assert can_complete_phase(state) is False
+    state = with_evidence(state, EvidenceItem(kind="tool", summary="graphify path query", passed=True))
+    next_state = transition(state, "complete")
+    assert next_state.phase == "implement"
 
 
 def test_retro_complete_marks_pipeline_done():

--- a/services/zoe-data/tests/test_pipeline_handoff.py
+++ b/services/zoe-data/tests/test_pipeline_handoff.py
@@ -1,0 +1,39 @@
+"""Tests for Kanban handoff → pipeline evidence parsing."""
+
+from pipeline_handoff import evidence_from_handoff, infer_outcome
+
+
+def test_evidence_from_implement_handoff_parses_tools_and_tests():
+    detail = {
+        "latest_summary": "PR_URL=https://github.com/o/r/pull/1\nTOOLS_USED=graphify,opensrc\nTESTS=pytest -q passed",
+        "comments": [],
+    }
+    items = evidence_from_handoff("implement", detail)
+    kinds = {item.kind for item in items}
+    assert "tool" in kinds
+    assert "test" in kinds
+    assert "pr" in kinds
+
+
+def test_evidence_from_verify_handoff_parses_validators():
+    detail = {
+        "latest_summary": "VALIDATORS=validate_structure.py pass\nTESTS=pytest services/zoe-data/tests -q pass",
+        "comments": [],
+    }
+    items = evidence_from_handoff("verify", detail)
+    assert {item.kind for item in items} >= {"validator", "test"}
+
+
+def test_infer_outcome_blocked_verify_loops():
+    assert (
+        infer_outcome(
+            "verify",
+            "blocked",
+            {"latest_summary": "BLOCKER=pytest failed", "comments": []},
+        )
+        == "verification_failed"
+    )
+
+
+def test_infer_outcome_done_without_blocker_completes():
+    assert infer_outcome("review", "done", {"latest_summary": "SUMMARY=approved", "comments": []}) == "complete"

--- a/services/zoe-data/tests/test_pipeline_store.py
+++ b/services/zoe-data/tests/test_pipeline_store.py
@@ -1,0 +1,67 @@
+"""Tests for pipeline JSONL store and sync."""
+
+import json
+
+import pytest
+
+import pipeline_store as store
+from pipeline_evidence import EvidenceItem, PipelineState, with_evidence
+
+
+@pytest.fixture
+def isolated_store(tmp_path, monkeypatch):
+    path = tmp_path / "runs.jsonl"
+    monkeypatch.setenv("ZOE_PIPELINE_STORE_PATH", str(path))
+    return path
+
+
+def test_bootstrap_and_reload(isolated_store):
+    state = store.bootstrap_state("multica:abc")
+    assert state.task_ref == "multica:abc"
+    assert state.phase == "implement"
+
+    reloaded = store.load_latest_state("multica:abc")
+    assert reloaded is not None
+    assert reloaded.phase == "implement"
+
+
+def test_pipeline_summary_reports_missing_evidence(isolated_store):
+    state = PipelineState(task_ref="multica:1", phase="implement", status="running")
+    summary = store.pipeline_summary(state)
+    assert summary["tracked"] is True
+    assert summary["evidence_ok"] is False
+    assert "tool" in summary["missing_evidence"]
+
+
+@pytest.mark.asyncio
+async def test_sync_pipeline_advances_on_complete_handoff(isolated_store):
+    store.bootstrap_state("multica:sync")
+
+    async def fetch_detail(_task_id: str):
+        return {
+            "latest_summary": "TOOLS_USED=graphify\nTESTS=pytest -q pass\nPR_URL=https://github.com/o/r/pull/9",
+            "comments": [],
+        }
+
+    phases = {"implement": {"id": "t1", "status": "done"}}
+    state = await store.sync_pipeline_from_chain("multica:sync", phases, fetch_detail)
+    assert state.phase == "verify"
+    assert state.status == "todo"
+
+    lines = isolated_store.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) >= 2
+    last = json.loads(lines[-1])
+    assert last["event"] in {"transition", "gate_blocked"}
+
+
+@pytest.mark.asyncio
+async def test_sync_pipeline_gate_blocks_missing_evidence(isolated_store):
+    store.bootstrap_state("multica:gate")
+
+    async def fetch_detail(_task_id: str):
+        return {"latest_summary": "SUMMARY=no tools listed", "comments": []}
+
+    phases = {"implement": {"id": "t1", "status": "done"}}
+    state = await store.sync_pipeline_from_chain("multica:gate", phases, fetch_detail)
+    assert state.phase == "implement"
+    assert any("gate_blocked" in line for line in isolated_store.read_text(encoding="utf-8").splitlines())

--- a/services/zoe-data/tests/test_pipeline_store.py
+++ b/services/zoe-data/tests/test_pipeline_store.py
@@ -16,7 +16,9 @@ def isolated_store(tmp_path, monkeypatch):
 
 
 def test_bootstrap_and_reload(isolated_store):
-    state = store.bootstrap_state("multica:abc")
+    import asyncio
+
+    state = asyncio.run(store.bootstrap_state("multica:abc"))
     assert state.task_ref == "multica:abc"
     assert state.phase == "implement"
 
@@ -35,7 +37,7 @@ def test_pipeline_summary_reports_missing_evidence(isolated_store):
 
 @pytest.mark.asyncio
 async def test_sync_pipeline_advances_on_complete_handoff(isolated_store):
-    store.bootstrap_state("multica:sync")
+    await store.bootstrap_state("multica:sync")
 
     async def fetch_detail(_task_id: str):
         return {
@@ -56,7 +58,7 @@ async def test_sync_pipeline_advances_on_complete_handoff(isolated_store):
 
 @pytest.mark.asyncio
 async def test_sync_pipeline_gate_blocks_missing_evidence(isolated_store):
-    store.bootstrap_state("multica:gate")
+    await store.bootstrap_state("multica:gate")
 
     async def fetch_detail(_task_id: str):
         return {"latest_summary": "SUMMARY=no tools listed", "comments": []}


### PR DESCRIPTION
## Summary
- Add `pipeline_store.py` JSONL persistence and `pipeline_handoff.py` metadata parsing
- Sync pipeline state during Kanban `poll()` with fail-closed evidence gates
- Bootstrap pipeline runs on `dispatch()`; expose `pipeline` summary in poll results
- Add scout phase to evidence contract (prep for 6-phase chain)

## Test plan
- [x] pytest test_pipeline_handoff.py test_pipeline_store.py test_pipeline_evidence.py test_kanban_adapter.py (41 passed)
- [x] validate_structure.py


Made with [Cursor](https://cursor.com)