### PR TITLE
Accept live review merge-ready metadata

### DIFF
--- a/services/zoe-data/pipeline_handoff.py
+++ b/services/zoe-data/pipeline_handoff.py
@@ -210,9 +210,15 @@ def _human_review_from_metadata(detail: dict[str, Any]) -> EvidenceItem | None:
 
     for source, metadata in _review_metadata_candidates(detail):
         readiness = str(metadata.get("merge_readiness") or "").strip().lower()
+        verdict = str(metadata.get("verdict") or "").strip().lower()
+        explicit_verdict_ready = metadata.get("merge_ready") is True and verdict in {"approve", "approved"}
+        if explicit_verdict_ready:
+            readiness = "merge_ready"
+        task = detail.get("task") if isinstance(detail.get("task"), dict) else {}
+        explicit_approver = metadata.get("approver") or metadata.get("approved_by")
         approver = str(
-            metadata.get("approver")
-            or metadata.get("approved_by")
+            explicit_approver
+            or (task.get("assignee") if explicit_verdict_ready else "")
             or ""
         ).strip()
 
@@ -225,6 +231,7 @@ def _human_review_from_metadata(detail: dict[str, Any]) -> EvidenceItem | None:
                     "source": source,
                     "approver": approver,
                     "merge_readiness": readiness,
+                    "verdict": verdict or None,
                 },
             )
 

--- a/services/zoe-data/tests/test_pipeline_handoff.py
+++ b/services/zoe-data/tests/test_pipeline_handoff.py
@@ -92,6 +92,32 @@ def test_evidence_from_review_prefers_top_level_metadata_over_run_metadata():
     assert human.metadata["approver"] == "top-level-reviewer"
 
 
+def test_evidence_from_live_review_run_metadata_accepts_merge_ready_verdict():
+    detail = {
+        "latest_summary": "APPROVE ZOE-5408 audit-only E2E.",
+        "comments": [],
+        "task": {"assignee": "zoe-reviewer"},
+        "runs": [
+            {
+                "metadata": {
+                    "verdict": "approve",
+                    "merge_ready": True,
+                    "audit_only": True,
+                }
+            }
+        ],
+    }
+
+    items = evidence_from_handoff("review", detail)
+
+    human = next(item for item in items if item.kind == "human")
+    assert human.passed is True
+    assert human.metadata["source"] == "kanban_run_metadata"
+    assert human.metadata["approver"] == "zoe-reviewer"
+    assert human.metadata["merge_readiness"] == "merge_ready"
+    assert human.metadata["verdict"] == "approve"
+
+
 def test_evidence_from_review_metadata_accepts_approved_readiness():
     detail = {
         "latest_summary": "Approved after review.",
@@ -115,6 +141,21 @@ def test_evidence_from_review_ignores_summary_without_approver():
         "latest_summary": "APPROVE ZOE-5401. PR is merge-ready.",
         "comments": [],
         "metadata": {},
+    }
+
+    items = evidence_from_handoff("review", detail)
+
+    assert not any(item.kind == "human" for item in items)
+
+
+def test_evidence_from_review_ignores_legacy_readiness_with_only_task_assignee():
+    detail = {
+        "latest_summary": "APPROVE ZOE-5401. PR is merge-ready.",
+        "comments": [],
+        "task": {"assignee": "zoe-reviewer"},
+        "metadata": {
+            "merge_readiness": "merge_ready",
+        },
     }
 
     items = evidence_from_handoff("review", detail)


### PR DESCRIPTION
## Summary
- treat live Hermes review metadata with merge_ready=true and verdict=approve as human review evidence
- fall back to the review task assignee as approver only when an explicit approval verdict is present
- add regression coverage for the ZOE-5408 live E2E review metadata shape

## Tests
- PYTHONPATH=services/zoe-data python3 -m pytest services/zoe-data/tests/test_pipeline_handoff.py services/zoe-data/tests/test_pipeline_store.py services/zoe-data/tests/test_kanban_adapter.py services/zoe-data/tests/test_main_multica_poll.py -q