### PR TITLE
ZOE-5429: align touch action allowlist

### DIFF
--- a/services/zoe-data/tests/test_ui_orchestrator_types.py
+++ b/services/zoe-data/tests/test_ui_orchestrator_types.py
@@ -35,3 +35,19 @@ def test_panel_set_mode_allowed():
 def test_existing_types_not_broken():
     for t in ("navigate", "open_panel", "focus", "fill", "notify", "refresh", "click"):
         assert t in ALLOWED_ACTION_TYPES, f"Broken: {t} missing from ALLOWED_ACTION_TYPES"
+
+
+def test_panel_show_action_form_allowed():
+    assert "panel_show_action_form" in ALLOWED_ACTION_TYPES
+
+
+def test_panel_update_field_allowed():
+    assert "panel_update_field" in ALLOWED_ACTION_TYPES
+
+
+def test_panel_list_update_allowed():
+    assert "panel_list_update" in ALLOWED_ACTION_TYPES
+
+
+def test_panel_close_action_form_allowed():
+    assert "panel_close_action_form" in ALLOWED_ACTION_TYPES

--- a/services/zoe-data/ui_orchestrator.py
+++ b/services/zoe-data/ui_orchestrator.py
@@ -33,6 +33,10 @@ ALLOWED_ACTION_TYPES = {
     "panel_open_form",
     "panel_stream_text",
     "panel_dismiss_ambient",
+    "panel_close_action_form",
+    "panel_list_update",
+    "panel_show_action_form",
+    "panel_update_field",
     "show_card",
 }
 DANGEROUS_ACTION_TYPES = {"delete_record"}


### PR DESCRIPTION
## Summary
- allow the four touch action-form event types already emitted by the kiosk
- add focused allowlist regression coverage

## Validation
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_ui_orchestrator_types.py (11 passed)
- python3 tools/audit/validate_structure.py (passed)