### PR TITLE
ZOE-5440: add shopping card builders

### DIFF
--- a/services/zoe-data/card_service.py
+++ b/services/zoe-data/card_service.py
@@ -100,6 +100,58 @@ def build_calendar_event_editor_content(slots: dict[str, Any] | None = None) -> 
     }
 
 
+def _list_items(slots: dict[str, Any]) -> list[str]:
+    raw_items = slots.get("items")
+    if isinstance(raw_items, list):
+        items = raw_items
+    elif raw_items:
+        items = [raw_items]
+    else:
+        item = slots.get("item") or slots.get("text")
+        items = [item] if item else []
+    return [_text(item) for item in items if _text(item)]
+
+
+def build_shopping_list_content(slots: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Build canonical content for a shopping/list view card."""
+    slots = slots or {}
+    list_name = _text(slots.get("list_name") or slots.get("list_type"), "Shopping")
+    items = _list_items(slots)
+    return {
+        "title": f"{list_name} List",
+        "list_name": list_name,
+        "items": items,
+        "item_count": len(items),
+        "view": "list",
+        "source": "list_show",
+    }
+
+
+def build_shopping_item_editor_content(slots: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Build canonical content for a shopping/list item editor card."""
+    slots = slots or {}
+    list_name = _text(slots.get("list_name") or slots.get("list_type"), "Shopping")
+    item = _text(slots.get("item") or slots.get("text"))
+    return {
+        "form_id": "shopping_item_editor",
+        "title": "Add List Item",
+        "fields": [
+            {"name": "item", "label": "Item", "type": "text", "value": item},
+            {"name": "list_name", "label": "List", "type": "text", "value": list_name},
+            {"name": "quantity", "label": "Quantity", "type": "text", "value": _text(slots.get("quantity"))},
+            {"name": "notes", "label": "Notes", "type": "textarea", "value": _text(slots.get("notes"))},
+        ],
+        "values": {
+            "item": item,
+            "list_name": list_name,
+            "list_type": _text(slots.get("list_type"), "shopping"),
+            "quantity": _text(slots.get("quantity")),
+            "notes": _text(slots.get("notes")),
+        },
+        "source": "list_add",
+    }
+
+
 class CardService:
     """Service layer for Zoe card operations."""
 
@@ -221,6 +273,21 @@ class CardService:
         )
 
 
+    def build_shopping_list_card(self, slots: dict[str, Any] | None = None) -> dict[str, Any]:
+        return self.build_card(
+            CardType.GENERIC.value,
+            build_shopping_list_content(slots),
+            producer="zoe-shopping",
+        )
+
+    def build_shopping_item_editor_card(self, slots: dict[str, Any] | None = None) -> dict[str, Any]:
+        return self.build_card(
+            CardType.ACTION_FORM.value,
+            build_shopping_item_editor_content(slots),
+            producer="zoe-shopping",
+        )
+
+
 
 # Global singleton instance
 card_service = CardService()
