### PR TITLE
feat(multica): make tickets the engineering source of truth

### DIFF
--- a/scripts/maintenance/multica_health_report.py
+++ b/scripts/maintenance/multica_health_report.py
@@ -50,7 +50,7 @@ async def run(*, ensure_shape: bool = False) -> dict:
     ]
     if ensure_shape:
         for label in required_labels:
-            await client.ensure_label(label)
+            await client.ensure_label(label, existing=labels)
         labels = await client.list_labels()
     present_labels = {str(label.get("name") or "").lower() for label in labels}
     report["checks"]["required_labels"] = {

--- a/scripts/maintenance/multica_health_report.py
+++ b/scripts/maintenance/multica_health_report.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Report whether Zoe can use Multica as the engineering ticket source of truth."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "services" / "zoe-data"))
+
+
+async def run(*, ensure_shape: bool = False) -> dict:
+    from multica_client import get_engineering_multica_agent_id, get_multica_client
+
+    client = get_multica_client()
+    report: dict = {
+        "configured": client.is_configured(),
+        "base_url": bool(os.environ.get("MULTICA_BASE_URL")),
+        "workspace_id": bool(os.environ.get("MULTICA_WORKSPACE_ID")),
+        "api_token": bool(os.environ.get("MULTICA_API_TOKEN")),
+        "webhook_secret": bool(os.environ.get("MULTICA_WEBHOOK_SECRET")),
+        "hermes_agent_id": get_engineering_multica_agent_id(),
+        "checks": {},
+    }
+    if not client.is_configured():
+        report["ok"] = False
+        return report
+
+    issues = await client.list_issues(status="todo")
+    labels = await client.list_labels()
+    projects = await client.list_projects()
+    report["checks"]["issues_api"] = isinstance(issues, list)
+    report["checks"]["labels_api"] = isinstance(labels, list)
+    report["checks"]["projects_api"] = isinstance(projects, list)
+
+    required_labels = [
+        "needs-split",
+        "blocked-external",
+        "in-review",
+        "greptile",
+        "ci-failed",
+        "audit-only",
+        "user-feedback",
+        "harness-fix",
+        "operator-task",
+    ]
+    if ensure_shape:
+        for label in required_labels:
+            await client.ensure_label(label)
+    present_labels = {str(label.get("name") or "").lower() for label in await client.list_labels()}
+    report["checks"]["required_labels"] = {
+        label: label.lower() in present_labels for label in required_labels
+    }
+    report["ok"] = (
+        report["configured"]
+        and report["checks"]["issues_api"]
+        and report["checks"]["labels_api"]
+        and report["checks"]["projects_api"]
+        and all(report["checks"]["required_labels"].values())
+        and report["webhook_secret"]
+    )
+    return report
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Check Zoe/Multica product surface health.")
+    parser.add_argument("--ensure-shape", action="store_true", help="Create missing canonical labels.")
+    args = parser.parse_args(argv)
+    report = asyncio.run(run(ensure_shape=args.ensure_shape))
+    print(json.dumps(report, sort_keys=True, indent=2))
+    return 0 if report.get("ok") else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/maintenance/multica_health_report.py
+++ b/scripts/maintenance/multica_health_report.py
@@ -51,7 +51,8 @@ async def run(*, ensure_shape: bool = False) -> dict:
     if ensure_shape:
         for label in required_labels:
             await client.ensure_label(label)
-    present_labels = {str(label.get("name") or "").lower() for label in await client.list_labels()}
+        labels = await client.list_labels()
+    present_labels = {str(label.get("name") or "").lower() for label in labels}
     report["checks"]["required_labels"] = {
         label: label.lower() in present_labels for label in required_labels
     }

--- a/scripts/maintenance/zoe_mark_greptile.py
+++ b/scripts/maintenance/zoe_mark_greptile.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+"""Record Greptile evidence for a Zoe engineering pipeline run."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "services" / "zoe-data"))
+
+from pipeline_evidence_commands import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(["mark-greptile", *sys.argv[1:]]))

--- a/scripts/maintenance/zoe_mark_reviewed.py
+++ b/scripts/maintenance/zoe_mark_reviewed.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+"""Record review evidence for a Zoe engineering pipeline run."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "services" / "zoe-data"))
+
+from pipeline_evidence_commands import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(["mark-reviewed", *sys.argv[1:]]))

--- a/scripts/maintenance/zoe_mark_tested.py
+++ b/scripts/maintenance/zoe_mark_tested.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+"""Record test evidence for a Zoe engineering pipeline run."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "services" / "zoe-data"))
+
+from pipeline_evidence_commands import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(["mark-tested", *sys.argv[1:]]))

--- a/scripts/maintenance/zoe_pr_maintenance.py
+++ b/scripts/maintenance/zoe_pr_maintenance.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Bounded PR maintenance phase for Zoe engineering runs.
+
+This command is intentionally a thin gate around the existing Greploop guard:
+it checks review/CI readiness, records Multica progress, and only merges when
+the guard reports readiness. It does not broaden scope beyond the PR.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "services" / "zoe-data"))
+
+
+def _run_guard(pr: int, *, merge_when_ready: bool) -> dict:
+    guard = Path(__file__).resolve().parents[2] / "services" / "zoe-data" / "greploop_guard.py"
+    cmd = [sys.executable, str(guard), "--pr", str(pr)]
+    if merge_when_ready:
+        cmd.append("--merge-when-ready")
+    proc = subprocess.run(cmd, text=True, capture_output=True, check=False)
+    output = (proc.stdout or proc.stderr or "").strip()
+    try:
+        parsed = json.loads(output)
+    except json.JSONDecodeError:
+        parsed = {"ok": False, "state": "ERROR", "output": output}
+    parsed.setdefault("exit_code", proc.returncode)
+    return parsed
+
+
+async def _record_issue_progress(issue_id: str | None, result: dict) -> None:
+    if not issue_id:
+        return
+    from multica_client import get_multica_client
+
+    client = get_multica_client()
+    if not client.is_configured():
+        return
+    state = str(result.get("state") or "")
+    status = "done" if state == "MERGED" else ("blocked" if state in {"BLOCKED", "ERROR"} else "in_review")
+    blocker = None if status != "blocked" else str(result.get("reason") or result.get("output") or state)
+    await client.record_progress(
+        issue_id,
+        phase="closeout",
+        greptile_status=str(result.get("greptile") or result.get("state") or ""),
+        merge_sha=result.get("merge_commit"),
+        blocker=blocker,
+        status=status,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run bounded Zoe PR maintenance.")
+    parser.add_argument("--pr", type=int, required=True)
+    parser.add_argument("--issue-id")
+    parser.add_argument("--merge-when-ready", action="store_true")
+    args = parser.parse_args(argv)
+
+    result = _run_guard(args.pr, merge_when_ready=args.merge_when_ready)
+    asyncio.run(_record_issue_progress(args.issue_id, result))
+    print(json.dumps(result, sort_keys=True))
+    return 0 if result.get("ok") else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/maintenance/zoe_pr_maintenance.py
+++ b/scripts/maintenance/zoe_pr_maintenance.py
@@ -50,6 +50,7 @@ async def _record_issue_progress(issue_id: str | None, result: dict) -> None:
         greptile_status=str(result.get("greptile") or result.get("state") or ""),
         merge_sha=result.get("merge_commit"),
         blocker=blocker,
+        clear_blocker=status in {"done", "in_review"},
         status=status,
     )
 

--- a/scripts/maintenance/zoe_split_ticket.py
+++ b/scripts/maintenance/zoe_split_ticket.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+"""Create child Multica tickets from a Zoe split packet."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "services" / "zoe-data"))
+
+from pipeline_evidence_commands import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(["split-ticket", *sys.argv[1:]]))

--- a/services/zoe-data/intent_router.py
+++ b/services/zoe-data/intent_router.py
@@ -1556,6 +1556,11 @@ async def execute_intent(intent: Intent, user_id: str = "family-admin") -> Optio
             )
             if issue.get("id"):
                 await client.attach_label(str(issue["id"]), "operator-task")
+            else:
+                return (
+                    "I tried to add that engineering task to Multica, but the API didn't return an issue. "
+                    "Please try again."
+                )
             ident = issue.get("identifier") or issue.get("id") or "(new)"
             return (
                 "I've added that to Multica for Zoe's engineering driver.\n\n"

--- a/services/zoe-data/intent_router.py
+++ b/services/zoe-data/intent_router.py
@@ -1712,7 +1712,7 @@ async def execute_intent(intent: Intent, user_id: str = "family-admin") -> Optio
                 )
                 if issue.get("id"):
                     await client.attach_label(str(issue["id"]), "user-feedback")
-                return _random.choice(_acks)
+                    return _random.choice(_acks)
         except Exception as _exc:
             logger.warning("user_issue_report: Multica capture failed: %s", _exc)
         try:

--- a/services/zoe-data/intent_router.py
+++ b/services/zoe-data/intent_router.py
@@ -1532,17 +1532,30 @@ async def execute_intent(intent: Intent, user_id: str = "family-admin") -> Optio
                 get_engineering_multica_agent_id,
                 get_multica_client,
             )
+            from multica_ticket_contract import describe_ticket  # type: ignore[import]
 
             client = get_multica_client()
             if not client.is_configured():
                 return "Multica isn't connected, so I can't track that engineering task on the board."
