### PR TITLE
Fix audit no-code pipeline evidence parsing

### DIFF
--- a/services/zoe-data/pipeline_handoff.py
+++ b/services/zoe-data/pipeline_handoff.py
@@ -91,7 +91,6 @@ def _reported_test_evidence_passed(raw: str, *, phase: PipelinePhase) -> bool:
             "audit-only",
             "audit only",
             "no-code",
-            "no code",
             "scout/plan",
             "no-code planning",
             "plan deliverable",

--- a/services/zoe-data/pipeline_handoff.py
+++ b/services/zoe-data/pipeline_handoff.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from pipeline_evidence import EvidenceItem, PipelinePhase, content_hash
 
-_KV_RE = re.compile(r"^([A-Z_]+)=(.*)$", re.MULTILINE)
+_KV_RE = re.compile(r"^[ \t]*([A-Z_]+)=(.*)$", re.MULTILINE)
 _TOOL_NAMES = (
     "graphify",
     "opensrc",
@@ -81,6 +81,26 @@ def _reported_evidence_passed(raw: str, *, unavailable_markers: tuple[str, ...])
             for marker in ("fail", "not applicable", "n/a", *unavailable_markers)
         )
         or re.search(r"\bblock(?:ed)?\b", lowered)
+    )
+
+
+def _reported_test_evidence_passed(raw: str, *, phase: PipelinePhase) -> bool:
+    lowered = raw.lower()
+    if phase == "verify" and "not applicable" in lowered:
+        no_code_markers = (
+            "audit-only",
+            "audit only",
+            "no-code",
+            "no code",
+            "scout/plan",
+            "planning",
+            "plan deliverable",
+        )
+        if any(marker in lowered for marker in no_code_markers):
+            return True
+    return _reported_evidence_passed(
+        raw,
+        unavailable_markers=("no tests",),
     )
 
 
