### PR TITLE
Fix harness prompt guards from ZOE-5382 E2E

### DIFF
--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -501,7 +501,8 @@ class KanbanAdapter:
             return common + _retro_cost_hint() + (
                 "You are retro (zoe-planner). Capture learnings after closeout — no silent prod changes.\n"
                 "- POST-CLOSEOUT FAST PATH: if closeout already records PR_URL, MERGE_SHA, and"
-                " GREPTILE=5/5 or already_merged, do not inspect worktrees, branch history, or GitHub."
+                " GREPTILE/greptile_status=5/5 or already_merged, do not inspect worktrees,"
+                " branch history, or GitHub."
                 " Use `kanban_show`, summarize one learning, and `kanban_complete`.\n"
                 "- AUDIT/NO-PR FAST PATH: if this was an audit-only/no-code run, keep retro to one"
                 " short handoff and do not load broad skills or inspect unrelated repo state.\n"

--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -501,7 +501,7 @@ class KanbanAdapter:
             return common + _retro_cost_hint() + (
                 "You are retro (zoe-planner). Capture learnings after closeout — no silent prod changes.\n"
                 "- POST-CLOSEOUT FAST PATH: if closeout already records PR_URL, MERGE_SHA, and"
-                " GREPTILE=5/5/already_merged, do not inspect worktrees, branch history, or GitHub."
+                " GREPTILE=5/5 or already_merged, do not inspect worktrees, branch history, or GitHub."
                 " Use `kanban_show`, summarize one learning, and `kanban_complete`.\n"
                 "- AUDIT/NO-PR FAST PATH: if this was an audit-only/no-code run, keep retro to one"
                 " short handoff and do not load broad skills or inspect unrelated repo state.\n"

--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -365,6 +365,10 @@ class KanbanAdapter:
             return common + (
                 "You are scout (zoe-planner, read-only). Gather context before any code changes.\n"
                 "- Start with `kanban_show` and read the Multica issue acceptance criteria.\n"
+                "- CHILD/FOLLOW-UP FAST PATH: if the issue is already a narrow child/follow-up with"
+                " concrete acceptance criteria and an existing prerequisite artifact/PR named in the"
+                " ticket block, do not inspect branch history or broad worktrees. Decide ready/blocked"
+                " from the ticket plus at most the named artifact files, then hand off.\n"
                 "- Keep this phase bounded: run at most one focused Graphify/doc lookup and no broad repo crawl.\n"
                 "- For smoke, audit-only, or harness-check tickets, do not over-investigate; summarize the"
                 " observed contract and complete the scout handoff.\n"
@@ -405,6 +409,8 @@ class KanbanAdapter:
                 " reuse service-layer helpers.\n"
                 "- If the task needs more than one PR or a large refactor, call `kanban_block` and"
                 " ask for a split — do not absorb unbounded work in one implement run.\n"
+                "- Do NOT create additional Hermes/Kanban tasks, scaffold subtasks, or sibling work items."
+                " If scope needs another task, use the NEEDS_SPLIT/SPLIT_PACKET block below and stop.\n"
                 "- Validate: `python3 tools/audit/validate_structure.py` and focused tests for touched modules.\n"
                 "- You already run on an isolated git worktree branch. Commit verified changes, then publish"
                 " the branch and open ONE small PR (do not merge) with EXACTLY these commands:\n"
@@ -494,6 +500,9 @@ class KanbanAdapter:
         if phase == "retro":
             return common + _retro_cost_hint() + (
                 "You are retro (zoe-planner). Capture learnings after closeout — no silent prod changes.\n"
+                "- POST-CLOSEOUT FAST PATH: if closeout already records PR_URL, MERGE_SHA, and"
+                " GREPTILE=5/5/already_merged, do not inspect worktrees, branch history, or GitHub."
+                " Use `kanban_show`, summarize one learning, and `kanban_complete`.\n"
                 "- AUDIT/NO-PR FAST PATH: if this was an audit-only/no-code run, keep retro to one"
                 " short handoff and do not load broad skills or inspect unrelated repo state.\n"
                 "- Read closeout/implement handoffs and any Greptile or validator notes.\n"

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -1281,6 +1281,8 @@ def test_retro_body_has_post_closeout_fast_path():
 
     assert "POST-CLOSEOUT FAST PATH" in body
     assert "PR_URL, MERGE_SHA" in body
+    assert "GREPTILE=5/5 or already_merged" in body
+    assert "GREPTILE=5/5/already_merged" not in body
     assert "do not inspect worktrees, branch history, or GitHub" in body
     assert "Use `kanban_show`, summarize one learning, and `kanban_complete`" in body
     assert body.index("POST-CLOSEOUT FAST PATH") < body.index("AUDIT/NO-PR FAST PATH")

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -1247,9 +1247,43 @@ def test_implement_body_puts_bounded_fast_paths_before_graphify():
     assert "SMALL EXPLICIT CODE FAST PATH" in body
     assert "Start editing within 6 tool/model steps" in body
     assert "BLOCKER=IMPLEMENT_BUDGET" in body
+    assert "Do NOT create additional Hermes/Kanban tasks" in body
+    assert "scaffold subtasks" in body
     assert "broad or ambiguous code-changing tickets only" in body
     assert body.index("AUDIT/SMOKE FAST PATH") < body.index("Graphify map")
     assert body.index("SMALL EXPLICIT CODE FAST PATH") < body.index("Graphify map")
+
+
+def test_scout_body_has_child_followup_fast_path():
+    body = ka.KanbanAdapter()._build_body(
+        "scout",
+        {
+            "id": "uuid-1",
+            "identifier": "ZOE-9",
+            "title": "child fixture follow-up",
+            "description": "zoe_kind: child\nacceptance criteria: focused fixture tests",
+        },
+        "ZOE-9",
+    )
+
+    assert "CHILD/FOLLOW-UP FAST PATH" in body
+    assert "do not inspect branch history or broad worktrees" in body
+    assert "at most the named artifact files" in body
+    assert body.index("CHILD/FOLLOW-UP FAST PATH") < body.index("Keep this phase bounded")
+
+
+def test_retro_body_has_post_closeout_fast_path():
+    body = ka.KanbanAdapter()._build_body(
+        "retro",
+        {"id": "uuid-1", "identifier": "ZOE-9", "title": "Retro", "description": ""},
+        "ZOE-9",
+    )
+
+    assert "POST-CLOSEOUT FAST PATH" in body
+    assert "PR_URL, MERGE_SHA" in body
+    assert "do not inspect worktrees, branch history, or GitHub" in body
+    assert "Use `kanban_show`, summarize one learning, and `kanban_complete`" in body
+    assert body.index("POST-CLOSEOUT FAST PATH") < body.index("AUDIT/NO-PR FAST PATH")
 
 
 def test_audit_no_pr_phases_do_not_preload_broad_skills():

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -1281,7 +1281,7 @@ def test_retro_body_has_post_closeout_fast_path():
 
     assert "POST-CLOSEOUT FAST PATH" in body
     assert "PR_URL, MERGE_SHA" in body
-    assert "GREPTILE=5/5 or already_merged" in body
+    assert "GREPTILE/greptile_status=5/5 or already_merged" in body
     assert "GREPTILE=5/5/already_merged" not in body
     assert "do not inspect worktrees, branch history, or GitHub" in body
     assert "Use `kanban_show`, summarize one learning, and `kanban_complete`" in body


### PR DESCRIPTION
## Summary
- add scout child/follow-up fast path to avoid branch/worktree over-exploration
- forbid implement workers from creating extra Hermes/Kanban scaffold subtasks
- add retro post-closeout fast path for already-merged / Greptile 5/5 runs
- cover these prompt guards in adapter tests

## Live finding
ZOE-5382 completed end to end, but exposed three cost/process blockers: scout overran budget, implement spawned a non-canonical scaffold task, and retro overran budget after closeout evidence already existed.

## Tests
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_kanban_adapter.py
- python3 tools/audit/validate_structure.py