### PR TITLE
Recover missing-row running scout journal

### DIFF
--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -335,7 +335,12 @@ class KanbanAdapter:
 
     async def _phases_for_ref(self, external_ref: str) -> dict[str, dict]:
         tasks = await self._run(["list", "--json"], expect_json=True)
-        rows = tasks if isinstance(tasks, list) else (tasks or {}).get("tasks", [])
+        if isinstance(tasks, list):
+            rows = tasks
+        elif isinstance(tasks, dict) and isinstance(tasks.get("tasks"), list):
+            rows = tasks["tasks"]
+        else:
+            raise KanbanCLIError(f"kanban list returned malformed JSON: {tasks!r}")
         prefix = f"{external_ref}:"
         phases: dict[str, dict] = {}
         for row in rows:
@@ -719,12 +724,15 @@ class KanbanAdapter:
             and phase_order
             and (
                 state.status == "todo"
-                or (state.status == "running" and current_status in _TERMINAL_KANBAN_STATUSES)
+                or (
+                    state.status == "running"
+                    and (not current_row or current_status in _TERMINAL_KANBAN_STATUSES)
+                )
             )
         )
         # Only adjust phases with no active effect. A stale running journal is
-        # reset only when its Kanban row is terminal; active rows stay blocked
-        # for operator review.
+        # reset only when its Kanban row is absent/terminal; active rows stay
+        # blocked for operator review.
         if entry is None and can_adjust_stale_phase:
             previous_phase = phase
             previous_status = state.status
@@ -741,6 +749,7 @@ class KanbanAdapter:
                         "from_status": previous_status,
                         "to_phase": phase,
                         "to_status": "todo",
+                        "kanban_row_absent": not bool(current_row),
                         "terminal_kanban_status": current_status or None,
                         "reason": "current issue plan no longer includes inactive journal phase",
                     },

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -485,6 +485,42 @@ async def test_dispatch_does_not_adjust_running_scout_journal_with_active_row():
 
 
 @pytest.mark.asyncio
+async def test_dispatch_adjusts_running_scout_journal_when_scout_row_is_missing():
+    from pipeline_evidence import PipelineState
+    from pipeline_store import load_latest_state, save_state
+
+    save_state(
+        PipelineState(
+            task_ref="multica:uuid-child-running-missing-scout",
+            phase="scout",
+            status="running",
+            evidence_profile="code",
+            attempts={"scout": 1},
+        ),
+        event="effect_requested",
+    )
+    a = _FakeAdapter(list_rows=[])
+
+    result = await a.dispatch(
+        {
+            "id": "uuid-child-running-missing-scout",
+            "identifier": "ZOE-5439",
+            "title": "calendar child",
+            "description": """```zoe-ticket
+{"zoe_kind":"child","source":"scope_split","acceptance_criteria":["calendar builder"]}
+```""",
+        }
+    )
+
+    assert result["ok"] is True
+    assert result["phase"] == "implement"
+    assert set(result["chain"]) == {"implement"}
+    latest = load_latest_state("multica:uuid-child-running-missing-scout")
+    assert latest.phase == "implement"
+    assert latest.status == "running"
+
+
+@pytest.mark.asyncio
 async def test_dispatch_keeps_scout_for_under_specified_scope_split_child():
     a = _FakeAdapter()
     result = await a.dispatch(
@@ -787,6 +823,20 @@ async def test_poll_not_found():
     out = await a.poll("multica:uuid-1")
     assert out["found"] is False
     assert out["status"] == "not_found"
+
+
+@pytest.mark.asyncio
+async def test_poll_fails_closed_on_malformed_kanban_list():
+    class _BadListAdapter(_FakeAdapter):
+        async def _run(self, args, *, expect_json=False):
+            self.calls.append(args)
+            if args[0] == "list":
+                return None
+            return await super()._run(args, expect_json=expect_json)
+
+    a = _BadListAdapter()
+    with pytest.raises(ka.KanbanCLIError, match="malformed JSON"):
+        await a.poll("multica:nope")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary\n- treat a missing Kanban row as inactive for stale running journal recovery\n- keep active/non-terminal rows protected from auto-adjustment\n- add a regression test for the live ZOE-5439 state where archived scout rows are absent from hermes list output\n\n## Validation\n- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_kanban_adapter.py\n- python3 tools/audit/validate_structure.py