### PR TITLE
Create harness follow-ups for implement blockers

### DIFF
--- a/services/zoe-data/main.py
+++ b/services/zoe-data/main.py
@@ -163,6 +163,98 @@ def _blocked_multica_chain_reason(chain: dict) -> str:
     return str(blocker)
 
 
+def _blocker_followup_marker(phase: str, blocker: str) -> str | None:
+    """Return the harness blocker class that should create a follow-up ticket."""
+    if phase != "implement":
+        return None
+    upper = blocker.upper()
+    for marker in ("IMPLEMENT_BUDGET", "PROTOCOL_VIOLATION"):
+        if marker in upper:
+            return marker
+    return None
+
+
+async def _ensure_blocker_followup_ticket(client, issue_id: str, chain: dict, blocker: str) -> dict:
+    """Create or reuse one harness-fix follow-up for implement budget/protocol blocks."""
+    pipeline = chain.get("pipeline") or {}
+    phase = str(pipeline.get("phase") or "implement")
+    marker = _blocker_followup_marker(phase, blocker)
+    if marker is None:
+        return {}
+
+    try:
+        from multica_ticket_contract import (
+            append_child_id,
+            describe_ticket,
+            parse_ticket_block,
+        )
+
+        parent = await client.get_issue(issue_id)
+        if not parent.get("id"):
+            return {}
+        parent_ident = parent.get("identifier") or issue_id
+        for status in ("backlog", "todo", "in_progress", "blocked", "in_review"):
+            for candidate in await client.list_issues(status=status, limit=1000) or []:
+                metadata = parse_ticket_block(candidate.get("description") or "")
+                if (
+                    metadata.get("source") == "engineering_blocker_followup"
+                    and str(metadata.get("parent_issue_id") or "") == str(issue_id)
+                    and metadata.get("source_blocker") == marker
+                ):
+                    return candidate
+
+        description = describe_ticket(
+            (
+                f"Follow up from {parent_ident}: the engineering driver blocked in "
+                f"implement with {marker}. Fix the harness so this class of block "
+                "is surfaced or prevented without manual product-ticket rescue."
+            ),
+            zoe_kind="harness_fix",
+            evidence_profile="code",
+            engineering_mode="interactive",
+            acceptance_criteria=[
+                f"{marker} implement blockers create or surface exactly one harness follow-up",
+                "Blocked source ticket remains dispatch_approved=false",
+                "Repeated poll cycles do not create duplicate follow-ups",
+                "Focused tests cover the blocker path",
+                "PR URL is recorded for code changes",
+            ],
+            evidence_expectations=["Focused tests", "Greptile 5/5", "PR URL"],
+            source="engineering_blocker_followup",
+            parent_issue_id=issue_id,
+        )
+        metadata = parse_ticket_block(description)
+        metadata["source_blocker"] = marker
+        metadata["source_block_reason"] = blocker
+        from multica_ticket_contract import write_ticket_block
+
+        issue = await client.create_issue(
+            title=f"Harness: follow up {marker} for {parent_ident}"[:140],
+            description=write_ticket_block(description, metadata),
+            priority="medium",
+            status="backlog",
+            assignee_id=parent.get("assignee_id"),
+            assignee_type=parent.get("assignee_type") or "agent",
+            project_id=parent.get("project_id"),
+        )
+        child_id = str(issue.get("id") or "")
+        if child_id:
+            await client.attach_label(child_id, "harness-fix")
+            await client.attach_label(child_id, marker.lower().replace("_", "-"))
+            await client.update_issue(
+                issue_id,
+                description=append_child_id(parent.get("description") or "", child_id),
+            )
+            await client.append_issue_note(
+                issue_id,
+                f"Harness follow-up created for {marker}: {issue.get('identifier') or child_id}",
+            )
+        return issue
+    except Exception as exc:
+        logger.warning("multica_poll: blocker follow-up creation failed for %s: %s", issue_id, exc)
+        return {}
+
+
 async def _record_blocked_multica_chain(client, issue_id: str, chain: dict) -> str:
     """Persist operator-visible block metadata for a stopped Multica chain."""
     pipeline = chain.get("pipeline") or {}
@@ -177,6 +269,7 @@ async def _record_blocked_multica_chain(client, issue_id: str, chain: dict) -> s
         status="blocked",
         dispatch_approved=False,
     )
+    await _ensure_blocker_followup_ticket(client, issue_id, chain, blocker)
     return blocker
 
 async def _run_memory_capture_startup_probe() -> None:

