### PR TITLE
feat(touch): add Skybridge voice-first interface

### DIFF
--- a/services/zoe-data/main.py
+++ b/services/zoe-data/main.py
@@ -29,6 +29,7 @@ from routers import (
     panel_provision_router,
     capability_matrix_router,
     music_router,
+    skybridge_router,
 )
 from routers.dashboard import router as dashboard_router
 from routers.stubs import router as stubs_router
@@ -778,6 +779,7 @@ app.include_router(panel_auth_router)
 app.include_router(panel_provision_router)
 app.include_router(capability_matrix_router)
 app.include_router(music_router)
+app.include_router(skybridge_router)
 
 from routers.portrait import router as portrait_router
 app.include_router(portrait_router)

--- a/services/zoe-data/routers/__init__.py
+++ b/services/zoe-data/routers/__init__.py
@@ -17,6 +17,7 @@ from .panel_auth import router as panel_auth_router
 from .panel_provision import router as panel_provision_router
 from .capability_matrix import router as capability_matrix_router
 from .music import router as music_router
+from .skybridge import router as skybridge_router
 
 __all__ = [
     "people_router",
@@ -38,4 +39,5 @@ __all__ = [
     "panel_provision_router",
     "capability_matrix_router",
     "music_router",
+    "skybridge_router",
 ]

--- a/services/zoe-data/routers/skybridge.py
+++ b/services/zoe-data/routers/skybridge.py
@@ -1,0 +1,36 @@
+"""Skybridge surface health and capability metadata."""
+
+from __future__ import annotations
+
+import os
+from fastapi import APIRouter
+
+
+router = APIRouter(prefix="/api/skybridge", tags=["skybridge"])
+
+
+@router.get("/status")
+async def get_skybridge_status():
+    """Return the runtime contract for the voice-first Skybridge interface."""
+    livekit_configured = bool(
+        os.environ.get("LIVEKIT_URL")
+        and os.environ.get("LIVEKIT_API_KEY")
+        and os.environ.get("LIVEKIT_API_SECRET")
+    )
+    return {
+        "ok": True,
+        "surface": "skybridge",
+        "status": "ready",
+        "entrypoint": "/touch/skybridge.html",
+        "version": 1,
+        "card_contract": "ag-ui-compatible",
+        "transports": {
+            "local_ws": True,
+            "livekit": livekit_configured,
+        },
+        "capabilities": {
+            "pages": 15,
+            "settings": 23,
+            "dynamic_cards": True,
+        },
+    }

--- a/services/zoe-data/routers/skybridge.py
+++ b/services/zoe-data/routers/skybridge.py
@@ -30,7 +30,7 @@ async def get_skybridge_status():
         },
         "capabilities": {
             "pages": 15,
-            "settings": 23,
+            "settings": 22,
             "dynamic_cards": True,
         },
     }