+            description = describe_ticket(
+                task_text,
+                zoe_kind="operator_task",
+                evidence_profile="code",
+                engineering_mode="interactive",
+                acceptance_criteria=["Deliver the requested behavior in a small, reviewable change."],
+                evidence_expectations=["Focused tests or validators", "PR URL when code changes are made"],
+                source="chat_engineering_task",
+            )
             issue = await client.create_issue(
                 title=task_text[:120],
-                description=task_text,
+                description=description,
                 priority="medium",
+                status="todo",
                 assignee_id=get_engineering_multica_agent_id(),
                 assignee_type="agent",
             )
+            if issue.get("id"):
+                await client.attach_label(str(issue["id"]), "operator-task")
             ident = issue.get("identifier") or issue.get("id") or "(new)"
             return (
                 "I've added that to Multica for Zoe's engineering driver.\n\n"
@@ -1670,15 +1683,42 @@ async def execute_intent(intent: Intent, user_id: str = "family-admin") -> Optio
     if intent.name == "user_issue_report":
         import random as _random
         _acks = [
-            "Got it, I've made a note of that.",
-            "Noted — I'll look into it.",
-            "Thanks for letting me know, I'll flag that for review.",
-            "I've logged that. I'll work on it.",
+            "Got it, I've logged that for review.",
+            "Noted. I've added that to the ticket backlog.",
+            "Thanks for letting me know. I've captured it so it can be triaged properly.",
+            "I've logged that as feedback rather than letting it disappear into chat.",
         ]
+        message = intent.slots.get("message", "")
+        try:
+            from multica_client import get_multica_client  # type: ignore[import]
+            from multica_ticket_contract import describe_ticket  # type: ignore[import]
+
+            client = get_multica_client()
+            if client.is_configured():
+                description = describe_ticket(
+                    f"User reported:\n\n{message}",
+                    zoe_kind="bug",
+                    evidence_profile="code",
+                    engineering_mode="interactive",
+                    acceptance_criteria=["Reproduce or explain the reported behavior.", "Propose a safe fix or mark blocked with reason."],
+                    evidence_expectations=["Issue triage note", "Test or validator if code changes are made"],
+                    source=f"chat_user_issue:{user_id}",
+                )
+                issue = await client.create_issue(
+                    title=f"User feedback: {message[:95]}",
+                    description=description,
+                    priority="medium",
+                    status="backlog",
+                )
+                if issue.get("id"):
+                    await client.attach_label(str(issue["id"]), "user-feedback")
+                return _random.choice(_acks)
+        except Exception as _exc:
+            logger.warning("user_issue_report: Multica capture failed: %s", _exc)
         try:
             from evolution_notice import record_user_issue  # type: ignore[import]
             await record_user_issue(
-                message=intent.slots.get("message", ""),
+                message=message,
                 user_id=user_id,
             )
         except Exception as _exc:

--- a/services/zoe-data/multica_client.py
+++ b/services/zoe-data/multica_client.py
@@ -269,12 +269,16 @@ class MULClient:
         from multica_ticket_contract import write_ticket_block
 
         issue = await self.get_issue(issue_id)
+        if not issue.get("id"):
+            return {}
         original = issue.get("description") or ""
         return await self.update_issue(issue_id, description=write_ticket_block(original, metadata))
 
     async def append_issue_note(self, issue_id: str, note: str) -> dict:
         """Append a visible progress note while preserving existing description."""
         issue = await self.get_issue(issue_id)
+        if not issue.get("id"):
+            return {}
         original = (issue.get("description") or "").rstrip()
         updated = f"{original}\n\nZoe note: {note.strip()}" if original else f"Zoe note: {note.strip()}"
         return await self.update_issue(issue_id, description=updated)
@@ -331,6 +335,8 @@ class MULClient:
         from multica_ticket_contract import update_ticket_progress
 
         issue = await self.get_issue(issue_id)
+        if not issue.get("id"):
+            return {}
         updated_description = update_ticket_progress(
             issue.get("description") or "",
             phase=phase,

--- a/services/zoe-data/multica_client.py
+++ b/services/zoe-data/multica_client.py
@@ -316,6 +316,7 @@ class MULClient:
             status=str(template.get("status") or "backlog"),
             assignee_id=template.get("assignee_id") or parent.get("assignee_id"),
             assignee_type=template.get("assignee_type") or parent.get("assignee_type") or "agent",
+            project_id=template.get("project_id") or parent.get("project_id"),
         )
         child_id = str(child.get("id") or "")
         for label in template.get("labels") or []:

--- a/services/zoe-data/multica_client.py
+++ b/services/zoe-data/multica_client.py
@@ -332,6 +332,7 @@ class MULClient:
         evidence: str | None = None,
         pr_url: str | None = None,
         blocker: str | None = None,
+        clear_blocker: bool = False,
         greptile_status: str | None = None,
         merge_sha: str | None = None,
         status: str | None = None,
@@ -348,6 +349,7 @@ class MULClient:
             evidence=evidence,
             pr_url=pr_url,
             blocker=blocker,
+            clear_blocker=clear_blocker,
             greptile_status=greptile_status,
             merge_sha=merge_sha,
         )

--- a/services/zoe-data/multica_client.py
+++ b/services/zoe-data/multica_client.py
@@ -310,7 +310,7 @@ class MULClient:
             assignee_type=template.get("assignee_type") or parent.get("assignee_type") or "agent",
         )
         child_id = str(child.get("id") or "")
-        for label in template.get("labels") or ["needs-split"]:
+        for label in template.get("labels") or []:
             if child_id:
                 await self.attach_label(child_id, str(label))
         return child

--- a/services/zoe-data/multica_client.py
+++ b/services/zoe-data/multica_client.py
@@ -24,6 +24,7 @@ _TIMEOUT = 10.0
 _DEFAULT_HERMES_MULTICA_AGENT_ID = "019ae0a7-62f1-47fe-9d46-75fd0ae5d570"
 _SELF_IMPROVEMENT_MULTICA_AGENT_ID = "ee8596da-3a08-4e10-98e8-d058e57ea3ff"
 _cached_engineering_agent_id: str | None = None
+_DEFAULT_LABEL_COLOR = "#64748b"
 
 
 def get_engineering_multica_agent_id() -> str:
@@ -88,17 +89,28 @@ class MULClient:
         priority: str = "medium",
         assignee_id: str | None = None,
         assignee_type: str | None = None,
+        status: str | None = None,
+        project_id: str | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> dict:
         """Create a Multica board issue. Returns the created issue dict."""
         if not self.is_configured():
             logger.debug("Multica not configured — skipping create_issue")
             return {}
+        if metadata:
+            from multica_ticket_contract import write_ticket_block
+
+            description = write_ticket_block(description, metadata)
         url = f"{self._base}/api/issues"
         payload: dict[str, Any] = {
             "title": title,
             "description": description,
             "priority": priority,
         }
+        if status:
+            payload["status"] = status
+        if project_id:
+            payload["project_id"] = project_id
         if assignee_id:
             payload["assignee_id"] = assignee_id
             payload["assignee_type"] = assignee_type or "agent"
@@ -162,6 +174,175 @@ class MULClient:
         except Exception as exc:
             logger.warning("Multica update_issue(%s) failed: %s", issue_id, exc)
             return {}
