### PR TITLE
Block runaway Hermes phase retries

### DIFF
--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -375,8 +375,13 @@ class KanbanAdapter:
                 " TOOLS_USED=audit-read, PR_URL= blank, AUDIT_ONLY=1, TESTS=not applicable/audit-only,"
                 " and SUMMARY= findings. Do not open a PR.\n"
                 "- Start with `kanban_show` to confirm this task id.\n"
-                "- For code-changing tickets only: read the charter + graphify map first"
-                " (graphify query/path/explain over raw grep).\n"
+                "- SMALL EXPLICIT CODE FAST PATH: when the ticket names the exact file, helper,"
+                " function, or focused test to change, inspect only those named files plus the"
+                " nearest existing test. Do not run a broad Graphify query, repo crawl, or unrelated"
+                " search. Start editing within 6 tool/model steps; if the change is still unclear by"
+                " then, call `kanban_block` with BLOCKER=IMPLEMENT_BUDGET instead of exploring further.\n"
+                "- For broad or ambiguous code-changing tickets only: read the charter and run at"
+                " most one focused Graphify map (graphify query/path/explain over raw grep).\n"
                 "- Use opensrc for any third-party library source before guessing APIs.\n"
                 "- Make the smallest reviewable change; do NOT rewrite existing functions into bloat;"
                 " reuse service-layer helpers.\n"
@@ -645,6 +650,8 @@ class KanbanAdapter:
             f"{external_ref}:{phase}",
             "--max-runtime",
             _max_runtime(mode),
+            "--max-retries",
+            "1",
             "--created-by",
             "zoe-bridge",
             "--body",

--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -650,6 +650,8 @@ class KanbanAdapter:
             f"{external_ref}:{phase}",
             "--max-runtime",
             _max_runtime(mode),
+            # Hermes trips the circuit breaker on the Nth failure; 1 means one
+            # total attempt and zero automatic retries.
             "--max-retries",
             "1",
             "--created-by",

