### PR TITLE
feat(pipeline): create retro follow-up tickets

### DIFF
--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -432,9 +432,10 @@ class KanbanAdapter:
                 "- Read closeout/implement handoffs and any Greptile or validator notes.\n"
                 "- Summarize what worked, what failed, and one small harness improvement proposal.\n"
                 "- Do NOT merge, refactor broadly, or change production behavior from this phase.\n"
+                "- If the run revealed a concrete harness improvement, include FOLLOW_UP_TITLE= and"
+                " FOLLOW_UP_DESCRIPTION= in the handoff; Zoe will create exactly one backlog ticket.\n"
                 "- Hand off with `kanban_complete` metadata: RETRO= or LEARNINGS= plus TOOLS_USED=.\n"
-                "- If a concrete follow-up needs code, note it for a NEW Multica issue — do not loop here"
-                " unless the operator explicitly marked this issue for a revision cycle.\n"
+                "- Do not change production behavior here; the follow-up ticket is the loop.\n"
                 "- TERMINAL PROTOCOL: end with `kanban_complete` or `kanban_block`."
             )
         # closeout

--- a/services/zoe-data/main.py
+++ b/services/zoe-data/main.py
@@ -95,6 +95,42 @@ async def _record_completed_multica_chain(client, issue_id: str, chain: dict) ->
         clear_blocker=True,
         status="done",
     )
+    follow_up = pipeline.get("retro_followup") if isinstance(pipeline, dict) else None
+    if phase != "retro" or not isinstance(follow_up, dict) or not follow_up.get("title"):
+        return
+    try:
+        from multica_ticket_contract import describe_ticket
+
+        parent = await client.get_issue(issue_id)
+        parent_ident = parent.get("identifier") or issue_id
+        description = describe_ticket(
+            str(follow_up.get("description") or follow_up.get("title")),
+            zoe_kind="harness_fix",
+            evidence_profile="code",
+            engineering_mode="interactive",
+            acceptance_criteria=["Address the retro-identified harness improvement in a small, reviewable change."],
+            evidence_expectations=["Focused tests or validators", "PR URL when code changes are made"],
+            source="retro_followup",
+            parent_issue_id=issue_id,
+        )
+        issue = await client.create_issue(
+            title=str(follow_up.get("title"))[:140],
+            description=description,
+            priority="medium",
+            status="backlog",
+            assignee_id=parent.get("assignee_id"),
+            assignee_type=parent.get("assignee_type") or "agent",
+            project_id=parent.get("project_id"),
+        )
+        child_id = str(issue.get("id") or "")
+        if child_id:
+            await client.attach_label(child_id, "harness-fix")
+            await client.append_issue_note(
+                issue_id,
+                f"Retro follow-up created: {issue.get('identifier') or child_id} from {parent_ident}",
+            )
+    except Exception as exc:
+        logger.warning("multica_poll: retro follow-up creation failed for %s: %s", issue_id, exc)
 
 
 async def _run_memory_capture_startup_probe() -> None:

--- a/services/zoe-data/pipeline_handoff.py
+++ b/services/zoe-data/pipeline_handoff.py
@@ -114,6 +114,23 @@ def _tool_summary(raw: str) -> str:
     return cleaned[:500] if cleaned else "tools recorded in handoff"
 
 
+def _retro_followup_metadata(fields: dict[str, str]) -> dict[str, Any]:
+    """Return optional retro-created follow-up ticket metadata from handoff fields."""
+    title = (fields.get("FOLLOW_UP_TITLE") or fields.get("FOLLOWUP_TITLE") or "").strip()
+    description = (
+        fields.get("FOLLOW_UP_DESCRIPTION")
+        or fields.get("FOLLOWUP_DESCRIPTION")
+        or ""
+    ).strip()
+    if not title:
+        return {}
+    return {
+        "title": title[:140],
+        "description": description[:2000] or title[:500],
+        "source": "retro",
+    }
+
+
 def _log_tail_snippet(detail: dict[str, Any], *, max_lines: int = 8) -> str:
     for chunk in reversed(_haystacks(detail)):
         lines = [ln.strip() for ln in chunk.splitlines() if ln.strip()]
