### PR TITLE
fix(multica): record progress when chains complete

### DIFF
--- a/services/zoe-data/main.py
+++ b/services/zoe-data/main.py
@@ -426,12 +426,20 @@ async def lifespan(app: FastAPI):
 
                         chain = await poll_ref(f"multica:{issue_id}")
                         if chain.get("found") and chain.get("status") == "done":
-                            await client.update_issue(issue_id, status="done")
+                            pr_url = chain.get("pr_url")
+                            await client.record_progress(
+                                issue_id,
+                                phase="closeout",
+                                evidence="Kanban chain done",
+                                pr_url=pr_url,
+                                clear_blocker=True,
+                                status="done",
+                            )
                             logger.info(
-                                "multica_poll: advanced issue %s ('%s') — Kanban chain done%s",
+                                "multica_poll: advanced issue %s (%s) - Kanban chain done%s",
                                 issue_id,
                                 title[:40],
-                                f" PR={chain.get('pr_url')}" if chain.get("pr_url") else "",
+                                f" PR={pr_url}" if pr_url else "",
                             )
                             # Push WebSocket notification to all connected clients
                             try:


### PR DESCRIPTION
Fixes the post-E2E gap where the Multica card moved to done but the Zoe ticket block lost operator-visible truth such as closeout phase, PR URL, and Greptile status.\n\n## Summary\n- Replace plain update_issue(status=done) for completed engineering chains with record_progress(...)\n- Preserve/update the Zoe ticket metadata block on done transitions\n- Keep the existing WebSocket notification path unchanged\n\n## Tests\n- python3 -m py_compile services/zoe-data/main.py\n- PYTHONPATH=services/zoe-data python3 -m pytest services/zoe-data/tests/test_multica_client_helpers.py services/zoe-data/tests/test_multica_poll_dispatch.py services/zoe-data/tests/test_agent_board.py -q