### PR TITLE
Fast-path audit closeout without Greptile

### DIFF
--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -183,6 +183,10 @@ def _max_runtime(mode: str = "interactive") -> str:
 
 
 _SKIP_SCOUT_TAG_RE = re.compile(r"skip_scout:\s*(true|yes|1)", re.I)
+_AUDIT_NO_PR_RE = re.compile(
+    r"\b(?:audit-only|smoke test only|no code change only|no code/config changes only|evidence_profile:\s*audit)\b",
+    re.I,
+)
 
 
 def _skip_scout(issue: dict | None = None) -> bool:
@@ -206,8 +210,28 @@ def _skip_scout(issue: dict | None = None) -> bool:
     return bool(_SKIP_SCOUT_TAG_RE.search(haystack))
 
 
+def _audit_no_pr_issue(issue: dict | None = None) -> bool:
+    issue = issue or {}
+    meta = issue.get("metadata") or {}
+    if str(meta.get("evidence_profile") or "").strip().lower() == "audit":
+        return True
+    haystack = " ".join(
+        [
+            str(issue.get("title") or ""),
+            str(issue.get("description") or ""),
+            json.dumps(meta),
+        ]
+    )
+    return bool(_AUDIT_NO_PR_RE.search(haystack))
+
+
 def _chain_for_issue(issue: dict) -> tuple[tuple[str, str, tuple[str, ...]], ...]:
     phases = _CHAIN
+    if _audit_no_pr_issue(issue):
+        phases = tuple(
+            (phase, assignee, () if phase == "closeout" else skills)
+            for phase, assignee, skills in phases
+        )
     if _skip_scout(issue):
         phases = tuple(p for p in phases if p[0] != "scout")
     return phases

--- a/services/zoe-data/pipeline_evidence.py
+++ b/services/zoe-data/pipeline_evidence.py
@@ -54,7 +54,7 @@ _EVIDENCE_PROFILES: dict[EvidenceProfile, dict[PipelinePhase, set[EvidenceKind]]
         "implement": {"tool"},
         "verify": {"validator"},
         "review": {"human"},
-        "closeout": {"greptile"},
+        "closeout": {"log"},
         "retro": {"log"},
     },
     "health": {

--- a/services/zoe-data/pipeline_handoff.py
+++ b/services/zoe-data/pipeline_handoff.py
@@ -413,6 +413,22 @@ def evidence_from_handoff(
                 items.append(review_item)
 
     if phase == "closeout":
+        summary_raw = fields.get("SUMMARY") or fields.get("CLOSEOUT") or ""
+        audit_only = (fields.get("AUDIT_ONLY") or "").strip().lower() in {"1", "true", "yes"}
+        # Some audit/no-code closeout workers omit AUDIT_ONLY but still report an
+        # audit-only summary and no PR. Treat only that explicit audit wording as inferred audit.
+        inferred_audit = bool(
+            summary_raw and "audit" in summary_raw.lower() and not (fields.get("PR_URL") or "").strip()
+        )
+        if audit_only or inferred_audit:
+            items.append(
+                EvidenceItem(
+                    kind="log",
+                    summary=(summary_raw or "audit-only closeout completed")[:500],
+                    passed=True,
+                    metadata={"source": "handoff", "phase": "closeout", "audit_only": audit_only or inferred_audit},
+                )
+            )
         greptile_item = _greptile_from_closeout(detail, skills)
         if greptile_item:
             items.append(greptile_item)

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -725,3 +725,22 @@ def test_implement_body_puts_audit_fast_path_before_graphify():
     assert "explicitly says audit-only" in body
     assert "uses trace/map with an audit/no-code qualifier" in body
     assert body.index("AUDIT/SMOKE FAST PATH") < body.index("graphify map")
+
+
+def test_audit_closeout_does_not_preload_greptile_skill():
+    from executors.kanban_adapter import _phase_plan_entry
+
+    audit_issue = {"title": "audit-only lifecycle", "description": "operator audit"}
+    no_code_issue = {"title": "no code/config changes only", "description": "operator check"}
+    smoke_only_issue = {"title": "smoke test only", "description": "operator check"}
+    code_smoke_issue = {"title": "add smoke test coverage", "description": "code change required"}
+    code_clause_issue = {
+        "title": "refactor auth flow",
+        "description": "code change required; no code change needed in legacy adapter",
+    }
+
+    assert _phase_plan_entry("closeout", audit_issue)[2] == ()
+    assert _phase_plan_entry("closeout", no_code_issue)[2] == ()
+    assert _phase_plan_entry("closeout", smoke_only_issue)[2] == ()
+    assert _phase_plan_entry("closeout", code_smoke_issue)[2] == ("github-greptile-loop",)
+    assert _phase_plan_entry("closeout", code_clause_issue)[2] == ("github-greptile-loop",)

--- a/services/zoe-data/tests/test_pipeline_evidence.py
+++ b/services/zoe-data/tests/test_pipeline_evidence.py
@@ -261,3 +261,10 @@ def test_verify_validator_hash_ignores_harness_sync_mismatch():
         ),
     )
     assert verify_validator_hash_matches(state) is True
