### PR TITLE
fix(pipeline): read review evidence from run metadata

### DIFF
--- a/services/zoe-data/pipeline_handoff.py
+++ b/services/zoe-data/pipeline_handoff.py
@@ -174,30 +174,42 @@ def _tool_from_log_markers(detail: dict[str, Any]) -> EvidenceItem | None:
     return None
 
 
-def _human_review_from_metadata(detail: dict[str, Any]) -> EvidenceItem | None:
+def _review_metadata_candidates(detail: dict[str, Any]) -> list[tuple[str, dict[str, Any]]]:
+    candidates: list[tuple[str, dict[str, Any]]] = []
     metadata = detail.get("metadata") or {}
-    if not isinstance(metadata, dict):
-        metadata = {}
+    if isinstance(metadata, dict):
+        candidates.append(("kanban_metadata", metadata))
+    for run in detail.get("runs") or []:
+        if not isinstance(run, dict):
+            continue
+        run_metadata = run.get("metadata") or {}
+        if isinstance(run_metadata, dict):
+            candidates.append(("kanban_run_metadata", run_metadata))
+    return candidates
 
-    readiness = str(metadata.get("merge_readiness") or "").strip().lower()
-    approver = str(
-        metadata.get("approver")
-        or metadata.get("approved_by")
-        or ""
-    ).strip()
+
+def _human_review_from_metadata(detail: dict[str, Any]) -> EvidenceItem | None:
     summary = str(detail.get("latest_summary") or "").strip()
 
-    if readiness in {"merge_ready", "approved"} and approver:
-        return EvidenceItem(
-            kind="human",
-            summary=(summary or f"review approved by {approver}")[:500],
-            passed=True,
-            metadata={
-                "source": "kanban_metadata",
-                "approver": approver,
-                "merge_readiness": readiness,
-            },
-        )
+    for source, metadata in _review_metadata_candidates(detail):
+        readiness = str(metadata.get("merge_readiness") or "").strip().lower()
+        approver = str(
+            metadata.get("approver")
+            or metadata.get("approved_by")
+            or ""
+        ).strip()
+
+        if readiness in {"merge_ready", "approved"} and approver:
+            return EvidenceItem(
+                kind="human",
+                summary=(summary or f"review approved by {approver}")[:500],
+                passed=True,
+                metadata={
+                    "source": source,
+                    "approver": approver,
+                    "merge_readiness": readiness,
+                },
+            )
 
     return None
 

--- a/services/zoe-data/tests/test_pipeline_handoff.py
+++ b/services/zoe-data/tests/test_pipeline_handoff.py
@@ -45,6 +45,53 @@ def test_evidence_from_review_metadata_records_human_approval():
     assert human.metadata["approver"] == "zoe-reviewer"
 
 
+def test_evidence_from_review_run_metadata_records_human_approval():
+    detail = {
+        "latest_summary": "APPROVE ZOE-5401. PR is merge-ready.",
+        "comments": [],
+        "runs": [
+            {
+                "metadata": {
+                    "merge_readiness": "merge_ready",
+                    "approver": "zoe-reviewer",
+                }
+            }
+        ],
+    }
+
+    items = evidence_from_handoff("review", detail)
+
+    human = next(item for item in items if item.kind == "human")
+    assert human.passed is True
+    assert human.metadata["source"] == "kanban_run_metadata"
+    assert human.metadata["approver"] == "zoe-reviewer"
+
+
+def test_evidence_from_review_prefers_top_level_metadata_over_run_metadata():
+    detail = {
+        "latest_summary": "APPROVE ZOE-5401. PR is merge-ready.",
+        "comments": [],
+        "metadata": {
+            "merge_readiness": "merge_ready",
+            "approver": "top-level-reviewer",
+        },
+        "runs": [
+            {
+                "metadata": {
+                    "merge_readiness": "merge_ready",
+                    "approver": "run-reviewer",
+                }
+            }
+        ],
+    }
+
+    items = evidence_from_handoff("review", detail)
+
+    human = next(item for item in items if item.kind == "human")
+    assert human.metadata["source"] == "kanban_metadata"
+    assert human.metadata["approver"] == "top-level-reviewer"
+
+
 def test_evidence_from_review_metadata_accepts_approved_readiness():
     detail = {
         "latest_summary": "Approved after review.",


### PR DESCRIPTION
Fixes the live ZOE-5401 E2E closeout blocker where the review task stores merge readiness and approver fields inside runs[].metadata, while the evidence parser only checked top-level metadata.\n\n## Summary\n- Add review metadata candidates from top-level Kanban metadata and run metadata\n- Preserve the strict approver + readiness requirement from PR #147\n- Add a regression test matching the live review task shape\n\n## Tests\n- PYTHONPATH=services/zoe-data python3 -m pytest services/zoe-data/tests/test_pipeline_handoff.py services/zoe-data/tests/test_pipeline_store.py -q\n- PYTHONPATH=services/zoe-data python3 -m pytest services/zoe-data/tests/test_zoe_pr_maintenance.py services/zoe-data/tests/test_worktree_bootstrap.py services/zoe-data/tests/test_multica_ticket_contract.py services/zoe-data/tests/test_multica_client_helpers.py services/zoe-data/tests/test_pipeline_evidence_commands.py services/zoe-data/tests/test_pipeline_handoff.py services/zoe-data/tests/test_agent_board.py services/zoe-data/tests/test_pipeline_evidence.py services/zoe-data/tests/test_pipeline_store.py services/zoe-data/tests/test_kanban_adapter.py services/zoe-data/tests/test_multica_poll_dispatch.py services/zoe-data/tests/test_multica_webhook_emitter.py services/zoe-data/tests/test_multica_autopilot_noise.py -q