### PR TITLE
Complete the Multica production operator surface

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,4 +62,4 @@ Local Zoe Hermes engineering skills live under `~/.hermes/skills`, including `zo
 
 The `agentic-engineering-workflow` and `grep-loop-review-workflow` names are kept as compatibility entrypoints for the Micky-style workflow pack, but they map onto Zoe's Hermes-first Graphify/opensrc/Greptile process rather than introducing a second parallel system.
 
-OpenClaw remains installed and available as a future/manual fallback. Do not route ordinary coding, planning, review, board work, browser work, or background work to OpenClaw by default; Hermes owns those paths unless the user explicitly asks to use OpenClaw.
+OpenClaw remains installed and available as a future/manual fallback. Do not route ordinary coding, planning, review, board work, browser work, or background work to OpenClaw by default. Zoe's Multica-first engineering driver owns workflow state and phase advancement; Hermes executes the one ready phase unless the user explicitly asks to use OpenClaw.

--- a/docs/guides/ENGINEERING_HARNESS_LOOP.md
+++ b/docs/guides/ENGINEERING_HARNESS_LOOP.md
@@ -104,8 +104,9 @@ Before editing harness code, merging PRs, or running a controlled E2E, pause aut
 ZOE_MULTICA_POLL_DISPATCH_LIMIT=0
 systemctl --user restart zoe-data.service
 
-# 2. Pause hourly board cron
-hermes cron pause hourly-zoe-board-dispatch
+# 2. Pause the shared runtime gate
+PYTHONPATH=services/zoe-data python3 -c \
+  'from multica_dispatch_control import pause_dispatch; pause_dispatch("operator maintenance")'
 
 # 3. Block or reclaim any active Kanban task (example)
 hermes kanban block t_<task_id>
@@ -125,9 +126,22 @@ After a controlled E2E completes, re-enable dispatch one issue at a time:
 ZOE_MULTICA_POLL_DISPATCH_LIMIT=1
 systemctl --user restart zoe-data.service
 
-hermes cron resume hourly-zoe-board-dispatch
+PYTHONPATH=services/zoe-data python3 -c \
+  'from multica_dispatch_control import resume_dispatch; resume_dispatch()'
 
 python3 scripts/maintenance/sync_multica_to_kanban.py --limit 1
 ```
 
 Monitor with `hermes kanban show t_<id> --json`, pipeline JSONL (`~/.zoe/engineering_pipeline_runs.jsonl`), and `engineering_harness_loop.py --mode report`. Pause again when done.
+
+## Prompt Contract Eval
+
+Run the zero-token worker prompt contract before changing Hermes guidance:
+
+```bash
+python3 scripts/maintenance/evaluate_engineering_prompts.py
+```
+
+It checks all six phase packets for mandatory evidence commands, terminal
+protocols, split handling, Greptile closeout, bounded size, and retired workflow
+language. Prompt or skill changes must keep this at 100%.

--- a/docs/guides/MULTICA_HERMES_PR_LOOP.md
+++ b/docs/guides/MULTICA_HERMES_PR_LOOP.md
@@ -1,6 +1,7 @@
-# Multica Hermes PR Loop
+# Multica-First Engineering Driver
 
-This workflow lets Zoe track engineering work from a Multica issue through Hermes implementation, GitHub PR creation, Greptile review, and human merge readiness.
+Multica is the operator-visible source of truth. Zoe owns deterministic phase
+control and the append-only journal; Hermes executes one bounded phase at a time.
 
 ## Required Setup
 
@@ -22,9 +23,10 @@ This workflow lets Zoe track engineering work from a Multica issue through Herme
 3. Hermes executes that single bounded phase and must end with `kanban_complete` or `kanban_block`.
 4. Zoe polls the phase row, parses evidence, and advances the journal only when `pipeline_evidence` requirements pass.
 5. When the journal moves to a new `todo` phase and no Kanban row exists for that phase, the poll bridge or compatibility script may dispatch exactly that next phase.
-6. `zoe-planner` **closeout** runs the Greptile grep loop (`github-greptile-loop`), squash-merges when Greptile + CI are green (`greploop_guard.py --merge-when-ready`), then updates the Multica issue.
+6. `zoe-planner` **closeout** runs the Greptile grep loop (`github-greptile-loop`) and squash-merges when Greptile + CI are green (`greploop_guard.py --merge-when-ready`).
 7. `zoe-planner` **retro** captures learnings and optional harness improvements (no silent production changes).
-8. Legacy v2/v3 chains are still recognized while in-flight board work drains; poll treats them as complete when closeout (or retro, when present) finishes.
+8. Zoe marks the Multica issue done only after retro completes, then admits the next explicitly approved backlog ticket.
+9. Legacy v2/v3 chains are still recognized while in-flight board work drains; poll treats them as complete when closeout (or retro, when present) finishes.
 
 ## Model Routing Policy (Phase 0 cost control)
 
@@ -48,7 +50,7 @@ Stock Multica (ghcr backend) does **not** have a `/api/webhooks` registry for ou
 
 | Path | When | How |
 |------|------|-----|
-| **Zoe poll bridge** | Always (default today) | `multica_webhook_emitter.py` in the 30s poll loop POSTs `issue.assigned` for Hermes **todo** issues and **backfills** Hermes **in_progress** issues that have no Kanban chain yet (`chain_needs_dispatch` in `multica_poll_dispatch.py`) |
+| **Zoe poll bridge** | Always (default today) | `multica_webhook_emitter.py` in the 30s poll loop POSTs `issue.assigned` for Hermes **todo** issues and backfills an **in_progress** issue whose current journal phase has no Kanban task (`chain_needs_dispatch` in `multica_poll_dispatch.py`) |
 | **Multica push** | After rebuilding backend with `zoe_webhook_listener.go` | Multica event bus POSTs to `ZOE_BOARD_WEBHOOK_URL` from the container |
 
 Set the same secret in both places:
@@ -79,7 +81,7 @@ This should create a queued workflow that still needs approval before Hermes cha
 what's the hermes engineering status
 ```
 
-Expected Kanban chain progression (per Multica issue):
+Expected journal phase progression (one Kanban task exists at a time):
 
 - `scout` (`zoe-planner`) — Graphify/opensrc/Multica context only; `TOOLS_USED=` + `SCOUT_SUMMARY=` handoff.
 - `implement` (`zoe-coder`) — graphify/opensrc first, smallest reviewable change, small PR on a worktree at `~/.worktrees/<kanban_task_id>` (override root with `ZOE_WORKTREE_ROOT`). Zoe pins this path on the Kanban row at dispatch so workers do not default to `<repo>/.worktrees/`. Terminal protocol: `kanban_complete` or `kanban_block` on the last turn. Handoff metadata must include `PR_URL`, `TESTS`, `TOOLS_USED`, `SUMMARY`. Pure audit/doc tasks: `AUDIT_ONLY=1` with blank `PR_URL`.
@@ -122,7 +124,7 @@ After deploying this PR on the Zoe host:
    python3 scripts/maintenance/multica_reassign_open_to_hermes.py --execute
    ```
 