@@ -434,10 +454,7 @@ def evidence_from_handoff(
 
     tests_raw = fields.get("TESTS") or ""
     if tests_raw and phase in {"implement", "verify"}:
-        passed = _reported_evidence_passed(
-            tests_raw,
-            unavailable_markers=("no tests",),
-        )
+        passed = _reported_test_evidence_passed(tests_raw, phase=phase)
         items.append(
             EvidenceItem(
                 kind="test",

--- a/services/zoe-data/pipeline_handoff.py
+++ b/services/zoe-data/pipeline_handoff.py
@@ -93,7 +93,7 @@ def _reported_test_evidence_passed(raw: str, *, phase: PipelinePhase) -> bool:
             "no-code",
             "no code",
             "scout/plan",
-            "planning",
+            "no-code planning",
             "plan deliverable",
         )
         if any(marker in lowered for marker in no_code_markers):

--- a/services/zoe-data/pipeline_handoff.py
+++ b/services/zoe-data/pipeline_handoff.py
@@ -300,7 +300,7 @@ def _greptile_from_closeout(detail: dict[str, Any], skills: tuple[str, ...] | li
 
     greptile_raw = fields.get("GREPTILE") or ""
     if greptile_raw:
-        passed = "fail" not in greptile_raw.lower() and "block" not in greptile_raw.lower()
+        passed = _reported_evidence_passed(greptile_raw, unavailable_markers=())
         return EvidenceItem(
             kind="greptile",
             summary=greptile_raw[:500],

--- a/services/zoe-data/tests/test_pipeline_handoff.py
+++ b/services/zoe-data/tests/test_pipeline_handoff.py
@@ -122,6 +122,23 @@ def test_audit_no_code_verify_tests_count_as_passed():
     assert test_item.passed is True
 
 
+def test_unhyphenated_no_code_verify_tests_do_not_count_as_passed():
+    detail = {
+        "runs": [
+            {
+                "metadata": {
+                    "TESTS": "not applicable — no code changes were made",
+                }
+            }
+        ]
+    }
+
+    items = evidence_from_handoff("verify", detail)
+    test_item = next(item for item in items if item.kind == "test")
+
+    assert test_item.passed is False
+
+
 def test_audit_no_code_test_exemption_is_verify_only():
     detail = {
         "runs": [

--- a/services/zoe-data/tests/test_pipeline_handoff.py
+++ b/services/zoe-data/tests/test_pipeline_handoff.py
@@ -122,6 +122,23 @@ def test_audit_no_code_verify_tests_count_as_passed():
     assert test_item.passed is True
 
 
+def test_audit_no_code_test_exemption_is_verify_only():
+    detail = {
+        "runs": [
+            {
+                "metadata": {
+                    "TESTS": "not applicable — audit-only no-code verification",
+                }
+            }
+        ]
+    }
+
+    items = evidence_from_handoff("implement", detail)
+    test_item = next(item for item in items if item.kind == "test")
+
+    assert test_item.passed is False
+
+
 def test_not_applicable_validators_do_not_count_as_passed():
     detail = {
         "runs": [

--- a/services/zoe-data/tests/test_pipeline_handoff.py
+++ b/services/zoe-data/tests/test_pipeline_handoff.py
@@ -86,7 +86,25 @@ def test_verify_evidence_reads_structured_run_metadata():
     assert {item.kind for item in items if item.passed is True} >= {"test", "validator"}
 
 
-def test_not_applicable_tests_do_not_count_as_passed():
+def test_generic_not_applicable_tests_do_not_count_as_passed():
+    detail = {
+        "runs": [
+            {
+                "metadata": {
+                    "TESTS": "not applicable",
+                    "VALIDATORS": "validate_structure.py passed",
+                }
+            }
+        ]
+    }
+
+    items = evidence_from_handoff("verify", detail)
+    test_item = next(item for item in items if item.kind == "test")
+
+    assert test_item.passed is False
+
+
+def test_audit_no_code_verify_tests_count_as_passed():
     detail = {
         "runs": [
             {
@@ -101,7 +119,7 @@ def test_not_applicable_tests_do_not_count_as_passed():
     items = evidence_from_handoff("verify", detail)
     test_item = next(item for item in items if item.kind == "test")
 
-    assert test_item.passed is False
+    assert test_item.passed is True
 
 
 def test_not_applicable_validators_do_not_count_as_passed():
@@ -602,6 +620,23 @@ PR_URL=""", "comments": []}
     assert log.metadata["phase"] == "closeout"
     assert log.metadata["audit_only"] is True
     assert not any(item.kind == "greptile" for item in items)
+
+
+def test_closeout_audit_only_handoff_accepts_indented_log_lines():
+    detail = {"log_tail": """
+     PR_URL=
+     MERGE_SHA=
+     GREPTILE=n/a (no-code plan)
+     AUDIT_ONLY=1
+     SUMMARY=4-phase card producer adoption plan approved; no code changes
+""", "comments": []}
+
+    items = evidence_from_handoff("closeout", detail, skills=("github-greptile-loop",))
+
+    log = next(item for item in items if item.kind == "log")
+    assert log.passed is True
+    assert log.summary == "4-phase card producer adoption plan approved; no code changes"
+    assert log.metadata["audit_only"] is True
 
 
 def test_closeout_infers_audit_log_only_from_audit_summary_without_pr():

--- a/services/zoe-data/tests/test_pipeline_handoff.py
+++ b/services/zoe-data/tests/test_pipeline_handoff.py
@@ -672,6 +672,11 @@ def test_closeout_audit_only_handoff_accepts_indented_log_lines():
     assert log.summary == "4-phase card producer adoption plan approved; no code changes"
     assert log.metadata["audit_only"] is True
 
+    greptile_items = [item for item in items if item.kind == "greptile"]
+    assert not any(item.passed is True for item in greptile_items), (
+        "GREPTILE=n/a should not produce a passed=True greptile evidence item"
+    )
+
 
 def test_closeout_infers_audit_log_only_from_audit_summary_without_pr():
     detail = {"latest_summary": """SUMMARY=audit-only closeout completed


### PR DESCRIPTION
## Summary
- parse indented KEY=value handoff lines from Hermes log tails
- treat verify TESTS=not applicable as passed only for explicit audit/no-code/planning evidence
- add coverage for audit closeout log evidence from indented handoffs

## Live finding
ZOE-5383 completed as a no-code adoption-plan ticket, but verify stayed missing test evidence and closeout stayed missing log evidence until operator rescue because the parser missed audit/no-code handoff shape.

## Tests
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_pipeline_handoff.py
- python3 tools/audit/validate_structure.py