### PR TITLE
Adjust stale scout journal for scope-split children

### DIFF
--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -708,7 +708,34 @@ class KanbanAdapter:
             }
 
         phase = state.phase if state is not None else ("implement" if _skip_scout(issue) else "scout")
-        entry = _phase_plan_entry(phase, issue)
+        plan = _chain_for_issue(issue)
+        phase_order = [p for p, _, _ in plan]
+        entry = next((plan_entry for plan_entry in plan if plan_entry[0] == phase), None)
+        # Only adjust not-yet-started phases. A stale running phase may still
+        # have an active worker/effect, so leave it blocked for operator review.
+        if entry is None and state is not None and state.status == "todo" and phase_order:
+            previous_phase = phase
+            phase = phase_order[0]
+            entry = next((plan_entry for plan_entry in plan if plan_entry[0] == phase), None)
+            try:
+                state = state.model_copy(update={"phase": phase})
+                state = await asyncio.to_thread(
+                    save_state,
+                    state,
+                    event="plan_adjusted",
+                    extra={
+                        "from_phase": previous_phase,
+                        "to_phase": phase,
+                        "reason": "current issue plan no longer includes journal phase",
+                    },
+                )
+            except Exception as exc:
+                logger.warning(
+                    "kanban_adapter: plan_adjusted save skipped for %s: %s; "
+                    "phase adjustment will still be applied via effect_requested",
+                    external_ref,
+                    exc,
+                )
         if entry is None:
             return {
                 "ok": False,
@@ -733,7 +760,6 @@ class KanbanAdapter:
                 "ready_phase_only": True,
             }
 
-        phase_order = [p for p, _, _ in _chain_for_issue(issue)]
         parent: str | None = None
         if phase in phase_order:
             idx = phase_order.index(phase)

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -310,6 +310,49 @@ async def test_dispatch_skips_scout_for_scope_split_child_ticket_block():
 
 
 @pytest.mark.asyncio
+async def test_dispatch_adjusts_stale_scout_journal_for_scope_split_child():
+    from pipeline_evidence import PipelineState
+    from pipeline_store import load_latest_state, save_state
+
+    save_state(
+        PipelineState(
+            task_ref="multica:uuid-child-stale-scout",
+            phase="scout",
+            status="todo",
+            evidence_profile="code",
+        ),
+        event="bootstrap",
+    )
+    rows = [
+        _row(
+            "scout",
+            "archived",
+            chain_version="v4",
+            issue_id="uuid-child-stale-scout",
+        )
+    ]
+    a = _FakeAdapter(list_rows=rows)
+
+    result = await a.dispatch(
+        {
+            "id": "uuid-child-stale-scout",
+            "identifier": "ZOE-5439",
+            "title": "calendar child",
+            "description": """```zoe-ticket
+{"zoe_kind":"child","source":"scope_split","acceptance_criteria":["calendar builder"]}
+```""",
+        }
+    )
+
+    assert result["ok"] is True
+    assert result["phase"] == "implement"
+    assert set(result["chain"]) == {"implement"}
+    latest = load_latest_state("multica:uuid-child-stale-scout")
+    assert latest.phase == "implement"
+    assert latest.status == "running"
+
+
+@pytest.mark.asyncio
 async def test_dispatch_keeps_scout_for_under_specified_scope_split_child():
     a = _FakeAdapter()
     result = await a.dispatch(


### PR DESCRIPTION
## Summary\n- reconcile todo journal phases that are no longer in the current issue plan\n- move stale scout state to the first planned phase for scope-split children\n- add a regression test for the live ZOE-5439 archived-scout blocker\n\n## Validation\n- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_kanban_adapter.py\n- python3 tools/audit/validate_structure.py