### PR TITLE
Base Kanban task worktrees on origin/main

### DIFF
--- a/services/zoe-data/tests/test_worktree_bootstrap.py
+++ b/services/zoe-data/tests/test_worktree_bootstrap.py
@@ -39,11 +39,47 @@ def test_ensure_worktree_creates_branch_and_path(git_repo, monkeypatch):
     assert branch == "wt/t_test123"
 
 
-def test_ensure_worktree_is_idempotent(git_repo):
+def test_ensure_worktree_uses_origin_main_when_local_main_is_stale(git_repo, tmp_path):
+    remote = tmp_path / "origin.git"
+    subprocess.run(["git", "init", "--bare", str(remote)], check=True, capture_output=True)
+    subprocess.run(["git", "remote", "add", "origin", str(remote)], cwd=git_repo, check=True)
+    subprocess.run(["git", "push", "-u", "origin", "main"], cwd=git_repo, check=True, capture_output=True)
+
+    (git_repo / "REMOTE_ONLY.md").write_text("remote tip\n", encoding="utf-8")
+    subprocess.run(["git", "add", "REMOTE_ONLY.md"], cwd=git_repo, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "remote tip"], cwd=git_repo, check=True, capture_output=True)
+    subprocess.run(["git", "push", "origin", "main"], cwd=git_repo, check=True, capture_output=True)
+    subprocess.run(["git", "reset", "--hard", "HEAD~1"], cwd=git_repo, check=True, capture_output=True)
+
+    wt = wb.ensure_worktree("t_remote")
+    assert (wt / "REMOTE_ONLY.md").read_text(encoding="utf-8") == "remote tip\n"
+
+
+def test_base_ref_warns_when_fetch_fails(git_repo, caplog):
+    caplog.set_level("WARNING")
+
+    ref = wb._base_ref(git_repo, "main")
+
+    assert ref == "main"
+    assert "fetch origin/main failed" in caplog.text
+
+
+def test_ensure_worktree_is_idempotent(git_repo, monkeypatch):
     first = wb.ensure_worktree("t_dup")
+
+    calls = []
+    original_run_git = wb._run_git
+
+    def spy_run_git(args, *, cwd, timeout):
+        calls.append(args)
+        return original_run_git(args, cwd=cwd, timeout=timeout)
+
+    monkeypatch.setattr(wb, "_run_git", spy_run_git)
+
     second = wb.ensure_worktree("t_dup")
     assert first == second
     assert first.exists()
+    assert not any(args[:3] == ["git", "fetch", "origin"] for args in calls)
 
 
 def test_ensure_worktree_rejects_invalid_task_id():

--- a/services/zoe-data/worktree_bootstrap.py
+++ b/services/zoe-data/worktree_bootstrap.py
@@ -133,6 +133,22 @@ def _worktree_registered(repo: Path, wt_path: Path) -> bool:
     return False
 
 
+def _base_ref(repo: Path, base_branch: str) -> str:
+    """Prefer the remote base branch so task worktrees do not start from stale local main."""
+    fetch_result = _run_git(["git", "fetch", "origin", base_branch], cwd=str(repo), timeout=120)
+    if fetch_result.returncode != 0:
+        logger.warning(
+            "worktree_bootstrap: fetch origin/%s failed (rc=%d); "
+            "falling back to local tracking ref or branch: %s",
+            base_branch,
+            fetch_result.returncode,
+            (fetch_result.stderr or "").strip(),
+        )
+    remote_ref = f"origin/{base_branch}"
+    check = _run_git(["git", "rev-parse", "--verify", remote_ref], cwd=str(repo), timeout=30)
+    return remote_ref if check.returncode == 0 else base_branch
+
+
 def ensure_worktree(task_id: str, *, base_branch: str = "main") -> Path:
     """Create ``~/.worktrees/<task_id>`` on ``wt/<task_id>`` if missing.
 
@@ -145,9 +161,10 @@ def ensure_worktree(task_id: str, *, base_branch: str = "main") -> Path:
     wt_path = worktree_path(task_id)
     branch = worktree_branch(task_id)
     repo = Path(zoe_repo_root())
-
     if _worktree_registered(repo, wt_path):
         return wt_path
+
+    base_ref = _base_ref(repo, base_branch)
 
     wt_path.parent.mkdir(parents=True, exist_ok=True)
 
@@ -158,7 +175,7 @@ def ensure_worktree(task_id: str, *, base_branch: str = "main") -> Path:
         str(wt_path),
         "-b",
         branch,
-        base_branch,
+        base_ref,
     ]
     result = _run_git(add_cmd, cwd=str(repo), timeout=120)
     if result.returncode == 0:


### PR DESCRIPTION
## Summary
- fetch and prefer origin/main when creating new Hermes task worktrees
- avoid basing task worktrees on a stale local main checked out in another worktree
- add regression coverage for stale local main vs newer origin/main

## Tests
- PYTHONPATH=services/zoe-data python3 -m pytest services/zoe-data/tests/test_zoe_pr_maintenance.py services/zoe-data/tests/test_worktree_bootstrap.py services/zoe-data/tests/test_multica_ticket_contract.py services/zoe-data/tests/test_multica_client_helpers.py services/zoe-data/tests/test_pipeline_evidence_commands.py services/zoe-data/tests/test_agent_board.py services/zoe-data/tests/test_pipeline_evidence.py services/zoe-data/tests/test_pipeline_store.py services/zoe-data/tests/test_kanban_adapter.py services/zoe-data/tests/test_multica_poll_dispatch.py services/zoe-data/tests/test_multica_webhook_emitter.py services/zoe-data/tests/test_multica_autopilot_noise.py -q