### PR TITLE
feat(kanban): add scout and retro 6-phase chain

### DIFF
--- a/docs/guides/MULTICA_HERMES_PR_LOOP.md
+++ b/docs/guides/MULTICA_HERMES_PR_LOOP.md
@@ -17,12 +17,14 @@ This workflow lets Zoe track engineering work from a Multica issue through Herme
 
 ## Flow
 
-1. A user, API caller, authenticated Multica webhook (`issue.assigned`), board approval, or the Zoe poll bridge creates a Hermes Kanban chain (**implement → verify → review → closeout**) on OpenRouter-routed worker profiles. Legacy in-flight chains may still be on the older **implement → review → closeout** path; poll treats them as complete when closeout finishes.
-2. `zoe-coder` implements on a worktree, opens a small PR, and hands off with `PR_URL=`, `BLOCKER=`, `TESTS=`, `TOOLS_USED=`, `SUMMARY=`.
-3. `zoe-reviewer` **verify** runs the objective evidence gate (structure validators, focused tests, live health) before review spends tokens.
-4. `zoe-reviewer` **review** checks diff scope and verify-phase evidence; blocks or requests changes when evidence is missing.
-5. `zoe-planner` **closeout** runs the Greptile grep loop (`github-greptile-loop`), squash-merges when Greptile + CI are green (`greploop_guard.py --merge-when-ready`), then updates the Multica issue.
-6. The Zoe poll loop advances Multica `in_progress` issues to `done` when the Kanban chain completes. Structured evidence uses the `pipeline_evidence` contract; fail-closed gates block phase advancement when required evidence is absent.
+1. A user, API caller, authenticated Multica webhook (`issue.assigned`), board approval, or the Zoe poll bridge creates a Hermes Kanban chain (**scout → implement → verify → review → closeout → retro**) on OpenRouter-routed worker profiles. Set `ZOE_KANBAN_SKIP_SCOUT=1` or issue `skip_scout` metadata to omit scout on well-scoped tasks. Legacy in-flight chains may still be on older paths; poll treats them as complete when closeout (or retro, when present) finishes.
+2. `zoe-planner` **scout** gathers Graphify/opensrc/Multica context read-only (no code changes).
+3. `zoe-coder` **implement** opens a small PR and hands off with `PR_URL=`, `BLOCKER=`, `TESTS=`, `TOOLS_USED=`, `SUMMARY=`.
+4. `zoe-reviewer` **verify** runs the objective evidence gate (structure validators, focused tests, live health) before review spends tokens.
+5. `zoe-reviewer` **review** checks diff scope and verify-phase evidence; blocks or requests changes when evidence is missing.
+6. `zoe-planner` **closeout** runs the Greptile grep loop (`github-greptile-loop`), squash-merges when Greptile + CI are green (`greploop_guard.py --merge-when-ready`), then updates the Multica issue.
+7. `zoe-planner` **retro** captures learnings and optional harness improvements (no silent production changes).
+8. The Zoe poll loop advances Multica `in_progress` issues to `done` when retro completes (or closeout for legacy/v2 chains without retro). Structured evidence uses `pipeline_evidence` + JSONL `pipeline_store`; fail-closed gates block phase advancement when required evidence is absent.
 
 ## Model Routing Policy (Phase 0 cost control)
 
@@ -78,12 +80,13 @@ what's the hermes engineering status
 
 Expected Kanban chain progression (per Multica issue):
 
+- `scout` (`zoe-planner`) — Graphify/opensrc/Multica context only; `TOOLS_USED=` + `SCOUT_SUMMARY=` handoff.
 - `implement` (`zoe-coder`) — graphify/opensrc first, smallest reviewable change, small PR on a worktree. Terminal protocol: `kanban_complete` or `kanban_block` on the last turn. Handoff metadata must include `PR_URL`, `TESTS`, `TOOLS_USED`, `SUMMARY`.
 - `verify` (`zoe-reviewer`) — objective test/evidence gate before review; records validator + test outcomes. Fail-closed: missing evidence blocks advancement.
 - `review` (`zoe-reviewer`) — diff/scope/architecture check against verify evidence; may loop back to implement via revision metadata.
 - `closeout` (`zoe-planner`) — Greptile grep loop, squash merge when ready, Multica status update.