--- a/services/zoe-data/pipeline_store.py
+++ b/services/zoe-data/pipeline_store.py
@@ -145,6 +145,15 @@ def resume_pipeline(
             "repeated_block_count": 0 if reset_fingerprint else state.repeated_block_count,
             "block_classification": None,
             "split_packet": None,
+            "history": (
+                [
+                    record
+                    for record in state.history
+                    if not (record.reason or "").startswith("fingerprint_abort:")
+                ]
+                if reset_fingerprint
+                else state.history
+            ),
         }
     )
     return save_state(
@@ -247,7 +256,13 @@ def pipeline_summary(state: PipelineState | None) -> dict[str, Any]:
     if not state:
         return {"tracked": False}
     missing = sorted(missing_required_evidence(state))
-    fingerprint_abort = state.status == "blocked" and state.repeated_block_count >= 2
+    fingerprint_abort = state.status == "blocked" and (
+        state.repeated_block_count >= 2
+        or any(
+            (record.reason or "").startswith("fingerprint_abort:")
+            for record in state.history
+        )
+    )
     terminal_block = state.status == "blocked" and (
         fingerprint_abort
         or state.block_classification == "scope_split_required"

--- a/services/zoe-data/pipeline_store.py
+++ b/services/zoe-data/pipeline_store.py
@@ -126,6 +126,38 @@ async def bootstrap_state(
     return state
 
 
+def resume_pipeline(
+    task_ref: str,
+    *,
+    reason: str = "operator retry",
+    reset_fingerprint: bool = False,
+) -> PipelineState:
+    """Journal an explicit retry of a blocked phase without erasing prior evidence."""
+    state = load_latest_state(task_ref)
+    if state is None:
+        raise ValueError(f"pipeline not found: {task_ref}")
+    if state.status != "blocked":
+        raise ValueError(f"pipeline is not blocked: {task_ref} ({state.status})")
+    resumed = state.model_copy(
+        update={
+            "status": "todo",
+            "last_block_fingerprint": None if reset_fingerprint else state.last_block_fingerprint,
+            "repeated_block_count": 0 if reset_fingerprint else state.repeated_block_count,
+            "block_classification": None,
+            "split_packet": None,
+        }
+    )
+    return save_state(
+        resumed,
+        event="operator_resumed",
+        extra={
+            "reason": reason,
+            "phase": resumed.phase,
+            "reset_fingerprint": reset_fingerprint,
+        },
+    )
+
+
 async def _append_harness_validators(state: PipelineState, phase: PipelinePhase) -> PipelineState:
     """Run repo validators when handoff lacks them; tag hash with phase."""
     if any(
@@ -215,13 +247,7 @@ def pipeline_summary(state: PipelineState | None) -> dict[str, Any]:
     if not state:
         return {"tracked": False}
     missing = sorted(missing_required_evidence(state))
-    fingerprint_abort = state.status == "blocked" and (
-        state.repeated_block_count >= 2
-        or any(
-            (rec.reason or "").startswith("fingerprint_abort:")
-            for rec in state.history
-        )
-    )
+    fingerprint_abort = state.status == "blocked" and state.repeated_block_count >= 2
     terminal_block = state.status == "blocked" and (
         fingerprint_abort
         or state.block_classification == "scope_split_required"
@@ -334,6 +360,8 @@ async def sync_pipeline_from_chain(
             ) or outcome
             split_requested, handoff_split_packet = split_request_from_handoff(detail)
             fingerprint = block_fingerprint(phase, str(block_reason))  # type: ignore[arg-type]
+            if state.status == "blocked" and fingerprint == state.last_block_fingerprint:
+                return state
             state, should_abort = record_block_fingerprint(state, fingerprint)
             explicit_split = scope_split_required(
                 phase, str(block_reason), explicit=split_requested  # type: ignore[arg-type]

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -234,6 +234,15 @@ async def test_dispatch_interactive_mode_uses_default_runtime(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_dispatch_blocks_on_first_worker_failure():
+    a = _FakeAdapter()
+    await a.dispatch({"id": "uuid-cost", "identifier": "ZOE-COST", "title": "Bound paid retries"})
+
+    creates = [c for c in a.calls if c[0] == "create"]
+    assert creates[0][creates[0].index("--max-retries") + 1] == "1"
+
+
+@pytest.mark.asyncio
 async def test_dispatch_overnight_mode_from_metadata(monkeypatch):
     monkeypatch.setenv("ZOE_KANBAN_OVERNIGHT_MAX_RUNTIME", "7h")
     a = _FakeAdapter()
@@ -981,7 +990,7 @@ def test_closeout_body_defers_multica_done_until_retro():
     assert "MULTICA=<Zoe updates after retro; report blocker if any>" in body
 
 
-def test_implement_body_puts_audit_fast_path_before_graphify():
+def test_implement_body_puts_bounded_fast_paths_before_graphify():
     body = ka.KanbanAdapter()._build_body(
         "implement",
         {"id": "uuid-1", "identifier": "ZOE-9", "title": "Audit driver", "description": "evidence_profile: audit"},
@@ -991,10 +1000,15 @@ def test_implement_body_puts_audit_fast_path_before_graphify():
     assert "AUDIT/SMOKE FAST PATH" in body
     assert "TOOLS_USED=audit-read" in body
     assert "TESTS=not applicable/audit-only" in body
-    assert "graphify map" in body
+    assert "Graphify map" in body
     assert "explicitly says audit-only" in body
     assert "uses trace/map with an audit/no-code qualifier" in body
-    assert body.index("AUDIT/SMOKE FAST PATH") < body.index("graphify map")
+    assert "SMALL EXPLICIT CODE FAST PATH" in body
+    assert "Start editing within 6 tool/model steps" in body
+    assert "BLOCKER=IMPLEMENT_BUDGET" in body
+    assert "broad or ambiguous code-changing tickets only" in body
+    assert body.index("AUDIT/SMOKE FAST PATH") < body.index("Graphify map")
+    assert body.index("SMALL EXPLICIT CODE FAST PATH") < body.index("Graphify map")
 
 
 def test_audit_no_pr_phases_do_not_preload_broad_skills():

--- a/services/zoe-data/tests/test_pipeline_store.py
+++ b/services/zoe-data/tests/test_pipeline_store.py
@@ -60,6 +60,28 @@ def test_pipeline_summary_needs_split_requires_blocked_status(isolated_store):
     assert summary["needs_split"] is False
 
 
+def test_resume_pipeline_can_reset_false_duplicate_fingerprint(isolated_store):
+    state = PipelineState(
+        task_ref="multica:false-duplicate",
+        phase="implement",
+        status="blocked",
+        last_block_fingerprint="abc123",
+        repeated_block_count=2,
+    )
+    store.save_state(state, event="fingerprint_abort")
+
+    resumed = store.resume_pipeline(
+        "multica:false-duplicate",
+        reason="duplicate poll guard deployed",
+        reset_fingerprint=True,
+    )
+
+    assert resumed.status == "todo"
+    assert resumed.last_block_fingerprint is None
+    assert resumed.repeated_block_count == 0
+    assert store.pipeline_summary(resumed)["terminal_block"] is False
+
+
 @pytest.mark.asyncio
 async def test_sync_pipeline_advances_on_complete_handoff(isolated_store):
     await store.bootstrap_state("multica:sync")
@@ -191,7 +213,7 @@ async def test_sync_pipeline_does_not_recover_mixed_protocol_and_real_block(isol
 
 
 @pytest.mark.asyncio
-async def test_sync_pipeline_fingerprint_abort(isolated_store):
+async def test_sync_pipeline_blocked_poll_is_idempotent(isolated_store):
     await store.bootstrap_state("multica:fp")
 
     async def fetch_detail(_task_id: str):
@@ -204,6 +226,23 @@ async def test_sync_pipeline_fingerprint_abort(isolated_store):
 
     state = await store.sync_pipeline_from_chain("multica:fp", phases, fetch_detail)
     assert state.status == "blocked"
+    assert state.repeated_block_count == 1
+    assert "fingerprint_abort" not in isolated_store.read_text(encoding="utf-8")
+
+@pytest.mark.asyncio
+async def test_sync_pipeline_fingerprint_abort_after_two_real_attempts(isolated_store):
+    await store.bootstrap_state("multica:fp-repeat")
+
+    async def fetch_detail(_task_id: str):
+        return {"latest_summary": "BLOCKER=WORKTREE_NOT_READY", "comments": []}
+
+    phases = {"implement": {"id": "t1", "status": "blocked", "block_reason": "WORKTREE_NOT_READY"}}
+    await store.sync_pipeline_from_chain("multica:fp-repeat", phases, fetch_detail)
+    resumed = store.resume_pipeline("multica:fp-repeat", reason="retry after repair")
+    assert resumed.status == "todo"
+    assert resumed.repeated_block_count == 1
+
+    state = await store.sync_pipeline_from_chain("multica:fp-repeat", phases, fetch_detail)
     assert any("fingerprint_abort" in (rec.reason or "") for rec in state.history)
     assert any("fingerprint_abort" in line for line in isolated_store.read_text(encoding="utf-8").splitlines())
 
@@ -223,6 +262,8 @@ async def test_sync_pipeline_fingerprint_abort_creates_split_packet_for_protocol
         }
     }
     await store.sync_pipeline_from_chain("multica:hard", phases, fetch_detail)
+    resumed = store.resume_pipeline("multica:hard", reason="retry after prompt repair")
+    assert resumed.repeated_block_count == 1
     state = await store.sync_pipeline_from_chain("multica:hard", phases, fetch_detail)
     summary = store.pipeline_summary(state)
 

--- a/services/zoe-data/tests/test_pipeline_store.py
+++ b/services/zoe-data/tests/test_pipeline_store.py
@@ -61,12 +61,22 @@ def test_pipeline_summary_needs_split_requires_blocked_status(isolated_store):
 
 
 def test_resume_pipeline_can_reset_false_duplicate_fingerprint(isolated_store):
+    from pipeline_evidence import TransitionRecord
+
     state = PipelineState(
         task_ref="multica:false-duplicate",
         phase="implement",
         status="blocked",
         last_block_fingerprint="abc123",
         repeated_block_count=2,
+        history=[
+            TransitionRecord(
+                from_phase="implement",
+                to_phase="implement",
+                outcome="block",
+                reason="fingerprint_abort:abc123",
+            )
+        ],
     )
     store.save_state(state, event="fingerprint_abort")
 
@@ -79,6 +89,10 @@ def test_resume_pipeline_can_reset_false_duplicate_fingerprint(isolated_store):
     assert resumed.status == "todo"
     assert resumed.last_block_fingerprint is None
     assert resumed.repeated_block_count == 0
+    assert not any(
+        (record.reason or "").startswith("fingerprint_abort:")
+        for record in resumed.history
+    )
     assert store.pipeline_summary(resumed)["terminal_block"] is False
 
 


### PR DESCRIPTION
## Summary
- block Zoe-created Hermes phases on the first worker failure instead of automatically paying for a second run
- add a bounded fast path for tickets that name the exact file/helper/test
- require an edit within six steps or a clean IMPLEMENT_BUDGET block

## Root cause
ZOE-5420 exhausted 22/22 iterations on broad exploration and Hermes reclaimed it two seconds later under the default retry policy.

## Validation
- 55 adapter tests passed
- validate_structure.py passed
- validate_critical_files.py passed
- git diff --check passed