### PR TITLE
Case-style pipeline evidence hashes and fingerprint abort

### DIFF
--- a/services/zoe-data/pipeline_evidence.py
+++ b/services/zoe-data/pipeline_evidence.py
@@ -6,6 +6,7 @@ defines the contract; the verify-phase integration can adopt it in a smaller PR.
 
 from __future__ import annotations
 
+import hashlib
 from datetime import datetime, timezone
 from typing import Any, Literal
 
@@ -47,6 +48,7 @@ class EvidenceItem(BaseModel):
     summary: str = Field(min_length=1, max_length=500)
     command: str | None = Field(default=None, max_length=500)
     artifact: str | None = Field(default=None, max_length=1000)
+    content_hash: str | None = Field(default=None, max_length=64)
     passed: bool | None = None
     created_at: str = Field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
     metadata: dict[str, Any] = Field(default_factory=dict)
@@ -77,6 +79,8 @@ class PipelineState(BaseModel):
     attempts: dict[PipelinePhase, int] = Field(default_factory=dict)
     evidence: list[EvidenceItem] = Field(default_factory=list)
     history: list[TransitionRecord] = Field(default_factory=list)
+    last_block_fingerprint: str | None = None
+    repeated_block_count: int = 0
 
     @field_validator("task_ref")
     @classmethod
@@ -88,6 +92,29 @@ class PipelineState(BaseModel):
 
 def evidence_kinds(state: PipelineState) -> set[EvidenceKind]:
     return {item.kind for item in state.evidence if item.passed is True}
+
+
+def content_hash(text: str) -> str:
+    """Stable SHA-256 hex digest for validator/test stdout or handoff bodies."""
+    return hashlib.sha256(text.strip().encode("utf-8")).hexdigest()
+
+
+def block_fingerprint(phase: PipelinePhase, reason: str) -> str:
+    """Fingerprint a blocked transition so identical failures can abort loops."""
+    normalized = f"{phase}:{reason.strip().lower()}"
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()[:16]
+
+
+def record_block_fingerprint(state: PipelineState, fingerprint: str) -> tuple[PipelineState, bool]:
+    """Track repeated identical block fingerprints; return (state, should_abort)."""
+    if fingerprint and fingerprint == state.last_block_fingerprint:
+        count = state.repeated_block_count + 1
+    else:
+        count = 1
+    updated = state.model_copy(
+        update={"last_block_fingerprint": fingerprint, "repeated_block_count": count}
+    )
+    return updated, count >= 2
 
 
 def missing_required_evidence(state: PipelineState, phase: PipelinePhase | None = None) -> set[EvidenceKind]:

--- a/services/zoe-data/pipeline_handoff.py
+++ b/services/zoe-data/pipeline_handoff.py
@@ -6,7 +6,7 @@ import json
 import re
 from typing import Any
 
