### PR TITLE
ZOE-5439: add calendar card builders

### DIFF
--- a/services/zoe-data/card_service.py
+++ b/services/zoe-data/card_service.py
@@ -7,8 +7,59 @@ from typing import Any
 from card_contract import (
     validate_card_contract,
     CardContractError,
+    CardType,
     renderer_accepts,
 )
+
+
+def _text(value: Any, default: str = "") -> str:
+    text = str(value or "").strip()
+    return text or default
+
+
+def build_calendar_timeline_content(slots: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Build canonical content for a calendar timeline summary card."""
+    slots = slots or {}
+    qualifier = _text(slots.get("qualifier") or slots.get("date"), "today")
+    events = slots.get("events") or []
+    if not isinstance(events, list):
+        events = [events]
+    return {
+        "title": f"Calendar for {qualifier}",
+        "summary": "Showing calendar",
+        "qualifier": qualifier,
+        "events": events,
+        "view": "timeline",
+        "source": "calendar_show",
+    }
+
+
+def build_calendar_event_editor_content(slots: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Build canonical content for a calendar event editor card."""
+    slots = slots or {}
+    title = _text(slots.get("title") or slots.get("event"), "New event")
+    return {
+        "form_id": "calendar_event_editor",
+        "title": "New Calendar Event",
+        "fields": [
+            {"name": "title", "label": "Title", "type": "text", "value": title},
+            {"name": "date", "label": "Date", "type": "date", "value": _text(slots.get("date"))},
+            {"name": "time", "label": "Time", "type": "time", "value": _text(slots.get("time"))},
+            {"name": "duration", "label": "Duration", "type": "text", "value": _text(slots.get("duration"))},
+            {"name": "location", "label": "Location", "type": "text", "value": _text(slots.get("location"))},
+            {"name": "notes", "label": "Notes", "type": "textarea", "value": _text(slots.get("notes"))},
+        ],
+        "values": {
+            "title": title,
+            "date": _text(slots.get("date")),
+            "time": _text(slots.get("time")),
+            "duration": _text(slots.get("duration")),
+            "location": _text(slots.get("location")),
+            "notes": _text(slots.get("notes")),
+            "category": _text(slots.get("category"), "general"),
+        },
+        "source": "calendar_create",
+    }
 
 
 class CardService:
@@ -103,5 +154,23 @@ class CardService:
         return self._domain_builders.get(card_type)
 
 
+    def build_calendar_timeline_card(self, slots: dict[str, Any] | None = None) -> dict[str, Any]:
+        return self.build_card(
+            CardType.GENERIC.value,
+            build_calendar_timeline_content(slots),
+            producer="zoe-calendar",
+        )
+
+    def build_calendar_event_editor_card(self, slots: dict[str, Any] | None = None) -> dict[str, Any]:
+        return self.build_card(
+            CardType.ACTION_FORM.value,
+            build_calendar_event_editor_content(slots),
+            producer="zoe-calendar",
+        )
+
+
+
 # Global singleton instance
 card_service = CardService()
+card_service.register_domain_builder("calendar_timeline", card_service.build_calendar_timeline_card)
+card_service.register_domain_builder("calendar_event_editor", card_service.build_calendar_event_editor_card)

--- a/services/zoe-data/routers/chat.py
+++ b/services/zoe-data/routers/chat.py
@@ -58,7 +58,7 @@ def _intent_card_data(intent) -> dict:
     slots = intent.slots or {}
     name = intent.name
     if name == "calendar_create":
-        return {
+        payload = {
             "type": "calendar",
             "data": {
                 "action": "Event added",
@@ -67,14 +67,28 @@ def _intent_card_data(intent) -> dict:
                 "time": slots.get("time") or "",
             },
         }
+        try:
+            from card_service import card_service
+
+            payload["card"] = card_service.build_calendar_event_editor_card(slots)
+        except Exception as exc:
+            logger.debug("calendar_create card contract build failed: %s", exc)
+        return payload
     if name == "calendar_show":
-        return {
+        payload = {
             "type": "calendar",
             "data": {
                 "action": "Showing calendar",
                 "qualifier": slots.get("qualifier") or "today",
             },
         }
+        try:
+            from card_service import card_service
+
+            payload["card"] = card_service.build_calendar_timeline_card(slots)
+        except Exception as exc:
+            logger.debug("calendar_show card contract build failed: %s", exc)
+        return payload
     if name == "list_add":
         return {
             "type": "list",
@@ -187,6 +201,8 @@ async def _broadcast_intent_nav(intent, panel_id: str | None = None) -> None:
                 # Also emit show_card for the dashboard bar.
                 card = _intent_card_data(intent)
                 card_payload: dict = {"type": card["type"], "data": card["data"]}
+                if card.get("card"):
+                    card_payload["card"] = card["card"]
                 if panel_id:
                     card_payload["panel_id"] = panel_id
                 await broadcaster.broadcast("all", "ui_action", {
@@ -224,6 +240,8 @@ async def _broadcast_intent_nav(intent, panel_id: str | None = None) -> None:
             })
         card = _intent_card_data(intent)
         card_payload_nav: dict = {"type": card["type"], "data": card["data"]}
+        if card.get("card"):
+            card_payload_nav["card"] = card["card"]
         if panel_id:
             card_payload_nav["panel_id"] = panel_id
         await broadcaster.broadcast("all", "ui_action", {
@@ -234,7 +252,7 @@ async def _broadcast_intent_nav(intent, panel_id: str | None = None) -> None:
             }
         })
     except Exception as exc:
-        logger.debug("_broadcast_intent_nav failed (non-fatal): %s", exc)
+        logger.warning("_broadcast_intent_nav failed (non-fatal): %s", exc)
 from openclaw_ws import openclaw_cli, chat_inject, discover_openclaw_capabilities, _zoe_context_prefix
 from zoe_acp_client import openclaw_acp_stream as _acp_stream
 from zoe_agent import (

--- a/services/zoe-data/tests/test_card_service.py
+++ b/services/zoe-data/tests/test_card_service.py
@@ -135,3 +135,38 @@ def test_global_card_service_instance():
         assert card_service.get_domain_builder("generic") is builder
     finally:
         card_service._domain_builders.clear()
+        card_service.register_domain_builder("calendar_timeline", card_service.build_calendar_timeline_card)
+        card_service.register_domain_builder("calendar_event_editor", card_service.build_calendar_event_editor_card)
+
+
+def test_card_service_build_calendar_timeline_card():
+    service = CardService()
+    card = service.build_calendar_timeline_card({"qualifier": "tomorrow", "events": [{"title": "School"}]})
+
+    assert card["card_type"] == CardType.GENERIC.value
+    assert card["producer"] == "zoe-calendar"
+    assert card["content"]["view"] == "timeline"
+    assert card["content"]["qualifier"] == "tomorrow"
+    assert card["content"]["events"] == [{"title": "School"}]
+
+
+def test_card_service_build_calendar_event_editor_card():
+    service = CardService()
+    card = service.build_calendar_event_editor_card({"title": "Dentist", "date": "tomorrow", "time": "9am"})
+
+    assert card["card_type"] == CardType.ACTION_FORM.value
+    assert card["producer"] == "zoe-calendar"
+    assert card["content"]["form_id"] == "calendar_event_editor"
+    assert card["content"]["values"]["title"] == "Dentist"
+    assert card["content"]["values"]["date"] == "tomorrow"
+    assert {field["name"] for field in card["content"]["fields"]} >= {"title", "date", "time"}
+
+
+def test_global_card_service_registers_calendar_builders():
+    timeline = card_service.get_domain_builder("calendar_timeline")
+    editor = card_service.get_domain_builder("calendar_event_editor")
+
+    assert callable(timeline)
+    assert callable(editor)
+    assert timeline({"qualifier": "today"})["content"]["view"] == "timeline"
+    assert editor({"title": "Dentist"})["content"]["form_id"] == "calendar_event_editor"

--- a/services/zoe-data/tests/test_chat_calendar_cards.py
+++ b/services/zoe-data/tests/test_chat_calendar_cards.py
@@ -1,0 +1,31 @@
+"""Tests for calendar intent canonical card emission."""
+
+from intent_router import Intent
+from routers.chat import _intent_card_data
+
+
+def test_calendar_show_payload_keeps_compat_shape_and_adds_contract():
+    payload = _intent_card_data(Intent("calendar_show", {"qualifier": "tomorrow"}))
+
+    assert payload["type"] == "calendar"
+    assert payload["data"] == {"action": "Showing calendar", "qualifier": "tomorrow"}
+    assert payload["card"]["card_type"] == "generic"
+    assert payload["card"]["content"]["view"] == "timeline"
+    assert payload["card"]["content"]["qualifier"] == "tomorrow"
+
+
+def test_calendar_create_payload_keeps_compat_shape_and_adds_editor_contract():
+    payload = _intent_card_data(
+        Intent("calendar_create", {"title": "Dentist", "date": "tomorrow", "time": "9am"})
+    )
+
+    assert payload["type"] == "calendar"
+    assert payload["data"] == {
+        "action": "Event added",
+        "title": "Dentist",
+        "date": "tomorrow",
+        "time": "9am",
+    }
+    assert payload["card"]["card_type"] == "action_form"
+    assert payload["card"]["content"]["form_id"] == "calendar_event_editor"
+    assert payload["card"]["content"]["values"]["title"] == "Dentist"


### PR DESCRIPTION
## Summary\n- add canonical calendar timeline and event-editor card builders to card_service\n- include canonical calendar cards in chat intent show_card payloads while preserving the existing {type,data} compatibility shape\n- add focused tests for calendar builders and chat payload emission\n\n## Validation\n- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_card_contract.py services/zoe-data/tests/test_card_service.py services/zoe-data/tests/test_chat_calendar_cards.py services/zoe-data/tests/test_voice_weather_queue.py\n- python3 tools/audit/validate_structure.py