### PR TITLE
fix(pipeline): complete Multica tickets after retro

### DIFF
--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -442,10 +442,10 @@ class KanbanAdapter:
         return common + escalation_hint + (
             "You are closeout (zoe-planner, orchestration only).\n"
             "- Read the implementer's PR_URL handoff and extract the PR number N (the trailing /pull/N)."
-            " If AUDIT_ONLY=1 or audit-only with blank PR_URL, `kanban_complete` and note Multica done"
+            " If AUDIT_ONLY=1 or audit-only with blank PR_URL, `kanban_complete` with closeout evidence"
             " — no grep loop or merge.\n"
-            "- For smoke/audit tickets with no code/config changes and no PR_URL, update the Multica issue"
-            " to done with completion reason, then `kanban_complete`; do not wait for Greptile.\n"
+            "- For smoke/audit tickets with no code/config changes and no PR_URL, report the closeout"
+            " completion reason, then `kanban_complete`; do not wait for Greptile.\n"
             "- If a code task has no PR, leave the issue blocked — do NOT open one yourself.\n"
             "- Address every substantive Greptile finding (fix_now or won't_fix with reason). Do not stop at"
             " merge-ready — merge when gates pass.\n"
@@ -462,10 +462,11 @@ class KanbanAdapter:
             "    python3 scripts/maintenance/greploop_guard.py --pr N --merge-when-ready\n"
             "  Or one iteration then merge: --once --merge-when-ready\n"
             "  If branch protection blocks merge, leave the issue blocked with the gh error — do not admin-merge.\n"
-            "- After a successful merge: update the Multica issue to done with PR_URL, merge SHA, GREPTILE status,"
-            " and summary. If merge did not happen, leave in_progress/blocked with the blocker.\n"
+            "- After a successful merge: report PR_URL, merge SHA, GREPTILE status, and summary in your"
+            " handoff. Zoe will update Multica after the retro phase completes. If merge did not happen,"
+            " leave the issue in_progress/blocked with the blocker.\n"
             "Final handoff MUST include:\nPR_URL=<url>\nMERGE_SHA=<sha or blank>\nGREPTILE=<status>\n"
-            "MULTICA=<updated? done/blocked>\nSUMMARY=<short>\n"
+            "MULTICA=<Zoe updates after retro; report blocker if any>\nSUMMARY=<short>\n"
             "- TERMINAL PROTOCOL: you MUST end with `kanban_complete` or `kanban_block` (no silent exit)."
         )
 

--- a/services/zoe-data/main.py
+++ b/services/zoe-data/main.py
@@ -85,10 +85,12 @@ for _handler in logging.getLogger().handlers:
 
 async def _record_completed_multica_chain(client, issue_id: str, chain: dict) -> None:
     """Persist operator-visible completion metadata for a finished Multica chain."""
+    pipeline = chain.get("pipeline") or {}
+    phase = pipeline.get("phase") or "closeout"
     await client.record_progress(
         issue_id,
-        phase="closeout",
-        evidence="Kanban chain done",
+        phase=phase,
+        evidence="Kanban chain done after retro" if phase == "retro" else "Kanban chain done",
         pr_url=chain.get("pr_url"),
         clear_blocker=True,
         status="done",

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -697,3 +697,15 @@ def test_audit_no_pr_phases_have_bounded_completion_path():
     assert "For smoke/audit tickets" in closeout
     assert "do not wait for Greptile" in closeout
     assert "- If a code task has no PR" in closeout
+
+
+def test_closeout_body_defers_multica_done_until_retro():
+    body = ka.KanbanAdapter()._build_body(
+        "closeout",
+        {"id": "uuid-1", "identifier": "ZOE-9", "title": "Fix thing", "description": ""},
+        "ZOE-9",
+    )
+    assert "Zoe will update Multica after the retro phase completes" in body
+    assert "update the Multica issue to done" not in body
+    assert "note Multica done" not in body
+    assert "MULTICA=<Zoe updates after retro; report blocker if any>" in body

--- a/services/zoe-data/tests/test_main_multica_poll.py
+++ b/services/zoe-data/tests/test_main_multica_poll.py
@@ -13,7 +13,7 @@ class RecordingClient:
 
 
 @pytest.mark.asyncio
-async def test_record_completed_multica_chain_preserves_progress_metadata():
+async def test_record_completed_multica_chain_records_explicit_retro_completion_metadata():
     from main import _record_completed_multica_chain
 
     client = RecordingClient()
@@ -21,15 +21,19 @@ async def test_record_completed_multica_chain_preserves_progress_metadata():
     await _record_completed_multica_chain(
         client,
         "issue-1",
-        {"status": "done", "pr_url": "https://github.com/o/r/pull/1"},
+        {
+            "status": "done",
+            "pipeline": {"phase": "retro"},
+            "pr_url": "https://github.com/o/r/pull/1",
+        },
     )
 
     assert client.calls == [
         (
             ("issue-1",),
             {
-                "phase": "closeout",
-                "evidence": "Kanban chain done",
+                "phase": "retro",
+                "evidence": "Kanban chain done after retro",
                 "pr_url": "https://github.com/o/r/pull/1",
                 "clear_blocker": True,
                 "status": "done",
@@ -39,7 +43,7 @@ async def test_record_completed_multica_chain_preserves_progress_metadata():
 
 
 @pytest.mark.asyncio
-async def test_record_completed_multica_chain_preserves_missing_pr_url():
+async def test_record_completed_multica_chain_preserves_legacy_closeout_completion():
     from main import _record_completed_multica_chain
 
     client = RecordingClient()
@@ -48,4 +52,22 @@ async def test_record_completed_multica_chain_preserves_missing_pr_url():
 
     assert client.calls[0][1]["pr_url"] is None
     assert client.calls[0][1]["phase"] == "closeout"
+    assert client.calls[0][1]["evidence"] == "Kanban chain done"
+    assert client.calls[0][1]["status"] == "done"
+
+
+@pytest.mark.asyncio
+async def test_record_completed_multica_chain_records_non_retro_pipeline_phase():
+    from main import _record_completed_multica_chain
+
+    client = RecordingClient()
+
+    await _record_completed_multica_chain(
+        client,
+        "issue-3",
+        {"status": "done", "pipeline": {"phase": "closeout"}},
+    )
+
+    assert client.calls[0][1]["phase"] == "closeout"
+    assert client.calls[0][1]["evidence"] == "Kanban chain done"
     assert client.calls[0][1]["status"] == "done"


### PR DESCRIPTION
## Summary
- stops closeout prompts from telling Hermes to mark Multica tickets done directly
- records final Multica completion as retro-phase completion from Zoe poll metadata
- adds regressions so closeout cannot bypass retro before Multica moves to done

## Test plan
- [x] PYTHONPATH=services/zoe-data python3 -m pytest services/zoe-data/tests/test_kanban_adapter.py services/zoe-data/tests/test_main_multica_poll.py services/zoe-data/tests/test_multica_poll_dispatch.py -q
- [x] python3 tools/audit/validate_structure.py
- [x] python3 tools/audit/validate_critical_files.py