@@ -395,7 +412,11 @@ def evidence_from_handoff(
 
     retro_raw = fields.get("RETRO") or fields.get("LEARNINGS") or fields.get("SUMMARY") or ""
     if retro_raw and phase == "retro":
-        items.append(EvidenceItem(kind="log", summary=retro_raw[:500], passed=True))
+        metadata = {"source": "handoff", "phase": "retro"}
+        follow_up = _retro_followup_metadata(fields)
+        if follow_up:
+            metadata["follow_up"] = follow_up
+        items.append(EvidenceItem(kind="log", summary=retro_raw[:500], passed=True, metadata=metadata))
 
     pr_url = fields.get("PR_URL") or ""
     if pr_url and phase in {"implement", "verify", "closeout"}:

--- a/services/zoe-data/pipeline_store.py
+++ b/services/zoe-data/pipeline_store.py
@@ -137,6 +137,19 @@ async def _append_harness_validators(state: PipelineState, phase: PipelinePhase)
     return with_evidence(state, validator_evidence_item(result, phase=phase))
 
 
+def _latest_retro_followup(state: PipelineState) -> dict[str, Any] | None:
+    for item in reversed(state.evidence):
+        if item.kind != "log":
+            continue
+        metadata = item.metadata if isinstance(item.metadata, dict) else {}
+        if metadata.get("phase") != "retro":
+            continue
+        follow_up = metadata.get("follow_up")
+        if isinstance(follow_up, dict) and follow_up.get("title"):
+            return follow_up
+    return None
+
+
 def pipeline_summary(state: PipelineState | None) -> dict[str, Any]:
     if not state:
         return {"tracked": False}
@@ -167,6 +180,7 @@ def pipeline_summary(state: PipelineState | None) -> dict[str, Any]:
         "needs_split": state.status == "blocked" and state.block_classification == "scope_split_required",
         "split_packet": state.split_packet,
         "validator_hash_ok": hash_ok,
+        "retro_followup": _latest_retro_followup(state),
     }
 
 

--- a/services/zoe-data/tests/test_main_multica_poll.py
+++ b/services/zoe-data/tests/test_main_multica_poll.py
@@ -71,3 +71,108 @@ async def test_record_completed_multica_chain_records_non_retro_pipeline_phase()
     assert client.calls[0][1]["phase"] == "closeout"
     assert client.calls[0][1]["evidence"] == "Kanban chain done"
     assert client.calls[0][1]["status"] == "done"
+
+
+@pytest.mark.asyncio
+async def test_record_completed_multica_chain_creates_retro_followup_ticket():
+    from main import _record_completed_multica_chain
+    from multica_ticket_contract import parse_ticket_block
+
+    class Client(RecordingClient):
+        async def get_issue(self, issue_id):
+            return {
+                "id": issue_id,
+                "identifier": "ZOE-1",
+                "assignee_id": "agent-1",
+                "assignee_type": "agent",
+                "project_id": "project-1",
+            }
+
+        async def create_issue(self, **kwargs):
+            self.calls.append(("create_issue", kwargs))
+            return {"id": "child-1", "identifier": "ZOE-2", **kwargs}
+
+        async def attach_label(self, issue_id, label_name):
+            self.calls.append(("attach_label", issue_id, label_name))
+            return {"id": label_name}
+
+        async def append_issue_note(self, issue_id, note):
+            self.calls.append(("append_issue_note", issue_id, note))
+            return {"id": issue_id}
+
+    client = Client()
+
+    await _record_completed_multica_chain(
+        client,
+        "parent-1",
+        {
+            "status": "done",
+            "pipeline": {
+                "phase": "retro",
+                "retro_followup": {
+                    "title": "Add retry guard regression",
+                    "description": "Retro found a missing retry guard test.",
+                },
+            },
+        },
+    )
+
+    create_call = next(call for call in client.calls if call[0] == "create_issue")
+    payload = create_call[1]
+    metadata = parse_ticket_block(payload["description"])
+    assert payload["status"] == "backlog"
+    assert payload["assignee_id"] == "agent-1"
+    assert metadata["zoe_kind"] == "harness_fix"
+    assert metadata["parent_issue_id"] == "parent-1"
+    assert ("attach_label", "child-1", "harness-fix") in client.calls
+    assert any(call[0] == "append_issue_note" for call in client.calls)
+
+
+@pytest.mark.asyncio
+async def test_record_completed_multica_chain_does_not_create_followup_without_retro():
+    from main import _record_completed_multica_chain
+
+    class Client(RecordingClient):
+        async def get_issue(self, issue_id):
+            raise AssertionError("no parent lookup without retro follow-up")
+
+        async def create_issue(self, **kwargs):
+            raise AssertionError("no follow-up should be created")
+
+    client = Client()
+
+    await _record_completed_multica_chain(
+        client,
+        "issue-1",
+        {"status": "done", "pipeline": {"phase": "closeout", "retro_followup": {"title": "ignored"}}},
+    )
+
+    assert client.calls[0][1]["phase"] == "closeout"
+
+
+@pytest.mark.asyncio
+async def test_record_completed_multica_chain_swallow_followup_creation_failure():
+    from main import _record_completed_multica_chain
+
+    class Client(RecordingClient):
+        async def get_issue(self, issue_id):
+            return {"id": issue_id, "identifier": "ZOE-1"}
+
+        async def create_issue(self, **kwargs):
+            raise RuntimeError("multica create failed")
+
+    client = Client()
+
+    await _record_completed_multica_chain(
+        client,
+        "parent-1",
+        {
+            "status": "done",
+            "pipeline": {
+                "phase": "retro",
+                "retro_followup": {"title": "Retry guard", "description": "Add coverage"},
+            },
+        },
+    )
+
+    assert client.calls[0][1]["phase"] == "retro"

