### PR TITLE
Run audit no-PR phases lightweight

### DIFF
--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -11,12 +11,11 @@ surface-agnostic.
 
 Worker profiles + pinned skills encode Zoe's agentic-engineering loop:
   - scout     (zoe-planner):  zoe-graphify, zoe-engineering     (read-only context)
-  - implement (zoe-coder):  zoe-engineering, zoe-graphify, source-code-context,
-                            code-structure-cleanup  (graph-first, opensrc, lean)
-  - verify    (zoe-reviewer): zoe-engineering           (tests/evidence gate; no preloaded skill for audit/no-PR)
-  - review    (zoe-reviewer): zoe-engineering           (verification gate)
-  - closeout  (zoe-planner):  github-greptile-loop      (grep-loop, merge, Multica done)
-  - retro     (zoe-planner):  zoe-status-refresh        (learnings, optional loop)
+  - implement (zoe-coder):  zoe-engineering             (no preloaded skill for audit/no-PR)
+  - verify    (zoe-reviewer): zoe-engineering           (no preloaded skill for audit/no-PR)
+  - review    (zoe-reviewer): zoe-engineering           (no preloaded skill for audit/no-PR)
+  - closeout  (zoe-planner):  github-greptile-loop      (no preloaded skill for audit/no-PR)
+  - retro     (zoe-planner):  zoe-status-refresh        (no preloaded skill for audit/no-PR)
 """
 from __future__ import annotations
 
@@ -228,10 +227,7 @@ def _audit_no_pr_issue(issue: dict | None = None) -> bool:
 def _chain_for_issue(issue: dict) -> tuple[tuple[str, str, tuple[str, ...]], ...]:
     phases = _CHAIN
     if _audit_no_pr_issue(issue):
-        phases = tuple(
-            (phase, assignee, () if phase in {"verify", "closeout"} else skills)
-            for phase, assignee, skills in phases
-        )
+        phases = tuple((phase, assignee, ()) for phase, assignee, _skills in phases)
     if _skip_scout(issue):
         phases = tuple(p for p in phases if p[0] != "scout")
     return phases
@@ -371,12 +367,13 @@ class KanbanAdapter:
             # Implement body intentionally omits full prior-phase logs; workers should
             # call kanban_show and read SCOUT_SUMMARY= from scout metadata when present.
             return common + overnight_hint + (
-                "You are the implementer (zoe-coder). Start with `kanban_show` to confirm this task id.\n"
+                "You are the implementer (zoe-coder).\n"
                 "- AUDIT/SMOKE FAST PATH: only if the title/body explicitly says audit-only, smoke test,"
                 " no code change, or uses trace/map with an audit/no-code qualifier, do not run Graphify"
                 " or repo exploration first. Complete in one bounded handoff with"
                 " TOOLS_USED=audit-read, PR_URL= blank, AUDIT_ONLY=1, TESTS=not applicable/audit-only,"
                 " and SUMMARY= findings. Do not open a PR.\n"
+                "- Start with `kanban_show` to confirm this task id.\n"
                 "- For code-changing tickets only: read the charter + graphify map first"
                 " (graphify query/path/explain over raw grep).\n"
                 "- Use opensrc for any third-party library source before guessing APIs.\n"
@@ -441,6 +438,9 @@ class KanbanAdapter:
             escalation_hint = _escalation_model_hint(issue) if escalation else ""
             return common + escalation_hint + (
                 "You are the reviewer (zoe-reviewer). Review the diff, scope, and verify-phase evidence.\n"
+                "- AUDIT/NO-PR FAST PATH: for audit-only/no-code handoffs with blank PR_URL, do not load"
+                " broad skills or explore the tree. Use `kanban_show`, compare verify evidence to the"
+                " acceptance criteria, then `kanban_complete` with a short verification note.\n"
                 "- Confirm the change is small and in scope. Audit-only / doc-only handoffs with blank PR_URL"
                 " need a short verification note, then `kanban_complete` — do not re-implement or burn turns"
                 " re-exploring the tree.\n"
@@ -458,6 +458,8 @@ class KanbanAdapter:
         if phase == "retro":
             return common + _retro_cost_hint() + (
                 "You are retro (zoe-planner). Capture learnings after closeout — no silent prod changes.\n"
+                "- AUDIT/NO-PR FAST PATH: if this was an audit-only/no-code run, keep retro to one"
+                " short handoff and do not load broad skills or inspect unrelated repo state.\n"
                 "- Read closeout/implement handoffs and any Greptile or validator notes.\n"
                 "- Summarize what worked, what failed, and one small harness improvement proposal.\n"
                 "- Do NOT merge, refactor broadly, or change production behavior from this phase.\n"

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -731,7 +731,7 @@ def test_implement_body_puts_audit_fast_path_before_graphify():
     assert body.index("AUDIT/SMOKE FAST PATH") < body.index("graphify map")
 
 
-def test_audit_no_pr_verify_and_closeout_do_not_preload_broad_skills():
+def test_audit_no_pr_phases_do_not_preload_broad_skills():
     from executors.kanban_adapter import _phase_plan_entry
 
     audit_issue = {"title": "audit-only lifecycle", "description": "operator audit"}
@@ -743,13 +743,19 @@ def test_audit_no_pr_verify_and_closeout_do_not_preload_broad_skills():
         "description": "code change required; no code change needed in legacy adapter",
     }
 
-    assert _phase_plan_entry("verify", audit_issue)[2] == ()
-    assert _phase_plan_entry("verify", no_code_issue)[2] == ()
-    assert _phase_plan_entry("verify", smoke_only_issue)[2] == ()
+    for phase in ("scout", "implement", "verify", "review", "closeout", "retro"):
+        assert _phase_plan_entry(phase, audit_issue)[2] == ()
+        assert _phase_plan_entry(phase, no_code_issue)[2] == ()
+        assert _phase_plan_entry(phase, smoke_only_issue)[2] == ()
+
+    assert _phase_plan_entry("implement", code_smoke_issue)[2] == ("zoe-engineering",)
+    assert _phase_plan_entry("review", code_smoke_issue)[2] == ("zoe-engineering",)
+    assert _phase_plan_entry("retro", code_smoke_issue)[2] == ("zoe-status-refresh",)
+    assert _phase_plan_entry("implement", code_clause_issue)[2] == ("zoe-engineering",)
+    assert _phase_plan_entry("review", code_clause_issue)[2] == ("zoe-engineering",)
+    assert _phase_plan_entry("retro", code_clause_issue)[2] == ("zoe-status-refresh",)
+
     assert _phase_plan_entry("verify", code_smoke_issue)[2] == ("zoe-engineering",)
     assert _phase_plan_entry("verify", code_clause_issue)[2] == ("zoe-engineering",)
-    assert _phase_plan_entry("closeout", audit_issue)[2] == ()
-    assert _phase_plan_entry("closeout", no_code_issue)[2] == ()
-    assert _phase_plan_entry("closeout", smoke_only_issue)[2] == ()
     assert _phase_plan_entry("closeout", code_smoke_issue)[2] == ("github-greptile-loop",)
     assert _phase_plan_entry("closeout", code_clause_issue)[2] == ("github-greptile-loop",)


### PR DESCRIPTION
## Summary
- strip preloaded skills from audit/no-PR issue phase plans across implement, verify, review, closeout, and retro
- move lightweight audit fast paths ahead of generic repo exploration instructions
- extend adapter tests so audit/no-PR phases stay lightweight while normal code tickets keep their skills

## Validation
- PYTHONPATH=services/zoe-data python3 -m pytest services/zoe-data/tests/test_kanban_adapter.py services/zoe-data/tests/test_pipeline_store.py services/zoe-data/tests/test_pipeline_handoff.py services/zoe-data/tests/test_pipeline_evidence.py services/zoe-data/tests/test_main_multica_poll.py -q