### PR TITLE
Use latest attempt timestamp for phase budgets

### DIFF
--- a/services/zoe-data/kanban_phase_budget.py
+++ b/services/zoe-data/kanban_phase_budget.py
@@ -137,16 +137,13 @@ def _timestamp(value: Any) -> float | None:
 
 def _started_timestamp(detail: dict[str, Any]) -> float | None:
     task = detail.get("task") if isinstance(detail.get("task"), dict) else {}
-    timestamps = [
-        timestamp
-        for run in detail.get("runs") or []
-        if isinstance(run, dict)
-        and (timestamp := _timestamp(run.get("started_at"))) is not None
-    ]
-    task_timestamp = _timestamp(task.get("started_at"))
-    if task_timestamp is not None:
-        timestamps.append(task_timestamp)
-    return max(timestamps) if timestamps else None
+    for run in reversed(detail.get("runs") or []):
+        if not isinstance(run, dict):
+            continue
+        timestamp = _timestamp(run.get("started_at"))
+        if timestamp is not None:
+            return timestamp
+    return _timestamp(task.get("started_at"))
 
 
 def phase_budget_reason(

--- a/services/zoe-data/kanban_phase_budget.py
+++ b/services/zoe-data/kanban_phase_budget.py
@@ -136,14 +136,17 @@ def _timestamp(value: Any) -> float | None:
 
 
 def _started_timestamp(detail: dict[str, Any]) -> float | None:
-    running = [
-        run
-        for run in detail.get("runs") or []
-        if isinstance(run, dict) and str(run.get("status") or "").lower() == "running"
-    ]
     task = detail.get("task") if isinstance(detail.get("task"), dict) else {}
-    started_at = (running[-1].get("started_at") if running else None) or task.get("started_at")
-    return _timestamp(started_at)
+    timestamps = [
+        timestamp
+        for run in detail.get("runs") or []
+        if isinstance(run, dict)
+        and (timestamp := _timestamp(run.get("started_at"))) is not None
+    ]
+    task_timestamp = _timestamp(task.get("started_at"))
+    if task_timestamp is not None:
+        timestamps.append(task_timestamp)
+    return max(timestamps) if timestamps else None
 
 
 def phase_budget_reason(

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -1019,19 +1019,19 @@ def test_stale_log_is_ignored_until_resumed_worker_writes(tmp_path, monkeypatch)
     assert kb.tool_step_count("t_scout", since=log_path.stat().st_mtime + 1) == 0
 
 
-def test_current_running_attempt_timestamp_wins_over_original_task_start():
+def test_latest_attempt_timestamp_wins_before_run_reaches_running():
     detail = {
         "task": {"started_at": 100},
         "runs": [
             {"status": "blocked", "started_at": 100},
-            {"status": "running", "started_at": 200},
+            {"status": "claimed", "started_at": 200},
         ],
     }
 
     assert kb._started_timestamp(detail) == 200
 
 
-def test_running_attempt_without_timestamp_falls_back_to_task_start():
+def test_attempt_without_timestamp_falls_back_to_task_start():
     detail = {
         "task": {"started_at": 100},
         "runs": [{"status": "running", "worker_pid": 4242}],

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -1023,7 +1023,7 @@ def test_latest_attempt_timestamp_wins_before_run_reaches_running():
     detail = {
         "task": {"started_at": 100},
         "runs": [
-            {"status": "blocked", "started_at": 100},
+            {"status": "blocked", "started_at": 300},
             {"status": "claimed", "started_at": 200},
         ],
     }


### PR DESCRIPTION
## Summary\n- use the newest Hermes run timestamp even before a resumed attempt reaches running\n- prevent stale task logs from immediately exhausting a resumed phase budget\n- add the exact claimed-run regression seen on ZOE-5422\n\n## Tests\n- 65 adapter tests passed\n- compileall and diff check passed\n\n## Production context\nZOE-5422 remains blocked and no other ticket is approved while this safety fix is reviewed.