### PR TITLE
fix(kanban): align worktree paths and audit-only verify gate

### DIFF
--- a/docs/guides/MULTICA_HERMES_PR_LOOP.md
+++ b/docs/guides/MULTICA_HERMES_PR_LOOP.md
@@ -82,7 +82,7 @@ what's the hermes engineering status
 Expected Kanban chain progression (per Multica issue):
 
 - `scout` (`zoe-planner`) — Graphify/opensrc/Multica context only; `TOOLS_USED=` + `SCOUT_SUMMARY=` handoff.
-- `implement` (`zoe-coder`) — graphify/opensrc first, smallest reviewable change, small PR on a worktree. Terminal protocol: `kanban_complete` or `kanban_block` on the last turn. Handoff metadata must include `PR_URL`, `TESTS`, `TOOLS_USED`, `SUMMARY`.
+- `implement` (`zoe-coder`) — graphify/opensrc first, smallest reviewable change, small PR on a worktree at `~/.worktrees/<kanban_task_id>` (override root with `ZOE_WORKTREE_ROOT`). Zoe pins this path on the Kanban row at dispatch so workers do not default to `<repo>/.worktrees/`. Terminal protocol: `kanban_complete` or `kanban_block` on the last turn. Handoff metadata must include `PR_URL`, `TESTS`, `TOOLS_USED`, `SUMMARY`. Pure audit/doc tasks: `AUDIT_ONLY=1` with blank `PR_URL`.
 - `verify` (`zoe-reviewer`) — objective test/evidence gate before review; records validator + test outcomes. Fail-closed: missing evidence blocks advancement.
 - `review` (`zoe-reviewer`) — diff/scope/architecture check against verify evidence; may loop back to implement via revision metadata.
 - `closeout` (`zoe-planner`) — Greptile grep loop, squash merge when ready, Multica status update.

--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -182,16 +182,28 @@ def _max_runtime(mode: str = "interactive") -> str:
     return os.environ.get("ZOE_KANBAN_MAX_RUNTIME", "45m")
 
 
+_SKIP_SCOUT_TAG_RE = re.compile(r"skip_scout:\s*(true|yes|1)", re.I)
+
+
 def _skip_scout(issue: dict | None = None) -> bool:
     issue = issue or {}
     if str(os.environ.get("ZOE_KANBAN_SKIP_SCOUT", "")).strip().lower() in {"1", "true", "yes"}:
         return True
     meta = issue.get("metadata") or {}
-    return str(meta.get("skip_scout") or issue.get("skip_scout") or "").strip().lower() in {
+    if str(meta.get("skip_scout") or issue.get("skip_scout") or "").strip().lower() in {
         "1",
         "true",
         "yes",
-    }
+    }:
+        return True
+    haystack = " ".join(
+        [
+            str(issue.get("title") or ""),
+            str(issue.get("description") or ""),
+            json.dumps(meta),
+        ]
+    )
+    return bool(_SKIP_SCOUT_TAG_RE.search(haystack))
 
 
 def _chain_for_issue(issue: dict) -> tuple[tuple[str, str, tuple[str, ...]], ...]:
@@ -500,9 +512,9 @@ class KanbanAdapter:
             if not (result or {}).get("deduplicated"):
                 created.append(phase)
             if phase in {"implement", "verify"}:
-                from worktree_bootstrap import ensure_worktree
+                from worktree_bootstrap import prepare_kanban_worktree
 
