### PR TITLE
Skip blocked recovered parents

### DIFF
--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -54,6 +54,7 @@ _V2_CHAIN_PHASES = ("implement", "verify", "review", "closeout")
 
 _ACTIVE_KANBAN_STATUSES = {"triage", "todo", "ready", "running", "blocked"}
 _TERMINAL_KANBAN_STATUSES = {"done", "archived"}
+_BLOCKING_PARENT_STATUSES = {"blocked", "cancelled", "error", "failed"}
 
 _PROTOCOL_VIOLATION_LIMIT = max(
     1, int(os.environ.get("ZOE_KANBAN_PROTOCOL_VIOLATION_LIMIT", "2") or "2")
@@ -621,7 +622,8 @@ class KanbanAdapter:
             idx = phase_order.index(phase)
             if idx > 0:
                 previous = existing_phases.get(phase_order[idx - 1]) or {}
-                parent = previous.get("id")
+                if (previous.get("status") or "").lower() not in _BLOCKING_PARENT_STATUSES:
+                    parent = previous.get("id")
 
         phase, assignee, skills = entry
         args = [

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -94,6 +94,88 @@ async def test_dispatch_refuses_to_create_without_pipeline_journal(monkeypatch):
     assert [c for c in a.calls if c[0] == "create"] == []
 
 
+
+
+@pytest.mark.asyncio
+async def test_dispatch_does_not_parent_recovered_phase_to_blocked_prior_row():
+    from pipeline_evidence import EvidenceItem, PipelineState
+    from pipeline_store import save_state
+
+    state = PipelineState(
+        task_ref="multica:uuid-recovered-parent",
+        phase="verify",
+        status="todo",
+        evidence_profile="audit",
+        attempts={"implement": 1},
+        evidence=[
+            EvidenceItem(
+                kind="tool",
+                summary="audit/no-PR implement auto-recovered",
+                passed=True,
+                metadata={"source": "audit_protocol_recovery", "phase": "implement"},
+            )
+        ],
+    )
+    save_state(state, event="transition")
+    rows = [_row("implement", "blocked", chain_version="v4", issue_id="uuid-recovered-parent")]
+    a = _FakeAdapter(list_rows=rows)
+    result = await a.dispatch(
+        {
+            "id": "uuid-recovered-parent",
+            "identifier": "ZOE-REC",
+            "title": "audit-only recovered parent",
+            "description": "evidence_profile: audit",
+        }
+    )
+
+    creates = [c for c in a.calls if c[0] == "create"]
+    assert result["ok"] is True
+    assert result["phase"] == "verify"
+    assert len(creates) == 1
+    assert "--parent" not in creates[0]
+
+
+
+
+@pytest.mark.asyncio
+async def test_dispatch_does_not_parent_recovered_phase_to_terminal_like_prior_row():
+    from pipeline_evidence import EvidenceItem, PipelineState
+    from pipeline_store import save_state
+
+    state = PipelineState(
+        task_ref="multica:uuid-recovered-error-parent",
+        phase="verify",
+        status="todo",
+        evidence_profile="audit",
+        attempts={"implement": 1},
+        evidence=[
+            EvidenceItem(
+                kind="tool",
+                summary="audit/no-PR implement auto-recovered",
+                passed=True,
+                metadata={"source": "audit_protocol_recovery", "phase": "implement"},
+            )
+        ],
+    )
+    save_state(state, event="transition")
+    rows = [_row("implement", "error", chain_version="v4", issue_id="uuid-recovered-error-parent")]
+    a = _FakeAdapter(list_rows=rows)
+    result = await a.dispatch(
+        {
+            "id": "uuid-recovered-error-parent",
+            "identifier": "ZOE-REC",
+            "title": "audit-only recovered parent",
+            "description": "evidence_profile: audit",
+        }
+    )
+
+    creates = [c for c in a.calls if c[0] == "create"]
+    assert result["ok"] is True
+    assert result["phase"] == "verify"
+    assert len(creates) == 1
+    assert "--parent" not in creates[0]
+
+
 @pytest.mark.asyncio
 async def test_dispatch_after_scout_evidence_creates_next_phase():
     from pipeline_store import bootstrap_state, save_state


### PR DESCRIPTION
## Summary
- avoid parenting a recovered audit phase to a prior blocked Kanban row
- let journal-advanced audit phases run independently when the previous Hermes task ended protocol-blocked
- add adapter coverage for recovered parentless phase dispatch

## Validation
- PYTHONPATH=services/zoe-data python3 -m pytest services/zoe-data/tests/test_kanban_adapter.py services/zoe-data/tests/test_pipeline_store.py services/zoe-data/tests/test_pipeline_handoff.py services/zoe-data/tests/test_pipeline_evidence.py services/zoe-data/tests/test_main_multica_poll.py -q