### PR TITLE
Reset phase budgets for explicit task resumes

### DIFF
--- a/services/zoe-data/kanban_phase_budget.py
+++ b/services/zoe-data/kanban_phase_budget.py
@@ -54,6 +54,9 @@ def tool_step_count(task_id: str) -> int:
         lines = _log_path(task_id).read_text(encoding="utf-8", errors="replace").splitlines()
     except OSError:
         return 0
+    query_starts = [index for index, line in enumerate(lines) if line.startswith("Query:")]
+    if query_starts:
+        lines = lines[query_starts[-1]:]
     count = sum(1 for line in lines if _STEP_LINE_RE.match(line))
     if not count:
         count = sum(1 for line in lines if _FALLBACK_STEP_RE.match(line))

--- a/services/zoe-data/kanban_phase_budget.py
+++ b/services/zoe-data/kanban_phase_budget.py
@@ -60,7 +60,14 @@ def tool_step_count(task_id: str) -> int:
     count = sum(1 for line in lines if _STEP_LINE_RE.match(line))
     if not count:
         count = sum(1 for line in lines if _FALLBACK_STEP_RE.match(line))
-    if not count and lines and task_id not in _ZERO_STEP_WARNED:
+    unparsed_activity = any(
+        line.strip()
+        and not line.startswith("Query:")
+        and "Initializing agent" not in line
+        and not set(line.strip()) <= {"─"}
+        for line in lines
+    )
+    if not count and unparsed_activity and task_id not in _ZERO_STEP_WARNED:
         _ZERO_STEP_WARNED.add(task_id)
         logger.warning(
             "kanban_phase_budget: could not identify tool steps in non-empty log for %s",

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -994,6 +994,19 @@ def test_tool_step_count_only_measures_latest_task_run(tmp_path, monkeypatch):
     assert kb.tool_step_count("t_scout") == 2
 
 
+def test_fresh_resumed_run_with_no_steps_does_not_warn(tmp_path, monkeypatch, caplog):
+    log_path = tmp_path / "task.log"
+    log_path.write_text(
+        "Query: work kanban task t_scout\nInitializing agent...\n────────────────\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(kb, "_log_path", lambda _task_id: log_path)
+    kb._ZERO_STEP_WARNED.discard("t_scout")
+
+    assert kb.tool_step_count("t_scout") == 0
+    assert "could not identify tool steps" not in caplog.text
+
+
 def test_running_worker_pids_require_expected_hermes_command(monkeypatch):
     monkeypatch.setattr(kb, "_is_expected_worker", lambda pid: pid == 4242)
     detail = {

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -975,6 +975,25 @@ def test_phase_budget_accepts_iso_timestamp_and_ascii_step_logs(tmp_path, monkey
     assert "runtime budget exceeded" in reason
 
 
+def test_tool_step_count_only_measures_latest_task_run(tmp_path, monkeypatch):
+    log_path = tmp_path / "task.log"
+    log_path.write_text(
+        "\n".join(
+            [
+                "Query: work kanban task t_scout",
+                *(["  ┊ old tool call"] * 9),
+                "Query: work kanban task t_scout",
+                "  ┊ current tool call",
+                "  ┊ current tool call",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(kb, "_log_path", lambda _task_id: log_path)
+
+    assert kb.tool_step_count("t_scout") == 2
+
+
 def test_running_worker_pids_require_expected_hermes_command(monkeypatch):
     monkeypatch.setattr(kb, "_is_expected_worker", lambda pid: pid == 4242)
     detail = {


### PR DESCRIPTION
## Summary
Count Hermes tool steps only within the latest task run segment so an explicit unblock/resume does not inherit the prior attempt budget.

## Validation
- 81 focused tests pass
- validate_structure.py passes
- regression covers a 9-step old attempt followed by a 2-step current attempt