### PR TITLE
Parse structured retro handoff metadata

### DIFF
--- a/services/zoe-data/pipeline_handoff.py
+++ b/services/zoe-data/pipeline_handoff.py
@@ -73,6 +73,29 @@ def _parse_kv_fields(text: str) -> dict[str, str]:
     return out
 
 
+def _structured_handoff_fields(detail: dict[str, Any]) -> dict[str, str]:
+    """Extract explicit KEY=value equivalents from Kanban metadata."""
+    out: dict[str, str] = {}
+    candidates = [detail.get("metadata")]
+    candidates.extend(
+        run.get("metadata")
+        for run in detail.get("runs") or []
+        if isinstance(run, dict)
+    )
+    for metadata in candidates:
+        if not isinstance(metadata, dict):
+            continue
+        for key, value in metadata.items():
+            if not isinstance(key, str) or not re.fullmatch(r"[A-Z_]+", key):
+                continue
+            if value is None or isinstance(value, (dict, list)):
+                continue
+            text = str(value).strip()
+            if text:
+                out[key] = text
+    return out
+
+
 def _json_field_value(text: str, key: str) -> str:
     """Extract a JSON object value from ``KEY=...``, allowing multiline JSON."""
     match = re.search(rf"^{re.escape(key)}=", text or "", re.MULTILINE)
@@ -341,7 +364,7 @@ def evidence_from_handoff(
     skills: tuple[str, ...] | list[str] = (),
 ) -> list[EvidenceItem]:
     """Best-effort extraction of structured evidence from a Kanban task show payload."""
-    fields: dict[str, str] = {}
+    fields = _structured_handoff_fields(detail)
     for chunk in _haystacks(detail):
         fields.update(_parse_kv_fields(chunk))
 

--- a/services/zoe-data/pipeline_handoff.py
+++ b/services/zoe-data/pipeline_handoff.py
@@ -364,7 +364,7 @@ def evidence_from_handoff(
     skills: tuple[str, ...] | list[str] = (),
 ) -> list[EvidenceItem]:
     """Best-effort extraction of structured evidence from a Kanban task show payload."""
-    fields = _structured_handoff_fields(detail)
+    fields = _structured_handoff_fields(detail) if phase == "retro" else {}
     for chunk in _haystacks(detail):
         fields.update(_parse_kv_fields(chunk))
 

--- a/services/zoe-data/tests/test_pipeline_handoff.py
+++ b/services/zoe-data/tests/test_pipeline_handoff.py
@@ -379,6 +379,45 @@ def test_retro_handoff_can_request_followup_ticket():
     assert log.metadata["follow_up"]["source"] == "retro"
 
 
+def test_retro_run_metadata_records_log_and_followup_evidence():
+    detail = {
+        "latest_summary": "Retro complete for ZOE-5347.",
+        "comments": [],
+        "runs": [
+            {
+                "metadata": {
+                    "RETRO": "Closeout reached the merge guard too late.",
+                    "LEARNINGS": "Front-load deterministic guard commands.",
+                    "TOOLS_USED": "kanban_show,terminal",
+                    "FOLLOW_UP_TITLE": "Reduce closeout orchestration overhead",
+                    "FOLLOW_UP_DESCRIPTION": "Run the merge guard before broad repository inspection.",
+                    "changed_files": ["ignored.py"],
+                }
+            }
+        ],
+    }
+
+    items = evidence_from_handoff("retro", detail)
+
+    log = next(item for item in items if item.kind == "log")
+    tool = next(item for item in items if item.kind == "tool")
+    assert log.summary == "Closeout reached the merge guard too late."
+    assert log.metadata["follow_up"]["title"] == "Reduce closeout orchestration overhead"
+    assert tool.summary == "kanban_show,terminal"
+
+
+def test_retro_generic_run_metadata_does_not_create_log_evidence():
+    detail = {
+        "latest_summary": "Retro complete.",
+        "comments": [],
+        "runs": [{"metadata": {"changed_files": ["ignored.py"], "tests_run": "2"}}],
+    }
+
+    items = evidence_from_handoff("retro", detail)
+
+    assert not any(item.kind == "log" for item in items)
+
+
 def test_retro_handoff_without_followup_title_only_logs():
     detail = {"latest_summary": "RETRO=No harness change needed", "comments": []}
 

--- a/services/zoe-data/tests/test_pipeline_handoff.py
+++ b/services/zoe-data/tests/test_pipeline_handoff.py
@@ -406,6 +406,24 @@ def test_retro_run_metadata_records_log_and_followup_evidence():
     assert tool.summary == "kanban_show,terminal"
 
 
+def test_retro_top_level_metadata_records_log_evidence():
+    detail = {
+        "latest_summary": "Retro complete.",
+        "comments": [],
+        "metadata": {
+            "RETRO": "Top-level structured retro evidence.",
+            "TOOLS_USED": "kanban_show",
+        },
+    }
+
+    items = evidence_from_handoff("retro", detail)
+
+    log = next(item for item in items if item.kind == "log")
+    tool = next(item for item in items if item.kind == "tool")
+    assert log.summary == "Top-level structured retro evidence."
+    assert tool.summary == "kanban_show"
+
+
 def test_retro_generic_run_metadata_does_not_create_log_evidence():
     detail = {
         "latest_summary": "Retro complete.",
@@ -416,6 +434,20 @@ def test_retro_generic_run_metadata_does_not_create_log_evidence():
     items = evidence_from_handoff("retro", detail)
 
     assert not any(item.kind == "log" for item in items)
+
+
+def test_review_structured_summary_does_not_bypass_approver_gate():
+    detail = {
+        "latest_summary": "Review task completed.",
+        "comments": [],
+        "task": {"assignee": "zoe-reviewer"},
+        "metadata": {"SUMMARY": "approved"},
+        "runs": [{"metadata": {"REVIEW": "approved"}}],
+    }
+
+    items = evidence_from_handoff("review", detail)
+
+    assert not any(item.kind == "human" for item in items)
 
 
 def test_retro_handoff_without_followup_title_only_logs():


### PR DESCRIPTION
## Summary
- convert explicit uppercase Kanban run metadata into handoff fields
- allow RETRO/LEARNINGS/TOOLS_USED and follow-up metadata to satisfy the retro evidence gate
- ignore arbitrary lowercase and structured metadata

## Validation
- focused orchestration suite: 123 passed

## Live blocker
Unblocks the completed ZOE-5347 retro from closing in the journal and Multica without rerunning Hermes.