### PR TITLE
ZOE-5347: Fix hardcoded localhost URLs in zoe_agent.py

### DIFF
--- a/services/zoe-data/tests/test_zoe_agent_skills.py
+++ b/services/zoe-data/tests/test_zoe_agent_skills.py
@@ -75,6 +75,18 @@ class TestSelectSkills:
         assert skills == set(zoe_agent._SKILL_TOOLS.keys())
 
 
+# ── Zoe self URL ──────────────────────────────────────────────────────────────
+
+def test_zoe_base_url_uses_env_and_strips_trailing_slash(monkeypatch):
+    monkeypatch.setenv("ZOE_CHAT_URL", "https://zoe.example.test/base/")
+    assert zoe_agent._zoe_base_url() == "https://zoe.example.test/base"
+
+
+def test_zoe_base_url_defaults_to_local_service(monkeypatch):
+    monkeypatch.delenv("ZOE_CHAT_URL", raising=False)
+    assert zoe_agent._zoe_base_url() == "http://localhost:8000"
+
+
 # ── _build_tools ──────────────────────────────────────────────────────────────
 
 class TestBuildTools:

--- a/services/zoe-data/zoe_agent.py
+++ b/services/zoe-data/zoe_agent.py
@@ -2856,7 +2856,8 @@ async def _dispatch_tool(tool_name: str, args: dict, user_id: str = "family-admi
     if tool_name == "list_openclaw_plugins":
         try:
             async with httpx.AsyncClient(timeout=5) as client:
-                r = await client.get("http://localhost:8000/api/openclaw/plugins")
+                base_url = str(os.environ.get("ZOE_CHAT_URL", "http://localhost:8000")).rstrip("/")
+                r = await client.get(f"{base_url}/api/openclaw/plugins")
                 plugin_data = r.json() if r.status_code == 200 else {"plugins": []}
         except Exception:
             plugin_data = {"plugins": []}
@@ -2869,7 +2870,8 @@ async def _dispatch_tool(tool_name: str, args: dict, user_id: str = "family-admi
     if tool_name == "list_openclaw_skills":
         try:
             async with httpx.AsyncClient(timeout=8) as client:
-                r = await client.get("http://localhost:8000/api/openclaw/skills")
+                base_url = str(os.environ.get("ZOE_CHAT_URL", "http://localhost:8000")).rstrip("/")
+                r = await client.get(f"{base_url}/api/openclaw/skills")
                 skill_data = r.json() if r.status_code == 200 else {"skills": []}
         except Exception:
             skill_data = {"skills": []}

--- a/services/zoe-data/zoe_agent.py
+++ b/services/zoe-data/zoe_agent.py
@@ -2705,6 +2705,10 @@ def _cap_tool_result(tool_name: str, result: str) -> str:
 
 # ── Tool dispatch ─────────────────────────────────────────────────────────────
 
+def _zoe_base_url() -> str:
+    return str(os.environ.get("ZOE_CHAT_URL", "http://localhost:8000")).rstrip("/")
+
+
 async def _dispatch_tool(tool_name: str, args: dict, user_id: str = "family-admin") -> str:
     """Dispatch a tool call and return result as string."""
     if tool_name in {
@@ -2731,7 +2735,7 @@ async def _dispatch_tool(tool_name: str, args: dict, user_id: str = "family-admi
     if tool_name == "open_touch_page":
         page = str((args or {}).get("page", "")).strip().lower()
         panel_id = str((args or {}).get("panel_id") or os.environ.get("ZOE_PANEL_ID", "zoe-touch-pi")).strip()
-        base_url = str(os.environ.get("ZOE_CHAT_URL", "http://localhost:8000")).rstrip("/")
+        base_url = _zoe_base_url()
         page_map = {
             "weather": f"{base_url}/touch/weather.html",
             "calendar": f"{base_url}/touch/calendar.html",
@@ -2856,7 +2860,7 @@ async def _dispatch_tool(tool_name: str, args: dict, user_id: str = "family-admi
     if tool_name == "list_openclaw_plugins":
         try:
             async with httpx.AsyncClient(timeout=5) as client:
-                base_url = str(os.environ.get("ZOE_CHAT_URL", "http://localhost:8000")).rstrip("/")
+                base_url = _zoe_base_url()
                 r = await client.get(f"{base_url}/api/openclaw/plugins")
                 plugin_data = r.json() if r.status_code == 200 else {"plugins": []}
         except Exception:
@@ -2870,7 +2874,7 @@ async def _dispatch_tool(tool_name: str, args: dict, user_id: str = "family-admi
     if tool_name == "list_openclaw_skills":
         try:
             async with httpx.AsyncClient(timeout=8) as client:
-                base_url = str(os.environ.get("ZOE_CHAT_URL", "http://localhost:8000")).rstrip("/")
+                base_url = _zoe_base_url()
                 r = await client.get(f"{base_url}/api/openclaw/skills")
                 skill_data = r.json() if r.status_code == 200 else {"skills": []}
         except Exception:


### PR DESCRIPTION
## Summary

Fixes ZOE-5347: Replace hardcoded  URLs in  lines 2859 and 2872 with  environment variable usage to match the existing pattern at line 2734.

## Changes

- Modified  tool handler (line 2859) to use 
- Modified  tool handler (line 2872) to use 
- Both now follow the same pattern as  tool handler

## Impact

OpenClaw plugin and skill discovery will now work correctly when Zoe is deployed behind reverse proxies, in containers with different internal hostnames, or on non-standard ports.

## Testing

- ✅ Python compilation passes
- ✅ Project structure validation passes
- ✅ Manual verification of URL construction pattern matches existing implementation

## Related Issues

This addresses the specific issue reported in ZOE-5347. Note that similar hardcoded URLs exist in  for A2A federation calls (lines 1407, 1408, 1409, 1458, 1557) - these should be addressed in a separate ticket as recommended by the scout analysis.