### PR TITLE
Recover archived running scout journal

### DIFF
--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -708,25 +708,41 @@ class KanbanAdapter:
             }
 
         phase = state.phase if state is not None else ("implement" if _skip_scout(issue) else "scout")
+        existing_phases = await self._phases_for_ref(external_ref)
         plan = _chain_for_issue(issue)
         phase_order = [p for p, _, _ in plan]
         entry = next((plan_entry for plan_entry in plan if plan_entry[0] == phase), None)
-        # Only adjust not-yet-started phases. A stale running phase may still
-        # have an active worker/effect, so leave it blocked for operator review.
-        if entry is None and state is not None and state.status == "todo" and phase_order:
+        current_row = existing_phases.get(phase) or {}
+        current_status = (current_row.get("status") or "").lower()
+        can_adjust_stale_phase = bool(
+            state is not None
+            and phase_order
+            and (
+                state.status == "todo"
+                or (state.status == "running" and current_status in _TERMINAL_KANBAN_STATUSES)
+            )
+        )
+        # Only adjust phases with no active effect. A stale running journal is
+        # reset only when its Kanban row is terminal; active rows stay blocked
+        # for operator review.
+        if entry is None and can_adjust_stale_phase:
             previous_phase = phase
+            previous_status = state.status
             phase = phase_order[0]
             entry = next((plan_entry for plan_entry in plan if plan_entry[0] == phase), None)
             try:
-                state = state.model_copy(update={"phase": phase})
+                state = state.model_copy(update={"phase": phase, "status": "todo"})
                 state = await asyncio.to_thread(
                     save_state,
                     state,
                     event="plan_adjusted",
                     extra={
                         "from_phase": previous_phase,
+                        "from_status": previous_status,
                         "to_phase": phase,
-                        "reason": "current issue plan no longer includes journal phase",
+                        "to_status": "todo",
+                        "terminal_kanban_status": current_status or None,
+                        "reason": "current issue plan no longer includes inactive journal phase",
                     },
                 )
             except Exception as exc:
@@ -747,7 +763,6 @@ class KanbanAdapter:
                 "mode": mode,
             }
 
-        existing_phases = await self._phases_for_ref(external_ref)
         existing_row = existing_phases.get(phase)
         if existing_row and existing_row.get("id"):
             return {

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -353,6 +353,138 @@ async def test_dispatch_adjusts_stale_scout_journal_for_scope_split_child():
 
 
 @pytest.mark.asyncio
+async def test_dispatch_adjusts_running_scout_journal_when_scout_row_is_archived():
+    from pipeline_evidence import PipelineState
+    from pipeline_store import load_latest_state, save_state
+
+    save_state(
+        PipelineState(
+            task_ref="multica:uuid-child-running-archived-scout",
+            phase="scout",
+            status="running",
+            evidence_profile="code",
+            attempts={"scout": 1},
+        ),
+        event="effect_requested",
+    )
+    rows = [
+        _row(
+            "scout",
+            "archived",
+            chain_version="v4",
+            issue_id="uuid-child-running-archived-scout",
+        )
+    ]
+    a = _FakeAdapter(list_rows=rows)
+
+    result = await a.dispatch(
+        {
+            "id": "uuid-child-running-archived-scout",
+            "identifier": "ZOE-5439",
+            "title": "calendar child",
+            "description": """```zoe-ticket
+{"zoe_kind":"child","source":"scope_split","acceptance_criteria":["calendar builder"]}
+```""",
+        }
+    )
+
+    assert result["ok"] is True
+    assert result["phase"] == "implement"
+    assert set(result["chain"]) == {"implement"}
+    latest = load_latest_state("multica:uuid-child-running-archived-scout")
+    assert latest.phase == "implement"
+    assert latest.status == "running"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_adjusts_running_scout_journal_when_scout_row_is_done():
+    from pipeline_evidence import PipelineState
+    from pipeline_store import load_latest_state, save_state
+
+    save_state(
+        PipelineState(
+            task_ref="multica:uuid-child-running-done-scout",
+            phase="scout",
+            status="running",
+            evidence_profile="code",
+            attempts={"scout": 1},
+        ),
+        event="effect_requested",
+    )
+    rows = [
+        _row(
+            "scout",
+            "done",
+            chain_version="v4",
+            issue_id="uuid-child-running-done-scout",
+        )
+    ]
+    a = _FakeAdapter(list_rows=rows)
+
+    result = await a.dispatch(
+        {
+            "id": "uuid-child-running-done-scout",
+            "identifier": "ZOE-5439",
+            "title": "calendar child",
+            "description": """```zoe-ticket
+{"zoe_kind":"child","source":"scope_split","acceptance_criteria":["calendar builder"]}
+```""",
+        }
+    )
+
+    assert result["ok"] is True
+    assert result["phase"] == "implement"
+    assert set(result["chain"]) == {"implement"}
+    latest = load_latest_state("multica:uuid-child-running-done-scout")
+    assert latest.phase == "implement"
+    assert latest.status == "running"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_does_not_adjust_running_scout_journal_with_active_row():
+    from pipeline_evidence import PipelineState
+    from pipeline_store import load_latest_state, save_state
+
+    save_state(
+        PipelineState(
+            task_ref="multica:uuid-child-running-active-scout",
+            phase="scout",
+            status="running",
+            evidence_profile="code",
+            attempts={"scout": 1},
+        ),
+        event="effect_requested",
+    )
+    rows = [
+        _row(
+            "scout",
+            "running",
+            chain_version="v4",
+            issue_id="uuid-child-running-active-scout",
+        )
+    ]
+    a = _FakeAdapter(list_rows=rows)
+
+    result = await a.dispatch(
+        {
+            "id": "uuid-child-running-active-scout",
+            "identifier": "ZOE-5439",
+            "title": "calendar child",
+            "description": """```zoe-ticket
+{"zoe_kind":"child","source":"scope_split","acceptance_criteria":["calendar builder"]}
+```""",
+        }
+    )
+
+    assert result["ok"] is False
+    assert result["reason"] == "phase scout is not in this issue plan"
+    assert [call for call in a.calls if call[0] == "create"] == []
+    latest = load_latest_state("multica:uuid-child-running-active-scout")
+    assert latest.phase == "scout"
+    assert latest.status == "running"
+
+
+@pytest.mark.asyncio
 async def test_dispatch_keeps_scout_for_under_specified_scope_split_child():
     a = _FakeAdapter()
     result = await a.dispatch(


### PR DESCRIPTION
## Summary\n- reconcile stale running journal phases only when the corresponding Kanban row is terminal\n- reset inactive stale phases to todo before requesting the next planned effect\n- add a regression test for the live ZOE-5439 running/scout journal plus archived scout row blocker\n\n## Validation\n- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_kanban_adapter.py\n- python3 tools/audit/validate_structure.py