### PR TITLE
Fix production queue blocking and health noise

### DIFF
--- a/scripts/maintenance/platform_health_check.sh
+++ b/scripts/maintenance/platform_health_check.sh
@@ -33,7 +33,9 @@ check_json_health() {
 if ! docker info >/dev/null 2>&1; then
     fail "Docker daemon is unreachable"
 else
+    container_count=0
     while IFS=$'\t' read -r name status health; do
+        ((container_count++)) || true
         if [[ "$status" != "running" ]]; then
             fail "Docker container $name is $status"
         elif [[ -n "$health" && "$health" != "healthy" ]]; then
@@ -46,7 +48,9 @@ else
                     sed 's#^/##'
             done
     )
-    if [[ "$failed" -eq 0 ]]; then
+    if [[ "$container_count" -eq 0 ]]; then
+        fail "Docker returned zero running containers"
+    elif [[ "$failed" -eq 0 ]]; then
         pass "required Docker containers are running"
     fi
 fi

--- a/scripts/maintenance/platform_health_check.sh
+++ b/scripts/maintenance/platform_health_check.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Production checks used by the Multica Platform Health autopilot.
+
+set -uo pipefail
+
+failed=0
+
+fail() {
+    printf 'FAIL: %s\n' "$*"
+    failed=1
+}
+
+pass() {
+    printf 'PASS: %s\n' "$*"
+}
+
+check_json_health() {
+    local label="$1"
+    local url="$2"
+    local body
+    body="$(curl --silent --show-error --fail --max-time 5 "$url" 2>&1)" || {
+        fail "$label is unreachable: $body"
+        return
+    }
+    if printf '%s' "$body" | python3 -c \
+        'import json,sys; value=json.load(sys.stdin); raise SystemExit(0 if value.get("status") == "ok" or value.get("ok") is True else 1)'; then
+        pass "$label reports healthy"
+    else
+        fail "$label returned an unhealthy payload: $body"
+    fi
+}
+
+while IFS=$'\t' read -r name status health; do
+    if [[ "$status" != "running" ]]; then
+        fail "Docker container $name is $status"
+    elif [[ -n "$health" && "$health" != "healthy" ]]; then
+        fail "Docker container $name health is $health"
+    fi
+done < <(
+    docker ps --format '{{.Names}}' |
+        while read -r name; do
+            docker inspect --format '{{.Name}}{{"\t"}}{{.State.Status}}{{"\t"}}{{if .State.Health}}{{.State.Health.Status}}{{end}}' "$name" |
+                sed 's#^/##'
+        done
+)
+
+if [[ "$failed" -eq 0 ]]; then
+    pass "required Docker containers are running"
+fi
+
+if docker exec zoe-database pg_isready -U zoe -d zoe >/dev/null 2>&1; then
+    pass "PostgreSQL accepts connections"
+else
+    fail "PostgreSQL is unavailable"
+fi
+
+check_json_health "zoe-data" "http://127.0.0.1:8000/health"
+check_json_health "Hermes" "http://127.0.0.1:8642/health"
+check_json_health "OpenClaw" "http://127.0.0.1:18789/health"
+
+exit "$failed"

--- a/scripts/maintenance/platform_health_check.sh
+++ b/scripts/maintenance/platform_health_check.sh
@@ -30,22 +30,25 @@ check_json_health() {
     fi
 }
 
-while IFS=$'\t' read -r name status health; do
-    if [[ "$status" != "running" ]]; then
-        fail "Docker container $name is $status"
-    elif [[ -n "$health" && "$health" != "healthy" ]]; then
-        fail "Docker container $name health is $health"
+if ! docker info >/dev/null 2>&1; then
+    fail "Docker daemon is unreachable"
+else
+    while IFS=$'\t' read -r name status health; do
+        if [[ "$status" != "running" ]]; then
+            fail "Docker container $name is $status"
+        elif [[ -n "$health" && "$health" != "healthy" ]]; then
+            fail "Docker container $name health is $health"
+        fi
+    done < <(
+        docker ps --format '{{.Names}}' |
+            while read -r name; do
+                docker inspect --format '{{.Name}}{{"\t"}}{{.State.Status}}{{"\t"}}{{if .State.Health}}{{.State.Health.Status}}{{end}}' "$name" |
+                    sed 's#^/##'
+            done
+    )
+    if [[ "$failed" -eq 0 ]]; then
+        pass "required Docker containers are running"
     fi
