### PR TITLE
ZOE-5381: add Zoe card contract schema

### DIFF
--- a/services/zoe-data/card_contract.py
+++ b/services/zoe-data/card_contract.py
@@ -162,7 +162,7 @@ def validate_card_contract(contract: dict[str, Any], *, supported_major: int | N
         "created_at": _parse_created_at(contract["created_at"]).isoformat().replace("+00:00", "Z"),
     }
     if contract.get("idempotency_key") is not None:
-        normalized["idempotency_key"] = str(contract["idempotency_key"])
+        normalized["idempotency_key"] = _required_text(contract["idempotency_key"], "idempotency_key")
     return normalized
 
 

--- a/services/zoe-data/card_contract.py
+++ b/services/zoe-data/card_contract.py
@@ -1,0 +1,164 @@
+"""Zoe card contract schema helpers.
+
+This module defines the stable envelope that Zoe producers should emit and
+renderers should accept before card-specific adoption work begins.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any
+from uuid import UUID
+
+
+class CardContractError(ValueError):
+    """Raised when a card contract does not satisfy the Zoe card schema."""
+
+
+class CardType(str, Enum):
+    """Renderer-facing card payload families."""
+
+    GENERIC = "generic"
+    ACTION_FORM = "action_form"
+    MEDIA = "media"
+    RESEARCH_REPORT = "research_report"
+    SMART_HOME = "smart_home"
+    FORM = "form"
+    STREAM_TEXT = "stream_text"
+    LIST = "list"
+    FIELD_UPDATE = "field_update"
+    CLOSE_ACTION_FORM = "close_action_form"
+
+
+REQUIRED_FIELDS = {
+    "card_id",
+    "schema_version",
+    "card_type",
+    "content",
+    "producer",
+    "producer_version",
+    "created_at",
+}
+
+RESERVED_PREFIXES = ("zoe_", "_zoe_")
+
+CONTENT_REQUIRED_FIELDS: dict[CardType, set[str]] = {
+    CardType.GENERIC: {"title"},
+    CardType.ACTION_FORM: {"form_id", "title", "fields"},
+    CardType.MEDIA: {"title", "items"},
+    CardType.RESEARCH_REPORT: {"title", "sections"},
+    CardType.SMART_HOME: {"title", "devices"},
+    CardType.FORM: {"form_id", "title", "fields"},
+    CardType.STREAM_TEXT: {"stream_id", "text"},
+    CardType.LIST: {"list_id", "items"},
+    CardType.FIELD_UPDATE: {"field_id", "value"},
+    CardType.CLOSE_ACTION_FORM: {"form_id"},
+}
+
+
+def parse_semver(version: str) -> tuple[int, int, int]:
+    """Parse strict MAJOR.MINOR.PATCH semver into integers."""
+    parts = str(version or "").split(".")
+    if len(parts) != 3:
+        raise CardContractError("schema_version must use MAJOR.MINOR.PATCH")
+    try:
+        major, minor, patch = (int(part) for part in parts)
+    except ValueError as exc:
+        raise CardContractError("schema_version must contain numeric semver parts") from exc
+    if major < 0 or minor < 0 or patch < 0:
+        raise CardContractError("schema_version cannot contain negative parts")
+    return major, minor, patch
+
+
+def renderer_accepts(contract_version: str, *, supported_major: int) -> bool:
+    """Return True when a renderer can accept this contract major version.
+
+    Compatibility rule: renderers accept a card iff their supported MAJOR is
+    greater than or equal to the contract's MAJOR. MINOR is additive optional
+    surface area; PATCH is clarification only.
+    """
+    contract_major, _minor, _patch = parse_semver(contract_version)
+    return int(supported_major) >= contract_major
+
+
+def _parse_created_at(value: str) -> datetime:
+    text = str(value or "").strip()
+    if not text:
+        raise CardContractError("created_at is required")
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise CardContractError("created_at must be ISO-8601") from exc
+    if parsed.tzinfo is None:
+        raise CardContractError("created_at must include timezone")
+    return parsed.astimezone(timezone.utc)
+
+
+def _validate_uuid(value: str) -> str:
+    try:
+        return str(UUID(str(value)))
+    except ValueError as exc:
+        raise CardContractError("card_id must be a UUID string") from exc
+
+
+def _card_type(value: str) -> CardType:
+    try:
+        return CardType(str(value))
+    except ValueError as exc:
+        allowed = ", ".join(card_type.value for card_type in CardType)
+        raise CardContractError(f"card_type must be one of: {allowed}") from exc
+
+
+def _validate_content(card_type: CardType, content: Any) -> dict[str, Any]:
+    if not isinstance(content, dict):
+        raise CardContractError("content must be an object")
+    missing = sorted(CONTENT_REQUIRED_FIELDS[card_type] - set(content))
+    if missing:
+        raise CardContractError(
+            f"content for {card_type.value} is missing required field(s): {', '.join(missing)}"
+        )
+    return dict(content)
+
+
+def validate_card_contract(contract: dict[str, Any], *, supported_major: int | None = None) -> dict[str, Any]:
+    """Validate and normalize a Zoe card contract.
+
+    Unknown fields are tolerated and ignored for validation purposes so renderers
+    can remain forward-compatible. Producers should keep Zoe-internal fields
+    under ``zoe_*`` or ``_zoe_*`` reserved prefixes.
+    """
+    if not isinstance(contract, dict):
+        raise CardContractError("card contract must be an object")
+    missing = sorted(REQUIRED_FIELDS - set(contract))
+    if missing:
+        raise CardContractError(f"missing required field(s): {', '.join(missing)}")
+
+    schema_version = str(contract["schema_version"])
+    if supported_major is not None and not renderer_accepts(schema_version, supported_major=supported_major):
+        raise CardContractError(
+            f"renderer supports MAJOR {supported_major}, cannot accept schema_version {schema_version}"
+        )
+
+    card_type = _card_type(contract["card_type"])
+    normalized = {
+        "card_id": _validate_uuid(contract["card_id"]),
+        "schema_version": schema_version,
+        "card_type": card_type.value,
+        "content": _validate_content(card_type, contract["content"]),
+        "producer": str(contract["producer"]),
+        "producer_version": str(contract["producer_version"]),
+        "created_at": _parse_created_at(contract["created_at"]).isoformat().replace("+00:00", "Z"),
+    }
+    if contract.get("idempotency_key") is not None:
+        normalized["idempotency_key"] = str(contract["idempotency_key"])
+    return normalized
+
+
+def reserved_field_names(fields: dict[str, Any]) -> list[str]:
+    """Return field names using Zoe-reserved extension prefixes."""
+    return sorted(
+        name
+        for name in fields
+        if any(str(name).startswith(prefix) for prefix in RESERVED_PREFIXES)
+    )

--- a/services/zoe-data/card_contract.py
+++ b/services/zoe-data/card_contract.py
@@ -103,6 +103,15 @@ def _validate_uuid(value: str) -> str:
         raise CardContractError("card_id must be a UUID string") from exc
 
 
+def _required_text(value: Any, field_name: str) -> str:
+    if value is None:
+        raise CardContractError(f"{field_name} is required")
+    text = str(value).strip()
+    if not text:
+        raise CardContractError(f"{field_name} cannot be empty")
+    return text
+
+
 def _card_type(value: str) -> CardType:
     try:
         return CardType(str(value))
@@ -148,8 +157,8 @@ def validate_card_contract(contract: dict[str, Any], *, supported_major: int | N
         "schema_version": schema_version,
         "card_type": card_type.value,
         "content": _validate_content(card_type, contract["content"]),
-        "producer": str(contract["producer"]),
-        "producer_version": str(contract["producer_version"]),
+        "producer": _required_text(contract["producer"], "producer"),
+        "producer_version": _required_text(contract["producer_version"], "producer_version"),
         "created_at": _parse_created_at(contract["created_at"]).isoformat().replace("+00:00", "Z"),
     }
     if contract.get("idempotency_key") is not None:

--- a/services/zoe-data/card_contract.py
+++ b/services/zoe-data/card_contract.py
@@ -65,6 +65,8 @@ def parse_semver(version: str) -> tuple[int, int, int]:
         raise CardContractError("schema_version must use MAJOR.MINOR.PATCH")
     if any(part != part.strip() for part in parts):
         raise CardContractError("schema_version must contain numeric semver parts")
+    if any(len(part) > 1 and part.startswith("0") for part in parts):
+        raise CardContractError("schema_version cannot contain leading-zero semver parts")
     try:
         major, minor, patch = (int(part) for part in parts)
     except ValueError as exc:

--- a/services/zoe-data/card_contract.py
+++ b/services/zoe-data/card_contract.py
@@ -63,6 +63,8 @@ def parse_semver(version: str) -> tuple[int, int, int]:
     parts = str(version or "").split(".")
     if len(parts) != 3:
         raise CardContractError("schema_version must use MAJOR.MINOR.PATCH")
+    if any(part != part.strip() for part in parts):
+        raise CardContractError("schema_version must contain numeric semver parts")
     try:
         major, minor, patch = (int(part) for part in parts)
     except ValueError as exc:

--- a/services/zoe-data/card_contract.py
+++ b/services/zoe-data/card_contract.py
@@ -6,6 +6,7 @@ renderers should accept before card-specific adoption work begins.
 
 from __future__ import annotations
 
+from copy import deepcopy
 from datetime import datetime, timezone
 from enum import Enum
 from typing import Any
@@ -118,7 +119,7 @@ def _validate_content(card_type: CardType, content: Any) -> dict[str, Any]:
         raise CardContractError(
             f"content for {card_type.value} is missing required field(s): {', '.join(missing)}"
         )
-    return dict(content)
+    return deepcopy(content)
 
 
 def validate_card_contract(contract: dict[str, Any], *, supported_major: int | None = None) -> dict[str, Any]:
@@ -135,6 +136,7 @@ def validate_card_contract(contract: dict[str, Any], *, supported_major: int | N
         raise CardContractError(f"missing required field(s): {', '.join(missing)}")
 
     schema_version = str(contract["schema_version"])
+    parse_semver(schema_version)
     if supported_major is not None and not renderer_accepts(schema_version, supported_major=supported_major):
         raise CardContractError(
             f"renderer supports MAJOR {supported_major}, cannot accept schema_version {schema_version}"

--- a/services/zoe-data/tests/test_card_contract.py
+++ b/services/zoe-data/tests/test_card_contract.py
@@ -128,6 +128,11 @@ def test_validate_card_contract_always_rejects_invalid_semver():
         validate_card_contract(_contract(schema_version="not-semver"))
 
 
+def test_validate_card_contract_rejects_whitespace_padded_semver():
+    with pytest.raises(CardContractError, match="numeric semver parts"):
+        validate_card_contract(_contract(schema_version=" 1.0.0 "))
+
+
 def test_normalized_content_does_not_share_nested_mutable_values():
     payload = _contract(content={"form_id": "reminder", "title": "Reminder", "fields": []})
 

--- a/services/zoe-data/tests/test_card_contract.py
+++ b/services/zoe-data/tests/test_card_contract.py
@@ -62,6 +62,12 @@ def test_producer_fields_require_non_empty_text(field):
         validate_card_contract(_contract(**{field: "   "}))
 
 
+def test_idempotency_key_is_optional_but_not_blank():
+    assert "idempotency_key" not in validate_card_contract(_contract(idempotency_key=None))
+    with pytest.raises(CardContractError, match="idempotency_key"):
+        validate_card_contract(_contract(idempotency_key="   "))
+
+
 def test_content_required_fields_are_per_card_type():
     with pytest.raises(CardContractError, match="fields"):
         validate_card_contract(_contract(content={"form_id": "x", "title": "Missing fields"}))

--- a/services/zoe-data/tests/test_card_contract.py
+++ b/services/zoe-data/tests/test_card_contract.py
@@ -54,6 +54,14 @@ def test_invalid_card_type_is_rejected():
         validate_card_contract(_contract(card_type="unknown"))
 
 
+@pytest.mark.parametrize("field", ["producer", "producer_version"])
+def test_producer_fields_require_non_empty_text(field):
+    with pytest.raises(CardContractError, match=field):
+        validate_card_contract(_contract(**{field: None}))
+    with pytest.raises(CardContractError, match=field):
+        validate_card_contract(_contract(**{field: "   "}))
+
+
 def test_content_required_fields_are_per_card_type():
     with pytest.raises(CardContractError, match="fields"):
         validate_card_contract(_contract(content={"form_id": "x", "title": "Missing fields"}))

--- a/services/zoe-data/tests/test_card_contract.py
+++ b/services/zoe-data/tests/test_card_contract.py
@@ -95,6 +95,20 @@ def test_validate_card_contract_rejects_unsupported_major():
         validate_card_contract(_contract(schema_version="2.0.0"), supported_major=1)
 
 
+def test_validate_card_contract_always_rejects_invalid_semver():
+    with pytest.raises(CardContractError, match="MAJOR.MINOR.PATCH"):
+        validate_card_contract(_contract(schema_version="not-semver"))
+
+
+def test_normalized_content_does_not_share_nested_mutable_values():
+    payload = _contract(content={"form_id": "reminder", "title": "Reminder", "fields": []})
+
+    normalized = validate_card_contract(payload)
+    normalized["content"]["fields"].append({"name": "when"})
+
+    assert payload["content"]["fields"] == []
+
+
 def test_parse_semver_is_strict():
     assert parse_semver("1.2.3") == (1, 2, 3)
     with pytest.raises(CardContractError):

--- a/services/zoe-data/tests/test_card_contract.py
+++ b/services/zoe-data/tests/test_card_contract.py
@@ -133,6 +133,11 @@ def test_validate_card_contract_rejects_whitespace_padded_semver():
         validate_card_contract(_contract(schema_version=" 1.0.0 "))
 
 
+def test_validate_card_contract_rejects_leading_zero_semver_parts():
+    with pytest.raises(CardContractError, match="leading-zero"):
+        validate_card_contract(_contract(schema_version="01.0.0"))
+
+
 def test_normalized_content_does_not_share_nested_mutable_values():
     payload = _contract(content={"form_id": "reminder", "title": "Reminder", "fields": []})
 

--- a/services/zoe-data/tests/test_card_contract.py
+++ b/services/zoe-data/tests/test_card_contract.py
@@ -1,0 +1,108 @@
+"""Tests for Zoe card contract validation."""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from card_contract import (
+    CardContractError,
+    CardType,
+    parse_semver,
+    renderer_accepts,
+    reserved_field_names,
+    validate_card_contract,
+)
+
+
+def _contract(**overrides):
+    payload = {
+        "card_id": "550e8400-e29b-41d4-a716-446655440000",
+        "schema_version": "1.0.0",
+        "card_type": CardType.ACTION_FORM.value,
+        "content": {"form_id": "reminder", "title": "Reminder", "fields": []},
+        "producer": "zoe-data",
+        "producer_version": "2026.06.08",
+        "created_at": "2026-06-08T04:00:00Z",
+        "idempotency_key": "card:reminder:1",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_valid_card_contract_normalizes_core_fields():
+    normalized = validate_card_contract(_contract(), supported_major=1)
+
+    assert normalized["card_type"] == "action_form"
+    assert normalized["card_id"] == "550e8400-e29b-41d4-a716-446655440000"
+    assert normalized["created_at"] == "2026-06-08T04:00:00Z"
+    assert normalized["idempotency_key"] == "card:reminder:1"
+
+
+def test_missing_required_field_is_rejected():
+    payload = _contract()
+    payload.pop("producer")
+
+    with pytest.raises(CardContractError, match="missing required field"):
+        validate_card_contract(payload)
+
+
+def test_invalid_card_type_is_rejected():
+    with pytest.raises(CardContractError, match="card_type must be one of"):
+        validate_card_contract(_contract(card_type="unknown"))
+
+
+def test_content_required_fields_are_per_card_type():
+    with pytest.raises(CardContractError, match="fields"):
+        validate_card_contract(_contract(content={"form_id": "x", "title": "Missing fields"}))
+
+    normalized = validate_card_contract(
+        _contract(
+            card_type=CardType.LIST.value,
+            content={"list_id": "shopping", "items": ["milk"]},
+        )
+    )
+    assert normalized["content"]["items"] == ["milk"]
+
+
+def test_unknown_fields_are_tolerated_for_forward_compatibility():
+    normalized = validate_card_contract(
+        _contract(
+            future_renderer_hint="compact",
+            content={
+                "form_id": "reminder",
+                "title": "Reminder",
+                "fields": [],
+                "future_field": True,
+            },
+        )
+    )
+
+    assert normalized["content"]["future_field"] is True
+    assert "future_renderer_hint" not in normalized
+
+
+def test_renderer_accepts_contract_by_major_version():
+    assert renderer_accepts("1.2.3", supported_major=1)
+    assert renderer_accepts("1.2.3", supported_major=2)
+    assert not renderer_accepts("2.0.0", supported_major=1)
+
+
+def test_validate_card_contract_rejects_unsupported_major():
+    with pytest.raises(CardContractError, match="cannot accept"):
+        validate_card_contract(_contract(schema_version="2.0.0"), supported_major=1)
+
+
+def test_parse_semver_is_strict():
+    assert parse_semver("1.2.3") == (1, 2, 3)
+    with pytest.raises(CardContractError):
+        parse_semver("1.2")
+
+
+def test_reserved_field_names_identifies_zoe_extensions():
+    assert reserved_field_names({"zoe_trace": "x", "_zoe_internal": True, "title": "Hi"}) == [
+        "_zoe_internal",
+        "zoe_trace",
+    ]

--- a/services/zoe-data/tests/test_card_contract.py
+++ b/services/zoe-data/tests/test_card_contract.py
@@ -10,6 +10,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from card_contract import (
     CardContractError,
     CardType,
+    CONTENT_REQUIRED_FIELDS,
     parse_semver,
     renderer_accepts,
     reserved_field_names,
@@ -79,6 +80,19 @@ def test_content_required_fields_are_per_card_type():
         )
     )
     assert normalized["content"]["items"] == ["milk"]
+
+
+@pytest.mark.parametrize("card_type", list(CardType))
+def test_every_card_type_has_minimal_valid_content(card_type):
+    content = {
+        field: [] if field in {"devices", "fields", "items", "sections"} else f"{field}-value"
+        for field in CONTENT_REQUIRED_FIELDS[card_type]
+    }
+
+    normalized = validate_card_contract(_contract(card_type=card_type.value, content=content))
+
+    assert normalized["card_type"] == card_type.value
+    assert set(CONTENT_REQUIRED_FIELDS[card_type]).issubset(normalized["content"])
 
 
 def test_unknown_fields_are_tolerated_for_forward_compatibility():


### PR DESCRIPTION
## Summary
- add a small Zoe card contract validation module
- define card type enum, required envelope fields, per-type content requirements, semver compatibility, and reserved Zoe extension prefixes
- add focused tests for valid/invalid contracts, version compatibility, and unknown-field tolerance

## Validation
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_card_contract.py (9 passed)
- python3 tools/audit/validate_structure.py (passed)