### PR TITLE
Surface terminal Multica blocks

### DIFF
--- a/services/zoe-data/main.py
+++ b/services/zoe-data/main.py
@@ -133,6 +133,36 @@ async def _record_completed_multica_chain(client, issue_id: str, chain: dict) ->
         logger.warning("multica_poll: retro follow-up creation failed for %s: %s", issue_id, exc)
 
 
+def _blocked_multica_chain_reason(chain: dict) -> str:
+    """Return the operator-visible reason for a blocked engineering chain."""
+    pipeline = chain.get("pipeline") or {}
+    phase = pipeline.get("phase") or "implement"
+    blocker = (
+        chain.get("blocker")
+        or pipeline.get("block_reason")
+        or pipeline.get("block_classification")
+        or f"pipeline blocked at {phase}"
+    )
+    if pipeline.get("terminal_block") and "terminal" not in str(blocker).lower():
+        blocker = f"terminal block: {blocker}"
+    return str(blocker)
+
+
+async def _record_blocked_multica_chain(client, issue_id: str, chain: dict) -> str:
+    """Persist operator-visible block metadata for a stopped Multica chain."""
+    pipeline = chain.get("pipeline") or {}
+    phase = pipeline.get("phase") or "implement"
+    blocker = _blocked_multica_chain_reason(chain)
+    await client.record_progress(
+        issue_id,
+        phase=phase,
+        evidence="Kanban chain blocked",
+        pr_url=chain.get("pr_url"),
+        blocker=blocker,
+        status="blocked",
+    )
+    return blocker
+
 async def _run_memory_capture_startup_probe() -> None:
     """Validate memory capture plumbing at startup.
 
@@ -497,6 +527,26 @@ async def lifespan(app: FastAPI):
                                 )
                             except Exception as _push_exc:
                                 logger.debug("multica_poll: ws push failed: %s", _push_exc)
+                        elif chain.get("found") and chain.get("status") == "blocked":
+                            blocker = await _record_blocked_multica_chain(client, str(issue_id), chain)
+                            logger.info(
+                                "multica_poll: blocked issue %s (%s) - %s",
+                                issue_id,
+                                title[:40],
+                                blocker,
+                            )
+                            try:
+                                await broadcaster.broadcast(
+                                    "all",
+                                    "multica_task_blocked",
+                                    {
+                                        "multica_issue_id": str(issue_id),
+                                        "title": title,
+                                        "blocker": blocker,
+                                    },
+                                )
+                            except Exception as _push_exc:
+                                logger.debug("multica_poll: ws block push failed: %s", _push_exc)
                     except Exception as _inner_exc:
                         logger.debug("multica_poll: inner error for issue %s: %s", issue_id, _inner_exc)
 

--- a/services/zoe-data/tests/test_main_multica_poll.py
+++ b/services/zoe-data/tests/test_main_multica_poll.py
@@ -176,3 +176,75 @@ async def test_record_completed_multica_chain_swallow_followup_creation_failure(
     )
 
     assert client.calls[0][1]["phase"] == "retro"
+
+
+@pytest.mark.asyncio
+async def test_record_blocked_multica_chain_records_terminal_block_metadata():
+    from main import _record_blocked_multica_chain
+
+    client = RecordingClient()
+
+    await _record_blocked_multica_chain(
+        client,
+        "issue-blocked",
+        {
+            "status": "blocked",
+            "blocker": "implement blocked",
+            "pr_url": "https://github.com/o/r/pull/7",
+            "pipeline": {"phase": "implement", "terminal_block": True},
+        },
+    )
+
+    assert client.calls == [
+        (
+            ("issue-blocked",),
+            {
+                "phase": "implement",
+                "evidence": "Kanban chain blocked",
+                "pr_url": "https://github.com/o/r/pull/7",
+                "blocker": "terminal block: implement blocked",
+                "status": "blocked",
+            },
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_record_blocked_multica_chain_uses_non_terminal_block_reason_without_prefix():
+    from main import _record_blocked_multica_chain
+
+    client = RecordingClient()
+
+    blocker = await _record_blocked_multica_chain(
+        client,
+        "issue-non-terminal",
+        {"pipeline": {"phase": "verify", "block_reason": "tests failed"}},
+    )
+
+    assert blocker == "tests failed"
+    assert client.calls[0][1]["phase"] == "verify"
+    assert client.calls[0][1]["blocker"] == "tests failed"
+    assert not client.calls[0][1]["blocker"].startswith("terminal block:")
+
+
+@pytest.mark.asyncio
+async def test_record_blocked_multica_chain_falls_back_to_classification_and_default():
+    from main import _record_blocked_multica_chain
+
+    client = RecordingClient()
+
+    classified = await _record_blocked_multica_chain(
+        client,
+        "issue-classified",
+        {"pipeline": {"phase": "review", "block_classification": "blocked_external"}},
+    )
+    defaulted = await _record_blocked_multica_chain(
+        client,
+        "issue-defaulted",
+        {"pipeline": {"phase": "retro"}},
+    )
+
+    assert classified == "blocked_external"
+    assert defaulted == "pipeline blocked at retro"
+    assert client.calls[0][1]["blocker"] == "blocked_external"
+    assert client.calls[1][1]["blocker"] == "pipeline blocked at retro"


### PR DESCRIPTION
## Summary
- record blocked engineering chains back into Multica with phase, blocker, PR URL, and blocked status
- broadcast a Multica blocked event from the poll loop
- add regression coverage for terminal block metadata writeback

## Tests
- PYTHONPATH=services/zoe-data python3 -m pytest services/zoe-data/tests/test_main_multica_poll.py services/zoe-data/tests/test_multica_client_helpers.py services/zoe-data/tests/test_pipeline_store.py services/zoe-data/tests/test_multica_poll_dispatch.py services/zoe-data/tests/test_kanban_adapter.py -q