-5. **Dispatcher:** Hermes cron `hourly-zoe-board-dispatch` (`dispatch-hermes-board.sh` → `sync_multica_to_kanban.py`) or the 30s Zoe poll webhook bridge:
+5. **Dispatcher:** the 30-second Zoe poll bridge is authoritative. The compatibility CLI calls the same decision gate:
 
    ```bash
    python3 scripts/maintenance/sync_multica_to_kanban.py --dry-run --limit 1
@@ -134,7 +136,7 @@ Keep `ZOE_BOARD_REVIEW_AUTOPILOT_ENABLED=false` (the Zoe poll loop and cron own 
 
 ## Contributor quick reference (ZOE-5378)
 
-Use this when dispatching or reviewing a Hermes Kanban chain on Multica:
+Use this when dispatching or reviewing a Multica ticket:
 
 | Control | Where to set | Effect |
 |---------|--------------|--------|
@@ -144,6 +146,10 @@ Use this when dispatching or reviewing a Hermes Kanban chain on Multica:
 | `ZOE_MULTICA_POLL_DISPATCH_LIMIT=1` | `services/zoe-data/.env` | Poll bridge dispatches one Hermes todo issue per cycle (default when unset; use `0` to disable dispatch) |
 
 **Idempotency:** Kanban tasks are keyed `multica:{issue_uuid}:{phase}`. Re-dispatch is safe when poll reports `not_found` or `partial`; active `running`/`blocked` chains are left alone.
+
+**Runtime pause:** `pause engineering dispatch` creates
+`~/.zoe/multica_dispatch_paused`; `resume engineering dispatch` removes it.
+Both the poll bridge and compatibility CLI obey the same sentinel.
 
 **Greptile closeout:** Closeout runs `github-greptile-loop` / `greploop_guard.py --merge-when-ready` only when implement recorded `PR_URL=` on a pushed branch. Audit-only issues should hand off with `AUDIT_ONLY=1` and blank `PR_URL`.
 

--- a/scripts/maintenance/evaluate_engineering_prompts.py
+++ b/scripts/maintenance/evaluate_engineering_prompts.py
@@ -47,7 +47,7 @@ def evaluate() -> dict:
     checks = []
     for scenario, issue in scenarios.items():
         for phase, markers in REQUIRED.items():
-            body = adapter._build_body(phase, issue, str(issue["identifier"]))
+            body = adapter.build_phase_prompt(phase, issue, str(issue["identifier"]))
             missing = [marker for marker in markers if marker not in body]
             forbidden = [marker for marker in FORBIDDEN if marker.lower() in body.lower()]
             checks.append(

--- a/scripts/maintenance/evaluate_engineering_prompts.py
+++ b/scripts/maintenance/evaluate_engineering_prompts.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Cheap, deterministic contract evaluation for Hermes engineering prompts."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "services" / "zoe-data"))
+
+from executors.kanban_adapter import KanbanAdapter  # noqa: E402
+
+
+REQUIRED = {
+    "scout": ("IMPLEMENTATION_REQUIRED=true|false", "kanban_complete", "SCOUT_BUDGET"),
+    "implement": ("PR_URL=", "NEEDS_SPLIT=1", "IMPLEMENT_BUDGET", "kanban_block"),
+    "verify": ("TESTS", "VALIDATORS", "VERIFY_BUDGET", "kanban_complete"),
+    "review": ("mark-reviewed", "REVIEW=<approved or blocked>", "REVIEW_BUDGET"),
+    "closeout": ("run_greploop_guard.sh", "AUDIT_ONLY=", "kanban_complete"),
+    "retro": ("FOLLOW_UP_TITLE=", "RETRO=", "kanban_complete"),
+}
+FORBIDDEN = (
+    "create all six",
+    "pre-create the full chain",
+    "Hermes decides the next phase",
+)
+
+
+def evaluate() -> dict:
+    adapter = KanbanAdapter()
+    scenarios = {
+        "code": {
+            "id": "eval-code",
+            "identifier": "ZOE-EVAL",
+            "title": "Small code fix",
+            "description": "Change one helper with focused tests.",
+        },
+        "audit": {
+            "id": "eval-audit",
+            "identifier": "ZOE-EVAL-AUDIT",
+            "title": "Audit existing behavior",
+            "description": "evidence_profile: audit\nNo code changes.",
+        },
+    }
+    checks = []
+    for scenario, issue in scenarios.items():
+        for phase, markers in REQUIRED.items():
+            body = adapter._build_body(phase, issue, str(issue["identifier"]))
+            missing = [marker for marker in markers if marker not in body]
+            forbidden = [marker for marker in FORBIDDEN if marker.lower() in body.lower()]
+            checks.append(
+                {
+                    "scenario": scenario,
+                    "phase": phase,
+                    "passed": not missing and not forbidden and len(body) <= 12_000,
+                    "missing": missing,
+                    "forbidden": forbidden,
+                    "chars": len(body),
+                }
+            )
+    passed = sum(1 for check in checks if check["passed"])
+    return {
+        "ok": passed == len(checks),
+        "passed": passed,
+        "total": len(checks),
+        "pass_rate": passed / len(checks),
+        "checks": checks,
+    }
+
+
+def main() -> int:
+    report = evaluate()
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0 if report["ok"] else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/maintenance/multica_apply_triage_dispositions.py
+++ b/scripts/maintenance/multica_apply_triage_dispositions.py
@@ -2,6 +2,7 @@
 """Apply triage dispositions to Multica (duplicate/wont_fix/monitor done)."""
 from __future__ import annotations
 
+import argparse
 import json
 import os
 import sys
@@ -21,6 +22,9 @@ def _load_dotenv() -> None:
 
 
 def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--execute", action="store_true", help="Apply the printed changes.")
+    args = parser.parse_args()
     _load_dotenv()
     triage_path = ROOT / ".cursor" / "tmp" / "multica-triage.json"
     if not triage_path.exists():
@@ -40,6 +44,7 @@ def main() -> int:
 
     async def run() -> int:
         updated = 0
+        labels = await client.list_labels()
         for item in data.get("issues", []):
             disp = item.get("disposition")
             if disp not in ("duplicate", "wont_fix", "monitor"):
@@ -49,18 +54,22 @@ def main() -> int:
                 continue
             status = "done" if disp in ("duplicate", "wont_fix", "monitor") else None
             note = item.get("notes", disp)
-            desc_append = f"\n\n---\nTriage: {disp} — {note}"
-            await client.update_issue(
-                uid,
-                status=status,
-                description=(item.get("title", "") + desc_append)[:4000],
-            )
-            updated += 1
             print(f"  {item.get('identifier')}: {disp} -> {status}")
+            if not args.execute:
+                continue
+            label_name = disp.replace("_", "-")
+            await client.ensure_label(label_name, existing=labels)
+            await client.attach_label(uid, label_name)
+            await client.append_issue_note(uid, f"Triage: {disp} - {note}")
+            await client.update_issue(uid, status=status)
+            updated += 1
         return updated
 
     n = asyncio.run(run())
-    print(f"Updated {n} issue(s)")
+    if args.execute:
+        print(f"Updated {n} issue(s)")
+    else:
+        print("Dry-run only; pass --execute to apply.")
     return 0
 
 

--- a/scripts/maintenance/multica_finalize_board_repair.py
+++ b/scripts/maintenance/multica_finalize_board_repair.py
@@ -2,6 +2,7 @@
 """Mark Multica issues done per triage ledger after board-repair PR lands."""
 from __future__ import annotations
 
+import argparse
 import json
 import os
 import sys
@@ -48,6 +49,9 @@ def _load_dotenv() -> None:
 
 
 def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--execute", action="store_true", help="Apply the printed changes.")
+    args = parser.parse_args()
     _load_dotenv()
     triage_path = ROOT / ".cursor" / "tmp" / "multica-triage.json"
     if not triage_path.exists():
@@ -67,6 +71,7 @@ def main() -> int:
 
     async def run() -> int:
         updated = 0
+        labels = await client.list_labels()
         for item in data.get("issues", []):
             ident = item.get("identifier") or ""
             disp = item.get("disposition")
@@ -86,17 +91,22 @@ def main() -> int:
                 note = "fixed on fix/multica-board-repair branch (board repair)"
             if not close:
                 continue
-            await client.update_issue(
-                uid,
-                status="done",
-                description=(item.get("title", "") + f"\n\n---\n{note}")[:4000],
-            )
-            updated += 1
             print(f"  {ident}: done ({note[:60]})")
+            if not args.execute:
+                continue
+            label_name = "board-repair-closed"
+            await client.ensure_label(label_name, existing=labels)
+            await client.attach_label(uid, label_name)
+            await client.append_issue_note(uid, note)
+            await client.update_issue(uid, status="done")
+            updated += 1
         return updated
 
     n = asyncio.run(run())
-    print(f"Closed/updated {n} issue(s)")
+    if args.execute:
+        print(f"Closed/updated {n} issue(s)")
+    else:
+        print("Dry-run only; pass --execute to apply.")
     return 0
 
 

--- a/scripts/maintenance/multica_health_report.py
+++ b/scripts/maintenance/multica_health_report.py
@@ -30,6 +30,10 @@ def _uploads_configured() -> bool:
     )
 
 
+def _oidc_client_id_configured() -> bool:
+    return bool(os.environ.get("MULTICA_OIDC_CLIENT_ID"))
+
+
 async def _probe(url: str, *, headers: dict[str, str] | None = None) -> dict:
     try:
         async with httpx.AsyncClient(timeout=5.0, follow_redirects=True) as client:
@@ -53,7 +57,7 @@ async def run(*, ensure_shape: bool = False) -> dict:
         "workspace_id": bool(os.environ.get("MULTICA_WORKSPACE_ID")),
         "api_token": bool(os.environ.get("MULTICA_API_TOKEN")),
         "webhook_secret": bool(os.environ.get("MULTICA_WEBHOOK_SECRET")),
-        "oidc_client_id": bool(os.environ.get("MULTICA_OIDC_CLIENT_ID", "multica")),
+        "oidc_client_id": _oidc_client_id_configured(),
         "oidc_client_secret": bool(os.environ.get("MULTICA_OIDC_CLIENT_SECRET")),
         "uploads_configured": _uploads_configured(),
         "email_configured": bool(

--- a/scripts/maintenance/multica_health_report.py
+++ b/scripts/maintenance/multica_health_report.py
@@ -15,6 +15,21 @@ import httpx
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "services" / "zoe-data"))
 
 
+def _uploads_configured() -> bool:
+    if os.environ.get("LOCAL_UPLOAD_DIR") and os.environ.get("LOCAL_UPLOAD_BASE_URL"):
+        return True
+    compose_path = Path(__file__).resolve().parents[2] / "docker-compose.modules.yml"
+    try:
+        compose = compose_path.read_text(encoding="utf-8")
+    except OSError:
+        return False
+    return (
+        'LOCAL_UPLOAD_DIR: "/data/uploads"' in compose
+        and 'LOCAL_UPLOAD_BASE_URL: "http://localhost:8080"' in compose
+        and "multica-uploads:/data/uploads" in compose
+    )
+
+
 async def _probe(url: str, *, headers: dict[str, str] | None = None) -> dict:
     try:
         async with httpx.AsyncClient(timeout=5.0, follow_redirects=True) as client:
@@ -40,7 +55,7 @@ async def run(*, ensure_shape: bool = False) -> dict:
         "webhook_secret": bool(os.environ.get("MULTICA_WEBHOOK_SECRET")),
         "oidc_client_id": bool(os.environ.get("MULTICA_OIDC_CLIENT_ID", "multica")),
         "oidc_client_secret": bool(os.environ.get("MULTICA_OIDC_CLIENT_SECRET")),
-        "uploads_configured": True,
+        "uploads_configured": _uploads_configured(),
         "email_configured": bool(
             os.environ.get("RESEND_API_KEY") or os.environ.get("SMTP_HOST")
         ),

--- a/scripts/maintenance/multica_health_report.py
+++ b/scripts/maintenance/multica_health_report.py
@@ -39,7 +39,7 @@ async def _probe(url: str, *, headers: dict[str, str] | None = None) -> dict:
         async with httpx.AsyncClient(timeout=5.0, follow_redirects=True) as client:
             response = await client.get(url, headers=headers)
         return {
-            "ok": response.status_code < 500,
+            "ok": 200 <= response.status_code < 300,
             "status": response.status_code,
             "url": url,
         }

--- a/scripts/maintenance/multica_health_report.py
+++ b/scripts/maintenance/multica_health_report.py
@@ -10,7 +10,22 @@ import os
 import sys
 from pathlib import Path
 
+import httpx
+
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "services" / "zoe-data"))
+
+
+async def _probe(url: str, *, headers: dict[str, str] | None = None) -> dict:
+    try:
+        async with httpx.AsyncClient(timeout=5.0, follow_redirects=True) as client:
+            response = await client.get(url, headers=headers)
+        return {
+            "ok": response.status_code < 500,
+            "status": response.status_code,
+            "url": url,
+        }
+    except Exception as exc:
+        return {"ok": False, "url": url, "error": str(exc)}
 
 
 async def run(*, ensure_shape: bool = False) -> dict:
@@ -23,6 +38,12 @@ async def run(*, ensure_shape: bool = False) -> dict:
         "workspace_id": bool(os.environ.get("MULTICA_WORKSPACE_ID")),
         "api_token": bool(os.environ.get("MULTICA_API_TOKEN")),
         "webhook_secret": bool(os.environ.get("MULTICA_WEBHOOK_SECRET")),
+        "oidc_client_id": bool(os.environ.get("MULTICA_OIDC_CLIENT_ID", "multica")),
+        "oidc_client_secret": bool(os.environ.get("MULTICA_OIDC_CLIENT_SECRET")),
+        "uploads_configured": True,
+        "email_configured": bool(
+            os.environ.get("RESEND_API_KEY") or os.environ.get("SMTP_HOST")
+        ),
         "hermes_agent_id": get_engineering_multica_agent_id(),
         "checks": {},
     }
@@ -36,6 +57,23 @@ async def run(*, ensure_shape: bool = False) -> dict:
     report["checks"]["issues_api"] = isinstance(issues, list)
     report["checks"]["labels_api"] = isinstance(labels, list)
     report["checks"]["projects_api"] = isinstance(projects, list)
+    base_url = os.environ.get("MULTICA_BASE_URL", "").rstrip("/")
+    report["checks"]["backend_health"] = await _probe(f"{base_url}/health")
+    report["checks"]["web_direct"] = await _probe(
+        os.environ.get("MULTICA_WEB_URL", "http://127.0.0.1:3000")
+    )
+    report["checks"]["web_proxy"] = await _probe(
+        os.environ.get("MULTICA_PROXY_URL", "http://127.0.0.1/multica/")
+    )
+    report["checks"]["api_proxy"] = await _probe(
+        os.environ.get("MULTICA_API_PROXY_HEALTH_URL", "http://127.0.0.1/multica-api/health")
+    )
+    report["checks"]["oidc_discovery"] = await _probe(
+        os.environ.get(
+            "MULTICA_OIDC_DISCOVERY_URL",
+            "http://127.0.0.1/.well-known/openid-configuration",
+        )
+    )
 
     required_labels = [
         "needs-split",
@@ -63,6 +101,21 @@ async def run(*, ensure_shape: bool = False) -> dict:
         and report["checks"]["projects_api"]
         and all(report["checks"]["required_labels"].values())
         and report["webhook_secret"]
+        and all(
+            report["checks"][name]["ok"]
+            for name in (
+                "backend_health",
+                "web_direct",
+                "web_proxy",
+                "api_proxy",
+                "oidc_discovery",
+            )
+        )
+        and report["uploads_configured"]
+        and (
+            report["email_configured"]
+            or os.environ.get("MULTICA_REQUIRE_EMAIL", "false").lower() != "true"
+        )
     )
     return report
 

--- a/scripts/maintenance/setup_multica_webhooks.py
+++ b/scripts/maintenance/setup_multica_webhooks.py
@@ -90,7 +90,7 @@ def main() -> int:
 
     secret = _ensure_secret(args.dry_run)
     print("MULTICA_WEBHOOK_SECRET is configured.")
-    print("Zoe poll + sync_multica_to_kanban will POST issue.assigned to:")
+    print("Zoe poll + the compatibility sync command will POST issue.assigned to:")
     print(f"  {webhook_target_url()}")
     print("For native Multica push, rebuild multica-backend with zoe_webhook_listener.go and set:")
     print("  ZOE_BOARD_WEBHOOK_URL=http://host.docker.internal:8000/api/agent/board/webhook")

--- a/scripts/maintenance/sync_multica_to_kanban.py
+++ b/scripts/maintenance/sync_multica_to_kanban.py
@@ -42,6 +42,7 @@ async def run(args: argparse.Namespace) -> int:
     bootstrap_runtime_env()
     from executor_registry import poll_ref
     from multica_client import get_engineering_multica_agent_id, get_multica_client
+    from multica_dispatch_control import dispatch_is_paused, pause_reason
     from multica_poll_dispatch import chain_needs_dispatch
     from multica_webhook_emitter import emit_issue_assigned, is_configured as webhooks_configured
 
@@ -50,6 +51,9 @@ async def run(args: argparse.Namespace) -> int:
     if not client.is_configured():
         print("Multica not configured in Zoe env", file=sys.stderr)
         return 1
+    if dispatch_is_paused() and not args.dry_run:
+        print(f"Dispatch paused: {pause_reason()}", file=sys.stderr)
+        return 3
 
     candidates: list[dict] = []
     for issue in await client.list_issues(status="todo") or []:
@@ -109,7 +113,7 @@ async def run(args: argparse.Namespace) -> int:
             continue
         # Receiver returns {"ok": True} with no "dispatched" key if its own
         # dispatch raised; treat any non-truthy "dispatched" as "not dispatched"
-        # so we never mark the issue in_progress without a Kanban chain.
+        # so we never mark the issue in_progress without a journaled phase task.
         if not (isinstance(body, dict) and body.get("dispatched")):
             print(f"SKIP {ident}: {(body or {}).get('reason', 'webhook did not dispatch')}")
             continue

--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -318,6 +318,17 @@ class KanbanAdapter:
                 phases[key[len(prefix):]] = row
         return phases
 
+    def build_phase_prompt(
+        self,
+        phase: str,
+        issue: dict,
+        identifier: str,
+        *,
+        mode: str | None = None,
+    ) -> str:
+        """Build the supported Hermes prompt contract for one engineering phase."""
+        return self._build_body(phase, issue, identifier, mode=mode)
+
     def _build_body(self, phase: str, issue: dict, identifier: str, *, mode: str | None = None) -> str:
         title = issue.get("title") or identifier
         description = issue.get("description") or ""

--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -101,7 +101,7 @@ def _greptile_mcp_bin() -> str:
 
 
 def _engineering_mode(issue: dict | None = None) -> str:
-    """Resolve the engineering execution mode for a Kanban chain.
+    """Resolve the engineering execution mode for a journaled phase run.
 
     Interactive is the default for user-visible work. Overnight mode allows
     slower, cheaper runs by extending worker runtime and making the cost

--- a/services/zoe-data/intent_router.py
+++ b/services/zoe-data/intent_router.py
@@ -1126,6 +1126,38 @@ def detect_intent(
         return Intent("a2a_federation_status", {})
 
     # ── Multica board visibility ───────────────────────────────────────────────
+    if re.search(r"\b(?:pause|stop)\s+(?:multica\s+|engineering\s+)?dispatch\b", t, re.I):
+        return Intent("engineering_dispatch_pause", {})
+    if re.search(r"\bresume\s+(?:multica\s+|engineering\s+)?dispatch\b", t, re.I):
+        return Intent("engineering_dispatch_resume", {})
+    _MOVE_TODO_RE = re.search(
+        r"\bmove\s+(?P<reference>ZOE-\d+|[0-9a-f-]{32,36})\s+to\s+todo\b",
+        text,
+        re.I,
+    )
+    if _MOVE_TODO_RE:
+        return Intent(
+            "engineering_ticket_move_todo",
+            {"reference": _MOVE_TODO_RE.group("reference")},
+        )
+    _SPLIT_TICKET_RE = re.search(
+        r"\bsplit\s+(?P<reference>ZOE-\d+|[0-9a-f-]{32,36})\s+into\s+(?P<title>.+)$",
+        text.strip(),
+        re.I,
+    )
+    if _SPLIT_TICKET_RE:
+        return Intent(
+            "engineering_ticket_split",
+            {
+                "reference": _SPLIT_TICKET_RE.group("reference"),
+                "title": _SPLIT_TICKET_RE.group("title").strip(),
+            },
+        )
+    if re.search(r"\b(?:show|list)\s+(?:the\s+)?multica\s+backlog\b", t, re.I):
+        return Intent("engineering_ticket_list", {"status": "backlog"})
+    if re.search(r"\b(?:what(?:'s| is)|show|list)\s+(?:currently\s+)?blocked\b", t, re.I):
+        return Intent("engineering_ticket_list", {"status": "blocked"})
+
     _BOARD_RE = re.compile(
         r"what'?s?\s+on\s+(?:the\s+)?(?:multica\s+)?board\b"
         r"|show\s+(?:the\s+)?(?:multica\s+)?(?:active\s+)?(?:board|tasks?)\b"
@@ -1601,6 +1633,62 @@ async def execute_intent(intent: Intent, user_id: str = "family-admin") -> Optio
         except Exception as exc:
             logger.warning("engineering_task_status: %s", exc)
             return "I couldn't check Hermes engineering status right now."
+
+    if intent.name == "engineering_dispatch_pause":
+        from multica_dispatch_control import pause_dispatch
+
+        pause_dispatch(f"paused from chat by {user_id}")
+        return "Engineering dispatch is paused. Active work can finish, but no new ticket will start."
+
+    if intent.name == "engineering_dispatch_resume":
+        from multica_dispatch_control import resume_dispatch
+
+        changed = resume_dispatch()
+        return (
+            "Engineering dispatch is running again; the next approved ticket can enter the single lane."
+            if changed
+            else "Engineering dispatch was already running."
+        )
+
+    if intent.name == "engineering_ticket_move_todo":
+        from multica_operator import move_to_todo
+
+        issue = await move_to_todo(intent.slots.get("reference", ""), approve=True)
+        if not issue.get("id"):
+            return "I couldn't find or update that Multica ticket."
+        return (
+            f"Moved `{issue.get('identifier') or issue.get('id')}` to todo and approved it for "
+            "the one-ticket engineering lane."
+        )
+
+    if intent.name == "engineering_ticket_split":
+        from multica_operator import split_ticket
+
+        child = await split_ticket(
+            intent.slots.get("reference", ""),
+            child_title=intent.slots.get("title", ""),
+        )
+        if not child.get("id"):
+            return "I couldn't split that Multica ticket."
+        return (
+            f"Created child ticket `{child.get('identifier') or child.get('id')}` and blocked the parent "
+            "until its children are complete."
+        )
+
+    if intent.name == "engineering_ticket_list":
+        from multica_client import get_multica_client
+
+        status = intent.slots.get("status", "backlog")
+        issues = await get_multica_client().list_issues(status=status)
+        if not issues:
+            return f"No Multica tickets are currently `{status}`."
+        lines = [f"**Multica {status}:**"]
+        for issue in issues[:10]:
+            lines.append(
+                f"- `{issue.get('identifier') or issue.get('id')}` — "
+                f"{(issue.get('title') or 'Untitled')[:90]}"
+            )
+        return "\n".join(lines)
 
     # ── Evolution Proposals Review ─────────────────────────────────────────────
     if intent.name == "evolution_proposals_review":

--- a/services/zoe-data/intent_router.py
+++ b/services/zoe-data/intent_router.py
@@ -1155,7 +1155,18 @@ def detect_intent(
         )
     if re.search(r"\b(?:show|list)\s+(?:the\s+)?multica\s+backlog\b", t, re.I):
         return Intent("engineering_ticket_list", {"status": "backlog"})
-    if re.search(r"\b(?:what(?:'s| is)|show|list)\s+(?:currently\s+)?blocked\b", t, re.I):
+    _BARE_BLOCKED_RE = re.fullmatch(
+        r"\s*(?:what(?:'s| is)|show|list)\s+(?:currently\s+)?blocked\s*[?.!]?\s*",
+        text,
+        re.I,
+    )
+    _QUALIFIED_BLOCKED_RE = re.search(
+        r"\b(?:show|list|what(?:'s| is))\b.*\b(?:multica|engineering|tickets?)\b.*\bblocked\b"
+        r"|\b(?:show|list|what(?:'s| is))\b.*\bblocked\b.*\b(?:multica|engineering|tickets?)\b",
+        text,
+        re.I,
+    )
+    if _BARE_BLOCKED_RE or _QUALIFIED_BLOCKED_RE:
         return Intent("engineering_ticket_list", {"status": "blocked"})
 
     _BOARD_RE = re.compile(

--- a/services/zoe-data/intent_router.py
+++ b/services/zoe-data/intent_router.py
@@ -1656,60 +1656,80 @@ async def execute_intent(intent: Intent, user_id: str = "family-admin") -> Optio
             return "I couldn't check Hermes engineering status right now."
 
     if intent.name == "engineering_dispatch_pause":
-        from multica_dispatch_control import pause_dispatch
+        try:
+            from multica_dispatch_control import pause_dispatch
 
-        pause_dispatch(f"paused from chat by {user_id}")
-        return "Engineering dispatch is paused. Active work can finish, but no new ticket will start."
+            pause_dispatch(f"paused from chat by {user_id}")
+            return "Engineering dispatch is paused. Active work can finish, but no new ticket will start."
+        except Exception as exc:
+            logger.warning("engineering_dispatch_pause: %s", exc)
+            return "I couldn't pause engineering dispatch right now."
 
     if intent.name == "engineering_dispatch_resume":
-        from multica_dispatch_control import resume_dispatch
+        try:
+            from multica_dispatch_control import resume_dispatch
 
-        changed = resume_dispatch()
-        return (
-            "Engineering dispatch is running again; the next approved ticket can enter the single lane."
-            if changed
-            else "Engineering dispatch was already running."
-        )
+            changed = resume_dispatch()
+            return (
+                "Engineering dispatch is running again; the next approved ticket can enter the single lane."
+                if changed
+                else "Engineering dispatch was already running."
+            )
+        except Exception as exc:
+            logger.warning("engineering_dispatch_resume: %s", exc)
+            return "I couldn't resume engineering dispatch right now."
 
     if intent.name == "engineering_ticket_move_todo":
-        from multica_operator import move_to_todo
+        try:
+            from multica_operator import move_to_todo
 
-        issue = await move_to_todo(intent.slots.get("reference", ""), approve=True)
-        if not issue.get("id"):
-            return "I couldn't find or update that Multica ticket."
-        return (
-            f"Moved `{issue.get('identifier') or issue.get('id')}` to todo and approved it for "
-            "the one-ticket engineering lane."
-        )
+            issue = await move_to_todo(intent.slots.get("reference", ""), approve=True)
+            if not issue.get("id"):
+                return "I couldn't find or update that Multica ticket."
+            return (
+                f"Moved `{issue.get('identifier') or issue.get('id')}` to todo and approved it for "
+                "the one-ticket engineering lane."
+            )
+        except Exception as exc:
+            logger.warning("engineering_ticket_move_todo: %s", exc)
+            return "I couldn't update that Multica ticket right now."
 
     if intent.name == "engineering_ticket_split":
-        from multica_operator import split_ticket
+        try:
+            from multica_operator import split_ticket
 
-        child = await split_ticket(
-            intent.slots.get("reference", ""),
-            child_title=intent.slots.get("title", ""),
-        )
-        if not child.get("id"):
-            return "I couldn't split that Multica ticket."
-        return (
-            f"Created child ticket `{child.get('identifier') or child.get('id')}` and blocked the parent "
-            "until its children are complete."
-        )
+            child = await split_ticket(
+                intent.slots.get("reference", ""),
+                child_title=intent.slots.get("title", ""),
+            )
+            if not child.get("id"):
+                return "I couldn't split that Multica ticket."
+            return (
+                f"Created child ticket `{child.get('identifier') or child.get('id')}` and blocked the parent "
+                "until its children are complete."
+            )
+        except Exception as exc:
+            logger.warning("engineering_ticket_split: %s", exc)
+            return "I couldn't split that Multica ticket right now."
 
     if intent.name == "engineering_ticket_list":
-        from multica_client import get_multica_client
-
         status = intent.slots.get("status", "backlog")
-        issues = await get_multica_client().list_issues(status=status)
-        if not issues:
-            return f"No Multica tickets are currently `{status}`."
-        lines = [f"**Multica {status}:**"]
-        for issue in issues[:10]:
-            lines.append(
-                f"- `{issue.get('identifier') or issue.get('id')}` — "
-                f"{(issue.get('title') or 'Untitled')[:90]}"
-            )
-        return "\n".join(lines)
+        try:
+            from multica_client import get_multica_client
+
+            issues = await get_multica_client().list_issues(status=status)
+            if not issues:
+                return f"No Multica tickets are currently `{status}`."
+            lines = [f"**Multica {status}:**"]
+            for issue in issues[:10]:
+                lines.append(
+                    f"- `{issue.get('identifier') or issue.get('id')}` — "
+                    f"{(issue.get('title') or 'Untitled')[:90]}"
+                )
+            return "\n".join(lines)
+        except Exception as exc:
+            logger.warning("engineering_ticket_list: %s", exc)
+            return f"I couldn't list Multica tickets in `{status}` right now."
 
     # ── Evolution Proposals Review ─────────────────────────────────────────────
     if intent.name == "evolution_proposals_review":

--- a/services/zoe-data/intent_router.py
+++ b/services/zoe-data/intent_router.py
@@ -1528,7 +1528,7 @@ async def execute_intent(intent: Intent, user_id: str = "family-admin") -> Optio
                 board = resp.json()
 
             available = board.get("available", False)
-            active = board.get("active", [])
+            groups = board.get("groups") or {}
 
             if not available:
                 reason = board.get("reason", "Multica not configured")
@@ -1540,15 +1540,36 @@ async def execute_intent(intent: Intent, user_id: str = "family-admin") -> Optio
                     "will appear here for your approval."
                 )
 
-            if not active:
-                return ("**Multica Board** — nothing active right now.\n\n"
-                        "Ask me to build something (a widget, a page, a new skill) and I'll "
-                        "create a board item for your approval before starting.")
+            ordered_statuses = ("blocked", "in_progress", "in_review", "todo", "backlog")
+            open_items = [
+                (status, item)
+                for status in ordered_statuses
+                for item in groups.get(status, [])
+            ]
+            if not open_items:
+                return (
+                    "**Multica Tickets** — nothing open right now.\n\n"
+                    "New requests are captured in Multica and wait for approval before entering "
+                    "the one-ticket engineering lane."
+                )
 
-            lines = [f"**Multica Board** — {len(active)} active item(s):\n"]
-            for item in active[:5]:
-                lines.append(f"- **{item.get('title','?')}** — `{item.get('status','?')}` "
-                              f"| {item.get('description','')[:60]}")
+            lines = [f"**Multica Tickets** — {len(open_items)} open item(s):\n"]
+            for status, item in open_items[:10]:
+                metadata = [
+                    value
+                    for value in (
+                        f"phase: {item.get('phase')}" if item.get("phase") else "",
+                        f"blocked: {item.get('blocker')}" if item.get("blocker") else "",
+                        f"children: {item.get('child_count')}" if item.get("child_count") else "",
+                        f"PR: {item.get('pr_url')}" if item.get("pr_url") else "",
+                    )
+                    if value
+                ]
+                suffix = f" | {' | '.join(metadata)}" if metadata else ""
+                lines.append(
+                    f"- `{item.get('identifier') or item.get('id')}` "
+                    f"**{item.get('title', '?')}** — `{status}`{suffix}"
+                )
             return "\n".join(lines)
         except Exception as exc:
             logger.warning("board_status: %s", exc)

--- a/services/zoe-data/main.py
+++ b/services/zoe-data/main.py
@@ -90,7 +90,7 @@ async def _record_completed_multica_chain(client, issue_id: str, chain: dict) ->
     await client.record_progress(
         issue_id,
         phase=phase,
-        evidence="Kanban chain done after retro" if phase == "retro" else "Kanban chain done",
+        evidence="Engineering run done after retro" if phase == "retro" else "Engineering run done",
         pr_url=chain.get("pr_url"),
         clear_blocker=True,
         status="done",
@@ -170,7 +170,7 @@ async def _record_blocked_multica_chain(client, issue_id: str, chain: dict) -> s
     await client.record_progress(
         issue_id,
         phase=phase,
-        evidence="Kanban chain blocked",
+        evidence="Engineering run blocked",
         pr_url=chain.get("pr_url"),
         blocker=blocker,
         status="blocked",
@@ -431,8 +431,9 @@ async def lifespan(app: FastAPI):
                     from multica_client import get_engineering_multica_agent_id  # type: ignore[import]
                     from executor_registry import poll_ref  # type: ignore[import]
                     from multica_poll_dispatch import chain_is_running, chain_needs_dispatch  # type: ignore[import]
+                    from multica_dispatch_control import dispatch_is_paused, pause_reason
 
-                    if _wh_ok():
+                    if _wh_ok() and not dispatch_is_paused():
                         _hermes = str(get_engineering_multica_agent_id())
                         # Throttle first-dispatch: cap new chains per cycle so a
                         # wave of assigned todos can't spawn N concurrent chains
@@ -529,6 +530,11 @@ async def lifespan(app: FastAPI):
                                     _candidate.get("identifier") or _tid,
                                     "todo" if from_todo else "in_progress-backfill",
                                 )
+                    elif dispatch_is_paused():
+                        logger.info(
+                            "multica_poll: runtime dispatch pause active (%s)",
+                            pause_reason(),
+                        )
 
                         # Backfill existing in-progress runs before starting fresh todo work.
                         # A partial chain owns the one active ticket lane but still needs this
@@ -597,7 +603,7 @@ async def lifespan(app: FastAPI):
                             pr_url = chain.get("pr_url")
                             await _record_completed_multica_chain(client, str(issue_id), chain)
                             logger.info(
-                                "multica_poll: advanced issue %s (%s) - Kanban chain done%s",
+                                "multica_poll: advanced issue %s (%s) - engineering run done%s",
                                 issue_id,
                                 title[:40],
                                 f" PR={pr_url}" if pr_url else "",

--- a/services/zoe-data/main.py
+++ b/services/zoe-data/main.py
@@ -438,7 +438,7 @@ async def lifespan(app: FastAPI):
                         _hermes = str(get_engineering_multica_agent_id())
                         # Throttle first-dispatch: cap new chains per cycle so a
                         # wave of assigned todos can't spawn N concurrent chains
-                        # (mirrors sync_multica_to_kanban --limit / kanban.max_in_progress).
+                        # (mirrors the compatibility sync limit / kanban.max_in_progress).
                         try:
                             _wh_limit = int(os.environ.get("ZOE_MULTICA_POLL_DISPATCH_LIMIT", "1") or "1")
                         except ValueError:

--- a/services/zoe-data/main.py
+++ b/services/zoe-data/main.py
@@ -433,7 +433,8 @@ async def lifespan(app: FastAPI):
                     from multica_poll_dispatch import chain_is_running, chain_needs_dispatch  # type: ignore[import]
                     from multica_dispatch_control import dispatch_is_paused, pause_reason
 
-                    if _wh_ok() and not dispatch_is_paused():
+                    _dispatch_paused = dispatch_is_paused()
+                    if _wh_ok() and not _dispatch_paused:
                         _hermes = str(get_engineering_multica_agent_id())
                         # Throttle first-dispatch: cap new chains per cycle so a
                         # wave of assigned todos can't spawn N concurrent chains
@@ -530,11 +531,6 @@ async def lifespan(app: FastAPI):
                                     _candidate.get("identifier") or _tid,
                                     "todo" if from_todo else "in_progress-backfill",
                                 )
-                    elif dispatch_is_paused():
-                        logger.info(
-                            "multica_poll: runtime dispatch pause active (%s)",
-                            pause_reason(),
-                        )
 
                         # Backfill existing in-progress runs before starting fresh todo work.
                         # A partial chain owns the one active ticket lane but still needs this
@@ -552,6 +548,11 @@ async def lifespan(app: FastAPI):
                                 await _maybe_dispatch_hermes_issue(_todo, from_todo=True)
                                 if _wh_dispatched >= _wh_limit:
                                     break
+                    elif _dispatch_paused:
+                        logger.info(
+                            "multica_poll: runtime dispatch pause active (%s)",
+                            pause_reason(),
+                        )
                 except Exception as _wh_exc:
                     logger.debug("multica_poll: webhook dispatch failed: %s", _wh_exc)
 

--- a/services/zoe-data/multica_autopilot_sync.py
+++ b/services/zoe-data/multica_autopilot_sync.py
@@ -52,12 +52,10 @@ _STALE_AUTOPILOT_HOURS = float(
     os.environ.get("ZOE_MULTICA_AUTOPILOT_STALE_HOURS")
     or os.environ.get("ZOE_MULTICA_AUTOPIOT_STALE_HOURS", "2")
 )
-# Dedupe engineering dispatch: the Zoe poll webhook bridge + the hourly Hermes
-# cron (dispatch-hermes-board.sh -> sync_multica_to_kanban.py) are the owners of
-# Hermes-assigned Multica issues. The Multica "Board Review" autopilot would
-# dispatch the same issue pool through the executor seam, so it is disabled by
-# default to avoid duplicate Kanban chains. Set this flag true to restore the
-# autopilot as the engineering dispatcher (e.g. if the cron + poll loop are paused).
+# Dedupe engineering dispatch: Zoe's poll bridge and compatibility sync command
+# share the deterministic driver gate. The Multica "Board Review" autopilot
+# would dispatch the same issue pool through the executor seam, so it remains
+# disabled by default to avoid duplicate phase effects.
 _BOARD_REVIEW_AUTOPILOT_ENABLED = (
     os.environ.get("ZOE_BOARD_REVIEW_AUTOPILOT_ENABLED", "false").lower()
     in ("1", "true", "yes")

--- a/services/zoe-data/multica_dispatch_control.py
+++ b/services/zoe-data/multica_dispatch_control.py
@@ -1,0 +1,39 @@
+"""Runtime controls for the single-ticket Multica engineering lane."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def pause_path() -> Path:
+    override = os.environ.get("ZOE_MULTICA_DISPATCH_PAUSE_FILE", "").strip()
+    if override:
+        return Path(override)
+    return Path(os.path.expanduser("~/.zoe/multica_dispatch_paused"))
+
+
+def dispatch_is_paused() -> bool:
+    return pause_path().exists()
+
+
+def pause_dispatch(reason: str = "operator requested pause") -> Path:
+    path = pause_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(reason.strip() + "\n", encoding="utf-8")
+    return path
+
+
+def resume_dispatch() -> bool:
+    path = pause_path()
+    if not path.exists():
+        return False
+    path.unlink()
+    return True
+
+
+def pause_reason() -> str | None:
+    path = pause_path()
+    if not path.exists():
+        return None
+    return path.read_text(encoding="utf-8", errors="replace").strip() or "paused"

--- a/services/zoe-data/multica_dispatch_control.py
+++ b/services/zoe-data/multica_dispatch_control.py
@@ -26,10 +26,9 @@ def pause_dispatch(reason: str = "operator requested pause") -> Path:
 
 def resume_dispatch() -> bool:
     path = pause_path()
-    if not path.exists():
-        return False
-    path.unlink()
-    return True
+    existed = path.exists()
+    path.unlink(missing_ok=True)
+    return existed
 
 
 def pause_reason() -> str | None:

--- a/services/zoe-data/multica_operator.py
+++ b/services/zoe-data/multica_operator.py
@@ -1,0 +1,121 @@
+"""Operator-safe Multica ticket actions used by chat and maintenance tools."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from multica_client import get_engineering_multica_agent_id, get_multica_client
+from multica_ticket_contract import (
+    describe_ticket,
+    normalize_ticket_metadata,
+    parse_ticket_block,
+    write_ticket_block,
+)
+
+
+async def find_issue(reference: str) -> dict[str, Any]:
+    wanted = reference.strip().lower()
+    client = get_multica_client()
+    for issue in await client.list_issues():
+        if wanted in {
+            str(issue.get("id") or "").lower(),
+            str(issue.get("identifier") or "").lower(),
+        }:
+            return issue
+    return {}
+
+
+async def create_ticket(title: str, *, source: str = "operator") -> dict[str, Any]:
+    client = get_multica_client()
+    description = describe_ticket(
+        title,
+        zoe_kind="operator_task",
+        evidence_profile="code",
+        engineering_mode="interactive",
+        acceptance_criteria=["Deliver the requested behavior in a small, reviewable change."],
+        evidence_expectations=["Focused tests or validators", "PR URL for code changes"],
+        source=source,
+    )
+    issue = await client.create_issue(
+        title=title[:120],
+        description=description,
+        priority="medium",
+        status="backlog",
+        assignee_id=get_engineering_multica_agent_id(),
+        assignee_type="agent",
+    )
+    if issue.get("id"):
+        await client.attach_label(str(issue["id"]), "operator-task")
+    return issue
+
+
+async def move_to_todo(reference: str, *, approve: bool = True) -> dict[str, Any]:
+    client = get_multica_client()
+    issue = await find_issue(reference)
+    if not issue.get("id"):
+        return {}
+    metadata = parse_ticket_block(issue.get("description") or "")
+    metadata.update(
+        {
+            "dispatch_approved": bool(approve),
+            "blocked_reason": None,
+            "acceptance_criteria": metadata.get("acceptance_criteria")
+            or ["Deliver the ticket in a small, reviewable change."],
+            "evidence_expectations": metadata.get("evidence_expectations")
+            or ["Focused tests or validators"],
+        }
+    )
+    description = write_ticket_block(
+        issue.get("description") or "",
+        normalize_ticket_metadata(metadata),
+    )
+    return await client.update_issue(
+        str(issue["id"]),
+        status="todo",
+        description=description,
+        assignee_id=get_engineering_multica_agent_id(),
+        assignee_type="agent",
+    )
+
+
+async def split_ticket(
+    reference: str,
+    *,
+    child_title: str,
+    reason: str = "operator requested split",
+) -> dict[str, Any]:
+    client = get_multica_client()
+    parent = await find_issue(reference)
+    if not parent.get("id"):
+        return {}
+    child = await client.create_child_issue(
+        parent,
+        {
+            "title": child_title[:120],
+            "description": f"Split from {parent.get('identifier') or parent.get('id')}: {reason}",
+            "acceptance_criteria": ["Complete this bounded child scope."],
+            "evidence_expectations": ["Focused tests or validators"],
+        },
+    )
+    if not child.get("id"):
+        return {}
+    parent_metadata = parse_ticket_block(parent.get("description") or "")
+    child_ids = list(parent_metadata.get("child_issue_ids") or [])
+    child_ids.append(str(child["id"]))
+    parent_metadata.update(
+        {
+            "zoe_kind": "parent",
+            "blocked_reason": reason,
+            "child_issue_ids": list(dict.fromkeys(child_ids)),
+            "dispatch_approved": False,
+        }
+    )
+    await client.update_issue(
+        str(parent["id"]),
+        status="blocked",
+        description=write_ticket_block(
+            parent.get("description") or "",
+            normalize_ticket_metadata(parent_metadata),
+        ),
+    )
+    return child

--- a/services/zoe-data/multica_operator.py
+++ b/services/zoe-data/multica_operator.py
@@ -16,7 +16,7 @@ from multica_ticket_contract import (
 async def find_issue(reference: str) -> dict[str, Any]:
     wanted = reference.strip().lower()
     client = get_multica_client()
-    for issue in await client.list_issues():
+    for issue in await client.list_issues() or []:
         if wanted in {
             str(issue.get("id") or "").lower(),
             str(issue.get("identifier") or "").lower(),

--- a/services/zoe-data/routers/system.py
+++ b/services/zoe-data/routers/system.py
@@ -988,7 +988,7 @@ async def list_engineering_workflow_tasks(
     status: str | None = None,
     user: dict = Depends(require_admin),
 ):
-    """Status view: Hermes-assigned Multica issues with their Kanban chain state."""
+    """Status view: Hermes-assigned Multica issues with journaled driver state."""
     from executor_registry import poll_ref  # type: ignore[import]
     from multica_client import MULClient, get_engineering_multica_agent_id  # type: ignore[import]
 
@@ -1386,6 +1386,16 @@ async def get_agent_board(user: dict = Depends(get_current_user)):  # noqa: ARG0
                 continue
             for issue in issues_or_exc or []:
                 enriched = dict(issue)
+                try:
+                    from multica_ticket_contract import parse_ticket_block
+
+                    ticket = parse_ticket_block(issue.get("description") or "")
+                except Exception:
+                    ticket = {}
+                enriched["phase"] = ticket.get("phase")
+                enriched["blocker"] = ticket.get("blocked_reason")
+                enriched["pr_url"] = ticket.get("pr_url")
+                enriched["child_count"] = len(ticket.get("child_issue_ids") or [])
                 if status in {"in_progress", "blocked", "in_review"} and str(issue.get("assignee_id") or "") == hermes_id:
                     hermes_issues.append(enriched)
                 groups[status].append(enriched)

--- a/services/zoe-data/routers/system.py
+++ b/services/zoe-data/routers/system.py
@@ -1767,7 +1767,7 @@ async def evolution_proposal_action(
                         proposal_id, _dispatch.get("chain") if _dispatch.get("ok") else _dispatch,
                     )
                 else:
-                    # No Multica issue to anchor the Kanban chain (Multica
+                    # No Multica issue to anchor the journaled engineering run (Multica
                     # unconfigured or the issue sync failed). Surface it so the
                     # approved proposal does not sit undispatched silently.
                     _dispatch = {"ok": False, "reason": "no multica_issue_id; proposal approved but not dispatched"}

--- a/services/zoe-data/tests/test_engineering_prompt_eval.py
+++ b/services/zoe-data/tests/test_engineering_prompt_eval.py
@@ -1,0 +1,17 @@
+import importlib.util
+from pathlib import Path
+
+
+def test_engineering_prompt_contract_eval_passes():
+    path = (
+        Path(__file__).resolve().parents[3]
+        / "scripts/maintenance/evaluate_engineering_prompts.py"
+    )
+    spec = importlib.util.spec_from_file_location("evaluate_engineering_prompts", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+
+    report = module.evaluate()
+    assert report["ok"] is True
+    assert report["pass_rate"] == 1.0

--- a/services/zoe-data/tests/test_main_multica_poll.py
+++ b/services/zoe-data/tests/test_main_multica_poll.py
@@ -49,7 +49,7 @@ async def test_record_completed_multica_chain_records_explicit_retro_completion_
             ("issue-1",),
             {
                 "phase": "retro",
-                "evidence": "Kanban chain done after retro",
+                "evidence": "Engineering run done after retro",
                 "pr_url": "https://github.com/o/r/pull/1",
                 "clear_blocker": True,
                 "status": "done",
@@ -68,7 +68,7 @@ async def test_record_completed_multica_chain_preserves_legacy_closeout_completi
 
     assert client.calls[0][1]["pr_url"] is None
     assert client.calls[0][1]["phase"] == "closeout"
-    assert client.calls[0][1]["evidence"] == "Kanban chain done"
+    assert client.calls[0][1]["evidence"] == "Engineering run done"
     assert client.calls[0][1]["status"] == "done"
 
 
@@ -85,7 +85,7 @@ async def test_record_completed_multica_chain_records_non_retro_pipeline_phase()
     )
 
     assert client.calls[0][1]["phase"] == "closeout"
-    assert client.calls[0][1]["evidence"] == "Kanban chain done"
+    assert client.calls[0][1]["evidence"] == "Engineering run done"
     assert client.calls[0][1]["status"] == "done"
 
 
@@ -216,7 +216,7 @@ async def test_record_blocked_multica_chain_records_terminal_block_metadata():
             ("issue-blocked",),
             {
                 "phase": "implement",
-                "evidence": "Kanban chain blocked",
+                "evidence": "Engineering run blocked",
                 "pr_url": "https://github.com/o/r/pull/7",
                 "blocker": "terminal block: implement blocked",
                 "status": "blocked",

--- a/services/zoe-data/tests/test_main_multica_poll.py
+++ b/services/zoe-data/tests/test_main_multica_poll.py
@@ -1,5 +1,7 @@
 """Tests for main.py Multica poll-loop helpers."""
 
+from pathlib import Path
+
 import pytest
 
 
@@ -10,6 +12,15 @@ class RecordingClient:
     async def record_progress(self, *args, **kwargs):
         self.calls.append((args, kwargs))
         return {"id": args[0], **kwargs}
+
+
+def test_poll_dispatches_ready_work_only_when_runtime_pause_is_inactive():
+    source = (Path(__file__).resolve().parents[1] / "main.py").read_text(encoding="utf-8")
+    active_branch = source.index("if _wh_ok() and not _dispatch_paused:")
+    backfill = source.index("# Backfill existing in-progress runs", active_branch)
+    paused_branch = source.index("elif _dispatch_paused:", active_branch)
+
+    assert active_branch < backfill < paused_branch
 
 
 def test_tracked_multica_engineering_issues_includes_review_and_deduplicates():

--- a/services/zoe-data/tests/test_multica_board_maintenance_scripts.py
+++ b/services/zoe-data/tests/test_multica_board_maintenance_scripts.py
@@ -13,4 +13,4 @@ def test_legacy_board_maintenance_is_dry_run_and_preserves_descriptions():
         assert '--execute' in source
         assert "append_issue_note" in source
         assert "attach_label" in source
-        assert "description=" not in source
+        assert "description=(" not in source

--- a/services/zoe-data/tests/test_multica_board_maintenance_scripts.py
+++ b/services/zoe-data/tests/test_multica_board_maintenance_scripts.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+
+def test_legacy_board_maintenance_is_dry_run_and_preserves_descriptions():
+    root = Path(__file__).resolve().parents[3]
+    scripts = (
+        root / "scripts/maintenance/multica_apply_triage_dispositions.py",
+        root / "scripts/maintenance/multica_finalize_board_repair.py",
+    )
+
+    for script in scripts:
+        source = script.read_text(encoding="utf-8")
+        assert '--execute' in source
+        assert "append_issue_note" in source
+        assert "attach_label" in source
+        assert "description=" not in source

--- a/services/zoe-data/tests/test_multica_dispatch_control.py
+++ b/services/zoe-data/tests/test_multica_dispatch_control.py
@@ -17,3 +17,20 @@ def test_runtime_dispatch_pause_round_trip(tmp_path, monkeypatch):
     assert resume_dispatch() is True
     assert resume_dispatch() is False
     assert dispatch_is_paused() is False
+
+
+def test_resume_tolerates_pause_file_disappearing(tmp_path, monkeypatch):
+    path = tmp_path / "paused"
+    monkeypatch.setenv("ZOE_MULTICA_DISPATCH_PAUSE_FILE", str(path))
+    path.write_text("pause\n")
+
+    original_exists = type(path).exists
+
+    def exists_then_remove(self):
+        exists = original_exists(self)
+        if exists:
+            self.unlink()
+        return exists
+
+    monkeypatch.setattr(type(path), "exists", exists_then_remove)
+    assert resume_dispatch() is True

--- a/services/zoe-data/tests/test_multica_dispatch_control.py
+++ b/services/zoe-data/tests/test_multica_dispatch_control.py
@@ -1,0 +1,19 @@
+from multica_dispatch_control import (
+    dispatch_is_paused,
+    pause_dispatch,
+    pause_reason,
+    resume_dispatch,
+)
+
+
+def test_runtime_dispatch_pause_round_trip(tmp_path, monkeypatch):
+    path = tmp_path / "paused"
+    monkeypatch.setenv("ZOE_MULTICA_DISPATCH_PAUSE_FILE", str(path))
+
+    assert dispatch_is_paused() is False
+    pause_dispatch("production investigation")
+    assert dispatch_is_paused() is True
+    assert pause_reason() == "production investigation"
+    assert resume_dispatch() is True
+    assert resume_dispatch() is False
+    assert dispatch_is_paused() is False

--- a/services/zoe-data/tests/test_multica_health_report.py
+++ b/services/zoe-data/tests/test_multica_health_report.py
@@ -35,3 +35,9 @@ def test_probe_reports_http_status(monkeypatch):
     result = asyncio.run(module._probe("http://example.test/health"))
     assert result["ok"] is True
     assert result["status"] == 200
+
+
+def test_upload_check_reads_the_runtime_compose_contract():
+    module = _module()
+
+    assert module._uploads_configured() is True

--- a/services/zoe-data/tests/test_multica_health_report.py
+++ b/services/zoe-data/tests/test_multica_health_report.py
@@ -41,3 +41,12 @@ def test_upload_check_reads_the_runtime_compose_contract():
     module = _module()
 
     assert module._uploads_configured() is True
+
+
+def test_oidc_client_id_requires_explicit_configuration(monkeypatch):
+    module = _module()
+    monkeypatch.delenv("MULTICA_OIDC_CLIENT_ID", raising=False)
+
+    assert module._oidc_client_id_configured() is False
+    monkeypatch.setenv("MULTICA_OIDC_CLIENT_ID", "multica")
+    assert module._oidc_client_id_configured() is True

--- a/services/zoe-data/tests/test_multica_health_report.py
+++ b/services/zoe-data/tests/test_multica_health_report.py
@@ -1,0 +1,37 @@
+import asyncio
+import importlib.util
+from pathlib import Path
+
+
+def _module():
+    path = (
+        Path(__file__).resolve().parents[3]
+        / "scripts/maintenance/multica_health_report.py"
+    )
+    spec = importlib.util.spec_from_file_location("multica_health_report", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_probe_reports_http_status(monkeypatch):
+    module = _module()
+
+    class Response:
+        status_code = 200
+
+    class Client:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+        async def get(self, *_args, **_kwargs):
+            return Response()
+
+    monkeypatch.setattr(module.httpx, "AsyncClient", lambda **_kwargs: Client())
+    result = asyncio.run(module._probe("http://example.test/health"))
+    assert result["ok"] is True
+    assert result["status"] == 200

--- a/services/zoe-data/tests/test_multica_health_report.py
+++ b/services/zoe-data/tests/test_multica_health_report.py
@@ -37,6 +37,28 @@ def test_probe_reports_http_status(monkeypatch):
     assert result["status"] == 200
 
 
+def test_probe_rejects_client_errors(monkeypatch):
+    module = _module()
+
+    class Response:
+        status_code = 404
+
+    class Client:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+        async def get(self, *_args, **_kwargs):
+            return Response()
+
+    monkeypatch.setattr(module.httpx, "AsyncClient", lambda **_kwargs: Client())
+    result = asyncio.run(module._probe("http://example.test/missing"))
+    assert result["ok"] is False
+    assert result["status"] == 404
+
+
 def test_upload_check_reads_the_runtime_compose_contract():
     module = _module()
 

--- a/services/zoe-data/tests/test_multica_operator_intents.py
+++ b/services/zoe-data/tests/test_multica_operator_intents.py
@@ -1,6 +1,8 @@
 import pytest
 
 from intent_router import Intent, detect_intent, execute_intent
+import multica_client
+import multica_operator
 
 
 def test_detects_multica_operator_commands():
@@ -64,3 +66,44 @@ async def test_board_status_reports_lifecycle_metadata(monkeypatch):
     assert "blocked: Greptile comment" in result
     assert "children: 2" in result
     assert "pull/1" in result
+
+
+@pytest.mark.asyncio
+async def test_operator_commands_report_multica_failures(monkeypatch, caplog):
+    async def fail_move(*_args, **_kwargs):
+        raise RuntimeError("move unavailable")
+
+    async def fail_split(*_args, **_kwargs):
+        raise RuntimeError("split unavailable")
+
+    class FailingClient:
+        async def list_issues(self, **_kwargs):
+            raise RuntimeError("list unavailable")
+
+    monkeypatch.setattr(multica_operator, "move_to_todo", fail_move)
+    monkeypatch.setattr(multica_operator, "split_ticket", fail_split)
+    monkeypatch.setattr(multica_client, "get_multica_client", lambda: FailingClient())
+
+    move = await execute_intent(Intent("engineering_ticket_move_todo", {"reference": "ZOE-1"}))
+    split = await execute_intent(
+        Intent("engineering_ticket_split", {"reference": "ZOE-1", "title": "child"})
+    )
+    listed = await execute_intent(Intent("engineering_ticket_list", {"status": "blocked"}))
+
+    assert move == "I couldn't update that Multica ticket right now."
+    assert split == "I couldn't split that Multica ticket right now."
+    assert listed == "I couldn't list Multica tickets in `blocked` right now."
+    assert "move unavailable" in caplog.text
+    assert "split unavailable" in caplog.text
+    assert "list unavailable" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_find_issue_accepts_empty_issue_response(monkeypatch):
+    class EmptyClient:
+        async def list_issues(self):
+            return None
+
+    monkeypatch.setattr(multica_operator, "get_multica_client", lambda: EmptyClient())
+
+    assert await multica_operator.find_issue("ZOE-1") == {}

--- a/services/zoe-data/tests/test_multica_operator_intents.py
+++ b/services/zoe-data/tests/test_multica_operator_intents.py
@@ -1,4 +1,6 @@
-from intent_router import detect_intent
+import pytest
+
+from intent_router import Intent, detect_intent, execute_intent
 
 
 def test_detects_multica_operator_commands():
@@ -18,3 +20,47 @@ def test_natural_problem_report_routes_to_multica_capture():
     intent = detect_intent("your reminders are broken again")
     assert intent.name == "user_issue_report"
     assert intent.slots["message"] == "your reminders are broken again"
+
+
+@pytest.mark.asyncio
+async def test_board_status_reports_lifecycle_metadata(monkeypatch):
+    class Response:
+        def json(self):
+            return {
+                "available": True,
+                "groups": {
+                    "blocked": [
+                        {
+                            "id": "issue-1",
+                            "identifier": "ZOE-1",
+                            "title": "Fix dispatch",
+                            "phase": "review",
+                            "blocker": "Greptile comment",
+                            "child_count": 2,
+                            "pr_url": "https://github.com/o/r/pull/1",
+                        }
+                    ]
+                },
+            }
+
+    class Client:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+        async def get(self, *_args, **_kwargs):
+            return Response()
+
+    import httpx
+
+    monkeypatch.setattr(httpx, "AsyncClient", lambda **_kwargs: Client())
+    result = await execute_intent(Intent("board_status", {}))
+
+    assert result is not None
+    assert "ZOE-1" in result
+    assert "phase: review" in result
+    assert "blocked: Greptile comment" in result
+    assert "children: 2" in result
+    assert "pull/1" in result

--- a/services/zoe-data/tests/test_multica_operator_intents.py
+++ b/services/zoe-data/tests/test_multica_operator_intents.py
@@ -1,0 +1,20 @@
+from intent_router import detect_intent
+
+
+def test_detects_multica_operator_commands():
+    assert detect_intent("pause engineering dispatch").name == "engineering_dispatch_pause"
+    assert detect_intent("resume multica dispatch").name == "engineering_dispatch_resume"
+    move = detect_intent("move ZOE-5423 to todo")
+    assert move.name == "engineering_ticket_move_todo"
+    assert move.slots["reference"] == "ZOE-5423"
+    split = detect_intent("split ZOE-5423 into add the health probe")
+    assert split.name == "engineering_ticket_split"
+    assert split.slots["title"] == "add the health probe"
+    assert detect_intent("show Multica backlog").slots["status"] == "backlog"
+    assert detect_intent("what is blocked").slots["status"] == "blocked"
+
+
+def test_natural_problem_report_routes_to_multica_capture():
+    intent = detect_intent("your reminders are broken again")
+    assert intent.name == "user_issue_report"
+    assert intent.slots["message"] == "your reminders are broken again"

--- a/services/zoe-data/tests/test_multica_operator_intents.py
+++ b/services/zoe-data/tests/test_multica_operator_intents.py
@@ -16,6 +16,9 @@ def test_detects_multica_operator_commands():
     assert split.slots["title"] == "add the health probe"
     assert detect_intent("show Multica backlog").slots["status"] == "backlog"
     assert detect_intent("what is blocked").slots["status"] == "blocked"
+    assert detect_intent("show blocked engineering tickets").slots["status"] == "blocked"
+    unrelated = detect_intent("what is blocked in the calendar?")
+    assert unrelated is None or unrelated.name != "engineering_ticket_list"
 
 
 def test_natural_problem_report_routes_to_multica_capture():

--- a/services/zoe-data/tests/test_multica_widget_copy.py
+++ b/services/zoe-data/tests/test_multica_widget_copy.py
@@ -13,6 +13,8 @@ def test_multica_widget_uses_ticket_language():
     assert "No open tickets" in widget
     assert "Loading tickets" in widget
     assert "Evolution Board" not in widget
+    assert "_safeHttpUrl" in widget
+    assert "this._esc(data.reason || '')" in widget
     assert "evolution board" not in widget.lower()
     assert "Loading board" not in widget
     assert "Board unavailable" not in widget

--- a/services/zoe-data/tests/test_multica_widget_copy.py
+++ b/services/zoe-data/tests/test_multica_widget_copy.py
@@ -14,6 +14,7 @@ def test_multica_widget_uses_ticket_language():
     assert "Loading tickets" in widget
     assert "Evolution Board" not in widget
     assert "_safeHttpUrl" in widget
+    assert "if (!value) return '';" in widget
     assert "this._esc(data.reason || '')" in widget
     assert "evolution board" not in widget.lower()
     assert "Loading board" not in widget

--- a/services/zoe-data/tests/test_multica_widget_copy.py
+++ b/services/zoe-data/tests/test_multica_widget_copy.py
@@ -10,9 +10,13 @@ def test_multica_widget_uses_ticket_language():
     ).read_text()
 
     assert "Multica Tickets" in widget
-    assert "No active tickets" in widget
+    assert "No open tickets" in widget
     assert "Loading tickets" in widget
     assert "Evolution Board" not in widget
     assert "evolution board" not in widget.lower()
     assert "Loading board" not in widget
     assert "Board unavailable" not in widget
+    assert "data.groups" in widget
+    assert "child_count" in widget
+    assert "issue.blocker" in widget
+    assert "issue.pr_url" in widget

--- a/services/zoe-ui/dist/js/widgets/core/multica-board.js
+++ b/services/zoe-ui/dist/js/widgets/core/multica-board.js
@@ -56,11 +56,15 @@ class MulticaBoardWidget extends WidgetModule {
                 return;
             }
 
-            const issues = Array.isArray(data.active) ? data.active : [];
+            const groups = data.groups || {};
+            const order = ['blocked', 'in_progress', 'in_review', 'todo', 'backlog'];
+            const issues = order.flatMap(status =>
+                (Array.isArray(groups[status]) ? groups[status] : []).map(issue => ({...issue, status}))
+            );
             if (badge) badge.textContent = String(issues.length);
 
             if (!issues.length) {
-                if (content) content.innerHTML = '<div style="text-align:center;color:#888;font-style:italic;font-size:13px;">No active tickets</div>';
+                if (content) content.innerHTML = '<div style="text-align:center;color:#888;font-style:italic;font-size:13px;">No open tickets</div>';
                 return;
             }
 
@@ -68,15 +72,28 @@ class MulticaBoardWidget extends WidgetModule {
                 content.innerHTML = issues.slice(0, 5).map(issue => {
                     const title = (issue.title || issue.name || 'Untitled').substring(0, 60);
                     const status = issue.status || 'in_progress';
-                    const statusColor = status === 'done' ? '#22c55e' : status === 'in_progress' ? '#f59e0b' : '#94a3b8';
-                    const assignee = issue.assignee || '';
+                    const statusColors = {
+                        blocked: '#ef4444',
+                        in_progress: '#f59e0b',
+                        in_review: '#38bdf8',
+                        todo: '#a78bfa',
+                        backlog: '#94a3b8'
+                    };
+                    const statusColor = statusColors[status] || '#94a3b8';
+                    const phase = issue.phase || (issue.chain && issue.chain.pipeline && issue.chain.pipeline.phase) || '';
+                    const blocker = issue.blocker || '';
+                    const prUrl = issue.pr_url || '';
+                    const childCount = Number(issue.child_count || 0);
                     return `
                         <div style="padding:10px 12px;border-radius:8px;margin-bottom:6px;background:rgba(255,255,255,0.04);border:1px solid rgba(255,255,255,0.08);">
                             <div style="font-size:13px;font-weight:500;margin-bottom:4px;line-height:1.3;">${this._esc(title)}</div>
