### PR TITLE
[codex] Improve voice STT observability

### DIFF
--- a/scripts/setup/pi_voice_daemon_install.sh
+++ b/scripts/setup/pi_voice_daemon_install.sh
@@ -106,6 +106,8 @@ SAMPLE_RATE=16000
 CHUNK_SIZE=1280
 RECORD_SECONDS_MAX=8
 SILENCE_TIMEOUT_S=1.5
+RECORD_SILENCE_AMPLITUDE=300
+ZOE_VOICE_LOG=/home/zoe/.zoe-voice/voice.log
 WAKEWORD_THRESHOLD=0.35
 # Set to 1 to log max wakeword score every 5s (verify mic + model sensitivity)
 WAKEWORD_DEBUG=0

--- a/scripts/setup/zoe-voice.env.example
+++ b/scripts/setup/zoe-voice.env.example
@@ -22,3 +22,11 @@ VERIFY_SSL=0
 
 # Wake word sensitivity (0.0-1.0, lower = more sensitive but more false positives)
 OWW_THRESHOLD=0.5
+
+# Recording controls
+RECORD_SECONDS_MAX=8
+SILENCE_TIMEOUT_S=1.5
+RECORD_SILENCE_AMPLITUDE=300
+
+# Persistent voice daemon log for recording stop reasons and STT results
+ZOE_VOICE_LOG=/home/zoe/.zoe-voice/voice.log

--- a/scripts/setup/zoe_voice_daemon.py
+++ b/scripts/setup/zoe_voice_daemon.py
@@ -59,8 +59,9 @@ DEVICE_TOKEN = os.environ.get("DEVICE_TOKEN", "")
 AUDIO_DEVICE = os.environ.get("AUDIO_DEVICE", "default")
 SAMPLE_RATE = int(os.environ.get("SAMPLE_RATE", "16000"))
 CHUNK_SIZE = int(os.environ.get("CHUNK_SIZE", "1280"))
-RECORD_SECONDS = int(os.environ.get("RECORD_SECONDS_MAX", "5"))
-SILENCE_TIMEOUT_S = float(os.environ.get("SILENCE_TIMEOUT_S", "1.0"))
+RECORD_SECONDS = int(os.environ.get("RECORD_SECONDS_MAX", "8"))
+SILENCE_TIMEOUT_S = float(os.environ.get("SILENCE_TIMEOUT_S", "1.5"))
+RECORD_SILENCE_AMPLITUDE = int(os.environ.get("RECORD_SILENCE_AMPLITUDE", "300"))
 # Default 0.28 — 0.35 misses many real mics/rooms; tune via WAKEWORD_THRESHOLD.
 WAKEWORD_THRESHOLD = float(os.environ.get("WAKEWORD_THRESHOLD", "0.28"))
 VERIFY_SSL = os.environ.get("VERIFY_SSL", "true").lower() not in ("false", "0", "no")
@@ -587,20 +588,27 @@ def record_command(pa: pyaudio.PyAudio) -> bytes | None:
             time.sleep(wait_s)
     frames = []
     silent_chunks = 0
+    stop_reason = "max_duration"
     max_silent = int(SILENCE_TIMEOUT_S * SAMPLE_RATE / CHUNK_SIZE)
     max_chunks = int(RECORD_SECONDS * SAMPLE_RATE / CHUNK_SIZE)
     for _ in range(max_chunks):
         data = stream.read(CHUNK_SIZE, exception_on_overflow=False)
         frames.append(data)
         amplitude = np.abs(np.frombuffer(data, dtype=np.int16)).mean()
-        if amplitude < 300:
+        if amplitude < RECORD_SILENCE_AMPLITUDE:
             silent_chunks += 1
             if silent_chunks >= max_silent and len(frames) > int(0.5 * SAMPLE_RATE / CHUNK_SIZE):
+                stop_reason = "silence"
                 break
         else:
             silent_chunks = 0
     stream.stop_stream()
     stream.close()