--- a/services/zoe-data/routers/voice_livekit.py
+++ b/services/zoe-data/routers/voice_livekit.py
@@ -190,6 +190,41 @@ async def _run_pipeline(local_participant, frames: list[bytes], user_id: str, se
     await _send_data(local_participant, {"type": "done"})
 
 
+async def _run_text_pipeline(local_participant, message: str, user_id: str, session_id: str) -> None:
+    """LLM → TTS pipeline for text commands sent over the LiveKit data channel."""
+    message = (message or "").strip()
+    if not message:
+        await _send_data(local_participant, {"type": "state", "state": "ambient"})
+        return
+
+    await _send_data(local_participant, {"type": "state", "state": "thinking"})
+    await _send_data(local_participant, {"type": "transcript", "role": "user", "text": message})
+
+    response = "Sorry, I had trouble with that."
+    try:
+        from zoe_agent import run_zoe_agent
+        response = await run_zoe_agent(message, session_id, user_id, voice_mode=True)
+    except Exception as exc:
+        logger.error("LiveKit text LLM error: %s", exc)
+
+    await _send_data(local_participant, {"type": "state", "state": "responding"})
+    await _send_data(local_participant, {"type": "transcript", "role": "zoe", "text": response})
+
+    try:
+        from routers.voice_tts import synthesize as _synth
+        tts_resp = await _synth({"text": response}, caller={"source": "livekit", "user_id": user_id})
+        await _send_data(local_participant, {
+            "type": "audio",
+            "audio_base64": base64.b64encode(tts_resp.body).decode("ascii"),
+            "content_type": tts_resp.media_type,
+        })
+    except Exception as exc:
+        logger.warning("LiveKit text TTS failed: %s", exc)
+        await _send_data(local_participant, {"type": "text", "content": response})
+
+    await _send_data(local_participant, {"type": "done"})
+
+
 async def _collect_audio_stream(
     track,
     sid: str,
@@ -418,6 +453,24 @@ def _build_room_handlers(room, participant_state: dict, audio_tasks: dict) -> No
                 ps["speech_count"] = 0
                 ps["silence_count"] = 0
                 logger.debug("LiveKit VAD [%s]: playback_done → IDLE", sid[:8])
+
+        elif msg_type == "text":
+            message = str(msg.get("message") or msg.get("text") or "").strip()
+            if not message:
+                return
+            ps["state"] = _ParticipantState.PROCESSING
+            task = asyncio.ensure_future(
+                _run_text_pipeline(
+                    room.local_participant,
+                    message,
+                    ps.get("user_id", "guest"),
+                    msg.get("session_id") or ps.get("session_id", f"livekit-{sid[:8]}"),
+                )
+            )
+            ps["pipeline_task"] = task
+            task.add_done_callback(
+                lambda _t, _sid=sid, _ps=ps: _on_pipeline_done(_sid, _ps)
+            )
 
 
 async def _agent_loop() -> None:

--- a/services/zoe-data/tests/test_skybridge_static.py
+++ b/services/zoe-data/tests/test_skybridge_static.py
@@ -88,3 +88,4 @@ def test_skybridge_is_registered_in_touch_menu():
     assert "{ id: 'skybridge'" in menu
     assert "/touch/skybridge.html" in menu
     assert "'skybridge.html'" in menu
+    assert "'dashboard', 'skybridge', 'calendar'" not in menu

--- a/services/zoe-data/tests/test_skybridge_static.py
+++ b/services/zoe-data/tests/test_skybridge_static.py
@@ -77,6 +77,13 @@ def test_skybridge_voice_normalizes_both_transports():
     assert "this.mediaRecorder.onstop = null" in voice
 
 
+def test_skybridge_renderer_keeps_button_actions_functional():
+    renderer = read(UI / "js" / "skybridge-renderer.js")
+
+    assert "Object.assign({}, props, { actions: cardActions })" in renderer
+    assert "Object.assign({ status: risk }, props, { actions: settingActions })" in renderer
+
+
 def test_skybridge_uses_backend_status_contract():
     app = read(UI / "js" / "skybridge.js")
 

--- a/services/zoe-data/tests/test_skybridge_static.py
+++ b/services/zoe-data/tests/test_skybridge_static.py
@@ -1,0 +1,79 @@
+"""Static contract checks for the Skybridge touch surface."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+UI = ROOT / "zoe-ui" / "dist" / "touch"
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_skybridge_page_loads_required_modules_in_order():
+    html = read(UI / "skybridge.html")
+    expected = [
+        "/touch/js/skybridge-capabilities.js",
+        "/touch/js/skybridge-renderer.js",
+        "/touch/js/skybridge-voice.js",
+        "/touch/js/skybridge.js",
+    ]
+
+    positions = [html.index(src) for src in expected]
+
+    assert positions == sorted(positions)
+    assert "/js/touch-ui-executor.js" in html
+    assert "id=\"skyCards\"" in html
+    assert "id=\"skyCommandForm\"" in html
+
+
+def test_skybridge_capability_registry_covers_core_touch_pages():
+    registry = read(UI / "js" / "skybridge-capabilities.js")
+
+    for page_id in [
+        "dashboard",
+        "chat",
+        "calendar",
+        "lists",
+        "notes",
+        "journal",
+        "memories",
+        "people",
+        "smart-home",
+        "music",
+        "weather",
+        "settings",
+    ]:
+        assert f"page('{page_id}'" in registry
+
+
+def test_skybridge_settings_manifest_marks_sensitive_sections():
+    registry = read(UI / "js" / "skybridge-capabilities.js")
+
+    assert "setting('security'" in registry
+    assert "setting('api'" in registry
+    assert "setting('trust-gate'" in registry
+    assert "setting('self-creation'" in registry
+    assert "'critical'" in registry
+    assert "confirm_change" in registry
+
+
+def test_skybridge_voice_normalizes_both_transports():
+    voice = read(UI / "js" / "skybridge-voice.js")
+
+    assert "class SkybridgeVoice" in voice
+    assert "connectLocal()" in voice
+    assert "connectLiveKit()" in voice
+    assert "handleServerEvent(msg)" in voice
+    assert "this.emit({ type: 'card'" in voice
+
+
+def test_skybridge_is_registered_in_touch_menu():
+    menu = read(UI / "js" / "touch-menu.js")
+
+    assert "{ id: 'skybridge'" in menu
+    assert "/touch/skybridge.html" in menu
+    assert "'skybridge.html'" in menu

--- a/services/zoe-data/tests/test_skybridge_static.py
+++ b/services/zoe-data/tests/test_skybridge_static.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 UI = ROOT / "zoe-ui" / "dist" / "touch"
+DATA = ROOT / "zoe-data"
 
 
 def read(path: Path) -> str:
@@ -77,6 +78,16 @@ def test_skybridge_voice_normalizes_both_transports():
     assert "this.mediaRecorder.onstop = null" in voice
     assert "const ab = await blob.arrayBuffer()" in voice
     assert "this.ws.send(ab)" in voice
+    assert "this.mode === 'livekit'" in voice
+    assert "publishData(payload, { reliable: true })" in voice
+
+
+def test_livekit_voice_router_accepts_text_commands():
+    router = read(DATA / "routers" / "voice_livekit.py")
+
+    assert "async def _run_text_pipeline" in router
+    assert "elif msg_type == \"text\"" in router
+    assert "run_zoe_agent(message, session_id, user_id, voice_mode=True)" in router
 
 
 def test_skybridge_renderer_keeps_button_actions_functional():

--- a/services/zoe-data/tests/test_skybridge_static.py
+++ b/services/zoe-data/tests/test_skybridge_static.py
@@ -72,6 +72,7 @@ def test_skybridge_voice_normalizes_both_transports():
     assert "this.emit({ type: 'card'" in voice
     assert "scheduleReconnect()" in voice
     assert "Malformed server event" in voice
+    assert "Skybridge LiveKit event parse failed" in voice
     assert "Voice transport unavailable" in voice
 
 

--- a/services/zoe-data/tests/test_skybridge_static.py
+++ b/services/zoe-data/tests/test_skybridge_static.py
@@ -28,6 +28,7 @@ def test_skybridge_page_loads_required_modules_in_order():
     assert "/js/touch-ui-executor.js" in html
     assert "id=\"skyCards\"" in html
     assert "id=\"skyCommandForm\"" in html
+    assert "window.confirm = function() { return true; }" not in html
 
 
 def test_skybridge_capability_registry_covers_core_touch_pages():
@@ -69,6 +70,16 @@ def test_skybridge_voice_normalizes_both_transports():
     assert "connectLiveKit()" in voice
     assert "handleServerEvent(msg)" in voice
     assert "this.emit({ type: 'card'" in voice
+    assert "scheduleReconnect()" in voice
+    assert "Malformed server event" in voice
+    assert "Voice transport unavailable" in voice
+
+
+def test_skybridge_uses_backend_status_contract():
+    app = read(UI / "js" / "skybridge.js")
+
+    assert "/api/skybridge/status" in app
+    assert "Skybridge runtime ready" in app
 
 
 def test_skybridge_is_registered_in_touch_menu():

--- a/services/zoe-data/tests/test_skybridge_static.py
+++ b/services/zoe-data/tests/test_skybridge_static.py
@@ -80,6 +80,8 @@ def test_skybridge_uses_backend_status_contract():
 
     assert "/api/skybridge/status" in app
     assert "Skybridge runtime ready" in app
+    assert "route && route.startsWith('/')" in app
+    assert "Unsupported card route" in app
 
 
 def test_skybridge_is_registered_in_touch_menu():

--- a/services/zoe-data/tests/test_skybridge_static.py
+++ b/services/zoe-data/tests/test_skybridge_static.py
@@ -74,6 +74,7 @@ def test_skybridge_voice_normalizes_both_transports():
     assert "Malformed server event" in voice
     assert "Skybridge LiveKit event parse failed" in voice
     assert "Voice transport unavailable" in voice
+    assert "this.mediaRecorder.onstop = null" in voice
 
 
 def test_skybridge_uses_backend_status_contract():

--- a/services/zoe-data/tests/test_skybridge_static.py
+++ b/services/zoe-data/tests/test_skybridge_static.py
@@ -75,6 +75,8 @@ def test_skybridge_voice_normalizes_both_transports():
     assert "Skybridge LiveKit event parse failed" in voice
     assert "Voice transport unavailable" in voice
     assert "this.mediaRecorder.onstop = null" in voice
+    assert "const ab = await blob.arrayBuffer()" in voice
+    assert "this.ws.send(ab)" in voice
 
 
 def test_skybridge_renderer_keeps_button_actions_functional():

--- a/services/zoe-data/tests/test_skybridge_status.py
+++ b/services/zoe-data/tests/test_skybridge_status.py
@@ -30,3 +30,4 @@ def test_skybridge_status_endpoint_returns_runtime_contract():
     assert data["card_contract"] == "ag-ui-compatible"
     assert data["transports"]["local_ws"] is True
     assert "livekit" in data["transports"]
+    assert data["capabilities"]["settings"] == 22

--- a/services/zoe-data/tests/test_skybridge_status.py
+++ b/services/zoe-data/tests/test_skybridge_status.py
@@ -1,0 +1,32 @@
+"""Backend contract tests for the Skybridge surface."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from routers.skybridge import router  # noqa: E402
+
+
+def test_skybridge_status_endpoint_returns_runtime_contract():
+    app = FastAPI()
+    app.include_router(router)
+
+    resp = TestClient(app).get("/api/skybridge/status")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["ok"] is True
+    assert data["surface"] == "skybridge"
+    assert data["status"] == "ready"
+    assert data["entrypoint"] == "/touch/skybridge.html"
+    assert data["card_contract"] == "ag-ui-compatible"
+    assert data["transports"]["local_ws"] is True
+    assert "livekit" in data["transports"]

--- a/services/zoe-ui/dist/touch/js/skybridge-capabilities.js
+++ b/services/zoe-ui/dist/touch/js/skybridge-capabilities.js
@@ -1,0 +1,148 @@
+/*
+ * Skybridge capabilities registry.
+ * The registry is intentionally data-first so pages can opt into Skybridge
+ * without copying rendering or voice transport code.
+ */
+(function () {
+    const pages = [
+        page('dashboard', 'Dashboard', '/touch/dashboard.html', ['home', 'overview', 'widgets'], 'Household overview, widgets, ambient panel state.', 'system'),
+        page('chat', 'Chat', '/touch/chat.html', ['conversation', 'messages', 'history'], 'Full Zoe conversation history and long-form agent work.', 'chat'),
+        page('calendar', 'Calendar', '/touch/calendar.html', ['schedule', 'events', 'planner'], 'Events, schedule views, planning, and calendar sync.', 'calendar'),
+        page('lists', 'Lists', '/touch/lists.html', ['shopping', 'todo', 'tasks', 'groceries'], 'Shopping lists, task lists, and custom household lists.', 'list'),
+        page('notes', 'Notes', '/touch/notes.html', ['note', 'scratchpad'], 'Quick notes and saved snippets.', 'note'),
+        page('journal', 'Journal', '/touch/journal.html', ['diary', 'reflection'], 'Journal entries, dictation, and personal reflection.', 'journal'),
+        page('memories', 'Memories', '/touch/memories.html', ['memory', 'remembered', 'facts'], 'Stored memories, facts, and recall controls.', 'memory'),
+        page('people', 'People', '/touch/people.html', ['contacts', 'relationships', 'family'], 'People, relationships, birthdays, and CRM-style context.', 'people'),
+        page('smart-home', 'Smart Home', '/touch/smart-home.html', ['lights', 'devices', 'home assistant'], 'Home Assistant devices, rooms, scenes, and controls.', 'home'),
+        page('music', 'Music', '/touch/music.html', ['media', 'now playing', 'player', 'spotify', 'youtube'], 'Music providers, queues, zones, and playback controls.', 'media'),
+        page('weather', 'Weather', '/touch/weather.html', ['forecast', 'temperature', 'rain'], 'Current weather, forecast, location, and weather preferences.', 'weather'),
+        page('cooking', 'Cooking', '/touch/cooking.html', ['recipes', 'kitchen', 'meal'], 'Recipes, kitchen workflows, and cooking helpers.', 'cooking'),
+        page('games', 'Games', '/touch/games.html', ['play', 'game'], 'Touch-friendly games and playful modes.', 'game'),
+        page('updates', 'Updates', '/touch/updates.html', ['system updates', 'release'], 'Zoe updates, system notices, and upgrade state.', 'updates'),
+        page('settings', 'Settings', '/touch/settings.html', ['preferences', 'configure', 'configuration', 'setup'], 'All Zoe configuration, integrations, panel options, and security controls.', 'settings')
+    ];
+
+    const settings = [
+        setting('profile', 'Profile', ['username', 'email', 'role'], 'User name, email, and account role.', 'medium', 'settings'),
+        setting('security', 'Security', ['pin', 'session', 'password', 'login'], 'PIN, sessions, authentication, and account protection.', 'high', 'settings'),
+        setting('panel-identity', 'Panel Identity', ['panel name', 'location', 'default user', 'guest'], 'Touch panel name, room, default user, allowed users, and guest behavior.', 'high', 'settings'),
+        setting('general', 'General', ['theme', 'appearance'], 'Theme and general application preferences.', 'low', 'settings'),
+        setting('display', 'Display', ['brightness', 'night', 'screen', 'volume', 'dim'], 'Panel brightness, idle dimming, night mode, screen-off timing, and device volume.', 'medium', 'display'),
+        setting('api', 'Integrations', ['home assistant', 'token', 'api key'], 'External integration endpoints and secrets.', 'critical', 'api'),
+        setting('music', 'Music Settings', ['provider', 'audio quality', 'autoplay', 'output'], 'Music providers, quality, output devices, and playback preferences.', 'medium', 'music'),
+        setting('calendar', 'Calendar Settings', ['calendar provider', 'sync', 'work hours', 'view'], 'Calendar view, providers, sync frequency, and work-hour preferences.', 'medium', 'calendar'),
+        setting('notifications', 'Notifications', ['alerts', 'quiet hours', 'push', 'reminders'], 'Push notifications, reminder timing, quiet hours, and device subscriptions.', 'medium', 'notifications'),
+        setting('productivity', 'Productivity', ['focus', 'break', 'pomodoro', 'tracking'], 'Focus timers, break reminders, and productivity tracking.', 'low', 'productivity'),
+        setting('time-location', 'Time and Location', ['timezone', 'language', 'date format', '24 hour'], 'Time format, timezone, date format, and language.', 'low', 'settings'),
+        setting('weather', 'Weather Settings', ['weather location', 'celsius', 'fahrenheit', 'unit'], 'Weather location, current-location permission, and temperature unit.', 'medium', 'weather'),
+        setting('data', 'Data', ['export', 'import', 'backup'], 'Data export, import, backup, and portability tools.', 'high', 'data'),
+        setting('system', 'System', ['status', 'version', 'uptime', 'health'], 'API health, version, uptime, and system diagnostics.', 'medium', 'system'),
+        setting('openclaw-brain', 'OpenClaw Brain', ['openclaw', 'brain', 'agent'], 'OpenClaw state and brain integration settings.', 'high', 'agent'),
+        setting('ai-training', 'AI Training', ['training', 'model', 'adapter', 'examples'], 'Training schedule, examples, adapters, and model learning controls.', 'high', 'training'),
+        setting('intelligence', 'Intelligence', ['proactive', 'learning', 'insights', 'do not disturb'], 'Proactive behavior, learning, insights, and assistant intelligence toggles.', 'medium', 'intelligence'),
+        setting('trust-gate', 'Trust Gate', ['allowlist', 'audit', 'approval'], 'Trust-gated actions, allowlists, and audit evidence.', 'critical', 'security'),
+        setting('skills', 'Skills', ['skills', 'capabilities'], 'Installed skills and runtime capability availability.', 'high', 'skills'),
+        setting('learnings', 'Learnings', ['pending learning', 'confirmed learning'], 'Pending and confirmed learned facts or behavior changes.', 'medium', 'learning'),
+        setting('scheduler', 'Scheduler', ['jobs', 'schedule', 'cron'], 'Scheduled jobs and proactive runtime timing.', 'high', 'scheduler'),
+        setting('self-creation', 'Self Creation', ['proposal', 'widget', 'evolution'], 'Self-improvement proposals and generated widget ideas.', 'critical', 'evolution')
+    ];
+
+    function page(id, title, route, aliases, summary, icon) {
+        return {
+            id,
+            title,
+            route,
+            aliases,
+            summary,
+            icon,
+            kind: 'page',
+            actions: ['show', 'open', 'summarize']
+        };
+    }
+
+    function setting(id, title, aliases, summary, risk, domain) {
+        return {
+            id,
+            title,
+            aliases,
+            summary,
+            risk,
+            domain,
+            kind: 'setting',
+            route: '/touch/settings.html#' + id,
+            actions: risk === 'critical'
+                ? ['show', 'open', 'prepare_change', 'confirm_change']
+                : ['show', 'open', 'change']
+        };
+    }
+
+    function normalize(text) {
+        return String(text || '').toLowerCase().replace(/[^a-z0-9]+/g, ' ').trim();
+    }
+
+    function scoreItem(item, query) {
+        const q = normalize(query);
+        if (!q) return 0;
+        const haystack = normalize([
+            item.id,
+            item.title,
+            item.summary,
+            (item.aliases || []).join(' ')
+        ].join(' '));
+        if (haystack.includes(q)) return 100;
+        return q.split(/\s+/).reduce((score, word) => {
+            if (!word) return score;
+            if (normalize(item.title).includes(word)) return score + 18;
+            if ((item.aliases || []).some(alias => normalize(alias).includes(word))) return score + 14;
+            if (haystack.includes(word)) return score + 8;
+            return score;
+        }, 0);
+    }
+
+    function find(query) {
+        const all = pages.concat(settings);
+        return all
+            .map(item => Object.assign({ score: scoreItem(item, query) }, item))
+            .filter(item => item.score > 0)
+            .sort((a, b) => b.score - a.score || a.title.localeCompare(b.title));
+    }
+
+    function getHomeCards() {
+        return [
+            {
+                component: 'status',
+                props: {
+                    title: 'Skybridge is ready',
+                    kicker: 'Voice-first surface',
+                    body: 'Ask for any page, setting, list, forecast, device, person, note, or system state. Cards will appear here and stay active for follow-ups.',
+                    status: 'Ready',
+                    wide: true,
+                    actions: [{ label: 'Show settings', query: 'settings' }, { label: 'Show weather', query: 'weather' }]
+                }
+            },
+            {
+                component: 'page_grid',
+                props: {
+                    title: 'Zoe pages',
+                    kicker: 'Capability map',
+                    items: pages.slice(0, 8)
+                }
+            },
+            {
+                component: 'settings_overview',
+                props: {
+                    title: 'Settings control',
+                    kicker: 'Full control with gates',
+                    items: settings.slice(0, 8)
+                }
+            }
+        ];
+    }
+
+    window.SkybridgeCapabilities = {
+        pages,
+        settings,
+        find,
+        getHomeCards
+    };
+})();

--- a/services/zoe-ui/dist/touch/js/skybridge-renderer.js
+++ b/services/zoe-ui/dist/touch/js/skybridge-renderer.js
@@ -1,0 +1,139 @@
+/*
+ * Skybridge renderer registry.
+ * Renderers consume Zoe card contracts, AG-UI custom payloads, and local
+ * capability cards through a small common shape: { component, props }.
+ */
+(function () {
+    function escapeHtml(value) {
+        return String(value == null ? '' : value)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#039;');
+    }
+
+    function buttonHtml(action, index) {
+        const label = escapeHtml(action.label || action.title || 'Open');
+        const query = escapeHtml(action.query || '');
+        const route = escapeHtml(action.route || '');
+        const kind = action.kind === 'warn' ? ' warn' : (index === 0 ? ' primary' : '');
+        return '<button type="button" class="' + kind.trim() + '" data-sky-action="' + escapeHtml(action.type || 'query') + '" data-query="' + query + '" data-route="' + route + '">' + label + '</button>';
+    }
+
+    function cardFrame(props, body, options) {
+        const wide = options && options.wide ? ' wide' : '';
+        const compact = options && options.compact ? ' compact' : '';
+        const actions = Array.isArray(props.actions) && props.actions.length
+            ? '<div class="sky-actions">' + props.actions.map(buttonHtml).join('') + '</div>'
+            : '';
+        return [
+            '<article class="sky-card' + wide + compact + '" data-card-id="' + escapeHtml(props.id || '') + '">',
+            '<div class="sky-card-header">',
+            '<div>',
+            props.kicker ? '<p class="sky-card-kicker">' + escapeHtml(props.kicker) + '</p>' : '',
+            '<h3 class="sky-card-title">' + escapeHtml(props.title || 'Zoe') + '</h3>',
+            '</div>',
+            props.status ? '<span class="sky-badge">' + escapeHtml(props.status) + '</span>' : '',
+            '</div>',
+            body,
+            actions,
+            '</article>'
+        ].join('');
+    }
+
+    function renderStatus(props) {
+        return cardFrame(props, '<div class="sky-card-body">' + escapeHtml(props.body || props.message || '') + '</div>', { wide: !!props.wide });
+    }
+
+    function renderPage(props) {
+        const fields = [
+            ['Route', props.route || ''],
+            ['Kind', props.kind || 'page'],
+            ['Actions', (props.actions || []).join(', ')]
+        ].map(pair => '<div class="sky-field"><span>' + escapeHtml(pair[0]) + '</span><strong>' + escapeHtml(pair[1]) + '</strong></div>').join('');
+        return cardFrame(Object.assign({
+            actions: [
+                { label: 'Open page', route: props.route, type: 'open' },
+                { label: 'Show related settings', query: props.title + ' settings' }
+            ]
+        }, props), '<div class="sky-card-body">' + escapeHtml(props.summary || '') + '</div><div class="sky-card-grid">' + fields + '</div>', { wide: true });
+    }
+
+    function renderSetting(props) {
+        const risk = props.risk || 'low';
+        const changeLabel = risk === 'critical' ? 'Prepare change' : 'Change setting';
+        const fields = [
+            ['Risk', risk],
+            ['Domain', props.domain || 'settings'],
+            ['Section', props.id || '']
+        ].map(pair => '<div class="sky-field"><span>' + escapeHtml(pair[0]) + '</span><strong>' + escapeHtml(pair[1]) + '</strong></div>').join('');
+        return cardFrame(Object.assign({
+            status: risk,
+            actions: [
+                { label: 'Open settings', route: props.route, type: 'open' },
+                { label: changeLabel, query: 'change ' + props.title, kind: risk === 'critical' ? 'warn' : 'normal' }
+            ]
+        }, props), '<div class="sky-card-body">' + escapeHtml(props.summary || '') + '</div><div class="sky-card-grid">' + fields + '</div>', { wide: true });
+    }
+
+    function renderPageGrid(props) {
+        const items = (props.items || []).map(item => {
+            return '<div class="sky-field"><span>' + escapeHtml(item.title) + '</span><strong>' + escapeHtml(item.summary) + '</strong></div>';
+        }).join('');
+        return cardFrame(props, '<div class="sky-card-grid">' + items + '</div>', { wide: true });
+    }
+
+    function renderSettingsOverview(props) {
+        const items = (props.items || []).map(item => {
+            return '<div class="sky-field"><span>' + escapeHtml(item.title) + ' · ' + escapeHtml(item.risk) + '</span><strong>' + escapeHtml(item.summary) + '</strong></div>';
+        }).join('');
+        return cardFrame(props, '<div class="sky-card-grid">' + items + '</div>', { wide: true });
+    }
+
+    function renderList(props) {
+        const rows = (props.items || []).map(item => '<div class="sky-field"><strong>' + escapeHtml(typeof item === 'string' ? item : item.title || item.text || JSON.stringify(item)) + '</strong></div>').join('');
+        return cardFrame(props, '<div class="sky-card-grid">' + rows + '</div>', { wide: true });
+    }
+
+    function normalizeCard(card) {
+        if (!card) return { component: 'status', props: { title: 'Empty card', body: '' } };
+        if (card.component) return { component: card.component, props: card.props || {} };
+        if (card.card_type && card.content) {
+            return { component: card.card_type, props: Object.assign({ id: card.card_id }, card.content) };
+        }
+        if (card.type === 'confirmation' || card.type === 'confirm') {
+            return { component: 'status', props: { title: card.title || 'Confirm', body: card.message || card.body || '', status: 'Confirm' } };
+        }
+        return { component: card.type || 'status', props: card };
+    }
+
+    const renderers = {
+        status: renderStatus,
+        info: renderStatus,
+        generic: renderStatus,
+        page: renderPage,
+        setting: renderSetting,
+        page_grid: renderPageGrid,
+        settings_overview: renderSettingsOverview,
+        list: renderList,
+        action_form: renderStatus,
+        form: renderStatus,
+        media: renderList,
+        smart_home: renderList,
+        research_report: renderList,
+        stream_text: renderStatus
+    };
+
+    function render(card) {
+        const normalized = normalizeCard(card);
+        const renderer = renderers[normalized.component] || renderStatus;
+        return renderer(normalized.props || {});
+    }
+
+    window.SkybridgeRenderer = {
+        render,
+        normalizeCard,
+        escapeHtml
+    };
+})();

--- a/services/zoe-ui/dist/touch/js/skybridge-renderer.js
+++ b/services/zoe-ui/dist/touch/js/skybridge-renderer.js
@@ -52,12 +52,11 @@
             ['Kind', props.kind || 'page'],
             ['Actions', (props.actions || []).join(', ')]
         ].map(pair => '<div class="sky-field"><span>' + escapeHtml(pair[0]) + '</span><strong>' + escapeHtml(pair[1]) + '</strong></div>').join('');
-        return cardFrame(Object.assign({
-            actions: [
-                { label: 'Open page', route: props.route, type: 'open' },
-                { label: 'Show related settings', query: props.title + ' settings' }
-            ]
-        }, props), '<div class="sky-card-body">' + escapeHtml(props.summary || '') + '</div><div class="sky-card-grid">' + fields + '</div>', { wide: true });
+        var cardActions = [
+            { label: 'Open page', route: props.route, type: 'open' },
+            { label: 'Show related settings', query: props.title + ' settings' }
+        ];
+        return cardFrame(Object.assign({}, props, { actions: cardActions }), '<div class="sky-card-body">' + escapeHtml(props.summary || '') + '</div><div class="sky-card-grid">' + fields + '</div>', { wide: true });
     }
 
     function renderSetting(props) {
@@ -68,13 +67,11 @@
             ['Domain', props.domain || 'settings'],
             ['Section', props.id || '']
         ].map(pair => '<div class="sky-field"><span>' + escapeHtml(pair[0]) + '</span><strong>' + escapeHtml(pair[1]) + '</strong></div>').join('');
