### PR TITLE
Allow resumed pipelines past stale blocked rows

### DIFF
--- a/services/zoe-data/multica_poll_dispatch.py
+++ b/services/zoe-data/multica_poll_dispatch.py
@@ -7,10 +7,13 @@ def chain_needs_dispatch(chain: dict) -> bool:
 
     The poll bridge dispatches when there is no active run yet (``not_found``) or
     when the journal has a next ready phase with no Kanban row yet (``partial``).
-    Legacy interrupted chains also report ``partial``. Active ``running`` /
-    ``blocked`` chains and completed ``done`` chains are left alone.
+    Legacy interrupted chains also report ``partial``. Active ``running`` and
+    completed ``done`` chains are left alone. ``blocked`` chains are also left
+    alone unless the pipeline has been reset to ``todo`` by an operator, in
+    which case the stale executor row is treated as resumable.
 
-    Pipeline ``fingerprint_abort`` / ``terminal_block`` also suppresses redispatch.
+    Pipeline ``fingerprint_abort`` / ``terminal_block`` suppresses redispatch
+    regardless of executor or pipeline status.
     """
     if not chain:
         return False
@@ -18,6 +21,8 @@ def chain_needs_dispatch(chain: dict) -> bool:
     if pipeline.get("terminal_block") or pipeline.get("fingerprint_abort"):
         return False
     status = chain.get("status")
+    if status == "blocked" and pipeline.get("status") == "todo":
+        return True
     if status in ("running", "blocked", "done"):
         return False
     if status == "partial":

--- a/services/zoe-data/tests/test_multica_poll_dispatch.py
+++ b/services/zoe-data/tests/test_multica_poll_dispatch.py
@@ -17,6 +17,34 @@ def test_chain_needs_dispatch_running_blocked_done():
     assert chain_needs_dispatch({"found": True, "status": "done"}) is False
 
 
+def test_chain_needs_dispatch_for_operator_resumed_blocked_executor_row():
+    chain = {
+        "found": True,
+        "status": "blocked",
+        "blocker": "SCOUT_BUDGET: stale blocked row from before a plan adjustment",
+        "pipeline": {"status": "todo", "terminal_block": False, "fingerprint_abort": False},
+    }
+    assert chain_needs_dispatch(chain) is True
+
+
+def test_chain_needs_dispatch_does_not_resume_terminal_blocked_pipeline():
+    chain = {
+        "found": True,
+        "status": "blocked",
+        "pipeline": {"status": "todo", "terminal_block": True, "fingerprint_abort": False},
+    }
+    assert chain_needs_dispatch(chain) is False
+
+
+def test_chain_needs_dispatch_does_not_resume_fingerprint_blocked_pipeline():
+    chain = {
+        "found": True,
+        "status": "blocked",
+        "pipeline": {"status": "todo", "terminal_block": False, "fingerprint_abort": True},
+    }
+    assert chain_needs_dispatch(chain) is False
+
+
 def test_chain_needs_dispatch_suppressed_on_fingerprint_abort():
     chain = {
         "found": True,


### PR DESCRIPTION
## Summary
- let the Multica dispatch gate retry an operator-resumed pipeline even when the old executor row is blocked
- keep terminal/fingerprint blocked pipelines suppressed
- add regression coverage for resumed and terminal blocked states

## Validation
- python3 -m py_compile services/zoe-data/multica_poll_dispatch.py services/zoe-data/tests/test_multica_poll_dispatch.py