-- Engineering mode: `ZOE_ENGINEERING_MODE=interactive|overnight` (or issue `engineering_mode` metadata) adjusts worker runtime and cost preference.
-- The Zoe poll loop advances the Multica issue to `done` when closeout (or retro, when present) completes.
+- `retro` (`zoe-planner`) — learnings + optional follow-up issue; pipeline completes when retro finishes.
+- Engineering mode: `ZOE_ENGINEERING_MODE=interactive|overnight|quality-escalation` (or issue metadata) adjusts worker runtime and cost preference.
 
 ## Board rollout
 

--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -1,19 +1,22 @@
 """Hermes Kanban executor adapter.
 
-Turns a Multica issue into a durable implement -> review -> closeout chain on
-the Hermes Kanban board, where OpenRouter-routed worker profiles do the work. All
-Kanban-specific behaviour lives here so it never leaks into Zoe core.
+Turns a Multica issue into a durable scout -> implement -> verify -> review ->
+closeout -> retro chain on the Hermes Kanban board, where OpenRouter-routed worker
+profiles do the work. All Kanban-specific behaviour lives here so it never leaks
+into Zoe core.
 
 Boundary: this shells the ``hermes kanban`` CLI (same SQLite DB the in-gateway
 dispatcher reads) rather than importing Hermes internals — keeping Zoe
 surface-agnostic.
 
 Worker profiles + pinned skills encode Zoe's agentic-engineering loop:
+  - scout     (zoe-planner):  zoe-graphify, zoe-engineering     (read-only context)
   - implement (zoe-coder):  zoe-engineering, zoe-graphify, source-code-context,
                             code-structure-cleanup  (graph-first, opensrc, lean)
   - verify    (zoe-reviewer): zoe-engineering           (tests/evidence gate)
   - review    (zoe-reviewer): zoe-engineering           (verification gate)
   - closeout  (zoe-planner):  github-greptile-loop      (grep-loop, merge, Multica done)
+  - retro     (zoe-planner):  zoe-status-refresh        (learnings, optional loop)
 """
 from __future__ import annotations
 
