### PR TITLE
Fix PR maintenance Greploop guard invocation

### DIFF
--- a/scripts/maintenance/zoe_pr_maintenance.py
+++ b/scripts/maintenance/zoe_pr_maintenance.py
@@ -24,6 +24,8 @@ def _run_guard(pr: int, *, merge_when_ready: bool) -> dict:
     async def _run() -> dict:
         if merge_when_ready:
             return await _merge_pr_when_ready(pr)
+        # Maintenance status checks should surface the next bounded repair packet
+        # without launching a cheap-model repair agent from this wrapper.
         return await run_guard_once(pr, packet_only=True)
 
     try:

--- a/scripts/maintenance/zoe_pr_maintenance.py
+++ b/scripts/maintenance/zoe_pr_maintenance.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import argparse
 import asyncio
 import json
-import subprocess
 import sys
 from pathlib import Path
 
@@ -19,17 +18,19 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "services" / "zoe-d
 
 
 def _run_guard(pr: int, *, merge_when_ready: bool) -> dict:
-    guard = Path(__file__).resolve().parents[2] / "services" / "zoe-data" / "greploop_guard.py"
-    cmd = [sys.executable, str(guard), "--pr", str(pr)]
-    if merge_when_ready:
-        cmd.append("--merge-when-ready")
-    proc = subprocess.run(cmd, text=True, capture_output=True, check=False)
-    output = (proc.stdout or proc.stderr or "").strip()
+    from greploop_guard import merge_pr_when_ready as _merge_pr_when_ready
+    from greploop_guard import run_guard_once
+
+    async def _run() -> dict:
+        if merge_when_ready:
+            return await _merge_pr_when_ready(pr)
+        return await run_guard_once(pr, packet_only=True)
+
     try:
-        parsed = json.loads(output)
-    except json.JSONDecodeError:
-        parsed = {"ok": False, "state": "ERROR", "output": output}
-    parsed.setdefault("exit_code", proc.returncode)
+        parsed = asyncio.run(_run())
+    except Exception as exc:  # noqa: BLE001 - maintenance must report guard failures as JSON.
+        parsed = {"ok": False, "state": "ERROR", "output": str(exc)}
+    parsed.setdefault("exit_code", 0 if parsed.get("ok") else 1)
     return parsed
 
 

--- a/services/zoe-data/tests/test_zoe_pr_maintenance.py
+++ b/services/zoe-data/tests/test_zoe_pr_maintenance.py
@@ -1,0 +1,48 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+def _load_module():
+    path = Path(__file__).resolve().parents[3] / "scripts" / "maintenance" / "zoe_pr_maintenance.py"
+    spec = importlib.util.spec_from_file_location("zoe_pr_maintenance_test", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_run_guard_calls_packet_guard(monkeypatch):
+    async def run_guard_once(pr, *, packet_only):
+        return {"ok": True, "state": "READY_TO_MERGE", "pr": pr, "packet_only": packet_only}
+
+    async def merge_pr_when_ready(pr):
+        raise AssertionError("merge path should not run")
+
+    monkeypatch.setitem(
+        sys.modules,
+        "greploop_guard",
+        types.SimpleNamespace(run_guard_once=run_guard_once, merge_pr_when_ready=merge_pr_when_ready),
+    )
+
+    result = _load_module()._run_guard(141, merge_when_ready=False)
+    assert result == {"ok": True, "state": "READY_TO_MERGE", "pr": 141, "packet_only": True, "exit_code": 0}
+
+
+def test_run_guard_calls_merge_guard(monkeypatch):
+    async def run_guard_once(pr, *, packet_only):
+        raise AssertionError("packet path should not run")
+
+    async def merge_pr_when_ready(pr):
+        return {"ok": True, "state": "MERGED", "pr": pr}
+
+    monkeypatch.setitem(
+        sys.modules,
+        "greploop_guard",
+        types.SimpleNamespace(run_guard_once=run_guard_once, merge_pr_when_ready=merge_pr_when_ready),
+    )
+
+    result = _load_module()._run_guard(141, merge_when_ready=True)
+    assert result == {"ok": True, "state": "MERGED", "pr": 141, "exit_code": 0}
+


### PR DESCRIPTION
## Summary
- call greploop_guard as a Python API instead of running the non-CLI module as a subprocess
- add tests for packet-only and merge-when-ready guard paths

## Tests
- PYTHONPATH=services/zoe-data python3 -m pytest services/zoe-data/tests/test_zoe_pr_maintenance.py services/zoe-data/tests/test_multica_ticket_contract.py services/zoe-data/tests/test_multica_client_helpers.py services/zoe-data/tests/test_pipeline_evidence_commands.py services/zoe-data/tests/test_agent_board.py services/zoe-data/tests/test_pipeline_evidence.py services/zoe-data/tests/test_pipeline_store.py services/zoe-data/tests/test_kanban_adapter.py services/zoe-data/tests/test_multica_poll_dispatch.py services/zoe-data/tests/test_multica_webhook_emitter.py services/zoe-data/tests/test_multica_autopilot_noise.py -q