-        return cardFrame(Object.assign({
-            status: risk,
-            actions: [
-                { label: 'Open settings', route: props.route, type: 'open' },
-                { label: changeLabel, query: 'change ' + props.title, kind: risk === 'critical' ? 'warn' : 'normal' }
-            ]
-        }, props), '<div class="sky-card-body">' + escapeHtml(props.summary || '') + '</div><div class="sky-card-grid">' + fields + '</div>', { wide: true });
+        var settingActions = [
+            { label: 'Open settings', route: props.route, type: 'open' },
+            { label: changeLabel, query: 'change ' + props.title, kind: risk === 'critical' ? 'warn' : 'normal' }
+        ];
+        return cardFrame(Object.assign({ status: risk }, props, { actions: settingActions }), '<div class="sky-card-body">' + escapeHtml(props.summary || '') + '</div><div class="sky-card-grid">' + fields + '</div>', { wide: true });
     }
 
     function renderPageGrid(props) {

--- a/services/zoe-ui/dist/touch/js/skybridge-voice.js
+++ b/services/zoe-ui/dist/touch/js/skybridge-voice.js
@@ -123,7 +123,10 @@
                     try {
                         const text = new TextDecoder().decode(payload);
                         this.handleServerEvent(JSON.parse(text));
-                    } catch (_) {}
+                    } catch (err) {
+                        console.warn('Skybridge LiveKit event parse failed', err);
+                        this.emit({ type: 'error', message: 'Malformed server event' });
+                    }
                 });
                 await room.connect(data.url, data.token);
                 this.room = room;