--- a/services/zoe-data/tests/test_main_multica_poll.py
+++ b/services/zoe-data/tests/test_main_multica_poll.py
@@ -8,10 +8,41 @@ import pytest
 class RecordingClient:
     def __init__(self):
         self.calls = []
+        self.issues = {}
+        self.created = []
+        self.labels = []
+        self.notes = []
 
     async def record_progress(self, *args, **kwargs):
         self.calls.append((args, kwargs))
         return {"id": args[0], **kwargs}
+
+    async def get_issue(self, issue_id):
+        return self.issues.get(issue_id, {})
+
+    async def list_issues(self, status=None, *, limit=None):
+        issues = list(self.issues.values()) + list(self.created)
+        if status is not None:
+            issues = [issue for issue in issues if issue.get("status") == status]
+        return issues[:limit] if limit is not None else issues
+
+    async def create_issue(self, **kwargs):
+        issue = {"id": f"child-{len(self.created) + 1}", "identifier": f"ZOE-C{len(self.created) + 1}", **kwargs}
+        self.created.append(issue)
+        return issue
+
+    async def attach_label(self, issue_id, label):
+        self.labels.append((issue_id, label))
+        return {"ok": True}
+
+    async def update_issue(self, issue_id, **kwargs):
+        issue = self.issues.setdefault(issue_id, {"id": issue_id})
+        issue.update(kwargs)
+        return issue
+
+    async def append_issue_note(self, issue_id, note):
+        self.notes.append((issue_id, note))
+        return {"ok": True}
 
 
 def test_poll_dispatches_ready_work_only_when_runtime_pause_is_inactive():
@@ -279,3 +310,192 @@ async def test_record_blocked_multica_chain_falls_back_to_classification_and_def
     assert client.calls[0][1]["dispatch_approved"] is False
     assert client.calls[1][1]["blocker"] == "pipeline blocked at retro"
     assert client.calls[1][1]["dispatch_approved"] is False