+
+    async def list_labels(self) -> list[dict]:
+        """List workspace labels."""
+        if not self.is_configured():
+            return []
+        try:
+            async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+                resp = await client.get(f"{self._base}/api/labels", headers=self._headers())
+                resp.raise_for_status()
+                data = resp.json()
+                return data if isinstance(data, list) else data.get("labels", [])
+        except Exception as exc:
+            logger.warning("Multica list_labels failed: %s", exc)
+            return []
+
+    async def ensure_label(self, name: str) -> dict:
+        """Return a label by name, creating it when possible."""
+        wanted = name.strip()
+        if not wanted or not self.is_configured():
+            return {}
+        for label in await self.list_labels():
+            if str(label.get("name") or "").lower() == wanted.lower():
+                return label
+        try:
+            async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+                resp = await client.post(
+                    f"{self._base}/api/labels",
+                    json={"name": wanted, "color": _DEFAULT_LABEL_COLOR},
+                    headers=self._headers(),
+                )
+                resp.raise_for_status()
+                return resp.json()
+        except Exception as exc:
+            logger.warning("Multica ensure_label(%s) failed: %s", wanted, exc)
+            return {}
+
+    async def attach_label(self, issue_id: str, label_name: str) -> dict:
+        """Attach a label to an issue by name."""
+        label = await self.ensure_label(label_name)
+        label_id = label.get("id") if isinstance(label, dict) else None
+        if not label_id or not self.is_configured():
+            return {}
+        try:
+            async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+                resp = await client.post(
+                    f"{self._base}/api/issues/{issue_id}/labels",
+                    json={"label_id": label_id},
+                    headers=self._headers(),
+                )
+                resp.raise_for_status()
+                return resp.json() if resp.content else {"ok": True}
+        except Exception as exc:
+            logger.warning("Multica attach_label(%s, %s) failed: %s", issue_id, label_name, exc)
+            return {}
+
+    async def list_projects(self) -> list[dict]:
+        """List workspace projects."""
+        if not self.is_configured():
+            return []
+        try:
+            async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+                resp = await client.get(f"{self._base}/api/projects", headers=self._headers())
+                resp.raise_for_status()
+                data = resp.json()
+                return data if isinstance(data, list) else data.get("projects", [])
+        except Exception as exc:
+            logger.warning("Multica list_projects failed: %s", exc)
+            return []
+
+    async def ensure_project(self, title: str) -> dict:
+        """Return a project by title, creating it when possible."""
+        wanted = title.strip()
+        if not wanted or not self.is_configured():
+            return {}
+        for project in await self.list_projects():
+            if str(project.get("title") or project.get("name") or "").lower() == wanted.lower():
+                return project
+        try:
+            async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+                resp = await client.post(
+                    f"{self._base}/api/projects",
+                    json={"title": wanted},
+                    headers=self._headers(),
+                )
+                resp.raise_for_status()
+                return resp.json()
+        except Exception as exc:
+            logger.warning("Multica ensure_project(%s) failed: %s", wanted, exc)
+            return {}
+
+    async def safe_patch_description(self, issue_id: str, metadata: dict[str, Any]) -> dict:
+        """Patch only the fenced Zoe ticket block in an issue description."""
+        from multica_ticket_contract import write_ticket_block
+
+        issue = await self.get_issue(issue_id)
+        original = issue.get("description") or ""
+        return await self.update_issue(issue_id, description=write_ticket_block(original, metadata))
+
+    async def append_issue_note(self, issue_id: str, note: str) -> dict:
+        """Append a visible progress note while preserving existing description."""
+        issue = await self.get_issue(issue_id)
+        original = (issue.get("description") or "").rstrip()
+        updated = f"{original}\n\nZoe note: {note.strip()}" if original else f"Zoe note: {note.strip()}"
+        return await self.update_issue(issue_id, description=updated)
+
+    async def create_child_issue(self, parent: dict, template: dict[str, Any]) -> dict:
+        """Create a child issue linked to a parent via the Zoe ticket block."""
+        from multica_ticket_contract import append_child_id, describe_ticket, parse_ticket_block
+
+        parent_id = str(parent.get("id") or "")
+        parent_meta = parse_ticket_block(parent.get("description") or "")
+        title = str(template.get("title") or f"{parent.get('identifier') or parent_id}: child task")[:140]
+        human_description = str(template.get("description") or "")
+        child_description = describe_ticket(
+            human_description,
+            zoe_kind="child",
+            evidence_profile=str(template.get("evidence_profile") or parent_meta.get("evidence_profile") or "code"),
+            engineering_mode=str(template.get("engineering_mode") or parent_meta.get("engineering_mode") or "interactive"),
+            acceptance_criteria=list(template.get("acceptance_criteria") or []),
+            evidence_expectations=list(template.get("evidence_expectations") or []),
+            source="scope_split",
+            parent_issue_id=parent_id,
+        )
+        child = await self.create_issue(
+            title=title,
+            description=child_description,
+            priority=str(template.get("priority") or parent.get("priority") or "medium"),
+            status=str(template.get("status") or "backlog"),
+            assignee_id=template.get("assignee_id") or parent.get("assignee_id"),
+            assignee_type=template.get("assignee_type") or parent.get("assignee_type") or "agent",
+        )
+        child_id = str(child.get("id") or "")
+        if child_id and parent_id:
+            await self.update_issue(
+                parent_id,
+                description=append_child_id(parent.get("description") or "", child_id),
+                status="blocked",
+            )
+        for label in template.get("labels") or ["needs-split"]:
+            if child_id:
+                await self.attach_label(child_id, str(label))
+        return child
+
+    async def record_progress(
+        self,
+        issue_id: str,
+        *,
+        phase: str | None = None,
+        evidence: str | None = None,
+        pr_url: str | None = None,
+        blocker: str | None = None,
+        greptile_status: str | None = None,
+        merge_sha: str | None = None,
+        status: str | None = None,
+    ) -> dict:
+        """Record operator-visible Zoe progress on a Multica issue."""
+        from multica_ticket_contract import update_ticket_progress
+
+        issue = await self.get_issue(issue_id)
+        updated_description = update_ticket_progress(
+            issue.get("description") or "",
+            phase=phase,
+            evidence=evidence,
+            pr_url=pr_url,
+            blocker=blocker,
+            greptile_status=greptile_status,
+            merge_sha=merge_sha,
+        )
+        return await self.update_issue(issue_id, status=status, description=updated_description)
 
 
 # Module-level singleton
