### PR TITLE
docs(hermes): verify aux routing and spike baseline

### DIFF
--- a/docs/guides/AGENT_SPIKE_PLAYBOOK.md
+++ b/docs/guides/AGENT_SPIKE_PLAYBOOK.md
@@ -45,3 +45,24 @@ commands. Attach the resulting JSON to the PR or Multica issue summary.
 - If the candidate increases cost, complexity, or dependency gravity without a
   measurable reliability gain, close it as "do not adopt."
 
+## 2026-06-01 baseline packets (Jetson host)
+
+Packets generated after the native evidence path landed (PR #127). Artifacts live
+outside the repo under `/tmp/zoe-agent-spikes/`:
+
+| Candidate | Available | Recommendation |
+|-----------|-----------|----------------|
+| Forge | no (proxy not installed) | Defer until `llama-server` + Forge proxy spike is scheduled |
+| Caveman | no (npm plugin not installed) | Defer; evaluate in disposable profile only if compression need is measured |
+| Babysitter | no (not installed) | Reference-only; Zoe owns orchestration via Kanban + `pipeline_store` |
+
+Commands used:
+
+```bash
+python3 scripts/maintenance/agent_spike_metrics.py forge --task "..." --output /tmp/zoe-agent-spikes/forge-spike.json
+python3 scripts/maintenance/agent_spike_metrics.py caveman --task "..." --output /tmp/zoe-agent-spikes/caveman-spike.json
+python3 scripts/maintenance/agent_spike_metrics.py babysitter --task "..." --output /tmp/zoe-agent-spikes/babysitter-spike.json
+```
+
+Do not install Babysitter, Forge, or Caveman into production from these packets alone.
+

--- a/docs/guides/HERMES_OPTIMIZATION_PLAYBOOK.md
+++ b/docs/guides/HERMES_OPTIMIZATION_PLAYBOOK.md
@@ -126,7 +126,8 @@ Routing was tightened to match the board-cost policy:
   - `google/gemini-2.5-flash`
   - `openrouter/free`
 - Root background auxiliaries were moved away from direct Gemini/OpenAI and `provider: auto` to `provider: openrouter` with `openrouter/free` where they are text-only (`web_extract`, `compression`, title/session/search/triage/curator/approval/MCP helpers, etc.) to avoid background calls silently routing to Codex or paid direct APIs.
-- Specialized non-engineering slots such as vision/TTS remain separate and are not part of the Kanban cost-control route.
+- `auxiliary.vision` was the last remaining `provider: auto` slot; it now uses `openrouter / openrouter/free` (2026-06-01 verification pass).
+- Specialized non-engineering slots such as TTS remain separate and are not part of the Kanban cost-control route.
 
 Verification run after apply:
 


### PR DESCRIPTION
## Summary
- Document last `provider: auto` fix (`auxiliary.vision` → openrouter/free)
- Record 2026-06-01 Forge/Caveman/Babysitter spike packets (all unavailable — defer)

## Test plan
- [x] validate_structure.py
- [x] Docs-only; host vision slot verified on Jetson operator host


Made with [Cursor](https://cursor.com)