### PR TITLE
fix(kanban): auto-block after protocol violations

### DIFF
--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -56,6 +56,10 @@ _V2_CHAIN_PHASES = ("implement", "verify", "review", "closeout")
 _ACTIVE_KANBAN_STATUSES = {"triage", "todo", "ready", "running", "blocked"}
 _TERMINAL_KANBAN_STATUSES = {"done", "archived"}
 
+_PROTOCOL_VIOLATION_LIMIT = max(
+    1, int(os.environ.get("ZOE_KANBAN_PROTOCOL_VIOLATION_LIMIT", "2") or "2")
+)
+
 # Matches the `zoe-ref: multica:{id}:{phase}` marker the adapter writes into each
 # task body at dispatch. Anchored to the start of a line so it never collides with
 # prose elsewhere in the body.
@@ -195,6 +199,13 @@ def _chain_for_issue(issue: dict) -> tuple[tuple[str, str, tuple[str, ...]], ...
     if _skip_scout(issue):
         phases = tuple(p for p in phases if p[0] != "scout")
     return phases
+
+
+def _protocol_violation_count(detail: dict[str, Any]) -> int:
+    events = detail.get("events") if isinstance(detail.get("events"), list) else []
+    return sum(
+        1 for event in events if isinstance(event, dict) and event.get("kind") == "protocol_violation"
+    )
 
 
 def _expected_phases(phases: dict[str, dict]) -> set[str]:
@@ -400,8 +411,47 @@ class KanbanAdapter:
             "- After a successful merge: update the Multica issue to done with PR_URL, merge SHA, GREPTILE status,"
             " and summary. If merge did not happen, leave in_progress/blocked with the blocker.\n"
             "Final handoff MUST include:\nPR_URL=<url>\nMERGE_SHA=<sha or blank>\nGREPTILE=<status>\n"
-            "MULTICA=<updated? done/blocked>\nSUMMARY=<short>"
+            "MULTICA=<updated? done/blocked>\nSUMMARY=<short>\n"
+            "- TERMINAL PROTOCOL: you MUST end with `kanban_complete` or `kanban_block` (no silent exit)."
         )