@@ -256,6 +437,20 @@ async def sync_evolution_proposal_to_multica(
     full_desc = description
     if evidence:
         full_desc = f"{description}\n\n**Evidence:** {evidence}"
+    try:
+        from multica_ticket_contract import describe_ticket
+
+        full_desc = describe_ticket(
+            full_desc,
+            zoe_kind="harness_fix" if proposal_type in {"bug", "fix", "harness"} else "feature",
+            evidence_profile="code",
+            engineering_mode="unattended",
+            acceptance_criteria=["Proposal is triaged into a narrow, reviewable change before dispatch."],
+            evidence_expectations=["Journal evidence", "Tests or validators", "Greptile 5/5 before merge"],
+            source=f"evolution_proposal:{proposal_id}",
+        )
+    except Exception:
+        pass
 
     payload: dict[str, Any] = {
         "title": title,
@@ -303,7 +498,7 @@ async def sync_evolution_proposal_to_multica(
                         try:
                             create_resp = await http.post(
                                 f"{client._base}/api/labels",
-                                json={"name": label_name},
+                                json={"name": label_name, "color": _DEFAULT_LABEL_COLOR},
                                 headers=headers,
                                 params=params,
                             )

--- a/services/zoe-data/multica_client.py
+++ b/services/zoe-data/multica_client.py
@@ -189,12 +189,16 @@ class MULClient:
             logger.warning("Multica list_labels failed: %s", exc)
             return []
 
-    async def ensure_label(self, name: str) -> dict:
-        """Return a label by name, creating it when possible."""
+    async def ensure_label(self, name: str, *, existing: list[dict] | None = None) -> dict:
+        """Return a label by name, creating it when possible.
+
+        Pass ``existing`` from a prior ``list_labels`` call when ensuring many
+        labels in a loop.
+        """
         wanted = name.strip()
         if not wanted or not self.is_configured():
             return {}
-        for label in await self.list_labels():
+        for label in (existing if existing is not None else await self.list_labels()):
             if str(label.get("name") or "").lower() == wanted.lower():
                 return label
         try:

--- a/services/zoe-data/multica_client.py
+++ b/services/zoe-data/multica_client.py
@@ -280,8 +280,12 @@ class MULClient:
         return await self.update_issue(issue_id, description=updated)
 
     async def create_child_issue(self, parent: dict, template: dict[str, Any]) -> dict:
-        """Create a child issue linked to a parent via the Zoe ticket block."""
-        from multica_ticket_contract import append_child_id, describe_ticket, parse_ticket_block
+        """Create a child issue linked to a parent via the Zoe ticket block.
+
+        Parent ``child_issue_ids`` updates are caller-owned so multi-child split
+        commands can write one consistent final parent state.
+        """
+        from multica_ticket_contract import describe_ticket, parse_ticket_block
 
         parent_id = str(parent.get("id") or "")
         parent_meta = parse_ticket_block(parent.get("description") or "")
@@ -306,12 +310,6 @@ class MULClient:
             assignee_type=template.get("assignee_type") or parent.get("assignee_type") or "agent",
         )
         child_id = str(child.get("id") or "")
-        if child_id and parent_id:
-            await self.update_issue(
-                parent_id,
-                description=append_child_id(parent.get("description") or "", child_id),
-                status="blocked",
-            )
         for label in template.get("labels") or ["needs-split"]:
             if child_id:
                 await self.attach_label(child_id, str(label))

--- a/services/zoe-data/multica_ticket_contract.py
+++ b/services/zoe-data/multica_ticket_contract.py
@@ -111,6 +111,7 @@ def update_ticket_progress(
     evidence: str | None = None,
     pr_url: str | None = None,
     blocker: str | None = None,
+    clear_blocker: bool = False,
     greptile_status: str | None = None,
     merge_sha: str | None = None,
     child_issue_ids: list[str] | None = None,
@@ -124,7 +125,9 @@ def update_ticket_progress(
         metadata["last_evidence"] = evidence
     if pr_url is not None:
         metadata["pr_url"] = pr_url
-    if blocker is not None:
+    if clear_blocker:
+        metadata["blocked_reason"] = None
+    elif blocker is not None:
         metadata["blocked_reason"] = blocker
     if greptile_status is not None:
         metadata["greptile_status"] = greptile_status

--- a/services/zoe-data/multica_ticket_contract.py
+++ b/services/zoe-data/multica_ticket_contract.py
@@ -68,9 +68,10 @@ def write_ticket_block(description: str | None, metadata: dict[str, Any]) -> str
     match = _BLOCK_RE.search(text)
     if match:
         start, end = match.span()
-        prefix = text[:start]
+        prefix = text[:start].rstrip()
         suffix = text[end:]
-        return f"{prefix.rstrip()}\n\n{block}{suffix}"
+        separator = "\n\n" if prefix else ""
+        return f"{prefix}{separator}{block}{suffix}"
     if not text:
         return block
     return f"{text}\n\n{block}"

--- a/services/zoe-data/multica_ticket_contract.py
+++ b/services/zoe-data/multica_ticket_contract.py
@@ -70,6 +70,7 @@ def write_ticket_block(description: str | None, metadata: dict[str, Any]) -> str
         start, end = match.span()
         prefix = text[:start].rstrip()
         suffix = text[end:]
+        suffix = ("\n" + suffix) if suffix and not suffix.startswith("\n") else suffix
         separator = "\n\n" if prefix else ""
         return f"{prefix}{separator}{block}{suffix}"
     if not text:

--- a/services/zoe-data/multica_ticket_contract.py
+++ b/services/zoe-data/multica_ticket_contract.py
@@ -1,0 +1,146 @@
+"""Structured Zoe ticket metadata embedded in Multica issue descriptions."""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import datetime, timezone
+from typing import Any
+
+FENCE_LANG = "zoe-ticket"
+SCHEMA_VERSION = 1
+
+_BLOCK_RE = re.compile(
+    r"(?P<prefix>^|\n)```zoe-ticket\s*\n(?P<body>.*?)\n```(?P<suffix>\n|$)",
+    re.DOTALL,
+)
+
+
+DEFAULT_TICKET: dict[str, Any] = {
+    "schema": SCHEMA_VERSION,
+    "zoe_kind": "operator_task",
+    "evidence_profile": "code",
+    "engineering_mode": "interactive",
+    "acceptance_criteria": [],
+    "evidence_expectations": [],
+    "parent_issue_id": None,
+    "child_issue_ids": [],
+    "blocked_reason": None,
+    "pr_url": None,
+    "merge_sha": None,
+    "greptile_status": None,
+    "phase": None,
+    "last_evidence": None,
+}
+
+
+def parse_ticket_block(description: str | None) -> dict[str, Any]:
+    """Return parsed Zoe metadata from a Multica description, if present."""
+    text = description or ""
+    match = _BLOCK_RE.search(text)
+    if not match:
+        return {}
+    try:
+        parsed = json.loads(match.group("body"))
+    except json.JSONDecodeError:
+        return {"schema": SCHEMA_VERSION, "parse_error": "invalid_json"}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def normalize_ticket_metadata(metadata: dict[str, Any] | None = None, **overrides: Any) -> dict[str, Any]:
+    """Merge caller metadata into the stable Zoe ticket schema."""
+    ticket = dict(DEFAULT_TICKET)
+    for key, value in (metadata or {}).items():
+        if value is not None:
+            ticket[key] = value
+    for key, value in overrides.items():
+        if value is not None:
+            ticket[key] = value
+    ticket["schema"] = SCHEMA_VERSION
+    ticket.setdefault("updated_at", datetime.now(timezone.utc).isoformat())
+    return ticket
+
+
+def write_ticket_block(description: str | None, metadata: dict[str, Any]) -> str:
+    """Replace only the fenced Zoe metadata block, preserving human prose."""
+    text = (description or "").rstrip()
+    block = "```zoe-ticket\n" + json.dumps(metadata, sort_keys=True, indent=2) + "\n```"
+    match = _BLOCK_RE.search(text)
+    if match:
+        start, end = match.span()
+        prefix = text[:start]
+        suffix = text[end:]
+        return f"{prefix.rstrip()}\n\n{block}{suffix}"
+    if not text:
+        return block
+    return f"{text}\n\n{block}"
+
+
+def describe_ticket(
+    human_description: str,
+    *,
+    zoe_kind: str = "operator_task",
+    evidence_profile: str = "code",
+    engineering_mode: str = "interactive",
+    acceptance_criteria: list[str] | None = None,
+    evidence_expectations: list[str] | None = None,
+    source: str | None = None,
+    parent_issue_id: str | None = None,
+) -> str:
+    """Build a Multica description with preserved prose plus Zoe metadata."""
+    metadata = normalize_ticket_metadata(
+        {
+            "zoe_kind": zoe_kind,
+            "evidence_profile": evidence_profile,
+            "engineering_mode": engineering_mode,
+            "acceptance_criteria": acceptance_criteria or [],
+            "evidence_expectations": evidence_expectations or [],
+            "source": source,
+            "parent_issue_id": parent_issue_id,
+        }
+    )
+    return write_ticket_block(human_description, metadata)
+
+
+def update_ticket_progress(
+    description: str | None,
+    *,
+    phase: str | None = None,
+    evidence: str | None = None,
+    pr_url: str | None = None,
+    blocker: str | None = None,
+    greptile_status: str | None = None,
+    merge_sha: str | None = None,
+    child_issue_ids: list[str] | None = None,
+) -> str:
+    """Patch progress fields inside the Zoe block without touching prose."""
+    current = parse_ticket_block(description)
+    metadata = normalize_ticket_metadata(current)
+    if phase is not None:
+        metadata["phase"] = phase
+    if evidence is not None:
+        metadata["last_evidence"] = evidence
+    if pr_url is not None:
+        metadata["pr_url"] = pr_url
+    if blocker is not None:
+        metadata["blocked_reason"] = blocker
+    if greptile_status is not None:
+        metadata["greptile_status"] = greptile_status
+    if merge_sha is not None:
+        metadata["merge_sha"] = merge_sha
+    if child_issue_ids is not None:
+        metadata["child_issue_ids"] = child_issue_ids
+    metadata["updated_at"] = datetime.now(timezone.utc).isoformat()
+    return write_ticket_block(description, metadata)
+
+
+def append_child_id(description: str | None, child_id: str) -> str:
+    """Add a child issue ID to the Zoe metadata block exactly once."""
+    current = parse_ticket_block(description)
+    metadata = normalize_ticket_metadata(current)
+    children = [str(item) for item in metadata.get("child_issue_ids") or []]
+    if child_id not in children:
+        children.append(child_id)
+    metadata["child_issue_ids"] = children
+    metadata["updated_at"] = datetime.now(timezone.utc).isoformat()
+    return write_ticket_block(description, metadata)

--- a/services/zoe-data/pipeline_evidence.py
+++ b/services/zoe-data/pipeline_evidence.py
@@ -215,6 +215,12 @@ def issue_evidence_profile(issue: dict | None) -> EvidenceProfile:
     """Resolve per-issue evidence requirements from Multica metadata or description tags."""
     issue = issue or {}
     meta = issue.get("metadata") or {}
+    try:
+        from multica_ticket_contract import parse_ticket_block
+
+        meta = {**parse_ticket_block(issue.get("description") or ""), **meta}
+    except Exception:
+        pass
     explicit = str(meta.get("evidence_profile") or issue.get("evidence_profile") or "").strip().lower()
     if explicit in _EVIDENCE_PROFILES:
         return explicit  # type: ignore[return-value]

--- a/services/zoe-data/pipeline_evidence_commands.py
+++ b/services/zoe-data/pipeline_evidence_commands.py
@@ -116,7 +116,10 @@ async def _cmd_split_ticket(args: argparse.Namespace) -> dict[str, Any]:
     parent = await client.get_issue(args.parent_issue_id)
     if not parent:
         raise SystemExit(f"Parent issue not found: {args.parent_issue_id}")
-    packet = json.loads(_read_text(args.packet, file_path=args.packet_file) or "{}")
+    raw_packet = _read_text(args.packet, file_path=args.packet_file)
+    if not raw_packet:
+        raise SystemExit("split-ticket requires --packet, --packet-file, or piped JSON on stdin")
+    packet = json.loads(raw_packet)
     templates = packet.get("children") or [packet.get("child_issue_template") or {}]
     children = []
     for template in templates:

--- a/services/zoe-data/pipeline_evidence_commands.py
+++ b/services/zoe-data/pipeline_evidence_commands.py
@@ -200,7 +200,7 @@ def main(argv: list[str] | None = None) -> int:
     if asyncio.iscoroutine(result):
         result = asyncio.run(result)
     print(json.dumps(result, sort_keys=True))
-    return 0
+    return 0 if result.get("ok", True) else 1
 
 
 if __name__ == "__main__":

--- a/services/zoe-data/pipeline_evidence_commands.py
+++ b/services/zoe-data/pipeline_evidence_commands.py
@@ -1,0 +1,199 @@
+"""Command helpers for marker-backed Zoe engineering evidence."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from pipeline_evidence import EvidenceItem, content_hash, transition, with_evidence
+from pipeline_store import load_latest_state, save_state
+
+
+def _read_text(value: str | None, *, file_path: str | None) -> str:
+    if file_path:
+        return Path(file_path).read_text(encoding="utf-8", errors="replace")
+    if value:
+        return value
+    if not sys.stdin.isatty():
+        try:
+            return sys.stdin.read()
+        except OSError:
+            return ""
+    return ""
+
+
+def _load_state(task_ref: str):
+    state = load_latest_state(task_ref)
+    if not state:
+        raise SystemExit(f"No pipeline state found for {task_ref}")
+    return state
+
+
+def record_evidence(
+    task_ref: str,
+    *,
+    kind: str,
+    summary: str,
+    passed: bool,
+    command: str | None = None,
+    artifact: str | None = None,
+    body: str = "",
+    metadata: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Append a command-written evidence item to a pipeline state."""
+    state = _load_state(task_ref)
+    item = EvidenceItem(
+        kind=kind,  # type: ignore[arg-type]
+        summary=summary,
+        command=command,
+        artifact=artifact,
+        content_hash=content_hash(body or summary),
+        passed=passed,
+        metadata={"source": "command", "phase": state.phase, **(metadata or {})},
+    )
+    state = with_evidence(state, item)
+    saved = save_state(state, event=f"evidence_{kind}", extra={"summary": summary, "passed": passed})
+    return {"ok": True, "task_ref": task_ref, "phase": saved.phase, "status": saved.status, "evidence": item.model_dump()}
+
+
+def _cmd_mark_tested(args: argparse.Namespace) -> dict[str, Any]:
+    output = _read_text(args.output, file_path=args.output_file)
+    passed = args.passed and not args.failed
+    summary = args.summary or ("tests passed" if passed else "tests failed")
+    return record_evidence(
+        args.task_ref,
+        kind="test",
+        summary=summary,
+        passed=passed,
+        command=args.command,
+        artifact=args.artifact,
+        body=output or summary,
+    )
+
+
+def _cmd_mark_reviewed(args: argparse.Namespace) -> dict[str, Any]:
+    critical = int(args.critical_count or 0)
+    passed = critical == 0 and not args.failed
+    summary = args.summary or ("review passed" if passed else f"review blocked: {critical} critical")
+    return record_evidence(
+        args.task_ref,
+        kind="human",
+        summary=summary,
+        passed=passed,
+        artifact=args.artifact,
+        body=summary,
+        metadata={"critical_count": critical},
+    )
+
+
+def _cmd_mark_greptile(args: argparse.Namespace) -> dict[str, Any]:
+    output = _read_text(args.output, file_path=args.output_file)
+    score = str(args.score or "").strip()
+    passed = score == "5/5" and not args.failed
+    summary = args.summary or f"Greptile {score or 'review'} {'passed' if passed else 'not ready'}"
+    return record_evidence(
+        args.task_ref,
+        kind="greptile",
+        summary=summary,
+        passed=passed,
+        artifact=args.artifact,
+        body=output or summary,
+        metadata={"score": score},
+    )
+
+
+async def _cmd_split_ticket(args: argparse.Namespace) -> dict[str, Any]:
+    from multica_client import get_multica_client
+    from multica_ticket_contract import update_ticket_progress
+
+    client = get_multica_client()
+    if not client.is_configured():
+        raise SystemExit("Multica is not configured")
+    parent = await client.get_issue(args.parent_issue_id)
+    if not parent:
+        raise SystemExit(f"Parent issue not found: {args.parent_issue_id}")
+    packet = json.loads(_read_text(args.packet, file_path=args.packet_file) or "{}")
+    templates = packet.get("children") or [packet.get("child_issue_template") or {}]
+    children = []
+    for template in templates:
+        if not isinstance(template, dict):
+            continue
+        child = await client.create_child_issue(parent, template)
+        if child.get("id"):
+            children.append(child)
+    state = load_latest_state(args.task_ref) if args.task_ref else None
+    if state:
+        state = state.model_copy(update={"block_classification": "scope_split_required", "split_packet": packet})
+        state = transition(state, "block", reason=args.reason or "scope_split_required")
+        save_state(state, event="split_ticket", extra={"parent_issue_id": args.parent_issue_id, "children": children})
+    child_ids = [str(child.get("id")) for child in children if child.get("id")]
+    await client.update_issue(
+        args.parent_issue_id,
+        status="blocked",
+        description=update_ticket_progress(
+            parent.get("description") or "",
+            blocker=args.reason or packet.get("reason") or "scope split required",
+            child_issue_ids=child_ids,
+        ),
+    )
+    return {"ok": True, "parent_issue_id": args.parent_issue_id, "child_issue_ids": child_ids}
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Write Zoe engineering evidence markers.")
+    sub = parser.add_subparsers(dest="command_name", required=True)
+
+    tested = sub.add_parser("mark-tested")
+    tested.add_argument("task_ref")
+    tested.add_argument("--summary")
+    tested.add_argument("--command")
+    tested.add_argument("--artifact")
+    tested.add_argument("--output")
+    tested.add_argument("--output-file")
+    tested.add_argument("--passed", action="store_true", default=True)
+    tested.add_argument("--failed", action="store_true")
+    tested.set_defaults(func=_cmd_mark_tested)
+
+    reviewed = sub.add_parser("mark-reviewed")
+    reviewed.add_argument("task_ref")
+    reviewed.add_argument("--summary")
+    reviewed.add_argument("--critical-count", type=int, default=0)
+    reviewed.add_argument("--artifact")
+    reviewed.add_argument("--failed", action="store_true")
+    reviewed.set_defaults(func=_cmd_mark_reviewed)
+
+    greptile = sub.add_parser("mark-greptile")
+    greptile.add_argument("task_ref")
+    greptile.add_argument("--score")
+    greptile.add_argument("--summary")
+    greptile.add_argument("--artifact")
+    greptile.add_argument("--output")
+    greptile.add_argument("--output-file")
+    greptile.add_argument("--failed", action="store_true")
+    greptile.set_defaults(func=_cmd_mark_greptile)
+
+    split = sub.add_parser("split-ticket")
+    split.add_argument("parent_issue_id")
+    split.add_argument("--task-ref")
+    split.add_argument("--packet")
+    split.add_argument("--packet-file")
+    split.add_argument("--reason")
+    split.set_defaults(func=_cmd_split_ticket)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    result = args.func(args)
+    if asyncio.iscoroutine(result):
+        result = asyncio.run(result)
+    print(json.dumps(result, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/zoe-data/pipeline_evidence_commands.py
+++ b/services/zoe-data/pipeline_evidence_commands.py
@@ -131,6 +131,13 @@ async def _cmd_split_ticket(args: argparse.Namespace) -> dict[str, Any]:
         state = transition(state, "block", reason=args.reason or "scope_split_required")
         save_state(state, event="split_ticket", extra={"parent_issue_id": args.parent_issue_id, "children": children})
     child_ids = [str(child.get("id")) for child in children if child.get("id")]
+    if not child_ids:
+        return {
+            "ok": False,
+            "parent_issue_id": args.parent_issue_id,
+            "child_issue_ids": [],
+            "reason": "no child issues created",
+        }
     await client.update_issue(
         args.parent_issue_id,
         status="blocked",

--- a/services/zoe-data/pipeline_evidence_commands.py
+++ b/services/zoe-data/pipeline_evidence_commands.py
@@ -62,7 +62,7 @@ def record_evidence(
 
 def _cmd_mark_tested(args: argparse.Namespace) -> dict[str, Any]:
     output = _read_text(args.output, file_path=args.output_file)
-    passed = args.passed and not args.failed
+    passed = bool(args.passed)
     summary = args.summary or ("tests passed" if passed else "tests failed")
     return record_evidence(
         args.task_ref,
@@ -154,8 +154,9 @@ def build_parser() -> argparse.ArgumentParser:
     tested.add_argument("--artifact")
     tested.add_argument("--output")
     tested.add_argument("--output-file")
-    tested.add_argument("--passed", action="store_true", default=True)
-    tested.add_argument("--failed", action="store_true")
+    tested_result = tested.add_mutually_exclusive_group(required=True)
+    tested_result.add_argument("--passed", action="store_true")
+    tested_result.add_argument("--failed", action="store_true")
     tested.set_defaults(func=_cmd_mark_tested)
 
     reviewed = sub.add_parser("mark-reviewed")

--- a/services/zoe-data/pipeline_evidence_commands.py
+++ b/services/zoe-data/pipeline_evidence_commands.py
@@ -125,7 +125,12 @@ async def _cmd_split_ticket(args: argparse.Namespace) -> dict[str, Any]:
     packet = json.loads(raw_packet)
     if not isinstance(packet, dict):
         raise SystemExit(f"split-ticket packet must be a JSON object, got {type(packet).__name__}")
-    templates = packet.get("children") or [packet.get("child_issue_template") or {}]
+    children_raw = packet.get("children")
+    if children_raw is None:
+        children_raw = [packet.get("child_issue_template") or {}]
+    templates = [template for template in children_raw if isinstance(template, dict) and template]
+    if not templates:
+        raise SystemExit("split-ticket packet must contain at least one child template")
     children = []
     for template in templates:
         if not isinstance(template, dict):

--- a/services/zoe-data/pipeline_evidence_commands.py
+++ b/services/zoe-data/pipeline_evidence_commands.py
@@ -131,6 +131,14 @@ async def _cmd_split_ticket(args: argparse.Namespace) -> dict[str, Any]:
     templates = [template for template in children_raw if isinstance(template, dict) and template]
     if not templates:
         raise SystemExit("split-ticket packet must contain at least one child template")
+    state = load_latest_state(args.task_ref) if args.task_ref else None
+    if args.task_ref and state is None:
+        return {
+            "ok": False,
+            "parent_issue_id": args.parent_issue_id,
+            "child_issue_ids": [],
+            "reason": f"pipeline state not found for task ref: {args.task_ref}",
+        }
     children = []
     for template in templates:
         if not isinstance(template, dict):
@@ -162,7 +170,6 @@ async def _cmd_split_ticket(args: argparse.Namespace) -> dict[str, Any]:
             "child_issue_ids": child_ids,
             "reason": "parent update failed; children created but parent not linked",
         }
-    state = load_latest_state(args.task_ref) if args.task_ref else None
     if state:
         state = state.model_copy(update={"block_classification": "scope_split_required", "split_packet": packet})
         state = transition(state, "block", reason=args.reason or "scope_split_required")

--- a/services/zoe-data/pipeline_evidence_commands.py
+++ b/services/zoe-data/pipeline_evidence_commands.py
@@ -125,11 +125,6 @@ async def _cmd_split_ticket(args: argparse.Namespace) -> dict[str, Any]:
         child = await client.create_child_issue(parent, template)
         if child.get("id"):
             children.append(child)
-    state = load_latest_state(args.task_ref) if args.task_ref else None
-    if state:
-        state = state.model_copy(update={"block_classification": "scope_split_required", "split_packet": packet})
-        state = transition(state, "block", reason=args.reason or "scope_split_required")
-        save_state(state, event="split_ticket", extra={"parent_issue_id": args.parent_issue_id, "children": children})
     child_ids = [str(child.get("id")) for child in children if child.get("id")]
     if not child_ids:
         return {
@@ -138,6 +133,11 @@ async def _cmd_split_ticket(args: argparse.Namespace) -> dict[str, Any]:
             "child_issue_ids": [],
             "reason": "no child issues created",
         }
+    state = load_latest_state(args.task_ref) if args.task_ref else None
+    if state:
+        state = state.model_copy(update={"block_classification": "scope_split_required", "split_packet": packet})
+        state = transition(state, "block", reason=args.reason or "scope_split_required")
+        save_state(state, event="split_ticket", extra={"parent_issue_id": args.parent_issue_id, "children": children})
     await client.update_issue(
         args.parent_issue_id,
         status="blocked",

--- a/services/zoe-data/pipeline_evidence_commands.py
+++ b/services/zoe-data/pipeline_evidence_commands.py
@@ -15,7 +15,10 @@ from pipeline_store import load_latest_state, save_state
 
 def _read_text(value: str | None, *, file_path: str | None) -> str:
     if file_path:
-        return Path(file_path).read_text(encoding="utf-8", errors="replace")
+        try:
+            return Path(file_path).read_text(encoding="utf-8", errors="replace")
+        except OSError as exc:
+            raise SystemExit(f"Cannot read file {file_path!r}: {exc}") from exc
     if value:
         return value
     if not sys.stdin.isatty():
@@ -114,7 +117,7 @@ async def _cmd_split_ticket(args: argparse.Namespace) -> dict[str, Any]:
     if not client.is_configured():
         raise SystemExit("Multica is not configured")
     parent = await client.get_issue(args.parent_issue_id)
-    if not parent:
+    if not parent.get("id"):
         raise SystemExit(f"Parent issue not found: {args.parent_issue_id}")
     raw_packet = _read_text(args.packet, file_path=args.packet_file)
     if not raw_packet:

--- a/services/zoe-data/pipeline_evidence_commands.py
+++ b/services/zoe-data/pipeline_evidence_commands.py
@@ -138,12 +138,7 @@ async def _cmd_split_ticket(args: argparse.Namespace) -> dict[str, Any]:
             "child_issue_ids": [],
             "reason": "no child issues created",
         }
-    state = load_latest_state(args.task_ref) if args.task_ref else None
-    if state:
-        state = state.model_copy(update={"block_classification": "scope_split_required", "split_packet": packet})
-        state = transition(state, "block", reason=args.reason or "scope_split_required")
-        save_state(state, event="split_ticket", extra={"parent_issue_id": args.parent_issue_id, "children": children})
-    await client.update_issue(
+    update_result = await client.update_issue(
         args.parent_issue_id,
         status="blocked",
         description=update_ticket_progress(
@@ -152,6 +147,18 @@ async def _cmd_split_ticket(args: argparse.Namespace) -> dict[str, Any]:
             child_issue_ids=child_ids,
         ),
     )
+    if not update_result.get("id"):
+        return {
+            "ok": False,
+            "parent_issue_id": args.parent_issue_id,
+            "child_issue_ids": child_ids,
+            "reason": "parent update failed; children created but parent not linked",
+        }
+    state = load_latest_state(args.task_ref) if args.task_ref else None
+    if state:
+        state = state.model_copy(update={"block_classification": "scope_split_required", "split_packet": packet})
+        state = transition(state, "block", reason=args.reason or "scope_split_required")
+        save_state(state, event="split_ticket", extra={"parent_issue_id": args.parent_issue_id, "children": children})
     return {"ok": True, "parent_issue_id": args.parent_issue_id, "child_issue_ids": child_ids}
 
 

--- a/services/zoe-data/pipeline_evidence_commands.py
+++ b/services/zoe-data/pipeline_evidence_commands.py
@@ -120,6 +120,8 @@ async def _cmd_split_ticket(args: argparse.Namespace) -> dict[str, Any]:
     if not raw_packet:
         raise SystemExit("split-ticket requires --packet, --packet-file, or piped JSON on stdin")
     packet = json.loads(raw_packet)
+    if not isinstance(packet, dict):
+        raise SystemExit(f"split-ticket packet must be a JSON object, got {type(packet).__name__}")
     templates = packet.get("children") or [packet.get("child_issue_template") or {}]
     children = []
     for template in templates:

--- a/services/zoe-data/routers/system.py
+++ b/services/zoe-data/routers/system.py
@@ -1386,7 +1386,7 @@ async def get_agent_board(user: dict = Depends(get_current_user)):  # noqa: ARG0
                 continue
             for issue in issues_or_exc or []:
                 enriched = dict(issue)
-                if status in {"in_progress", "in_review"} and str(issue.get("assignee_id") or "") == hermes_id:
+                if status in {"in_progress", "blocked", "in_review"} and str(issue.get("assignee_id") or "") == hermes_id:
                     hermes_issues.append(enriched)
                 groups[status].append(enriched)
                 if status in {"in_progress", "in_review"}:

--- a/services/zoe-data/tests/test_agent_board.py
+++ b/services/zoe-data/tests/test_agent_board.py
@@ -47,6 +47,7 @@ async def test_agent_board_keeps_active_and_chain_enrichment_bounded(monkeypatch
 
     assert [issue["id"] for issue in board["active"]] == ["progress-1", "review-1"]
     assert sorted(board["groups"]) == ["backlog", "blocked", "in_progress", "in_review", "todo"]
-    assert polled_refs == ["multica:progress-1", "multica:review-1"]
+    assert polled_refs == ["multica:progress-1", "multica:blocked-1", "multica:review-1"]
     assert board["groups"]["backlog"][0].get("chain") is None
     assert board["groups"]["in_progress"][0]["phase"] == "implement"
+    assert board["groups"]["blocked"][0]["phase"] == "implement"

--- a/services/zoe-data/tests/test_multica_client_helpers.py
+++ b/services/zoe-data/tests/test_multica_client_helpers.py
@@ -1,6 +1,7 @@
 import pytest
 
 from multica_client import MULClient
+from multica_ticket_contract import describe_ticket, parse_ticket_block, update_ticket_progress
 
 
 class GuardedClient(MULClient):
@@ -27,3 +28,21 @@ async def test_append_issue_note_skips_when_get_issue_fails():
 @pytest.mark.asyncio
 async def test_record_progress_skips_when_get_issue_fails():
     assert await GuardedClient().record_progress("missing", phase="verify") == {}
+
+
+@pytest.mark.asyncio
+async def test_record_progress_can_clear_blocker():
+    class Client(MULClient):
+        async def get_issue(self, issue_id):
+            return {
+                "id": issue_id,
+                "description": update_ticket_progress(describe_ticket("Blocked issue"), blocker="old blocker"),
+            }
+
+        async def update_issue(self, issue_id, **kwargs):
+            return {"id": issue_id, **kwargs}
+
+    updated = await Client().record_progress("issue-1", phase="closeout", status="done", clear_blocker=True)
+    metadata = parse_ticket_block(updated["description"])
+    assert metadata["blocked_reason"] is None
+    assert metadata["phase"] == "closeout"

--- a/services/zoe-data/tests/test_multica_client_helpers.py
+++ b/services/zoe-data/tests/test_multica_client_helpers.py
@@ -1,0 +1,29 @@
+import pytest
+
+from multica_client import MULClient
+
+
+class GuardedClient(MULClient):
+    def is_configured(self):
+        return True
+
+    async def get_issue(self, issue_id):
+        return {}
+
+    async def update_issue(self, *args, **kwargs):
+        raise AssertionError("description write must not run when get_issue fails")
+
+
+@pytest.mark.asyncio
+async def test_safe_patch_description_skips_when_get_issue_fails():
+    assert await GuardedClient().safe_patch_description("missing", {"schema": 1}) == {}
+
+
+@pytest.mark.asyncio
+async def test_append_issue_note_skips_when_get_issue_fails():
+    assert await GuardedClient().append_issue_note("missing", "note") == {}
+
+
+@pytest.mark.asyncio
+async def test_record_progress_skips_when_get_issue_fails():
+    assert await GuardedClient().record_progress("missing", phase="verify") == {}

--- a/services/zoe-data/tests/test_multica_ticket_contract.py
+++ b/services/zoe-data/tests/test_multica_ticket_contract.py
@@ -1,0 +1,36 @@
+from multica_ticket_contract import (
+    append_child_id,
+    describe_ticket,
+    parse_ticket_block,
+    update_ticket_progress,
+    write_ticket_block,
+)
+
+
+def test_ticket_block_preserves_human_description():
+    description = "Human prose stays here."
+    updated = write_ticket_block(description, {"schema": 1, "zoe_kind": "bug"})
+
+    assert updated.startswith(description)
+    assert parse_ticket_block(updated)["zoe_kind"] == "bug"
+
+
+def test_ticket_block_replaces_only_zoe_section():
+    first = describe_ticket("Fix reminders", zoe_kind="bug", acceptance_criteria=["works"])
+    second = write_ticket_block(first, {"schema": 1, "zoe_kind": "child", "parent_issue_id": "p1"})
+
+    assert second.count("```zoe-ticket") == 1
+    assert second.startswith("Fix reminders")
+    assert parse_ticket_block(second)["parent_issue_id"] == "p1"
+
+
+def test_progress_and_children_patch_metadata_only():
+    description = describe_ticket("Implement widget", zoe_kind="feature")
+    progressed = update_ticket_progress(description, phase="verify", pr_url="https://github/pr/1")
+    linked = append_child_id(progressed, "child-1")
+    linked = append_child_id(linked, "child-1")
+
+    meta = parse_ticket_block(linked)
+    assert meta["phase"] == "verify"
+    assert meta["pr_url"] == "https://github/pr/1"
+    assert meta["child_issue_ids"] == ["child-1"]

--- a/services/zoe-data/tests/test_multica_ticket_contract.py
+++ b/services/zoe-data/tests/test_multica_ticket_contract.py
@@ -42,3 +42,10 @@ def test_block_only_description_does_not_gain_leading_blank_lines():
 
     assert updated.startswith("```zoe-ticket")
     assert not updated.startswith("\n")
+
+
+def test_replacing_middle_block_preserves_suffix_newline():
+    description = "Intro\n\n```zoe-ticket\n{\"schema\": 1}\n```\nTrailing prose"
+    updated = write_ticket_block(description, {"schema": 1, "zoe_kind": "bug"})
+
+    assert "```\nTrailing prose" in updated

--- a/services/zoe-data/tests/test_multica_ticket_contract.py
+++ b/services/zoe-data/tests/test_multica_ticket_contract.py
@@ -34,3 +34,11 @@ def test_progress_and_children_patch_metadata_only():
     assert meta["phase"] == "verify"
     assert meta["pr_url"] == "https://github/pr/1"
     assert meta["child_issue_ids"] == ["child-1"]
+
+
+def test_block_only_description_does_not_gain_leading_blank_lines():
+    description = describe_ticket("", zoe_kind="bug")
+    updated = write_ticket_block(description, {"schema": 1, "zoe_kind": "child"})
+
+    assert updated.startswith("```zoe-ticket")
+    assert not updated.startswith("\n")

--- a/services/zoe-data/tests/test_pipeline_evidence_commands.py
+++ b/services/zoe-data/tests/test_pipeline_evidence_commands.py
@@ -160,6 +160,42 @@ def test_split_ticket_does_not_save_pipeline_block_when_parent_update_fails(tmp_
     assert state.status == "todo"
 
 
+def test_split_ticket_rejects_missing_task_ref_before_multica_mutation(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("ZOE_PIPELINE_STORE_PATH", str(tmp_path / "runs.jsonl"))
+
+    class FakeClient:
+        def is_configured(self):
+            return True
+
+        async def get_issue(self, issue_id):
+            return {"id": issue_id, "description": "parent"}
+
+        async def create_child_issue(self, parent, template):
+            raise AssertionError("missing task-ref must stop before child creation")
+
+        async def update_issue(self, *args, **kwargs):
+            raise AssertionError("missing task-ref must stop before parent update")
+
+    monkeypatch.setitem(
+        sys.modules,
+        "multica_client",
+        types.SimpleNamespace(get_multica_client=lambda: FakeClient()),
+    )
+
+    assert main([
+        "split-ticket",
+        "parent-1",
+        "--task-ref",
+        "multica:missing",
+        "--packet",
+        '{"child_issue_template":{"title":"child"}}',
+    ]) == 1
+
+    out = json.loads(capsys.readouterr().out)
+    assert out["ok"] is False
+    assert out["reason"] == "pipeline state not found for task ref: multica:missing"
+
+
 def test_split_ticket_requires_packet(monkeypatch):
     class FakeClient:
         def is_configured(self):

--- a/services/zoe-data/tests/test_pipeline_evidence_commands.py
+++ b/services/zoe-data/tests/test_pipeline_evidence_commands.py
@@ -182,6 +182,28 @@ def test_split_ticket_requires_packet(monkeypatch):
         raise AssertionError("split-ticket without a packet should fail")
 
 
+def test_split_ticket_requires_parent_id(monkeypatch):
+    class FakeClient:
+        def is_configured(self):
+            return True
+
+        async def get_issue(self, issue_id):
+            return {"error": "not_found"}
+
+    monkeypatch.setitem(
+        sys.modules,
+        "multica_client",
+        types.SimpleNamespace(get_multica_client=lambda: FakeClient()),
+    )
+
+    try:
+        main(["split-ticket", "parent-1", "--packet", '{"child_issue_template":{"title":"child"}}'])
+    except SystemExit as exc:
+        assert "Parent issue not found" in str(exc)
+    else:
+        raise AssertionError("split-ticket should reject parent responses without an id")
+
+
 def test_split_ticket_requires_object_packet(monkeypatch):
     class FakeClient:
         def is_configured(self):
@@ -202,3 +224,25 @@ def test_split_ticket_requires_object_packet(monkeypatch):
         assert "must be a JSON object" in str(exc)
     else:
         raise AssertionError("split-ticket with a non-object packet should fail")
+
+
+def test_split_ticket_reports_unreadable_packet_file(monkeypatch):
+    class FakeClient:
+        def is_configured(self):
+            return True
+
+        async def get_issue(self, issue_id):
+            return {"id": issue_id, "description": "parent"}
+
+    monkeypatch.setitem(
+        sys.modules,
+        "multica_client",
+        types.SimpleNamespace(get_multica_client=lambda: FakeClient()),
+    )
+
+    try:
+        main(["split-ticket", "parent-1", "--packet-file", "/tmp/zoe-missing-split-packet.json"])
+    except SystemExit as exc:
+        assert "Cannot read file" in str(exc)
+    else:
+        raise AssertionError("split-ticket should report unreadable packet files cleanly")

--- a/services/zoe-data/tests/test_pipeline_evidence_commands.py
+++ b/services/zoe-data/tests/test_pipeline_evidence_commands.py
@@ -136,3 +136,25 @@ def test_split_ticket_requires_packet(monkeypatch):
         assert "requires --packet" in str(exc)
     else:
         raise AssertionError("split-ticket without a packet should fail")
+
+
+def test_split_ticket_requires_object_packet(monkeypatch):
+    class FakeClient:
+        def is_configured(self):
+            return True
+
+        async def get_issue(self, issue_id):
+            return {"id": issue_id, "description": "parent"}
+
+    monkeypatch.setitem(
+        sys.modules,
+        "multica_client",
+        types.SimpleNamespace(get_multica_client=lambda: FakeClient()),
+    )
+
+    try:
+        main(["split-ticket", "parent-1", "--packet", '[{"title":"child"}]'])
+    except SystemExit as exc:
+        assert "must be a JSON object" in str(exc)
+    else:
+        raise AssertionError("split-ticket with a non-object packet should fail")

--- a/services/zoe-data/tests/test_pipeline_evidence_commands.py
+++ b/services/zoe-data/tests/test_pipeline_evidence_commands.py
@@ -116,6 +116,50 @@ def test_split_ticket_does_not_save_pipeline_block_when_children_fail(tmp_path, 
     assert state.status == "todo"
 
 
+def test_split_ticket_does_not_save_pipeline_block_when_parent_update_fails(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("ZOE_PIPELINE_STORE_PATH", str(tmp_path / "runs.jsonl"))
+    import asyncio
+
+    asyncio.run(bootstrap_state("multica:parent-update-fail", start_phase="implement"))
+
+    class FakeClient:
+        def is_configured(self):
+            return True
+
+        async def get_issue(self, issue_id):
+            return {"id": issue_id, "description": "parent"}
+
+        async def create_child_issue(self, parent, template):
+            return {"id": "child-1", "description": "child"}
+
+        async def update_issue(self, *args, **kwargs):
+            return {}
+
+    monkeypatch.setitem(
+        sys.modules,
+        "multica_client",
+        types.SimpleNamespace(get_multica_client=lambda: FakeClient()),
+    )
+
+    assert main([
+        "split-ticket",
+        "parent-1",
+        "--task-ref",
+        "multica:parent-update-fail",
+        "--packet",
+        '{"child_issue_template":{"title":"child"}}',
+    ]) == 1
+
+    out = json.loads(capsys.readouterr().out)
+    assert out["ok"] is False
+    assert out["reason"] == "parent update failed; children created but parent not linked"
+    assert out["child_issue_ids"] == ["child-1"]
+
+    state = load_latest_state("multica:parent-update-fail")
+    assert state is not None
+    assert state.status == "todo"
+
+
 def test_split_ticket_requires_packet(monkeypatch):
     class FakeClient:
         def is_configured(self):

--- a/services/zoe-data/tests/test_pipeline_evidence_commands.py
+++ b/services/zoe-data/tests/test_pipeline_evidence_commands.py
@@ -114,3 +114,25 @@ def test_split_ticket_does_not_save_pipeline_block_when_children_fail(tmp_path, 
     state = load_latest_state("multica:split-fail")
     assert state is not None
     assert state.status == "todo"
+
+
+def test_split_ticket_requires_packet(monkeypatch):
+    class FakeClient:
+        def is_configured(self):
+            return True
+
+        async def get_issue(self, issue_id):
+            return {"id": issue_id, "description": "parent"}
+
+    monkeypatch.setitem(
+        sys.modules,
+        "multica_client",
+        types.SimpleNamespace(get_multica_client=lambda: FakeClient()),
+    )
+
+    try:
+        main(["split-ticket", "parent-1"])
+    except SystemExit as exc:
+        assert "requires --packet" in str(exc)
+    else:
+        raise AssertionError("split-ticket without a packet should fail")

--- a/services/zoe-data/tests/test_pipeline_evidence_commands.py
+++ b/services/zoe-data/tests/test_pipeline_evidence_commands.py
@@ -1,0 +1,47 @@
+import json
+
+from pipeline_evidence_commands import main
+from pipeline_store import bootstrap_state, load_latest_state
+
+
+def test_mark_tested_records_hashed_evidence(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("ZOE_PIPELINE_STORE_PATH", str(tmp_path / "runs.jsonl"))
+    import asyncio
+
+    asyncio.run(bootstrap_state("multica:test", start_phase="verify"))
+    assert main(["mark-tested", "multica:test", "--summary", "pytest passed", "--output", "ok"]) == 0
+
+    out = json.loads(capsys.readouterr().out)
+    state = load_latest_state("multica:test")
+    assert out["ok"] is True
+    assert state is not None
+    assert state.evidence[-1].kind == "test"
+    assert state.evidence[-1].content_hash
+
+
+def test_mark_reviewed_requires_zero_critical(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("ZOE_PIPELINE_STORE_PATH", str(tmp_path / "runs.jsonl"))
+    import asyncio
+
+    asyncio.run(bootstrap_state("multica:review", start_phase="review"))
+    main(["mark-reviewed", "multica:review", "--critical-count", "2"])
+
+    json.loads(capsys.readouterr().out)
+    state = load_latest_state("multica:review")
+    assert state is not None
+    assert state.evidence[-1].kind == "human"
+    assert state.evidence[-1].passed is False
+
+
+def test_mark_greptile_passes_only_on_five_of_five(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("ZOE_PIPELINE_STORE_PATH", str(tmp_path / "runs.jsonl"))
+    import asyncio
+
+    asyncio.run(bootstrap_state("multica:greptile", start_phase="closeout"))
+    main(["mark-greptile", "multica:greptile", "--score", "5/5"])
+
+    json.loads(capsys.readouterr().out)
+    state = load_latest_state("multica:greptile")
+    assert state is not None
+    assert state.evidence[-1].kind == "greptile"
+    assert state.evidence[-1].passed is True

--- a/services/zoe-data/tests/test_pipeline_evidence_commands.py
+++ b/services/zoe-data/tests/test_pipeline_evidence_commands.py
@@ -1,4 +1,6 @@
 import json
+import sys
+import types
 
 from pipeline_evidence_commands import main
 from pipeline_store import bootstrap_state, load_latest_state
@@ -45,3 +47,31 @@ def test_mark_greptile_passes_only_on_five_of_five(tmp_path, monkeypatch, capsys
     assert state is not None
     assert state.evidence[-1].kind == "greptile"
     assert state.evidence[-1].passed is True
+
+
+def test_split_ticket_does_not_block_parent_when_children_fail(monkeypatch, capsys):
+    class FakeClient:
+        def is_configured(self):
+            return True
+
+        async def get_issue(self, issue_id):
+            return {"id": issue_id, "description": "parent"}
+
+        async def create_child_issue(self, parent, template):
+            return {}
+
+        async def update_issue(self, *args, **kwargs):
+            raise AssertionError("parent must not be mutated when no child was created")
+
+    monkeypatch.setitem(
+        sys.modules,
+        "multica_client",
+        types.SimpleNamespace(get_multica_client=lambda: FakeClient()),
+    )
+
+    main(["split-ticket", "parent-1", "--packet", '{"child_issue_template":{"title":"child"}}'])
+
+    out = json.loads(capsys.readouterr().out)
+    assert out["ok"] is False
+    assert out["reason"] == "no child issues created"
+    assert out["child_issue_ids"] == []

--- a/services/zoe-data/tests/test_pipeline_evidence_commands.py
+++ b/services/zoe-data/tests/test_pipeline_evidence_commands.py
@@ -69,7 +69,7 @@ def test_split_ticket_does_not_block_parent_when_children_fail(monkeypatch, caps
         types.SimpleNamespace(get_multica_client=lambda: FakeClient()),
     )
 
-    main(["split-ticket", "parent-1", "--packet", '{"child_issue_template":{"title":"child"}}'])
+    assert main(["split-ticket", "parent-1", "--packet", '{"child_issue_template":{"title":"child"}}']) == 1
 
     out = json.loads(capsys.readouterr().out)
     assert out["ok"] is False

--- a/services/zoe-data/tests/test_pipeline_evidence_commands.py
+++ b/services/zoe-data/tests/test_pipeline_evidence_commands.py
@@ -226,6 +226,56 @@ def test_split_ticket_requires_object_packet(monkeypatch):
         raise AssertionError("split-ticket with a non-object packet should fail")
 
 
+def test_split_ticket_requires_at_least_one_child_template(monkeypatch):
+    class FakeClient:
+        def is_configured(self):
+            return True
+
+        async def get_issue(self, issue_id):
+            return {"id": issue_id, "description": "parent"}
+
+        async def create_child_issue(self, parent, template):
+            raise AssertionError("empty children list must not create a fallback child")
+
+    monkeypatch.setitem(
+        sys.modules,
+        "multica_client",
+        types.SimpleNamespace(get_multica_client=lambda: FakeClient()),
+    )
+
+    try:
+        main(["split-ticket", "parent-1", "--packet", '{"children":[]}'])
+    except SystemExit as exc:
+        assert "at least one child template" in str(exc)
+    else:
+        raise AssertionError("split-ticket should reject empty children lists")
+
+
+def test_split_ticket_rejects_empty_child_template(monkeypatch):
+    class FakeClient:
+        def is_configured(self):
+            return True
+
+        async def get_issue(self, issue_id):
+            return {"id": issue_id, "description": "parent"}
+
+        async def create_child_issue(self, parent, template):
+            raise AssertionError("empty child template must not create a fallback child")
+
+    monkeypatch.setitem(
+        sys.modules,
+        "multica_client",
+        types.SimpleNamespace(get_multica_client=lambda: FakeClient()),
+    )
+
+    try:
+        main(["split-ticket", "parent-1", "--packet", '{"child_issue_template":{}}'])
+    except SystemExit as exc:
+        assert "at least one child template" in str(exc)
+    else:
+        raise AssertionError("split-ticket should reject empty child templates")
+
+
 def test_split_ticket_reports_unreadable_packet_file(monkeypatch):
     class FakeClient:
         def is_configured(self):

--- a/services/zoe-data/tests/test_pipeline_evidence_commands.py
+++ b/services/zoe-data/tests/test_pipeline_evidence_commands.py
@@ -9,7 +9,7 @@ def test_mark_tested_records_hashed_evidence(tmp_path, monkeypatch, capsys):
     import asyncio
 
     asyncio.run(bootstrap_state("multica:test", start_phase="verify"))
-    assert main(["mark-tested", "multica:test", "--summary", "pytest passed", "--output", "ok"]) == 0
+    assert main(["mark-tested", "multica:test", "--passed", "--summary", "pytest passed", "--output", "ok"]) == 0
 
     out = json.loads(capsys.readouterr().out)
     state = load_latest_state("multica:test")

--- a/services/zoe-data/tests/test_pipeline_evidence_commands.py
+++ b/services/zoe-data/tests/test_pipeline_evidence_commands.py
@@ -75,3 +75,42 @@ def test_split_ticket_does_not_block_parent_when_children_fail(monkeypatch, caps
     assert out["ok"] is False
     assert out["reason"] == "no child issues created"
     assert out["child_issue_ids"] == []
+
+
+def test_split_ticket_does_not_save_pipeline_block_when_children_fail(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("ZOE_PIPELINE_STORE_PATH", str(tmp_path / "runs.jsonl"))
+    import asyncio
+
+    asyncio.run(bootstrap_state("multica:split-fail", start_phase="implement"))
+
+    class FakeClient:
+        def is_configured(self):
+            return True
+
+        async def get_issue(self, issue_id):
+            return {"id": issue_id, "description": "parent"}
+
+        async def create_child_issue(self, parent, template):
+            return {}
+
+        async def update_issue(self, *args, **kwargs):
+            raise AssertionError("parent must not be mutated when no child was created")
+
+    monkeypatch.setitem(
+        sys.modules,
+        "multica_client",
+        types.SimpleNamespace(get_multica_client=lambda: FakeClient()),
+    )
+
+    assert main([
+        "split-ticket",
+        "parent-1",
+        "--task-ref",
+        "multica:split-fail",
+        "--packet",
+        '{"child_issue_template":{"title":"child"}}',
+    ]) == 1
+    json.loads(capsys.readouterr().out)
+    state = load_latest_state("multica:split-fail")
+    assert state is not None
+    assert state.status == "todo"


### PR DESCRIPTION
## Summary
- add a fenced zoe-ticket contract for Multica issue metadata while preserving human descriptions
- extend the Multica client with safe metadata patching, labels/projects, progress records, and child issue creation
- route natural issue capture and engineering task creation into structured Multica tickets
- add marker-backed evidence commands and bounded PR maintenance wrapper
- add a Multica health report for runtime/API/webhook/canonical label validation

## Validation
- PYTHONPATH=services/zoe-data python3 -m pytest services/zoe-data/tests/test_multica_ticket_contract.py services/zoe-data/tests/test_pipeline_evidence_commands.py services/zoe-data/tests/test_agent_board.py services/zoe-data/tests/test_pipeline_evidence.py services/zoe-data/tests/test_pipeline_store.py services/zoe-data/tests/test_kanban_adapter.py services/zoe-data/tests/test_multica_poll_dispatch.py services/zoe-data/tests/test_multica_webhook_emitter.py services/zoe-data/tests/test_multica_autopilot_noise.py -q
- live multica_health_report.py --ensure-shape returned ok=true
- live natural issue capture created backlog ticket a6ba3db5-6501-4503-960f-5c207601d1f0 with zoe-ticket metadata
- live split command created child c50431d4-a6ce-418e-b01d-beee47a3efcd from parent 6f7bd63e-e37c-4268-95fd-d06edca4faf9
- live evidence commands wrote hashed test/review/greptile journal evidence