### PR TITLE
Add safe production ticket admission

### DIFF
--- a/services/zoe-data/main.py
+++ b/services/zoe-data/main.py
@@ -397,6 +397,7 @@ async def lifespan(app: FastAPI):
                 # Fast-path: auto-close stale autopilot tracker todos (no agent needed)
                 stale_todos = await client.list_issues(status="todo")
                 _now_ts = _t.time()
+                _closed_stale_ids: set[str] = set()
                 for _stale in stale_todos or []:
                     _stale_title = _stale.get("title", "")
                     _stale_id = _stale.get("id")
@@ -410,9 +411,16 @@ async def lifespan(app: FastAPI):
                         )).total_seconds() / 3600
                         if _age_h >= 2:
                             await client.update_issue(_stale_id, status="done")
+                            _closed_stale_ids.add(str(_stale_id))
                             logger.info("multica_poll: auto-closed stale todo '%s'", _stale_title[:50])
                     except Exception as _se:
                         logger.debug("multica_poll: stale-todo close error: %s", _se)
+                if _closed_stale_ids:
+                    stale_todos = [
+                        issue
+                        for issue in stale_todos
+                        if str(issue.get("id") or "") not in _closed_stale_ids
+                    ]
 
                 in_progress_issues = await client.list_issues(status="in_progress") or []
                 in_review_issues = await client.list_issues(status="in_review") or []

--- a/services/zoe-data/main.py
+++ b/services/zoe-data/main.py
@@ -433,6 +433,35 @@ async def lifespan(app: FastAPI):
                             _wh_limit = int(os.environ.get("ZOE_MULTICA_POLL_DISPATCH_LIMIT", "1") or "1")
                         except ValueError:
                             _wh_limit = 1
+                        if (
+                            _wh_limit > 0
+                            and os.environ.get("ZOE_MULTICA_AUTO_ADMIT", "false").lower() == "true"
+                            and not stale_todos
+                            and not in_progress_issues
+                            and not in_review_issues
+                        ):
+                            from multica_admission import select_next_approved_issue
+
+                            _backlog = await client.list_issues(status="backlog") or []
+                            _all_issues = await client.list_issues() or []
+                            _admitted, _held = select_next_approved_issue(
+                                _backlog,
+                                _all_issues,
+                                hermes_agent_id=_hermes,
+                            )
+                            for _reason in _held:
+                                logger.info("multica_poll: admission held %s", _reason)
+                            if _admitted and _admitted.get("id"):
+                                _admitted = await client.update_issue(
+                                    str(_admitted["id"]),
+                                    status="todo",
+                                )
+                                if _admitted.get("id"):
+                                    stale_todos.append(_admitted)
+                                    logger.info(
+                                        "multica_poll: admitted %s from backlog into the single ticket lane",
+                                        _admitted.get("identifier") or _admitted.get("id"),
+                                    )
                         _chain_cache: dict[str, dict] = {}
 
                         async def _poll_chain(_tid: str) -> dict:

--- a/services/zoe-data/multica_admission.py
+++ b/services/zoe-data/multica_admission.py
@@ -14,6 +14,13 @@ _GENERIC_PHASE_RE = re.compile(r"(?i)^([\w][\w-]*)\s*:\s*phase\s*(\d+)")
 _PRIORITY = {"urgent": 0, "high": 1, "medium": 2, "low": 3, "none": 4}
 
 
+def _queue_position(value: Any) -> int:
+    try:
+        return int(value) if value is not None else 1_000_000
+    except (TypeError, ValueError):
+        return 1_000_000
+
+
 def parse_phased_title(title: str) -> tuple[str, int] | None:
     text = (title or "").strip()
     match = _CARD_UPGRADE_RE.match(text)