-done < <(
-    docker ps --format '{{.Names}}' |
-        while read -r name; do
-            docker inspect --format '{{.Name}}{{"\t"}}{{.State.Status}}{{"\t"}}{{if .State.Health}}{{.State.Health.Status}}{{end}}' "$name" |
-                sed 's#^/##'
-        done
-)
-
-if [[ "$failed" -eq 0 ]]; then
-    pass "required Docker containers are running"
 fi
 
 if docker exec zoe-database pg_isready -U zoe -d zoe >/dev/null 2>&1; then

--- a/scripts/setup/populate_multica.py
+++ b/scripts/setup/populate_multica.py
@@ -659,8 +659,8 @@ _AUTOPILOTS = [
     },
     {
         "title": "Platform Health Check",
-        "agent": "Hermes",
-        "execution_mode": "create_issue",
+        "agent": "Zoe Core",
+        "execution_mode": "run_only",
         "cron": "0 6 * * *",
         "issue_title_template": "Platform Health — {date}",
     },

--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -374,8 +374,11 @@ class KanbanAdapter:
                 "and IMPLEMENTATION_REQUIRED=true|false.\n"
                 "- Set IMPLEMENTATION_REQUIRED=false only when the acceptance criteria are already "
                 "satisfied by identified merged changes; Zoe will route directly to verification.\n"
-                "- If you cannot finish context gathering within 8 tool/model steps, call `kanban_block`"
-                " with BLOCKER=SCOUT_BUDGET and the missing information instead of timing out.\n"
+                "- Finish context gathering within 8 tool/model steps. Reserve the final 2 calls for"
+                " `kanban_complete` or `kanban_block`; do not spend that terminal-call headroom on"
+                " more exploration.\n"
+                "- If the answer is still unclear at step 8, call `kanban_block` with"
+                " BLOCKER=SCOUT_BUDGET and the missing information instead of exploring further.\n"
                 "- TERMINAL PROTOCOL: end with `kanban_complete` or `kanban_block` (no silent exit)."
             )
         if phase == "implement":

--- a/services/zoe-data/kanban_phase_budget.py
+++ b/services/zoe-data/kanban_phase_budget.py
@@ -21,6 +21,7 @@ _TOOL_DEFAULTS = {
     "closeout": 12,
     "retro": 8,
 }
