### PR TITLE
Guard Multica dispatch by active chains

### DIFF
--- a/services/zoe-data/main.py
+++ b/services/zoe-data/main.py
@@ -407,7 +407,7 @@ async def lifespan(app: FastAPI):
                     from multica_webhook_emitter import emit_issue_assigned, is_configured as _wh_ok
                     from multica_client import get_engineering_multica_agent_id  # type: ignore[import]
                     from executor_registry import poll_ref  # type: ignore[import]
-                    from multica_poll_dispatch import chain_needs_dispatch  # type: ignore[import]
+                    from multica_poll_dispatch import chain_is_running, chain_needs_dispatch  # type: ignore[import]
 
                     if _wh_ok():
                         _hermes = str(get_engineering_multica_agent_id())
@@ -418,8 +418,31 @@ async def lifespan(app: FastAPI):
                             _wh_limit = int(os.environ.get("ZOE_MULTICA_POLL_DISPATCH_LIMIT", "1") or "1")
                         except ValueError:
                             _wh_limit = 1
-                        _wh_dispatched = 0
+                        _chain_cache: dict[str, dict] = {}
+
+                        async def _poll_chain(_tid: str) -> dict:
+                            if _tid not in _chain_cache:
+                                _chain_cache[_tid] = await poll_ref(f"multica:{_tid}")
+                            return _chain_cache[_tid]
+
+                        _running_chains = 0
+                        for _ip_issue in in_progress_issues:
+                            if str(_ip_issue.get("assignee_id") or "") != _hermes:
+                                continue
+                            if (_ip_issue.get("title") or "").lower().startswith("autopilot:"):
+                                continue
+                            _ip_tid = str(_ip_issue.get("id") or "")
+                            if _ip_tid and chain_is_running(await _poll_chain(_ip_tid)):
+                                _running_chains += 1
+
+                        _wh_dispatched = min(_running_chains, _wh_limit)
                         _wh_dispatched_ids: set[str] = set()
+                        if _running_chains >= _wh_limit:
+                            logger.info(
+                                "multica_poll: dispatch paused; %d running Hermes chain(s) already at limit %d",
+                                _running_chains,
+                                _wh_limit,
+                            )
 
                         async def _maybe_dispatch_hermes_issue(_candidate: dict, *, from_todo: bool) -> None:
                             nonlocal _wh_dispatched
@@ -432,7 +455,7 @@ async def lifespan(app: FastAPI):
                             _tid = str(_candidate.get("id") or "")
                             if not _tid:
                                 return
-                            _chain = await poll_ref(f"multica:{_tid}")
+                            _chain = await _poll_chain(_tid)
                             if not chain_needs_dispatch(_chain):
                                 return
                             _emit = await emit_issue_assigned(_candidate)
@@ -455,18 +478,20 @@ async def lifespan(app: FastAPI):
                                     "todo" if from_todo else "in_progress-backfill",
                                 )
 
-                        # Reuse the todo list already fetched above for the stale autopilot pass.
-                        for _todo in stale_todos or []:
-                            await _maybe_dispatch_hermes_issue(_todo, from_todo=True)
-                            if _wh_dispatched >= _wh_limit:
-                                break
-                        # Backfill: in_progress Multica rows with no Kanban chain (e.g. manual
-                        # status moves or dispatch that never created tasks).
+                        # Backfill existing in-progress runs before starting fresh todo work.
+                        # A partial chain owns the one active ticket lane but still needs this
+                        # dispatch path to create its next ready phase.
                         if _wh_dispatched < _wh_limit:
                             for _ip_issue in in_progress_issues:
                                 if str(_ip_issue.get("id") or "") in _wh_dispatched_ids:
                                     continue
                                 await _maybe_dispatch_hermes_issue(_ip_issue, from_todo=False)
+                                if _wh_dispatched >= _wh_limit:
+                                    break
+                        # Reuse the todo list already fetched above for the stale autopilot pass.
+                        if _wh_dispatched < _wh_limit:
+                            for _todo in stale_todos or []:
+                                await _maybe_dispatch_hermes_issue(_todo, from_todo=True)
                                 if _wh_dispatched >= _wh_limit:
                                     break
                 except Exception as _wh_exc:

