### PR TITLE
Preserve Multica ticket metadata during dispatch

### DIFF
--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -332,10 +332,14 @@ class KanbanAdapter:
             return common + (
                 "You are scout (zoe-planner, read-only). Gather context before any code changes.\n"
                 "- Start with `kanban_show` and read the Multica issue acceptance criteria.\n"
-                "- Use Graphify (query/path/explain) and existing docs before raw repo scanning.\n"
+                "- Keep this phase bounded: run at most one focused Graphify/doc lookup and no broad repo crawl.\n"
+                "- For smoke, audit-only, or harness-check tickets, do not over-investigate; summarize the"
+                " observed contract and complete the scout handoff.\n"
                 "- Use opensrc for third-party APIs; reference Multica comments/state as source of truth.\n"
                 "- Do NOT edit code, open PRs, or mutate production config.\n"
                 "- Hand off with `kanban_complete` metadata including TOOLS_USED= and SCOUT_SUMMARY=.\n"
+                "- If you cannot finish context gathering within 8 tool/model steps, call `kanban_block`"
+                " with BLOCKER=SCOUT_BUDGET and the missing information instead of timing out.\n"
                 "- TERMINAL PROTOCOL: end with `kanban_complete` or `kanban_block` (no silent exit)."
             )
         if phase == "implement":

--- a/services/zoe-data/multica_client.py
+++ b/services/zoe-data/multica_client.py
@@ -98,9 +98,9 @@ class MULClient:
             logger.debug("Multica not configured — skipping create_issue")
             return {}
         if metadata:
-            from multica_ticket_contract import write_ticket_block
+            from multica_ticket_contract import normalize_ticket_metadata, parse_ticket_block, write_ticket_block
 
-            description = write_ticket_block(description, metadata)
+            description = write_ticket_block(description, normalize_ticket_metadata(parse_ticket_block(description), **metadata))
         url = f"{self._base}/api/issues"
         payload: dict[str, Any] = {
             "title": title,

--- a/services/zoe-data/multica_client.py
+++ b/services/zoe-data/multica_client.py
@@ -100,7 +100,10 @@ class MULClient:
         if metadata:
             from multica_ticket_contract import normalize_ticket_metadata, parse_ticket_block, write_ticket_block
 
-            description = write_ticket_block(description, normalize_ticket_metadata(parse_ticket_block(description), **metadata))
+            ticket_metadata = parse_ticket_block(description)
+            ticket_metadata.update(metadata)
+            ticket_metadata.pop("updated_at", None)
+            description = write_ticket_block(description, normalize_ticket_metadata(ticket_metadata))
         url = f"{self._base}/api/issues"
         payload: dict[str, Any] = {
             "title": title,

--- a/services/zoe-data/tests/test_multica_client_helpers.py
+++ b/services/zoe-data/tests/test_multica_client_helpers.py
@@ -46,3 +46,57 @@ async def test_record_progress_can_clear_blocker():
     metadata = parse_ticket_block(updated["description"])
     assert metadata["blocked_reason"] is None
     assert metadata["phase"] == "closeout"
+
+
+@pytest.mark.asyncio
+async def test_create_issue_metadata_preserves_existing_ticket_fields():
+    created_payload = {}
+
+    class Response:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"id": "issue-1", **created_payload}
+
+    class HTTP:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return None
+
+        async def post(self, url, json, headers):
+            created_payload.update(json)
+            return Response()
+
+    class Client(MULClient):
+        def is_configured(self):
+            return True
+
+        def _headers(self):
+            return {}
+
+    import multica_client
+
+    original = multica_client.httpx.AsyncClient
+    multica_client.httpx.AsyncClient = lambda timeout: HTTP()
+    try:
+        description = describe_ticket(
+            "Keep my fields",
+            acceptance_criteria=["dispatch once"],
+            evidence_expectations=["chain exists"],
+            source="initial",
+        )
+        client = Client()
+        client._base = "http://multica"
+        client._token = "token"
+        client._workspace = "workspace"
+        await client.create_issue("ticket", description=description, metadata={"source": "override"})
+    finally:
+        multica_client.httpx.AsyncClient = original
+
+    metadata = parse_ticket_block(created_payload["description"])
+    assert metadata["acceptance_criteria"] == ["dispatch once"]
+    assert metadata["evidence_expectations"] == ["chain exists"]
+    assert metadata["source"] == "override"

--- a/services/zoe-data/tests/test_multica_client_helpers.py
+++ b/services/zoe-data/tests/test_multica_client_helpers.py
@@ -88,6 +88,8 @@ async def test_create_issue_metadata_preserves_existing_ticket_fields():
             evidence_expectations=["chain exists"],
             source="initial",
         )
+        description = update_ticket_progress(description, evidence="old evidence")
+        old_updated_at = parse_ticket_block(description)["updated_at"]
         client = Client()
         client._base = "http://multica"
         client._token = "token"
@@ -100,3 +102,5 @@ async def test_create_issue_metadata_preserves_existing_ticket_fields():
     assert metadata["acceptance_criteria"] == ["dispatch once"]
     assert metadata["evidence_expectations"] == ["chain exists"]
     assert metadata["source"] == "override"
+    assert metadata["last_evidence"] == "old evidence"
+    assert metadata["updated_at"] != old_updated_at


### PR DESCRIPTION
## Summary
- preserve existing zoe-ticket fields when create_issue receives additional metadata
- bound the scout phase instructions so smoke/audit tickets complete or block explicitly instead of timing out
- add regression coverage for metadata preservation

## Tests
- PYTHONPATH=services/zoe-data python3 -m pytest services/zoe-data/tests/test_zoe_pr_maintenance.py services/zoe-data/tests/test_multica_ticket_contract.py services/zoe-data/tests/test_multica_client_helpers.py services/zoe-data/tests/test_pipeline_evidence_commands.py services/zoe-data/tests/test_agent_board.py services/zoe-data/tests/test_pipeline_evidence.py services/zoe-data/tests/test_pipeline_store.py services/zoe-data/tests/test_kanban_adapter.py services/zoe-data/tests/test_multica_poll_dispatch.py services/zoe-data/tests/test_multica_webhook_emitter.py services/zoe-data/tests/test_multica_autopilot_noise.py -q