### PR TITLE
Skip scout for narrow harness-fix tickets

### DIFF
--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -227,6 +227,11 @@ def _skip_scout(issue: dict | None = None) -> bool:
         and bool(meta.get("acceptance_criteria"))
     ):
         return True
+    if (
+        str(meta.get("zoe_kind") or "").strip().lower() == "harness_fix"
+        and bool(meta.get("acceptance_criteria"))
+    ):
+        return True
     haystack = " ".join(
         [
             str(issue.get("title") or ""),

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -310,6 +310,57 @@ async def test_dispatch_skips_scout_for_scope_split_child_ticket_block():
 
 
 @pytest.mark.asyncio
+async def test_dispatch_skips_scout_for_harness_fix_with_acceptance_criteria():
+    a = _FakeAdapter()
+    result = await a.dispatch(
+        {
+            "id": "uuid-harness-fix",
+            "identifier": "ZOE-5446",
+            "title": "Harness follow-up for implement budget blocks",
+            "description": (
+                "```zoe-ticket\n"
+                '{"zoe_kind":"harness_fix","acceptance_criteria":["idempotent follow-up ticket"]}'
+                "\n```"
+            ),
+        }
+    )
+    assert "scout" not in result["chain"]
+    assert set(result["chain"]) == {"implement"}
+
+
+@pytest.mark.asyncio
+async def test_dispatch_skips_scout_for_harness_fix_metadata_with_acceptance_criteria():
+    a = _FakeAdapter()
+    result = await a.dispatch(
+        {
+            "id": "uuid-harness-fix-meta",
+            "identifier": "ZOE-5447",
+            "title": "Harness follow-up for scout budget blocks",
+            "metadata": {
+                "zoe_kind": "harness_fix",
+                "acceptance_criteria": ["budget blockers create one follow-up ticket"],
+            },
+        }
+    )
+    assert "scout" not in result["chain"]
+    assert set(result["chain"]) == {"implement"}
+
+
+@pytest.mark.asyncio
+async def test_dispatch_keeps_scout_for_harness_fix_without_acceptance_criteria():
+    a = _FakeAdapter()
+    result = await a.dispatch(
+        {
+            "id": "uuid-harness-fix-no-criteria",
+            "identifier": "ZOE-5448",
+            "title": "Harness follow-up without a concrete contract",
+            "metadata": {"zoe_kind": "harness_fix"},
+        }
+    )
+    assert set(result["chain"]) == {"scout"}
+
+
+@pytest.mark.asyncio
 async def test_dispatch_adjusts_stale_scout_journal_for_scope_split_child():
     from pipeline_evidence import PipelineState
     from pipeline_store import load_latest_state, save_state


### PR DESCRIPTION
## Summary
- skip the scout phase for narrow `harness_fix` tickets that already have acceptance criteria
- add regression coverage for the ZOE-5446 failure shape

## Why
The ZOE-5446 system-only test proved blocked-ticket metadata now works, but scout spent 13 tool steps and hit SCOUT_BUDGET on a narrow harness-fix ticket. Harness-fix tickets with explicit acceptance criteria are already scoped enough to start at implement, just like scope-split child tickets.

## Tests
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_kanban_adapter.py services/zoe-data/tests/test_multica_poll_dispatch.py

Live host result: 93 passed.
