### PR TITLE
Read Zoe ticket metadata from Multica descriptions

### DIFF
--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -100,6 +100,26 @@ def _greptile_mcp_bin() -> str:
     return os.path.expanduser("~/bin/greptile-mcp.py")
 
 
+def _ticket_metadata(issue: dict | None = None) -> dict[str, Any]:
+    issue = issue or {}
+    cached = issue.get("_zoe_ticket_metadata_cache")
+    if isinstance(cached, dict):
+        return dict(cached)
+
+    meta = dict(issue.get("metadata") or {})
+    if issue.get("description"):
+        try:
+            from multica_ticket_contract import parse_ticket_block
+
+            parsed = parse_ticket_block(issue.get("description") or "")
+            if isinstance(parsed, dict):
+                meta = {**parsed, **meta}
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("_ticket_metadata: parse_ticket_block failed: %s", exc)
+    issue["_zoe_ticket_metadata_cache"] = dict(meta)
+    return meta
+
+
 def _engineering_mode(issue: dict | None = None) -> str:
     """Resolve the engineering execution mode for a journaled phase run.
 
@@ -110,7 +130,7 @@ def _engineering_mode(issue: dict | None = None) -> str:
     issue = issue or {}
     raw = (
         issue.get("engineering_mode")
-        or (issue.get("metadata") or {}).get("engineering_mode")
+        or _ticket_metadata(issue).get("engineering_mode")
         or os.environ.get("ZOE_ENGINEERING_MODE")
         or "interactive"
     )
@@ -125,7 +145,7 @@ def _engineering_mode(issue: dict | None = None) -> str:
 def _model_escalation_active(issue: dict | None, mode: str) -> bool:
     """True when review/verify/closeout may use stronger models after cheap paths fail."""
     issue = issue or {}
-    meta = issue.get("metadata") or {}
+    meta = _ticket_metadata(issue)
     if str(meta.get("model_escalation") or issue.get("model_escalation") or "").strip().lower() in {
         "1",
         "true",
@@ -138,7 +158,7 @@ def _model_escalation_active(issue: dict | None, mode: str) -> bool:
 def _escalation_model_hint(issue: dict | None) -> str:
     """Paid-model escalation guard — never suggest openrouter/auto without explicit opt-in."""
     issue = issue or {}
-    meta = issue.get("metadata") or {}
+    meta = _ticket_metadata(issue)
     paid_auto_ok = str(meta.get("confirm_paid_auto") or issue.get("confirm_paid_auto") or "").strip().lower() in {
         "1",
         "true",
@@ -194,7 +214,7 @@ def _skip_scout(issue: dict | None = None) -> bool:
     issue = issue or {}
     if str(os.environ.get("ZOE_KANBAN_SKIP_SCOUT", "")).strip().lower() in {"1", "true", "yes"}:
         return True
-    meta = issue.get("metadata") or {}
+    meta = _ticket_metadata(issue)
     if str(meta.get("skip_scout") or issue.get("skip_scout") or "").strip().lower() in {
         "1",
         "true",
@@ -219,7 +239,7 @@ def _skip_scout(issue: dict | None = None) -> bool:
 
 def _audit_no_pr_issue(issue: dict | None = None) -> bool:
     issue = issue or {}
-    meta = issue.get("metadata") or {}
+    meta = _ticket_metadata(issue)
     if str(meta.get("evidence_profile") or "").strip().lower() == "audit":
         return True
     haystack = " ".join(

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -295,6 +295,21 @@ async def test_dispatch_skips_scout_for_scope_split_child():
 
 
 @pytest.mark.asyncio
+async def test_dispatch_skips_scout_for_scope_split_child_ticket_block():
+    a = _FakeAdapter()
+    result = await a.dispatch(
+        {
+            "id": "uuid-child-block",
+            "identifier": "ZOE-5439",
+            "title": "calendar child",
+            "description": '```zoe-ticket\n{"zoe_kind":"child","source":"scope_split","acceptance_criteria":["calendar builder"]}\n```',
+        }
+    )
+    assert "scout" not in result["chain"]
+    assert set(result["chain"]) == {"implement"}
+
+
+@pytest.mark.asyncio
 async def test_dispatch_keeps_scout_for_under_specified_scope_split_child():
     a = _FakeAdapter()
     result = await a.dispatch(
@@ -362,6 +377,20 @@ async def test_dispatch_model_escalation_from_metadata():
     )
     assert "zoe-model-escalation: true" in review_body
     assert "anthropic/claude-sonnet-4.6" in review_body
+
+
+@pytest.mark.asyncio
+async def test_model_escalation_from_ticket_block():
+    issue = {
+        "id": "uuid-block-esc",
+        "identifier": "ZOE-ESC",
+        "title": "Escalate from block",
+        "description": "```zoe-ticket\n{\"model_escalation\":true,\"confirm_paid_auto\":true}\n```",
+    }
+    review_body = ka.KanbanAdapter()._build_body("review", issue, "ZOE-ESC")
+    assert "zoe-model-escalation: true" in review_body
+    assert "anthropic/claude-sonnet-4.6" in review_body
+    assert "openrouter/auto is allowed" in review_body
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes the ZOE-5439 blocker where scope-split child metadata existed only in the fenced zoe-ticket block, so the adapter failed to skip scout and created an unnecessary scout row.\n\nChanges:\n- parse fenced zoe-ticket metadata inside the Kanban adapter\n- use parsed metadata for engineering mode, audit/no-PR detection, and skip-scout\n- add regression coverage for a scope_split child whose metadata only exists in the description block\n\nValidation:\n- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_kanban_adapter.py\n- python3 tools/audit/validate_structure.py