### PR TITLE
Recover audit protocol-only phases

### DIFF
--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -777,20 +777,22 @@ class KanbanAdapter:
             pipeline_info = pipeline_summary(state)
             if pipeline_info.get("missing_evidence") and agg == "running":
                 pipeline_info["gate"] = "evidence_required"
-            if pipeline_info.get("terminal_block") and agg not in {"done", "blocked"}:
+            current_phase = pipeline_info.get("phase")
+            current_status = pipeline_info.get("status")
+            if is_v4 and current_status == "done":
+                agg = "done"
+                blocker = None
+            elif pipeline_info.get("terminal_block"):
                 agg = "blocked"
-                blocker = blocker or f"pipeline terminal block at {pipeline_info.get('phase')}"
-            elif agg not in {"done", "blocked"} and is_v4:
-                current_phase = pipeline_info.get("phase")
-                current_status = pipeline_info.get("status")
-                if current_status == "done":
-                    agg = "done"
-                elif current_status == "blocked":
+                blocker = blocker or f"pipeline terminal block at {current_phase}"
+            elif is_v4:
+                if current_status == "blocked":
                     agg = "blocked"
                     blocker = blocker or f"pipeline blocked at {current_phase}"
                 elif current_status == "todo" and current_phase not in phases:
                     agg = "partial"
-                else:
+                    blocker = None
+                elif agg not in {"done", "blocked"}:
                     agg = "running"
         except Exception as exc:
             logger.warning("kanban_adapter: pipeline sync failed for %s: %s", external_ref, exc)

