### PR TITLE
Keep recovered audit runs active

### DIFF
--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -792,6 +792,9 @@ class KanbanAdapter:
                 elif current_status == "todo" and current_phase not in phases:
                     agg = "partial"
                     blocker = None
+                elif current_status == "running":
+                    agg = "running"
+                    blocker = None
                 elif agg not in {"done", "blocked"}:
                     agg = "running"
         except Exception as exc:

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -616,6 +616,48 @@ async def test_poll_non_v4_pipeline_terminal_block_stays_blocked():
     assert "pipeline terminal block" in out["blocker"]
 
 
+
+
+@pytest.mark.asyncio
+async def test_poll_v4_running_pipeline_clears_stale_recovered_blocker():
+    from pipeline_evidence import EvidenceItem, PipelineState
+    from pipeline_store import save_state
+
+    state = PipelineState(
+        task_ref="multica:uuid-9",
+        phase="verify",
+        status="running",
+        evidence_profile="audit",
+        attempts={"implement": 1, "verify": 1},
+        evidence=[
+            EvidenceItem(
+                kind="tool",
+                summary="audit/no-PR implement auto-recovered",
+                passed=True,
+                metadata={"source": "audit_protocol_recovery", "phase": "implement"},
+            ),
+            EvidenceItem(
+                kind="validator",
+                summary="verify pending",
+                passed=True,
+                metadata={"phase": "verify"},
+            ),
+        ],
+    )
+    save_state(state, event="effect_requested")
+    rows = [
+        _row("implement", "blocked", chain_version="v4", block_reason="implement blocked"),
+        _row("verify", "running", chain_version="v4"),
+    ]
+    a = _FakeAdapter(list_rows=rows)
+    out = await a.poll("multica:uuid-9")
+
+    assert out["status"] == "running"
+    assert out["blocker"] is None
+    assert out["pipeline"]["phase"] == "verify"
+    assert out["pipeline"]["status"] == "running"
+
+
 @pytest.mark.asyncio
 async def test_poll_v4_audit_protocol_recovery_reports_partial_for_next_phase():
     from pipeline_store import bootstrap_state


### PR DESCRIPTION
## Summary
- keep v4 poll status running when the journal has advanced to a running current phase after an older blocked row was recovered
- clear stale blockers from prior recovered phases so Multica is not marked blocked mid-run
- add adapter coverage for stale blocker override during audit protocol recovery

## Validation
- PYTHONPATH=services/zoe-data python3 -m pytest services/zoe-data/tests/test_kanban_adapter.py services/zoe-data/tests/test_pipeline_store.py services/zoe-data/tests/test_pipeline_handoff.py services/zoe-data/tests/test_pipeline_evidence.py services/zoe-data/tests/test_main_multica_poll.py -q