### PR TITLE
Use audit evidence for no-code implementation skips

### DIFF
--- a/services/zoe-data/pipeline_evidence.py
+++ b/services/zoe-data/pipeline_evidence.py
@@ -354,6 +354,14 @@ def transition(state: PipelineState, outcome: TransitionOutcome, *, reason: str 
         TransitionRecord(from_phase=state.phase, to_phase=next_phase, outcome=outcome, reason=reason),
     ]
     evidence = [] if outcome in {"request_changes", "verification_failed"} else state.evidence
+    evidence_profile = "audit" if outcome == "skip_implementation" else state.evidence_profile
     return state.model_copy(
-        update={"phase": next_phase, "status": next_status, "attempts": attempts, "evidence": evidence, "history": history}
+        update={
+            "phase": next_phase,
+            "status": next_status,
+            "attempts": attempts,
+            "evidence": evidence,
+            "evidence_profile": evidence_profile,
+            "history": history,
+        }
     )

--- a/services/zoe-data/pipeline_handoff.py
+++ b/services/zoe-data/pipeline_handoff.py
@@ -381,9 +381,10 @@ def evidence_from_handoff(
     skills: tuple[str, ...] | list[str] = (),
 ) -> list[EvidenceItem]:
     """Best-effort extraction of structured evidence from a Kanban task show payload."""
-    fields = _structured_handoff_fields(detail) if phase == "retro" else {}
+    fields: dict[str, str] = {}
     for chunk in _haystacks(detail):
         fields.update(_parse_kv_fields(chunk))
+    fields.update(_structured_handoff_fields(detail))
 
     items: list[EvidenceItem] = []
 
