### PR TITLE
Ignore stale phase logs on task resume

### DIFF
--- a/services/zoe-data/kanban_phase_budget.py
+++ b/services/zoe-data/kanban_phase_budget.py
@@ -142,7 +142,7 @@ def _started_timestamp(detail: dict[str, Any]) -> float | None:
         if isinstance(run, dict) and str(run.get("status") or "").lower() == "running"
     ]
     task = detail.get("task") if isinstance(detail.get("task"), dict) else {}
-    started_at = running[-1].get("started_at") if running else task.get("started_at")
+    started_at = (running[-1].get("started_at") if running else None) or task.get("started_at")
     return _timestamp(started_at)
 
 

--- a/services/zoe-data/kanban_phase_budget.py
+++ b/services/zoe-data/kanban_phase_budget.py
@@ -49,9 +49,12 @@ def _log_path(task_id: str) -> Path:
     return hermes_home / "kanban" / "logs" / f"{task_id}.log"
 
 
-def tool_step_count(task_id: str) -> int:
+def tool_step_count(task_id: str, *, since: float | None = None) -> int:
+    path = _log_path(task_id)
     try:
-        lines = _log_path(task_id).read_text(encoding="utf-8", errors="replace").splitlines()
+        if since is not None and path.stat().st_mtime < since:
+            return 0
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
     except OSError:
         return 0
     query_starts = [index for index, line in enumerate(lines) if line.startswith("Query:")]
@@ -132,6 +135,17 @@ def _timestamp(value: Any) -> float | None:
     return parsed.timestamp()
 
 
+def _started_timestamp(detail: dict[str, Any]) -> float | None:
+    running = [
+        run
+        for run in detail.get("runs") or []
+        if isinstance(run, dict) and str(run.get("status") or "").lower() == "running"
+    ]
+    task = detail.get("task") if isinstance(detail.get("task"), dict) else {}
+    started_at = running[-1].get("started_at") if running else task.get("started_at")
+    return _timestamp(started_at)
+
+
 def phase_budget_reason(
     task_id: str,
     phase: str,
@@ -139,7 +153,8 @@ def phase_budget_reason(
     *,
     now: float | None = None,
 ) -> str | None:
-    tool_steps = tool_step_count(task_id)
+    started_ts = _started_timestamp(detail)
+    tool_steps = tool_step_count(task_id, since=started_ts)
     tool_limit = _limit(phase, "tools")
     if tool_steps > tool_limit:
         return (
@@ -147,16 +162,6 @@ def phase_budget_reason(
             f"(steps={tool_steps}, limit={tool_limit})"
         )
 
-    task = detail.get("task") if isinstance(detail.get("task"), dict) else {}
-    started_at = task.get("started_at")
-    if not started_at:
-        running = [
-            run
-            for run in detail.get("runs") or []
-            if isinstance(run, dict) and str(run.get("status") or "").lower() == "running"
-        ]
-        started_at = running[-1].get("started_at") if running else None
-    started_ts = _timestamp(started_at)
     if started_ts is None:
         return None
     elapsed = (now if now is not None else time.time()) - started_ts

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -1031,6 +1031,15 @@ def test_current_running_attempt_timestamp_wins_over_original_task_start():
     assert kb._started_timestamp(detail) == 200
 
 
+def test_running_attempt_without_timestamp_falls_back_to_task_start():
+    detail = {
+        "task": {"started_at": 100},
+        "runs": [{"status": "running", "worker_pid": 4242}],
+    }
+
+    assert kb._started_timestamp(detail) == 100
+
+
 def test_running_worker_pids_require_expected_hermes_command(monkeypatch):
     monkeypatch.setattr(kb, "_is_expected_worker", lambda pid: pid == 4242)
     detail = {

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -1007,6 +1007,30 @@ def test_fresh_resumed_run_with_no_steps_does_not_warn(tmp_path, monkeypatch, ca
     assert "could not identify tool steps" not in caplog.text
 
 
+def test_stale_log_is_ignored_until_resumed_worker_writes(tmp_path, monkeypatch):
+    log_path = tmp_path / "task.log"
+    log_path.write_text(
+        "Query: work kanban task t_scout\n" + "\n".join(["  ┊ old tool call"] * 9),
+        encoding="utf-8",
+    )
+    log_path.touch()
+    monkeypatch.setattr(kb, "_log_path", lambda _task_id: log_path)
+
+    assert kb.tool_step_count("t_scout", since=log_path.stat().st_mtime + 1) == 0
+
+
+def test_current_running_attempt_timestamp_wins_over_original_task_start():
+    detail = {
+        "task": {"started_at": 100},
+        "runs": [
+            {"status": "blocked", "started_at": 100},
+            {"status": "running", "started_at": 200},
+        ],
+    }
+
+    assert kb._started_timestamp(detail) == 200
+
+
 def test_running_worker_pids_require_expected_hermes_command(monkeypatch):
     monkeypatch.setattr(kb, "_is_expected_worker", lambda pid: pid == 4242)
     detail = {


### PR DESCRIPTION
## Summary
- ignore a task log whose mtime predates the current Hermes run
- prefer the latest active run timestamp over the original task timestamp
- preserve latest-Query segmentation once the resumed worker writes

## Validation
- 92 focused tests pass
- validate_structure.py passes
- live ZOE-5422 schema simulation reports 0 steps for the fresh retry instead of inheriting 24 old steps