### PR TITLE
ZOE-5401: Document worktree origin-main guard

### DIFF
--- a/docs/guides/ENGINEERING_HARNESS_LOOP.md
+++ b/docs/guides/ENGINEERING_HARNESS_LOOP.md
@@ -38,7 +38,7 @@ Use `--skip-scout` with kanban modes to set `ZOE_KANBAN_SKIP_SCOUT=1` on dispatc
 Hermes task worktrees are created from `origin/main` by default to ensure fresh base branches. The worktree bootstrap process:
 
 1. Attempts `git fetch origin <base_branch>` (default `main`)
-2. If fetch fails, logs a warning: "fetch origin/<base_branch> failed; falling back to local tracking ref or branch"
+2. If fetch fails, logs a warning: `"worktree_bootstrap: fetch origin/<base_branch> failed (rc=<N>); falling back to local tracking ref or branch: <stderr>"`
 3. Creates worktree using the fetched remote reference when available
 
 This prevents task worktrees from starting from stale local main branches. The fetch fallback warning indicates a possible stale base branch, which could affect task execution.

--- a/docs/guides/ENGINEERING_HARNESS_LOOP.md
+++ b/docs/guides/ENGINEERING_HARNESS_LOOP.md
@@ -33,6 +33,16 @@ Use `--skip-scout` with kanban modes to set `ZOE_KANBAN_SKIP_SCOUT=1` on dispatc
 - `test_worktree_bootstrap.py`, `test_background_runner.py`
 - `test_multica_poll_dispatch.py`, `test_greploop_guard.py`
 
+## Worktree base provenance
+
+Hermes task worktrees are created from `origin/main` by default to ensure fresh base branches. The worktree bootstrap process:
+
+1. Attempts `git fetch origin <base_branch>` (default `main`)
+2. If fetch fails, logs a warning: "fetch origin/<base_branch> failed; falling back to local tracking ref or branch"
+3. Creates worktree using the fetched remote reference when available
+
+This prevents task worktrees from starting from stale local main branches. The fetch fallback warning indicates a possible stale base branch, which could affect task execution.
+
 ## Critical pipeline patterns (non-zero exit)
 
 Recorded in findings; **fail exit** when any of:


### PR DESCRIPTION
Adds documentation explaining that Hermes task worktrees are created from origin/main by default to ensure fresh base branches.

## Summary
- Documents the worktree bootstrap process that fetches origin/main
- Explains fetch fallback warnings indicate possible stale base branches
- References existing test coverage in test_worktree_bootstrap.py

## Acceptance Criteria
- [x] docs/guides/ENGINEERING_HARNESS_LOOP.md contains a concise worktree base note
- [x] the note mentions origin/main and fetch fallback warnings
- [x] a PR is opened for the documentation change

This is a documentation-only change that clarifies existing behavior without altering runtime functionality.