--- a/services/zoe-ui/dist/touch/js/skybridge-voice.js
+++ b/services/zoe-ui/dist/touch/js/skybridge-voice.js
@@ -1,0 +1,250 @@
+/*
+ * Skybridge voice transport adapters.
+ * Both local WebSocket and LiveKit fallback emit the same browser events.
+ */
+(function () {
+    function getSessionId() {
+        try {
+            const session = JSON.parse(localStorage.getItem('zoe_session') || '{}');
+            return session.session_id || '';
+        } catch (_) {
+            return '';
+        }
+    }
+
+    class SkybridgeVoice {
+        constructor(options) {
+            this.mode = options.mode || 'local';
+            this.onEvent = options.onEvent;
+            this.ws = null;
+            this.room = null;
+            this.micStream = null;
+            this.mediaRecorder = null;
+            this.audioChunks = [];
+            this.audioCtx = null;
+            this.analyser = null;
+            this.isRecording = false;
+            this.serverBusy = false;
+            this.speaking = false;
+            this.maxRecordedRms = 0;
+            this.silenceTimer = null;
+            this.autoListenTimer = null;
+            this.silenceThreshold = 0.01;
+            this.silenceMs = 1600;
+        }
+
+        emit(event) {
+            if (typeof this.onEvent === 'function') this.onEvent(event);
+        }
+
+        async start() {
+            if (this.mode === 'livekit') {
+                await this.connectLiveKit();
+            } else {
+                this.connectLocal();
+            }
+        }
+
+        stop() {
+            clearTimeout(this.autoListenTimer);
+            clearTimeout(this.silenceTimer);
+            if (this.ws) this.ws.close();
+            if (this.room) this.room.disconnect();
+            if (this.micStream) this.micStream.getTracks().forEach(track => track.stop());
+            this.ws = null;
+            this.room = null;
+            this.micStream = null;
+            this.isRecording = false;
+            this.serverBusy = false;
+            this.emit({ type: 'state', state: 'ambient' });
+        }
+
+        connectLocal() {
+            const proto = location.protocol === 'https:' ? 'wss' : 'ws';
+            const wsUrl = proto + '://' + location.host + '/ws/voice/?session_id=' + encodeURIComponent(getSessionId());
+            this.ws = new WebSocket(wsUrl);
+            this.ws.binaryType = 'arraybuffer';
+            this.ws.onopen = () => this.emit({ type: 'ready', mode: 'local' });
+            this.ws.onmessage = event => {
+                try {
+                    const msg = typeof event.data === 'string' ? JSON.parse(event.data) : null;
+                    if (msg) this.handleServerEvent(msg);
+                } catch (_) {}
+            };
+            this.ws.onclose = () => {
+                this.serverBusy = false;
+                this.emit({ type: 'state', state: 'ambient' });
+                this.emit({ type: 'error', message: 'Voice disconnected' });
+            };
+        }
+
+        async connectLiveKit() {
+            if (typeof LivekitClient === 'undefined') {
+                this.mode = 'local';
+                this.connectLocal();
+                return;
+            }
+            try {
+                const resp = await fetch('/api/voice/livekit-token', { headers: { 'X-Session-ID': getSessionId() } });
+                if (!resp.ok) throw new Error('Token fetch failed');
+                const data = await resp.json();
+                if (data.livekit_available === false) {
+                    this.mode = 'local';
+                    this.connectLocal();
+                    return;
+                }
+                const room = new LivekitClient.Room({ adaptiveStream: true, dynacast: true });
+                room.on(LivekitClient.RoomEvent.DataReceived, payload => {
+                    try {
+                        const text = new TextDecoder().decode(payload);
+                        this.handleServerEvent(JSON.parse(text));
+                    } catch (_) {}
+                });
+                await room.connect(data.url, data.token);
+                this.room = room;
+                this.emit({ type: 'ready', mode: 'livekit' });
+            } catch (err) {
+                this.emit({ type: 'error', message: 'LiveKit unavailable, using local voice' });
+                this.mode = 'local';
+                this.connectLocal();
+            }
+        }
+
+        handleServerEvent(msg) {
+            const type = msg.type || msg.event;
+            if (type === 'state') {
+                this.emit({ type: 'state', state: msg.state || 'ambient' });
+            } else if (type === 'transcript') {
+                this.emit({ type: 'transcript', role: msg.role || 'zoe', text: msg.text || '' });
+            } else if (type === 'audio') {
+                this.playAudio(msg.audio_base64, msg.content_type || 'audio/wav');
+            } else if (type === 'agui' || type === 'ui_component') {
+                this.emit({ type: 'card', card: msg.data || msg });
+            } else if (type === 'done') {
+                this.serverBusy = false;
+                this.emit({ type: 'done' });
+            } else if (type === 'text') {
+                this.emit({ type: 'transcript', role: 'zoe', text: msg.content || msg.text || '' });
+            }
+        }
+
+        sendText(message) {
+            const text = String(message || '').trim();
+            if (!text) return;
+            this.emit({ type: 'transcript', role: 'user', text });
+            if (this.ws && this.ws.readyState === WebSocket.OPEN) {
+                this.serverBusy = true;
+                this.emit({ type: 'state', state: 'thinking' });
+                this.ws.send(JSON.stringify({ type: 'text', message: text }));
+            }
+        }
+
+        async startRecording() {
+            if (this.isRecording || this.speaking || this.serverBusy) return;
+            if (!this.micStream) {
+                this.micStream = await navigator.mediaDevices.getUserMedia({ audio: true });
+            }
+            this.audioCtx = this.audioCtx || new (window.AudioContext || window.webkitAudioContext)();
+            const source = this.audioCtx.createMediaStreamSource(this.micStream);
+            this.analyser = this.audioCtx.createAnalyser();
+            this.analyser.fftSize = 512;
+            source.connect(this.analyser);
+            this.audioChunks = [];
+            this.maxRecordedRms = 0;
+            const mimeType = MediaRecorder.isTypeSupported('audio/webm;codecs=opus') ? 'audio/webm;codecs=opus' : 'audio/webm';
+            this.mediaRecorder = new MediaRecorder(this.micStream, { mimeType });
+            this.mediaRecorder.ondataavailable = event => {
+                if (event.data.size > 0) this.audioChunks.push(event.data);
+            };
+            this.mediaRecorder.onstop = () => this.sendRecording();
+            this.mediaRecorder.start(100);
+            this.isRecording = true;
+            this.emit({ type: 'state', state: 'listening' });
+            this.watchSilence();
+        }
+
+        stopRecording() {
+            if (!this.isRecording) return;
+            this.isRecording = false;
+            clearTimeout(this.silenceTimer);
+            if (this.mediaRecorder && this.mediaRecorder.state !== 'inactive') this.mediaRecorder.stop();
+            this.emit({ type: 'state', state: 'thinking' });
+        }
+
+        watchSilence() {
+            const buf = new Float32Array(this.analyser.fftSize);
+            const check = () => {
+                if (!this.isRecording) return;
+                this.analyser.getFloatTimeDomainData(buf);
+                let sum = 0;
+                for (let i = 0; i < buf.length; i++) sum += buf[i] * buf[i];
+                const rms = Math.sqrt(sum / buf.length);
+                this.maxRecordedRms = Math.max(this.maxRecordedRms, rms);
+                if (rms < this.silenceThreshold) {
+                    if (!this.silenceTimer) this.silenceTimer = setTimeout(() => this.stopRecording(), this.silenceMs);
+                } else {
+                    clearTimeout(this.silenceTimer);
+                    this.silenceTimer = null;
+                }
+                if (this.isRecording) requestAnimationFrame(check);
+            };
+            requestAnimationFrame(check);
+        }
+
+        async sendRecording() {
+            if (!this.audioChunks.length || this.maxRecordedRms < 0.008) {
+                this.emit({ type: 'state', state: 'ambient' });
+                return;
+            }
+            const blob = new Blob(this.audioChunks, { type: this.mediaRecorder.mimeType || 'audio/webm' });
+            this.audioChunks = [];
+            this.serverBusy = true;
+            if (this.mode === 'livekit') {
+                const form = new FormData();
+                form.append('audio', blob, 'skybridge.webm');
+                form.append('session_id', getSessionId());
+                try {
+                    const resp = await fetch('/api/voice/livekit-audio', {
+                        method: 'POST',
+                        headers: { 'X-Session-ID': getSessionId() },
+                        body: form
+                    });
+                    const data = await resp.json();
+                    if (data.transcript) this.emit({ type: 'transcript', role: 'user', text: data.transcript });
+                    if (data.response_text) this.emit({ type: 'transcript', role: 'zoe', text: data.response_text });
+                    if (data.audio_base64) this.playAudio(data.audio_base64, data.content_type || 'audio/wav');
+                    this.serverBusy = false;
+                    this.emit({ type: 'done' });
+                } catch (err) {
+                    this.serverBusy = false;
+                    this.emit({ type: 'error', message: 'Voice upload failed' });
+                }
+            } else if (this.ws && this.ws.readyState === WebSocket.OPEN) {
+                this.ws.send(await blob.arrayBuffer());
+            }
+        }
+
+        playAudio(b64, contentType) {
+            try {
+                const bin = atob(b64);
+                const bytes = new Uint8Array(bin.length);
+                for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+                const url = URL.createObjectURL(new Blob([bytes], { type: contentType }));
+                const audio = new Audio(url);
+                this.speaking = true;
+                this.emit({ type: 'state', state: 'responding' });
+                audio.onended = () => {
+                    URL.revokeObjectURL(url);
+                    this.speaking = false;
+                    this.emit({ type: 'state', state: 'ambient' });
+                };
+                audio.onerror = audio.onended;
+                audio.play().catch(audio.onended);
+            } catch (_) {
+                this.speaking = false;
+            }
+        }
+    }
+
+    window.SkybridgeVoice = SkybridgeVoice;
+})();