+
+    async def _maybe_auto_block_protocol_violation(
+        self,
+        task_id: str,
+        phase: str,
+        row: dict[str, Any],
+        detail: dict[str, Any],
+    ) -> bool:
+        """Block a task after repeated Hermes protocol violations (silent worker exit)."""
+        status = (row.get("status") or "").lower()
+        if status in _TERMINAL_KANBAN_STATUSES or status == "blocked":
+            return False
+        violations = _protocol_violation_count(detail)
+        if violations < _PROTOCOL_VIOLATION_LIMIT:
+            return False
+        reason = (
+            "BLOCKER=PROTOCOL_VIOLATION: worker exited without kanban_complete/kanban_block "
+            f"({violations} violations on {phase})"
+        )
+        try:
+            await self._run(["block", task_id, reason])
+        except KanbanCLIError as exc:
+            logger.warning(
+                "kanban_adapter: protocol auto-block failed for %s (%s): %s",
+                task_id,
+                phase,
+                exc,
+            )
+            return False
+        row["status"] = "blocked"
+        row["block_reason"] = reason
+        logger.info(
+            "kanban_adapter: auto-blocked %s (%s) after %d protocol violations",
+            task_id,
+            phase,
+            violations,
+        )
+        return True
 
     async def dispatch(self, issue: dict) -> dict:
         """Create (idempotently) the scout->implement->verify->review->closeout->retro chain.
@@ -510,6 +560,21 @@ class KanbanAdapter:
                 phases[key[len(prefix):]] = row
         if not phases:
             return {"found": False, "status": "not_found", "phases": {}, "pr_url": None, "blocker": None}
+
+        for phase, row in list(phases.items()):
+            task_id = row.get("id")
+            if not task_id:
+                continue
+            status = (row.get("status") or "").lower()
+            if status in _TERMINAL_KANBAN_STATUSES or status == "blocked":
+                continue
+            try:
+                detail = await self._run(["show", task_id, "--json"], expect_json=True)
+            except KanbanCLIError as exc:
+                logger.debug("kanban_adapter: show failed for %s: %s", task_id, exc)
+                continue
+            if await self._maybe_auto_block_protocol_violation(task_id, phase, row, detail):
+                phases[phase] = row
 
         statuses = {p: (r.get("status") or "") for p, r in phases.items()}
         blocker = None

--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -561,6 +561,7 @@ class KanbanAdapter:
         if not phases:
             return {"found": False, "status": "not_found", "phases": {}, "pr_url": None, "blocker": None}
 
+        detail_cache: dict[str, dict[str, Any]] = {}
         for phase, row in list(phases.items()):
             task_id = row.get("id")
             if not task_id:
@@ -573,6 +574,7 @@ class KanbanAdapter:
             except KanbanCLIError as exc:
                 logger.debug("kanban_adapter: show failed for %s: %s", task_id, exc)
                 continue
+            detail_cache[task_id] = detail
             if await self._maybe_auto_block_protocol_violation(task_id, phase, row, detail):
                 phases[phase] = row
 
@@ -606,7 +608,12 @@ class KanbanAdapter:
             from pipeline_store import pipeline_summary, sync_pipeline_from_chain
 
             async def _fetch_detail(task_id: str) -> dict:
-                return await self._run(["show", task_id, "--json"], expect_json=True)
+                cached = detail_cache.get(task_id)
+                if cached is not None:
+                    return cached
+                detail = await self._run(["show", task_id, "--json"], expect_json=True)
+                detail_cache[task_id] = detail
+                return detail
 
             start_phase = "scout" if "scout" in phases else "implement"
             state = await sync_pipeline_from_chain(
@@ -625,14 +632,20 @@ class KanbanAdapter:
             "found": True,
             "status": agg,
             "phases": statuses,
-            "pr_url": await self._extract_pr_url(phases),
+            "pr_url": await self._extract_pr_url(phases, detail_cache=detail_cache),
             "blocker": blocker,
             "pipeline": pipeline_info,
         }
 
-    async def _extract_pr_url(self, phases: dict[str, dict]) -> str | None:
+    async def _extract_pr_url(
+        self,
+        phases: dict[str, dict],
+        *,
+        detail_cache: dict[str, dict[str, Any]] | None = None,
+    ) -> str | None:
         """Pull a PR URL from the implement/closeout task summaries or comments."""
         pattern = re.compile(r"https://github\.com/[^/\s]+/[^/\s]+/pull/\d+")
+        cache = detail_cache or {}
         for phase in ("closeout", "retro", "implement", "verify", "review", "scout"):
             row = phases.get(phase)
             if not row:
@@ -640,10 +653,12 @@ class KanbanAdapter:
             task_id = row.get("id")
             if not task_id:
                 continue
-            try:
-                detail = await self._run(["show", task_id, "--json"], expect_json=True)
-            except KanbanCLIError:
-                continue
+            detail = cache.get(task_id)
+            if detail is None:
+                try:
+                    detail = await self._run(["show", task_id, "--json"], expect_json=True)
+                except KanbanCLIError:
+                    continue
             haystacks = [json.dumps(detail.get("latest_summary") or "")]
             for c in detail.get("comments", []) or []:
                 haystacks.append(str(c.get("body") or c.get("text") or ""))

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -554,7 +554,7 @@ def test_protocol_violation_count():
 
 @pytest.mark.asyncio
 async def test_poll_auto_blocks_after_protocol_violations(monkeypatch):
-    monkeypatch.setenv("ZOE_KANBAN_PROTOCOL_VIOLATION_LIMIT", "2")
+    monkeypatch.setattr(ka, "_PROTOCOL_VIOLATION_LIMIT", 2)
     rows = [_row("implement", "running")]
     show = {
         "t_implement": {

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -57,6 +57,8 @@ class _FakeAdapter(ka.KanbanAdapter):
             return self._list_rows
         if verb == "show":
             return self._show_map.get(args[1], {"comments": [], "latest_summary": ""})
+        if verb == "block":
+            return ""
         return ""
 
 
@@ -537,3 +539,44 @@ async def test_poll_done_and_pr_extracted():
     out = await a.poll("multica:u")
     assert out["status"] == "done"
     assert out["pr_url"] == "https://github.com/o/r/pull/42"
+
+
+def test_protocol_violation_count():
+    detail = {
+        "events": [
+            {"kind": "claimed"},
+            {"kind": "protocol_violation", "payload": {"exit_code": 0}},
+            {"kind": "protocol_violation", "payload": {"exit_code": 0}},
+        ]
+    }
+    assert ka._protocol_violation_count(detail) == 2
+
+
+@pytest.mark.asyncio
+async def test_poll_auto_blocks_after_protocol_violations(monkeypatch):
+    monkeypatch.setenv("ZOE_KANBAN_PROTOCOL_VIOLATION_LIMIT", "2")
+    rows = [_row("implement", "running")]
+    show = {
+        "t_implement": {
+            "events": [
+                {"kind": "protocol_violation", "payload": {"exit_code": 0}},
+                {"kind": "protocol_violation", "payload": {"exit_code": 0}},
+            ]
+        }
+    }
+    a = _FakeAdapter(list_rows=rows, show_map=show)
+    out = await a.poll("multica:uuid-9")
+    assert out["status"] == "blocked"
+    assert "PROTOCOL_VIOLATION" in (out["blocker"] or "")
+    assert any(c[0] == "block" for c in a.calls)
+
+
+def test_closeout_body_requires_terminal_protocol():
+    body = ka.KanbanAdapter()._build_body(
+        "closeout",
+        {"id": "uuid-1", "identifier": "ZOE-9", "title": "Fix thing", "description": ""},
+        "ZOE-9",
+    )
+    assert "TERMINAL PROTOCOL" in body
+    assert "kanban_complete" in body
+    assert "kanban_block" in body

--- a/services/zoe-data/tests/test_multica_poll_dispatch.py
+++ b/services/zoe-data/tests/test_multica_poll_dispatch.py
@@ -1,5 +1,6 @@
 """Tests for Multica poll-loop dispatch helpers."""
 from multica_poll_dispatch import chain_needs_dispatch
+import executors.kanban_adapter as ka
 
 
 def test_chain_needs_dispatch_not_found():
@@ -42,3 +43,12 @@ def test_implement_body_requires_kanban_terminal_tools():
     assert "kanban_block" in body
     assert "kanban_show" in body
     assert "TERMINAL PROTOCOL" in body
+
+
+def test_chain_needs_dispatch_false_when_blocked_protocol_violation():
+    chain = {
+        "found": True,
+        "status": "blocked",
+        "blocker": "BLOCKER=PROTOCOL_VIOLATION: worker exited without kanban_complete/kanban_block",
+    }
+    assert chain_needs_dispatch(chain) is False


### PR DESCRIPTION
## Summary
- After N Hermes `protocol_violation` events (default 2, `ZOE_KANBAN_PROTOCOL_VIOLATION_LIMIT`), `KanbanAdapter.poll()` auto-runs `hermes kanban block` with `BLOCKER=PROTOCOL_VIOLATION` so dispatcher retry loops stop.
- Adds closeout phase terminal-protocol prompt line (scout/implement/verify/review/retro already had it).

## Test plan
- [x] `pytest services/zoe-data/tests/test_kanban_adapter.py services/zoe-data/tests/test_multica_poll_dispatch.py -q` → 43 passed
- [ ] Greptile + greploop on PR
- [ ] E2E: verify phase no longer spins on silent worker exit


Made with [Cursor](https://cursor.com)