### PR TITLE
ZOE-5438: add card service foundation

### DIFF
--- a/services/zoe-data/card_service.py
+++ b/services/zoe-data/card_service.py
@@ -1,0 +1,107 @@
+"""Zoe card service foundation for Phase 3 card upgrade.
+
+Implements build/validate/convert_emit against Phase 2 contract.
+"""
+
+from typing import Any
+from card_contract import (
+    validate_card_contract,
+    CardContractError,
+    renderer_accepts,
+)
+
+
+class CardService:
+    """Service layer for Zoe card operations."""
+
+    def __init__(self):
+        self._domain_builders = {}
+
+    def build_card(self, card_type: str, content: dict[str, Any], **kwargs) -> dict[str, Any]:
+        """Build a Zoe card contract from domain-specific content.
+        
+        Args:
+            card_type: CardType string
+            content: Card-specific content payload
+            **kwargs: Additional envelope fields (producer, producer_version, etc.)
+            
+        Returns:
+            Validated and normalized card contract
+        """
+        from uuid import uuid4
+        from datetime import datetime, timezone
+        
+        contract = {
+            "card_id": str(uuid4()),
+            "schema_version": "1.0.0",
+            "card_type": card_type,
+            "content": content,
+            "producer": kwargs.get("producer", "zoe-card-service"),
+            "producer_version": kwargs.get("producer_version", "1.0.0"),
+            "created_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        }
+        
+        if "idempotency_key" in kwargs:
+            contract["idempotency_key"] = kwargs["idempotency_key"]
+            
+        return self.validate_card(contract)
+
+    def validate_card(self, contract: dict[str, Any]) -> dict[str, Any]:
+        """Validate and normalize a card contract against Phase 2 schema.
+        
+        Args:
+            contract: Raw card contract
+            
+        Returns:
+            Validated and normalized contract
+            
+        Raises:
+            CardContractError: If contract fails validation
+        """
+        return validate_card_contract(contract)
+
+    def convert_emit(self, contract: dict[str, Any], target_major: int = 1) -> dict[str, Any]:
+        """Convert card contract for emission to renderers.
+        
+        Args:
+            contract: Validated card contract
+            target_major: Target major version for renderer compatibility
+            
+        Returns:
+            Contract ready for emission
+            
+        Raises:
+            CardContractError: If renderer cannot accept the contract
+        """
+        schema_version = contract.get("schema_version")
+        if schema_version is None:
+            raise CardContractError("schema_version is required")
+        if not renderer_accepts(str(schema_version), supported_major=target_major):
+            raise CardContractError(
+                f"Renderer MAJOR {target_major} cannot accept schema_version {schema_version}"
+            )
+        return contract
+
+    def register_domain_builder(self, card_type: str, builder_func) -> None:
+        """Register a domain-specific card builder function.
+        
+        Args:
+            card_type: CardType string
+            builder_func: Function that returns card content
+        """
+        self._domain_builders[card_type] = builder_func
+
+    def get_domain_builder(self, card_type: str):
+        """Get registered domain builder for card type.
+        
+        Args:
+            card_type: CardType string
+            
+        Returns:
+            Builder function or None if not registered
+        """
+        return self._domain_builders.get(card_type)
+
+
+# Global singleton instance
+card_service = CardService()

--- a/services/zoe-data/tests/test_card_service.py
+++ b/services/zoe-data/tests/test_card_service.py
@@ -1,0 +1,137 @@
+"""Tests for Zoe card service foundation."""
+
+import pytest
+from unittest.mock import Mock
+from card_service import CardService, card_service
+from card_contract import CardContractError, CardType
+
+
+def test_card_service_build_valid_card():
+    """Test building a valid card contract."""
+    service = CardService()
+    
+    content = {
+        "title": "Test Card",
+        "message": "This is a test"
+    }
+    
+    card = service.build_card("generic", content)
+    
+    assert "card_id" in card
+    assert card["card_type"] == "generic"
+    assert card["schema_version"] == "1.0.0"
+    assert card["content"] == content
+    assert card["producer"] == "zoe-card-service"
+    assert "producer_version" in card
+    assert "created_at" in card
+
+
+def test_card_service_validate_valid_contract():
+    """Test validating a valid card contract."""
+    service = CardService()
+    
+    valid_contract = {
+        "card_id": "123e4567-e89b-12d3-a456-426614174000",
+        "schema_version": "1.0.0",
+        "card_type": "generic",
+        "content": {"title": "Test"},
+        "producer": "test",
+        "producer_version": "1.0.0",
+        "created_at": "2026-01-01T00:00:00Z"
+    }
+    
+    validated = service.validate_card(valid_contract)
+    assert validated["card_id"] == valid_contract["card_id"]
+    assert validated["card_type"] == "generic"
+
+
+def test_card_service_validate_invalid_contract():
+    """Test validating an invalid card contract raises error."""
+    service = CardService()
+    
+    invalid_contract = {
+        "card_id": "invalid",
+        "schema_version": "1.0.0",
+        "card_type": "generic",
+        "content": {},
+        "producer": "test",
+        "producer_version": "1.0.0",
+        "created_at": "2026-01-01T00:00:00Z"
+    }
+    
+    with pytest.raises(CardContractError):
+        service.validate_card(invalid_contract)
+
+
+def test_card_service_convert_emit_compatible():
+    """Test converting compatible contract for emission."""
+    service = CardService()
+    
+    contract = {
+        "card_id": "123e4567-e89b-12d3-a456-426614174000",
+        "schema_version": "1.0.0",
+        "card_type": "generic",
+        "content": {"title": "Test"},
+        "producer": "test",
+        "producer_version": "1.0.0",
+        "created_at": "2026-01-01T00:00:00Z"
+    }
+    
+    emitted = service.convert_emit(contract, target_major=1)
+    assert emitted == contract
+
+
+def test_card_service_convert_emit_incompatible():
+    """Test converting incompatible contract raises error."""
+    service = CardService()
+    
+    contract = {
+        "card_id": "123e4567-e89b-12d3-a456-426614174000",
+        "schema_version": "2.0.0",
+        "card_type": "generic",
+        "content": {"title": "Test"},
+        "producer": "test",
+        "producer_version": "1.0.0",
+        "created_at": "2026-01-01T00:00:00Z"
+    }
+    
+    with pytest.raises(CardContractError):
+        service.convert_emit(contract, target_major=1)
+
+
+def test_card_service_convert_emit_missing_schema_version_raises_card_error():
+    service = CardService()
+    with pytest.raises(CardContractError, match="schema_version is required"):
+        service.convert_emit({"card_type": "generic"}, target_major=1)
+
+
+def test_card_service_domain_builder_registry():
+    """Test domain builder registry functionality."""
+    service = CardService()
+    
+    # Test registry is initially empty
+    assert service.get_domain_builder("generic") is None
+    
+    # Register a builder
+    builder = Mock()
+    service.register_domain_builder("generic", builder)
+    
+    # Verify retrieval
+    assert service.get_domain_builder("generic") is builder
+    assert service.get_domain_builder("nonexistent") is None
+
+
+def test_global_card_service_instance():
+    """Test global card service instance."""
+    assert isinstance(card_service, CardService)
+
+    card_service._domain_builders.clear()
+    try:
+        # Test domain builder registry on global instance
+        assert card_service.get_domain_builder("generic") is None
+
+        builder = Mock()
+        card_service.register_domain_builder("generic", builder)
+        assert card_service.get_domain_builder("generic") is builder
+    finally:
+        card_service._domain_builders.clear()


### PR DESCRIPTION
Implements the first Phase 3 split child from ZOE-5288.\n\nScope:\n- add card_service.py foundation for building, validating, converting, and emitting card contracts\n- add a domain builder registry stub\n- add focused tests for service behavior\n\nValidation:\n- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_card_service.py services/zoe-data/tests/test_card_contract.py\n- python3 tools/audit/validate_structure.py