### PR TITLE
Enforce phase budgets and deterministic Greploop launch

### DIFF
--- a/scripts/maintenance/run_greploop_guard.sh
+++ b/scripts/maintenance/run_greploop_guard.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+USER_SITE="$(python3 -c 'import site; print(site.getusersitepackages())')"
+export PYTHONPATH="${USER_SITE}:${ROOT}/services/zoe-data${PYTHONPATH:+:${PYTHONPATH}}"
+
+for env_file in "${ROOT}/services/zoe-data/.env" "${ROOT}/.env" "${HOME}/.hermes/.env"; do
+    if [[ -f "${env_file}" ]]; then
+        set -a
+        # shellcheck disable=SC1090
+        source "${env_file}"
+        set +a
+    fi
+done
+
+exec python3 "${ROOT}/scripts/maintenance/greploop_guard.py" "$@"

--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -28,6 +28,7 @@ from pathlib import Path
 from typing import Any
 
 from hermes_http import hermes_bin, zoe_repo_root
+from kanban_phase_budget import phase_budget_reason, terminate_running_workers
 
 logger = logging.getLogger(__name__)
 
@@ -486,7 +487,7 @@ class KanbanAdapter:
             " completion reason, then `kanban_complete`; do not wait for Greptile.\n"
             "- If a code task has no PR, leave the issue blocked — do NOT open one yourself.\n"
             "- COST/ITERATION FAST PATH: after extracting N, make the first repository command:\n"
-            "    python3 scripts/maintenance/greploop_guard.py --pr N --merge-when-ready\n"
+            "    scripts/maintenance/run_greploop_guard.sh --pr N --merge-when-ready\n"
             "  If it reports ok=true, hand off and `kanban_complete` immediately. Do not run broad git"
             " log/show/diff, worktree inventories, duplicate `gh pr view`, or separate comment queries"
             " before this guard; it is the source of truth for Greptile, threads, CI, and merge state.\n"
@@ -497,7 +498,7 @@ class KanbanAdapter:
             " merge-ready — merge when gates pass.\n"
             "- Drive the Greptile grep loop with the pinned github-greptile-loop skill (guard REQUIRES --pr N;"
             " <=5 rounds, target confidence 5). Each round:\n"
-            "    python3 scripts/maintenance/greploop_guard.py --pr N --once\n"
+            "    scripts/maintenance/run_greploop_guard.sh --pr N --once\n"
             "  Apply fixes yourself when the guard returns ESCALATE_HERMES or PACKET_READY; use --packet-only"
             " only to hand off to a cheap Cursor runner.\n"
             "  Re-trigger review when needed via"
@@ -505,7 +506,7 @@ class KanbanAdapter:
             " (operator-local binary; override with GREPTILE_MCP_BIN).\n"
             "- When Greptile is clear (confidence 5/5, no unaddressed findings) and CI is green, squash-merge"
             " via normal GitHub (never --admin, never force, never --no-verify):\n"
-            "    python3 scripts/maintenance/greploop_guard.py --pr N --merge-when-ready\n"
+            "    scripts/maintenance/run_greploop_guard.sh --pr N --merge-when-ready\n"
             "  Or one iteration then merge: --once --merge-when-ready\n"
             "  If branch protection blocks merge, leave the issue blocked with the gh error — do not admin-merge.\n"
             "- After a successful merge: report PR_URL, merge SHA, GREPTILE status, and summary in your"
@@ -552,6 +553,36 @@ class KanbanAdapter:
             phase,
             violations,
         )
+        return True
+
+    async def _maybe_auto_block_phase_budget(
+        self,
+        task_id: str,
+        phase: str,
+        row: dict[str, Any],
+        detail: dict[str, Any],
+    ) -> bool:
+        """Stop a running worker when its code-enforced phase budget is exhausted."""
+        status = (row.get("status") or "").lower()
+        if status in _TERMINAL_KANBAN_STATUSES or status == "blocked":
+            return False
+        reason = phase_budget_reason(task_id, phase, detail)
+        if not reason:
+            return False
+        try:
+            await self._run(["block", task_id, reason])
+        except KanbanCLIError as exc:
+            logger.warning(
+                "kanban_adapter: budget auto-block failed for %s (%s): %s",
+                task_id,
+                phase,
+                exc,
+            )
+            return False
+        terminate_running_workers(detail)
+        row["status"] = "blocked"
+        row["block_reason"] = reason
+        logger.warning("kanban_adapter: stopped %s (%s): %s", task_id, phase, reason)
         return True
 
     async def dispatch(self, issue: dict) -> dict:
@@ -748,6 +779,9 @@ class KanbanAdapter:
                 logger.debug("kanban_adapter: show failed for %s: %s", task_id, exc)
                 continue
             detail_cache[task_id] = detail
