### PR TITLE
feat(engineering): dispatch one ready phase at a time

### DIFF
--- a/docs/guides/GOVERNED_SELF_EVOLUTION.md
+++ b/docs/guides/GOVERNED_SELF_EVOLUTION.md
@@ -1,0 +1,38 @@
+# Governed Self-Evolution
+
+Zoe can improve its own software only through a governed engineering loop. The
+agent or executor is never the workflow authority.
+
+## Contract
+
+- Multica is the operator-facing ticket system.
+- Zoe owns process state in an append-only journal.
+- Executors such as Hermes, Pi Agent, or future agents receive one bounded phase.
+- A phase advances only after Zoe records required evidence.
+- Broad tickets block the parent and produce a split packet instead of continuing.
+- PR changes merge only after CI, Greptile confidence, and review-thread gates pass.
+- Risky or destructive work requires operator approval.
+
+## Current Executor
+
+Hermes Kanban remains the current executor adapter. New v4 engineering runs create
+one ready phase at a time. Legacy v2/v3 Kanban chains are still recognized while
+existing board work drains.
+
+## Future Executor Swap
+
+Pi Agent can be evaluated later as another executor adapter. It should not replace
+Zoe's journal, outcome matrix, Multica ticket contract, or evidence gates. A safe
+swap means:
+
+- the same Multica issue produces the same journal events;
+- the same evidence requirements gate phase advancement;
+- the same Greptile/CI merge guard applies;
+- the executor can be disabled without corrupting run state.
+
+## Not Allowed
+
+- no unattended recursive self-modification;
+- no prompt-only phase advancement;
+- no full Kanban chain creation for new v4 runs;
+- no production dispatch re-enable until controlled E2E scenarios pass.

--- a/docs/guides/MULTICA_HERMES_PR_LOOP.md
+++ b/docs/guides/MULTICA_HERMES_PR_LOOP.md
@@ -17,14 +17,14 @@ This workflow lets Zoe track engineering work from a Multica issue through Herme
 
 ## Flow
 
-1. A user, API caller, authenticated Multica webhook (`issue.assigned`), board approval, or the Zoe poll bridge creates a Hermes Kanban chain (**scout → implement → verify → review → closeout → retro**) on OpenRouter-routed worker profiles. Set `ZOE_KANBAN_SKIP_SCOUT=1` or issue `skip_scout` metadata to omit scout on well-scoped tasks. Legacy in-flight chains may still be on older paths; poll treats them as complete when closeout (or retro, when present) finishes.
-2. `zoe-planner` **scout** gathers Graphify/opensrc/Multica context read-only (no code changes).
-3. `zoe-coder` **implement** opens a small PR and hands off with `PR_URL=`, `BLOCKER=`, `TESTS=`, `TOOLS_USED=`, `SUMMARY=`.
-4. `zoe-reviewer` **verify** runs the objective evidence gate (structure validators, focused tests, live health) before review spends tokens.
-5. `zoe-reviewer` **review** checks diff scope and verify-phase evidence; blocks or requests changes when evidence is missing.
+1. A user, API caller, authenticated Multica webhook (`issue.assigned`), board approval, or the Zoe poll bridge asks Zoe to dispatch a Hermes-assigned issue. For new `zoe-chain: v4` runs, Zoe creates only the current ready phase from the JSONL pipeline journal. It does **not** pre-create the full chain.
+2. Zoe bootstraps or replays `pipeline_store` state and emits one Hermes Kanban task for the current phase (`scout`, or `implement` when scout is skipped).
+3. Hermes executes that single bounded phase and must end with `kanban_complete` or `kanban_block`.
+4. Zoe polls the phase row, parses evidence, and advances the journal only when `pipeline_evidence` requirements pass.
+5. When the journal moves to a new `todo` phase and no Kanban row exists for that phase, the poll bridge or compatibility script may dispatch exactly that next phase.
 6. `zoe-planner` **closeout** runs the Greptile grep loop (`github-greptile-loop`), squash-merges when Greptile + CI are green (`greploop_guard.py --merge-when-ready`), then updates the Multica issue.
 7. `zoe-planner` **retro** captures learnings and optional harness improvements (no silent production changes).
-8. The Zoe poll loop advances Multica `in_progress` issues to `done` when retro completes (or closeout for legacy/v2 chains without retro). Structured evidence uses `pipeline_evidence` + JSONL `pipeline_store`; fail-closed gates block phase advancement when required evidence is absent.
+8. Legacy v2/v3 chains are still recognized while in-flight board work drains; poll treats them as complete when closeout (or retro, when present) finishes.
 
 ## Model Routing Policy (Phase 0 cost control)
 

--- a/scripts/maintenance/sync_multica_to_kanban.py
+++ b/scripts/maintenance/sync_multica_to_kanban.py
@@ -42,6 +42,7 @@ async def run(args: argparse.Namespace) -> int:
     bootstrap_runtime_env()
     from executor_registry import poll_ref
     from multica_client import get_engineering_multica_agent_id, get_multica_client
+    from multica_poll_dispatch import chain_needs_dispatch
     from multica_webhook_emitter import emit_issue_assigned, is_configured as webhooks_configured
 
     hermes_id = get_engineering_multica_agent_id()
@@ -63,9 +64,9 @@ async def run(args: argparse.Namespace) -> int:
         print("No Hermes-assigned todo issues to dispatch")
         return 0
 