@@ -33,6 +36,7 @@ NAME = "kanban"
 # Phases of the per-issue chain, in order. Each maps to a worker profile and the
 # skills it must load. Keys double as the idempotency-key suffix (multica:{id}:<phase>).
 _CHAIN = (
+    ("scout", "zoe-planner", ("zoe-graphify", "zoe-engineering")),
     (
         "implement",
         "zoe-coder",
@@ -41,8 +45,10 @@ _CHAIN = (
     ("verify", "zoe-reviewer", ("zoe-engineering",)),
     ("review", "zoe-reviewer", ("zoe-engineering",)),
     ("closeout", "zoe-planner", ("github-greptile-loop",)),
+    ("retro", "zoe-planner", ("zoe-status-refresh",)),
 )
 _LEGACY_CHAIN_PHASES = ("implement", "review", "closeout")
+_V2_CHAIN_PHASES = ("implement", "verify", "review", "closeout")
 
 _ACTIVE_KANBAN_STATUSES = {"triage", "todo", "ready", "running", "blocked"}
 _TERMINAL_KANBAN_STATUSES = {"done", "archived"}
@@ -125,13 +131,49 @@ def _engineering_mode(issue: dict | None = None) -> str:
     mode = str(raw).strip().lower()
     if mode in {"overnight", "background", "self_evolution", "self-evolution"}:
         return "overnight"
+    if mode in {"quality-escalation", "quality_escalation", "escalation"}:
+        return "quality-escalation"
     return "interactive"
 
 
 def _max_runtime(mode: str = "interactive") -> str:
     if mode == "overnight":
         return os.environ.get("ZOE_KANBAN_OVERNIGHT_MAX_RUNTIME", "6h")
+    if mode == "quality-escalation":
+        return os.environ.get("ZOE_KANBAN_ESCALATION_MAX_RUNTIME", "90m")
     return os.environ.get("ZOE_KANBAN_MAX_RUNTIME", "45m")
+
+
+def _skip_scout(issue: dict | None = None) -> bool:
+    issue = issue or {}
+    if str(os.environ.get("ZOE_KANBAN_SKIP_SCOUT", "")).strip().lower() in {"1", "true", "yes"}:
+        return True
+    meta = issue.get("metadata") or {}
+    return str(meta.get("skip_scout") or issue.get("skip_scout") or "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+    }
+
+
+def _chain_for_issue(issue: dict) -> tuple[tuple[str, str, tuple[str, ...]], ...]:
+    phases = _CHAIN
+    if _skip_scout(issue):
+        phases = tuple(p for p in phases if p[0] != "scout")
+    return phases
+
+
+def _expected_phases(phases: dict[str, dict]) -> set[str]:
+    present = set(phases)
+    if present <= set(_LEGACY_CHAIN_PHASES) and "verify" not in present:
+        return set(_LEGACY_CHAIN_PHASES)
+    if "scout" in present:
+        return {p for p, _, _ in _CHAIN}
+    if "retro" in present:
+        return set(_V2_CHAIN_PHASES) | {"retro"}
+    if "verify" in present:
+        return set(_V2_CHAIN_PHASES)
+    return {p for p, _, _ in _CHAIN}
 
 
 class KanbanCLIError(RuntimeError):
@@ -181,6 +223,9 @@ class KanbanAdapter:
             "Engineering mode: overnight. Prioritize free/reliable local or OpenRouter-low-cost routes;"
             " latency is secondary to evidence quality.\n"
             if mode == "overnight"
+            else "Engineering mode: quality-escalation. Paid quality routes are allowed only after"
+            " evidence shows cheaper paths failed or architecture sensitivity requires it.\n"
+            if mode == "quality-escalation"
             else "Engineering mode: interactive. Keep user-visible latency and review size tight.\n"
         )
         # `zoe-ref:` is a machine marker that lets poll() correlate this task back
@@ -198,6 +243,16 @@ class KanbanAdapter:
             f"Repo: {_repo_root()}  |  Base branch: main  |  Workspace: git worktree\n\n"
             f"Title: {title}\n\n{description}\n\n"
         )
+        if phase == "scout":
+            return common + (
+                "You are scout (zoe-planner, read-only). Gather context before any code changes.\n"
+                "- Start with `kanban_show` and read the Multica issue acceptance criteria.\n"
+                "- Use Graphify (query/path/explain) and existing docs before raw repo scanning.\n"
+                "- Use opensrc for third-party APIs; reference Multica comments/state as source of truth.\n"
+                "- Do NOT edit code, open PRs, or mutate production config.\n"
+                "- Hand off with `kanban_complete` metadata including TOOLS_USED= and SCOUT_SUMMARY=.\n"
+                "- TERMINAL PROTOCOL: end with `kanban_complete` or `kanban_block` (no silent exit)."
+            )
         if phase == "implement":
             return common + (
                 "You are the implementer (zoe-coder). Start with `kanban_show` to confirm this task id.\n"
@@ -261,6 +316,17 @@ class KanbanAdapter:
                 " with an explicit reason instead.\n"
                 "- Record findings (pass/fail/concern) and a merge-readiness verdict in your handoff."
             )
+        if phase == "retro":
+            return common + (
+                "You are retro (zoe-planner). Capture learnings after closeout — no silent prod changes.\n"
+                "- Read closeout/implement handoffs and any Greptile or validator notes.\n"
+                "- Summarize what worked, what failed, and one small harness improvement proposal.\n"
+                "- Do NOT merge, refactor broadly, or change production behavior from this phase.\n"
+                "- Hand off with `kanban_complete` metadata: RETRO= or LEARNINGS= plus TOOLS_USED=.\n"
+                "- If a concrete follow-up needs code, note it for a NEW Multica issue — do not loop here"
+                " unless the operator explicitly marked this issue for a revision cycle.\n"
+                "- TERMINAL PROTOCOL: end with `kanban_complete` or `kanban_block`."
+            )
         # closeout
         return common + (
             "You are closeout (zoe-planner, orchestration only).\n"
@@ -305,7 +371,8 @@ class KanbanAdapter:
         created: list[str] = []
         parent: str | None = None
         mode = _engineering_mode(issue)
-        for phase, assignee, skills in _CHAIN:
+        phase_plan = _chain_for_issue(issue)
+        for phase, assignee, skills in phase_plan:
             args = [
                 "create",
                 self._title(phase, identifier, issue),
@@ -342,19 +409,26 @@ class KanbanAdapter:
         try:
             from pipeline_store import bootstrap_state
 
-            await bootstrap_state(external_ref, start_phase="implement")
+            await bootstrap_state(
+                external_ref,
+                start_phase="implement" if _skip_scout(issue) else "scout",
+            )
         except Exception as exc:
             logger.debug("kanban_adapter: pipeline bootstrap skipped for %s: %s", external_ref, exc)
         return {"ok": True, "external_ref": external_ref, "chain": chain, "created": created, "mode": mode}
 
     def _title(self, phase: str, identifier: str, issue: dict) -> str:
         base = issue.get("title") or identifier
+        if phase == "scout":
+            return f"Scout {identifier}"[:140]
         if phase == "implement":
             return f"{identifier}: {base}"[:140]
         if phase == "review":
             return f"Review {identifier}"[:140]
         if phase == "verify":
             return f"Verify {identifier}"[:140]
+        if phase == "retro":
+            return f"Retro {identifier}"[:140]
         return f"Closeout {identifier}"[:140]
 
     async def poll(self, external_ref: str) -> dict:
@@ -392,13 +466,12 @@ class KanbanAdapter:
                 break
 
         closeout = phases.get("closeout", {})
-        # Format invariant: new chains are created serially as implement->verify->review->closeout.
-        # If `verify` is absent, the row set is either a legacy 3-phase chain or a partial
-        # new chain that failed before verify; both are safe to evaluate against the legacy
-        # required set so re-dispatch can backfill only genuinely missing phases.
-        expected = set(tuple(p for p, _, _ in _CHAIN) if "verify" in phases else _LEGACY_CHAIN_PHASES)
+        retro = phases.get("retro", {})
+        expected = _expected_phases(phases)
         missing = expected - set(phases)
-        if (closeout.get("status") or "") in _TERMINAL_KANBAN_STATUSES:
+        if retro and (retro.get("status") or "") in _TERMINAL_KANBAN_STATUSES:
+            agg = "done"
+        elif (closeout.get("status") or "") in _TERMINAL_KANBAN_STATUSES and "retro" not in expected:
             agg = "done"
         elif blocker:
             agg = "blocked"
@@ -439,7 +512,7 @@ class KanbanAdapter:
     async def _extract_pr_url(self, phases: dict[str, dict]) -> str | None:
         """Pull a PR URL from the implement/closeout task summaries or comments."""
         pattern = re.compile(r"https://github\.com/[^/\s]+/[^/\s]+/pull/\d+")
-        for phase in ("closeout", "implement", "verify", "review"):
+        for phase in ("closeout", "retro", "implement", "verify", "review", "scout"):
             row = phases.get(phase)
             if not row:
                 continue

--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -165,10 +165,14 @@ def _chain_for_issue(issue: dict) -> tuple[tuple[str, str, tuple[str, ...]], ...
 
 def _expected_phases(phases: dict[str, dict]) -> set[str]:
     present = set(phases)
+    bodies = [(phases[p].get("body") or "") for p in present]
+    v3_chain = any("zoe-chain: v3" in body for body in bodies)
     if present <= set(_LEGACY_CHAIN_PHASES) and "verify" not in present:
         return set(_LEGACY_CHAIN_PHASES)
     if "scout" in present:
         return {p for p, _, _ in _CHAIN}
+    if v3_chain:
+        return set(_V2_CHAIN_PHASES) | {"retro"}
     if "retro" in present:
         return set(_V2_CHAIN_PHASES) | {"retro"}
     if "verify" in present:
@@ -239,6 +243,7 @@ class KanbanAdapter:
         common = (
             f"Multica issue: {identifier} (id {issue_id})\n"
             f"zoe-ref: multica:{issue_id}:{phase}\n"
+            f"zoe-chain: v3\n"
             f"{mode_note}"
             f"Repo: {_repo_root()}  |  Base branch: main  |  Workspace: git worktree\n\n"
             f"Title: {title}\n\n{description}\n\n"
@@ -356,7 +361,7 @@ class KanbanAdapter:
         )
 
     async def dispatch(self, issue: dict) -> dict:
-        """Create (idempotently) the implement->verify->review->closeout chain for a Multica issue.
+        """Create (idempotently) the scout->implement->verify->review->closeout->retro chain.
 
         Returns {ok, external_ref, chain:{phase:task_id}, created:[phases], mode}.
         """

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -196,12 +196,12 @@ async def test_retro_body_captures_learnings():
 @pytest.mark.asyncio
 async def test_poll_done_when_retro_completes():
     rows = [
-        _row("scout", "done"),
-        _row("implement", "done"),
-        _row("verify", "done"),
-        _row("review", "done"),
-        _row("closeout", "done"),
-        _row("retro", "done"),
+        _row("scout", "done", v3=True),
+        _row("implement", "done", v3=True),
+        _row("verify", "done", v3=True),
+        _row("review", "done", v3=True),
+        _row("closeout", "done", v3=True),
+        _row("retro", "done", v3=True),
     ]
     a = _FakeAdapter(list_rows=rows)
     out = await a.poll("multica:uuid-9")
@@ -223,18 +223,45 @@ async def test_poll_v2_chain_done_at_closeout_without_retro():
 
 
 @pytest.mark.asyncio
+async def test_poll_skip_scout_v3_chain_done_when_retro_completes():
+    rows = [
+        _row("implement", "done", v3=True),
+        _row("verify", "done", v3=True),
+        _row("review", "done", v3=True),
+        _row("closeout", "done", v3=True),
+        _row("retro", "done", v3=True),
+    ]
+    a = _FakeAdapter(list_rows=rows)
+    out = await a.poll("multica:uuid-9")
+    assert out["status"] == "done"
+
+
+@pytest.mark.asyncio
 async def test_poll_running_when_closeout_done_but_retro_pending():
     rows = [
-        _row("scout", "done"),
-        _row("implement", "done"),
-        _row("verify", "done"),
-        _row("review", "done"),
-        _row("closeout", "done"),
-        _row("retro", "todo"),
+        _row("scout", "done", v3=True),
+        _row("implement", "done", v3=True),
+        _row("verify", "done", v3=True),
+        _row("review", "done", v3=True),
+        _row("closeout", "done", v3=True),
+        _row("retro", "todo", v3=True),
     ]
     a = _FakeAdapter(list_rows=rows)
     out = await a.poll("multica:uuid-9")
     assert out["status"] == "running"
+
+
+@pytest.mark.asyncio
+async def test_poll_skip_scout_v3_partial_missing_retro_is_redispatchable():
+    rows = [
+        _row("implement", "done", v3=True),
+        _row("verify", "done", v3=True),
+        _row("review", "done", v3=True),
+        _row("closeout", "done", v3=True),
+    ]
+    a = _FakeAdapter(list_rows=rows)
+    out = await a.poll("multica:uuid-9")
+    assert out["status"] == "partial"
 
 
 @pytest.mark.asyncio
@@ -325,9 +352,12 @@ async def test_poll_partial_chain_is_redispatchable():
 
 def _row(phase, status, **extra):
     """A Kanban list row shaped like the real CLI: body marker, NO idempotency_key."""
+    body = f"Multica issue: ZOE-9 (id uuid-9)\nzoe-ref: multica:uuid-9:{phase}\nTitle: x"
+    if extra.pop("v3", False):
+        body = f"Multica issue: ZOE-9 (id uuid-9)\nzoe-ref: multica:uuid-9:{phase}\nzoe-chain: v3\nTitle: x"
     return {
         "id": f"t_{phase}",
-        "body": f"Multica issue: ZOE-9 (id uuid-9)\nzoe-ref: multica:uuid-9:{phase}\nTitle: x",
+        "body": body,
         "status": status,
         **extra,
     }

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -31,26 +31,33 @@ class _FakeAdapter(ka.KanbanAdapter):
 
 
 @pytest.mark.asyncio
-async def test_dispatch_creates_four_linked_phases():
+async def test_dispatch_creates_six_linked_phases():
     a = _FakeAdapter()
     issue = {"id": "uuid-1", "identifier": "ZOE-9", "title": "Fix thing", "description": "do it"}
     result = await a.dispatch(issue)
     assert result["ok"] is True
     assert result["external_ref"] == "multica:uuid-1"
-    assert set(result["chain"]) == {"implement", "verify", "review", "closeout"}
+    assert set(result["chain"]) == {
+        "scout",
+        "implement",
+        "verify",
+        "review",
+        "closeout",
+        "retro",
+    }
     creates = [c for c in a.calls if c[0] == "create"]
-    assert len(creates) == 4
-    # verify + review + closeout must be linked to a parent
-    assert "--parent" in creates[1]
-    assert "--parent" in creates[2]
-    assert "--parent" in creates[3]
-    # idempotency keys are phase-scoped
+    assert len(creates) == 6
+    # verify + review + closeout + retro must be linked to a parent
+    for create in creates[1:]:
+        assert "--parent" in create
     keys = [c[c.index("--idempotency-key") + 1] for c in creates]
     assert keys == [
+        "multica:uuid-1:scout",
         "multica:uuid-1:implement",
         "multica:uuid-1:verify",
         "multica:uuid-1:review",
         "multica:uuid-1:closeout",
+        "multica:uuid-1:retro",
     ]
     assert result["mode"] == "interactive"
 
@@ -70,9 +77,9 @@ async def test_dispatch_overnight_mode_extends_runtime(monkeypatch):
 
     creates = [c for c in a.calls if c[0] == "create"]
     runtimes = [c[c.index("--max-runtime") + 1] for c in creates]
-    body = creates[0][creates[0].index("--body") + 1]
+    body = creates[1][creates[1].index("--body") + 1]
     assert result["mode"] == "overnight"
-    assert runtimes == ["8h", "8h", "8h", "8h"]
+    assert runtimes == ["8h"] * 6
     assert "latency is secondary" in body
 
 
@@ -84,8 +91,8 @@ async def test_dispatch_interactive_mode_uses_default_runtime(monkeypatch):
     await a.dispatch({"id": "uuid-fast", "identifier": "ZOE-FAST", "title": "Immediate work"})
 
     creates = [c for c in a.calls if c[0] == "create"]
-    assert creates[0][creates[0].index("--max-runtime") + 1] == "30m"
-    body = creates[0][creates[0].index("--body") + 1]
+    assert creates[1][creates[1].index("--max-runtime") + 1] == "30m"
+    body = creates[1][creates[1].index("--body") + 1]
     assert "Engineering mode: interactive" in body
 
 
@@ -113,13 +120,38 @@ async def test_dispatch_overnight_mode_from_env(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_dispatch_skip_scout_when_env_set(monkeypatch):
+    monkeypatch.setenv("ZOE_KANBAN_SKIP_SCOUT", "1")
+    a = _FakeAdapter()
+    result = await a.dispatch({"id": "uuid-skip", "identifier": "ZOE-SKIP", "title": "t"})
+    assert "scout" not in result["chain"]
+    assert set(result["chain"]) == {"implement", "verify", "review", "closeout", "retro"}
+
+
+@pytest.mark.asyncio
+async def test_dispatch_quality_escalation_mode(monkeypatch):
+    monkeypatch.setenv("ZOE_KANBAN_ESCALATION_MAX_RUNTIME", "75m")
+    a = _FakeAdapter()
+    result = await a.dispatch(
+        {"id": "uuid-q", "identifier": "ZOE-Q", "title": "Hard task", "engineering_mode": "quality-escalation"}
+    )
+    creates = [c for c in a.calls if c[0] == "create"]
+    assert result["mode"] == "quality-escalation"
+    assert creates[0][creates[0].index("--max-runtime") + 1] == "75m"
+    body = creates[1][creates[1].index("--body") + 1]
+    assert "quality-escalation" in body
+
+
+@pytest.mark.asyncio
 async def test_dispatch_writes_zoe_ref_marker_into_body():
     # poll() correlates on the `zoe-ref:` body marker because the live
     # `hermes kanban list --json` output does not expose the idempotency key.
     a = _FakeAdapter()
     await a.dispatch({"id": "uuid-7", "identifier": "ZOE-7", "title": "t"})
     creates = [c for c in a.calls if c[0] == "create"]
-    for phase, create in zip(("implement", "verify", "review", "closeout"), creates):
+    for phase, create in zip(
+        ("scout", "implement", "verify", "review", "closeout", "retro"), creates
+    ):
         body = create[create.index("--body") + 1]
         assert f"zoe-ref: multica:uuid-7:{phase}" in body
 
@@ -136,6 +168,73 @@ async def test_closeout_body_instructs_merge_when_ready():
     assert "MERGE_SHA=" in body
     assert "--packet-only" in body
     assert "never --admin" in body
+
+
+@pytest.mark.asyncio
+async def test_scout_body_is_read_only():
+    body = ka.KanbanAdapter()._build_body(
+        "scout",
+        {"id": "uuid-1", "identifier": "ZOE-9", "title": "Fix thing", "description": ""},
+        "ZOE-9",
+    )
+    assert "read-only" in body
+    assert "Do NOT edit code" in body
+    assert "TOOLS_USED" in body
+
+
+@pytest.mark.asyncio
+async def test_retro_body_captures_learnings():
+    body = ka.KanbanAdapter()._build_body(
+        "retro",
+        {"id": "uuid-1", "identifier": "ZOE-9", "title": "Fix thing", "description": ""},
+        "ZOE-9",
+    )
+    assert "RETRO=" in body or "LEARNINGS=" in body
+    assert "Do NOT merge" in body
+
+
+@pytest.mark.asyncio
+async def test_poll_done_when_retro_completes():
+    rows = [
+        _row("scout", "done"),
+        _row("implement", "done"),
+        _row("verify", "done"),
+        _row("review", "done"),
+        _row("closeout", "done"),
+        _row("retro", "done"),
+    ]
+    a = _FakeAdapter(list_rows=rows)
+    out = await a.poll("multica:uuid-9")
+    assert out["status"] == "done"
+    assert out["phases"]["retro"] == "done"
+
+
+@pytest.mark.asyncio
+async def test_poll_v2_chain_done_at_closeout_without_retro():
+    rows = [
+        _row("implement", "done"),
+        _row("verify", "done"),
+        _row("review", "done"),
+        _row("closeout", "done"),
+    ]
+    a = _FakeAdapter(list_rows=rows)
+    out = await a.poll("multica:uuid-9")
+    assert out["status"] == "done"
+
+
+@pytest.mark.asyncio
+async def test_poll_running_when_closeout_done_but_retro_pending():
+    rows = [
+        _row("scout", "done"),
+        _row("implement", "done"),
+        _row("verify", "done"),
+        _row("review", "done"),
+        _row("closeout", "done"),
+        _row("retro", "todo"),
+    ]
+    a = _FakeAdapter(list_rows=rows)
+    out = await a.poll("multica:uuid-9")
+    assert out["status"] == "running"
 
 
 @pytest.mark.asyncio
@@ -168,12 +267,16 @@ async def test_dispatch_pins_expected_skills():
     a = _FakeAdapter()
     await a.dispatch({"id": "u", "identifier": "ZOE-1", "title": "t"})
     creates = [c for c in a.calls if c[0] == "create"]
-    impl_skills = [creates[0][i + 1] for i, v in enumerate(creates[0]) if v == "--skill"]
-    verify_skills = [creates[1][i + 1] for i, v in enumerate(creates[1]) if v == "--skill"]
-    closeout_skills = [creates[3][i + 1] for i, v in enumerate(creates[3]) if v == "--skill"]
+    impl_skills = [creates[1][i + 1] for i, v in enumerate(creates[1]) if v == "--skill"]
+    scout_skills = [creates[0][i + 1] for i, v in enumerate(creates[0]) if v == "--skill"]
+    verify_skills = [creates[2][i + 1] for i, v in enumerate(creates[2]) if v == "--skill"]
+    closeout_skills = [creates[4][i + 1] for i, v in enumerate(creates[4]) if v == "--skill"]
+    retro_skills = [creates[5][i + 1] for i, v in enumerate(creates[5]) if v == "--skill"]
+    assert "zoe-graphify" in scout_skills
     assert "zoe-graphify" in impl_skills and "code-structure-cleanup" in impl_skills
     assert "zoe-engineering" in verify_skills
     assert "github-greptile-loop" in closeout_skills
+    assert "zoe-status-refresh" in retro_skills
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Extend Kanban adapter to **scout→implement→verify→review→closeout→retro**
- Legacy v1 (3-phase) and v2 (4-phase) chains still complete at closeout
- Add `quality-escalation` engineering mode and `ZOE_KANBAN_SKIP_SCOUT` escape hatch
- Update MULTICA_HERMES_PR_LOOP.md for full 6-phase flow

## Test plan
- [x] 53 pytest (kanban + pipeline + poll dispatch)
- [x] validate_structure.py


Made with [Cursor](https://cursor.com)