### PR TITLE
Ignore stale skipped phases on resumed dispatch

### DIFF
--- a/scripts/maintenance/sync_multica_to_kanban.py
+++ b/scripts/maintenance/sync_multica_to_kanban.py
@@ -91,7 +91,7 @@ async def run(args: argparse.Namespace) -> int:
         # abort the whole batch and skip the remaining candidates. Mirrors the
         # outer try/except that guards board_approve and the Multica webhook handler.
         try:
-            existing = await poll_ref(f"multica:{issue_id}")
+            existing = await poll_ref(f"multica:{issue_id}", issue=issue)
             if not chain_needs_dispatch(existing):
                 print(f"SKIP {ident}: chain status={existing.get('status')}")
                 continue

--- a/services/zoe-data/executor_registry.py
+++ b/services/zoe-data/executor_registry.py
@@ -44,8 +44,8 @@ async def dispatch_issue(issue: dict) -> dict:
     return await adapter.dispatch(issue)
 
 
-async def poll_ref(external_ref: str, *, backend: str = "kanban") -> dict:
+async def poll_ref(external_ref: str, *, backend: str = "kanban", issue: dict | None = None) -> dict:
     """Poll an external reference for its aggregate status."""
     if backend == "kanban":
-        return await _kanban.poll(external_ref)
+        return await _kanban.poll(external_ref, issue=issue)
     return {"found": False, "status": "not_found", "reason": f"unknown backend {backend}"}

--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -873,7 +873,7 @@ class KanbanAdapter:
             return f"Retro {identifier}"[:140]
         return f"Closeout {identifier}"[:140]
 