-                await asyncio.to_thread(ensure_worktree, str(task_id))
+                await asyncio.to_thread(prepare_kanban_worktree, str(task_id))
             parent = task_id
 
         logger.info(

--- a/services/zoe-data/pipeline_evidence.py
+++ b/services/zoe-data/pipeline_evidence.py
@@ -168,6 +168,7 @@ def issue_evidence_profile(issue: dict | None) -> EvidenceProfile:
     if (
         "audit-only" in haystack
         or str(meta.get("audit_only") or issue.get("audit_only") or "").strip().lower() in {"1", "true", "yes"}
+        or str(meta.get("AUDIT_ONLY") or issue.get("AUDIT_ONLY") or "").strip().lower() in {"1", "true", "yes"}
     ):
         return "audit"
     if "health check" in haystack or str(meta.get("health") or "").strip().lower() in {"1", "true", "yes"}:

--- a/services/zoe-data/pipeline_handoff.py
+++ b/services/zoe-data/pipeline_handoff.py
@@ -172,6 +172,20 @@ def _greptile_from_closeout(detail: dict[str, Any], skills: tuple[str, ...] | li
     )
 
 
+def audit_only_from_handoff(detail: dict[str, Any]) -> bool:
+    """True when implement/verify handoff marks the task as audit-only (no PR/tests)."""
+    fields: dict[str, str] = {}
+    for chunk in _haystacks(detail):
+        fields.update(_parse_kv_fields(chunk))
+    if fields.get("AUDIT_ONLY", "").strip().lower() in {"1", "true", "yes"}:
+        return True
+    metadata = detail.get("metadata") or {}
+    if isinstance(metadata, dict):
+        raw = metadata.get("AUDIT_ONLY") or metadata.get("audit_only") or ""
+        return str(raw).strip().lower() in {"1", "true", "yes"}
+    return False
+
+
 def evidence_from_handoff(
     phase: PipelinePhase,
     detail: dict[str, Any],

--- a/services/zoe-data/pipeline_store.py
+++ b/services/zoe-data/pipeline_store.py
@@ -170,7 +170,7 @@ async def sync_pipeline_from_chain(
     issue: dict | None = None,
 ) -> PipelineState:
     """Advance pipeline state from terminal Kanban phase rows and parsed handoffs."""
-    from pipeline_handoff import block_reason_from_handoff, evidence_from_handoff, infer_outcome
+    from pipeline_handoff import audit_only_from_handoff, block_reason_from_handoff, evidence_from_handoff, infer_outcome
 
     state = await bootstrap_state(task_ref, start_phase=start_phase, issue=issue)
     if state.status == "done":
@@ -206,6 +206,9 @@ async def sync_pipeline_from_chain(
 
         for item in evidence_from_handoff(phase, detail, skills=skills):  # type: ignore[arg-type]
             state = with_evidence(state, item)
+
+        if phase == "implement" and audit_only_from_handoff(detail):
+            state = state.model_copy(update={"evidence_profile": "audit"})
 
         if phase == "implement" and row_status in {"done", "archived"}:
             state = await _append_harness_validators(state, "implement")

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -11,7 +11,7 @@ import executors.kanban_adapter as ka
 def _mock_ensure_worktree(monkeypatch):
     """Dispatch tests must not run real git worktree subprocesses."""
     monkeypatch.setattr(
-        "worktree_bootstrap.ensure_worktree",
+        "worktree_bootstrap.prepare_kanban_worktree",
         lambda task_id, **kwargs: Path(f"/tmp/worktrees/{task_id}"),
     )
 

--- a/services/zoe-data/tests/test_pipeline_handoff.py
+++ b/services/zoe-data/tests/test_pipeline_handoff.py
@@ -92,3 +92,11 @@ def test_block_reason_ignores_dynamic_log_tail_without_stable_token():
         "comments": [{"body": "retry 3 at 2026-06-01T12:00:00Z\nstill waiting..."}],
     }
     assert block_reason_from_handoff(detail) == ""
+
+
+def test_audit_only_from_handoff_detects_kv_field():
+    from pipeline_handoff import audit_only_from_handoff
+
+    detail = {"latest_summary": "AUDIT_ONLY=1\nSUMMARY=findings only", "comments": []}
+    assert audit_only_from_handoff(detail) is True
+    assert audit_only_from_handoff({"latest_summary": "SUMMARY=code change", "comments": []}) is False

--- a/services/zoe-data/tests/test_pipeline_store.py
+++ b/services/zoe-data/tests/test_pipeline_store.py
@@ -78,6 +78,28 @@ async def test_sync_pipeline_gate_blocks_verify_without_test(isolated_store):
 
 
 @pytest.mark.asyncio
+async def test_sync_pipeline_audit_only_verify_skips_test_gate(isolated_store):
+    await store.bootstrap_state("multica:audit-gate")
+
+    async def fetch_detail(task_id: str):
+        if task_id == "t_impl":
+            return {
+                "latest_summary": "AUDIT_ONLY=1\nTOOLS_USED=graphify\nSUMMARY=audit complete",
+                "comments": [],
+            }
+        return {"latest_summary": "VALIDATORS=validate_structure pass", "comments": []}
+
+    phases = {
+        "implement": {"id": "t_impl", "status": "done"},
+        "verify": {"id": "t_verify", "status": "done"},
+    }
+    state = await store.sync_pipeline_from_chain("multica:audit-gate", phases, fetch_detail)
+    assert state.phase == "review"
+    assert state.evidence_profile == "audit"
+    assert not any("gate_blocked" in line for line in isolated_store.read_text(encoding="utf-8").splitlines())
+
+
+@pytest.mark.asyncio
 async def test_sync_pipeline_fingerprint_abort(isolated_store):
     await store.bootstrap_state("multica:fp")
 

--- a/services/zoe-data/tests/test_worktree_bootstrap.py
+++ b/services/zoe-data/tests/test_worktree_bootstrap.py
@@ -95,7 +95,45 @@ def test_pin_kanban_workspace_updates_task_row(tmp_path, monkeypatch):
     assert row[0] == str(wt.resolve())
 
 
-def test_kanban_db_path_default_board():
+def test_kanban_db_path_default_board(monkeypatch):
+    monkeypatch.delenv("ZOE_KANBAN_DB_PATH", raising=False)
+    monkeypatch.delenv("ZOE_KANBAN_BOARD", raising=False)
     path = wb.kanban_db_path()
     assert path.name == "kanban.db"
     assert path.parent.name == ".hermes"
+
+
+def test_pin_kanban_workspace_falls_back_without_worktree_kind(tmp_path, monkeypatch):
+    import sqlite3
+
+    db = tmp_path / "kanban.db"
+    conn = sqlite3.connect(str(db))
+    conn.execute(
+        """
+        CREATE TABLE tasks (
+            id TEXT PRIMARY KEY,
+            workspace_kind TEXT,
+            workspace_path TEXT
+        )
+        """
+    )
+    conn.execute(
+        "INSERT INTO tasks (id, workspace_kind, workspace_path) VALUES (?, ?, ?)",
+        ("t_fallback", "git_worktree", None),
+    )
+    conn.commit()
+    conn.close()
+
+    monkeypatch.setenv("ZOE_KANBAN_DB_PATH", str(db))
+    wt = tmp_path / "worktrees" / "t_fallback"
+    wt.mkdir(parents=True)
+
+    pinned = wb.pin_kanban_workspace("t_fallback", wt)
+    assert pinned == wt.resolve()
+
+    conn = sqlite3.connect(str(db))
+    row = conn.execute(
+        "SELECT workspace_path FROM tasks WHERE id = ?", ("t_fallback",)
+    ).fetchone()
+    conn.close()
+    assert row[0] == str(wt.resolve())

--- a/services/zoe-data/tests/test_worktree_bootstrap.py
+++ b/services/zoe-data/tests/test_worktree_bootstrap.py
@@ -57,3 +57,45 @@ def test_ensure_worktree_raises_when_repo_not_git(tmp_path, monkeypatch):
     (tmp_path / "not-git").mkdir()
     with pytest.raises(RuntimeError, match="git worktree add failed"):
         wb.ensure_worktree("t_badrepo")
+
+
+def test_pin_kanban_workspace_updates_task_row(tmp_path, monkeypatch):
+    import sqlite3
+
+    db = tmp_path / "kanban.db"
+    conn = sqlite3.connect(str(db))
+    conn.execute(
+        """
+        CREATE TABLE tasks (
+            id TEXT PRIMARY KEY,
+            workspace_kind TEXT,
+            workspace_path TEXT
+        )
+        """
+    )
+    conn.execute(
+        "INSERT INTO tasks (id, workspace_kind, workspace_path) VALUES (?, ?, ?)",
+        ("t_pin", "worktree", None),
+    )
+    conn.commit()
+    conn.close()
+
+    monkeypatch.setenv("ZOE_KANBAN_DB_PATH", str(db))
+    wt = tmp_path / "worktrees" / "t_pin"
+    wt.mkdir(parents=True)
+
+    pinned = wb.pin_kanban_workspace("t_pin", wt)
+    assert pinned == wt.resolve()
+
+    conn = sqlite3.connect(str(db))
+    row = conn.execute(
+        "SELECT workspace_path FROM tasks WHERE id = ?", ("t_pin",)
+    ).fetchone()
+    conn.close()
+    assert row[0] == str(wt.resolve())
+
+
+def test_kanban_db_path_default_board():
+    path = wb.kanban_db_path()
+    assert path.name == "kanban.db"
+    assert path.parent.name == ".hermes"

--- a/services/zoe-data/worktree_bootstrap.py
+++ b/services/zoe-data/worktree_bootstrap.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import os
 import re
+import sqlite3
 import subprocess
 from pathlib import Path
 
@@ -44,6 +45,45 @@ def worktree_path(task_id: str) -> Path:
 
 def worktree_branch(task_id: str) -> str:
     return f"wt/{task_id}"
+
+
+def kanban_db_path() -> Path:
+    """Path to the Hermes Kanban SQLite DB for the active board."""
+    override = os.environ.get("ZOE_KANBAN_DB_PATH", "").strip()
+    if override:
+        return Path(override).expanduser()
+    board = os.environ.get("ZOE_KANBAN_BOARD", "default").strip() or "default"
+    home = Path.home() / ".hermes"
+    if board == "default":
+        return home / "kanban.db"
+    return home / "kanban" / "boards" / board / "kanban.db"
+
+
+def pin_kanban_workspace(task_id: str, wt_path: Path | None = None) -> Path:
+    """Persist the absolute worktree path on a Kanban task before claim.
+
+    Hermes defaults unset worktree paths to ``<dispatcher-cwd>/.worktrees/<id>``.
+    Zoe bootstrap uses ``~/.worktrees/<id>`` (or ``ZOE_WORKTREE_ROOT``). Pin
+    the bootstrap path on the task row so workers and ``ensure_worktree`` agree.
+    """
+    task_id = _validate_task_id(task_id)
+    path = (wt_path or worktree_path(task_id)).resolve()
+    abs_path = str(path)
+    db = kanban_db_path()
+    if not db.exists():
+        raise RuntimeError(f"kanban db not found: {db}")
+
+    with sqlite3.connect(str(db)) as conn:
+        cur = conn.execute(
+            "UPDATE tasks SET workspace_path = ? WHERE id = ? AND workspace_kind = 'worktree'",
+            (abs_path, task_id),
+        )
+        conn.commit()
+        if cur.rowcount == 0:
+            raise RuntimeError(f"kanban task {task_id!r} not found or not a worktree task in {db}")
+
+    logger.info("worktree_bootstrap: pinned kanban workspace %s -> %s", task_id, abs_path)
+    return path
 
 
 def _validate_task_id(task_id: str) -> str:
@@ -118,3 +158,10 @@ def ensure_worktree(task_id: str, *, base_branch: str = "main") -> Path:
 
     stderr = (retry.stderr or result.stderr or "").strip()
     raise RuntimeError(f"git worktree add failed for {task_id}: {stderr or 'unknown error'}")
+
+
+def prepare_kanban_worktree(task_id: str, *, base_branch: str = "main") -> Path:
+    """Create the git worktree and pin its path on the Kanban task row."""
+    wt_path = ensure_worktree(task_id, base_branch=base_branch)
+    pin_kanban_workspace(task_id, wt_path)
+    return wt_path

--- a/services/zoe-data/worktree_bootstrap.py
+++ b/services/zoe-data/worktree_bootstrap.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import os
 import re
-import sqlite3
+import sqlite3  # operator-local Hermes Kanban DB (~/.hermes), not Zoe PostgreSQL
 import subprocess
 from pathlib import Path
 
@@ -65,6 +65,9 @@ def pin_kanban_workspace(task_id: str, wt_path: Path | None = None) -> Path:
     Hermes defaults unset worktree paths to ``<dispatcher-cwd>/.worktrees/<id>``.
     Zoe bootstrap uses ``~/.worktrees/<id>`` (or ``ZOE_WORKTREE_ROOT``). Pin
     the bootstrap path on the task row so workers and ``ensure_worktree`` agree.
+
+    Writes operator-local ``~/.hermes/kanban.db`` (Hermes Kanban), not Zoe's
+    PostgreSQL store.
     """
     task_id = _validate_task_id(task_id)
     path = (wt_path or worktree_path(task_id)).resolve()
@@ -73,6 +76,8 @@ def pin_kanban_workspace(task_id: str, wt_path: Path | None = None) -> Path:
     if not db.exists():
         raise RuntimeError(f"kanban db not found: {db}")
 
+    # Hermes ``hermes kanban create --workspace worktree`` sets workspace_kind to
+    # ``worktree``; fall back to id-only update if the row uses another value.
     with sqlite3.connect(str(db)) as conn:
         cur = conn.execute(
             "UPDATE tasks SET workspace_path = ? WHERE id = ? AND workspace_kind = 'worktree'",
@@ -80,7 +85,21 @@ def pin_kanban_workspace(task_id: str, wt_path: Path | None = None) -> Path:
         )
         conn.commit()
         if cur.rowcount == 0:
-            raise RuntimeError(f"kanban task {task_id!r} not found or not a worktree task in {db}")
+            logger.warning(
+                "worktree_bootstrap: no row for %s with workspace_kind='worktree' in %s; "
+                "retrying id-only workspace_path update",
+                task_id,
+                db,
+            )
+            cur = conn.execute(
+                "UPDATE tasks SET workspace_path = ? WHERE id = ?",
+                (abs_path, task_id),
+            )
+            conn.commit()
+            if cur.rowcount == 0:
+                raise RuntimeError(
+                    f"kanban task {task_id!r} not found in {db}"
+                )
 
     logger.info("worktree_bootstrap: pinned kanban workspace %s -> %s", task_id, abs_path)
     return path
@@ -163,5 +182,13 @@ def ensure_worktree(task_id: str, *, base_branch: str = "main") -> Path:
 def prepare_kanban_worktree(task_id: str, *, base_branch: str = "main") -> Path:
     """Create the git worktree and pin its path on the Kanban task row."""
     wt_path = ensure_worktree(task_id, base_branch=base_branch)
-    pin_kanban_workspace(task_id, wt_path)
+    try:
+        pin_kanban_workspace(task_id, wt_path)
+    except RuntimeError as exc:
+        # Pin is best-effort: dispatch must not orphan an already-created chain.
+        logger.warning(
+            "worktree_bootstrap: could not pin kanban workspace for %s: %s",
+            task_id,
+            exc,
+        )
     return wt_path


### PR DESCRIPTION
## Summary
- Pin `~/.worktrees/<task_id>` on Hermes Kanban rows at dispatch via `prepare_kanban_worktree`, so workers no longer default to `<repo>/.worktrees/` while bootstrap creates under `$HOME/.worktrees`.
- Promote pipeline `evidence_profile=audit` when implement handoffs include `AUDIT_ONLY=1`, so verify no longer spuriously `gate_blocked` on missing `test` evidence.
- Document canonical worktree location in `MULTICA_HERMES_PR_LOOP.md`.

## Test plan
- [x] `python3 -m pytest services/zoe-data/tests/test_worktree_bootstrap.py services/zoe-data/tests/test_pipeline_store.py services/zoe-data/tests/test_pipeline_handoff.py services/zoe-data/tests/test_pipeline_evidence.py services/zoe-data/tests/test_kanban_adapter.py -q` (79 passed)
- [x] `python3 tools/audit/validate_structure.py`
- [x] Manually pinned in-flight ZOE-5378 implement/verify tasks; implement completed with PR #136, verify running on corrected path
- [ ] Greptile review + merge when green


Made with [Cursor](https://cursor.com)