### PR TITLE
test(multica): cover done-chain progress metadata

### DIFF
--- a/services/zoe-data/main.py
+++ b/services/zoe-data/main.py
@@ -83,6 +83,18 @@ for _handler in logging.getLogger().handlers:
     _handler.addFilter(RequestIdFilter())
 
 
+async def _record_completed_multica_chain(client, issue_id: str, chain: dict) -> None:
+    """Persist operator-visible completion metadata for a finished Multica chain."""
+    await client.record_progress(
+        issue_id,
+        phase="closeout",
+        evidence="Kanban chain done",
+        pr_url=chain.get("pr_url"),
+        clear_blocker=True,
+        status="done",
+    )
+
+
 async def _run_memory_capture_startup_probe() -> None:
     """Validate memory capture plumbing at startup.
 
@@ -427,14 +439,7 @@ async def lifespan(app: FastAPI):
                         chain = await poll_ref(f"multica:{issue_id}")
                         if chain.get("found") and chain.get("status") == "done":
                             pr_url = chain.get("pr_url")
-                            await client.record_progress(
-                                issue_id,
-                                phase="closeout",
-                                evidence="Kanban chain done",
-                                pr_url=pr_url,
-                                clear_blocker=True,
-                                status="done",
-                            )
+                            await _record_completed_multica_chain(client, str(issue_id), chain)
                             logger.info(
                                 "multica_poll: advanced issue %s (%s) - Kanban chain done%s",
                                 issue_id,

--- a/services/zoe-data/tests/test_main_multica_poll.py
+++ b/services/zoe-data/tests/test_main_multica_poll.py
@@ -1,0 +1,51 @@
+"""Tests for main.py Multica poll-loop helpers."""
+
+import pytest
+
+
+class RecordingClient:
+    def __init__(self):
+        self.calls = []
+
+    async def record_progress(self, *args, **kwargs):
+        self.calls.append((args, kwargs))
+        return {"id": args[0], **kwargs}
+
+
+@pytest.mark.asyncio
+async def test_record_completed_multica_chain_preserves_progress_metadata():
+    from main import _record_completed_multica_chain
+
+    client = RecordingClient()
+
+    await _record_completed_multica_chain(
+        client,
+        "issue-1",
+        {"status": "done", "pr_url": "https://github.com/o/r/pull/1"},
+    )
+
+    assert client.calls == [
+        (
+            ("issue-1",),
+            {
+                "phase": "closeout",
+                "evidence": "Kanban chain done",
+                "pr_url": "https://github.com/o/r/pull/1",
+                "clear_blocker": True,
+                "status": "done",
+            },
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_record_completed_multica_chain_preserves_missing_pr_url():
+    from main import _record_completed_multica_chain
+
+    client = RecordingClient()
+
+    await _record_completed_multica_chain(client, "issue-2", {"status": "done"})
+
+    assert client.calls[0][1]["pr_url"] is None
+    assert client.calls[0][1]["phase"] == "closeout"
+    assert client.calls[0][1]["status"] == "done"


### PR DESCRIPTION
Adds a regression seam for the Multica poll-loop done transition so completed chains continue to preserve Zoe ticket metadata via record_progress.\n\n## Summary\n- Extract _record_completed_multica_chain helper from the poll-loop done branch\n- Add a focused test asserting phase/evidence/PR/status metadata is recorded\n- Keep production behavior unchanged\n\n## Tests\n- python3 -m py_compile services/zoe-data/main.py\n- PYTHONPATH=services/zoe-data python3 -m pytest services/zoe-data/tests/test_multica_poll_dispatch.py services/zoe-data/tests/test_multica_client_helpers.py services/zoe-data/tests/test_agent_board.py -q