### PR TITLE
fix(touch): prevent weather queue replay loop

### DIFF
--- a/services/zoe-data/routers/voice_tts.py
+++ b/services/zoe-data/routers/voice_tts.py
@@ -419,6 +419,22 @@ async def _synthesize_kokoro(text: str, voice: str = "af_sky") -> Optional[bytes
         return None
 
 
+def _should_supersede_voice_weather_action(row, nav_key: str, card_key: str) -> bool:
+    if row["idempotency_key"] in {nav_key, card_key}:
+        return False
+    try:
+        payload = json.loads(row["payload"] or "{}")
+    except Exception:
+        payload = {}
+    return (
+        row["action_type"] == "panel_navigate"
+        and payload.get("url") == "/touch/weather.html"
+    ) or (
+        row["action_type"] == "show_card"
+        and payload.get("type") == "weather"
+    )
+
+
 def _split_sentences(text: str) -> list[str]:
     """Split text into spoken sentences for streaming TTS.
 
@@ -473,12 +489,6 @@ async def _broadcast_weather_ui(
         },
     }
     try:
-        from push import broadcaster
-        await broadcaster.broadcast("all", "ui_action", {"action": nav_action})
-        await broadcaster.broadcast("all", "ui_action", {"action": card_action})
-    except Exception as exc:
-        logger.debug("voice weather ui broadcast failed (non-fatal): %s", exc)
-    try:
         from database import get_db as _get_db
         from ui_orchestrator import enqueue_ui_action as _enqueue_ui_action
         async for _db in _get_db():
@@ -493,24 +503,59 @@ async def _broadcast_weather_ui(
                     _panel_user_id = str(_row["user_id"])
             except Exception:
                 pass
-            await _enqueue_ui_action(
-                _db,
-                user_id=_panel_user_id,
-                panel_id=panel_id,
-                action_type="panel_navigate",
-                payload=nav_action["payload"],
-                requested_by="voice",
-                idempotency_key=f"voice_weather_nav_{panel_id}_{delivery_key}",
-            )
-            await _enqueue_ui_action(
-                _db,
-                user_id=_panel_user_id,
-                panel_id=panel_id,
-                action_type="show_card",
-                payload=card_action["payload"],
-                requested_by="voice",
-                idempotency_key=f"voice_weather_card_{panel_id}_{delivery_key}",
-            )
+            nav_key = f"voice_weather_nav_{panel_id}_{delivery_key}"
+            card_key = f"voice_weather_card_{panel_id}_{delivery_key}"
+            async with _db.transaction():
+                await _enqueue_ui_action(
+                    _db,
+                    user_id=_panel_user_id,
+                    panel_id=panel_id,
+                    action_type="panel_navigate",
+                    payload=nav_action["payload"],
+                    requested_by="voice",
+                    idempotency_key=nav_key,
+                    commit=False,
+                    broadcast=False,
+                )
+                await _enqueue_ui_action(
+                    _db,
+                    user_id=_panel_user_id,
+                    panel_id=panel_id,
+                    action_type="show_card",
+                    payload=card_action["payload"],
+                    requested_by="voice",
+                    idempotency_key=card_key,
+                    commit=False,
+                    broadcast=False,
+                )
+                _cur = await _db.execute(
+                    """SELECT id, action_type, payload, idempotency_key
+                       FROM ui_actions
+                       WHERE panel_id = ?
+                         AND requested_by = 'voice'
+                         AND status IN ('queued', 'running')""",
+                    (panel_id,),
+                )
+                _rows = await _cur.fetchall()
+                _superseded_at = datetime.now(timezone.utc).isoformat()
+                for _row in _rows:
+                    if not _should_supersede_voice_weather_action(_row, nav_key, card_key):
+                        continue
+                    await _db.execute(
+                        """UPDATE ui_actions
+                           SET status = 'skipped',
+                               error_code = 'superseded',
+                               error_message = 'Superseded by newer voice weather request',
+                               updated_at = ?
+                           WHERE id = ?""",
+                        (_superseded_at, _row["id"]),
+                    )
+            try:
+                from push import broadcaster
+                await broadcaster.broadcast("all", "ui_action", {"action": nav_action})
+                await broadcaster.broadcast("all", "ui_action", {"action": card_action})
+            except Exception as exc:
+                logger.debug("voice weather ui broadcast failed (non-fatal): %s", exc)
             break
     except Exception as exc:
         logger.debug("voice weather ui enqueue failed (non-fatal): %s", exc)

--- a/services/zoe-data/tests/test_voice_weather_queue.py
+++ b/services/zoe-data/tests/test_voice_weather_queue.py
@@ -1,6 +1,13 @@
 import json
+import sys
+import types
 
-from routers.voice_tts import _should_supersede_voice_weather_action
+import pytest
+
+from routers.voice_tts import (
+    _broadcast_weather_ui,
+    _should_supersede_voice_weather_action,
+)
 
 
 def _row(action_type: str, payload: dict, key: str = "old-key") -> dict:
@@ -47,4 +54,137 @@ def test_ignores_non_weather_actions() -> None:
         _row("show_card", {"type": "calendar"}),
         "new-nav",
         "new-card",
+    )
+
+
+class _Cursor:
+    def __init__(self, *, row: dict | None = None, rows: list[dict] | None = None):
+        self._row = row
+        self._rows = rows or []
+
+    async def fetchone(self):
+        return self._row
+
+    async def fetchall(self):
+        return self._rows
+
+
+class _Transaction:
+    def __init__(self, db):
+        self._db = db
+
+    async def __aenter__(self):
+        self._db.events.append("transaction_enter")
+        return self._db
+
+    async def __aexit__(self, exc_type, exc, tb):
+        self._db.events.append("transaction_exit")
+        return False
+
+
+class _Db:
+    def __init__(self):
+        self.events: list[str] = []
+        self.updated_ids: list[str] = []
+        self.voice_rows = [
+            {
+                "id": "old-nav-null-key",
+                "action_type": "panel_navigate",
+                "payload": json.dumps({"url": "/touch/weather.html"}),
+                "idempotency_key": None,
+            },
+            {
+                "id": "old-card",
+                "action_type": "show_card",
+                "payload": json.dumps({"type": "weather"}),
+                "idempotency_key": "old-card-key",
+            },
+            {
+                "id": "current-nav",
+                "action_type": "panel_navigate",
+                "payload": json.dumps({"url": "/touch/weather.html"}),
+                "idempotency_key": "voice_weather_nav_panel-1_turn-1",
+            },
+            {
+                "id": "current-card",
+                "action_type": "show_card",
+                "payload": json.dumps({"type": "weather"}),
+                "idempotency_key": "voice_weather_card_panel-1_turn-1",
+            },
+            {
+                "id": "calendar",
+                "action_type": "panel_navigate",
+                "payload": json.dumps({"url": "/touch/calendar.html"}),
+                "idempotency_key": "calendar-key",
+            },
+        ]
+
+    def transaction(self):
+        return _Transaction(self)
+
+    async def execute(self, sql: str, params: tuple = ()):
+        if "FROM ui_panel_sessions" in sql:
+            return _Cursor(row={"user_id": "panel-user"})
+        if "FROM ui_actions" in sql:
+            return _Cursor(rows=self.voice_rows)
+        if "UPDATE ui_actions" in sql:
+            self.updated_ids.append(params[1])
+            self.events.append(f"updated:{params[1]}")
+            return _Cursor()
+        raise AssertionError(f"unexpected SQL: {sql}")
+
+
+@pytest.mark.asyncio
+async def test_broadcast_weather_ui_supersedes_stale_rows_after_deduped_enqueue(
+    monkeypatch,
+) -> None:
+    db = _Db()
+    enqueue_calls = []
+    broadcasts = []
+
+    async def get_db():
+        yield db
+
+    async def enqueue_ui_action(_db, **kwargs):
+        enqueue_calls.append(kwargs)
+        db.events.append(f"enqueue:{kwargs['idempotency_key']}")
+        return {
+            "id": kwargs["idempotency_key"],
+            "status": "queued",
+            "deduped": True,
+            "panel_id": kwargs["panel_id"],
+        }
+
+    class Broadcaster:
+        async def broadcast(self, channel, event, payload):
+            broadcasts.append((channel, event, payload))
+            db.events.append(f"broadcast:{payload['action']['id']}")
+
+    monkeypatch.setitem(sys.modules, "database", types.SimpleNamespace(get_db=get_db))
+    monkeypatch.setitem(
+        sys.modules,
+        "ui_orchestrator",
+        types.SimpleNamespace(enqueue_ui_action=enqueue_ui_action),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "push",
+        types.SimpleNamespace(broadcaster=Broadcaster()),
+    )
+
+    await _broadcast_weather_ui("panel-1", summary="Rain later", turn_key="turn-1")
+
+    assert [call["idempotency_key"] for call in enqueue_calls] == [
+        "voice_weather_nav_panel-1_turn-1",
+        "voice_weather_card_panel-1_turn-1",
+    ]
+    assert all(call["commit"] is False for call in enqueue_calls)
+    assert all(call["broadcast"] is False for call in enqueue_calls)
+    assert db.updated_ids == ["old-nav-null-key", "old-card"]
+    assert [item[2]["action"]["id"] for item in broadcasts] == [
+        "voice_weather_nav_panel-1_turn-1",
+        "voice_weather_card_panel-1_turn-1",
+    ]
+    assert db.events.index("transaction_exit") < db.events.index(
+        "broadcast:voice_weather_nav_panel-1_turn-1"
     )

--- a/services/zoe-data/tests/test_voice_weather_queue.py
+++ b/services/zoe-data/tests/test_voice_weather_queue.py
@@ -1,0 +1,50 @@
+import json
+
+from routers.voice_tts import _should_supersede_voice_weather_action
+
+
+def _row(action_type: str, payload: dict, key: str = "old-key") -> dict:
+    return {
+        "action_type": action_type,
+        "payload": json.dumps(payload),
+        "idempotency_key": key,
+    }
+
+
+def test_supersedes_old_voice_weather_actions() -> None:
+    assert _should_supersede_voice_weather_action(
+        _row("panel_navigate", {"url": "/touch/weather.html"}),
+        "new-nav",
+        "new-card",
+    )
+    assert _should_supersede_voice_weather_action(
+        _row("show_card", {"type": "weather"}),
+        "new-nav",
+        "new-card",
+    )
+
+
+def test_preserves_current_weather_actions() -> None:
+    assert not _should_supersede_voice_weather_action(
+        _row("panel_navigate", {"url": "/touch/weather.html"}, key="new-nav"),
+        "new-nav",
+        "new-card",
+    )
+    assert not _should_supersede_voice_weather_action(
+        _row("show_card", {"type": "weather"}, key="new-card"),
+        "new-nav",
+        "new-card",
+    )
+
+
+def test_ignores_non_weather_actions() -> None:
+    assert not _should_supersede_voice_weather_action(
+        _row("panel_navigate", {"url": "/touch/calendar.html"}),
+        "new-nav",
+        "new-card",
+    )
+    assert not _should_supersede_voice_weather_action(
+        _row("show_card", {"type": "calendar"}),
+        "new-nav",
+        "new-card",
+    )

--- a/services/zoe-data/ui_orchestrator.py
+++ b/services/zoe-data/ui_orchestrator.py
@@ -79,6 +79,8 @@ async def enqueue_ui_action(
     chat_session_id: Optional[str] = None,
     idempotency_key: Optional[str] = None,
     confirmation_token: Optional[str] = None,
+    commit: bool = True,
+    broadcast: bool = True,
 ) -> Dict[str, Any]:
     if action_type not in ALLOWED_ACTION_TYPES:
         raise ValueError(f"Unsupported action type: {action_type}")
@@ -161,7 +163,8 @@ async def enqueue_ui_action(
             "requires_confirmation": bool(requires_confirmation),
         },
     )
-    await db.commit()
+    if commit:
+        await db.commit()
 
     message = {
         "action_id": action_id,
@@ -174,8 +177,9 @@ async def enqueue_ui_action(
         "requires_confirmation": bool(requires_confirmation),
         "confirmation_token": confirmation_token if requires_confirmation else None,
     }
-    if panel_id:
-        await broadcaster.broadcast_to_panel(panel_id, "ui_action", message)
-    else:
-        await broadcaster.broadcast("all", "ui_action", message)
+    if broadcast:
+        if panel_id:
+            await broadcaster.broadcast_to_panel(panel_id, "ui_action", message)
+        else:
+            await broadcaster.broadcast("all", "ui_action", message)
     return message

--- a/services/zoe-ui/dist/touch/weather.html
+++ b/services/zoe-ui/dist/touch/weather.html
@@ -932,6 +932,8 @@
 
     async function fetchWeather() {
         try {
+            const fc = document.getElementById('forecastSection');
+            if (fc) fc.style.opacity = '';
             const [curRes, fcRes] = await Promise.all([
                 fetch('/api/weather/current'),
                 fetch('/api/weather/forecast'),
@@ -943,9 +945,12 @@
                 else document.getElementById('heroSection').innerHTML = `
                     <div class="weather-error"><div class="err-icon">🌐</div><div>Weather data unavailable</div></div>`;
             } else if (curRes.status === 401 || curRes.status === 403) {
-                // Session expired — redirect to login (preserve destination).
-                try { sessionStorage.setItem('zoe_redirect_after_login', window.location.pathname + window.location.search); } catch (_) {}
-                window.location.assign('/touch/index.html');
+                document.getElementById('heroSection').innerHTML = `
+                    <div class="weather-error">
+                        <div class="err-icon">🔒</div>
+                        <div>Sign in to view weather</div>
+                    </div>`;
+                if (fc) fc.style.opacity = '0.35';
                 return;
             }
             if (fcRes.ok) {

--- a/services/zoe-ui/dist/touch/weather.html
+++ b/services/zoe-ui/dist/touch/weather.html
@@ -933,7 +933,6 @@
     async function fetchWeather() {
         try {
             const fc = document.getElementById('forecastSection');
-            if (fc) fc.style.opacity = '';
             const [curRes, fcRes] = await Promise.all([
                 fetch('/api/weather/current'),
                 fetch('/api/weather/forecast'),
@@ -954,6 +953,7 @@
                 return;
             }
             if (fcRes.ok) {
+                if (fc) fc.style.opacity = '';
                 try { renderForecast(await fcRes.json()); } catch (_) {}
             }
             _lastFetch = Date.now();

--- a/services/zoe-ui/dist/touch/weather.html
+++ b/services/zoe-ui/dist/touch/weather.html
@@ -938,6 +938,7 @@
                 fetch('/api/weather/forecast'),
             ]);
             if (curRes.ok) {
+                if (fc) fc.style.opacity = '';
                 let curData;
                 try { curData = await curRes.json(); } catch (_) { curData = null; }
                 if (curData) renderCurrent(curData);
@@ -953,7 +954,6 @@
                 return;
             }
             if (fcRes.ok) {
-                if (fc) fc.style.opacity = '';
                 try { renderForecast(await fcRes.json()); } catch (_) {}
             }
             _lastFetch = Date.now();


### PR DESCRIPTION
## Summary
- collapse older queued/running voice weather panel actions before queuing a new weather open
- keep the touch weather page on a logged-out safe state instead of redirecting into login/backlog replay
- cleared the live stale queue separately as an operational hotfix; this PR lands the code path normally

## Verification
- python3 -m py_compile services/zoe-data/routers/voice_tts.py
- python3 -m pytest -q services/zoe-data/tests/test_ui_orchestrator_types.py services/zoe-data/tests/test_voice_scope.py
- python3 tools/audit/validate_structure.py
