### PR TITLE
Accept explicit approved review metadata

### DIFF
--- a/services/zoe-data/pipeline_handoff.py
+++ b/services/zoe-data/pipeline_handoff.py
@@ -212,13 +212,15 @@ def _human_review_from_metadata(detail: dict[str, Any]) -> EvidenceItem | None:
         readiness = str(metadata.get("merge_readiness") or "").strip().lower()
         verdict = str(metadata.get("verdict") or "").strip().lower()
         explicit_verdict_ready = metadata.get("merge_ready") is True and verdict in {"approve", "approved"}
-        if explicit_verdict_ready:
+        explicit_approved_ready = metadata.get("approved") is True and readiness == "ready"
+        explicit_approval = explicit_verdict_ready or explicit_approved_ready
+        if explicit_approval:
             readiness = "merge_ready"
         task = detail.get("task") if isinstance(detail.get("task"), dict) else {}
         explicit_approver = metadata.get("approver") or metadata.get("approved_by")
         approver = str(
             explicit_approver
-            or (task.get("assignee") if explicit_verdict_ready else "")
+            or (task.get("assignee") if explicit_approval else "")
             or ""
         ).strip()
 

--- a/services/zoe-data/tests/test_pipeline_handoff.py
+++ b/services/zoe-data/tests/test_pipeline_handoff.py
@@ -202,6 +202,25 @@ def test_evidence_from_review_ignores_ready_without_explicit_approval():
     assert not any(item.kind == "human" for item in items)
 
 
+def test_evidence_from_review_run_ignores_ready_without_explicit_approval():
+    detail = {
+        "latest_summary": "Reviewer says this looks ready.",
+        "comments": [],
+        "task": {"assignee": "zoe-reviewer"},
+        "runs": [
+            {
+                "metadata": {
+                    "merge_readiness": "ready",
+                }
+            }
+        ],
+    }
+
+    items = evidence_from_handoff("review", detail)
+
+    assert not any(item.kind == "human" for item in items)
+
+
 def test_evidence_from_review_ignores_generic_pass_readiness():
     detail = {
         "latest_summary": "Reviewer pass note",

--- a/services/zoe-data/tests/test_pipeline_handoff.py
+++ b/services/zoe-data/tests/test_pipeline_handoff.py
@@ -118,6 +118,30 @@ def test_evidence_from_live_review_run_metadata_accepts_merge_ready_verdict():
     assert human.metadata["verdict"] == "approve"
 
 
+def test_evidence_from_live_review_run_metadata_accepts_explicit_approved_ready():
+    detail = {
+        "latest_summary": "APPROVE ZOE-5347. Merge-ready.",
+        "comments": [],
+        "task": {"assignee": "zoe-reviewer"},
+        "runs": [
+            {
+                "metadata": {
+                    "approved": True,
+                    "merge_readiness": "ready",
+                }
+            }
+        ],
+    }
+
+    items = evidence_from_handoff("review", detail)
+
+    human = next(item for item in items if item.kind == "human")
+    assert human.passed is True
+    assert human.metadata["source"] == "kanban_run_metadata"
+    assert human.metadata["approver"] == "zoe-reviewer"
+    assert human.metadata["merge_readiness"] == "merge_ready"
+
+
 def test_evidence_from_review_metadata_accepts_approved_readiness():
     detail = {
         "latest_summary": "Approved after review.",
@@ -155,6 +179,21 @@ def test_evidence_from_review_ignores_legacy_readiness_with_only_task_assignee()
         "task": {"assignee": "zoe-reviewer"},
         "metadata": {
             "merge_readiness": "merge_ready",
+        },
+    }
+
+    items = evidence_from_handoff("review", detail)
+
+    assert not any(item.kind == "human" for item in items)
+
+
+def test_evidence_from_review_ignores_ready_without_explicit_approval():
+    detail = {
+        "latest_summary": "Reviewer says this looks ready.",
+        "comments": [],
+        "task": {"assignee": "zoe-reviewer"},
+        "metadata": {
+            "merge_readiness": "ready",
         },
     }
 


### PR DESCRIPTION
## Summary
- recognize Hermes review runs that emit approved=true with merge_readiness=ready
- require explicit approval before using the assigned reviewer as approver identity
- preserve rejection of readiness-only metadata

## Validation
- PYTHONPATH=services/zoe-data python3 -m pytest services/zoe-data/tests/test_pipeline_handoff.py services/zoe-data/tests/test_pipeline_store.py services/zoe-data/tests/test_kanban_adapter.py services/zoe-data/tests/test_multica_poll_dispatch.py services/zoe-data/tests/test_main_multica_poll.py -q
- 120 passed

## Live blocker
Unblocks the journaled ZOE-5347 run at review without creating another Hermes task.