@@ -94,7 +101,7 @@ def select_next_approved_issue(
             eligible.append((issue, metadata))
     eligible.sort(
         key=lambda item: (
-            int(item[1].get("queue_order") or 1_000_000),
+            _queue_position(item[1].get("queue_order")),
             _PRIORITY.get(str(item[0].get("priority") or "none").lower(), 4),
             str(item[0].get("identifier") or item[0].get("id") or ""),
         )

--- a/services/zoe-data/multica_admission.py
+++ b/services/zoe-data/multica_admission.py
@@ -1,0 +1,103 @@
+"""Safe single-lane admission from Multica backlog into the engineering driver."""
+
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+from typing import Any
+
+from multica_ticket_contract import parse_ticket_block
+
+_CARD_UPGRADE_RE = re.compile(r"(?i)^(card-upgrade)\s*:\s*phase\s*(\d+)")
+_SKYBRIDGE_RE = re.compile(r"(?i)^skybridge\s+p(\d+)")
+_GENERIC_PHASE_RE = re.compile(r"(?i)^([\w][\w-]*)\s*:\s*phase\s*(\d+)")
+_PRIORITY = {"urgent": 0, "high": 1, "medium": 2, "low": 3, "none": 4}
+
+
+def parse_phased_title(title: str) -> tuple[str, int] | None:
+    text = (title or "").strip()
+    match = _CARD_UPGRADE_RE.match(text)
+    if match:
+        return match.group(1).lower(), int(match.group(2))
+    match = _SKYBRIDGE_RE.match(text)
+    if match:
+        return "skybridge", int(match.group(1))
+    match = _GENERIC_PHASE_RE.match(text)
+    if match:
+        return match.group(1).lower(), int(match.group(2))
+    return None
+
+
+def ticket_is_dispatch_approved(issue: dict[str, Any], *, hermes_agent_id: str) -> bool:
+    if str(issue.get("assignee_id") or "") != str(hermes_agent_id):
+        return False
+    if str(issue.get("assignee_type") or "agent") not in {"", "agent"}:
+        return False
+    metadata = parse_ticket_block(issue.get("description") or "")
+    if metadata.get("schema") != 1 or metadata.get("parse_error"):
+        return False
+    if metadata.get("dispatch_approved") is not True:
+        return False
+    if metadata.get("blocked_reason"):
+        return False
+    if not metadata.get("acceptance_criteria") or not metadata.get("evidence_expectations"):
+        return False
+    if str(metadata.get("zoe_kind") or "") == "parent":
+        return False
+    source = str(metadata.get("source") or "").lower()
+    if "smoke" in source or "e2e" in source:
+        return False
+    return True
+
+
+def _predecessors_done(
+    sequence: str,
+    phase: int,
+    by_sequence: dict[str, list[dict[str, Any]]],
+) -> bool:
+    for sibling in by_sequence.get(sequence) or []:
+        parsed = parse_phased_title(sibling.get("title") or "")
+        if not parsed or parsed[0] != sequence or parsed[1] >= phase:
+            continue
+        if sibling.get("status") != "done":
+            return False
+    return True
+
+
+def select_next_approved_issue(
+    backlog: list[dict[str, Any]],
+    all_issues: list[dict[str, Any]],
+    *,
+    hermes_agent_id: str,
+) -> tuple[dict[str, Any] | None, list[str]]:
+    """Return one approved backlog ticket, preserving phased predecessor order."""
+    by_sequence: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for issue in all_issues:
+        parsed = parse_phased_title(issue.get("title") or "")
+        if parsed:
+            by_sequence[parsed[0]].append(issue)
+
+    eligible = [
+        issue
+        for issue in backlog
+        if ticket_is_dispatch_approved(issue, hermes_agent_id=hermes_agent_id)
+    ]
+    eligible.sort(
+        key=lambda issue: (
+            int(parse_ticket_block(issue.get("description") or "").get("queue_order") or 1_000_000),
+            _PRIORITY.get(str(issue.get("priority") or "none").lower(), 4),
+            str(issue.get("identifier") or issue.get("id") or ""),
+        )
+    )
+
+    held: list[str] = []
+    for issue in eligible:
+        parsed = parse_phased_title(issue.get("title") or "")
+        if parsed and not _predecessors_done(parsed[0], parsed[1], by_sequence):
+            held.append(
+                f"{issue.get('identifier') or issue.get('id')}: "
+                f"{parsed[0]} phase {parsed[1]} waiting for predecessor"
+            )
+            continue
+        return issue, held
+    return None, held

--- a/services/zoe-data/multica_admission.py
+++ b/services/zoe-data/multica_admission.py
@@ -28,12 +28,18 @@ def parse_phased_title(title: str) -> tuple[str, int] | None:
     return None
 
 
-def ticket_is_dispatch_approved(issue: dict[str, Any], *, hermes_agent_id: str) -> bool:
+def ticket_is_dispatch_approved(
+    issue: dict[str, Any],
+    *,
+    hermes_agent_id: str,
+    metadata: dict[str, Any] | None = None,
+) -> bool:
     if str(issue.get("assignee_id") or "") != str(hermes_agent_id):
         return False
     if str(issue.get("assignee_type") or "agent") not in {"", "agent"}:
         return False
-    metadata = parse_ticket_block(issue.get("description") or "")
+    if metadata is None:
+        metadata = parse_ticket_block(issue.get("description") or "")
     if metadata.get("schema") != 1 or metadata.get("parse_error"):
         return False
     if metadata.get("dispatch_approved") is not True:
@@ -77,21 +83,25 @@ def select_next_approved_issue(
         if parsed:
             by_sequence[parsed[0]].append(issue)
 
-    eligible = [
-        issue
-        for issue in backlog
-        if ticket_is_dispatch_approved(issue, hermes_agent_id=hermes_agent_id)
-    ]
+    eligible: list[tuple[dict[str, Any], dict[str, Any]]] = []
+    for issue in backlog:
+        metadata = parse_ticket_block(issue.get("description") or "")
+        if ticket_is_dispatch_approved(
+            issue,
+            hermes_agent_id=hermes_agent_id,
+            metadata=metadata,
+        ):
+            eligible.append((issue, metadata))
     eligible.sort(
-        key=lambda issue: (
-            int(parse_ticket_block(issue.get("description") or "").get("queue_order") or 1_000_000),
-            _PRIORITY.get(str(issue.get("priority") or "none").lower(), 4),
-            str(issue.get("identifier") or issue.get("id") or ""),
+        key=lambda item: (
+            int(item[1].get("queue_order") or 1_000_000),
+            _PRIORITY.get(str(item[0].get("priority") or "none").lower(), 4),
+            str(item[0].get("identifier") or item[0].get("id") or ""),
         )
     )
 
     held: list[str] = []
-    for issue in eligible:
+    for issue, _metadata in eligible:
         parsed = parse_phased_title(issue.get("title") or "")
         if parsed and not _predecessors_done(parsed[0], parsed[1], by_sequence):
             held.append(

--- a/services/zoe-data/tests/test_multica_admission.py
+++ b/services/zoe-data/tests/test_multica_admission.py
@@ -1,5 +1,6 @@
 """Tests for safe production backlog admission."""
 
+import multica_admission
 from multica_admission import select_next_approved_issue, ticket_is_dispatch_approved
 from multica_ticket_contract import describe_ticket, parse_ticket_block, write_ticket_block
 
@@ -59,6 +60,29 @@ def test_selects_one_approved_issue_by_queue_order():
 
     assert selected == first
     assert held == []
+
+
+def test_ticket_metadata_is_parsed_once_per_backlog_issue(monkeypatch):
+    first = _issue("ZOE-1", "First fix", dispatch_approved=True, queue_order=1)
+    second = _issue("ZOE-2", "Second fix", dispatch_approved=True, queue_order=2)
+    real_parse = multica_admission.parse_ticket_block
+    calls = 0
+
+    def counting_parse(description):
+        nonlocal calls
+        calls += 1
+        return real_parse(description)
+
+    monkeypatch.setattr(multica_admission, "parse_ticket_block", counting_parse)
+
+    selected, _held = select_next_approved_issue(
+        [second, first],
+        [second, first],
+        hermes_agent_id=HERMES,
+    )
+
+    assert selected == first
+    assert calls == 2
 
 
 def test_phased_ticket_waits_for_predecessor():

--- a/services/zoe-data/tests/test_multica_admission.py
+++ b/services/zoe-data/tests/test_multica_admission.py
@@ -85,6 +85,32 @@ def test_ticket_metadata_is_parsed_once_per_backlog_issue(monkeypatch):
     assert calls == 2
 
 
+def test_malformed_queue_order_cannot_wedge_admission():
+    malformed = _issue("ZOE-1", "Malformed", dispatch_approved=True, queue_order="soon")
+    ordered = _issue("ZOE-2", "Ordered", dispatch_approved=True, queue_order=2)
+
+    selected, _held = select_next_approved_issue(
+        [malformed, ordered],
+        [malformed, ordered],
+        hermes_agent_id=HERMES,
+    )
+
+    assert selected == ordered
+
+
+def test_zero_queue_order_is_highest_priority():
+    later = _issue("ZOE-2", "Later", dispatch_approved=True, queue_order=1)
+    first = _issue("ZOE-1", "First", dispatch_approved=True, queue_order=0)
+
+    selected, _held = select_next_approved_issue(
+        [later, first],
+        [later, first],
+        hermes_agent_id=HERMES,
+    )
+
+    assert selected == first
+
+
 def test_phased_ticket_waits_for_predecessor():
     phase_one = _issue(
         "ZOE-1",

--- a/services/zoe-data/tests/test_multica_admission.py
+++ b/services/zoe-data/tests/test_multica_admission.py
@@ -1,0 +1,100 @@
+"""Tests for safe production backlog admission."""
+
+from multica_admission import select_next_approved_issue, ticket_is_dispatch_approved
+from multica_ticket_contract import describe_ticket, parse_ticket_block, write_ticket_block
+
+
+HERMES = "hermes-agent"
+
+
+def _issue(identifier: str, title: str, *, status: str = "backlog", **metadata):
+    description = describe_ticket(
+        "Small production ticket.",
+        zoe_kind=metadata.pop("zoe_kind", "harness_fix"),
+        acceptance_criteria=["Change is complete."],
+        evidence_expectations=["Focused tests", "PR URL"],
+        source=metadata.pop("source", "operator_approved"),
+    )
+    ticket = parse_ticket_block(description)
+    ticket.update(metadata)
+    return {
+        "id": identifier.lower(),
+        "identifier": identifier,
+        "title": title,
+        "description": write_ticket_block(description, ticket),
+        "status": status,
+        "priority": "medium",
+        "assignee_id": HERMES,
+        "assignee_type": "agent",
+    }
+
+
+def test_unapproved_or_unstructured_backlog_is_not_admitted():
+    unapproved = _issue("ZOE-1", "Small fix")
+    legacy = {
+        "id": "legacy",
+        "identifier": "ZOE-2",
+        "title": "Legacy fix",
+        "description": "no ticket contract",
+        "assignee_id": HERMES,
+    }
+
+    assert not ticket_is_dispatch_approved(unapproved, hermes_agent_id=HERMES)
+    assert select_next_approved_issue(
+        [unapproved, legacy],
+        [unapproved, legacy],
+        hermes_agent_id=HERMES,
+    )[0] is None
+
+
+def test_selects_one_approved_issue_by_queue_order():
+    second = _issue("ZOE-2", "Second fix", dispatch_approved=True, queue_order=2)
+    first = _issue("ZOE-1", "First fix", dispatch_approved=True, queue_order=1)
+
+    selected, held = select_next_approved_issue(
+        [second, first],
+        [second, first],
+        hermes_agent_id=HERMES,
+    )
+
+    assert selected == first
+    assert held == []
+
+
+def test_phased_ticket_waits_for_predecessor():
+    phase_one = _issue(
+        "ZOE-1",
+        "card-upgrade: Phase 1 - contract",
+        status="in_progress",
+        dispatch_approved=True,
+    )
+    phase_two = _issue(
+        "ZOE-2",
+        "card-upgrade: Phase 2 - renderer",
+        dispatch_approved=True,
+    )
+
+    selected, held = select_next_approved_issue(
+        [phase_two],
+        [phase_one, phase_two],
+        hermes_agent_id=HERMES,
+    )
+
+    assert selected is None
+    assert held == ["ZOE-2: card-upgrade phase 2 waiting for predecessor"]
+
+
+def test_smoke_sources_and_parent_tickets_are_never_auto_admitted():
+    smoke = _issue("ZOE-1", "Smoke", dispatch_approved=True, source="codex_live_e2e")
+    parent = _issue(
+        "ZOE-2",
+        "Parent",
+        dispatch_approved=True,
+        zoe_kind="parent",
+    )
+
+    assert select_next_approved_issue(
+        [smoke, parent],
+        [smoke, parent],
+        hermes_agent_id=HERMES,
+    )[0] is None


### PR DESCRIPTION
## Summary
- auto-admit at most one backlog ticket when the production lane is completely idle
- require structured ticket metadata plus an explicit dispatch_approved marker
- preserve phased predecessor ordering and reject smoke/E2E/parent tickets
- leave the large legacy backlog inert

## Validation
- 24 focused admission/poll tests passed
- structure and critical-file validators passed
- git diff --check passed