+            if await self._maybe_auto_block_phase_budget(task_id, phase, row, detail):
+                phases[phase] = row
+                continue
             if await self._maybe_auto_block_protocol_violation(task_id, phase, row, detail):
                 phases[phase] = row
 

--- a/services/zoe-data/kanban_phase_budget.py
+++ b/services/zoe-data/kanban_phase_budget.py
@@ -7,6 +7,7 @@ import os
 import re
 import signal
 import time
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -28,6 +29,9 @@ _RUNTIME_DEFAULTS = {
     "closeout": 900,
     "retro": 300,
 }
+_STEP_LINE_RE = re.compile(r"^\s*(?:┊|\|)\s+\S")
+_FALLBACK_STEP_RE = re.compile(r"^\s*\S.*\s+\d+(?:\.\d+)?s(?:\s+\[.*\])?\s*$")
+_ZERO_STEP_WARNED: set[str] = set()
 
 
 def _limit(phase: str, kind: str) -> int:
@@ -50,7 +54,29 @@ def tool_step_count(task_id: str) -> int:
         lines = _log_path(task_id).read_text(encoding="utf-8", errors="replace").splitlines()
     except OSError:
         return 0
-    return sum(1 for line in lines if re.match(r"^\s*┊\s+\S", line))
+    count = sum(1 for line in lines if _STEP_LINE_RE.match(line))
+    if not count:
+        count = sum(1 for line in lines if _FALLBACK_STEP_RE.match(line))
+    if not count and lines and task_id not in _ZERO_STEP_WARNED:
+        _ZERO_STEP_WARNED.add(task_id)
+        logger.warning(
+            "kanban_phase_budget: could not identify tool steps in non-empty log for %s",
+            task_id,
+        )
+    return count
+
+
+def _is_expected_worker(pid: int) -> bool:
+    if pid <= 100:
+        return False
+    try:
+        command = (Path("/proc") / str(pid) / "cmdline").read_bytes().replace(b"\0", b" ").decode(
+            "utf-8",
+            errors="replace",
+        )
+    except OSError:
+        return False
+    return "hermes" in command and "work kanban task" in command
 
 
 def running_worker_pids(detail: dict[str, Any]) -> list[int]:
@@ -62,7 +88,7 @@ def running_worker_pids(detail: dict[str, Any]) -> list[int]:
             pid = int(run.get("worker_pid") or 0)
         except (TypeError, ValueError):
             continue
-        if pid > 1:
+        if _is_expected_worker(pid):
             pids.append(pid)
     return pids
 
@@ -75,6 +101,25 @@ def terminate_running_workers(detail: dict[str, Any]) -> None:
             continue
         except OSError as exc:
             logger.warning("kanban_phase_budget: failed to stop worker pid=%s: %s", pid, exc)