--- a/services/zoe-data/pipeline_store.py
+++ b/services/zoe-data/pipeline_store.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any, Awaitable, Callable
 
 from pipeline_evidence import (
+    EvidenceItem,
     PipelinePhase,
     PipelineState,
     block_fingerprint,
@@ -137,6 +138,66 @@ async def _append_harness_validators(state: PipelineState, phase: PipelinePhase)
     return with_evidence(state, validator_evidence_item(result, phase=phase))
 
 
+def _protocol_only_block(detail: dict[str, Any]) -> bool:
+    """True when Hermes only failed the terminal protocol for a no-op phase."""
+    protocol_seen = False
+
+    def classify(text: str) -> bool | None:
+        lowered = text.strip().lower()
+        if not lowered:
+            return None
+        if "protocol violation" in lowered or "without calling kanban_complete" in lowered:
+            return True
+        if lowered in {"crashed", "failed"}:
+            return None
+        return False
+
+    for event in detail.get("events") or []:
+        if not isinstance(event, dict):
+            continue
+        if event.get("kind") == "protocol_violation":
+            protocol_seen = True
+        payload = event.get("payload")
+        if isinstance(payload, dict):
+            for value in (payload.get("error"), payload.get("trigger_outcome"), payload.get("reason")):
+                verdict = classify(str(value or ""))
+                if verdict is False:
+                    return False
+                protocol_seen = protocol_seen or verdict is True
+    for run in detail.get("runs") or []:
+        if not isinstance(run, dict):
+            continue
+        for value in (run.get("error"), run.get("outcome"), run.get("status")):
+            verdict = classify(str(value or ""))
+            if verdict is False:
+                return False
+            protocol_seen = protocol_seen or verdict is True
+    return protocol_seen
+
+
+def _append_audit_protocol_recovery_evidence(state: PipelineState, phase: PipelinePhase) -> PipelineState:
+    kind_by_phase = {
+        "scout": "tool",
+        "implement": "tool",
+        "verify": "validator",
+        "review": "human",
+        "closeout": "log",
+        "retro": "log",
+    }
+    kind = kind_by_phase[phase]
+    if any(item.kind == kind and item.metadata.get("phase") == phase for item in state.evidence):
+        return state
+    return with_evidence(
+        state,
+        EvidenceItem(
+            kind=kind,  # type: ignore[arg-type]
+            summary=f"audit/no-PR {phase} auto-recovered after protocol-only Hermes exit",
+            passed=True,
+            metadata={"source": "audit_protocol_recovery", "phase": phase},
+        ),
+    )
+
+
 def _latest_retro_followup(state: PipelineState) -> dict[str, Any] | None:
     for item in reversed(state.evidence):
         if item.kind != "log":
@@ -247,6 +308,22 @@ async def sync_pipeline_from_chain(
         outcome = infer_outcome(phase, row_status, detail)  # type: ignore[arg-type]
         if not outcome:
             continue
+        if (
+            state.evidence_profile == "audit"
+            and outcome in {"block", "verification_failed", "request_changes", "merge_blocked"}
+            and _protocol_only_block(detail)
+        ):
+            state = _append_audit_protocol_recovery_evidence(state, phase)  # type: ignore[arg-type]
+            if can_complete_phase(state):
+                await _run_io(
+                    partial(
+                        save_state,
+                        state,
+                        event="audit_protocol_recovered",
+                        extra={"row_phase": phase, "outcome": outcome},
+                    )
+                )
+                outcome = "complete"
 
         block_reason = None
         split_requested = False

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -591,6 +591,63 @@ async def test_poll_v4_pipeline_sync_failure_blocks_redispatch(monkeypatch):
     assert "pipeline store unavailable" in out["pipeline"]["error"]
 
 
+
+
+
+
+@pytest.mark.asyncio
+async def test_poll_non_v4_pipeline_terminal_block_stays_blocked():
+    from pipeline_evidence import PipelineState
+    from pipeline_store import save_state
+
+    state = PipelineState(
+        task_ref="multica:uuid-9",
+        phase="implement",
+        status="blocked",
+        repeated_block_count=2,
+        last_block_fingerprint="abc123",
+    )
+    save_state(state, event="fingerprint_abort")
+    rows = [_row("implement", "running")]
+    a = _FakeAdapter(list_rows=rows)
+    out = await a.poll("multica:uuid-9")
+
+    assert out["status"] == "blocked"
+    assert "pipeline terminal block" in out["blocker"]
+
+
+@pytest.mark.asyncio
+async def test_poll_v4_audit_protocol_recovery_reports_partial_for_next_phase():
+    from pipeline_store import bootstrap_state
+
+    await bootstrap_state(
+        "multica:uuid-9",
+        issue={"description": "evidence_profile: audit"},
+    )
+    rows = [_row("implement", "blocked", chain_version="v4", block_reason="implement blocked")]
+    show = {
+        "t_implement": {
+            "latest_summary": "",
+            "comments": [],
+            "events": [{"kind": "protocol_violation", "payload": {"exit_code": 0}}],
+            "runs": [
+                {
+                    "status": "crashed",
+                    "outcome": "crashed",
+                    "error": "worker exited cleanly without calling kanban_complete",
+                }
+            ],
+        }
+    }
+    a = _FakeAdapter(list_rows=rows, show_map=show)
+    out = await a.poll("multica:uuid-9")
+
+    assert out["status"] == "partial"
+    assert out["blocker"] is None
+    assert out["pipeline"]["phase"] == "verify"
+    assert out["pipeline"]["status"] == "todo"
+
+
 @pytest.mark.asyncio
 async def test_poll_v4_does_not_promote_kanban_blocked_to_partial():
     rows = [_row("implement", "blocked", chain_version="v4", block_reason="dirty tree")]

--- a/services/zoe-data/tests/test_pipeline_store.py
+++ b/services/zoe-data/tests/test_pipeline_store.py
@@ -124,6 +124,72 @@ async def test_sync_pipeline_audit_only_verify_skips_test_gate(isolated_store):
     assert not any("gate_blocked" in line for line in isolated_store.read_text(encoding="utf-8").splitlines())
 
 
+
+
+@pytest.mark.asyncio
+async def test_sync_pipeline_recovers_audit_protocol_only_block(isolated_store):
+    await store.bootstrap_state(
+        "multica:audit-protocol",
+        issue={"description": "evidence_profile: audit"},
+    )
+
+    async def fetch_detail(_task_id: str):
+        return {
+            "latest_summary": "",
+            "comments": [],
+            "events": [{"kind": "protocol_violation", "payload": {"exit_code": 0}}],
+            "runs": [
+                {
+                    "status": "crashed",
+                    "outcome": "crashed",
+                    "error": "worker exited cleanly without calling kanban_complete",
+                }
+            ],
+        }
+
+    phases = {"implement": {"id": "t1", "status": "blocked", "block_reason": "implement blocked"}}
+    state = await store.sync_pipeline_from_chain("multica:audit-protocol", phases, fetch_detail)
+
+    assert state.phase == "verify"
+    assert state.status == "todo"
+    assert any(
+        item.kind == "tool" and item.metadata.get("source") == "audit_protocol_recovery"
+        for item in state.evidence
+    )
+    assert "audit_protocol_recovered" in isolated_store.read_text(encoding="utf-8")
+
+
+
+
+@pytest.mark.asyncio
+async def test_sync_pipeline_does_not_recover_mixed_protocol_and_real_block(isolated_store):
+    await store.bootstrap_state(
+        "multica:audit-mixed-block",
+        issue={"description": "evidence_profile: audit"},
+    )
+
+    async def fetch_detail(_task_id: str):
+        return {
+            "latest_summary": "",
+            "comments": [],
+            "events": [{"kind": "protocol_violation", "payload": {"exit_code": 0}}],
+            "runs": [
+                {
+                    "status": "crashed",
+                    "outcome": "crashed",
+                    "error": "dirty tree prevented evidence collection",
+                }
+            ],
+        }
+
+    phases = {"implement": {"id": "t1", "status": "blocked", "block_reason": "dirty tree"}}
+    state = await store.sync_pipeline_from_chain("multica:audit-mixed-block", phases, fetch_detail)
+
+    assert state.phase == "implement"
+    assert state.status == "blocked"
+    assert "audit_protocol_recovered" not in isolated_store.read_text(encoding="utf-8")
+
+
 @pytest.mark.asyncio
 async def test_sync_pipeline_fingerprint_abort(isolated_store):
     await store.bootstrap_state("multica:fp")


### PR DESCRIPTION
## Summary
- let audit/no-PR phases recover from protocol-only Hermes exits by writing synthetic phase evidence in the journal
- allow v4 poll status to follow recovered journal state instead of an older blocked Kanban row
- add store and adapter tests for audit protocol recovery and next-phase redispatch

## Validation
- PYTHONPATH=services/zoe-data python3 -m pytest services/zoe-data/tests/test_kanban_adapter.py services/zoe-data/tests/test_pipeline_store.py services/zoe-data/tests/test_pipeline_handoff.py services/zoe-data/tests/test_pipeline_evidence.py services/zoe-data/tests/test_main_multica_poll.py -q