### PR TITLE
fix(pipeline): accept review metadata as human evidence

### DIFF
--- a/services/zoe-data/pipeline_handoff.py
+++ b/services/zoe-data/pipeline_handoff.py
@@ -174,6 +174,34 @@ def _tool_from_log_markers(detail: dict[str, Any]) -> EvidenceItem | None:
     return None
 
 
+def _human_review_from_metadata(detail: dict[str, Any]) -> EvidenceItem | None:
+    metadata = detail.get("metadata") or {}
+    if not isinstance(metadata, dict):
+        metadata = {}
+
+    readiness = str(metadata.get("merge_readiness") or "").strip().lower()
+    approver = str(
+        metadata.get("approver")
+        or metadata.get("approved_by")
+        or ""
+    ).strip()
+    summary = str(detail.get("latest_summary") or "").strip()
+
+    if readiness in {"merge_ready", "approved"} and approver:
+        return EvidenceItem(
+            kind="human",
+            summary=(summary or f"review approved by {approver}")[:500],
+            passed=True,
+            metadata={
+                "source": "kanban_metadata",
+                "approver": approver,
+                "merge_readiness": readiness,
+            },
+        )
+
+    return None
+
+
 def _greptile_from_closeout(detail: dict[str, Any], skills: tuple[str, ...] | list[str]) -> EvidenceItem | None:
     fields: dict[str, str] = {}
     for chunk in _haystacks(detail):
@@ -343,6 +371,10 @@ def evidence_from_handoff(
         review_note = fields.get("SUMMARY") or fields.get("REVIEW") or ""
         if review_note:
             items.append(EvidenceItem(kind="human", summary=review_note[:500], passed=True))
+        else:
+            review_item = _human_review_from_metadata(detail)
+            if review_item:
+                items.append(review_item)
 
     if phase == "closeout":
         greptile_item = _greptile_from_closeout(detail, skills)

--- a/services/zoe-data/tests/test_pipeline_handoff.py
+++ b/services/zoe-data/tests/test_pipeline_handoff.py
@@ -27,6 +27,84 @@ def test_evidence_from_verify_handoff_parses_validators():
     assert len(validator.content_hash) == 64
 
 
+def test_evidence_from_review_metadata_records_human_approval():
+    detail = {
+        "latest_summary": "APPROVE ZOE-5401. PR is merge-ready.",
+        "comments": [],
+        "metadata": {
+            "merge_readiness": "merge_ready",
+            "approver": "zoe-reviewer",
+        },
+    }
+
+    items = evidence_from_handoff("review", detail)
+
+    human = next(item for item in items if item.kind == "human")
+    assert human.passed is True
+    assert human.metadata["source"] == "kanban_metadata"
+    assert human.metadata["approver"] == "zoe-reviewer"
+
+
+def test_evidence_from_review_metadata_accepts_approved_readiness():
+    detail = {
+        "latest_summary": "Approved after review.",
+        "comments": [],
+        "metadata": {
+            "merge_readiness": "approved",
+            "approved_by": "zoe-reviewer",
+        },
+    }
+
+    items = evidence_from_handoff("review", detail)
+
+    human = next(item for item in items if item.kind == "human")
+    assert human.passed is True
+    assert human.metadata["approver"] == "zoe-reviewer"
+    assert human.metadata["merge_readiness"] == "approved"
+
+
+def test_evidence_from_review_ignores_summary_without_approver():
+    detail = {
+        "latest_summary": "APPROVE ZOE-5401. PR is merge-ready.",
+        "comments": [],
+        "metadata": {},
+    }
+
+    items = evidence_from_handoff("review", detail)
+
+    assert not any(item.kind == "human" for item in items)
+
+
+def test_evidence_from_review_ignores_generic_pass_readiness():
+    detail = {
+        "latest_summary": "Reviewer pass note",
+        "comments": [],
+        "metadata": {
+            "merge_readiness": "pass",
+            "approver": "zoe-reviewer",
+        },
+    }
+
+    items = evidence_from_handoff("review", detail)
+
+    assert not any(item.kind == "human" for item in items)
+
+
+def test_evidence_from_review_ignores_reviewer_assignment():
+    detail = {
+        "latest_summary": "Review assigned and PR looks ready.",
+        "comments": [],
+        "metadata": {
+            "merge_readiness": "merge_ready",
+            "reviewer": "zoe-reviewer",
+        },
+    }
+
+    items = evidence_from_handoff("review", detail)
+
+    assert not any(item.kind == "human" for item in items)
+
+
 def test_block_reason_from_handoff_prefers_blocker_field():
     from pipeline_handoff import block_reason_from_handoff
 


### PR DESCRIPTION
Fixes a live E2E blocker where a completed review task recorded merge readiness and approver metadata, but the pipeline parser still reported missing human evidence.\n\n## Summary\n- Parse review-phase Kanban metadata as human approval evidence when merge_readiness is merge_ready and an approver is present\n- Keep existing SUMMARY=/REVIEW= parsing intact\n- Add a regression test based on the live ZOE-5401 review task shape\n\n## Tests\n- PYTHONPATH=services/zoe-data python3 -m pytest services/zoe-data/tests/test_pipeline_handoff.py services/zoe-data/tests/test_pipeline_store.py -q\n- PYTHONPATH=services/zoe-data python3 -m pytest services/zoe-data/tests/test_zoe_pr_maintenance.py services/zoe-data/tests/test_worktree_bootstrap.py services/zoe-data/tests/test_multica_ticket_contract.py services/zoe-data/tests/test_multica_client_helpers.py services/zoe-data/tests/test_pipeline_evidence_commands.py services/zoe-data/tests/test_pipeline_handoff.py services/zoe-data/tests/test_agent_board.py services/zoe-data/tests/test_pipeline_evidence.py services/zoe-data/tests/test_pipeline_store.py services/zoe-data/tests/test_kanban_adapter.py services/zoe-data/tests/test_multica_poll_dispatch.py services/zoe-data/tests/test_multica_webhook_emitter.py services/zoe-data/tests/test_multica_autopilot_noise.py -q