### PR TITLE
Surface Hermes block reasons in Multica

### DIFF
--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -961,11 +961,15 @@ class KanbanAdapter:
             elif is_v4:
                 if pipeline_info.get("terminal_block"):
                     agg = "blocked"
-                    blocker = f"pipeline terminal block at {current_phase}"
+                    blocker = pipeline_info.get("block_reason") or f"pipeline terminal block at {current_phase}"
                 elif current_status == "blocked":
                     agg = "blocked"
                     current_row = phases.get(str(current_phase or ""), {})
-                    blocker = current_row.get("block_reason") or f"pipeline blocked at {current_phase}"
+                    blocker = (
+                        pipeline_info.get("block_reason")
+                        or current_row.get("block_reason")
+                        or f"pipeline blocked at {current_phase}"
+                    )
                 elif current_status == "todo":
                     agg = "partial" if current_phase not in phases else "running"
                     blocker = None

--- a/services/zoe-data/main.py
+++ b/services/zoe-data/main.py
@@ -175,6 +175,7 @@ async def _record_blocked_multica_chain(client, issue_id: str, chain: dict) -> s
         pr_url=chain.get("pr_url"),
         blocker=blocker,
         status="blocked",
+        dispatch_approved=False,
     )
     return blocker
 

--- a/services/zoe-data/multica_client.py
+++ b/services/zoe-data/multica_client.py
@@ -346,6 +346,7 @@ class MULClient:
         greptile_status: str | None = None,
         merge_sha: str | None = None,
         status: str | None = None,
+        dispatch_approved: bool | None = None,
     ) -> dict:
         """Record operator-visible Zoe progress on a Multica issue."""
         from multica_ticket_contract import update_ticket_progress
@@ -362,6 +363,7 @@ class MULClient:
             clear_blocker=clear_blocker,
             greptile_status=greptile_status,
             merge_sha=merge_sha,
+            dispatch_approved=dispatch_approved,
         )
         return await self.update_issue(issue_id, status=status, description=updated_description)
 

--- a/services/zoe-data/multica_ticket_contract.py
+++ b/services/zoe-data/multica_ticket_contract.py
@@ -115,6 +115,7 @@ def update_ticket_progress(
     greptile_status: str | None = None,
     merge_sha: str | None = None,
     child_issue_ids: list[str] | None = None,
+    dispatch_approved: bool | None = None,
 ) -> str:
     """Patch progress fields inside the Zoe block without touching prose."""
     current = parse_ticket_block(description)
