### PR TITLE
Reconcile completed Multica tickets in review

### DIFF
--- a/services/zoe-data/main.py
+++ b/services/zoe-data/main.py
@@ -516,13 +516,20 @@ async def lifespan(app: FastAPI):
                     in_progress_issues,
                     in_review_issues,
                 )
-                for issue in issues or []:
+                in_review_ids = {
+                    str(issue.get("id") or "")
+                    for issue in in_review_issues
+                    if issue.get("id")
+                }
+                for issue in issues:
                     # Check whether a linked engineering workflow has reached a terminal state.
                     issue_id = issue.get("id")
                     title = issue.get("title", "")
                     if not issue_id:
                         continue
                     if title.startswith("Autopilot:"):
+                        if str(issue_id) in in_review_ids:
+                            continue
                         try:
                             import datetime as _dt
 
@@ -538,8 +545,9 @@ async def lifespan(app: FastAPI):
                             if _age_h >= 2:
                                 await client.update_issue(issue_id, status="done")
                                 logger.info(
-                                    "multica_poll: closed stale in_progress autopilot '%s'",
+                                    "multica_poll: closed stale autopilot '%s' (was %s)",
                                     title[:50],
+                                    issue.get("status", "in_progress"),
                                 )
                         except Exception as _ap_exc:
                             logger.debug("multica_poll: autopilot in_progress close: %s", _ap_exc)

--- a/services/zoe-data/main.py
+++ b/services/zoe-data/main.py
@@ -133,6 +133,20 @@ async def _record_completed_multica_chain(client, issue_id: str, chain: dict) ->
         logger.warning("multica_poll: retro follow-up creation failed for %s: %s", issue_id, exc)
 
 
+def _tracked_multica_engineering_issues(*groups: list[dict]) -> list[dict]:
+    """Return unique active/review issues whose engineering chain needs reconciliation."""
+    tracked: list[dict] = []
+    seen: set[str] = set()
+    for group in groups:
+        for issue in group or []:
+            issue_id = str(issue.get("id") or "")
+            if not issue_id or issue_id in seen:
+                continue
+            seen.add(issue_id)
+            tracked.append(issue)
+    return tracked
+
+
 def _blocked_multica_chain_reason(chain: dict) -> str:
     """Return the operator-visible reason for a blocked engineering chain."""
     pipeline = chain.get("pipeline") or {}
@@ -401,6 +415,7 @@ async def lifespan(app: FastAPI):
                         logger.debug("multica_poll: stale-todo close error: %s", _se)
 
                 in_progress_issues = await client.list_issues(status="in_progress") or []
+                in_review_issues = await client.list_issues(status="in_review") or []
 
                 # Webhook bridge: Hermes-assigned todos / in_progress (no chain) → issue.assigned.
                 try:
@@ -497,7 +512,10 @@ async def lifespan(app: FastAPI):
                 except Exception as _wh_exc:
                     logger.debug("multica_poll: webhook dispatch failed: %s", _wh_exc)
 
-                issues = in_progress_issues
+                issues = _tracked_multica_engineering_issues(
+                    in_progress_issues,
+                    in_review_issues,
+                )
                 for issue in issues or []:
                     # Check whether a linked engineering workflow has reached a terminal state.
                     issue_id = issue.get("id")
@@ -575,7 +593,7 @@ async def lifespan(app: FastAPI):
                     except Exception as _inner_exc:
                         logger.debug("multica_poll: inner error for issue %s: %s", issue_id, _inner_exc)
 
-                for _review in await client.list_issues(status="in_review") or []:
+                for _review in in_review_issues:
                     _rt = _review.get("title", "")
                     _rid = _review.get("id")
                     if _rid and _rt.startswith("Autopilot:"):

--- a/services/zoe-data/tests/test_main_multica_poll.py
+++ b/services/zoe-data/tests/test_main_multica_poll.py
@@ -12,6 +12,22 @@ class RecordingClient:
         return {"id": args[0], **kwargs}
 
 
+def test_tracked_multica_engineering_issues_includes_review_and_deduplicates():
+    from main import _tracked_multica_engineering_issues
+
+    in_progress = [{"id": "one", "status": "in_progress"}]
+    in_review = [
+        {"id": "one", "status": "in_review"},
+        {"id": "two", "status": "in_review"},
+        {"title": "missing id"},
+    ]
+
+    assert _tracked_multica_engineering_issues(in_progress, in_review) == [
+        in_progress[0],
+        in_review[1],
+    ]
+
+
 @pytest.mark.asyncio
 async def test_record_completed_multica_chain_records_explicit_retro_completion_metadata():
     from main import _record_completed_multica_chain


### PR DESCRIPTION
## Summary
- include regular in_review tickets in engineering-chain reconciliation
- deduplicate tickets across active status groups
- reuse the fetched in_review list for autopilot cleanup

## Root cause
The engineering loop moves PR-bearing tickets to in_review, but the completion poll only examined in_progress, leaving merged tickets stuck.

## Validation
- 20 focused poll/dispatch tests passed
- structure and critical-file validators passed
- git diff --check passed