--- a/services/zoe-data/tests/test_pipeline_handoff.py
+++ b/services/zoe-data/tests/test_pipeline_handoff.py
@@ -261,3 +261,45 @@ def test_split_request_from_handoff_parses_multiline_packet():
     assert requested is True
     assert packet["child_issue_template"]["title"] == "ZOE-1: multiline child"
     assert packet["reason"] == "too broad"
+
+
+def test_retro_handoff_can_request_followup_ticket():
+    detail = {
+        "latest_summary": (
+            "RETRO=Worktree guard prevented drift\n"
+            "FOLLOW_UP_TITLE=Add regression for retro follow-up tickets\n"
+            "FOLLOW_UP_DESCRIPTION=Create a focused test so retro follow-up metadata keeps creating backlog tickets."
+        ),
+        "comments": [],
+    }
+
+    items = evidence_from_handoff("retro", detail)
+
+    log = next(item for item in items if item.kind == "log")
+    assert log.metadata["follow_up"]["title"] == "Add regression for retro follow-up tickets"
+    assert log.metadata["follow_up"]["source"] == "retro"
+
+
+def test_retro_handoff_without_followup_title_only_logs():
+    detail = {"latest_summary": "RETRO=No harness change needed", "comments": []}
+
+    items = evidence_from_handoff("retro", detail)
+
+    log = next(item for item in items if item.kind == "log")
+    assert "follow_up" not in log.metadata
+
+
+def test_retro_handoff_ignores_undocumented_followup_description_aliases():
+    detail = {
+        "latest_summary": (
+            "RETRO=Captured learnings\n"
+            "FOLLOW_UP_TITLE=Document prompt contract\n"
+            "FOLLOW_UP=This should not become the ticket description"
+        ),
+        "comments": [],
+    }
+
+    items = evidence_from_handoff("retro", detail)
+
+    log = next(item for item in items if item.kind == "log")
+    assert log.metadata["follow_up"]["description"] == "Document prompt contract"

--- a/services/zoe-data/tests/test_pipeline_store.py
+++ b/services/zoe-data/tests/test_pipeline_store.py
@@ -251,3 +251,37 @@ async def test_sync_pipeline_auto_validators_on_implement_done(isolated_store, m
     state = await store.sync_pipeline_from_chain("multica:val", phases, fetch_detail)
     assert state.phase == "verify"
     assert any(item.kind == "validator" and item.metadata.get("phase") == "implement" for item in state.evidence)
+
+
+def test_pipeline_summary_surfaces_latest_retro_followup(isolated_store):
+    state = PipelineState(task_ref="multica:retro", phase="retro", status="done")
+    state = with_evidence(
+        state,
+        EvidenceItem(
+            kind="log",
+            summary="retro captured",
+            passed=True,
+            metadata={"phase": "retro", "follow_up": {"title": "Tighten retry guard", "description": "Add coverage"}},
+        ),
+    )
+
+    summary = store.pipeline_summary(state)
+
+    assert summary["retro_followup"]["title"] == "Tighten retry guard"
+
+
+def test_pipeline_summary_ignores_non_retro_followup_metadata(isolated_store):
+    state = PipelineState(task_ref="multica:non-retro", phase="verify", status="running")
+    state = with_evidence(
+        state,
+        EvidenceItem(
+            kind="log",
+            summary="not retro",
+            passed=True,
+            metadata={"phase": "verify", "follow_up": {"title": "Ignore me"}},
+        ),
+    )
+
+    summary = store.pipeline_summary(state)
+
+    assert summary["retro_followup"] is None


### PR DESCRIPTION
## Summary
- lets retro handoffs opt into one structured follow-up ticket with FOLLOW_UP_TITLE/FOLLOW_UP_DESCRIPTION
- surfaces retro follow-up metadata through the pipeline summary returned by Kanban polling
- creates a linked backlog Multica harness-fix ticket after retro completion, without allowing retro to mutate production directly

## Test plan
- [x] PYTHONPATH=services/zoe-data python3 -m pytest services/zoe-data/tests/test_pipeline_handoff.py services/zoe-data/tests/test_pipeline_store.py services/zoe-data/tests/test_main_multica_poll.py services/zoe-data/tests/test_kanban_adapter.py services/zoe-data/tests/test_pipeline_evidence_commands.py -q
- [x] python3 tools/audit/validate_structure.py
- [x] python3 tools/audit/validate_critical_files.py