### PR TITLE
ZOE-5420: Guard Zoe self-call base URL

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -89,6 +89,7 @@ jobs:
             services/zoe-data/tests/test_ui_orchestrator_types.py \
             services/zoe-data/tests/test_greptile_client.py \
             services/zoe-data/tests/test_greploop_guard.py \
+            services/zoe-data/tests/test_zoe_agent_self_url.py \
             -x -q \
             --override-ini="asyncio_mode=auto"
           PYTHONPATH="${{ github.workspace }}/services/zoe-auth:${{ github.workspace }}/services/zoe-auth/tests" pytest \

--- a/services/zoe-data/tests/test_zoe_agent_self_url.py
+++ b/services/zoe-data/tests/test_zoe_agent_self_url.py
@@ -4,12 +4,13 @@ import ast
 from pathlib import Path
 
 
-AGENT_PATH = Path(__file__).resolve().parents[1] / "zoe_agent.py"
 LOCAL_URL = "http://localhost:8000"
 
 
 def test_localhost_default_only_exists_in_zoe_base_url() -> None:
-    tree = ast.parse(AGENT_PATH.read_text(encoding="utf-8"))
+    agent_path = Path(__file__).resolve().parents[1] / "zoe_agent.py"
+    assert agent_path.is_file(), f"Zoe agent source not found: {agent_path}"
+    tree = ast.parse(agent_path.read_text(encoding="utf-8"))
     helper = next(
         (
             node

--- a/services/zoe-data/tests/test_zoe_agent_self_url.py
+++ b/services/zoe-data/tests/test_zoe_agent_self_url.py
@@ -1,0 +1,34 @@
+"""Regression guard for Zoe's internal HTTP base URL."""
+
+import ast
+from pathlib import Path
+
+
+AGENT_PATH = Path(__file__).resolve().parents[1] / "zoe_agent.py"
+LOCAL_URL = "http://localhost:8000"
+
+
+def test_localhost_default_only_exists_in_zoe_base_url() -> None:
+    tree = ast.parse(AGENT_PATH.read_text(encoding="utf-8"))
+    helper = next(
+        (
+            node
+            for node in tree.body
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and node.name == "_zoe_base_url"
+        ),
+        None,
+    )
+
+    assert helper is not None, "_zoe_base_url() must own Zoe's internal base URL"
+    occurrences = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Constant) and node.value == LOCAL_URL
+    ]
+
+    assert len(occurrences) == 1, (
+        f"{LOCAL_URL} must appear exactly once in zoe_agent.py; "
+        "new self-call sites must use _zoe_base_url()"
+    )
+    assert helper.lineno <= occurrences[0].lineno <= helper.end_lineno


### PR DESCRIPTION
## Summary
- add an AST regression test that permits the localhost default only inside 
- run the focused guard in the existing Validate workflow

## Validation
- 48 focused Zoe agent tests passed
- validate_structure.py passed
- validate_critical_files.py passed
- git diff --check passed