@@ -228,3 +295,5 @@ card_service.register_domain_builder("calendar_timeline", card_service.build_cal
 card_service.register_domain_builder("calendar_event_editor", card_service.build_calendar_event_editor_card)
 card_service.register_domain_builder("weather_current", card_service.build_weather_current_card)
 card_service.register_domain_builder("weather_forecast", card_service.build_weather_forecast_card)
+card_service.register_domain_builder("shopping_list", card_service.build_shopping_list_card)
+card_service.register_domain_builder("shopping_item_editor", card_service.build_shopping_item_editor_card)

--- a/services/zoe-data/routers/chat.py
+++ b/services/zoe-data/routers/chat.py
@@ -90,13 +90,38 @@ def _intent_card_data(intent) -> dict:
             logger.debug("calendar_show card contract build failed: %s", exc)
         return payload
     if name == "list_add":
-        return {
+        payload = {
             "type": "list",
             "data": {
                 "list_name": slots.get("list_name") or "List",
                 "item": slots.get("item") or slots.get("text") or "",
             },
         }
+        try:
+            from card_service import card_service
+
+            payload["card"] = card_service.build_shopping_item_editor_card(slots)
+        except Exception as exc:
+            logger.debug("list_add card contract build failed: %s", exc)
+        return payload
+    if name == "list_show":
+        items = slots.get("items") or []
+        if items and not isinstance(items, list):
+            items = [items]
+        payload = {
+            "type": "list",
+            "data": {
+                "list_name": slots.get("list_name") or "Shopping",
+                "items": items,
+            },
+        }
+        try:
+            from card_service import card_service
+
+            payload["card"] = card_service.build_shopping_list_card(slots)
+        except Exception as exc:
+            logger.debug("list_show card contract build failed: %s", exc)
+        return payload
     if name == "timer_create":
         return {
             "type": "timer",

--- a/services/zoe-data/routers/chat.py
+++ b/services/zoe-data/routers/chat.py
@@ -117,7 +117,7 @@ def _intent_card_data(intent) -> dict:
         payload = {
             "type": "list",
             "data": {
-                "list_name": slots.get("list_name") or "Shopping",
+                "list_name": slots.get("list_name") or slots.get("list_type") or "Shopping",
                 "items": items,
             },
         }
@@ -190,7 +190,7 @@ def _intent_action_form_payload(intent, panel_id: str | None = None) -> dict | N
             "panel_type": "shopping_list",
             "title": f"{slots.get('list_name', 'Shopping')} List",
             "data": {
-                "list_name": slots.get("list_name") or "Shopping",
+                "list_name": slots.get("list_name") or slots.get("list_type") or "Shopping",
                 "items": items,
                 "item": slots.get("item") or "",
             },

--- a/services/zoe-data/routers/chat.py
+++ b/services/zoe-data/routers/chat.py
@@ -93,7 +93,7 @@ def _intent_card_data(intent) -> dict:
         payload = {
             "type": "list",
             "data": {
-                "list_name": slots.get("list_name") or "List",
+                "list_name": slots.get("list_name") or slots.get("list_type") or "Shopping",
                 "item": slots.get("item") or slots.get("text") or "",
             },
         }
@@ -105,9 +105,15 @@ def _intent_card_data(intent) -> dict:
             logger.debug("list_add card contract build failed: %s", exc)
         return payload
     if name == "list_show":
-        items = slots.get("items") or []
-        if items and not isinstance(items, list):
-            items = [items]
+        raw_items = slots.get("items")
+        if isinstance(raw_items, list):
+            items = raw_items
+        elif raw_items:
+            items = [raw_items]
+        elif slots.get("item") or slots.get("text"):
+            items = [slots.get("item") or slots.get("text")]
+        else:
+            items = []
         payload = {
             "type": "list",
             "data": {

--- a/services/zoe-data/routers/chat.py
+++ b/services/zoe-data/routers/chat.py
@@ -188,7 +188,7 @@ def _intent_action_form_payload(intent, panel_id: str | None = None) -> dict | N
             items = raw if isinstance(raw, list) else [str(raw)]
         return {
             "panel_type": "shopping_list",
-            "title": f"{slots.get('list_name', 'Shopping')} List",
+            "title": f"{slots.get('list_name') or slots.get('list_type') or 'Shopping'} List",
             "data": {
                 "list_name": slots.get("list_name") or slots.get("list_type") or "Shopping",
                 "items": items,

--- a/services/zoe-data/tests/test_card_service.py
+++ b/services/zoe-data/tests/test_card_service.py
@@ -137,6 +137,8 @@ def test_global_card_service_instance():
         card_service._domain_builders.clear()
         card_service.register_domain_builder("calendar_timeline", card_service.build_calendar_timeline_card)
         card_service.register_domain_builder("calendar_event_editor", card_service.build_calendar_event_editor_card)
+        card_service.register_domain_builder("shopping_list", card_service.build_shopping_list_card)
+        card_service.register_domain_builder("shopping_item_editor", card_service.build_shopping_item_editor_card)
 
 
 def test_card_service_build_calendar_timeline_card():
@@ -170,3 +172,37 @@ def test_global_card_service_registers_calendar_builders():
     assert callable(editor)
     assert timeline({"qualifier": "today"})["content"]["view"] == "timeline"
     assert editor({"title": "Dentist"})["content"]["form_id"] == "calendar_event_editor"
+
+
+def test_card_service_build_shopping_list_card():
+    service = CardService()
+    card = service.build_shopping_list_card({"list_name": "Groceries", "items": ["milk", "bread"]})
+
+    assert card["card_type"] == CardType.GENERIC.value
+    assert card["producer"] == "zoe-shopping"
+    assert card["content"]["view"] == "list"
+    assert card["content"]["list_name"] == "Groceries"
+    assert card["content"]["items"] == ["milk", "bread"]
+    assert card["content"]["item_count"] == 2
+
+
+def test_card_service_build_shopping_item_editor_card():
+    service = CardService()
+    card = service.build_shopping_item_editor_card({"list_name": "Groceries", "item": "milk", "quantity": "2"})
+
+    assert card["card_type"] == CardType.ACTION_FORM.value
+    assert card["producer"] == "zoe-shopping"
+    assert card["content"]["form_id"] == "shopping_item_editor"
+    assert card["content"]["values"]["item"] == "milk"
+    assert card["content"]["values"]["list_name"] == "Groceries"
+    assert {field["name"] for field in card["content"]["fields"]} >= {"item", "list_name", "quantity"}
+
+
+def test_global_card_service_registers_shopping_builders():
+    list_builder = card_service.get_domain_builder("shopping_list")
+    editor_builder = card_service.get_domain_builder("shopping_item_editor")
+
+    assert callable(list_builder)
+    assert callable(editor_builder)
+    assert list_builder({"items": ["milk"]})["content"]["view"] == "list"
+    assert editor_builder({"item": "milk"})["content"]["form_id"] == "shopping_item_editor"

--- a/services/zoe-data/tests/test_chat_shopping_cards.py
+++ b/services/zoe-data/tests/test_chat_shopping_cards.py
@@ -1,0 +1,26 @@
+"""Tests for shopping/list intent canonical card emission."""
+
+from intent_router import Intent
+from routers.chat import _intent_card_data
+
+
+def test_list_show_payload_keeps_compat_shape_and_adds_contract():
+    payload = _intent_card_data(Intent("list_show", {"list_name": "Groceries", "items": ["milk"]}))
+
+    assert payload["type"] == "list"
+    assert payload["data"] == {"list_name": "Groceries", "items": ["milk"]}
+    assert payload["card"]["card_type"] == "generic"
+    assert payload["card"]["content"]["view"] == "list"
+    assert payload["card"]["content"]["list_name"] == "Groceries"
+    assert payload["card"]["content"]["items"] == ["milk"]
+
+
+def test_list_add_payload_keeps_compat_shape_and_adds_editor_contract():
+    payload = _intent_card_data(Intent("list_add", {"list_name": "Groceries", "item": "milk"}))
+
+    assert payload["type"] == "list"
+    assert payload["data"] == {"list_name": "Groceries", "item": "milk"}
+    assert payload["card"]["card_type"] == "action_form"
+    assert payload["card"]["content"]["form_id"] == "shopping_item_editor"
+    assert payload["card"]["content"]["values"]["item"] == "milk"
+    assert payload["card"]["content"]["values"]["list_name"] == "Groceries"

--- a/services/zoe-data/tests/test_chat_shopping_cards.py
+++ b/services/zoe-data/tests/test_chat_shopping_cards.py
@@ -1,7 +1,7 @@
 """Tests for shopping/list intent canonical card emission."""
 
 from intent_router import Intent
-from routers.chat import _intent_card_data
+from routers.chat import _intent_action_form_payload, _intent_card_data
 
 
 def test_list_show_payload_keeps_compat_shape_and_adds_contract():
@@ -45,3 +45,10 @@ def test_list_show_payload_list_type_matches_contract():
 
     assert payload["data"]["list_name"] == "Hardware"
     assert payload["card"]["content"]["list_name"] == "Hardware"
+
+
+def test_list_action_form_title_list_type_matches_data():
+    payload = _intent_action_form_payload(Intent("list_show", {"list_type": "Hardware", "items": ["screws"]}))
+
+    assert payload["title"] == "Hardware List"
+    assert payload["data"]["list_name"] == "Hardware"

--- a/services/zoe-data/tests/test_chat_shopping_cards.py
+++ b/services/zoe-data/tests/test_chat_shopping_cards.py
@@ -24,3 +24,17 @@ def test_list_add_payload_keeps_compat_shape_and_adds_editor_contract():
     assert payload["card"]["content"]["form_id"] == "shopping_item_editor"
     assert payload["card"]["content"]["values"]["item"] == "milk"
     assert payload["card"]["content"]["values"]["list_name"] == "Groceries"
+
+
+def test_list_add_payload_defaults_match_contract():
+    payload = _intent_card_data(Intent("list_add", {"item": "milk"}))
+
+    assert payload["data"]["list_name"] == "Shopping"
+    assert payload["card"]["content"]["values"]["list_name"] == "Shopping"
+
+
+def test_list_show_payload_singular_item_matches_contract():
+    payload = _intent_card_data(Intent("list_show", {"item": "milk"}))
+
+    assert payload["data"]["items"] == ["milk"]
+    assert payload["card"]["content"]["items"] == ["milk"]

--- a/services/zoe-data/tests/test_chat_shopping_cards.py
+++ b/services/zoe-data/tests/test_chat_shopping_cards.py
@@ -38,3 +38,10 @@ def test_list_show_payload_singular_item_matches_contract():
 
     assert payload["data"]["items"] == ["milk"]
     assert payload["card"]["content"]["items"] == ["milk"]
+
+
+def test_list_show_payload_list_type_matches_contract():
+    payload = _intent_card_data(Intent("list_show", {"list_type": "Hardware", "items": ["screws"]}))
+
+    assert payload["data"]["list_name"] == "Hardware"
+    assert payload["card"]["content"]["list_name"] == "Hardware"


### PR DESCRIPTION
## Summary
- add canonical shopping/list view and item-editor card builders
- attach shopping card contracts to list_show/list_add chat intent payloads while preserving compat data
- add focused card service and chat intent tests

## Tests
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_card_contract.py services/zoe-data/tests/test_card_service.py services/zoe-data/tests/test_chat_calendar_cards.py services/zoe-data/tests/test_chat_shopping_cards.py services/zoe-data/tests/test_voice_weather_queue.py
- python3 tools/audit/validate_structure.py

## Production note
- Real ticket ZOE-5440; Hermes implement t_dd187be3 hit the new budget guard with no changes, so this PR is manual repair under paused dispatch.