### PR TITLE
Fast-path audit verify tasks

### DIFF
--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -13,7 +13,7 @@ Worker profiles + pinned skills encode Zoe's agentic-engineering loop:
   - scout     (zoe-planner):  zoe-graphify, zoe-engineering     (read-only context)
   - implement (zoe-coder):  zoe-engineering, zoe-graphify, source-code-context,
                             code-structure-cleanup  (graph-first, opensrc, lean)
-  - verify    (zoe-reviewer): zoe-engineering           (tests/evidence gate)
+  - verify    (zoe-reviewer): zoe-engineering           (tests/evidence gate; no preloaded skill for audit/no-PR)
   - review    (zoe-reviewer): zoe-engineering           (verification gate)
   - closeout  (zoe-planner):  github-greptile-loop      (grep-loop, merge, Multica done)
   - retro     (zoe-planner):  zoe-status-refresh        (learnings, optional loop)
@@ -229,7 +229,7 @@ def _chain_for_issue(issue: dict) -> tuple[tuple[str, str, tuple[str, ...]], ...
     phases = _CHAIN
     if _audit_no_pr_issue(issue):
         phases = tuple(
-            (phase, assignee, () if phase == "closeout" else skills)
+            (phase, assignee, () if phase in {"verify", "closeout"} else skills)
             for phase, assignee, skills in phases
         )
     if _skip_scout(issue):
@@ -418,10 +418,12 @@ class KanbanAdapter:
             escalation_hint = _escalation_model_hint(issue) if escalation else ""
             return common + escalation_hint + (
                 "You are verify (zoe-reviewer). This is the objective test/evidence gate before review.\n"
+                "- AUDIT/NO-PR FAST PATH: if this is audit-only, smoke, or has no code/config changes"
+                " and no PR_URL, do not load broad skills, hunt for a PR, or explore the repo. Run"
+                " `kanban_show`, compare the implementer handoff to the Multica acceptance criteria,"
+                " then call `kanban_complete` in this turn with TESTS=not applicable/audit evidence,"
+                " VALIDATORS=not applicable/audit-only, PR_URL= blank, and a short pass/fail summary.\n"
                 "- Start with `kanban_show` to read the implementer handoff and PR_URL.\n"
-                "- If this is audit-only, smoke, or has no code/config changes and no PR_URL, do not hunt"
-                " for a PR. Check the handoff against the Multica acceptance criteria, record TESTS=not"
-                " applicable/audit evidence, VALIDATORS=not applicable/audit-only, and `kanban_complete`.\n"
                 "- Do not redesign or refactor. Run the declared tests and the minimum extra checks needed"
                 " for the touched surface.\n"
                 "- Always run and record `python3 tools/audit/validate_structure.py` and"

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -689,9 +689,13 @@ def test_audit_no_pr_phases_have_bounded_completion_path():
     review = adapter._build_body("review", issue, "ZOE-9")
     closeout = adapter._build_body("closeout", issue, "ZOE-9")
 
-    assert "audit-only, smoke" in verify
+    assert "AUDIT/NO-PR FAST PATH" in verify
     assert "no PR_URL" in verify
+    assert "do not load broad skills" in verify
+    assert "TESTS=not applicable/audit evidence" in verify
+    assert "VALIDATORS=not applicable/audit-only" in verify
     assert "VERIFY_BUDGET" in verify
+    assert verify.index("AUDIT/NO-PR FAST PATH") < verify.index("Start with `kanban_show`")
     assert "audit-only/no-code" in review
     assert "REVIEW_BUDGET" in review
     assert "For smoke/audit tickets" in closeout
@@ -727,7 +731,7 @@ def test_implement_body_puts_audit_fast_path_before_graphify():
     assert body.index("AUDIT/SMOKE FAST PATH") < body.index("graphify map")
 
 
-def test_audit_closeout_does_not_preload_greptile_skill():
+def test_audit_no_pr_verify_and_closeout_do_not_preload_broad_skills():
     from executors.kanban_adapter import _phase_plan_entry
 
     audit_issue = {"title": "audit-only lifecycle", "description": "operator audit"}
@@ -739,6 +743,11 @@ def test_audit_closeout_does_not_preload_greptile_skill():
         "description": "code change required; no code change needed in legacy adapter",
     }
 
+    assert _phase_plan_entry("verify", audit_issue)[2] == ()
+    assert _phase_plan_entry("verify", no_code_issue)[2] == ()
+    assert _phase_plan_entry("verify", smoke_only_issue)[2] == ()
+    assert _phase_plan_entry("verify", code_smoke_issue)[2] == ("zoe-engineering",)
+    assert _phase_plan_entry("verify", code_clause_issue)[2] == ("zoe-engineering",)
     assert _phase_plan_entry("closeout", audit_issue)[2] == ()
     assert _phase_plan_entry("closeout", no_code_issue)[2] == ()
     assert _phase_plan_entry("closeout", smoke_only_issue)[2] == ()


### PR DESCRIPTION
## Summary
- avoid preloading broad Zoe engineering skills for audit/no-PR verify phases
- put the audit/no-PR verify terminal handoff before generic repo/test instructions
- extend adapter tests to cover audit verify and closeout skill selection

## Validation
- PYTHONPATH=services/zoe-data python3 -m pytest services/zoe-data/tests/test_kanban_adapter.py services/zoe-data/tests/test_pipeline_store.py services/zoe-data/tests/test_pipeline_handoff.py services/zoe-data/tests/test_pipeline_evidence.py services/zoe-data/tests/test_main_multica_poll.py -q