### PR TITLE
ZOE-5382: add card contract validation fixtures

### DIFF
--- a/services/zoe-data/tests/fixtures/card_contract_invalid.json
+++ b/services/zoe-data/tests/fixtures/card_contract_invalid.json
@@ -1,0 +1,65 @@
+[
+  {
+    "name": "missing action form fields",
+    "error_contains": "content for action_form is missing required field(s): fields",
+    "card": {
+      "card_id": "550e8400-e29b-41d4-a716-446655440010",
+      "schema_version": "1.0.0",
+      "card_type": "action_form",
+      "content": {
+        "form_id": "reminder",
+        "title": "Reminder"
+      },
+      "producer": "zoe-data",
+      "producer_version": "2026.06.08",
+      "created_at": "2026-06-08T04:00:00Z"
+    }
+  },
+  {
+    "name": "invalid card id",
+    "error_contains": "card_id must be a UUID string",
+    "card": {
+      "card_id": "not-a-uuid",
+      "schema_version": "1.0.0",
+      "card_type": "generic",
+      "content": {
+        "title": "Status"
+      },
+      "producer": "zoe-data",
+      "producer_version": "2026.06.08",
+      "created_at": "2026-06-08T04:00:00Z"
+    }
+  },
+  {
+    "name": "blank producer",
+    "error_contains": "producer cannot be empty",
+    "card": {
+      "card_id": "550e8400-e29b-41d4-a716-446655440011",
+      "schema_version": "1.0.0",
+      "card_type": "list",
+      "content": {
+        "list_id": "shopping",
+        "items": []
+      },
+      "producer": "   ",
+      "producer_version": "2026.06.08",
+      "created_at": "2026-06-08T04:00:00Z"
+    }
+  },
+  {
+    "name": "unsupported renderer major",
+    "supported_major": 1,
+    "error_contains": "renderer supports MAJOR 1, cannot accept schema_version 2.0.0",
+    "card": {
+      "card_id": "550e8400-e29b-41d4-a716-446655440012",
+      "schema_version": "2.0.0",
+      "card_type": "generic",
+      "content": {
+        "title": "Future Card"
+      },
+      "producer": "zoe-data",
+      "producer_version": "2026.06.08",
+      "created_at": "2026-06-08T04:00:00Z"
+    }
+  }
+]

--- a/services/zoe-data/tests/fixtures/card_contract_valid.json
+++ b/services/zoe-data/tests/fixtures/card_contract_valid.json
@@ -1,0 +1,57 @@
+[
+  {
+    "name": "generic status",
+    "card": {
+      "card_id": "550e8400-e29b-41d4-a716-446655440020",
+      "schema_version": "1.0.0",
+      "card_type": "generic",
+      "content": {
+        "title": "System Status",
+        "summary": "All services healthy"
+      },
+      "producer": "zoe-data",
+      "producer_version": "2026.06.08",
+      "created_at": "2026-06-08T04:00:00Z"
+    }
+  },
+  {
+    "name": "action form",
+    "card": {
+      "card_id": "550e8400-e29b-41d4-a716-446655440021",
+      "schema_version": "1.0.0",
+      "card_type": "action_form",
+      "content": {
+        "form_id": "reminder",
+        "title": "Create Reminder",
+        "fields": [
+          {
+            "name": "when",
+            "type": "datetime"
+          }
+        ]
+      },
+      "producer": "zoe-data",
+      "producer_version": "2026.06.08",
+      "created_at": "2026-06-08T04:00:00Z",
+      "idempotency_key": "card:reminder:fixture"
+    }
+  },
+  {
+    "name": "list card",
+    "card": {
+      "card_id": "550e8400-e29b-41d4-a716-446655440022",
+      "schema_version": "1.0.0",
+      "card_type": "list",
+      "content": {
+        "list_id": "shopping",
+        "items": [
+          "milk",
+          "bread"
+        ]
+      },
+      "producer": "zoe-data",
+      "producer_version": "2026.06.08",
+      "created_at": "2026-06-08T04:00:00Z"
+    }
+  }
+]

