### PR TITLE
Bootstrap git worktrees before Kanban implement

### DIFF
--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -445,17 +445,10 @@ class KanbanAdapter:
             chain[phase] = task_id
             if not (result or {}).get("deduplicated"):
                 created.append(phase)
-            try:
+            if phase in {"implement", "verify"}:
                 from worktree_bootstrap import ensure_worktree
 
                 await asyncio.to_thread(ensure_worktree, str(task_id))
-            except Exception as exc:
-                logger.warning(
-                    "kanban_adapter: worktree bootstrap failed for %s phase=%s: %s",
-                    task_id,
-                    phase,
-                    exc,
-                )
             parent = task_id
 
         logger.info(

--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -445,6 +445,17 @@ class KanbanAdapter:
             chain[phase] = task_id
             if not (result or {}).get("deduplicated"):
                 created.append(phase)
+            try:
+                from worktree_bootstrap import ensure_worktree
+
+                await asyncio.to_thread(ensure_worktree, str(task_id))
+            except Exception as exc:
+                logger.warning(
+                    "kanban_adapter: worktree bootstrap failed for %s phase=%s: %s",
+                    task_id,
+                    phase,
+                    exc,
+                )
             parent = task_id
 
         logger.info(

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -1,9 +1,19 @@
 """Tests for the Hermes Kanban executor adapter (CLI mocked)."""
 import json
+from pathlib import Path
 
 import pytest
 
 import executors.kanban_adapter as ka
+
+
+@pytest.fixture(autouse=True)
+def _mock_ensure_worktree(monkeypatch):
+    """Dispatch tests must not run real git worktree subprocesses."""
+    monkeypatch.setattr(
+        "worktree_bootstrap.ensure_worktree",
+        lambda task_id, **kwargs: Path(f"/tmp/worktrees/{task_id}"),
+    )
 
 
 class _FakeAdapter(ka.KanbanAdapter):

--- a/services/zoe-data/tests/test_worktree_bootstrap.py
+++ b/services/zoe-data/tests/test_worktree_bootstrap.py
@@ -44,3 +44,16 @@ def test_ensure_worktree_is_idempotent(git_repo):
     second = wb.ensure_worktree("t_dup")
     assert first == second
     assert first.exists()
+
+
+def test_ensure_worktree_rejects_invalid_task_id():
+    with pytest.raises(ValueError, match="invalid characters"):
+        wb.ensure_worktree("../escape")
+
+
+def test_ensure_worktree_raises_when_repo_not_git(tmp_path, monkeypatch):
+    monkeypatch.setenv("ZOE_REPO_ROOT", str(tmp_path / "not-git"))
+    monkeypatch.setenv("ZOE_WORKTREE_ROOT", str(tmp_path / "worktrees"))
+    (tmp_path / "not-git").mkdir()
+    with pytest.raises(RuntimeError, match="git worktree add failed"):
+        wb.ensure_worktree("t_badrepo")

--- a/services/zoe-data/tests/test_worktree_bootstrap.py
+++ b/services/zoe-data/tests/test_worktree_bootstrap.py
@@ -1,0 +1,46 @@
+"""Tests for worktree_bootstrap."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+import worktree_bootstrap as wb
+
+
+@pytest.fixture
+def git_repo(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-b", "main"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=repo, check=True)
+    (repo / "README.md").write_text("hi\n", encoding="utf-8")
+    subprocess.run(["git", "add", "README.md"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=repo, check=True, capture_output=True)
+    monkeypatch.setenv("ZOE_REPO_ROOT", str(repo))
+    monkeypatch.setenv("ZOE_WORKTREE_ROOT", str(tmp_path / "worktrees"))
+    return repo
+
+
+def test_ensure_worktree_creates_branch_and_path(git_repo, monkeypatch):
+    wt = wb.ensure_worktree("t_test123")
+    assert wt.exists()
+    assert (wt / ".git").exists()
+    branch = subprocess.run(
+        ["git", "branch", "--show-current"],
+        cwd=wt,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    assert branch == "wt/t_test123"
+
+
+def test_ensure_worktree_is_idempotent(git_repo):
+    first = wb.ensure_worktree("t_dup")
+    second = wb.ensure_worktree("t_dup")
+    assert first == second
+    assert first.exists()

--- a/services/zoe-data/worktree_bootstrap.py
+++ b/services/zoe-data/worktree_bootstrap.py
@@ -15,6 +15,22 @@ logger = logging.getLogger(__name__)
 _TASK_ID_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 
 
+def _run_git(args: list[str], *, cwd: str, timeout: int) -> subprocess.CompletedProcess[str]:
+    try:
+        return subprocess.run(
+            args,
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(
+            f"git command timed out after {timeout}s: {' '.join(args)}"
+        ) from exc
+
+
 def worktree_root() -> Path:
     override = os.environ.get("ZOE_WORKTREE_ROOT", "").strip()
     if override:
@@ -40,13 +56,10 @@ def _validate_task_id(task_id: str) -> str:
 
 
 def _worktree_registered(repo: Path, wt_path: Path) -> bool:
-    listed = subprocess.run(
+    listed = _run_git(
         ["git", "worktree", "list", "--porcelain"],
         cwd=str(repo),
-        capture_output=True,
-        text=True,
         timeout=30,
-        check=False,
     )
     if listed.returncode != 0:
         return False
@@ -88,26 +101,16 @@ def ensure_worktree(task_id: str, *, base_branch: str = "main") -> Path:
         branch,
         base_branch,
     ]
-    result = subprocess.run(
-        add_cmd,
-        cwd=str(repo),
-        capture_output=True,
-        text=True,
-        timeout=120,
-        check=False,
-    )
+    result = _run_git(add_cmd, cwd=str(repo), timeout=120)
     if result.returncode == 0:
         logger.info("worktree_bootstrap: created %s on %s", wt_path, branch)
         return wt_path
 
     # Branch may already exist from a prior partial run — attach worktree to it.
-    retry = subprocess.run(
+    retry = _run_git(
         ["git", "worktree", "add", str(wt_path), branch],
         cwd=str(repo),
-        capture_output=True,
-        text=True,
         timeout=120,
-        check=False,
     )
     if retry.returncode == 0:
         logger.info("worktree_bootstrap: attached %s to existing %s", wt_path, branch)

--- a/services/zoe-data/worktree_bootstrap.py
+++ b/services/zoe-data/worktree_bootstrap.py
@@ -1,0 +1,85 @@
+"""Bootstrap git worktrees for Hermes Kanban implement/verify phases."""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+from pathlib import Path
+
+from hermes_http import zoe_repo_root
+
+logger = logging.getLogger(__name__)
+
+
+def worktree_root() -> Path:
+    override = os.environ.get("ZOE_WORKTREE_ROOT", "").strip()
+    if override:
+        return Path(override).expanduser()
+    return Path.home() / ".worktrees"
+
+
+def worktree_path(task_id: str) -> Path:
+    return worktree_root() / task_id
+
+
+def worktree_branch(task_id: str) -> str:
+    return f"wt/{task_id}"
+
+
+def ensure_worktree(task_id: str, *, base_branch: str = "main") -> Path:
+    """Create ``~/.worktrees/<task_id>`` on ``wt/<task_id>`` if missing.
+
+    Hermes Kanban resolves worktree workspace paths at claim time but does not
+    run ``git worktree add``. Workers used to self-bootstrap; Zoe pre-creates
+    the tree at dispatch so implement does not block with WORKTREE_NOT_READY.
+    """
+    task_id = task_id.strip()
+    if not task_id:
+        raise ValueError("task_id is required")
+
+    wt_path = worktree_path(task_id)
+    branch = worktree_branch(task_id)
+    repo = Path(zoe_repo_root())
+
+    if wt_path.exists() and (wt_path / ".git").exists():
+        return wt_path
+
+    wt_path.parent.mkdir(parents=True, exist_ok=True)
+
+    add_cmd = [
+        "git",
+        "worktree",
+        "add",
+        str(wt_path),
+        "-b",
+        branch,
+        base_branch,
+    ]
+    result = subprocess.run(
+        add_cmd,
+        cwd=str(repo),
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+    if result.returncode == 0:
+        logger.info("worktree_bootstrap: created %s on %s", wt_path, branch)
+        return wt_path
+
+    # Branch may already exist from a prior partial run — attach worktree to it.
+    retry = subprocess.run(
+        ["git", "worktree", "add", str(wt_path), branch],
+        cwd=str(repo),
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+    if retry.returncode == 0:
+        logger.info("worktree_bootstrap: attached %s to existing %s", wt_path, branch)
+        return wt_path
+
+    stderr = (retry.stderr or result.stderr or "").strip()
+    raise RuntimeError(f"git worktree add failed for {task_id}: {stderr or 'unknown error'}")

--- a/services/zoe-data/worktree_bootstrap.py
+++ b/services/zoe-data/worktree_bootstrap.py
@@ -4,12 +4,15 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 import subprocess
 from pathlib import Path
 
 from hermes_http import zoe_repo_root
 
 logger = logging.getLogger(__name__)
+
+_TASK_ID_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 
 
 def worktree_root() -> Path:
@@ -27,6 +30,37 @@ def worktree_branch(task_id: str) -> str:
     return f"wt/{task_id}"
 
 
+def _validate_task_id(task_id: str) -> str:
+    cleaned = task_id.strip()
+    if not cleaned:
+        raise ValueError("task_id is required")
+    if not _TASK_ID_RE.fullmatch(cleaned):
+        raise ValueError(f"task_id contains invalid characters: {task_id!r}")
+    return cleaned
+
+
+def _worktree_registered(repo: Path, wt_path: Path) -> bool:
+    listed = subprocess.run(
+        ["git", "worktree", "list", "--porcelain"],
+        cwd=str(repo),
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    if listed.returncode != 0:
+        return False
+    target = str(wt_path.resolve())
+    block_path = ""
+    for line in listed.stdout.splitlines():
+        if line.startswith("worktree "):
+            block_path = line.removeprefix("worktree ").strip()
+            continue
+        if block_path == target and line.startswith("branch "):
+            return True
+    return False
+
+
 def ensure_worktree(task_id: str, *, base_branch: str = "main") -> Path:
     """Create ``~/.worktrees/<task_id>`` on ``wt/<task_id>`` if missing.
 
@@ -34,15 +68,13 @@ def ensure_worktree(task_id: str, *, base_branch: str = "main") -> Path:
     run ``git worktree add``. Workers used to self-bootstrap; Zoe pre-creates
     the tree at dispatch so implement does not block with WORKTREE_NOT_READY.
     """
-    task_id = task_id.strip()
-    if not task_id:
-        raise ValueError("task_id is required")
+    task_id = _validate_task_id(task_id)
 
     wt_path = worktree_path(task_id)
     branch = worktree_branch(task_id)
     repo = Path(zoe_repo_root())
 
-    if wt_path.exists() and (wt_path / ".git").exists():
+    if _worktree_registered(repo, wt_path):
         return wt_path
 
     wt_path.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- Add `worktree_bootstrap.py` to pre-create `~/.worktrees/<task_id>` on branch `wt/<task_id>` at dispatch time.
- Wire bootstrap into `kanban_adapter.dispatch()` so Hermes workers no longer hit `WORKTREE_NOT_READY` when the path is resolved but the tree was never created.

## Test plan
- [x] `pytest services/zoe-data/tests/test_worktree_bootstrap.py tests/test_kanban_adapter.py` (35 passed)
- [x] `validate_structure.py` + `validate_critical_files.py`


Made with [Cursor](https://cursor.com)