### PR TITLE
Route background tasks and Kanban escalation off Codex

### DIFF
--- a/docs/guides/HERMES_OPTIMIZATION_PLAYBOOK.md
+++ b/docs/guides/HERMES_OPTIMIZATION_PLAYBOOK.md
@@ -22,7 +22,8 @@ phases as ready-to-run prompts.
 - Hourly engineering loop = Hermes built-in cron `hourly-zoe-issue-fix-greptile-merge`
   in `~/.hermes/cron/jobs.json` (every 60m).
 - Zoe integrates via `services/zoe-data/routers/chat.py` (`escalate_to_hermes`),
-  `background_runner.py`, and the executor seam (`executor_registry.py` →
+  `background_runner.py` (background tasks via `hermes -p zoe-coder -z`, not the
+  Codex gateway API), and the executor seam (`executor_registry.py` →
   `executors/kanban_adapter.py`) that dispatches Multica issues to Hermes Kanban.
 
 ## The bigger why — the411 / Nudge
@@ -120,9 +121,9 @@ Routing was tightened to match the board-cost policy:
 - Main Hermes (`~/.hermes/config.yaml`) now uses `openai-codex / gpt-5.4` as primary.
 - Main fallback is now a single controlled path: `openrouter / openrouter/free`.
 - Main fallback entries for direct `gemini` and `openai-api` were removed from the fallback chain.
-- Planner profile now uses `openrouter` directly (`anthropic/claude-sonnet-4.6`) instead of `provider: auto`.
+- Planner profile now uses `openrouter` directly (`minimax/minimax-m3`) instead of `provider: auto`.
 - Kanban worker profiles (`zoe-planner`, `zoe-coder`, `zoe-reviewer`) now keep fallback chains OpenRouter-only:
-  - `anthropic/claude-sonnet-4.6`
+  - `minimax/minimax-m3` (planner/reviewer primary; first fallback for coder)
   - `google/gemini-2.5-flash`
   - `openrouter/free`
 - Root background auxiliaries were moved away from direct Gemini/OpenAI and `provider: auto` to `provider: openrouter` with `openrouter/free` where they are text-only (`web_extract`, `compression`, title/session/search/triage/curator/approval/MCP helpers, etc.) to avoid background calls silently routing to Codex or paid direct APIs.

--- a/docs/guides/MULTICA_HERMES_PR_LOOP.md
+++ b/docs/guides/MULTICA_HERMES_PR_LOOP.md
@@ -35,7 +35,8 @@ Worker-chain routing is intentionally different from main chat routing:
   - Fallback: `openrouter / openrouter/free`
 - **Kanban workers** (`zoe-planner`, `zoe-coder`, `zoe-reviewer`):
   - Primary/fallbacks are OpenRouter-only (no direct `gemini` or `openai-api` provider entries)
-  - Current fallback order: `anthropic/claude-sonnet-4.6` → `google/gemini-2.5-flash` → `openrouter/free`
+  - Planner/reviewer primary: `minimax/minimax-m3`; coder primary: `deepseek/deepseek-chat-v3.1`
+  - Fallback order: `minimax/minimax-m3` → `google/gemini-2.5-flash` → `openrouter/free`
 
 This keeps board execution off Codex usage while preserving a deterministic low-cost fallback path.
 

--- a/services/zoe-data/background_runner.py
+++ b/services/zoe-data/background_runner.py
@@ -14,12 +14,11 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-import shutil
 import time
 import uuid
 from datetime import datetime, timezone
 
-from hermes_http import hermes_auth_headers
+from hermes_http import hermes_auth_headers, hermes_bin, zoe_repo_root
 
 logger = logging.getLogger(__name__)
 
@@ -36,16 +35,6 @@ _MAX_REQUEST_DEPTH = 3
 # Background tasks run through a Kanban worker profile (OpenRouter), not the main
 # Codex gateway. Override with HERMES_BACKGROUND_PROFILE or HERMES_BACKGROUND_MODEL.
 _DEFAULT_BACKGROUND_PROFILE = "zoe-coder"
-
-
-def _hermes_bin() -> str:
-    override = os.environ.get("HERMES_BIN", "").strip()
-    if override:
-        return override
-    found = shutil.which("hermes")
-    if found:
-        return found
-    return os.path.expanduser("~/.local/bin/hermes")
 
 
 def _background_profile() -> str:
@@ -243,7 +232,7 @@ async def _run_hermes_background_task(task: str, *, user_id: str, task_id: int) 
     """
     profile = _background_profile()
     timeout_s = float(os.environ.get("HERMES_BACKGROUND_TIMEOUT_S", "900"))
-    repo_root = os.environ.get("ZOE_REPO_ROOT", "/home/zoe/assistant")
+    repo_root = zoe_repo_root()
     prompt = (
         "You are Hermes running a Zoe background task. "
         "Use Zoe tools and CloakBrowser MCP tools when needed. "
@@ -253,7 +242,7 @@ async def _run_hermes_background_task(task: str, *, user_id: str, task_id: int) 
         f"Task:\n{task}"
     )
     cmd = [
-        _hermes_bin(),
+        hermes_bin(),
         "-p",
         profile,
         "--accept-hooks",

--- a/services/zoe-data/background_runner.py
+++ b/services/zoe-data/background_runner.py
@@ -14,11 +14,10 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import shutil
 import time
 import uuid
 from datetime import datetime, timezone
-
-import httpx
 
 from hermes_http import hermes_auth_headers
 
@@ -33,6 +32,32 @@ _running: dict[int, asyncio.Task] = {}
 
 # Max A2A delegation depth to prevent infinite loops
 _MAX_REQUEST_DEPTH = 3
+
+# Background tasks run through a Kanban worker profile (OpenRouter), not the main
+# Codex gateway. Override with HERMES_BACKGROUND_PROFILE or HERMES_BACKGROUND_MODEL.
+_DEFAULT_BACKGROUND_PROFILE = "zoe-coder"
+
+
+def _hermes_bin() -> str:
+    override = os.environ.get("HERMES_BIN", "").strip()
+    if override:
+        return override
+    found = shutil.which("hermes")
+    if found:
+        return found
+    return os.path.expanduser("~/.local/bin/hermes")
+
+
+def _background_profile() -> str:
+    for key in ("HERMES_BACKGROUND_PROFILE", "HERMES_BACKGROUND_MODEL"):
+        val = os.environ.get(key, "").strip()
+        if val:
+            return val
+    # Legacy HERMES_MODEL only when explicitly set to a worker profile / OpenRouter id.
+    legacy = os.environ.get("HERMES_MODEL", "").strip()
+    if legacy and legacy not in {"hermes-agent", "hermes"}:
+        return legacy
+    return _DEFAULT_BACKGROUND_PROFILE
 
 
 async def _record_cost_event(
@@ -161,11 +186,11 @@ async def _run_task(
         _est_tokens = len(result) // 4
         await _record_cost_event(
             agent_name="hermes",
-            model=os.environ.get("HERMES_MODEL", "hermes-agent"),
+            model=_background_profile(),
             task_id=task_id,
             user_id=user_id,
             output_tokens=_est_tokens,
-            estimated_cost_usd=_est_tokens * 0.000015,  # rough codex output rate
+            estimated_cost_usd=_est_tokens * 0.000002,  # rough OpenRouter worker output rate
         )
         try:
             from push import broadcaster
@@ -210,10 +235,15 @@ async def _run_task(
 
 
 async def _run_hermes_background_task(task: str, *, user_id: str, task_id: int) -> str:
-    """Run a background task through Hermes' OpenAI-compatible API."""
-    api_url = os.environ.get("HERMES_API_URL", "http://127.0.0.1:8642").rstrip("/")
-    model = os.environ.get("HERMES_MODEL", "hermes-agent")
+    """Run a background task via ``hermes -p <worker-profile> -z`` (OpenRouter path).
+
+    The main gateway API ignores per-request model overrides and always uses the
+    Codex default, so background work is routed through a Kanban worker profile
+    (default ``zoe-coder`` / DeepSeek on OpenRouter) instead.
+    """
+    profile = _background_profile()
     timeout_s = float(os.environ.get("HERMES_BACKGROUND_TIMEOUT_S", "900"))
+    repo_root = os.environ.get("ZOE_REPO_ROOT", "/home/zoe/assistant")
     prompt = (
         "You are Hermes running a Zoe background task. "
         "Use Zoe tools and CloakBrowser MCP tools when needed. "
@@ -222,25 +252,37 @@ async def _run_hermes_background_task(task: str, *, user_id: str, task_id: int) 
         f"user_id={user_id}, task_id={task_id}.\n\n"
         f"Task:\n{task}"
     )
-    payload = {
-        "model": model,
-        "messages": [{"role": "user", "content": prompt}],
-        "stream": False,
-    }
-    async with httpx.AsyncClient(timeout=timeout_s) as client:
-        resp = await client.post(
-            f"{api_url}/v1/chat/completions",
-            json=payload,
-            headers=_hermes_headers(session_id=f"background-task-{task_id}"),
-        )
-        resp.raise_for_status()
-        data = resp.json()
-    return (
-        data.get("choices", [{}])[0]
-        .get("message", {})
-        .get("content", "")
-        .strip()
+    cmd = [
+        _hermes_bin(),
+        "-p",
+        profile,
+        "--accept-hooks",
+        "-z",
+        prompt,
+    ]
+    env = dict(os.environ)
+    env.setdefault("HERMES_YOLO_MODE", "1")
+    env["HERMES_SESSION_ID"] = f"background-task-{task_id}"
+    proc = await asyncio.create_subprocess_exec(
+        *cmd,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        cwd=repo_root,
+        env=env,
     )
+    try:
+        out, err = await asyncio.wait_for(proc.communicate(), timeout=timeout_s)
+    except asyncio.TimeoutError:
+        proc.kill()
+        await proc.wait()
+        raise TimeoutError(f"Background Hermes task timed out after {timeout_s:.0f}s")
+    stdout = (out or b"").decode("utf-8", errors="replace").strip()
+    stderr = (err or b"").decode("utf-8", errors="replace").strip()
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"hermes -p {profile} -z exited {proc.returncode}: {stderr or stdout or 'no output'}"
+        )
+    return stdout or "(No result returned)"
 
 
 async def get_pending_tasks(user_id: str) -> list[dict]:

--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -136,6 +136,59 @@ def _engineering_mode(issue: dict | None = None) -> str:
     return "interactive"
 
 
+def _model_escalation_active(issue: dict | None, mode: str) -> bool:
+    """True when review/verify/closeout may use stronger models after cheap paths fail."""
+    issue = issue or {}
+    meta = issue.get("metadata") or {}
+    if str(meta.get("model_escalation") or issue.get("model_escalation") or "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+    }:
+        return True
+    return mode == "quality-escalation"
+
+
+def _escalation_model_hint(issue: dict | None) -> str:
+    """Paid-model escalation guard — never suggest openrouter/auto without explicit opt-in."""
+    issue = issue or {}
+    meta = issue.get("metadata") or {}
+    paid_auto_ok = str(meta.get("confirm_paid_auto") or issue.get("confirm_paid_auto") or "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+    }
+    lines = [
+        "Model escalation: if profile defaults and fallbacks"
+        " (minimax/minimax-m3, google/gemini-2.5-flash, openrouter/free) fail twice on this phase,"
+        " you MAY switch to anthropic/claude-sonnet-4.6 for this task only.",
+    ]
+    if paid_auto_ok:
+        lines.append(
+            "Operator confirmed paid auto-routing: openrouter/auto is allowed as a last resort"
+            " when Sonnet also fails."
+        )
+    else:
+        lines.append(
+            "Do NOT use openrouter/auto on this task — confirm_paid_auto is not set on the issue."
+        )
+    return "\n".join(lines) + "\n"
+
+
+def _overnight_implement_cost_hint() -> str:
+    return (
+        "Overnight cost routing: prefer profile defaults first; after two failures on the same check,"
+        " retry with openrouter/free before any paid escalation.\n"
+    )
+
+
+def _retro_cost_hint() -> str:
+    return (
+        "Retro cost routing: summaries only — prefer google/gemini-2.5-flash or openrouter/free;"
+        " do not burn premium models on long re-reads.\n"
+    )
+
+
 def _max_runtime(mode: str = "interactive") -> str:
     if mode == "overnight":
         return os.environ.get("ZOE_KANBAN_OVERNIGHT_MAX_RUNTIME", "6h")
@@ -240,10 +293,13 @@ class KanbanAdapter:
         # whitespace-padded id would desync the marker from external_ref and poll()
         # would never match): multica:{id}:{phase}.
         issue_id = str(issue.get("id") or "").strip()
+        escalation = _model_escalation_active(issue, mode)
+        escalation_marker = "zoe-model-escalation: true\n" if escalation else ""
         common = (
             f"Multica issue: {identifier} (id {issue_id})\n"
             f"zoe-ref: multica:{issue_id}:{phase}\n"
             f"zoe-chain: v3\n"
+            f"{escalation_marker}"
             f"{mode_note}"
             f"Repo: {_repo_root()}  |  Base branch: main  |  Workspace: git worktree\n\n"
             f"Title: {title}\n\n{description}\n\n"
@@ -259,7 +315,8 @@ class KanbanAdapter:
                 "- TERMINAL PROTOCOL: end with `kanban_complete` or `kanban_block` (no silent exit)."
             )
         if phase == "implement":
-            return common + (
+            overnight_hint = _overnight_implement_cost_hint() if mode == "overnight" else ""
+            return common + overnight_hint + (
                 "You are the implementer (zoe-coder). Start with `kanban_show` to confirm this task id.\n"
                 "- Read the charter + graphify map first (graphify query/path/explain over raw grep).\n"
                 "- Use opensrc for any third-party library source before guessing APIs.\n"
@@ -294,7 +351,8 @@ class KanbanAdapter:
                 "Changed files + branch/worktree details for the reviewer."
             )
         if phase == "verify":
-            return common + (
+            escalation_hint = _escalation_model_hint(issue) if escalation else ""
+            return common + escalation_hint + (
                 "You are verify (zoe-reviewer). This is the objective test/evidence gate before review.\n"
                 "- Start with `kanban_show` to read the implementer handoff and PR_URL.\n"
                 "- Do not redesign or refactor. Run the declared tests and the minimum extra checks needed"
@@ -309,7 +367,8 @@ class KanbanAdapter:
                 "- TERMINAL PROTOCOL: end with `kanban_complete` or `kanban_block` (no silent exit)."
             )
         if phase == "review":
-            return common + (
+            escalation_hint = _escalation_model_hint(issue) if escalation else ""
+            return common + escalation_hint + (
                 "You are the reviewer (zoe-reviewer). Review the diff, scope, and verify-phase evidence.\n"
                 "- Confirm the change is small and in scope. Audit-only / doc-only handoffs with blank PR_URL"
                 " need a short verification note, then `kanban_complete` — do not re-implement or burn turns"
@@ -322,7 +381,7 @@ class KanbanAdapter:
                 "- Record findings (pass/fail/concern) and a merge-readiness verdict in your handoff."
             )
         if phase == "retro":
-            return common + (
+            return common + _retro_cost_hint() + (
                 "You are retro (zoe-planner). Capture learnings after closeout — no silent prod changes.\n"
                 "- Read closeout/implement handoffs and any Greptile or validator notes.\n"
                 "- Summarize what worked, what failed, and one small harness improvement proposal.\n"
@@ -333,7 +392,8 @@ class KanbanAdapter:
                 "- TERMINAL PROTOCOL: end with `kanban_complete` or `kanban_block`."
             )
         # closeout
-        return common + (
+        escalation_hint = _escalation_model_hint(issue) if escalation else ""
+        return common + escalation_hint + (
             "You are closeout (zoe-planner, orchestration only).\n"
             "- Read the implementer's PR_URL handoff and extract the PR number N (the trailing /pull/N)."
             " If AUDIT_ONLY=1 or audit-only with blank PR_URL, `kanban_complete` and note Multica done"

--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -25,9 +25,10 @@ import json
 import logging
 import os
 import re
-import shutil
 from pathlib import Path
 from typing import Any
+
+from hermes_http import hermes_bin, zoe_repo_root
 
 logger = logging.getLogger(__name__)
 
@@ -74,28 +75,6 @@ def _row_ref_key(row: dict) -> str:
     return match.group(1) if match else ""
 
 
-def _hermes_bin() -> str:
-    """Locate the hermes CLI; honour HERMES_BIN override."""
-    override = os.environ.get("HERMES_BIN", "").strip()
-    if override:
-        return override
-    found = shutil.which("hermes")
-    if found:
-        return found
-    candidate = os.path.expanduser("~/.local/bin/hermes")
-    return candidate
-
-
-def _repo_root() -> str:
-    env = os.environ.get("ZOE_REPO_ROOT", "").strip()
-    if env:
-        return env
-    # Derive the repo root from this file's location so non-standard deployments
-    # (different user/install path) work without ZOE_REPO_ROOT set:
-    # services/zoe-data/executors/kanban_adapter.py -> repo root is 3 levels up.
-    return str(Path(__file__).resolve().parents[3])
-
-
 def _board() -> str:
     return os.environ.get("ZOE_KANBAN_BOARD", "default")
 
@@ -104,7 +83,7 @@ def _greptile_mcp_bin() -> str:
     """Locate the operator-local greptile MCP CLI; honour GREPTILE_MCP_BIN override.
 
     This is an operator-installed binary (not in the repo), so mirror the
-    ``_hermes_bin`` pattern: prefer the env override, fall back to the standard
+    ``hermes_bin`` pattern: prefer the env override, fall back to the standard
     install path. Keeps the closeout worker portable across hosts/users instead
     of silently stalling the Greptile loop when the path differs.
     """
@@ -243,7 +222,7 @@ class KanbanAdapter:
     name = NAME
 
     async def _run(self, args: list[str], *, expect_json: bool = False) -> Any:
-        cmd = [_hermes_bin(), "kanban", "--board", _board(), *args]
+        cmd = [hermes_bin(), "kanban", "--board", _board(), *args]
         env = dict(os.environ)
         env.setdefault("HERMES_KANBAN_BOARD", _board())
         try:
@@ -251,7 +230,7 @@ class KanbanAdapter:
                 *cmd,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
-                cwd=_repo_root(),
+                cwd=zoe_repo_root(),
                 env=env,
             )
         except OSError as exc:
@@ -301,7 +280,7 @@ class KanbanAdapter:
             f"zoe-chain: v3\n"
             f"{escalation_marker}"
             f"{mode_note}"
-            f"Repo: {_repo_root()}  |  Base branch: main  |  Workspace: git worktree\n\n"
+            f"Repo: {zoe_repo_root()}  |  Base branch: main  |  Workspace: git worktree\n\n"
             f"Title: {title}\n\n{description}\n\n"
         )
         if phase == "scout":

--- a/services/zoe-data/hermes_http.py
+++ b/services/zoe-data/hermes_http.py
@@ -1,10 +1,32 @@
-"""Shared Hermes gateway HTTP helpers (auth headers for :8642 /v1/*)."""
+"""Shared Hermes helpers (gateway auth, CLI paths, repo root)."""
 
 from __future__ import annotations
 
 import os
+import shutil
+from pathlib import Path
 
 from runtime_env import bootstrap_runtime_env
+
+
+def hermes_bin() -> str:
+    """Locate the hermes CLI; honour HERMES_BIN override."""
+    override = os.environ.get("HERMES_BIN", "").strip()
+    if override:
+        return override
+    found = shutil.which("hermes")
+    if found:
+        return found
+    return os.path.expanduser("~/.local/bin/hermes")
+
+
+def zoe_repo_root() -> str:
+    """Repo root for subprocess cwd; honour ZOE_REPO_ROOT or derive from this file."""
+    env = os.environ.get("ZOE_REPO_ROOT", "").strip()
+    if env:
+        return env
+    # services/zoe-data/hermes_http.py -> repo root is two levels up from zoe-data.
+    return str(Path(__file__).resolve().parents[2])
 
 
 def hermes_api_key() -> str:

--- a/services/zoe-data/tests/test_background_runner.py
+++ b/services/zoe-data/tests/test_background_runner.py
@@ -1,0 +1,49 @@
+"""Tests for background_runner Hermes worker-profile routing."""
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import background_runner as br
+
+
+def test_background_profile_defaults_to_zoe_coder(monkeypatch):
+    monkeypatch.delenv("HERMES_BACKGROUND_PROFILE", raising=False)
+    monkeypatch.delenv("HERMES_BACKGROUND_MODEL", raising=False)
+    monkeypatch.delenv("HERMES_MODEL", raising=False)
+    assert br._background_profile() == "zoe-coder"
+
+
+def test_background_profile_honours_env_override(monkeypatch):
+    monkeypatch.setenv("HERMES_BACKGROUND_PROFILE", "zoe-planner")
+    assert br._background_profile() == "zoe-planner"
+
+
+@pytest.mark.asyncio
+async def test_run_hermes_background_task_uses_worker_cli(monkeypatch):
+    captured = {}
+
+    async def fake_communicate():
+        return b"done", b""
+
+    proc = MagicMock()
+    proc.communicate = fake_communicate
+    proc.returncode = 0
+    proc.kill = MagicMock()
+    proc.wait = AsyncMock()
+
+    async def fake_exec(*cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["kwargs"] = kwargs
+        return proc
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+    monkeypatch.setenv("HERMES_BACKGROUND_PROFILE", "zoe-coder")
+
+    result = await br._run_hermes_background_task("audit validators only", user_id="u1", task_id=99)
+
+    assert result == "done"
+    cmd = captured["cmd"]
+    assert "-p" in cmd and "zoe-coder" in cmd
+    assert "--accept-hooks" in cmd and "-z" in cmd
+    assert "audit validators only" in cmd[-1]

--- a/services/zoe-data/tests/test_background_runner.py
+++ b/services/zoe-data/tests/test_background_runner.py
@@ -1,10 +1,12 @@
 """Tests for background_runner Hermes worker-profile routing."""
 import asyncio
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 import background_runner as br
+from hermes_http import zoe_repo_root
 
 
 def test_background_profile_defaults_to_zoe_coder(monkeypatch):
@@ -17,6 +19,12 @@ def test_background_profile_defaults_to_zoe_coder(monkeypatch):
 def test_background_profile_honours_env_override(monkeypatch):
     monkeypatch.setenv("HERMES_BACKGROUND_PROFILE", "zoe-planner")
     assert br._background_profile() == "zoe-planner"
+
+
+def test_zoe_repo_root_is_portable(monkeypatch):
+    monkeypatch.delenv("ZOE_REPO_ROOT", raising=False)
+    root = zoe_repo_root()
+    assert (Path(root) / "services" / "zoe-data").is_dir()
 
 
 @pytest.mark.asyncio
@@ -47,3 +55,4 @@ async def test_run_hermes_background_task_uses_worker_cli(monkeypatch):
     assert "-p" in cmd and "zoe-coder" in cmd
     assert "--accept-hooks" in cmd and "-z" in cmd
     assert "audit validators only" in cmd[-1]
+    assert captured["kwargs"]["cwd"] == zoe_repo_root()

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -140,6 +140,48 @@ async def test_dispatch_quality_escalation_mode(monkeypatch):
     assert creates[0][creates[0].index("--max-runtime") + 1] == "75m"
     body = creates[1][creates[1].index("--body") + 1]
     assert "quality-escalation" in body
+    verify_body = creates[2][creates[2].index("--body") + 1]
+    assert "zoe-model-escalation: true" in verify_body
+    assert "anthropic/claude-sonnet-4.6" in verify_body
+    assert "Do NOT use openrouter/auto" in verify_body
+
+
+@pytest.mark.asyncio
+async def test_dispatch_model_escalation_from_metadata():
+    a = _FakeAdapter()
+    await a.dispatch(
+        {
+            "id": "uuid-meta-esc",
+            "identifier": "ZOE-ESC",
+            "title": "Escalate on metadata",
+            "metadata": {"model_escalation": True},
+        }
+    )
+    creates = [c for c in a.calls if c[0] == "create"]
+    review_body = creates[3][creates[3].index("--body") + 1]
+    assert "zoe-model-escalation: true" in review_body
+    assert "anthropic/claude-sonnet-4.6" in review_body
+
+
+@pytest.mark.asyncio
+async def test_dispatch_overnight_implement_mentions_free_fallback():
+    a = _FakeAdapter()
+    await a.dispatch(
+        {"id": "uuid-night2", "identifier": "ZOE-N2", "title": "Night work", "engineering_mode": "overnight"}
+    )
+    creates = [c for c in a.calls if c[0] == "create"]
+    impl_body = creates[1][creates[1].index("--body") + 1]
+    assert "openrouter/free" in impl_body
+
+
+@pytest.mark.asyncio
+async def test_retro_body_prefers_cheap_summary_models():
+    body = ka.KanbanAdapter()._build_body(
+        "retro",
+        {"id": "uuid-1", "identifier": "ZOE-9", "title": "Fix thing", "description": ""},
+        "ZOE-9",
+    )
+    assert "gemini-2.5-flash" in body or "openrouter/free" in body
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Background runner now uses `hermes -p zoe-coder -z` (OpenRouter worker profile) instead of the main Codex gateway API.
- Kanban quality-escalation mode injects model hints into verify/review/closeout bodies, with `confirm_paid_auto` guardrails blocking `openrouter/auto` unless explicitly opted in.
- Overnight implement and retro phases get cheaper-tier routing hints; docs updated to reflect M3/DeepSeek worker routing.

## Test plan
- [x] `pytest services/zoe-data/tests/test_kanban_adapter.py services/zoe-data/tests/test_background_runner.py` (36 passed)
- [x] `validate_structure.py` + `validate_critical_files.py`
- [x] Restarted `zoe-data.service`
- [x] Dispatched audit smoke chain `multica:smoke-llm-routing-20260601` — verify body shows escalation hints; implement worker spawned on zoe-coder (blocked on missing worktree, infra pre-existing)


Made with [Cursor](https://cursor.com)