--- a/services/zoe-data/multica_poll_dispatch.py
+++ b/services/zoe-data/multica_poll_dispatch.py
@@ -25,3 +25,34 @@ def chain_needs_dispatch(chain: dict) -> bool:
     if not chain.get("found"):
         return status == "not_found"
     return False
+
+
+def _pipeline_suppressed(chain: dict) -> bool:
+    pipeline = chain.get("pipeline") or {}
+    return bool(pipeline.get("terminal_block") or pipeline.get("fingerprint_abort"))
+
+
+def chain_is_active(chain: dict) -> bool:
+    """Return True when a chain belongs to the one-ticket-at-a-time lane.
+
+    ``running`` is actively executing. ``partial`` means the journal has an
+    existing run with a ready next phase that still needs dispatch, so it must
+    also stay in the active lane. Terminal pipeline flags suppress dispatch and
+    therefore also suppress occupying a slot.
+    """
+    if not chain or _pipeline_suppressed(chain):
+        return False
+    if chain.get("status") in ("running", "partial"):
+        return True
+    pipeline = chain.get("pipeline") or {}
+    return pipeline.get("status") in ("running", "todo")
+
+
+def chain_is_running(chain: dict) -> bool:
+    """Return True only for active chains that do not need another dispatch."""
+    if not chain or _pipeline_suppressed(chain):
+        return False
+    if chain.get("status") == "running":
+        return True
+    pipeline = chain.get("pipeline") or {}
+    return pipeline.get("status") == "running"

--- a/services/zoe-data/tests/test_multica_poll_dispatch.py
+++ b/services/zoe-data/tests/test_multica_poll_dispatch.py
@@ -1,5 +1,5 @@
 """Tests for Multica poll-loop dispatch helpers."""
-from multica_poll_dispatch import chain_needs_dispatch
+from multica_poll_dispatch import chain_is_active, chain_is_running, chain_needs_dispatch
 import executors.kanban_adapter as ka
 
 
@@ -52,3 +52,28 @@ def test_chain_needs_dispatch_false_when_blocked_protocol_violation():
         "blocker": "BLOCKER=PROTOCOL_VIOLATION: worker exited without kanban_complete/kanban_block",
     }
     assert chain_needs_dispatch(chain) is False
+
+
+def test_chain_is_active_counts_running_and_partial():
+    assert chain_is_active({"found": True, "status": "running"}) is True
+    assert chain_is_active({"found": True, "status": "partial"}) is True
+    assert chain_is_active({"found": True, "status": "blocked"}) is False
+    assert chain_is_active({"found": True, "status": "done"}) is False
+    assert chain_is_active({"found": False, "status": "not_found"}) is False
+
+
+def test_chain_is_active_counts_journal_ready_phase_without_terminal_block():
+    assert chain_is_active({"pipeline": {"status": "todo"}}) is True
+    assert chain_is_active({"pipeline": {"status": "running"}}) is True
+    assert chain_is_active({"status": "partial", "pipeline": {"terminal_block": True}}) is False
+    assert chain_is_active({"status": "partial", "pipeline": {"fingerprint_abort": True}}) is False
+    assert chain_is_active({"pipeline": {"status": "todo", "terminal_block": True}}) is False
+    assert chain_is_active({"pipeline": {"status": "todo", "fingerprint_abort": True}}) is False
+
+
+def test_chain_is_running_excludes_partial_backfill_work():
+    assert chain_is_running({"found": True, "status": "running"}) is True
+    assert chain_is_running({"found": True, "status": "partial"}) is False
+    assert chain_is_running({"pipeline": {"status": "running"}}) is True
+    assert chain_is_running({"pipeline": {"status": "todo"}}) is False
+    assert chain_is_running({"status": "running", "pipeline": {"terminal_block": True}}) is False


### PR DESCRIPTION
## Summary
- count active Hermes in-progress chains before dispatching any todo tickets
- treat running and partial journal states as occupying the single active slot
- cache poll_ref results within a poll cycle to avoid duplicate chain reads

## Tests
- PYTHONPATH=services/zoe-data python3 -m pytest services/zoe-data/tests/test_multica_poll_dispatch.py services/zoe-data/tests/test_main_multica_poll.py services/zoe-data/tests/test_kanban_adapter.py services/zoe-data/tests/test_pipeline_store.py services/zoe-data/tests/test_pipeline_handoff.py services/zoe-data/tests/test_pipeline_evidence.py -q