+    duration_s = len(frames) * CHUNK_SIZE / float(SAMPLE_RATE)
+    log.info(
+        "Recorded command: duration=%.2fs chunks=%d stop=%s silence_timeout=%.2fs silence_amp=%d",
+        duration_s, len(frames), stop_reason, SILENCE_TIMEOUT_S, RECORD_SILENCE_AMPLITUDE,
+    )
     if len(frames) < int(0.3 * SAMPLE_RATE / CHUNK_SIZE):
         log.info("Command too short, ignoring.")
         return None
@@ -833,20 +841,27 @@ def _follow_up_listen(pa: pyaudio.PyAudio) -> bytes | None:
         log.info("Recording follow-up command (max %ds)...", RECORD_SECONDS)
         frames = list(pre_frames)
         silent_chunks = 0
+        stop_reason = "max_duration"
         max_silent = int(SILENCE_TIMEOUT_S * SAMPLE_RATE / CHUNK_SIZE)
         max_chunks = int(RECORD_SECONDS * SAMPLE_RATE / CHUNK_SIZE)
         for _ in range(max_chunks):
             data = stream.read(CHUNK_SIZE, exception_on_overflow=False)
             frames.append(data)
             amplitude = np.abs(np.frombuffer(data, dtype=np.int16)).mean()
-            if amplitude < 300:
+            if amplitude < RECORD_SILENCE_AMPLITUDE:
                 silent_chunks += 1
                 if silent_chunks >= max_silent and len(frames) > int(0.5 * SAMPLE_RATE / CHUNK_SIZE):
+                    stop_reason = "silence"
                     break
             else:
                 silent_chunks = 0
         stream.stop_stream()
         stream.close()
+        duration_s = len(frames) * CHUNK_SIZE / float(SAMPLE_RATE)
+        log.info(
+            "Recorded follow-up: duration=%.2fs chunks=%d stop=%s silence_timeout=%.2fs silence_amp=%d",
+            duration_s, len(frames), stop_reason, SILENCE_TIMEOUT_S, RECORD_SILENCE_AMPLITUDE,
+        )
 
         if len(frames) < int(0.3 * SAMPLE_RATE / CHUNK_SIZE):
             log.info("Follow-up too short, ignoring.")

--- a/services/zoe-data/routers/voice_tts.py
+++ b/services/zoe-data/routers/voice_tts.py
@@ -1558,11 +1558,11 @@ async def _run_faster_whisper(wav_path: str) -> str:
     if model is None:
         raise RuntimeError("faster-whisper not available; install with: pip install faster-whisper")
     lang = (os.environ.get("ZOE_WHISPER_LANG") or "en").strip()
-    vad_threshold = float(os.environ.get("ZOE_WHISPER_VAD_THRESHOLD", "0.50"))
-    min_speech_ms = int(os.environ.get("ZOE_WHISPER_MIN_SPEECH_MS", "120"))
-    min_silence_ms = int(os.environ.get("ZOE_WHISPER_MIN_SILENCE_MS", "350"))
-    speech_pad_ms = int(os.environ.get("ZOE_WHISPER_SPEECH_PAD_MS", "220"))
-    timeout = float(os.environ.get("ZOE_WHISPER_TIMEOUT_S", "20"))
+    vad_threshold = _env_float("ZOE_WHISPER_VAD_THRESHOLD", 0.50)
+    min_speech_ms = _env_int("ZOE_WHISPER_MIN_SPEECH_MS", 120)
+    min_silence_ms = _env_int("ZOE_WHISPER_MIN_SILENCE_MS", 350)
+    speech_pad_ms = _env_int("ZOE_WHISPER_SPEECH_PAD_MS", 220)
+    timeout = _env_float("ZOE_WHISPER_TIMEOUT_S", 20.0)
 
     _MAX_STT_OOM_RETRIES = 2
 
@@ -1606,6 +1606,20 @@ async def _run_faster_whisper(wav_path: str) -> str:
 
 
 