+
+
+def _timestamp(value: Any) -> float | None:
+    if isinstance(value, (int, float)):
+        return float(value)
+    text = str(value or "").strip()
+    if not text:
+        return None
+    try:
+        return float(text)
+    except ValueError:
+        pass
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.timestamp()
 
 
 def phase_budget_reason(
@@ -101,10 +146,10 @@ def phase_budget_reason(
             if isinstance(run, dict) and str(run.get("status") or "").lower() == "running"
         ]
         started_at = running[-1].get("started_at") if running else None
-    try:
-        elapsed = (now if now is not None else time.time()) - float(started_at)
-    except (TypeError, ValueError):
+    started_ts = _timestamp(started_at)
+    if started_ts is None:
         return None
+    elapsed = (now if now is not None else time.time()) - started_ts
     runtime_limit = _limit(phase, "runtime")
     if elapsed > runtime_limit:
         return (

--- a/services/zoe-data/kanban_phase_budget.py
+++ b/services/zoe-data/kanban_phase_budget.py
@@ -1,0 +1,114 @@
+"""Code-enforced runtime and tool-call budgets for Hermes Kanban phases."""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import signal
+import time
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_TOOL_DEFAULTS = {
+    "scout": 8,
+    "implement": 24,
+    "verify": 10,
+    "review": 10,
+    "closeout": 12,
+    "retro": 8,
+}
+_RUNTIME_DEFAULTS = {
+    "scout": 300,
+    "implement": 1800,
+    "verify": 600,
+    "review": 600,
+    "closeout": 900,
+    "retro": 300,
+}
+
+
+def _limit(phase: str, kind: str) -> int:
+    defaults = _TOOL_DEFAULTS if kind == "tools" else _RUNTIME_DEFAULTS
+    suffix = "TOOL_BUDGET" if kind == "tools" else "RUNTIME_BUDGET_SECONDS"
+    raw = os.environ.get(f"ZOE_KANBAN_{phase.upper()}_{suffix}", "")
+    try:
+        return max(1, int(raw)) if raw else defaults.get(phase, 10)
+    except ValueError:
+        return defaults.get(phase, 10)
+
+
+def _log_path(task_id: str) -> Path:
+    hermes_home = Path(os.path.expanduser(os.environ.get("HERMES_HOME", "~/.hermes")))
+    return hermes_home / "kanban" / "logs" / f"{task_id}.log"
+
+
+def tool_step_count(task_id: str) -> int:
+    try:
+        lines = _log_path(task_id).read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        return 0
+    return sum(1 for line in lines if re.match(r"^\s*┊\s+\S", line))
+
+
+def running_worker_pids(detail: dict[str, Any]) -> list[int]:
+    pids: list[int] = []
+    for run in detail.get("runs") or []:
+        if not isinstance(run, dict) or str(run.get("status") or "").lower() != "running":
+            continue
+        try:
+            pid = int(run.get("worker_pid") or 0)
+        except (TypeError, ValueError):
+            continue
+        if pid > 1:
+            pids.append(pid)
+    return pids
+
+
+def terminate_running_workers(detail: dict[str, Any]) -> None:
+    for pid in running_worker_pids(detail):
+        try:
+            os.kill(pid, signal.SIGTERM)
+        except ProcessLookupError:
+            continue
+        except OSError as exc:
+            logger.warning("kanban_phase_budget: failed to stop worker pid=%s: %s", pid, exc)
+
+
+def phase_budget_reason(
+    task_id: str,
+    phase: str,
+    detail: dict[str, Any],
+    *,
+    now: float | None = None,
+) -> str | None:
+    tool_steps = tool_step_count(task_id)
+    tool_limit = _limit(phase, "tools")
+    if tool_steps > tool_limit:
+        return (
+            f"BLOCKER={phase.upper()}_BUDGET: code-enforced tool budget exceeded "
+            f"(steps={tool_steps}, limit={tool_limit})"
+        )
+
+    task = detail.get("task") if isinstance(detail.get("task"), dict) else {}
+    started_at = task.get("started_at")
+    if not started_at:
+        running = [
+            run
+            for run in detail.get("runs") or []
+            if isinstance(run, dict) and str(run.get("status") or "").lower() == "running"
+        ]
+        started_at = running[-1].get("started_at") if running else None
+    try:
+        elapsed = (now if now is not None else time.time()) - float(started_at)
+    except (TypeError, ValueError):
+        return None
+    runtime_limit = _limit(phase, "runtime")
+    if elapsed > runtime_limit:
+        return (
+            f"BLOCKER={phase.upper()}_BUDGET: code-enforced runtime budget exceeded "
+            f"(elapsed={int(elapsed)}s, limit={runtime_limit}s)"
+        )
+    return None

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -957,6 +957,37 @@ def test_phase_budget_reason_enforces_tool_and_runtime_limits(tmp_path, monkeypa
     assert "runtime budget exceeded" in reason
 
 
+def test_phase_budget_accepts_iso_timestamp_and_ascii_step_logs(tmp_path, monkeypatch):
+    log_path = tmp_path / "task.log"
+    log_path.write_text("| shell command  0.2s\n", encoding="utf-8")
+    monkeypatch.setattr(kb, "_log_path", lambda _task_id: log_path)
+    monkeypatch.setenv("ZOE_KANBAN_SCOUT_TOOL_BUDGET", "5")
+    monkeypatch.setenv("ZOE_KANBAN_SCOUT_RUNTIME_BUDGET_SECONDS", "5")
+
+    assert kb.tool_step_count("t_scout") == 1
+    reason = kb.phase_budget_reason(
+        "t_scout",
+        "scout",
+        {"task": {"started_at": "2026-06-05T12:00:00Z"}},
+        now=kb._timestamp("2026-06-05T12:00:06Z"),
+    )
+    assert reason is not None
+    assert "runtime budget exceeded" in reason
+
+
+def test_running_worker_pids_require_expected_hermes_command(monkeypatch):
+    monkeypatch.setattr(kb, "_is_expected_worker", lambda pid: pid == 4242)
+    detail = {
+        "runs": [
+            {"status": "running", "worker_pid": 2},
+            {"status": "running", "worker_pid": 4242},
+            {"status": "done", "worker_pid": 5252},
+        ]
+    }
+
+    assert kb.running_worker_pids(detail) == [4242]
+
+
 @pytest.mark.asyncio
 async def test_poll_auto_blocks_and_terminates_worker_after_phase_budget(monkeypatch):
     rows = [_row("scout", "running")]
@@ -972,6 +1003,7 @@ async def test_poll_auto_blocks_and_terminates_worker_after_phase_budget(monkeyp
         "phase_budget_reason",
         lambda *_args, **_kwargs: "BLOCKER=SCOUT_BUDGET: test limit",
     )
+    monkeypatch.setattr(kb, "_is_expected_worker", lambda pid: pid == 4242)
     monkeypatch.setattr(ka, "terminate_running_workers", lambda detail: stopped.extend(kb.running_worker_pids(detail)))
     a = _FakeAdapter(list_rows=rows, show_map=show)
 

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 
 import executors.kanban_adapter as ka
+import kanban_phase_budget as kb
 
 
 @pytest.fixture(autouse=True)
@@ -380,7 +381,7 @@ async def test_closeout_body_instructs_merge_when_ready():
         {"id": "uuid-1", "identifier": "ZOE-9", "title": "Fix thing", "description": ""},
         "ZOE-9",
     )
-    assert "greploop_guard.py --pr N --once" in body
+    assert "run_greploop_guard.sh --pr N --once" in body
     assert "--merge-when-ready" in body
     assert "MERGE_SHA=" in body
     assert "--packet-only" in body
@@ -927,6 +928,61 @@ def test_protocol_violation_count():
     assert ka._protocol_violation_count(detail) == 2
 
 
+def test_phase_budget_reason_enforces_tool_and_runtime_limits(tmp_path, monkeypatch):
+    log_path = tmp_path / "task.log"
+    log_path.write_text("\n".join(["  ┊ tool call"] * 9), encoding="utf-8")
+    monkeypatch.setattr(kb, "_log_path", lambda _task_id: log_path)
+    monkeypatch.setenv("ZOE_KANBAN_SCOUT_TOOL_BUDGET", "8")
+
+    reason = kb.phase_budget_reason(
+        "t_scout",
+        "scout",
+        {"task": {"started_at": 100}},
+        now=110,
+    )
+
+    assert reason is not None
+    assert "SCOUT_BUDGET" in reason
+    assert "steps=9" in reason
+
+    log_path.write_text("", encoding="utf-8")
+    monkeypatch.setenv("ZOE_KANBAN_SCOUT_RUNTIME_BUDGET_SECONDS", "5")
+    reason = kb.phase_budget_reason(
+        "t_scout",
+        "scout",
+        {"runs": [{"status": "running", "started_at": 100, "worker_pid": 123}]},
+        now=106,
+    )
+    assert reason is not None
+    assert "runtime budget exceeded" in reason
+
+
+@pytest.mark.asyncio
+async def test_poll_auto_blocks_and_terminates_worker_after_phase_budget(monkeypatch):
+    rows = [_row("scout", "running")]
+    show = {
+        "t_scout": {
+            "task": {"started_at": 100},
+            "runs": [{"status": "running", "started_at": 100, "worker_pid": 4242}],
+        }
+    }
+    stopped = []
+    monkeypatch.setattr(
+        ka,
+        "phase_budget_reason",
+        lambda *_args, **_kwargs: "BLOCKER=SCOUT_BUDGET: test limit",
+    )
+    monkeypatch.setattr(ka, "terminate_running_workers", lambda detail: stopped.extend(kb.running_worker_pids(detail)))
+    a = _FakeAdapter(list_rows=rows, show_map=show)
+
+    out = await a.poll("multica:uuid-9")
+
+    assert out["status"] == "blocked"
+    assert "SCOUT_BUDGET" in (out["blocker"] or "")
+    assert stopped == [4242]
+    assert any(call[0] == "block" for call in a.calls)
+
+
 @pytest.mark.asyncio
 async def test_poll_auto_blocks_after_protocol_violations(monkeypatch):
     monkeypatch.setattr(ka, "_PROTOCOL_VIOLATION_LIMIT", 2)
@@ -955,6 +1011,17 @@ def test_closeout_body_requires_terminal_protocol():
     assert "TERMINAL PROTOCOL" in body
     assert "kanban_complete" in body
     assert "kanban_block" in body
+
+
+def test_closeout_body_uses_supported_greploop_launcher():
+    body = ka.KanbanAdapter()._build_body(
+        "closeout",
+        {"id": "uuid-1", "identifier": "ZOE-9", "title": "Fix thing", "description": ""},
+        "ZOE-9",
+    )
+
+    assert "scripts/maintenance/run_greploop_guard.sh --pr N --merge-when-ready" in body
+    assert "python3 scripts/maintenance/greploop_guard.py" not in body
 
 
 def test_audit_no_pr_phases_have_bounded_completion_path():


### PR DESCRIPTION
## Summary
- enforce per-phase tool and runtime budgets in Zoe polling
- block over-budget tasks and terminate the active Hermes worker
- route closeout through a deterministic Greploop launcher with user-site dependencies and established env files

## Validation
- 172 focused orchestration tests pass
- validate_structure.py passes
- validate_critical_files.py passes
- launcher works with PYTHONNOUSERSITE=1

## Live evidence
ZOE-5422 scout exceeded its 8-step prompt budget (24 tool calls observed) and was manually stopped; this patch moves that stop condition into code.