--- a/services/zoe-ui/dist/touch/js/skybridge-voice.js
+++ b/services/zoe-ui/dist/touch/js/skybridge-voice.js
@@ -162,11 +162,26 @@
             }
         }
 
-        sendText(message) {
+        async sendText(message) {
             const text = String(message || '').trim();
             if (!text) return;
             this.emit({ type: 'transcript', role: 'user', text });
-            if (this.ws && this.ws.readyState === WebSocket.OPEN) {
+            if (this.mode === 'livekit' && this.room && this.room.localParticipant) {
+                this.serverBusy = true;
+                this.emit({ type: 'state', state: 'thinking' });
+                try {
+                    const payload = new TextEncoder().encode(JSON.stringify({
+                        type: 'text',
+                        message: text,
+                        session_id: getSessionId()
+                    }));
+                    await this.room.localParticipant.publishData(payload, { reliable: true });
+                } catch (err) {
+                    this.serverBusy = false;
+                    this.emit({ type: 'state', state: 'ambient' });
+                    this.emit({ type: 'error', message: 'Voice transport unavailable' });
+                }
+            } else if (this.ws && this.ws.readyState === WebSocket.OPEN) {
                 this.serverBusy = true;
                 this.emit({ type: 'state', state: 'thinking' });
                 this.ws.send(JSON.stringify({ type: 'text', message: text }));

--- a/services/zoe-ui/dist/touch/js/skybridge-voice.js
+++ b/services/zoe-ui/dist/touch/js/skybridge-voice.js
@@ -161,6 +161,10 @@
                 this.serverBusy = true;
                 this.emit({ type: 'state', state: 'thinking' });
                 this.ws.send(JSON.stringify({ type: 'text', message: text }));
+            } else {
+                this.serverBusy = false;
+                this.emit({ type: 'state', state: 'ambient' });
+                this.emit({ type: 'error', message: 'Voice transport unavailable' });
             }
         }
 

--- a/services/zoe-ui/dist/touch/js/skybridge-voice.js
+++ b/services/zoe-ui/dist/touch/js/skybridge-voice.js
@@ -258,7 +258,14 @@
                     this.emit({ type: 'error', message: 'Voice upload failed' });
                 }
             } else if (this.ws && this.ws.readyState === WebSocket.OPEN) {
-                this.ws.send(await blob.arrayBuffer());
+                const ab = await blob.arrayBuffer();
+                if (this.ws && this.ws.readyState === WebSocket.OPEN) {
+                    this.ws.send(ab);
+                } else {
+                    this.serverBusy = false;
+                    this.emit({ type: 'state', state: 'ambient' });
+                    this.emit({ type: 'error', message: 'Voice transport unavailable' });
+                }
             } else {
                 this.serverBusy = false;
                 this.emit({ type: 'state', state: 'ambient' });

--- a/services/zoe-ui/dist/touch/js/skybridge-voice.js
+++ b/services/zoe-ui/dist/touch/js/skybridge-voice.js
@@ -29,6 +29,9 @@
             this.maxRecordedRms = 0;
             this.silenceTimer = null;
             this.autoListenTimer = null;
+            this.reconnectTimer = null;
+            this.reconnectDelayMs = 1000;
+            this.stopped = true;
             this.silenceThreshold = 0.01;
             this.silenceMs = 1600;
         }
@@ -38,6 +41,7 @@
         }
 
         async start() {
+            this.stopped = false;
             if (this.mode === 'livekit') {
                 await this.connectLiveKit();
             } else {
@@ -46,6 +50,8 @@
         }
 
         stop() {
+            this.stopped = true;
+            clearTimeout(this.reconnectTimer);
             clearTimeout(this.autoListenTimer);
             clearTimeout(this.silenceTimer);
             if (this.ws) this.ws.close();
@@ -60,22 +66,41 @@
         }
 
         connectLocal() {
+            clearTimeout(this.reconnectTimer);
             const proto = location.protocol === 'https:' ? 'wss' : 'ws';
             const wsUrl = proto + '://' + location.host + '/ws/voice/?session_id=' + encodeURIComponent(getSessionId());
             this.ws = new WebSocket(wsUrl);
             this.ws.binaryType = 'arraybuffer';
-            this.ws.onopen = () => this.emit({ type: 'ready', mode: 'local' });
+            this.ws.onopen = () => {
+                this.reconnectDelayMs = 1000;
+                this.emit({ type: 'ready', mode: 'local' });
+            };
             this.ws.onmessage = event => {
                 try {
                     const msg = typeof event.data === 'string' ? JSON.parse(event.data) : null;
                     if (msg) this.handleServerEvent(msg);
-                } catch (_) {}
+                } catch (err) {
+                    console.warn('Skybridge voice event parse failed', err);
+                    this.emit({ type: 'error', message: 'Malformed server event' });
+                }
             };
             this.ws.onclose = () => {
+                this.ws = null;
                 this.serverBusy = false;
                 this.emit({ type: 'state', state: 'ambient' });
                 this.emit({ type: 'error', message: 'Voice disconnected' });
+                this.scheduleReconnect();
             };
+        }
+
+        scheduleReconnect() {
+            if (this.stopped || this.mode !== 'local') return;
+            clearTimeout(this.reconnectTimer);
+            const delay = this.reconnectDelayMs;
+            this.reconnectDelayMs = Math.min(this.reconnectDelayMs * 2, 15000);
+            this.reconnectTimer = setTimeout(() => {
+                if (!this.stopped && this.mode === 'local') this.connectLocal();
+            }, delay);
         }
 
         async connectLiveKit() {
@@ -221,6 +246,10 @@
                 }
             } else if (this.ws && this.ws.readyState === WebSocket.OPEN) {
                 this.ws.send(await blob.arrayBuffer());
+            } else {
+                this.serverBusy = false;
+                this.emit({ type: 'state', state: 'ambient' });
+                this.emit({ type: 'error', message: 'Voice transport unavailable' });
             }
         }
 

--- a/services/zoe-ui/dist/touch/js/skybridge-voice.js
+++ b/services/zoe-ui/dist/touch/js/skybridge-voice.js
@@ -54,12 +54,18 @@
             clearTimeout(this.reconnectTimer);
             clearTimeout(this.autoListenTimer);
             clearTimeout(this.silenceTimer);
+            if (this.mediaRecorder && this.mediaRecorder.state !== 'inactive') {
+                this.mediaRecorder.onstop = null;
+                this.mediaRecorder.stop();
+            }
+            this.audioChunks = [];
             if (this.ws) this.ws.close();
             if (this.room) this.room.disconnect();
             if (this.micStream) this.micStream.getTracks().forEach(track => track.stop());
             this.ws = null;
             this.room = null;
             this.micStream = null;
+            this.mediaRecorder = null;
             this.isRecording = false;
             this.serverBusy = false;
             this.emit({ type: 'state', state: 'ambient' });

--- a/services/zoe-ui/dist/touch/js/skybridge.js
+++ b/services/zoe-ui/dist/touch/js/skybridge.js
@@ -21,8 +21,20 @@
         bindEvents();
         startOrb();
         renderHome();
+        loadBackendStatus();
         setMode(mode);
         if (typeof TouchMenu !== 'undefined') TouchMenu.init({ page: 'skybridge' });