@@ -421,7 +422,11 @@ def evidence_from_handoff(
 
     tests_raw = fields.get("TESTS") or ""
     if tests_raw and phase in {"implement", "verify"}:
-        passed = "fail" not in tests_raw.lower()
+        lowered = tests_raw.lower()
+        passed = not any(
+            marker in lowered
+            for marker in ("fail", "block", "not applicable", "n/a", "no tests")
+        )
         items.append(
             EvidenceItem(
                 kind="test",

--- a/services/zoe-data/pipeline_handoff.py
+++ b/services/zoe-data/pipeline_handoff.py
@@ -73,6 +73,17 @@ def _parse_kv_fields(text: str) -> dict[str, str]:
     return out
 
 
+def _reported_evidence_passed(raw: str, *, unavailable_markers: tuple[str, ...]) -> bool:
+    lowered = raw.lower()
+    return not (
+        any(
+            marker in lowered
+            for marker in ("fail", "not applicable", "n/a", *unavailable_markers)
+        )
+        or re.search(r"\bblock(?:ed)?\b", lowered)
+    )
+
+
 def _structured_handoff_fields(detail: dict[str, Any]) -> dict[str, str]:
     """Extract explicit KEY=value equivalents from Kanban metadata."""
     out: dict[str, str] = {}
@@ -423,10 +434,9 @@ def evidence_from_handoff(
 
     tests_raw = fields.get("TESTS") or ""
     if tests_raw and phase in {"implement", "verify"}:
-        lowered = tests_raw.lower()
-        passed = not any(
-            marker in lowered
-            for marker in ("fail", "block", "not applicable", "n/a", "no tests")
+        passed = _reported_evidence_passed(
+            tests_raw,
+            unavailable_markers=("no tests",),
         )
         items.append(
             EvidenceItem(
@@ -440,7 +450,10 @@ def evidence_from_handoff(
 
     validators_raw = fields.get("VALIDATORS") or ""
     if validators_raw and phase in {"implement", "verify"}:
-        passed = "fail" not in validators_raw.lower()
+        passed = _reported_evidence_passed(
+            validators_raw,
+            unavailable_markers=("no validators",),
+        )
         items.append(
             EvidenceItem(
                 kind="validator",

--- a/services/zoe-data/pipeline_handoff.py
+++ b/services/zoe-data/pipeline_handoff.py
@@ -381,9 +381,10 @@ def evidence_from_handoff(
     skills: tuple[str, ...] | list[str] = (),
 ) -> list[EvidenceItem]:
     """Best-effort extraction of structured evidence from a Kanban task show payload."""
-    fields: dict[str, str] = {}
+    text_fields: dict[str, str] = {}
     for chunk in _haystacks(detail):
-        fields.update(_parse_kv_fields(chunk))
+        text_fields.update(_parse_kv_fields(chunk))
+    fields = dict(text_fields)
     fields.update(_structured_handoff_fields(detail))
 
     items: list[EvidenceItem] = []
@@ -451,7 +452,7 @@ def evidence_from_handoff(
         )
 
     if phase == "review":
-        review_note = fields.get("SUMMARY") or fields.get("REVIEW") or ""
+        review_note = text_fields.get("SUMMARY") or text_fields.get("REVIEW") or ""
         if review_note:
             items.append(EvidenceItem(kind="human", summary=review_note[:500], passed=True))
         else:

--- a/services/zoe-data/tests/test_pipeline_evidence.py
+++ b/services/zoe-data/tests/test_pipeline_evidence.py
@@ -304,3 +304,16 @@ def test_skip_implementation_rejects_invalid_phase():
         match="skip_implementation is only valid from scout or implement",
     ):
         transition(state, "skip_implementation")
+
+
+def test_skip_implementation_uses_audit_evidence_profile():
+    state = PipelineState(task_ref="multica:no-code", phase="scout", status="running")
+    state = with_evidence(
+        state,
+        EvidenceItem(kind="tool", summary="merged work inspected", passed=True),
+    )
+
+    skipped = transition(state, "skip_implementation")
+
+    assert skipped.phase == "verify"
+    assert skipped.evidence_profile == "audit"

--- a/services/zoe-data/tests/test_pipeline_handoff.py
+++ b/services/zoe-data/tests/test_pipeline_handoff.py
@@ -69,6 +69,41 @@ def test_evidence_from_verify_handoff_parses_validators():
     assert len(validator.content_hash) == 64
 
 
+def test_verify_evidence_reads_structured_run_metadata():
+    detail = {
+        "runs": [
+            {
+                "metadata": {
+                    "TESTS": "pytest -q passed",
+                    "VALIDATORS": "validate_structure.py passed",
+                }
+            }
+        ]
+    }
+
+    items = evidence_from_handoff("verify", detail)
+
+    assert {item.kind for item in items if item.passed is True} >= {"test", "validator"}
+
+
+def test_not_applicable_tests_do_not_count_as_passed():
+    detail = {
+        "runs": [
+            {
+                "metadata": {
+                    "TESTS": "not applicable — audit-only no-code verification",
+                    "VALIDATORS": "validate_structure.py passed",
+                }
+            }
+        ]
+    }
+
+    items = evidence_from_handoff("verify", detail)
+    test_item = next(item for item in items if item.kind == "test")
+
+    assert test_item.passed is False
+
+
 def test_evidence_from_review_metadata_records_human_approval():
     detail = {
         "latest_summary": "APPROVE ZOE-5401. PR is merge-ready.",

--- a/services/zoe-data/tests/test_pipeline_handoff.py
+++ b/services/zoe-data/tests/test_pipeline_handoff.py
@@ -104,6 +104,43 @@ def test_not_applicable_tests_do_not_count_as_passed():
     assert test_item.passed is False
 
 
+def test_not_applicable_validators_do_not_count_as_passed():
+    detail = {
+        "runs": [
+            {
+                "metadata": {
+                    "VALIDATORS": "not applicable — validators were not run",
+                }
+            }
+        ]
+    }
+
+    items = evidence_from_handoff("verify", detail)
+    validator = next(item for item in items if item.kind == "validator")
+
+    assert validator.passed is False
+
+
+def test_blocked_validator_does_not_count_as_passed():
+    detail = {"latest_summary": "VALIDATORS=gate blocked pending repository access"}
+
+    items = evidence_from_handoff("verify", detail)
+    validator = next(item for item in items if item.kind == "validator")
+
+    assert validator.passed is False
+
+
+def test_block_substrings_do_not_reject_successful_test_evidence():
+    detail = {
+        "latest_summary": "TESTS=unblocked blockchain tests; pytest passed",
+    }
+
+    items = evidence_from_handoff("verify", detail)
+    test_item = next(item for item in items if item.kind == "test")
+
+    assert test_item.passed is True
+
+
 def test_evidence_from_review_metadata_records_human_approval():
     detail = {
         "latest_summary": "APPROVE ZOE-5401. PR is merge-ready.",

--- a/services/zoe-data/tests/test_pipeline_store.py
+++ b/services/zoe-data/tests/test_pipeline_store.py
@@ -159,7 +159,6 @@ async def test_sync_pipeline_advances_on_complete_handoff(isolated_store):
     state = await store.sync_pipeline_from_chain("multica:sync", phases, fetch_detail)
     assert state.phase == "verify"
     assert state.status == "todo"
-    assert state.evidence_profile == "audit"
 
     lines = isolated_store.read_text(encoding="utf-8").strip().splitlines()
     assert len(lines) >= 2
@@ -195,6 +194,7 @@ async def test_sync_pipeline_skips_implementation_when_scout_marks_it_unneeded(i
 
     assert state.phase == "verify"
     assert state.status == "todo"
+    assert state.evidence_profile == "audit"
     assert state.history[-1].outcome == "skip_implementation"
     assert state.history[-1].reason == "scout proved implementation not required"
 

--- a/services/zoe-data/tests/test_pipeline_store.py
+++ b/services/zoe-data/tests/test_pipeline_store.py
@@ -122,6 +122,7 @@ def test_skip_blocked_implementation_moves_to_verify(isolated_store):
 
     assert skipped.phase == "verify"
     assert skipped.status == "todo"
+    assert skipped.evidence_profile == "audit"
     assert skipped.last_block_fingerprint is None
     assert skipped.repeated_block_count == 0
     assert skipped.block_classification is None
@@ -158,6 +159,7 @@ async def test_sync_pipeline_advances_on_complete_handoff(isolated_store):
     state = await store.sync_pipeline_from_chain("multica:sync", phases, fetch_detail)
     assert state.phase == "verify"
     assert state.status == "todo"
+    assert state.evidence_profile == "audit"
 
     lines = isolated_store.read_text(encoding="utf-8").strip().splitlines()
     assert len(lines) >= 2


### PR DESCRIPTION
## Summary\n- switch explicit no-code implementation skips to the audit evidence profile\n- parse structured worker metadata for test and validator evidence in every phase\n- refuse to count not-applicable test text as a passing test\n- preserve the separate reviewer approval gate\n\n## Tests\n- 155 focused pipeline, handoff, evidence, and adapter tests passed\n- compileall and diff check passed\n\n## Production evidence\nZOE-5422 verify completed with validators but correctly remained gate-blocked because TESTS was not applicable. This change models that no-code path honestly instead of fabricating test evidence.