### PR TITLE
Skip scout for scope-split child tickets

### DIFF
--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -201,6 +201,12 @@ def _skip_scout(issue: dict | None = None) -> bool:
         "yes",
     }:
         return True
+    if (
+        str(meta.get("zoe_kind") or "").strip().lower() == "child"
+        and str(meta.get("source") or "").strip().lower() == "scope_split"
+        and bool(meta.get("acceptance_criteria"))
+    ):
+        return True
     haystack = " ".join(
         [
             str(issue.get("title") or ""),

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -276,6 +276,43 @@ async def test_dispatch_skip_scout_when_env_set(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_dispatch_skips_scout_for_scope_split_child():
+    a = _FakeAdapter()
+    result = await a.dispatch(
+        {
+            "id": "uuid-child",
+            "identifier": "ZOE-5438",
+            "title": "card_service foundation",
+            "metadata": {
+                "zoe_kind": "child",
+                "source": "scope_split",
+                "acceptance_criteria": ["card_service.py foundation"],
+            },
+        }
+    )
+    assert "scout" not in result["chain"]
+    assert set(result["chain"]) == {"implement"}
+
+
+@pytest.mark.asyncio
+async def test_dispatch_keeps_scout_for_under_specified_scope_split_child():
+    a = _FakeAdapter()
+    result = await a.dispatch(
+        {
+            "id": "uuid-child-empty",
+            "identifier": "ZOE-EMPTY",
+            "title": "under-specified child",
+            "metadata": {
+                "zoe_kind": "child",
+                "source": "scope_split",
+                "acceptance_criteria": [],
+            },
+        }
+    )
+    assert set(result["chain"]) == {"scout"}
+
+
+@pytest.mark.asyncio
 async def test_dispatch_quality_escalation_mode(monkeypatch):
     monkeypatch.setenv("ZOE_KANBAN_ESCALATION_MAX_RUNTIME", "75m")
     a = _FakeAdapter()


### PR DESCRIPTION
Fixes the ZOE-5438 production blocker exposed after splitting ZOE-5288. Scope-split child tickets already have concrete acceptance criteria from parent scout, so the driver should start them at implement instead of burning a scout budget.\n\nChanges:\n- skip scout for child tickets created from scope_split with acceptance criteria\n- add adapter regression coverage\n\nValidation:\n- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_kanban_adapter.py\n- python3 tools/audit/validate_structure.py