+
+
+def test_audit_profile_closeout_requires_log_not_greptile():
+    state = PipelineState(task_ref="multica:1", phase="closeout", evidence_profile="audit")
+    assert missing_required_evidence(state) == {"log"}
+    state = with_evidence(state, EvidenceItem(kind="log", summary="audit-only closeout", passed=True))
+    assert missing_required_evidence(state) == set()

--- a/services/zoe-data/tests/test_pipeline_handoff.py
+++ b/services/zoe-data/tests/test_pipeline_handoff.py
@@ -344,3 +344,37 @@ def test_retro_handoff_ignores_undocumented_followup_description_aliases():
 
     log = next(item for item in items if item.kind == "log")
     assert log.metadata["follow_up"]["description"] == "Document prompt contract"
+
+
+def test_closeout_audit_only_handoff_records_log_evidence():
+    detail = {"latest_summary": """AUDIT_ONLY=1
+SUMMARY=audit-only closeout completed
+PR_URL=""", "comments": []}
+
+    items = evidence_from_handoff("closeout", detail, skills=())
+
+    log = next(item for item in items if item.kind == "log")
+    assert log.passed is True
+    assert log.summary == "audit-only closeout completed"
+    assert log.metadata["phase"] == "closeout"
+    assert log.metadata["audit_only"] is True
+    assert not any(item.kind == "greptile" for item in items)
+
+
+def test_closeout_infers_audit_log_only_from_audit_summary_without_pr():
+    detail = {"latest_summary": """SUMMARY=audit-only closeout completed
+PR_URL=""", "comments": []}
+
+    items = evidence_from_handoff("closeout", detail, skills=())
+
+    log = next(item for item in items if item.kind == "log")
+    assert log.metadata["audit_only"] is True
+
+
+def test_closeout_does_not_infer_audit_log_from_generic_summary_without_pr():
+    detail = {"latest_summary": """SUMMARY=closeout finished
+PR_URL=""", "comments": []}
+
+    items = evidence_from_handoff("closeout", detail, skills=())
+
+    assert not any(item.kind == "log" for item in items)


### PR DESCRIPTION
## Summary
- do not preload github-greptile-loop for audit/no-PR closeout tasks
- require log evidence, not Greptile evidence, for audit-profile closeout
- parse audit-only closeout handoffs as log evidence

## Tests
- PYTHONPATH=services/zoe-data python3 -m pytest services/zoe-data/tests/test_pipeline_evidence.py services/zoe-data/tests/test_pipeline_handoff.py services/zoe-data/tests/test_pipeline_store.py services/zoe-data/tests/test_kanban_adapter.py services/zoe-data/tests/test_main_multica_poll.py -q