### PR TITLE
Enforce phase budgets only while workers run

### DIFF
--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -526,7 +526,7 @@ class KanbanAdapter:
     ) -> bool:
         """Block a task after repeated Hermes protocol violations (silent worker exit)."""
         status = (row.get("status") or "").lower()
-        if status in _TERMINAL_KANBAN_STATUSES or status == "blocked":
+        if status != "running":
             return False
         violations = _protocol_violation_count(detail)
         if violations < _PROTOCOL_VIOLATION_LIMIT:

--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -564,7 +564,7 @@ class KanbanAdapter:
     ) -> bool:
         """Stop a running worker when its code-enforced phase budget is exhausted."""
         status = (row.get("status") or "").lower()
-        if status in _TERMINAL_KANBAN_STATUSES or status == "blocked":
+        if status != "running":
             return False
         reason = phase_budget_reason(task_id, phase, detail)
         if not reason:

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -1103,6 +1103,26 @@ async def test_poll_does_not_apply_previous_attempt_budget_to_ready_task(monkeyp
 
 
 @pytest.mark.asyncio
+async def test_poll_does_not_apply_previous_protocol_violations_to_ready_task(monkeypatch):
+    monkeypatch.setattr(ka, "_PROTOCOL_VIOLATION_LIMIT", 2)
+    rows = [_row("scout", "ready")]
+    show = {
+        "t_scout": {
+            "events": [
+                {"kind": "protocol_violation", "payload": {"exit_code": 0}},
+                {"kind": "protocol_violation", "payload": {"exit_code": 0}},
+            ]
+        }
+    }
+    a = _FakeAdapter(list_rows=rows, show_map=show)
+
+    out = await a.poll("multica:uuid-9")
+
+    assert out["status"] == "partial"
+    assert not any(call[0] == "block" for call in a.calls)
+
+
+@pytest.mark.asyncio
 async def test_poll_auto_blocks_after_protocol_violations(monkeypatch):
     monkeypatch.setattr(ka, "_PROTOCOL_VIOLATION_LIMIT", 2)
     rows = [_row("implement", "running")]

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -1098,7 +1098,7 @@ async def test_poll_does_not_apply_previous_attempt_budget_to_ready_task(monkeyp
 
     out = await a.poll("multica:uuid-9")
 
-    assert out["status"] == "running"
+    assert out["status"] == "partial"
     assert not any(call[0] == "block" for call in a.calls)
 
 

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -1081,6 +1081,28 @@ async def test_poll_auto_blocks_and_terminates_worker_after_phase_budget(monkeyp
 
 
 @pytest.mark.asyncio
+async def test_poll_does_not_apply_previous_attempt_budget_to_ready_task(monkeypatch):
+    rows = [_row("scout", "ready")]
+    show = {
+        "t_scout": {
+            "task": {"started_at": 100},
+            "runs": [{"status": "blocked", "started_at": 100}],
+        }
+    }
+    monkeypatch.setattr(
+        ka,
+        "phase_budget_reason",
+        lambda *_args, **_kwargs: pytest.fail("ready task must not be budgeted"),
+    )
+    a = _FakeAdapter(list_rows=rows, show_map=show)
+
+    out = await a.poll("multica:uuid-9")
+
+    assert out["status"] == "running"
+    assert not any(call[0] == "block" for call in a.calls)
+
+
+@pytest.mark.asyncio
 async def test_poll_auto_blocks_after_protocol_violations(monkeypatch):
     monkeypatch.setattr(ka, "_PROTOCOL_VIOLATION_LIMIT", 2)
     rows = [_row("implement", "running")]


### PR DESCRIPTION
## Summary\n- skip tool/runtime budget enforcement while a Hermes task is ready but not yet claimed\n- keep enforcement unchanged for running workers\n- cover the production ZOE-5422 race where a previous attempt timestamp was applied before the next run existed\n\n## Tests\n- 66 adapter tests passed\n- compileall and diff check passed\n\nZOE-5422 remains blocked and is the only approved production ticket.