-    # Dispatch routes through the Zoe board webhook receiver; the secret is a
-    # batch-wide prerequisite, so check it once up front rather than per candidate.
-    if not webhooks_configured():
+    # Live dispatch routes through the Zoe board webhook receiver; the secret is
+    # a batch-wide prerequisite. Dry runs should still work without webhook auth.
+    if not args.dry_run and not webhooks_configured():
         print(
             "ERROR: MULTICA_WEBHOOK_SECRET unset — set it in .env so dispatch uses /api/agent/board/webhook",
             file=sys.stderr,
@@ -87,8 +88,8 @@ async def run(args: argparse.Namespace) -> int:
         # outer try/except that guards board_approve and the Multica webhook handler.
         try:
             existing = await poll_ref(f"multica:{issue_id}")
-            if existing.get("found") and existing.get("status") in ("running", "blocked"):
-                print(f"SKIP {ident}: chain exists status={existing['status']}")
+            if not chain_needs_dispatch(existing):
+                print(f"SKIP {ident}: chain status={existing.get('status')}")
                 continue
 
             if args.dry_run:

--- a/scripts/maintenance/sync_multica_to_kanban.py
+++ b/scripts/maintenance/sync_multica_to_kanban.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
-"""Sync Hermes-assigned Multica issues into Hermes Kanban chains (cheap DeepSeek).
+"""Sync Hermes-assigned Multica issues into active Hermes Kanban phases (cheap DeepSeek).
 
 Replaces the old engineering_workflow/background_runner (Sonnet) dispatch path.
-For each Hermes-assigned ``todo`` Multica issue without an active Kanban chain,
-create an implement->review->closeout chain via the executor registry, then set
-the Multica issue to ``in_progress``.
+For each Hermes-assigned ``todo`` Multica issue whose current ready phase has no
+Kanban row yet, dispatch exactly that one phase via the executor registry, then
+set the Multica issue to ``in_progress``.
 
-Idempotent: chains are keyed ``multica:{issue_id}:<phase>`` so re-runs are safe.
+Idempotent: phases are keyed ``multica:{issue_id}:<phase>`` so re-runs are safe.
 """
 from __future__ import annotations
 

--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -521,7 +521,14 @@ class KanbanAdapter:
             )
         except Exception as exc:
             logger.warning("kanban_adapter: pipeline bootstrap failed for %s: %s", external_ref, exc)
-            state = None
+            return {
+                "ok": False,
+                "external_ref": external_ref,
+                "reason": "pipeline bootstrap failed",
+                "chain": {},
+                "created": [],
+                "mode": mode,
+            }
 
         if state is not None and state.status in {"blocked", "done"}:
             return {

--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -724,7 +724,7 @@ class KanbanAdapter:
             if pipeline_info.get("terminal_block") and agg not in {"done", "blocked"}:
                 agg = "blocked"
                 blocker = blocker or f"pipeline terminal block at {pipeline_info.get('phase')}"
-            elif any("zoe-chain: v4" in (row.get("body") or "") for row in phases.values()):
+            elif agg not in {"done", "blocked"} and any("zoe-chain: v4" in (row.get("body") or "") for row in phases.values()):
                 current_phase = pipeline_info.get("phase")
                 current_status = pipeline_info.get("status")
                 if current_status == "done":

--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -1,9 +1,9 @@
 """Hermes Kanban executor adapter.
 
-Turns a Multica issue into a durable scout -> implement -> verify -> review ->
-closeout -> retro chain on the Hermes Kanban board, where OpenRouter-routed worker
-profiles do the work. All Kanban-specific behaviour lives here so it never leaks
-into Zoe core.
+Turns a Multica issue into a durable evidence-gated engineering run. New runs
+create only the current ready phase; pipeline_store owns phase advancement and a
+later dispatch call creates the next phase. Legacy in-flight chains are still
+recognized while the board drains.
 
 Boundary: this shells the ``hermes kanban`` CLI (same SQLite DB the in-gateway
 dispatcher reads) rather than importing Hermes internals — keeping Zoe
@@ -34,7 +34,7 @@ logger = logging.getLogger(__name__)
 
 NAME = "kanban"
 
-# Phases of the per-issue chain, in order. Each maps to a worker profile and the
+# Phases of the per-issue run, in order. Each maps to a worker profile and the
 # skills it must load. Keys double as the idempotency-key suffix (multica:{id}:<phase>).
 _CHAIN = (
     ("scout", "zoe-planner", ("zoe-graphify", "zoe-engineering")),
@@ -213,6 +213,13 @@ def _chain_for_issue(issue: dict) -> tuple[tuple[str, str, tuple[str, ...]], ...
     return phases
 
 
+def _phase_plan_entry(phase: str, issue: dict) -> tuple[str, str, tuple[str, ...]] | None:
+    for entry in _chain_for_issue(issue):
+        if entry[0] == phase:
+            return entry
+    return None
+
+
 def _protocol_violation_count(detail: dict[str, Any]) -> int:
     events = detail.get("events") if isinstance(detail.get("events"), list) else []
     return sum(
@@ -223,6 +230,8 @@ def _protocol_violation_count(detail: dict[str, Any]) -> int:
 def _expected_phases(phases: dict[str, dict]) -> set[str]:
     present = set(phases)
     bodies = [(phases[p].get("body") or "") for p in present]
+    if any("zoe-chain: v4" in body for body in bodies):
+        return set(present)
     v3_chain = any("zoe-chain: v3" in body for body in bodies)
     if present <= set(_LEGACY_CHAIN_PHASES) and "verify" not in present:
         return set(_LEGACY_CHAIN_PHASES)
@@ -276,6 +285,17 @@ class KanbanAdapter:
         except json.JSONDecodeError as exc:
             raise KanbanCLIError(f"non-JSON output from kanban {args[0]}: {exc}: {stdout[:200]}")
 
+    async def _phases_for_ref(self, external_ref: str) -> dict[str, dict]:
+        tasks = await self._run(["list", "--json"], expect_json=True)
+        rows = tasks if isinstance(tasks, list) else (tasks or {}).get("tasks", [])
+        prefix = f"{external_ref}:"
+        phases: dict[str, dict] = {}
+        for row in rows:
+            key = _row_ref_key(row)
+            if key.startswith(prefix):
+                phases[key[len(prefix):]] = row
+        return phases
+
     def _build_body(self, phase: str, issue: dict, identifier: str, *, mode: str | None = None) -> str:
         title = issue.get("title") or identifier
         description = issue.get("description") or ""
@@ -302,7 +322,7 @@ class KanbanAdapter:
         common = (
             f"Multica issue: {identifier} (id {issue_id})\n"
             f"zoe-ref: multica:{issue_id}:{phase}\n"
-            f"zoe-chain: v3\n"
+            f"zoe-chain: v4\n"
             f"{escalation_marker}"
             f"{mode_note}"
             f"Repo: {zoe_repo_root()}  |  Base branch: main  |  Workspace: git worktree\n\n"
@@ -473,9 +493,11 @@ class KanbanAdapter:
         return True
 
     async def dispatch(self, issue: dict) -> dict:
-        """Create (idempotently) the scout->implement->verify->review->closeout->retro chain.
+        """Create the single current ready phase for a Multica engineering run.
 
-        Returns {ok, external_ref, chain:{phase:task_id}, created:[phases], mode}.
+        Returns {ok, external_ref, chain:{phase:task_id}, created:[phase], mode}.
+        Repeated calls are idempotent: if the current phase already has a Kanban
+        row, dispatch reports it without creating downstream phases.
         """
         issue_id = str(issue.get("id") or "").strip()
         if not issue_id:
@@ -486,58 +508,123 @@ class KanbanAdapter:
 
         chain: dict[str, str] = {}
         created: list[str] = []
-        parent: str | None = None
         mode = _engineering_mode(issue)
-        phase_plan = _chain_for_issue(issue)
-        for phase, assignee, skills in phase_plan:
-            args = [
-                "create",
-                self._title(phase, identifier, issue),
-                "--assignee",
-                assignee,
-                "--workspace",
-                "worktree",
-                "--idempotency-key",
-                f"{external_ref}:{phase}",
-                "--max-runtime",
-                _max_runtime(mode),
-                "--created-by",
-                "zoe-bridge",
-                "--body",
-                self._build_body(phase, issue, identifier, mode=mode),
-                "--json",
-            ]
-            for skill in skills:
-                args += ["--skill", skill]
-            if parent:
-                args += ["--parent", parent]
-            result = await self._run(args, expect_json=True)
-            task_id = (result or {}).get("id") or (result or {}).get("task", {}).get("id")
-            if not task_id:
-                raise KanbanCLIError(f"create returned no id for phase={phase}: {result}")
-            chain[phase] = task_id
-            if not (result or {}).get("deduplicated"):
-                created.append(phase)
-            if phase in {"implement", "verify"}:
-                from worktree_bootstrap import prepare_kanban_worktree
 
-                await asyncio.to_thread(prepare_kanban_worktree, str(task_id))
-            parent = task_id
-
-        logger.info(
-            "kanban_adapter: dispatched %s -> chain=%s (new=%s)", identifier, chain, created
-        )
         try:
-            from pipeline_store import bootstrap_state
+            from pipeline_evidence import transition
+            from pipeline_store import bootstrap_state, save_state
 
-            await bootstrap_state(
+            state = await bootstrap_state(
                 external_ref,
                 start_phase="implement" if _skip_scout(issue) else "scout",
                 issue=issue,
             )
         except Exception as exc:
-            logger.debug("kanban_adapter: pipeline bootstrap skipped for %s: %s", external_ref, exc)
-        return {"ok": True, "external_ref": external_ref, "chain": chain, "created": created, "mode": mode}
+            logger.warning("kanban_adapter: pipeline bootstrap failed for %s: %s", external_ref, exc)
+            state = None
+
+        if state is not None and state.status in {"blocked", "done"}:
+            return {
+                "ok": False,
+                "external_ref": external_ref,
+                "reason": f"pipeline {state.status}",
+                "phase": state.phase,
+                "chain": {},
+                "created": [],
+                "mode": mode,
+            }
+
+        phase = state.phase if state is not None else ("implement" if _skip_scout(issue) else "scout")
+        entry = _phase_plan_entry(phase, issue)
+        if entry is None:
+            return {
+                "ok": False,
+                "external_ref": external_ref,
+                "reason": f"phase {phase} is not in this issue plan",
+                "phase": phase,
+                "chain": {},
+                "created": [],
+                "mode": mode,
+            }
+
+        existing_phases = await self._phases_for_ref(external_ref)
+        existing_row = existing_phases.get(phase)
+        if existing_row and existing_row.get("id"):
+            return {
+                "ok": True,
+                "external_ref": external_ref,
+                "chain": {phase: existing_row["id"]},
+                "created": [],
+                "mode": mode,
+                "phase": phase,
+                "ready_phase_only": True,
+            }
+
+        phase_order = [p for p, _, _ in _chain_for_issue(issue)]
+        parent: str | None = None
+        if phase in phase_order:
+            idx = phase_order.index(phase)
+            if idx > 0:
+                previous = existing_phases.get(phase_order[idx - 1]) or {}
+                parent = previous.get("id")
+
+        phase, assignee, skills = entry
+        args = [
+            "create",
+            self._title(phase, identifier, issue),
+            "--assignee",
+            assignee,
+            "--workspace",
+            "worktree",
+            "--idempotency-key",
+            f"{external_ref}:{phase}",
+            "--max-runtime",
+            _max_runtime(mode),
+            "--created-by",
+            "zoe-bridge",
+            "--body",
+            self._build_body(phase, issue, identifier, mode=mode),
+            "--json",
+        ]
+        for skill in skills:
+            args += ["--skill", skill]
+        if parent:
+            args += ["--parent", parent]
+        result = await self._run(args, expect_json=True)
+        task_id = (result or {}).get("id") or (result or {}).get("task", {}).get("id")
+        if not task_id:
+            raise KanbanCLIError(f"create returned no id for phase={phase}: {result}")
+        chain[phase] = task_id
+        if not (result or {}).get("deduplicated"):
+            created.append(phase)
+        if phase in {"implement", "verify"}:
+            from worktree_bootstrap import prepare_kanban_worktree
+
+            await asyncio.to_thread(prepare_kanban_worktree, str(task_id))
+        if state is not None and state.status == "todo":
+            try:
+                running = transition(state, "start")
+                await asyncio.to_thread(
+                    save_state,
+                    running,
+                    event="effect_requested",
+                    extra={"phase": phase, "task_id": task_id},
+                )
+            except Exception as exc:
+                logger.debug("kanban_adapter: effect_requested save skipped for %s: %s", external_ref, exc)
+
+        logger.info(
+            "kanban_adapter: dispatched %s -> phase=%s chain=%s (new=%s)", identifier, phase, chain, created
+        )
+        return {
+            "ok": True,
+            "external_ref": external_ref,
+            "chain": {phase: task_id},
+            "created": created,
+            "mode": mode,
+            "phase": phase,
+            "ready_phase_only": True,
+        }
 
     def _title(self, phase: str, identifier: str, issue: dict) -> str:
         base = issue.get("title") or identifier
@@ -569,14 +656,7 @@ class KanbanAdapter:
         # each row via _row_ref_key (the `zoe-ref:` body marker) in Python. This is
         # O(board size) per candidate; acceptable while the board is small. Revisit
         # (push the filter into the CLI) if the board grows large enough to matter.
-        tasks = await self._run(["list", "--json"], expect_json=True)
-        rows = tasks if isinstance(tasks, list) else (tasks or {}).get("tasks", [])
-        prefix = f"{external_ref}:"
-        phases: dict[str, dict] = {}
-        for row in rows:
-            key = _row_ref_key(row)
-            if key.startswith(prefix):
-                phases[key[len(prefix):]] = row
+        phases = await self._phases_for_ref(external_ref)
         if not phases:
             return {"found": False, "status": "not_found", "phases": {}, "pr_url": None, "blocker": None}
 
@@ -644,6 +724,18 @@ class KanbanAdapter:
             if pipeline_info.get("terminal_block") and agg not in {"done", "blocked"}:
                 agg = "blocked"
                 blocker = blocker or f"pipeline terminal block at {pipeline_info.get('phase')}"
+            elif any("zoe-chain: v4" in (row.get("body") or "") for row in phases.values()):
+                current_phase = pipeline_info.get("phase")
+                current_status = pipeline_info.get("status")
+                if current_status == "done":
+                    agg = "done"
+                elif current_status == "blocked":
+                    agg = "blocked"
+                    blocker = blocker or f"pipeline blocked at {current_phase}"
+                elif current_status == "todo" and current_phase not in phases:
+                    agg = "partial"
+                else:
+                    agg = "running"
         except Exception as exc:
             logger.debug("kanban_adapter: pipeline sync skipped for %s: %s", external_ref, exc)
 

--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -693,6 +693,7 @@ class KanbanAdapter:
 
         closeout = phases.get("closeout", {})
         retro = phases.get("retro", {})
+        is_v4 = any("zoe-chain: v4" in (row.get("body") or "") for row in phases.values())
         expected = _expected_phases(phases)
         missing = expected - set(phases)
         if retro and (retro.get("status") or "") in _TERMINAL_KANBAN_STATUSES:
@@ -731,7 +732,7 @@ class KanbanAdapter:
             if pipeline_info.get("terminal_block") and agg not in {"done", "blocked"}:
                 agg = "blocked"
                 blocker = blocker or f"pipeline terminal block at {pipeline_info.get('phase')}"
-            elif agg not in {"done", "blocked"} and any("zoe-chain: v4" in (row.get("body") or "") for row in phases.values()):
+            elif agg not in {"done", "blocked"} and is_v4:
                 current_phase = pipeline_info.get("phase")
                 current_status = pipeline_info.get("status")
                 if current_status == "done":
@@ -744,7 +745,10 @@ class KanbanAdapter:
                 else:
                     agg = "running"
         except Exception as exc:
-            logger.debug("kanban_adapter: pipeline sync skipped for %s: %s", external_ref, exc)
+            logger.warning("kanban_adapter: pipeline sync failed for %s: %s", external_ref, exc)
+            pipeline_info = {"tracked": False, "error": str(exc)}
+            if is_v4 and agg not in {"done", "blocked"}:
+                agg = "partial"
 
         return {
             "found": True,

--- a/services/zoe-data/intent_router.py
+++ b/services/zoe-data/intent_router.py
@@ -1545,10 +1545,9 @@ async def execute_intent(intent: Intent, user_id: str = "family-admin") -> Optio
             )
             ident = issue.get("identifier") or issue.get("id") or "(new)"
             return (
-                "I've added that to the Multica board for Hermes.\n\n"
+                "I've added that to Multica for Zoe's engineering driver.\n\n"
                 f"- Issue: `{ident}`\n"
-                "It'll be picked up by the Kanban engineering loop (implement → review → closeout) "
-                "and I'll keep the board status in sync."
+                "Zoe will dispatch one bounded Hermes phase at a time and keep the ticket status in sync."
             )
         except Exception as exc:
             logger.warning("engineering_task_create: %s", exc)

--- a/services/zoe-data/multica_poll_dispatch.py
+++ b/services/zoe-data/multica_poll_dispatch.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 def chain_needs_dispatch(chain: dict) -> bool:
     """Return True when a Hermes-assigned Multica issue should receive a Kanban chain.
 
-    The poll bridge dispatches when there is no active chain yet (``not_found``) or
-    when a prior dispatch was interrupted (``partial``). Active ``running`` /
+    The poll bridge dispatches when there is no active run yet (``not_found``) or
+    when the journal has a next ready phase with no Kanban row yet (``partial``).
+    Legacy interrupted chains also report ``partial``. Active ``running`` /
     ``blocked`` chains and completed ``done`` chains are left alone.
 
     Pipeline ``fingerprint_abort`` / ``terminal_block`` also suppresses redispatch.

--- a/services/zoe-data/routers/system.py
+++ b/services/zoe-data/routers/system.py
@@ -1383,7 +1383,8 @@ async def get_agent_board(user: dict = Depends(get_current_user)):
                 if str(issue.get("assignee_id") or "") == hermes_id:
                     hermes_issues.append(enriched)
                 groups[status].append(enriched)
-                active.append(enriched)
+                if status in {"in_progress", "in_review"}:
+                    active.append(enriched)
 
         async def enrich_chain(issue: dict) -> None:
             try:

--- a/services/zoe-data/routers/system.py
+++ b/services/zoe-data/routers/system.py
@@ -1358,7 +1358,7 @@ async def get_llm_stats(
 
 
 @_agent_card_router.get("/board")
-async def get_agent_board():
+async def get_agent_board(user: dict = Depends(get_current_user)):
     """Return Multica engineering ticket state for AG-UI display.
 
     Falls back gracefully if Multica is not configured or unavailable.

--- a/services/zoe-data/routers/system.py
+++ b/services/zoe-data/routers/system.py
@@ -1380,7 +1380,7 @@ async def get_agent_board(user: dict = Depends(get_current_user)):
         for status in statuses:
             for issue in await client.list_issues(status=status) or []:
                 enriched = dict(issue)
-                if str(issue.get("assignee_id") or "") == hermes_id:
+                if status in {"in_progress", "in_review"} and str(issue.get("assignee_id") or "") == hermes_id:
                     hermes_issues.append(enriched)
                 groups[status].append(enriched)
                 if status in {"in_progress", "in_review"}:

--- a/services/zoe-data/routers/system.py
+++ b/services/zoe-data/routers/system.py
@@ -1375,22 +1375,33 @@ async def get_agent_board(user: dict = Depends(get_current_user)):
         hermes_id = str(get_engineering_multica_agent_id())
         groups: dict[str, list[dict]] = {status: [] for status in statuses}
         active: list[dict] = []
+        hermes_issues: list[dict] = []
 
         for status in statuses:
             for issue in await client.list_issues(status=status) or []:
                 enriched = dict(issue)
                 if str(issue.get("assignee_id") or "") == hermes_id:
-                    chain = await poll_ref(f"multica:{issue.get('id')}")
-                    enriched["chain"] = chain
-                    pipeline = chain.get("pipeline") if isinstance(chain, dict) else None
-                    if isinstance(pipeline, dict):
-                        enriched["phase"] = pipeline.get("phase")
-                        enriched["needs_split"] = pipeline.get("needs_split")
-                        enriched["split_packet"] = pipeline.get("split_packet")
-                    enriched["blocker"] = chain.get("blocker") if isinstance(chain, dict) else None
-                    enriched["pr_url"] = chain.get("pr_url") if isinstance(chain, dict) else None
+                    hermes_issues.append(enriched)
                 groups[status].append(enriched)
                 active.append(enriched)
+
+        async def enrich_chain(issue: dict) -> None:
+            try:
+                chain = await poll_ref(f"multica:{issue.get('id')}")
+            except Exception as exc:
+                issue["chain_error"] = str(exc)
+                return
+            issue["chain"] = chain
+            pipeline = chain.get("pipeline") if isinstance(chain, dict) else None
+            if isinstance(pipeline, dict):
+                issue["phase"] = pipeline.get("phase")
+                issue["needs_split"] = pipeline.get("needs_split")
+                issue["split_packet"] = pipeline.get("split_packet")
+            issue["blocker"] = chain.get("blocker") if isinstance(chain, dict) else None
+            issue["pr_url"] = chain.get("pr_url") if isinstance(chain, dict) else None
+
+        if hermes_issues:
+            await asyncio.gather(*(enrich_chain(issue) for issue in hermes_issues))
 
         return {"active": active, "groups": groups, "available": True}
     except ImportError:

--- a/services/zoe-data/routers/system.py
+++ b/services/zoe-data/routers/system.py
@@ -1359,21 +1359,44 @@ async def get_llm_stats(
 
 @_agent_card_router.get("/board")
 async def get_agent_board():
-    """Return active Multica board issues for AG-UI display.
+    """Return Multica engineering ticket state for AG-UI display.
 
     Falls back gracefully if Multica is not configured or unavailable.
     """
     try:
-        from multica_client import MULClient  # type: ignore[import]
+        from executor_registry import poll_ref  # type: ignore[import]
+        from multica_client import MULClient, get_engineering_multica_agent_id  # type: ignore[import]
+
         client = MULClient()
         if not client.is_configured():
-            return {"active": [], "available": False, "reason": "Multica not configured"}
-        issues = await client.list_issues(status="in_progress")
-        return {"active": issues, "available": True}
+            return {"active": [], "groups": {}, "available": False, "reason": "Multica not configured"}
+
+        statuses = ("backlog", "todo", "in_progress", "blocked", "in_review")
+        hermes_id = str(get_engineering_multica_agent_id())
+        groups: dict[str, list[dict]] = {status: [] for status in statuses}
+        active: list[dict] = []
+
+        for status in statuses:
+            for issue in await client.list_issues(status=status) or []:
+                enriched = dict(issue)
+                if str(issue.get("assignee_id") or "") == hermes_id:
+                    chain = await poll_ref(f"multica:{issue.get('id')}")
+                    enriched["chain"] = chain
+                    pipeline = chain.get("pipeline") if isinstance(chain, dict) else None
+                    if isinstance(pipeline, dict):
+                        enriched["phase"] = pipeline.get("phase")
+                        enriched["needs_split"] = pipeline.get("needs_split")
+                        enriched["split_packet"] = pipeline.get("split_packet")
+                    enriched["blocker"] = chain.get("blocker") if isinstance(chain, dict) else None
+                    enriched["pr_url"] = chain.get("pr_url") if isinstance(chain, dict) else None
+                groups[status].append(enriched)
+                active.append(enriched)
+
+        return {"active": active, "groups": groups, "available": True}
     except ImportError:
-        return {"active": [], "available": False, "reason": "Multica client not installed"}
+        return {"active": [], "groups": {}, "available": False, "reason": "Multica client not installed"}
     except Exception as exc:
-        return {"active": [], "available": False, "reason": str(exc)}
+        return {"active": [], "groups": {}, "available": False, "reason": str(exc)}
 
 
 @_agent_card_router.post("/board/approve")

--- a/services/zoe-data/tests/test_agent_board.py
+++ b/services/zoe-data/tests/test_agent_board.py
@@ -1,0 +1,52 @@
+import types
+
+import pytest
+
+from routers import system
+
+
+@pytest.mark.asyncio
+async def test_agent_board_keeps_active_and_chain_enrichment_bounded(monkeypatch):
+    issues_by_status = {
+        "backlog": [{"id": "backlog-1", "assignee_id": "hermes"}],
+        "todo": [{"id": "todo-1", "assignee_id": "hermes"}],
+        "in_progress": [{"id": "progress-1", "assignee_id": "hermes"}],
+        "blocked": [{"id": "blocked-1", "assignee_id": "hermes"}],
+        "in_review": [{"id": "review-1", "assignee_id": "hermes"}],
+    }
+    polled_refs: list[str] = []
+
+    class FakeMULClient:
+        def is_configured(self):
+            return True
+
+        async def list_issues(self, *, status):
+            return issues_by_status[status]
+
+    async def fake_poll_ref(ref):
+        polled_refs.append(ref)
+        return {
+            "status": "running",
+            "pipeline": {"phase": "implement", "status": "running"},
+            "blocker": None,
+            "pr_url": "https://github.example/pr/1",
+        }
+
+    monkeypatch.setitem(
+        __import__("sys").modules,
+        "multica_client",
+        types.SimpleNamespace(MULClient=FakeMULClient, get_engineering_multica_agent_id=lambda: "hermes"),
+    )
+    monkeypatch.setitem(
+        __import__("sys").modules,
+        "executor_registry",
+        types.SimpleNamespace(poll_ref=fake_poll_ref),
+    )
+
+    board = await system.get_agent_board(user={"sub": "test"})
+
+    assert [issue["id"] for issue in board["active"]] == ["progress-1", "review-1"]
+    assert sorted(board["groups"]) == ["backlog", "blocked", "in_progress", "in_review", "todo"]
+    assert polled_refs == ["multica:progress-1", "multica:review-1"]
+    assert board["groups"]["backlog"][0].get("chain") is None
+    assert board["groups"]["in_progress"][0]["phase"] == "implement"

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -561,6 +561,15 @@ async def test_poll_v4_done_phase_with_ready_next_phase_is_partial():
 
 
 @pytest.mark.asyncio
+async def test_poll_v4_does_not_promote_kanban_blocked_to_partial():
+    rows = [_row("implement", "blocked", chain_version="v4", block_reason="dirty tree")]
+    a = _FakeAdapter(list_rows=rows)
+    out = await a.poll("multica:uuid-9")
+    assert out["status"] == "blocked"
+    assert "dirty tree" in (out["blocker"] or "")
+
+
+@pytest.mark.asyncio
 async def test_poll_current_partial_chain_with_verify_is_redispatchable():
     rows = [
         _row("implement", "done"),

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -63,35 +63,44 @@ class _FakeAdapter(ka.KanbanAdapter):
 
 
 @pytest.mark.asyncio
-async def test_dispatch_creates_six_linked_phases():
+async def test_dispatch_creates_one_ready_phase():
     a = _FakeAdapter()
     issue = {"id": "uuid-1", "identifier": "ZOE-9", "title": "Fix thing", "description": "do it"}
     result = await a.dispatch(issue)
     assert result["ok"] is True
     assert result["external_ref"] == "multica:uuid-1"
-    assert set(result["chain"]) == {
-        "scout",
-        "implement",
-        "verify",
-        "review",
-        "closeout",
-        "retro",
-    }
+    assert result["phase"] == "scout"
+    assert result["ready_phase_only"] is True
+    assert set(result["chain"]) == {"scout"}
     creates = [c for c in a.calls if c[0] == "create"]
-    assert len(creates) == 6
-    # verify + review + closeout + retro must be linked to a parent
-    for create in creates[1:]:
-        assert "--parent" in create
+    assert len(creates) == 1
+    assert "--parent" not in creates[0]
     keys = [c[c.index("--idempotency-key") + 1] for c in creates]
-    assert keys == [
-        "multica:uuid-1:scout",
-        "multica:uuid-1:implement",
-        "multica:uuid-1:verify",
-        "multica:uuid-1:review",
-        "multica:uuid-1:closeout",
-        "multica:uuid-1:retro",
-    ]
+    assert keys == ["multica:uuid-1:scout"]
     assert result["mode"] == "interactive"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_after_scout_evidence_creates_next_phase():
+    from pipeline_store import bootstrap_state, save_state
+    from pipeline_evidence import EvidenceItem, transition, with_evidence
+
+    state = await bootstrap_state("multica:uuid-next", start_phase="scout")
+    state = with_evidence(state, EvidenceItem(kind="tool", summary="graphify map", passed=True))
+    state = transition(state, "complete")
+    save_state(state, event="transition", extra={"row_phase": "scout"})
+
+    rows = [_row("scout", "done", chain_version="v4", issue_id="uuid-next")]
+    a = _FakeAdapter(list_rows=rows)
+    result = await a.dispatch({"id": "uuid-next", "identifier": "ZOE-NEXT", "title": "Fix thing"})
+
+    creates = [c for c in a.calls if c[0] == "create"]
+    assert result["phase"] == "implement"
+    assert set(result["chain"]) == {"implement"}
+    assert len(creates) == 1
+    assert creates[0][creates[0].index("--idempotency-key") + 1] == "multica:uuid-next:implement"
+    assert "--parent" in creates[0]
+    assert creates[0][creates[0].index("--parent") + 1] == "t_scout"
 
 
 @pytest.mark.asyncio
@@ -109,9 +118,9 @@ async def test_dispatch_overnight_mode_extends_runtime(monkeypatch):
 
     creates = [c for c in a.calls if c[0] == "create"]
     runtimes = [c[c.index("--max-runtime") + 1] for c in creates]
-    body = creates[1][creates[1].index("--body") + 1]
+    body = creates[0][creates[0].index("--body") + 1]
     assert result["mode"] == "overnight"
-    assert runtimes == ["8h"] * 6
+    assert runtimes == ["8h"]
     assert "latency is secondary" in body
 
 
@@ -123,8 +132,8 @@ async def test_dispatch_interactive_mode_uses_default_runtime(monkeypatch):
     await a.dispatch({"id": "uuid-fast", "identifier": "ZOE-FAST", "title": "Immediate work"})
 
     creates = [c for c in a.calls if c[0] == "create"]
-    assert creates[1][creates[1].index("--max-runtime") + 1] == "30m"
-    body = creates[1][creates[1].index("--body") + 1]
+    assert creates[0][creates[0].index("--max-runtime") + 1] == "30m"
+    body = creates[0][creates[0].index("--body") + 1]
     assert "Engineering mode: interactive" in body
 
 
@@ -157,7 +166,7 @@ async def test_dispatch_skip_scout_when_env_set(monkeypatch):
     a = _FakeAdapter()
     result = await a.dispatch({"id": "uuid-skip", "identifier": "ZOE-SKIP", "title": "t"})
     assert "scout" not in result["chain"]
-    assert set(result["chain"]) == {"implement", "verify", "review", "closeout", "retro"}
+    assert set(result["chain"]) == {"implement"}
 
 
 @pytest.mark.asyncio
@@ -170,9 +179,18 @@ async def test_dispatch_quality_escalation_mode(monkeypatch):
     creates = [c for c in a.calls if c[0] == "create"]
     assert result["mode"] == "quality-escalation"
     assert creates[0][creates[0].index("--max-runtime") + 1] == "75m"
-    body = creates[1][creates[1].index("--body") + 1]
+    body = creates[0][creates[0].index("--body") + 1]
     assert "quality-escalation" in body
-    verify_body = creates[2][creates[2].index("--body") + 1]
+    verify_body = ka.KanbanAdapter()._build_body(
+        "verify",
+        {
+            "id": "uuid-q",
+            "identifier": "ZOE-Q",
+            "title": "Hard task",
+            "engineering_mode": "quality-escalation",
+        },
+        "ZOE-Q",
+    )
     assert "zoe-model-escalation: true" in verify_body
     assert "anthropic/claude-sonnet-4.6" in verify_body
     assert "Do NOT use openrouter/auto" in verify_body
@@ -189,20 +207,29 @@ async def test_dispatch_model_escalation_from_metadata():
             "metadata": {"model_escalation": True},
         }
     )
-    creates = [c for c in a.calls if c[0] == "create"]
-    review_body = creates[3][creates[3].index("--body") + 1]
+    review_body = ka.KanbanAdapter()._build_body(
+        "review",
+        {
+            "id": "uuid-meta-esc",
+            "identifier": "ZOE-ESC",
+            "title": "Escalate on metadata",
+            "metadata": {"model_escalation": True},
+        },
+        "ZOE-ESC",
+    )
     assert "zoe-model-escalation: true" in review_body
     assert "anthropic/claude-sonnet-4.6" in review_body
 
 
 @pytest.mark.asyncio
-async def test_dispatch_overnight_implement_mentions_free_fallback():
+async def test_dispatch_overnight_implement_mentions_free_fallback(monkeypatch):
+    monkeypatch.setenv("ZOE_KANBAN_SKIP_SCOUT", "1")
     a = _FakeAdapter()
     await a.dispatch(
         {"id": "uuid-night2", "identifier": "ZOE-N2", "title": "Night work", "engineering_mode": "overnight"}
     )
     creates = [c for c in a.calls if c[0] == "create"]
-    impl_body = creates[1][creates[1].index("--body") + 1]
+    impl_body = creates[0][creates[0].index("--body") + 1]
     assert "openrouter/free" in impl_body
 
 
@@ -235,11 +262,10 @@ async def test_dispatch_writes_zoe_ref_marker_into_body():
     a = _FakeAdapter()
     await a.dispatch({"id": "uuid-7", "identifier": "ZOE-7", "title": "t"})
     creates = [c for c in a.calls if c[0] == "create"]
-    for phase, create in zip(
-        ("scout", "implement", "verify", "review", "closeout", "retro"), creates
-    ):
-        body = create[create.index("--body") + 1]
-        assert f"zoe-ref: multica:uuid-7:{phase}" in body
+    assert len(creates) == 1
+    body = creates[0][creates[0].index("--body") + 1]
+    assert "zoe-ref: multica:uuid-7:scout" in body
+    assert "zoe-chain: v4" in body
 
 
 @pytest.mark.asyncio
@@ -380,16 +406,18 @@ async def test_dispatch_pins_expected_skills():
     a = _FakeAdapter()
     await a.dispatch({"id": "u", "identifier": "ZOE-1", "title": "t"})
     creates = [c for c in a.calls if c[0] == "create"]
-    impl_skills = [creates[1][i + 1] for i, v in enumerate(creates[1]) if v == "--skill"]
     scout_skills = [creates[0][i + 1] for i, v in enumerate(creates[0]) if v == "--skill"]
-    verify_skills = [creates[2][i + 1] for i, v in enumerate(creates[2]) if v == "--skill"]
-    closeout_skills = [creates[4][i + 1] for i, v in enumerate(creates[4]) if v == "--skill"]
-    retro_skills = [creates[5][i + 1] for i, v in enumerate(creates[5]) if v == "--skill"]
     assert "zoe-graphify" in scout_skills
+
+
+@pytest.mark.asyncio
+async def test_dispatch_pins_implement_skill_when_scout_skipped(monkeypatch):
+    monkeypatch.setenv("ZOE_KANBAN_SKIP_SCOUT", "1")
+    a = _FakeAdapter()
+    await a.dispatch({"id": "u", "identifier": "ZOE-1", "title": "t"})
+    creates = [c for c in a.calls if c[0] == "create"]
+    impl_skills = [creates[0][i + 1] for i, v in enumerate(creates[0]) if v == "--skill"]
     assert impl_skills == ["zoe-engineering"]
-    assert "zoe-engineering" in verify_skills
-    assert "github-greptile-loop" in closeout_skills
-    assert "zoe-status-refresh" in retro_skills
 
 
 @pytest.mark.asyncio
@@ -438,9 +466,17 @@ async def test_poll_partial_chain_is_redispatchable():
 
 def _row(phase, status, **extra):
     """A Kanban list row shaped like the real CLI: body marker, NO idempotency_key."""
-    body = f"Multica issue: ZOE-9 (id uuid-9)\nzoe-ref: multica:uuid-9:{phase}\nTitle: x"
+    issue_id = extra.pop("issue_id", "uuid-9")
+    body = f"Multica issue: ZOE-9 (id {issue_id})\nzoe-ref: multica:{issue_id}:{phase}\nTitle: x"
+    chain_version = extra.pop("chain_version", None)
+    if chain_version:
+        body = (
+            f"Multica issue: ZOE-9 (id {issue_id})\n"
+            f"zoe-ref: multica:{issue_id}:{phase}\n"
+            f"zoe-chain: {chain_version}\nTitle: x"
+        )
     if extra.pop("v3", False):
-        body = f"Multica issue: ZOE-9 (id uuid-9)\nzoe-ref: multica:uuid-9:{phase}\nzoe-chain: v3\nTitle: x"
+        body = f"Multica issue: ZOE-9 (id {issue_id})\nzoe-ref: multica:{issue_id}:{phase}\nzoe-chain: v3\nTitle: x"
     return {
         "id": f"t_{phase}",
         "body": body,
@@ -510,6 +546,18 @@ async def test_poll_partial_chain_via_body_marker_is_redispatchable():
     out = await a.poll("multica:uuid-9")
     assert out["found"] is True
     assert out["status"] == "partial"
+
+
+@pytest.mark.asyncio
+async def test_poll_v4_done_phase_with_ready_next_phase_is_partial():
+    rows = [_row("scout", "done", chain_version="v4")]
+    show = {"t_scout": {"latest_summary": "TOOLS_USED=graphify\nSCOUT_SUMMARY=small", "comments": []}}
+    a = _FakeAdapter(list_rows=rows, show_map=show)
+    out = await a.poll("multica:uuid-9")
+    assert out["found"] is True
+    assert out["status"] == "partial"
+    assert out["pipeline"]["phase"] == "implement"
+    assert out["pipeline"]["status"] == "todo"
 
 
 @pytest.mark.asyncio

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -81,6 +81,20 @@ async def test_dispatch_creates_one_ready_phase():
 
 
 @pytest.mark.asyncio
+async def test_dispatch_refuses_to_create_without_pipeline_journal(monkeypatch):
+    async def fail_bootstrap(*args, **kwargs):
+        raise RuntimeError("store offline")
+
+    monkeypatch.setattr("pipeline_store.bootstrap_state", fail_bootstrap)
+    a = _FakeAdapter()
+    result = await a.dispatch({"id": "uuid-no-journal", "identifier": "ZOE-NJ", "title": "No journal"})
+
+    assert result["ok"] is False
+    assert result["reason"] == "pipeline bootstrap failed"
+    assert [c for c in a.calls if c[0] == "create"] == []
+
+
+@pytest.mark.asyncio
 async def test_dispatch_after_scout_evidence_creates_next_phase():
     from pipeline_store import bootstrap_state, save_state
     from pipeline_evidence import EvidenceItem, transition, with_evidence

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -575,6 +575,21 @@ async def test_poll_v4_done_phase_with_ready_next_phase_is_partial():
 
 
 @pytest.mark.asyncio
+async def test_poll_v4_pipeline_sync_failure_is_partial(monkeypatch):
+    async def fail_sync(*args, **kwargs):
+        raise RuntimeError("pipeline store unavailable")
+
+    monkeypatch.setattr("pipeline_store.sync_pipeline_from_chain", fail_sync)
+    rows = [_row("scout", "done", chain_version="v4")]
+    a = _FakeAdapter(list_rows=rows)
+    out = await a.poll("multica:uuid-9")
+
+    assert out["status"] == "partial"
+    assert out["pipeline"]["tracked"] is False
+    assert "pipeline store unavailable" in out["pipeline"]["error"]
+
+
+@pytest.mark.asyncio
 async def test_poll_v4_does_not_promote_kanban_blocked_to_partial():
     rows = [_row("implement", "blocked", chain_version="v4", block_reason="dirty tree")]
     a = _FakeAdapter(list_rows=rows)


### PR DESCRIPTION
## Summary
- change new Hermes engineering runs to create only the current ready journal phase
- treat v4 partial as next ready phase missing, while preserving legacy v2/v3 chain polling
- unify sync_multica_to_kanban with chain_needs_dispatch and allow dry-run without webhook auth
- expose grouped Multica board state with pipeline phase/blocker/PR metadata
- document governed self-evolution and the future executor-adapter boundary

## Validation
- python3 -m pytest services/zoe-data/tests -q (415 passed)
- python3 scripts/maintenance/engineering_harness_loop.py --mode kanban-dry --no-pipeline
- python3 tools/audit/validate_structure.py
- python3 tools/audit/validate_critical_files.py

Dispatch remains paused; this PR does not re-enable ZOE_MULTICA_POLL_DISPATCH_LIMIT.