### PR TITLE
Ignore stale prior blockers in v4 poll state

### DIFF
--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -784,21 +784,26 @@ class KanbanAdapter:
             if is_v4 and current_status == "done":
                 agg = "done"
                 blocker = None
-            elif pipeline_info.get("terminal_block"):
-                agg = "blocked"
-                blocker = blocker or f"pipeline terminal block at {current_phase}"
             elif is_v4:
-                if current_status == "blocked":
+                if pipeline_info.get("terminal_block"):
                     agg = "blocked"
-                    blocker = blocker or f"pipeline blocked at {current_phase}"
-                elif current_status == "todo" and current_phase not in phases:
-                    agg = "partial"
+                    blocker = f"pipeline terminal block at {current_phase}"
+                elif current_status == "blocked":
+                    agg = "blocked"
+                    current_row = phases.get(str(current_phase or ""), {})
+                    blocker = current_row.get("block_reason") or f"pipeline blocked at {current_phase}"
+                elif current_status == "todo":
+                    agg = "partial" if current_phase not in phases else "running"
                     blocker = None
                 elif current_status == "running":
                     agg = "running"
                     blocker = None
                 elif agg not in {"done", "blocked"}:
                     agg = "running"
+                    blocker = None
+            elif pipeline_info.get("terminal_block"):
+                agg = "blocked"
+                blocker = blocker or f"pipeline terminal block at {current_phase}"
         except Exception as exc:
             logger.warning("kanban_adapter: pipeline sync failed for %s: %s", external_ref, exc)
             pipeline_info = {

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -741,6 +741,87 @@ async def test_poll_v4_running_pipeline_clears_stale_recovered_blocker():
 
 
 @pytest.mark.asyncio
+async def test_poll_v4_partial_clears_stale_prior_phase_blocker():
+    from pipeline_evidence import EvidenceItem, PipelineState
+    from pipeline_store import save_state
+
+    state = PipelineState(
+        task_ref="multica:uuid-9",
+        phase="verify",
+        status="todo",
+        evidence_profile="audit",
+        attempts={"scout": 1, "implement": 1},
+        evidence=[
+            EvidenceItem(
+                kind="tool",
+                summary="audit/no-PR scout auto-recovered",
+                passed=True,
+                metadata={"source": "audit_protocol_recovery", "phase": "scout"},
+            ),
+            EvidenceItem(
+                kind="tool",
+                summary="audit/no-PR implement auto-recovered",
+                passed=True,
+                metadata={"source": "audit_protocol_recovery", "phase": "implement"},
+            ),
+        ],
+    )
+    save_state(state, event="transition")
+    rows = [
+        _row("scout", "blocked", chain_version="v4"),
+        _row("implement", "blocked", chain_version="v4"),
+    ]
+    a = _FakeAdapter(list_rows=rows)
+    out = await a.poll("multica:uuid-9")
+
+    assert out["status"] == "partial"
+    assert out["blocker"] is None
+    assert out["pipeline"]["phase"] == "verify"
+    assert out["pipeline"]["status"] == "todo"
+
+
+@pytest.mark.asyncio
+async def test_poll_v4_todo_existing_phase_clears_stale_prior_blocker():
+    from pipeline_evidence import EvidenceItem, PipelineState
+    from pipeline_store import save_state
+
+    state = PipelineState(
+        task_ref="multica:uuid-9",
+        phase="verify",
+        status="todo",
+        evidence_profile="audit",
+        attempts={"scout": 1, "implement": 1, "verify": 1},
+        evidence=[
+            EvidenceItem(
+                kind="tool",
+                summary="audit/no-PR scout auto-recovered",
+                passed=True,
+                metadata={"source": "audit_protocol_recovery", "phase": "scout"},
+            ),
+            EvidenceItem(
+                kind="tool",
+                summary="audit/no-PR implement auto-recovered",
+                passed=True,
+                metadata={"source": "audit_protocol_recovery", "phase": "implement"},
+            ),
+        ],
+    )
+    save_state(state, event="transition")
+    rows = [
+        _row("scout", "blocked", chain_version="v4"),
+        _row("implement", "blocked", chain_version="v4"),
+        _row("verify", "ready", chain_version="v4"),
+    ]
+    a = _FakeAdapter(list_rows=rows)
+    out = await a.poll("multica:uuid-9")
+
+    assert out["status"] == "running"
+    assert out["blocker"] is None
+    assert out["pipeline"]["phase"] == "verify"
+    assert out["pipeline"]["status"] == "todo"
+
+
+@pytest.mark.asyncio
 async def test_poll_v4_audit_protocol_recovery_reports_partial_for_next_phase():
     from pipeline_store import bootstrap_state
 


### PR DESCRIPTION
## Summary
- let v4 pipeline state override stale blocked rows from prior phases after recovery
- preserve current-phase blocker messages for genuine blocked states
- add regression coverage from live Multica ticket ZOE-5415

## Tests
- PYTHONPATH=services/zoe-data python3 -m pytest services/zoe-data/tests/test_kanban_adapter.py services/zoe-data/tests/test_pipeline_store.py services/zoe-data/tests/test_pipeline_handoff.py services/zoe-data/tests/test_pipeline_evidence.py services/zoe-data/tests/test_main_multica_poll.py -q