+def _env_float(name: str, default: float) -> float:
+    try:
+        return float(os.environ.get(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
+def _env_int(name: str, default: int) -> int:
+    try:
+        return int(os.environ.get(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
 def _voice_stt_log_path() -> Path:
     configured = (os.environ.get("ZOE_VOICE_STT_LOG") or "").strip()
     if configured:
@@ -1622,6 +1636,21 @@ def _wav_duration_seconds(wav_path: str) -> float | None:
             return round(wf.getnframes() / float(rate), 3)
     except Exception:
         return None
+
+
+def _rotate_voice_stt_log(path: Path) -> None:
+    max_bytes = _env_int("ZOE_VOICE_STT_LOG_MAX_BYTES", 5_000_000)
+    if max_bytes <= 0 or not path.exists():
+        return
+    try:
+        if path.stat().st_size < max_bytes:
+            return
+        rotated = path.with_name(path.name + ".1")
+        if rotated.exists():
+            rotated.unlink()
+        path.replace(rotated)
+    except OSError as exc:
+        logger.debug("voice STT audit rotation failed: %s", exc)
 
 
 def _log_voice_stt_sample(
@@ -1651,13 +1680,14 @@ def _log_voice_stt_sample(
             "model": (os.environ.get("ZOE_WHISPER_MODEL") or "base.en").strip(),
             "device": (os.environ.get("ZOE_WHISPER_DEVICE") or "").strip(),
             "compute_type": (os.environ.get("ZOE_WHISPER_COMPUTE_TYPE") or "").strip(),
-            "vad_threshold": os.environ.get("ZOE_WHISPER_VAD_THRESHOLD", "0.50"),
-            "min_speech_ms": os.environ.get("ZOE_WHISPER_MIN_SPEECH_MS", "120"),
-            "min_silence_ms": os.environ.get("ZOE_WHISPER_MIN_SILENCE_MS", "350"),
-            "speech_pad_ms": os.environ.get("ZOE_WHISPER_SPEECH_PAD_MS", "220"),
+            "vad_threshold": _env_float("ZOE_WHISPER_VAD_THRESHOLD", 0.50),
+            "min_speech_ms": _env_int("ZOE_WHISPER_MIN_SPEECH_MS", 120),
+            "min_silence_ms": _env_int("ZOE_WHISPER_MIN_SILENCE_MS", 350),
+            "speech_pad_ms": _env_int("ZOE_WHISPER_SPEECH_PAD_MS", 220),
         }
         if error:
             record["error"] = error[:500]
+        _rotate_voice_stt_log(path)
         with path.open("a", encoding="utf-8") as fh:
             fh.write(json.dumps(record, ensure_ascii=False) + "\n")
     except Exception as exc:
@@ -1698,6 +1728,9 @@ async def voice_transcribe(payload: dict, caller: dict = Depends(_require_voice_
     elif len(raw) >= 2 and raw[:2] == b"\xff\xfb":
         suffix = ".mp3"
 
+    duration_s: float | None = None
+    stt_s: float | None = None
+    t_stt_start: float | None = None
     try:
         text = ""
         with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
@@ -1744,13 +1777,46 @@ async def voice_transcribe(payload: dict, caller: dict = Depends(_require_voice_
         except Exception:
             pass
         return {"ok": True, "panel_id": panel_id, "text": stripped}
-    except asyncio.TimeoutError:
+    except asyncio.TimeoutError as exc:
+        if t_stt_start is not None:
+            stt_s = time.monotonic() - t_stt_start
+        _log_voice_stt_sample(
+            route="transcribe",
+            panel_id=panel_id,
+            audio_bytes=len(raw),
+            suffix=suffix,
+            duration_seconds=duration_s,
+            stt_seconds=stt_s,
+            error=str(exc) or "Transcription timed out",
+        )
         logger.warning("voice/transcribe timeout panel=%s", panel_id)
         raise HTTPException(status_code=504, detail="Transcription timed out") from None
     except RuntimeError as exc:
+        if t_stt_start is not None:
+            stt_s = time.monotonic() - t_stt_start
+        _log_voice_stt_sample(
+            route="transcribe",
+            panel_id=panel_id,
+            audio_bytes=len(raw),
+            suffix=suffix,
+            duration_seconds=duration_s,
+            stt_seconds=stt_s,
+            error=str(exc),
+        )
         logger.warning("voice/transcribe unavailable: %s", exc)
         raise HTTPException(status_code=503, detail=str(exc)) from exc
     except Exception as exc:
+        if t_stt_start is not None:
+            stt_s = time.monotonic() - t_stt_start
+        _log_voice_stt_sample(
+            route="transcribe",
+            panel_id=panel_id,
+            audio_bytes=len(raw),
+            suffix=suffix,
+            duration_seconds=duration_s,
+            stt_seconds=stt_s,
+            error=str(exc),
+        )
         logger.error("voice/transcribe error: %s", exc)
         raise HTTPException(status_code=500, detail="Transcription failed") from exc
 
@@ -3294,6 +3360,7 @@ async def voice_turn(payload: dict, caller: dict = Depends(_require_voice_auth),
 
     # ── Phase 1: STT ──
     t_stt_start = time.monotonic()
+    duration_s: float | None = None
     try:
         with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
             tmp.write(raw)
@@ -3307,6 +3374,16 @@ async def voice_turn(payload: dict, caller: dict = Depends(_require_voice_auth),
             except OSError:
                 pass
     except Exception as exc:
+        t_stt = time.monotonic() - t_stt_start
+        _log_voice_stt_sample(
+            route="turn",
+            panel_id=panel_id,
+            audio_bytes=len(raw),
+            suffix=suffix,
+            duration_seconds=duration_s,
+            stt_seconds=t_stt,
+            error=str(exc),
+        )
         logger.error("voice/turn STT failed: %s", exc)
         try:
             from voice_metrics import voice_turn_count, voice_failure_reason_count

--- a/services/zoe-data/routers/voice_tts.py
+++ b/services/zoe-data/routers/voice_tts.py
@@ -7,6 +7,7 @@ import re
 import shutil
 import tempfile
 import time
+import wave
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
@@ -1604,6 +1605,65 @@ async def _run_faster_whisper(wav_path: str) -> str:
     return text
 
 
+
+def _voice_stt_log_path() -> Path:
+    configured = (os.environ.get("ZOE_VOICE_STT_LOG") or "").strip()
+    if configured:
+        return Path(configured)
+    return Path.home() / ".zoe-voice" / "voice_stt.jsonl"
+
+
+def _wav_duration_seconds(wav_path: str) -> float | None:
+    try:
+        with wave.open(wav_path, "rb") as wf:
+            rate = wf.getframerate() or 0
+            if rate <= 0:
+                return None
+            return round(wf.getnframes() / float(rate), 3)
+    except Exception:
+        return None
+
+
+def _log_voice_stt_sample(
+    *,
+    route: str,
+    panel_id: str,
+    audio_bytes: int,
+    suffix: str,
+    transcript: str = "",
+    duration_seconds: float | None = None,
+    stt_seconds: float | None = None,
+    error: str | None = None,
+) -> None:
+    try:
+        path = _voice_stt_log_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        record = {
+            "ts": datetime.now(timezone.utc).isoformat(),
+            "route": route,
+            "panel_id": panel_id,
+            "audio_bytes": audio_bytes,
+            "audio_suffix": suffix,
+            "audio_duration_seconds": duration_seconds,
+            "stt_seconds": round(stt_seconds, 3) if stt_seconds is not None else None,
+            "transcript": transcript,
+            "transcript_chars": len(transcript or ""),
+            "model": (os.environ.get("ZOE_WHISPER_MODEL") or "base.en").strip(),
+            "device": (os.environ.get("ZOE_WHISPER_DEVICE") or "").strip(),
+            "compute_type": (os.environ.get("ZOE_WHISPER_COMPUTE_TYPE") or "").strip(),
+            "vad_threshold": os.environ.get("ZOE_WHISPER_VAD_THRESHOLD", "0.50"),
+            "min_speech_ms": os.environ.get("ZOE_WHISPER_MIN_SPEECH_MS", "120"),
+            "min_silence_ms": os.environ.get("ZOE_WHISPER_MIN_SILENCE_MS", "350"),
+            "speech_pad_ms": os.environ.get("ZOE_WHISPER_SPEECH_PAD_MS", "220"),
+        }
+        if error:
+            record["error"] = error[:500]
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+    except Exception as exc:
+        logger.debug("voice STT audit log failed: %s", exc)
+
+
 async def _transcribe_audio(wav_path: str) -> str:
     """
     Transcription waterfall:
@@ -1643,6 +1703,8 @@ async def voice_transcribe(payload: dict, caller: dict = Depends(_require_voice_
         with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
             tmp.write(raw)
             wav_path = tmp.name
+        duration_s = _wav_duration_seconds(wav_path) if suffix == ".wav" else None
+        t_stt_start = time.monotonic()
         try:
             text = await _transcribe_audio(wav_path)
         finally:
@@ -1650,9 +1712,22 @@ async def voice_transcribe(payload: dict, caller: dict = Depends(_require_voice_
                 os.unlink(wav_path)
             except OSError:
                 pass
-        logger.info("voice/transcribe panel=%s chars=%d", panel_id, len(text))
-        # Broadcast the transcribed user text so the UI shows what was heard.
         stripped = text.strip()
+        stt_s = time.monotonic() - t_stt_start
+        _log_voice_stt_sample(
+            route="transcribe",
+            panel_id=panel_id,
+            audio_bytes=len(raw),
+            suffix=suffix,
+            transcript=stripped,
+            duration_seconds=duration_s,
+            stt_seconds=stt_s,
+        )
+        logger.info(
+            "voice/transcribe panel=%s audio=%.2fs STT=%.2fs chars=%d",
+            panel_id, duration_s or 0.0, stt_s, len(stripped),
+        )
+        # Broadcast the transcribed user text so the UI shows what was heard.
         if stripped:
             try:
                 from push import broadcaster
@@ -3223,6 +3298,7 @@ async def voice_turn(payload: dict, caller: dict = Depends(_require_voice_auth),
         with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
             tmp.write(raw)
             wav_path = tmp.name
+        duration_s = _wav_duration_seconds(wav_path) if suffix == ".wav" else None
         try:
             transcript = await _transcribe_audio(wav_path)
         finally:
@@ -3252,6 +3328,15 @@ async def voice_turn(payload: dict, caller: dict = Depends(_require_voice_auth),
         pass
 
     transcript = transcript.strip()
+    _log_voice_stt_sample(
+        route="turn",
+        panel_id=panel_id,
+        audio_bytes=len(raw),
+        suffix=suffix,
+        transcript=transcript,
+        duration_seconds=duration_s,
+        stt_seconds=t_stt,
+    )
     if not transcript:
         try:
             from voice_metrics import voice_turn_count, voice_failure_reason_count

--- a/services/zoe-data/tests/test_voice_transcribe.py
+++ b/services/zoe-data/tests/test_voice_transcribe.py
@@ -83,6 +83,10 @@ def test_transcribe_writes_stt_audit_log(client, monkeypatch, tmp_path):
     assert record["transcript"] == "hello audit"
     assert record["model"] == "small.en"
     assert record["audio_bytes"] == len(wav)
+    assert isinstance(record["vad_threshold"], float)
+    assert isinstance(record["min_speech_ms"], int)
+    assert isinstance(record["min_silence_ms"], int)
+    assert isinstance(record["speech_pad_ms"], int)
 
 
 def test_transcribe_missing_body_400(client):
@@ -90,12 +94,14 @@ def test_transcribe_missing_body_400(client):
     assert r.status_code == 400
 
 
-def test_transcribe_503_when_whisper_missing(client, monkeypatch):
+def test_transcribe_503_when_whisper_missing(client, monkeypatch, tmp_path):
     from routers import voice_tts
 
     async def _boom(path: str) -> str:
         raise RuntimeError("whisper.cpp binary not found")
 
+    log_path = tmp_path / "voice_stt.jsonl"
+    monkeypatch.setenv("ZOE_VOICE_STT_LOG", str(log_path))
     monkeypatch.setattr(voice_tts, "_transcribe_audio", _boom)
     wav = b"RIFF" + b"\x01" * 20
     r = client.post(
@@ -103,6 +109,32 @@ def test_transcribe_503_when_whisper_missing(client, monkeypatch):
         json={"audio_base64": base64.b64encode(wav).decode()},
     )
     assert r.status_code == 503
+    record = json.loads(log_path.read_text().strip())
+    assert record["route"] == "transcribe"
+    assert record["audio_bytes"] == len(wav)
+    assert record["transcript"] == ""
+    assert "whisper.cpp binary not found" in record["error"]
+
+
+def test_stt_audit_log_rotates_when_capped(monkeypatch, tmp_path):
+    from routers import voice_tts
+
+    log_path = tmp_path / "voice_stt.jsonl"
+    log_path.write_text("x" * 50)
+    monkeypatch.setenv("ZOE_VOICE_STT_LOG", str(log_path))
+    monkeypatch.setenv("ZOE_VOICE_STT_LOG_MAX_BYTES", "10")
+
+    voice_tts._log_voice_stt_sample(
+        route="transcribe",
+        panel_id="p-rotate",
+        audio_bytes=1,
+        suffix=".wav",
+    )
+
+    rotated = tmp_path / "voice_stt.jsonl.1"
+    assert rotated.read_text() == "x" * 50
+    record = json.loads(log_path.read_text().strip())
+    assert record["panel_id"] == "p-rotate"
 
 
 def test_recent_panel_session_user_is_trusted(monkeypatch):

--- a/services/zoe-data/tests/test_voice_transcribe.py
+++ b/services/zoe-data/tests/test_voice_transcribe.py
@@ -2,6 +2,7 @@
 
 import base64
 import asyncio
+import json
 import sys
 import time
 from datetime import datetime, timedelta, timezone
@@ -56,6 +57,32 @@ def test_transcribe_ok_with_mock_whisper(client, monkeypatch):
     data = r.json()
     assert data.get("ok") is True
     assert data.get("text") == "hello world"
+
+
+def test_transcribe_writes_stt_audit_log(client, monkeypatch, tmp_path):
+    from routers import voice_tts
+
+    async def _fake_run(path: str) -> str:
+        return "hello audit"
+
+    log_path = tmp_path / "voice_stt.jsonl"
+    monkeypatch.setenv("ZOE_VOICE_STT_LOG", str(log_path))
+    monkeypatch.setenv("ZOE_WHISPER_MODEL", "small.en")
+    monkeypatch.setattr(voice_tts, "_transcribe_audio", _fake_run)
+    wav = b"RIFF" + b"\x00" * 12
+
+    r = client.post(
+        "/api/voice/transcribe",
+        json={"audio_base64": base64.b64encode(wav).decode(), "panel_id": "p-audit"},
+    )
+
+    assert r.status_code == 200
+    record = json.loads(log_path.read_text().strip())
+    assert record["route"] == "transcribe"
+    assert record["panel_id"] == "p-audit"
+    assert record["transcript"] == "hello audit"
+    assert record["model"] == "small.en"
+    assert record["audio_bytes"] == len(wav)
 
 
 def test_transcribe_missing_body_400(client):


### PR DESCRIPTION
## Summary
- add JSONL audit logging for Zoe voice STT turns, including model/VAD settings, audio duration, transcript length, and STT latency
- expose Pi daemon recording controls for max duration, silence timeout, and silence amplitude
- log Pi command/follow-up recording duration and stop reason so clipped audio can be diagnosed

## Why
Voice-to-text mistakes were hard to debug because recent bad turns were not visible in persisted app state and the Pi daemon did not log why recordings stopped. The runtime was also tuned for speed with the smaller `base.en` model and aggressive VAD settings; production config has been adjusted separately to use `small.en` and less aggressive VAD.

## Production evidence
Applied and verified on the canonical Zoe host and touch panel before opening this PR:
- `zoe-data.service` restarted and healthy
- `zoe-touch-pi` `zoe-voice.service` restarted and healthy
- live synthesize -> transcribe smoke returned `Add milk to the shopping list.`
- live STT audit entry recorded `model=small.en`, CUDA, VAD settings, audio duration `2.275s`, and STT time `6.273s`

## Validation
- `python3 -m py_compile services/zoe-data/routers/voice_tts.py scripts/setup/zoe_voice_daemon.py services/zoe-data/tests/test_voice_transcribe.py`
- `cd services/zoe-data && python3 -m pytest tests/test_voice_transcribe.py -q` (`8 passed`)
- `git diff --check`
- Grep-loop support tests were run on the canonical worktree before this clean PR branch: `tests/test_greploop_guard.py tests/test_greptile_client.py` (`20 passed`)

## Notes
The production `.env` tuning is intentionally not committed here because it is environment-specific. The code now supports the audit log path via `ZOE_VOICE_STT_LOG`, defaulting to `~/.zoe-voice/voice_stt.jsonl`.