-    async def poll(self, external_ref: str) -> dict:
+    async def poll(self, external_ref: str, *, issue: dict | None = None) -> dict:
         """Report aggregate state of a chain by idempotency-key prefix.
 
         Returns {found, status, phases:{phase:status}, pr_url, blocker}.
@@ -892,6 +892,37 @@ class KanbanAdapter:
         phases = await self._phases_for_ref(external_ref)
         if not phases:
             return {"found": False, "status": "not_found", "phases": {}, "pr_url": None, "blocker": None}
+
+        if issue:
+            try:
+                from pipeline_store import load_latest_state, pipeline_summary
+
+                existing_state = await asyncio.to_thread(load_latest_state, external_ref)
+                expected_phase_names = {entry[0] for entry in _chain_for_issue(issue)}
+                if (
+                    existing_state is not None
+                    and existing_state.status == "todo"
+                    and existing_state.phase not in expected_phase_names
+                ):
+                    phases = {
+                        phase: row
+                        for phase, row in phases.items()
+                        if phase in expected_phase_names
+                    }
+                    if not phases:
+                        return {
+                            "found": True,
+                            "status": "partial",
+                            "phases": {},
+                            "pr_url": None,
+                            "blocker": None,
+                            "pipeline": {
+                                **pipeline_summary(existing_state),
+                                "stale_executor_phase": existing_state.phase,
+                            },
+                        }
+            except Exception as exc:
+                logger.debug("kanban_adapter: stale phase filter skipped for %s: %s", external_ref, exc)
 
         detail_cache: dict[str, dict[str, Any]] = {}
         for phase, row in list(phases.items()):

--- a/services/zoe-data/intent_router.py
+++ b/services/zoe-data/intent_router.py
@@ -1657,7 +1657,7 @@ async def execute_intent(intent: Intent, user_id: str = "family-admin") -> Optio
             lines = ["**Active Hermes engineering issues:**"]
             for status, issue in active[:5]:
                 ident = issue.get("identifier") or issue.get("id")
-                chain = await poll_ref(f"multica:{issue.get('id')}")
+                chain = await poll_ref(f"multica:{issue.get('id')}", issue=issue)
                 phase = chain.get("status") if chain.get("found") else status
                 pr = f" | PR: {chain.get('pr_url')}" if chain.get("pr_url") else ""
                 lines.append(f"- `{ident}` — {phase} — {(issue.get('title') or '')[:80]}{pr}")

--- a/services/zoe-data/main.py
+++ b/services/zoe-data/main.py
@@ -476,9 +476,10 @@ async def lifespan(app: FastAPI):
                                     )
                         _chain_cache: dict[str, dict] = {}
 
-                        async def _poll_chain(_tid: str) -> dict:
+                        async def _poll_chain(_issue: dict) -> dict:
+                            _tid = str(_issue.get("id") or "")
                             if _tid not in _chain_cache:
-                                _chain_cache[_tid] = await poll_ref(f"multica:{_tid}")
+                                _chain_cache[_tid] = await poll_ref(f"multica:{_tid}", issue=_issue)
                             return _chain_cache[_tid]
 
                         _running_chains = 0
@@ -488,7 +489,7 @@ async def lifespan(app: FastAPI):
                             if (_ip_issue.get("title") or "").lower().startswith("autopilot:"):
                                 continue
                             _ip_tid = str(_ip_issue.get("id") or "")
-                            if _ip_tid and chain_is_running(await _poll_chain(_ip_tid)):
+                            if _ip_tid and chain_is_running(await _poll_chain(_ip_issue)):
                                 _running_chains += 1
 
                         _wh_dispatched = min(_running_chains, _wh_limit)
@@ -511,7 +512,7 @@ async def lifespan(app: FastAPI):
                             _tid = str(_candidate.get("id") or "")
                             if not _tid:
                                 return
-                            _chain = await _poll_chain(_tid)
+                            _chain = await _poll_chain(_candidate)
                             if not chain_needs_dispatch(_chain):
                                 return
                             _emit = await emit_issue_assigned(_candidate)
@@ -601,7 +602,7 @@ async def lifespan(app: FastAPI):
                     try:
                         from executor_registry import poll_ref  # type: ignore[import]
 
-                        chain = await poll_ref(f"multica:{issue_id}")
+                        chain = await poll_ref(f"multica:{issue_id}", issue=issue)
                         if chain.get("found") and chain.get("status") == "done":
                             pr_url = chain.get("pr_url")
                             await _record_completed_multica_chain(client, str(issue_id), chain)

--- a/services/zoe-data/multica_autopilot_sync.py
+++ b/services/zoe-data/multica_autopilot_sync.py
@@ -342,7 +342,7 @@ async def _run_board_review() -> None:
                         title,
                     )
                     continue
-                existing = await poll_ref(f"multica:{issue_id}")
+                existing = await poll_ref(f"multica:{issue_id}", issue=issue)
                 if existing.get("found") and existing.get("status") in ("running", "blocked"):
                     continue
                 result = await dispatch_issue(issue)

--- a/services/zoe-data/routers/system.py
+++ b/services/zoe-data/routers/system.py
@@ -1004,7 +1004,7 @@ async def list_engineering_workflow_tasks(
                 continue
             if (issue.get("title") or "").lower().startswith("autopilot:"):
                 continue
-            chain = await poll_ref(f"multica:{issue.get('id')}")
+            chain = await poll_ref(f"multica:{issue.get('id')}", issue=issue)
             tasks.append({
                 "issue_id": issue.get("id"),
                 "identifier": issue.get("identifier"),
@@ -1404,7 +1404,7 @@ async def get_agent_board(user: dict = Depends(get_current_user)):  # noqa: ARG0
 
         async def enrich_chain(issue: dict) -> None:
             try:
-                chain = await poll_ref(f"multica:{issue.get('id')}")
+                chain = await poll_ref(f"multica:{issue.get('id')}", issue=issue)
             except Exception as exc:
                 issue["chain_error"] = str(exc)
                 return

--- a/services/zoe-data/tests/test_agent_board.py
+++ b/services/zoe-data/tests/test_agent_board.py
@@ -23,7 +23,7 @@ async def test_agent_board_keeps_active_and_chain_enrichment_bounded(monkeypatch
         async def list_issues(self, *, status):
             return issues_by_status[status]
 
-    async def fake_poll_ref(ref):
+    async def fake_poll_ref(ref, **_kwargs):
         polled_refs.append(ref)
         return {
             "status": "running",

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -1140,6 +1140,39 @@ async def test_poll_v4_partial_clears_stale_prior_phase_blocker():
 
 
 @pytest.mark.asyncio
+async def test_poll_v4_resumed_skip_scout_ignores_stale_scout_blocker():
+    from pipeline_evidence import PipelineState
+    from pipeline_store import save_state
+
+    state = PipelineState(
+        task_ref="multica:uuid-9",
+        phase="scout",
+        status="todo",
+        evidence_profile="code",
+        attempts={"scout": 1},
+    )
+    save_state(state, event="operator_resumed")
+    rows = [_row("scout", "blocked", chain_version="v4", block_reason="SCOUT_BUDGET")]
+    issue = {
+        "id": "uuid-9",
+        "identifier": "ZOE-5446",
+        "title": "Harness follow-up",
+        "metadata": {
+            "zoe_kind": "harness_fix",
+            "acceptance_criteria": ["budget blockers create one follow-up ticket"],
+        },
+    }
+    a = _FakeAdapter(list_rows=rows)
+    out = await a.poll("multica:uuid-9", issue=issue)
+
+    assert out["status"] == "partial"
+    assert out["blocker"] is None
+    assert out["pipeline"]["phase"] == "scout"
+    assert out["pipeline"]["status"] == "todo"
+    assert out["pipeline"]["stale_executor_phase"] == "scout"
+
+
+@pytest.mark.asyncio
 async def test_poll_v4_todo_existing_phase_clears_stale_prior_blocker():
     from pipeline_evidence import EvidenceItem, PipelineState
     from pipeline_store import save_state


### PR DESCRIPTION
## Summary
- pass Multica issue context into the sync poll path
- ignore stale executor phases when an operator-resumed journal now plans to skip that phase
- keep terminal blocked rows untouched and add ZOE-5446-style regression coverage

## Validation
- python3 -m py_compile services/zoe-data/executors/kanban_adapter.py services/zoe-data/executor_registry.py services/zoe-data/tests/test_kanban_adapter.py scripts/maintenance/sync_multica_to_kanban.py