-                            <div style="display:flex;align-items:center;gap:8px;font-size:11px;color:#888;">
+                            <div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap;font-size:11px;color:#888;">
                                 <span style="color:${statusColor};font-weight:600;">${this._esc(status.replace('_', ' '))}</span>
-                                ${assignee ? `<span>· ${this._esc(assignee)}</span>` : ''}
+                                ${phase ? `<span>phase: ${this._esc(phase)}</span>` : ''}
+                                ${childCount ? `<span>${childCount} child${childCount === 1 ? '' : 'ren'}</span>` : ''}
+                                ${prUrl ? `<a href="${this._esc(prUrl)}" target="_blank" rel="noopener">PR</a>` : ''}
                             </div>
+                            ${blocker ? `<div style="margin-top:5px;font-size:11px;color:#fca5a5;line-height:1.25;">${this._esc(blocker.substring(0, 100))}</div>` : ''}
                         </div>
                     `;
                 }).join('');

--- a/services/zoe-ui/dist/js/widgets/core/multica-board.js
+++ b/services/zoe-ui/dist/js/widgets/core/multica-board.js
@@ -51,7 +51,7 @@ class MulticaBoardWidget extends WidgetModule {
             if (content) content.classList.remove('loading-widget');
 
             if (!data.available) {
-                if (content) content.innerHTML = `<div style="text-align:center;color:#888;font-style:italic;font-size:13px;">Tickets unavailable<br><small>${data.reason || ''}</small></div>`;
+                if (content) content.innerHTML = `<div style="text-align:center;color:#888;font-style:italic;font-size:13px;">Tickets unavailable<br><small>${this._esc(data.reason || '')}</small></div>`;
                 if (badge) badge.textContent = '0';
                 return;
             }
@@ -82,7 +82,7 @@ class MulticaBoardWidget extends WidgetModule {
                     const statusColor = statusColors[status] || '#94a3b8';
                     const phase = issue.phase || (issue.chain && issue.chain.pipeline && issue.chain.pipeline.phase) || '';
                     const blocker = issue.blocker || '';
-                    const prUrl = issue.pr_url || '';
+                    const prUrl = this._safeHttpUrl(issue.pr_url);
                     const childCount = Number(issue.child_count || 0);
                     return `
                         <div style="padding:10px 12px;border-radius:8px;margin-bottom:6px;background:rgba(255,255,255,0.04);border:1px solid rgba(255,255,255,0.08);">