-from pipeline_evidence import EvidenceItem, PipelinePhase
+from pipeline_evidence import EvidenceItem, PipelinePhase, content_hash
 
 _KV_RE = re.compile(r"^([A-Z_]+)=(.*)$", re.MULTILINE)
 _TOOL_NAMES = (
@@ -74,13 +74,25 @@ def evidence_from_handoff(phase: PipelinePhase, detail: dict[str, Any]) -> list[
     tests_raw = fields.get("TESTS") or ""
     if tests_raw and phase in {"implement", "verify"}:
         passed = "fail" not in tests_raw.lower()
-        items.append(EvidenceItem(kind="test", summary=tests_raw[:500], passed=passed))
+        items.append(
+            EvidenceItem(
+                kind="test",
+                summary=tests_raw[:500],
+                content_hash=content_hash(tests_raw),
+                passed=passed,
+            )
+        )
 
     validators_raw = fields.get("VALIDATORS") or ""
     if validators_raw and phase in {"implement", "verify"}:
         passed = "fail" not in validators_raw.lower()
         items.append(
-            EvidenceItem(kind="validator", summary=validators_raw[:500], passed=passed)
+            EvidenceItem(
+                kind="validator",
+                summary=validators_raw[:500],
+                content_hash=content_hash(validators_raw),
+                passed=passed,
+            )
         )
 
     if phase == "review":
@@ -111,6 +123,13 @@ def evidence_from_handoff(phase: PipelinePhase, detail: dict[str, Any]) -> list[
                 break
 
     return items
+
+
+def block_reason_from_handoff(detail: dict[str, Any], *, row_block_reason: str | None = None) -> str:
+    fields: dict[str, str] = {}
+    for chunk in _haystacks(detail):
+        fields.update(_parse_kv_fields(chunk))
+    return (fields.get("BLOCKER") or row_block_reason or "").strip()
 
 
 def infer_outcome(phase: PipelinePhase, row_status: str, detail: dict[str, Any]) -> str | None:

--- a/services/zoe-data/pipeline_store.py
+++ b/services/zoe-data/pipeline_store.py
@@ -128,7 +128,7 @@ async def sync_pipeline_from_chain(
     from pipeline_handoff import block_reason_from_handoff, evidence_from_handoff, infer_outcome
 
     state = await bootstrap_state(task_ref, start_phase=start_phase)
-    if state.status == "done":
+    if state.status in {"done", "blocked"}:
         return state
 
     for phase in ("scout", "implement", "verify", "review", "closeout", "retro"):

--- a/services/zoe-data/pipeline_store.py
+++ b/services/zoe-data/pipeline_store.py
@@ -14,8 +14,10 @@ from typing import Any, Awaitable, Callable
 from pipeline_evidence import (
     PipelinePhase,
     PipelineState,
+    block_fingerprint,
     can_complete_phase,
     missing_required_evidence,
+    record_block_fingerprint,
     transition,
     with_evidence,
 )
@@ -123,7 +125,7 @@ async def sync_pipeline_from_chain(
     start_phase: PipelinePhase = "implement",
 ) -> PipelineState:
     """Advance pipeline state from terminal Kanban phase rows and parsed handoffs."""
-    from pipeline_handoff import evidence_from_handoff, infer_outcome
+    from pipeline_handoff import block_reason_from_handoff, evidence_from_handoff, infer_outcome
 
     state = await bootstrap_state(task_ref, start_phase=start_phase)
     if state.status == "done":
@@ -151,6 +153,25 @@ async def sync_pipeline_from_chain(
         outcome = infer_outcome(phase, row_status, detail)  # type: ignore[arg-type]
         if not outcome:
             continue
+
+        block_reason = None
+        if outcome in {"block", "verification_failed", "request_changes", "merge_blocked"}:
+            block_reason = block_reason_from_handoff(
+                detail, row_block_reason=row.get("block_reason")
+            ) or outcome
+            fingerprint = block_fingerprint(phase, str(block_reason))  # type: ignore[arg-type]
+            state, should_abort = record_block_fingerprint(state, fingerprint)
+            if should_abort:
+                state = transition(state, "block", reason=f"fingerprint_abort:{fingerprint}")
+                await _run_io(
+                    partial(
+                        save_state,
+                        state,
+                        event="fingerprint_abort",
+                        extra={"row_phase": phase, "fingerprint": fingerprint, "reason": block_reason},
+                    )
+                )
+                return state
 
         if outcome == "complete" and not can_complete_phase(state):
             await _run_io(

--- a/services/zoe-data/tests/test_pipeline_evidence.py
+++ b/services/zoe-data/tests/test_pipeline_evidence.py
@@ -3,8 +3,11 @@ import pytest
 from pipeline_evidence import (
     EvidenceItem,
     PipelineState,
+    block_fingerprint,
     can_complete_phase,
+    content_hash,
     missing_required_evidence,
+    record_block_fingerprint,
     transition,
     with_evidence,
 )
@@ -148,4 +151,23 @@ def test_retro_complete_marks_pipeline_done():
 
     assert done.phase == "retro"
     assert done.status == "done"
+
+
+def test_content_hash_is_stable():
+    assert content_hash("validate_structure passed") == content_hash("validate_structure passed")
+    assert content_hash("a") != content_hash("b")
+
+
+def test_block_fingerprint_aborts_after_two_identical():
+    reason = "WORKTREE_NOT_READY: missing worktree"
+    fp = block_fingerprint("implement", reason)
+    state = PipelineState(task_ref="multica:1", phase="implement", status="running")
+
+    state, abort = record_block_fingerprint(state, fp)
+    assert abort is False
+    assert state.repeated_block_count == 1
+
+    state, abort = record_block_fingerprint(state, fp)
+    assert abort is True
+    assert state.repeated_block_count == 2
 

--- a/services/zoe-data/tests/test_pipeline_handoff.py
+++ b/services/zoe-data/tests/test_pipeline_handoff.py
@@ -22,6 +22,16 @@ def test_evidence_from_verify_handoff_parses_validators():
     }
     items = evidence_from_handoff("verify", detail)
     assert {item.kind for item in items} >= {"validator", "test"}
+    validator = next(item for item in items if item.kind == "validator")
+    assert validator.content_hash
+    assert len(validator.content_hash) == 64
+
+
+def test_block_reason_from_handoff_prefers_blocker_field():
+    from pipeline_handoff import block_reason_from_handoff
+
+    detail = {"latest_summary": "BLOCKER=WORKTREE_NOT_READY", "comments": []}
+    assert block_reason_from_handoff(detail) == "WORKTREE_NOT_READY"
 
 
 def test_infer_outcome_blocked_verify_loops():


### PR DESCRIPTION
## Summary
- Add `content_hash` on `EvidenceItem` and compute hashes from TESTS/VALIDATORS handoff fields.
- Track `last_block_fingerprint` / `repeated_block_count` on pipeline state; abort after two identical block reasons with `fingerprint_abort` JSONL events.

## Test plan
- [x] `pytest services/zoe-data/tests/test_pipeline_evidence.py tests/test_pipeline_handoff.py tests/test_pipeline_store.py` (23 passed)
- [x] Validators pass


Made with [Cursor](https://cursor.com)