--- a/services/zoe-data/tests/test_card_contract.py
+++ b/services/zoe-data/tests/test_card_contract.py
@@ -1,7 +1,9 @@
 """Tests for Zoe card contract validation."""
 
+import json
 import os
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -16,6 +18,9 @@ from card_contract import (
     reserved_field_names,
     validate_card_contract,
 )
+
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures"
 
 
 def _contract(**overrides):
@@ -33,6 +38,10 @@ def _contract(**overrides):
     return payload
 
 
+def _load_fixture(name):
+    return json.loads((FIXTURE_DIR / name).read_text(encoding="utf-8"))
+
+
 def test_valid_card_contract_normalizes_core_fields():
     normalized = validate_card_contract(_contract(), supported_major=1)
 
@@ -40,6 +49,31 @@ def test_valid_card_contract_normalizes_core_fields():
     assert normalized["card_id"] == "550e8400-e29b-41d4-a716-446655440000"
     assert normalized["created_at"] == "2026-06-08T04:00:00Z"
     assert normalized["idempotency_key"] == "card:reminder:1"
+
+
+def test_valid_card_contract_fixtures_normalize_without_unknown_envelope_fields():
+    for case in _load_fixture("card_contract_valid.json"):
+        normalized = validate_card_contract(case["card"], supported_major=1)
+
+        assert normalized["card_id"] == case["card"]["card_id"]
+        assert normalized["schema_version"] == case["card"]["schema_version"]
+        assert normalized["card_type"] == case["card"]["card_type"]
+        assert normalized["producer"] == case["card"]["producer"]
+        assert "name" not in normalized
+
+
+def test_invalid_card_contract_fixtures_return_actionable_errors():
+    for case in _load_fixture("card_contract_invalid.json"):
+        with pytest.raises(CardContractError) as exc_info:
+            validate_card_contract(
+                case["card"],
+                supported_major=case.get("supported_major"),
+            )
+
+        message = str(exc_info.value)
+        assert case["error_contains"] in message
+        assert "Traceback" not in message
+        assert "card_contract.py" not in message
 
 
 def test_missing_required_field_is_rejected():

--- a/services/zoe-data/tests/test_card_contract.py
+++ b/services/zoe-data/tests/test_card_contract.py
@@ -52,7 +52,10 @@ def test_valid_card_contract_normalizes_core_fields():
 
 
 def test_valid_card_contract_fixtures_normalize_without_unknown_envelope_fields():
-    for case in _load_fixture("card_contract_valid.json"):
+    cases = _load_fixture("card_contract_valid.json")
+    assert cases, "card_contract_valid.json must contain at least one test case"
+
+    for case in cases:
         normalized = validate_card_contract(case["card"], supported_major=1)
 
         assert normalized["card_id"] == case["card"]["card_id"]
@@ -63,7 +66,10 @@ def test_valid_card_contract_fixtures_normalize_without_unknown_envelope_fields(
 
 
 def test_invalid_card_contract_fixtures_return_actionable_errors():
-    for case in _load_fixture("card_contract_invalid.json"):
+    cases = _load_fixture("card_contract_invalid.json")
+    assert cases, "card_contract_invalid.json must contain at least one test case"
+
+    for case in cases:
         with pytest.raises(CardContractError) as exc_info:
             validate_card_contract(
                 case["card"],
@@ -72,8 +78,6 @@ def test_invalid_card_contract_fixtures_return_actionable_errors():
 
         message = str(exc_info.value)
         assert case["error_contains"] in message
-        assert "Traceback" not in message
-        assert "card_contract.py" not in message
 
 
 def test_missing_required_field_is_rejected():


### PR DESCRIPTION
## Summary
- add reusable valid and invalid Zoe card contract JSON fixtures
- add fixture-driven validation tests for normalization and actionable errors
- keep producer/renderer migration out of scope

## Tests
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_card_contract.py
- python3 tools/audit/validate_structure.py

## Live note
Hermes implement spawned an extra scaffold subtask and then stopped without a PR; Codex blocked the extra task and rescued this narrow implementation from the canonical worktree.