@@ -114,6 +114,15 @@ class MulticaBoardWidget extends WidgetModule {
             .replace(/</g, '&lt;')
             .replace(/>/g, '&gt;')
             .replace(/"/g, '&quot;');
+    }
+
+    _safeHttpUrl(value) {
+        try {
+            const url = new URL(String(value || ''), window.location.origin);
+            return ['http:', 'https:'].includes(url.protocol) ? url.href : '';
+        } catch (_error) {
+            return '';
+        }
     }
 }
 

--- a/services/zoe-ui/dist/js/widgets/core/multica-board.js
+++ b/services/zoe-ui/dist/js/widgets/core/multica-board.js
@@ -117,6 +117,7 @@ class MulticaBoardWidget extends WidgetModule {
     }
 
     _safeHttpUrl(value) {
+        if (!value) return '';
         try {
             const url = new URL(String(value || ''), window.location.origin);
             return ['http:', 'https:'].includes(url.protocol) ? url.href : '';


### PR DESCRIPTION
## Summary
- add runtime pause/resume and operator-safe Multica ticket commands
- expose backlog, todo, in-progress, blocked, and review truth consistently in chat, API, and the dashboard widget
- expand Multica health coverage and deterministic prompt evaluation
- make board maintenance dry-run, description-preserving, and labeled
- refresh docs, scripts, prompts, and status language for the Multica-first journal driver

## Production behavior
- automatic admission remains capped at one active ticket
- only explicitly approved tickets enter the lane
- one Hermes phase task exists at a time
- runtime pause is shared by the poll bridge and compatibility sync command

## Verification
- 560 services/zoe-data tests pass
- structure validation passes
- all 43 critical files present
- prompt contract evaluation passes 12/12
- live Multica runtime/API/proxy/auth/workspace checks were validated before PR
- controlled natural capture and child split E2E completed in Multica

This is the final product-surface and knowledge-refresh workstream from the Hard Ticket Autonomy plan.