@@ -135,6 +136,8 @@ def update_ticket_progress(
         metadata["merge_sha"] = merge_sha
     if child_issue_ids is not None:
         metadata["child_issue_ids"] = child_issue_ids
+    if dispatch_approved is not None:
+        metadata["dispatch_approved"] = dispatch_approved
     metadata["updated_at"] = datetime.now(timezone.utc).isoformat()
     return write_ticket_block(description, metadata)
 

--- a/services/zoe-data/pipeline_store.py
+++ b/services/zoe-data/pipeline_store.py
@@ -359,6 +359,12 @@ def pipeline_summary(state: PipelineState | None) -> dict[str, Any]:
     if not state:
         return {"tracked": False}
     missing = sorted(missing_required_evidence(state))
+    block_reason = None
+    if state.status == "blocked":
+        for record in reversed(state.history):
+            if record.outcome in {"block", "verification_failed", "request_changes", "merge_blocked"}:
+                block_reason = record.reason
+                break
     fingerprint_abort = state.status == "blocked" and (
         state.repeated_block_count >= 2
         or any(
@@ -381,6 +387,7 @@ def pipeline_summary(state: PipelineState | None) -> dict[str, Any]:
         "attempts": dict(state.attempts),
         "terminal_block": terminal_block,
         "fingerprint_abort": fingerprint_abort,
+        "block_reason": block_reason,
         "block_classification": state.block_classification,
         "needs_split": state.status == "blocked" and state.block_classification == "scope_split_required",
         "split_packet": state.split_packet,

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -1171,6 +1171,36 @@ async def test_poll_v4_does_not_promote_kanban_blocked_to_partial():
 
 
 @pytest.mark.asyncio
+async def test_poll_v4_prefers_journal_block_reason_over_kanban_row():
+    rows = [
+        _row(
+            "implement",
+            "blocked",
+            chain_version="v4",
+            block_reason="pipeline blocked at implement",
+        )
+    ]
+    show = {
+        "t_implement": {
+            "latest_summary": (
+                "BLOCKER=IMPLEMENT_BUDGET: code-enforced tool budget exceeded "
+                "(steps=17, guidance_limit=14, hard_limit=16)"
+            ),
+            "comments": [],
+        }
+    }
+    a = _FakeAdapter(list_rows=rows, show_map=show)
+    out = await a.poll("multica:uuid-9")
+
+    assert out["status"] == "blocked"
+    assert out["blocker"] == (
+        "IMPLEMENT_BUDGET: code-enforced tool budget exceeded "
+        "(steps=17, guidance_limit=14, hard_limit=16)"
+    )
+    assert out["pipeline"]["block_reason"] == out["blocker"]
+
+
+@pytest.mark.asyncio
 async def test_poll_current_partial_chain_with_verify_is_redispatchable():
     rows = [
         _row("implement", "done"),

--- a/services/zoe-data/tests/test_main_multica_poll.py
+++ b/services/zoe-data/tests/test_main_multica_poll.py
@@ -231,6 +231,7 @@ async def test_record_blocked_multica_chain_records_terminal_block_metadata():
                 "pr_url": "https://github.com/o/r/pull/7",
                 "blocker": "terminal block: implement blocked",
                 "status": "blocked",
+                "dispatch_approved": False,
             },
         )
     ]
@@ -251,6 +252,7 @@ async def test_record_blocked_multica_chain_uses_non_terminal_block_reason_witho
     assert blocker == "tests failed"
     assert client.calls[0][1]["phase"] == "verify"
     assert client.calls[0][1]["blocker"] == "tests failed"
+    assert client.calls[0][1]["dispatch_approved"] is False
     assert not client.calls[0][1]["blocker"].startswith("terminal block:")
 
 
@@ -274,4 +276,6 @@ async def test_record_blocked_multica_chain_falls_back_to_classification_and_def
     assert classified == "blocked_external"
     assert defaulted == "pipeline blocked at retro"
     assert client.calls[0][1]["blocker"] == "blocked_external"
+    assert client.calls[0][1]["dispatch_approved"] is False
     assert client.calls[1][1]["blocker"] == "pipeline blocked at retro"
+    assert client.calls[1][1]["dispatch_approved"] is False

--- a/services/zoe-data/tests/test_multica_client_helpers.py
+++ b/services/zoe-data/tests/test_multica_client_helpers.py
@@ -48,6 +48,29 @@ async def test_record_progress_can_clear_blocker():
     assert metadata["phase"] == "closeout"
 
 
+def test_update_ticket_progress_can_clear_dispatch_approval():
+    from multica_ticket_contract import parse_ticket_block, update_ticket_progress, write_ticket_block
+
+    description = write_ticket_block(
+        "Human prose",
+        {
+            "schema": 1,
+            "dispatch_approved": True,
+            "blocked_reason": None,
+        },
+    )
+
+    updated = update_ticket_progress(
+        description,
+        blocker="IMPLEMENT_BUDGET: code-enforced tool budget exceeded",
+        dispatch_approved=False,
+    )
+
+    metadata = parse_ticket_block(updated)
+    assert metadata["dispatch_approved"] is False
+    assert metadata["blocked_reason"] == "IMPLEMENT_BUDGET: code-enforced tool budget exceeded"
+
+
 @pytest.mark.asyncio
 async def test_create_issue_metadata_preserves_existing_ticket_fields():
     created_payload = {}

--- a/services/zoe-data/tests/test_pipeline_store.py
+++ b/services/zoe-data/tests/test_pipeline_store.py
@@ -748,6 +748,7 @@ async def test_sync_pipeline_blocked_records_reason_in_history(isolated_store):
     state = await store.sync_pipeline_from_chain("multica:block-reason", phases, fetch_detail)
     assert state.status == "blocked"
     assert state.history[-1].reason == "dirty tree"
+    assert store.pipeline_summary(state)["block_reason"] == "dirty tree"
 
     last = json.loads(isolated_store.read_text(encoding="utf-8").strip().splitlines()[-1])
     assert last["meta"]["block_reason"] == "dirty tree"


### PR DESCRIPTION
## Summary
- expose the latest journaled pipeline block reason in pipeline summaries
- prefer that journal reason when Kanban rows do not carry a block_reason
- record blocked Multica progress with dispatch_approved=false so blocked tickets cannot look eligible for redispatch

## Why
A real production test on ZOE-5440 hit the implement budget guard. Zoe journal had the exact blocker, but Multica only showed a generic pipeline-blocked message and still had dispatch_approved=true. This PR fixes that system failure path instead of manually advancing product tickets.

## Tests
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_pipeline_store.py services/zoe-data/tests/test_kanban_adapter.py services/zoe-data/tests/test_main_multica_poll.py services/zoe-data/tests/test_multica_client_helpers.py services/zoe-data/tests/test_multica_poll_dispatch.py

Live host result: 141 passed.