+_TERMINAL_GRACE_DEFAULT = 2
 _RUNTIME_DEFAULTS = {
     "scout": 300,
     "implement": 1800,
@@ -156,10 +157,18 @@ def phase_budget_reason(
     started_ts = _started_timestamp(detail)
     tool_steps = tool_step_count(task_id, since=started_ts)
     tool_limit = _limit(phase, "tools")
-    if tool_steps > tool_limit:
+    try:
+        terminal_grace = max(
+            0,
+            int(os.environ.get("ZOE_KANBAN_TERMINAL_TOOL_GRACE", _TERMINAL_GRACE_DEFAULT)),
+        )
+    except ValueError:
+        terminal_grace = _TERMINAL_GRACE_DEFAULT
+    hard_limit = tool_limit + terminal_grace
+    if tool_steps > hard_limit:
         return (
             f"BLOCKER={phase.upper()}_BUDGET: code-enforced tool budget exceeded "
-            f"(steps={tool_steps}, limit={tool_limit})"
+            f"(steps={tool_steps}, guidance_limit={tool_limit}, hard_limit={hard_limit})"
         )
 
     if started_ts is None:

--- a/services/zoe-data/multica_admission.py
+++ b/services/zoe-data/multica_admission.py
@@ -84,6 +84,21 @@ def select_next_approved_issue(
     hermes_agent_id: str,
 ) -> tuple[dict[str, Any] | None, list[str]]:
     """Return one approved backlog ticket, preserving phased predecessor order."""
+    blocked_approved = []
+    for issue in all_issues:
+        if issue.get("status") != "blocked":
+            continue
+        metadata = parse_ticket_block(issue.get("description") or "")
+        if metadata.get("dispatch_approved") is True:
+            blocked_approved.append(
+                str(issue.get("identifier") or issue.get("id") or "unknown")
+            )
+    if blocked_approved:
+        return None, [
+            "single ticket lane halted by approved blocked ticket(s): "
+            + ", ".join(sorted(blocked_approved))
+        ]
+
     by_sequence: dict[str, list[dict[str, Any]]] = defaultdict(list)
     for issue in all_issues:
         parsed = parse_phased_title(issue.get("title") or "")

--- a/services/zoe-data/multica_admission.py
+++ b/services/zoe-data/multica_admission.py
@@ -88,6 +88,8 @@ def select_next_approved_issue(
     for issue in all_issues:
         if issue.get("status") != "blocked":
             continue
+        if str(issue.get("assignee_id") or "") != str(hermes_agent_id):
+            continue
         metadata = parse_ticket_block(issue.get("description") or "")
         if metadata.get("dispatch_approved") is True:
             blocked_approved.append(

--- a/services/zoe-data/multica_autopilot_sync.py
+++ b/services/zoe-data/multica_autopilot_sync.py
@@ -235,7 +235,7 @@ async def _run_platform_health_check() -> None:
     script = Path(
         os.environ.get(
             "ZOE_HEALTH_CHECK_SCRIPT",
-            str(Path.home() / "bin" / "zoe-health-check.sh"),
+            str(Path.home() / "assistant" / "scripts" / "maintenance" / "platform_health_check.sh"),
         )
     )
     if not script.exists():
@@ -278,8 +278,7 @@ async def _run_platform_health_check() -> None:
                     f"```\n{tail}\n```"
                 ),
                 priority="high",
-                assignee_id=_hermes_agent_id(),
-                assignee_type="agent",
+                status="backlog",
             )
         except Exception as exc:
             logger.warning("autopilot: failed to create health failure issue: %s", exc)
@@ -339,6 +338,8 @@ def _should_create_tracker_issue(autopilot_title: str, mode: str, task_fn) -> bo
     if mode != "create_issue" or not _is_configured():
         return False
     title_lower = autopilot_title.lower().strip()
+    if task_fn is _run_platform_health_check:
+        return False
     if title_lower in _CREATE_ISSUES_FOR:
         return True
     if _CREATE_ISSUES:

--- a/services/zoe-data/multica_autopilot_sync.py
+++ b/services/zoe-data/multica_autopilot_sync.py
@@ -473,7 +473,7 @@ async def _fire_autopilot_job(
 
     1. Creates a Multica issue (if mode == 'create_issue').
     2. Runs the matching Zoe task function if one is mapped.
-    3. Marks the issue done on success, or resets it to todo on failure/no-op.
+    3. Marks a wrapper issue done on success or cancelled on failure/no-op.
     """
     logger.info(
         "autopilot fire: id=%s title=%r mode=%s",

--- a/services/zoe-data/multica_autopilot_sync.py
+++ b/services/zoe-data/multica_autopilot_sync.py
@@ -288,10 +288,7 @@ async def _run_platform_health_check() -> None:
             if existing and existing.get("id"):
                 await client.update_issue(
                     str(existing["id"]),
-                    status="backlog",
                     description=description,
-                    assignee_id=None,
-                    assignee_type=None,
                 )
             else:
                 await client.create_issue(

--- a/services/zoe-data/multica_autopilot_sync.py
+++ b/services/zoe-data/multica_autopilot_sync.py
@@ -279,7 +279,7 @@ async def _run_platform_health_check() -> None:
             existing = next(
                 (
                     issue
-                    for issue in await client.list_issues()
+                    for issue in await client.list_issues(limit=1000)
                     if issue.get("title") == title
                     and issue.get("status") not in {"done", "cancelled", "archived"}
                 ),

--- a/services/zoe-data/multica_autopilot_sync.py
+++ b/services/zoe-data/multica_autopilot_sync.py
@@ -271,15 +271,35 @@ async def _run_platform_health_check() -> None:
             from multica_client import get_multica_client  # type: ignore[import]
 
             client = get_multica_client()
-            await client.create_issue(
-                title="Platform health failures detected",
-                description=(
-                    "The scheduled Platform Health Check found failing services.\n\n"
-                    f"```\n{tail}\n```"
-                ),
-                priority="high",
-                status="backlog",
+            title = "Platform health failures detected"
+            description = (
+                "The scheduled Platform Health Check found failing services.\n\n"
+                f"```\n{tail}\n```"
             )
+            existing = next(
+                (
+                    issue
+                    for issue in await client.list_issues()
+                    if issue.get("title") == title
+                    and issue.get("status") not in {"done", "cancelled", "archived"}
+                ),
+                None,
+            )
+            if existing and existing.get("id"):
+                await client.update_issue(
+                    str(existing["id"]),
+                    status="backlog",
+                    description=description,
+                    assignee_id=None,
+                    assignee_type=None,
+                )
+            else:
+                await client.create_issue(
+                    title=title,
+                    description=description,
+                    priority="high",
+                    status="backlog",
+                )
         except Exception as exc:
             logger.warning("autopilot: failed to create health failure issue: %s", exc)
 

--- a/services/zoe-data/multica_autopilot_sync.py
+++ b/services/zoe-data/multica_autopilot_sync.py
@@ -276,12 +276,14 @@ async def _run_platform_health_check() -> None:
                 "The scheduled Platform Health Check found failing services.\n\n"
                 f"```\n{tail}\n```"
             )
+            open_issues = []
+            for status in ("backlog", "todo", "in_progress", "blocked", "in_review"):
+                open_issues.extend(await client.list_issues(status=status, limit=1000))
             existing = next(
                 (
                     issue
-                    for issue in await client.list_issues(limit=1000)
+                    for issue in open_issues
                     if issue.get("title") == title
-                    and issue.get("status") not in {"done", "cancelled", "archived"}
                 ),
                 None,
             )

--- a/services/zoe-data/multica_client.py
+++ b/services/zoe-data/multica_client.py
@@ -140,7 +140,12 @@ class MULClient:
             logger.warning("Multica get_issue(%s) failed: %s", issue_id, exc)
             return {}
 
-    async def list_issues(self, status: str | None = None) -> list[dict]:
+    async def list_issues(
+        self,
+        status: str | None = None,
+        *,
+        limit: int | None = None,
+    ) -> list[dict]:
         """List issues in the workspace, optionally filtered by status."""
         if not self.is_configured():
             return []
@@ -148,6 +153,8 @@ class MULClient:
         params = {}
         if status:
             params["status"] = status
+        if limit is not None:
+            params["limit"] = max(1, int(limit))
         try:
             async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
                 resp = await client.get(url, params=params, headers=self._headers())

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -944,9 +944,20 @@ def test_phase_budget_reason_enforces_tool_and_runtime_limits(tmp_path, monkeypa
         now=110,
     )
 
+    assert reason is None
+
+    log_path.write_text("\n".join(["  ┊ tool call"] * 11), encoding="utf-8")
+    reason = kb.phase_budget_reason(
+        "t_scout",
+        "scout",
+        {"task": {"started_at": 100}},
+        now=110,
+    )
     assert reason is not None
     assert "SCOUT_BUDGET" in reason
-    assert "steps=9" in reason
+    assert "steps=11" in reason
+    assert "guidance_limit=8" in reason
+    assert "hard_limit=10" in reason
 
     log_path.write_text("", encoding="utf-8")
     monkeypatch.setenv("ZOE_KANBAN_SCOUT_RUNTIME_BUDGET_SECONDS", "5")

--- a/services/zoe-data/tests/test_multica_admission.py
+++ b/services/zoe-data/tests/test_multica_admission.py
@@ -62,6 +62,31 @@ def test_selects_one_approved_issue_by_queue_order():
     assert held == []
 
 
+def test_approved_blocked_ticket_halts_single_ticket_lane():
+    blocked = _issue(
+        "ZOE-1",
+        "First fix",
+        status="blocked",
+        dispatch_approved=True,
+        queue_order=1,
+    )
+    next_issue = _issue(
+        "ZOE-2",
+        "Second fix",
+        dispatch_approved=True,
+        queue_order=2,
+    )
+
+    selected, held = select_next_approved_issue(
+        [next_issue],
+        [blocked, next_issue],
+        hermes_agent_id=HERMES,
+    )
+
+    assert selected is None
+    assert held == ["single ticket lane halted by approved blocked ticket(s): ZOE-1"]
+
+
 def test_ticket_metadata_is_parsed_once_per_backlog_issue(monkeypatch):
     first = _issue("ZOE-1", "First fix", dispatch_approved=True, queue_order=1)
     second = _issue("ZOE-2", "Second fix", dispatch_approved=True, queue_order=2)

--- a/services/zoe-data/tests/test_multica_admission.py
+++ b/services/zoe-data/tests/test_multica_admission.py
@@ -87,6 +87,26 @@ def test_approved_blocked_ticket_halts_single_ticket_lane():
     assert held == ["single ticket lane halted by approved blocked ticket(s): ZOE-1"]
 
 
+def test_non_hermes_blocked_ticket_does_not_halt_lane():
+    blocked = _issue(
+        "ZOE-1",
+        "Other workflow",
+        status="blocked",
+        dispatch_approved=True,
+    )
+    blocked["assignee_id"] = "another-agent"
+    next_issue = _issue("ZOE-2", "Hermes fix", dispatch_approved=True)
+
+    selected, held = select_next_approved_issue(
+        [next_issue],
+        [blocked, next_issue],
+        hermes_agent_id=HERMES,
+    )
+
+    assert selected == next_issue
+    assert held == []
+
+
 def test_ticket_metadata_is_parsed_once_per_backlog_issue(monkeypatch):
     first = _issue("ZOE-1", "First fix", dispatch_approved=True, queue_order=1)
     second = _issue("ZOE-2", "Second fix", dispatch_approved=True, queue_order=2)

--- a/services/zoe-data/tests/test_multica_autopilot_noise.py
+++ b/services/zoe-data/tests/test_multica_autopilot_noise.py
@@ -79,7 +79,8 @@ async def test_platform_health_failure_reuses_open_issue(monkeypatch, tmp_path):
     creates = []
 
     class FakeClient:
-        async def list_issues(self):
+        async def list_issues(self, *, limit=None):
+            assert limit == 1000
             return [
                 {
                     "id": "health-1",

--- a/services/zoe-data/tests/test_multica_autopilot_noise.py
+++ b/services/zoe-data/tests/test_multica_autopilot_noise.py
@@ -71,6 +71,60 @@ def test_platform_health_never_creates_wrapper_issue():
 
 
 @pytest.mark.asyncio
+async def test_platform_health_failure_reuses_open_issue(monkeypatch, tmp_path):
+    script = tmp_path / "health.sh"
+    script.write_text("#!/bin/sh\necho broken\nexit 1\n", encoding="utf-8")
+    script.chmod(0o755)
+    updates = []
+    creates = []
+
+    class FakeClient:
+        async def list_issues(self):
+            return [
+                {
+                    "id": "health-1",
+                    "title": "Platform health failures detected",
+                    "status": "blocked",
+                }
+            ]
+
+        async def update_issue(self, issue_id, status=None, **kwargs):
+            updates.append((issue_id, status, kwargs))
+            return {"id": issue_id}
+
+        async def create_issue(self, **kwargs):
+            creates.append(kwargs)
+            return {"id": "new"}
+
+    monkeypatch.setenv("ZOE_HEALTH_CHECK_SCRIPT", str(script))
+    monkeypatch.setattr(mas, "_is_configured", lambda: True)
+    monkeypatch.setitem(
+        sys.modules,
+        "multica_client",
+        types.SimpleNamespace(get_multica_client=lambda: FakeClient()),
+    )
+
+    with pytest.raises(RuntimeError, match="Platform health check failed"):
+        await mas._run_platform_health_check()
+
+    assert creates == []
+    assert updates == [
+        (
+            "health-1",
+            "backlog",
+            {
+                "description": (
+                    "The scheduled Platform Health Check found failing services.\n\n"
+                    "```\nbroken\n```"
+                ),
+                "assignee_id": None,
+                "assignee_type": None,
+            },
+        )
+    ]
+
+
+@pytest.mark.asyncio
 async def test_fire_autopilot_job_skips_create_when_disabled(monkeypatch):
     posts: list = []
 

--- a/services/zoe-data/tests/test_multica_autopilot_noise.py
+++ b/services/zoe-data/tests/test_multica_autopilot_noise.py
@@ -59,6 +59,17 @@ def test_should_create_tracker_issue_allowlist():
                 assert mas._should_create_tracker_issue("Platform Health Check", "create_issue", fn) is True
 
 
+def test_platform_health_never_creates_wrapper_issue():
+    with patch.object(mas, "_is_configured", lambda: True):
+        with patch.object(mas, "_CREATE_ISSUES", True):
+            with patch.object(mas, "_CREATE_ISSUES_FOR", {"platform health check"}):
+                assert mas._should_create_tracker_issue(
+                    "Platform Health Check",
+                    "create_issue",
+                    mas._run_platform_health_check,
+                ) is False
+
+
 @pytest.mark.asyncio
 async def test_fire_autopilot_job_skips_create_when_disabled(monkeypatch):
     posts: list = []

--- a/services/zoe-data/tests/test_multica_autopilot_noise.py
+++ b/services/zoe-data/tests/test_multica_autopilot_noise.py
@@ -111,14 +111,12 @@ async def test_platform_health_failure_reuses_open_issue(monkeypatch, tmp_path):
     assert updates == [
         (
             "health-1",
-            "backlog",
+            None,
             {
                 "description": (
                     "The scheduled Platform Health Check found failing services.\n\n"
                     "```\nbroken\n```"
                 ),
-                "assignee_id": None,
-                "assignee_type": None,
             },
         )
     ]

--- a/services/zoe-data/tests/test_multica_autopilot_noise.py
+++ b/services/zoe-data/tests/test_multica_autopilot_noise.py
@@ -77,17 +77,19 @@ async def test_platform_health_failure_reuses_open_issue(monkeypatch, tmp_path):
     script.chmod(0o755)
     updates = []
     creates = []
+    list_calls = []
 
     class FakeClient:
-        async def list_issues(self, *, limit=None):
+        async def list_issues(self, status=None, *, limit=None):
             assert limit == 1000
+            list_calls.append(status)
             return [
                 {
                     "id": "health-1",
                     "title": "Platform health failures detected",
                     "status": "blocked",
                 }
-            ]
+            ] if status == "blocked" else []
 
         async def update_issue(self, issue_id, status=None, **kwargs):
             updates.append((issue_id, status, kwargs))
@@ -109,6 +111,7 @@ async def test_platform_health_failure_reuses_open_issue(monkeypatch, tmp_path):
         await mas._run_platform_health_check()
 
     assert creates == []
+    assert list_calls == ["backlog", "todo", "in_progress", "blocked", "in_review"]
     assert updates == [
         (
             "health-1",

--- a/services/zoe-data/tests/test_multica_client.py
+++ b/services/zoe-data/tests/test_multica_client.py
@@ -4,6 +4,7 @@ import sys
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 import multica_client
+import pytest
 
 
 def test_get_engineering_multica_agent_id_prefers_env(monkeypatch):
@@ -29,6 +30,42 @@ def test_mul_client_reads_env_at_instantiation(monkeypatch):
     assert client._token == "token-1"
     assert client._workspace == "workspace-1"
     assert client.is_configured() is True
+
+
+@pytest.mark.asyncio
+async def test_list_issues_forwards_explicit_limit(monkeypatch):
+    requests = []
+
+    class FakeResponse:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"issues": []}
+
+    class FakeHttpClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return None
+
+        async def get(self, url, **kwargs):
+            requests.append((url, kwargs))
+            return FakeResponse()
+
+    monkeypatch.setenv("MULTICA_BASE_URL", "https://multica.example")
+    monkeypatch.setenv("MULTICA_API_TOKEN", "token-1")
+    monkeypatch.setenv("MULTICA_WORKSPACE_ID", "workspace-1")
+    monkeypatch.setattr(
+        multica_client.httpx,
+        "AsyncClient",
+        lambda **_kwargs: FakeHttpClient(),
+    )
+
+    await multica_client.MULClient().list_issues(status="backlog", limit=1000)
+
+    assert requests[0][1]["params"] == {"status": "backlog", "limit": 1000}
 
 
 def test_get_multica_client_refreshes_cached_client_when_env_changes(monkeypatch):


### PR DESCRIPTION
## What changed
- halt single-lane auto-admission when an approved ticket is blocked
- reserve two Hermes calls for scout terminal protocol instead of killing at the guidance threshold
- replace false-positive platform health checks with structured JSON/container-state checks
- prevent Platform Health from creating duplicate Hermes-dispatched wrapper tickets

## Why
The approved card queue advanced after ZOE-5429 blocked in scout, causing later tickets to consume paid runs. Daily platform-health jobs also produced two false-positive engineering tickets because spaced JSON and containers without healthchecks were treated as failures.

## Validation
- 83 focused admission/autopilot/Kanban tests passed
- 71 dispatch/pipeline/Multica regression tests passed
- live health script passed Docker, PostgreSQL, zoe-data, Hermes, and OpenClaw checks