+
+
+@pytest.mark.asyncio
+async def test_record_blocked_multica_chain_creates_budget_followup_once():
+    from main import _record_blocked_multica_chain
+    from multica_ticket_contract import parse_ticket_block
+
+    client = RecordingClient()
+    client.issues["issue-budget"] = {
+        "id": "issue-budget",
+        "identifier": "ZOE-1",
+        "description": "Parent prose",
+        "assignee_id": "hermes",
+        "assignee_type": "agent",
+        "project_id": "project-1",
+    }
+    chain = {
+        "pipeline": {
+            "phase": "implement",
+            "block_reason": "IMPLEMENT_BUDGET: code-enforced tool budget exceeded",
+        }
+    }
+
+    blocker = await _record_blocked_multica_chain(client, "issue-budget", chain)
+
+    assert blocker == "IMPLEMENT_BUDGET: code-enforced tool budget exceeded"
+    assert client.calls[0][1]["dispatch_approved"] is False
+    assert len(client.created) == 1
+    created = client.created[0]
+    metadata = parse_ticket_block(created["description"])
+    assert metadata["source"] == "engineering_blocker_followup"
+    assert metadata["source_blocker"] == "IMPLEMENT_BUDGET"
+    assert metadata["parent_issue_id"] == "issue-budget"
+    assert ("child-1", "harness-fix") in client.labels
+    assert ("child-1", "implement-budget") in client.labels
+    parent_metadata = parse_ticket_block(client.issues["issue-budget"]["description"])
+    assert parent_metadata["child_issue_ids"] == ["child-1"]
+    assert client.notes
+
+
+@pytest.mark.asyncio
+async def test_record_blocked_multica_chain_reuses_existing_in_progress_budget_followup():
+    from main import _record_blocked_multica_chain
+    from multica_ticket_contract import describe_ticket, parse_ticket_block, write_ticket_block
+
+    client = RecordingClient()
+    client.issues["issue-budget"] = {
+        "id": "issue-budget",
+        "identifier": "ZOE-1",
+        "description": "Parent prose",
+        "assignee_id": "hermes",
+    }
+    existing_description = describe_ticket(
+        "Existing follow-up",
+        zoe_kind="harness_fix",
+        source="engineering_blocker_followup",
+        parent_issue_id="issue-budget",
+    )
+    existing_metadata = parse_ticket_block(existing_description)
+    existing_metadata["source_blocker"] = "IMPLEMENT_BUDGET"
+    client.issues["existing-child"] = {
+        "id": "existing-child",
+        "identifier": "ZOE-C1",
+        "status": "in_progress",
+        "description": write_ticket_block(existing_description, existing_metadata),
+    }
+
+    await _record_blocked_multica_chain(
+        client,
+        "issue-budget",
+        {
+            "pipeline": {
+                "phase": "implement",
+                "block_reason": "IMPLEMENT_BUDGET: code-enforced tool budget exceeded",
+            }
+        },
+    )
+
+    assert client.created == []
+    assert client.labels == []
+    assert client.notes == []
+
+
+@pytest.mark.asyncio
+async def test_record_blocked_multica_chain_reopens_after_done_budget_followup():
+    from main import _record_blocked_multica_chain
+    from multica_ticket_contract import describe_ticket, parse_ticket_block, write_ticket_block
+
+    client = RecordingClient()
+    client.issues["issue-budget"] = {
+        "id": "issue-budget",
+        "identifier": "ZOE-1",
+        "description": "Parent prose",
+        "assignee_id": "hermes",
+    }
+    existing_description = describe_ticket(
+        "Done follow-up",
+        zoe_kind="harness_fix",
+        source="engineering_blocker_followup",
+        parent_issue_id="issue-budget",
+    )
+    existing_metadata = parse_ticket_block(existing_description)
+    existing_metadata["source_blocker"] = "IMPLEMENT_BUDGET"
+    client.issues["done-child"] = {
+        "id": "done-child",
+        "identifier": "ZOE-C-DONE",
+        "status": "done",
+        "description": write_ticket_block(existing_description, existing_metadata),
+    }
+
+    await _record_blocked_multica_chain(
+        client,
+        "issue-budget",
+        {
+            "pipeline": {
+                "phase": "implement",
+                "block_reason": "IMPLEMENT_BUDGET: code-enforced tool budget exceeded",
+            }
+        },
+    )
+
+    assert len(client.created) == 1
+    metadata = parse_ticket_block(client.created[0]["description"])
+    assert metadata["source_blocker"] == "IMPLEMENT_BUDGET"
+
+
+@pytest.mark.asyncio
+async def test_record_blocked_multica_chain_creates_protocol_followup():
+    from main import _record_blocked_multica_chain
+    from multica_ticket_contract import parse_ticket_block
+
+    client = RecordingClient()
+    client.issues["issue-protocol"] = {
+        "id": "issue-protocol",
+        "identifier": "ZOE-2",
+        "description": "Parent prose",
+        "assignee_id": "hermes",
+        "status": "blocked",
+    }
+
+    await _record_blocked_multica_chain(
+        client,
+        "issue-protocol",
+        {"pipeline": {"phase": "implement", "block_reason": "PROTOCOL_VIOLATION: missing terminal handoff"}},
+    )
+
+    assert len(client.created) == 1
+    metadata = parse_ticket_block(client.created[0]["description"])
+    assert metadata["source_blocker"] == "PROTOCOL_VIOLATION"
+    assert metadata["parent_issue_id"] == "issue-protocol"
+    assert ("child-1", "protocol-violation") in client.labels
+
+
+@pytest.mark.asyncio
+async def test_record_blocked_multica_chain_reuses_existing_protocol_followup():
+    from main import _record_blocked_multica_chain
+    from multica_ticket_contract import describe_ticket, parse_ticket_block, write_ticket_block
+
+    client = RecordingClient()
+    client.issues["issue-protocol"] = {
+        "id": "issue-protocol",
+        "identifier": "ZOE-2",
+        "description": "Parent prose",
+        "assignee_id": "hermes",
+    }
+    existing_description = describe_ticket(
+        "Existing protocol follow-up",
+        zoe_kind="harness_fix",
+        source="engineering_blocker_followup",
+        parent_issue_id="issue-protocol",
+    )
+    existing_metadata = parse_ticket_block(existing_description)
+    existing_metadata["source_blocker"] = "PROTOCOL_VIOLATION"
+    client.issues["existing-protocol-child"] = {
+        "id": "existing-protocol-child",
+        "identifier": "ZOE-C2",
+        "status": "backlog",
+        "description": write_ticket_block(existing_description, existing_metadata),
+    }
+
+    await _record_blocked_multica_chain(
+        client,
+        "issue-protocol",
+        {"pipeline": {"phase": "implement", "block_reason": "PROTOCOL_VIOLATION: missing terminal handoff"}},
+    )
+
+    assert client.created == []
+    assert client.labels == []
+    assert client.notes == []


### PR DESCRIPTION
## Summary
- create/reuse one Multica harness-fix follow-up when implement blocks on IMPLEMENT_BUDGET or PROTOCOL_VIOLATION
- keep the source ticket blocked and dispatch_approved=false
- add tests for follow-up creation and idempotent reuse

## Validation
- python3 -m py_compile services/zoe-data/main.py services/zoe-data/tests/test_main_multica_poll.py