+    }
+
+    async function loadBackendStatus() {
+        try {
+            const resp = await fetch('/api/skybridge/status', { headers: { 'Accept': 'application/json' } });
+            if (!resp.ok) return;
+            const data = await resp.json();
+            if (data && data.status === 'ready') setStatus('Skybridge runtime ready');
+        } catch (_) {
+            // The interface can still render local cards if the API is offline.
+        }
     }
 
     function cacheEls() {

--- a/services/zoe-ui/dist/touch/js/skybridge.js
+++ b/services/zoe-ui/dist/touch/js/skybridge.js
@@ -76,8 +76,10 @@
             if (!btn) return;
             const route = btn.dataset.route;
             const query = btn.dataset.query;
-            if (route) {
+            if (route && route.startsWith('/')) {
                 location.href = route;
+            } else if (route) {
+                showError('Unsupported card route');
             } else if (query) {
                 submitCommand(query);
             }

--- a/services/zoe-ui/dist/touch/js/skybridge.js
+++ b/services/zoe-ui/dist/touch/js/skybridge.js
@@ -1,0 +1,256 @@
+/*
+ * Skybridge app orchestration.
+ */
+(function () {
+    const els = {};
+    let voice = null;
+    let mode = new URLSearchParams(location.search).get('mode') || 'local';
+    let orbState = 'ambient';
+    let phase = 0;
+    let animationFrame = null;
+
+    const colors = {
+        ambient: ['#5fc6ff', '#66d19e'],
+        listening: ['#5fc6ff', '#d8f3ff'],
+        thinking: ['#f7bf5f', '#66d19e'],
+        responding: ['#8c7dff', '#ff7b7b']
+    };
+
+    function init() {
+        cacheEls();
+        bindEvents();
+        startOrb();
+        renderHome();
+        setMode(mode);
+        if (typeof TouchMenu !== 'undefined') TouchMenu.init({ page: 'skybridge' });
+    }
+
+    function cacheEls() {
+        els.cards = document.getElementById('skyCards');
+        els.statusText = document.getElementById('skyStatusText');
+        els.statusDot = document.getElementById('skyStatusDot');
+        els.contextTitle = document.getElementById('skyContextTitle');
+        els.contextDetail = document.getElementById('skyContextDetail');
+        els.transcript = document.getElementById('skyTranscript');
+        els.copy = document.getElementById('skyListeningCopy');
+        els.form = document.getElementById('skyCommandForm');
+        els.input = document.getElementById('skyCommandInput');
+        els.mic = document.getElementById('skyMicBtn');
+        els.home = document.getElementById('skyHomeBtn');
+        els.canvas = document.getElementById('skyOrb');
+        els.ctx = els.canvas.getContext('2d');
+    }
+
+    function bindEvents() {
+        document.querySelectorAll('[data-mode]').forEach(btn => {
+            btn.addEventListener('click', () => setMode(btn.dataset.mode));
+        });
+        els.form.addEventListener('submit', event => {
+            event.preventDefault();
+            submitCommand(els.input.value);
+            els.input.value = '';
+        });
+        els.mic.addEventListener('click', () => {
+            if (!voice) return;
+            if (voice.isRecording) {
+                voice.stopRecording();
+            } else {
+                voice.startRecording().catch(err => showError(err.message || 'Microphone unavailable'));
+            }
+        });
+        els.home.addEventListener('click', renderHome);
+        els.cards.addEventListener('click', event => {
+            const btn = event.target.closest('button[data-sky-action]');
+            if (!btn) return;
+            const route = btn.dataset.route;
+            const query = btn.dataset.query;
+            if (route) {
+                location.href = route;
+            } else if (query) {
+                submitCommand(query);
+            }
+        });
+    }
+
+    function setMode(nextMode) {
+        mode = nextMode || 'local';
+        document.querySelectorAll('[data-mode]').forEach(btn => {
+            btn.classList.toggle('active', btn.dataset.mode === mode);
+        });
+        if (voice) voice.stop();
+        voice = new window.SkybridgeVoice({ mode, onEvent: handleVoiceEvent });
+        voice.start().catch(err => showError(err.message || 'Voice failed to start'));
+        setStatus('Connecting ' + mode);
+    }
+
+    function handleVoiceEvent(event) {
+        if (event.type === 'ready') {
+            setStatus('Ready on ' + event.mode);
+        } else if (event.type === 'state') {
+            setState(event.state || 'ambient');
+        } else if (event.type === 'transcript') {
+            addTranscript(event.role, event.text);
+            if (event.role === 'user') projectCards(event.text);
+        } else if (event.type === 'card') {
+            addCard(event.card, true);
+        } else if (event.type === 'error') {
+            showError(event.message);
+        } else if (event.type === 'done') {
+            setState('ambient');
+        }
+    }
+
+    function submitCommand(text) {
+        const query = String(text || '').trim();
+        if (!query) return;
+        projectCards(query);
+        if (voice) voice.sendText(query);
+    }
+
+    function projectCards(query) {
+        const matches = window.SkybridgeCapabilities.find(query);
+        if (!matches.length) {
+            addCard({
+                component: 'status',
+                props: {
+                    title: 'I can work from here',
+                    kicker: 'No exact page match',
+                    body: 'I will keep the conversation here. If this needs a page or setting, Skybridge can add a new capability mapping for it.',
+                    status: 'General'
+                }
+            }, true);
+            return;
+        }
+        const top = matches[0];
+        if (top.kind === 'setting') {
+            setContext('Settings', top.title + ' is active for follow-up commands.');
+            addCard({ component: 'setting', props: top }, true);
+        } else {
+            setContext(top.title, top.summary);
+            addCard({ component: 'page', props: top }, true);
+        }
+        if (matches.length > 1) {
+            addCard({
+                component: 'list',
+                props: {
+                    title: 'Related matches',
+                    kicker: 'Skybridge context',
+                    items: matches.slice(1, 5).map(item => item.title + ' - ' + item.summary),
+                    actions: matches.slice(1, 3).map(item => ({ label: item.title, query: item.title }))
+                }
+            });
+        }
+    }
+
+    function renderHome() {
+        setContext('Home surface', 'Cards appear here as Zoe understands the request.');
+        els.cards.innerHTML = '';
+        window.SkybridgeCapabilities.getHomeCards().forEach(card => addCard(card));
+    }
+
+    function addCard(card, prepend) {
+        const wrapper = document.createElement('div');
+        wrapper.innerHTML = window.SkybridgeRenderer.render(card);
+        const node = wrapper.firstElementChild;
+        if (!node) return;
+        if (prepend && els.cards.firstChild) {
+            els.cards.insertBefore(node, els.cards.firstChild);
+        } else {
+            els.cards.appendChild(node);
+        }
+    }
+
+    function setContext(title, detail) {
+        els.contextTitle.textContent = title;
+        els.contextDetail.textContent = detail;
+    }
+
+    function addTranscript(role, text) {
+        if (!text) return;
+        const line = document.createElement('div');
+        line.className = 'sky-line';
+        line.innerHTML = '<strong>' + (role === 'user' ? 'You' : 'Zoe') + ':</strong> ' + window.SkybridgeRenderer.escapeHtml(text);
+        els.transcript.appendChild(line);
+        els.transcript.scrollTop = els.transcript.scrollHeight;
+    }
+
+    function setStatus(text) {
+        els.statusText.textContent = text;
+    }
+
+    function showError(message) {
+        setStatus(message || 'Something needs attention');
+        addCard({
+            component: 'status',
+            props: {
+                title: 'Skybridge notice',
+                kicker: 'Runtime',
+                body: message || 'Something needs attention.',
+                status: 'Notice'
+            }
+        }, true);
+    }
+
+    function setState(state) {
+        orbState = state;
+        els.mic.classList.toggle('recording', state === 'listening');
+        const copy = {
+            ambient: 'Say what you need. Skybridge will shape the screen around it.',
+            listening: 'Listening...',
+            thinking: 'Finding the right page, data, or card...',
+            responding: 'Zoe is speaking. You can interrupt when needed.'
+        };
+        els.copy.textContent = copy[state] || copy.ambient;
+        setStatus(state.charAt(0).toUpperCase() + state.slice(1));
+    }
+
+    function resizeOrb() {
+        const rect = els.canvas.getBoundingClientRect();
+        els.canvas.width = Math.max(1, Math.floor(rect.width * window.devicePixelRatio));
+        els.canvas.height = Math.max(1, Math.floor(rect.height * window.devicePixelRatio));
+    }
+
+    function startOrb() {
+        resizeOrb();
+        window.addEventListener('resize', resizeOrb);
+        const draw = () => {
+            animationFrame = requestAnimationFrame(draw);
+            phase += 0.012;
+            const ctx = els.ctx;
+            const w = els.canvas.width;
+            const h = els.canvas.height;
+            ctx.clearRect(0, 0, w, h);
+            const cx = w / 2;
+            const cy = h / 2;
+            const base = Math.min(w, h) * 0.22;
+            const pulse = 1 + (orbState === 'listening' ? 0.06 : orbState === 'responding' ? 0.08 : 0.025) * Math.sin(phase * 2);
+            const r = base * pulse;
+            const pair = colors[orbState] || colors.ambient;
+            const glow = ctx.createRadialGradient(cx, cy, r * 0.2, cx, cy, r * 2.4);
+            glow.addColorStop(0, pair[0] + '88');
+            glow.addColorStop(0.55, pair[1] + '33');
+            glow.addColorStop(1, 'transparent');
+            ctx.fillStyle = glow;
+            ctx.beginPath();
+            ctx.arc(cx, cy, r * 2.4, 0, Math.PI * 2);
+            ctx.fill();
+            const orb = ctx.createRadialGradient(cx - r * 0.3, cy - r * 0.35, r * 0.1, cx, cy, r);
+            orb.addColorStop(0, '#ffffff');
+            orb.addColorStop(0.15, pair[0]);
+            orb.addColorStop(0.75, pair[1]);
+            orb.addColorStop(1, '#070910');
+            ctx.fillStyle = orb;
+            ctx.beginPath();
+            ctx.arc(cx, cy, r, 0, Math.PI * 2);
+            ctx.fill();
+        };
+        draw();
+    }
+
+    window.addEventListener('beforeunload', () => {
+        if (animationFrame) cancelAnimationFrame(animationFrame);
+        if (voice) voice.stop();
+    });
+
+    document.addEventListener('DOMContentLoaded', init);
+})();

--- a/services/zoe-ui/dist/touch/js/touch-menu.js
+++ b/services/zoe-ui/dist/touch/js/touch-menu.js
@@ -15,6 +15,7 @@ const TouchMenu = (() => {
 
     const PRIMARY = [
         { id: 'dashboard', path: '/touch/dashboard.html',  label: 'Home'     },
+        { id: 'skybridge', path: '/touch/skybridge.html',  label: 'Skybridge' },
         { id: 'calendar',  path: '/touch/calendar.html',   label: 'Calendar' },
         { id: 'lists',     path: '/touch/lists.html',      label: 'Lists'    },
         { id: 'chat',      path: '/touch/chat.html',       label: 'Chat'     },
@@ -22,6 +23,7 @@ const TouchMenu = (() => {
 
     const ALL_PAGES = [
         { id: 'dashboard',  path: '/touch/dashboard.html',  icon: '🏠', label: 'Home'       },
+        { id: 'skybridge',  path: '/touch/skybridge.html',  icon: '◇',  label: 'Skybridge'  },
         { id: 'calendar',   path: '/touch/calendar.html',   icon: '📅', label: 'Calendar'   },
         { id: 'lists',      path: '/touch/lists.html',      icon: '☰',  label: 'Lists'      },
         { id: 'notes',      path: '/touch/notes.html',      icon: '📝', label: 'Notes'      },
@@ -38,7 +40,7 @@ const TouchMenu = (() => {
         { id: 'settings',   path: '/touch/settings.html',   icon: '⚙️', label: 'Settings'   },
     ];
     const GUEST_ALLOWED_PAGE_IDS = new Set([
-        'dashboard', 'calendar', 'lists', 'chat', 'weather', 'smarthome', 'timers', 'music',
+        'dashboard', 'skybridge', 'calendar', 'lists', 'chat', 'weather', 'smarthome', 'timers', 'music',
     ]); // Fallback if matrix is unavailable.
 
     let _pageId = 'dashboard';
@@ -535,7 +537,7 @@ html.dark-mode .ztm-ctx-item { color: rgba(255,255,255,0.88); border-bottom-colo
             const p = u.pathname || '/';
             const base = p.split('/').pop() || '';
             const allowed = new Set([
-                'dashboard.html', 'calendar.html', 'lists.html', 'chat.html', 'notes.html',
+                'dashboard.html', 'skybridge.html', 'calendar.html', 'lists.html', 'chat.html', 'notes.html',
                 'journal.html', 'people.html', 'music.html', 'smart-home.html', 'weather.html',
                 'settings.html', 'memories.html', 'cooking.html', 'timers.html', 'updates.html',
                 'index.html'

--- a/services/zoe-ui/dist/touch/js/touch-menu.js
+++ b/services/zoe-ui/dist/touch/js/touch-menu.js
@@ -40,7 +40,7 @@ const TouchMenu = (() => {
         { id: 'settings',   path: '/touch/settings.html',   icon: '⚙️', label: 'Settings'   },
     ];
     const GUEST_ALLOWED_PAGE_IDS = new Set([
-        'dashboard', 'skybridge', 'calendar', 'lists', 'chat', 'weather', 'smarthome', 'timers', 'music',
+        'dashboard', 'calendar', 'lists', 'chat', 'weather', 'smarthome', 'timers', 'music',
     ]); // Fallback if matrix is unavailable.
 
     let _pageId = 'dashboard';

--- a/services/zoe-ui/dist/touch/skybridge.html
+++ b/services/zoe-ui/dist/touch/skybridge.html
@@ -1,0 +1,521 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <script>
+    (function(){
+        if (localStorage.getItem('zoe_kiosk') === '1') return;
+        var p = new URLSearchParams(location.search);
+        if (p.get('kiosk') === '1') localStorage.setItem('zoe_kiosk', '1');
+    })();
+    (function(){
+        var s = localStorage.getItem('zoe_theme') || 'auto';
+        var h = new Date().getHours();
+        var dark = s === 'dark' || (s === 'auto' && (h < 7 || h >= 19));
+        if (dark) document.documentElement.classList.add('dark-mode');
+    })();
+    window.prompt = function(msg, def) { return def || ''; };
+    window.alert = function() {};
+    window.confirm = function() { return true; };
+    </script>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+    <meta name="theme-color" content="#0b0d12">
+    <title>Zoe Skybridge</title>
+    <link rel="stylesheet" href="/touch/css/touch-adapter.css">
+    <script src="/lib/livekit/livekit-client.umd.min.js" onerror="console.warn('LiveKit client not loaded')"></script>
+    <style>
+        :root {
+            --sky-bg: #0b0d12;
+            --sky-panel: rgba(19, 23, 31, 0.78);
+            --sky-panel-strong: rgba(24, 30, 42, 0.94);
+            --sky-border: rgba(255, 255, 255, 0.1);
+            --sky-text: #f6f8fb;
+            --sky-muted: rgba(246, 248, 251, 0.64);
+            --sky-soft: rgba(246, 248, 251, 0.1);
+            --sky-blue: #5fc6ff;
+            --sky-green: #66d19e;
+            --sky-amber: #f7bf5f;
+            --sky-coral: #ff7b7b;
+            --sky-violet: #8c7dff;
+            --sky-radius: 8px;
+        }
+
+        * { box-sizing: border-box; }
+        html, body {
+            width: 100%;
+            min-height: 100%;
+            margin: 0;
+            background:
+                radial-gradient(circle at 14% 12%, rgba(95, 198, 255, 0.16), transparent 30%),
+                radial-gradient(circle at 88% 18%, rgba(102, 209, 158, 0.12), transparent 28%),
+                linear-gradient(145deg, #0b0d12 0%, #11151d 48%, #080a0e 100%);
+            color: var(--sky-text);
+            font-family: -apple-system, BlinkMacSystemFont, "SF Pro Display", "Segoe UI", system-ui, sans-serif;
+            overflow: hidden;
+            touch-action: manipulation;
+            padding-top: var(--ta-nav-h, 64px);
+        }
+
+        body {
+            display: grid;
+            grid-template-rows: auto 1fr auto;
+            height: 100dvh;
+        }
+
+        .sky-topbar {
+            display: grid;
+            grid-template-columns: minmax(0, 1fr) auto;
+            gap: 18px;
+            align-items: center;
+            padding: 18px 28px 12px;
+        }
+
+        .sky-title {
+            display: flex;
+            align-items: center;
+            gap: 14px;
+            min-width: 0;
+        }
+
+        .sky-mark {
+            width: 42px;
+            height: 42px;
+            border-radius: 50%;
+            background:
+                radial-gradient(circle at 35% 30%, #ffffff 0%, rgba(255,255,255,0.35) 12%, transparent 30%),
+                conic-gradient(from 210deg, var(--sky-blue), var(--sky-green), var(--sky-amber), var(--sky-violet), var(--sky-blue));
+            box-shadow: 0 0 34px rgba(95, 198, 255, 0.24);
+            flex: 0 0 auto;
+        }
+
+        .sky-heading {
+            min-width: 0;
+        }
+
+        .sky-heading h1 {
+            margin: 0;
+            font-size: 24px;
+            line-height: 1.05;
+            font-weight: 700;
+            letter-spacing: 0;
+        }
+
+        .sky-heading p {
+            margin: 5px 0 0;
+            color: var(--sky-muted);
+            font-size: 13px;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+
+        .sky-status {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            padding: 10px 12px;
+            border: 1px solid var(--sky-border);
+            background: rgba(255, 255, 255, 0.06);
+            border-radius: var(--sky-radius);
+            min-height: 44px;
+        }
+
+        .sky-status-dot {
+            width: 10px;
+            height: 10px;
+            border-radius: 50%;
+            background: var(--sky-green);
+            box-shadow: 0 0 18px rgba(102, 209, 158, 0.72);
+        }
+
+        .sky-status-text {
+            font-size: 13px;
+            color: var(--sky-muted);
+        }
+
+        .sky-shell {
+            display: grid;
+            grid-template-columns: minmax(300px, 34vw) minmax(0, 1fr);
+            gap: 22px;
+            min-height: 0;
+            padding: 8px 28px 18px;
+        }
+
+        .sky-orb-panel,
+        .sky-stage {
+            min-height: 0;
+            border: 1px solid var(--sky-border);
+            background: linear-gradient(180deg, rgba(255,255,255,0.08), rgba(255,255,255,0.035));
+            backdrop-filter: blur(22px);
+            -webkit-backdrop-filter: blur(22px);
+            border-radius: var(--sky-radius);
+            box-shadow: 0 22px 80px rgba(0, 0, 0, 0.32);
+        }
+
+        .sky-orb-panel {
+            display: grid;
+            grid-template-rows: minmax(0, 1fr) auto;
+            overflow: hidden;
+            position: relative;
+        }
+
+        #skyOrb {
+            width: 100%;
+            height: 100%;
+            min-height: 320px;
+            display: block;
+        }
+
+        .sky-listening-copy {
+            position: absolute;
+            left: 22px;
+            right: 22px;
+            bottom: 112px;
+            text-align: center;
+            color: var(--sky-muted);
+            font-size: 15px;
+            line-height: 1.45;
+            pointer-events: none;
+        }
+
+        .sky-transcript {
+            display: grid;
+            gap: 8px;
+            padding: 16px;
+            border-top: 1px solid var(--sky-border);
+            background: rgba(0, 0, 0, 0.14);
+            max-height: 190px;
+            overflow: auto;
+        }
+
+        .sky-line {
+            font-size: 13px;
+            line-height: 1.45;
+            color: var(--sky-muted);
+        }
+
+        .sky-line strong {
+            color: var(--sky-text);
+            font-weight: 650;
+        }
+
+        .sky-stage {
+            display: grid;
+            grid-template-rows: auto 1fr;
+            overflow: hidden;
+        }
+
+        .sky-stage-header {
+            display: grid;
+            grid-template-columns: minmax(0, 1fr) auto;
+            gap: 16px;
+            align-items: center;
+            padding: 16px 18px;
+            border-bottom: 1px solid var(--sky-border);
+        }
+
+        .sky-context h2 {
+            margin: 0;
+            font-size: 18px;
+            font-weight: 700;
+            letter-spacing: 0;
+        }
+
+        .sky-context p {
+            margin: 4px 0 0;
+            color: var(--sky-muted);
+            font-size: 13px;
+        }
+
+        .sky-mode-toggle {
+            display: flex;
+            gap: 6px;
+            padding: 4px;
+            border: 1px solid var(--sky-border);
+            background: rgba(0,0,0,0.16);
+            border-radius: var(--sky-radius);
+        }
+
+        .sky-mode-toggle button,
+        .sky-card button,
+        .sky-command button {
+            min-height: 44px;
+            border: 0;
+            border-radius: 7px;
+            color: var(--sky-text);
+            background: rgba(255,255,255,0.08);
+            padding: 0 14px;
+            font: inherit;
+            cursor: pointer;
+        }
+
+        .sky-mode-toggle button.active {
+            background: rgba(95, 198, 255, 0.2);
+            color: #d9f4ff;
+        }
+
+        .sky-card-stack {
+            min-height: 0;
+            overflow: auto;
+            padding: 18px;
+            display: grid;
+            grid-template-columns: repeat(12, minmax(0, 1fr));
+            align-content: start;
+            gap: 14px;
+        }
+
+        .sky-card {
+            grid-column: span 6;
+            min-height: 168px;
+            border: 1px solid var(--sky-border);
+            border-radius: var(--sky-radius);
+            background: var(--sky-panel);
+            padding: 16px;
+            display: grid;
+            gap: 12px;
+            align-content: start;
+            box-shadow: 0 12px 30px rgba(0,0,0,0.2);
+        }
+
+        .sky-card.wide { grid-column: span 12; }
+        .sky-card.compact { grid-column: span 4; min-height: 132px; }
+
+        .sky-card-header {
+            display: flex;
+            align-items: flex-start;
+            justify-content: space-between;
+            gap: 12px;
+        }
+
+        .sky-card-title {
+            margin: 0;
+            font-size: 17px;
+            font-weight: 700;
+            letter-spacing: 0;
+        }
+
+        .sky-card-kicker {
+            margin: 0 0 4px;
+            color: var(--sky-muted);
+            font-size: 12px;
+            text-transform: uppercase;
+        }
+
+        .sky-badge {
+            flex: 0 0 auto;
+            border-radius: 999px;
+            border: 1px solid var(--sky-border);
+            padding: 5px 9px;
+            color: var(--sky-muted);
+            font-size: 12px;
+            background: rgba(255,255,255,0.05);
+        }
+
+        .sky-card-body {
+            color: rgba(246,248,251,0.78);
+            font-size: 14px;
+            line-height: 1.45;
+        }
+
+        .sky-card-grid {
+            display: grid;
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+            gap: 8px;
+        }
+
+        .sky-field {
+            border: 1px solid var(--sky-border);
+            background: rgba(0,0,0,0.14);
+            border-radius: 7px;
+            padding: 10px;
+            min-width: 0;
+        }
+
+        .sky-field span {
+            display: block;
+            color: var(--sky-muted);
+            font-size: 12px;
+            margin-bottom: 5px;
+        }
+
+        .sky-field strong {
+            display: block;
+            font-size: 14px;
+            overflow-wrap: anywhere;
+        }
+
+        .sky-actions {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+            align-self: start;
+        }
+
+        .sky-actions button.primary {
+            background: linear-gradient(135deg, rgba(95,198,255,0.88), rgba(102,209,158,0.88));
+            color: #071017;
+            font-weight: 700;
+        }
+
+        .sky-actions button.warn {
+            background: rgba(255, 123, 123, 0.18);
+            color: #ffd5d5;
+        }
+
+        .sky-command {
+            display: grid;
+            grid-template-columns: auto minmax(0, 1fr) auto auto;
+            gap: 10px;
+            align-items: center;
+            padding: 12px 28px max(18px, env(safe-area-inset-bottom, 18px));
+            background: rgba(5, 7, 10, 0.72);
+            border-top: 1px solid var(--sky-border);
+            backdrop-filter: blur(20px);
+            -webkit-backdrop-filter: blur(20px);
+        }
+
+        .sky-command input {
+            width: 100%;
+            min-height: 48px;
+            border: 1px solid var(--sky-border);
+            border-radius: var(--sky-radius);
+            background: rgba(255,255,255,0.08);
+            color: var(--sky-text);
+            padding: 0 14px;
+            font: inherit;
+            outline: none;
+        }
+
+        .sky-command input:focus {
+            border-color: rgba(95, 198, 255, 0.7);
+            box-shadow: 0 0 0 3px rgba(95, 198, 255, 0.12);
+        }
+
+        .sky-command .primary {
+            background: var(--sky-green);
+            color: #071017;
+            font-weight: 700;
+        }
+
+        .sky-command .recording {
+            background: var(--sky-coral);
+            color: #190707;
+        }
+
+        @media (max-width: 980px) {
+            .sky-shell {
+                grid-template-columns: 1fr;
+            }
+            .sky-orb-panel {
+                min-height: 330px;
+            }
+            #skyOrb {
+                min-height: 260px;
+            }
+            .sky-card { grid-column: span 12; }
+            .sky-card.compact { grid-column: span 6; }
+        }
+
+        @media (max-width: 640px) {
+            body { overflow-y: auto; overflow-x: hidden; height: auto; max-width: 100vw; }
+            .sky-topbar,
+            .sky-shell,
+            .sky-command {
+                padding-left: 14px;
+                padding-right: 14px;
+            }
+            .sky-topbar,
+            .sky-stage-header,
+            .sky-command {
+                grid-template-columns: 1fr;
+            }
+            #ztm-tabs {
+                overflow-x: auto;
+                scrollbar-width: none;
+            }
+            #ztm-tabs::-webkit-scrollbar {
+                display: none;
+            }
+            #ztm-right {
+                display: none;
+            }
+            .sky-heading p,
+            .sky-listening-copy {
+                white-space: normal;
+                overflow: visible;
+                overflow-wrap: anywhere;
+                text-overflow: clip;
+            }
+            .sky-heading p {
+                max-width: 270px;
+            }
+            .sky-listening-copy {
+                left: 38px;
+                right: auto;
+                transform: none;
+                width: 300px;
+                font-size: 14px;
+            }
+            .sky-mode-toggle {
+                justify-self: start;
+            }
+            .sky-card.compact { grid-column: span 12; }
+        }
+    </style>
+</head>
+<body>
+    <header class="sky-topbar">
+        <div class="sky-title">
+            <div class="sky-mark" aria-hidden="true"></div>
+            <div class="sky-heading">
+                <h1>Skybridge</h1>
+                <p id="skySubtitle">Voice-first control for Zoe's pages, settings, and live cards.</p>
+            </div>
+        </div>
+        <div class="sky-status" aria-live="polite">
+            <span class="sky-status-dot" id="skyStatusDot"></span>
+            <span class="sky-status-text" id="skyStatusText">Starting</span>
+        </div>
+    </header>
+
+    <main class="sky-shell">
+        <section class="sky-orb-panel" aria-label="Voice state">
+            <canvas id="skyOrb"></canvas>
+            <div class="sky-listening-copy" id="skyListeningCopy">Say what you need. Skybridge will shape the screen around it.</div>
+            <div class="sky-transcript" id="skyTranscript" aria-live="polite"></div>
+        </section>
+
+        <section class="sky-stage" aria-label="Skybridge cards">
+            <div class="sky-stage-header">
+                <div class="sky-context">
+                    <h2 id="skyContextTitle">Home surface</h2>
+                    <p id="skyContextDetail">Cards appear here as Zoe understands the request.</p>
+                </div>
+                <div class="sky-mode-toggle" aria-label="Voice transport">
+                    <button type="button" data-mode="local">Local</button>
+                    <button type="button" data-mode="livekit">LiveKit</button>
+                </div>
+            </div>
+            <div class="sky-card-stack" id="skyCards"></div>
+        </section>
+    </main>
+
+    <form class="sky-command" id="skyCommandForm">
+        <button type="button" id="skyHomeBtn" title="Show home cards">Home</button>
+        <input id="skyCommandInput" autocomplete="off" placeholder="Ask Zoe to show or change anything..." aria-label="Ask Zoe">
+        <button type="button" id="skyMicBtn">Speak</button>
+        <button type="submit" class="primary">Send</button>
+    </form>
+
+    <script src="/js/websocket-sync.js"></script>
+    <script src="/touch/js/gestures.js"></script>
+    <script src="/touch/js/touch-menu.js"></script>
+    <script src="/js/touch-ui-executor.js"></script>
+    <script src="/touch/js/skybridge-capabilities.js"></script>
+    <script src="/touch/js/skybridge-renderer.js"></script>
+    <script src="/touch/js/skybridge-voice.js"></script>
+    <script src="/touch/js/skybridge.js"></script>
+</body>
+</html>

--- a/services/zoe-ui/dist/touch/skybridge.html
+++ b/services/zoe-ui/dist/touch/skybridge.html
@@ -16,7 +16,6 @@
     })();
     window.prompt = function(msg, def) { return def || ''; };
     window.alert = function() {};
-    window.confirm = function() { return true; };
     </script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
     <meta name="apple-mobile-web-app-capable" content="yes">


### PR DESCRIPTION
## Summary
- Adds `/touch/skybridge.html` as a touch-first, voice-first Skybridge shell for live cards and page/settings control.
- Adds a data-first capability registry for Zoe touch pages and settings sections.
- Adds reusable Skybridge card rendering and voice transport adapters for local WebSocket and LiveKit fallback.
- Registers Skybridge in the universal touch menu.

## Verification
- `python3 -m pytest services/zoe-data/tests/test_skybridge_static.py services/zoe-data/tests/test_ui_orchestrator_types.py services/zoe-data/tests/test_ag_ui_chat_contract.py -q`
- `python3 tools/audit/validate_structure.py`
- `python3 tools/audit/validate_critical_files.py`
- Headless Chrome screenshots verified at 1280x800 and 390x844 via temporary static server.

## Notes
- This is frontend-first foundation work. Existing backend voice/card paths continue to work; richer backend card production can plug into the Skybridge renderer through the card/event normalizer.
- LiveKit remains a transport, not a UI dependency. Skybridge falls back to local WebSocket voice.
