### PR TITLE
Allow resumed blocked phases to retry

### DIFF
--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -730,6 +730,30 @@ class KanbanAdapter:
         entry = next((plan_entry for plan_entry in plan if plan_entry[0] == phase), None)
         current_row = existing_phases.get(phase) or {}
         current_status = (current_row.get("status") or "").lower()
+        if state is not None and state.status == "todo" and current_status == "blocked":
+            task_id = current_row.get("id")
+            if task_id:
+                try:
+                    await self._run(["archive", str(task_id)])
+                except KanbanCLIError as exc:
+                    logger.warning(
+                        "kanban_adapter: archive of stale blocked task %s failed for %s: %s",
+                        task_id,
+                        external_ref,
+                        exc,
+                    )
+                    return {
+                        "ok": False,
+                        "external_ref": external_ref,
+                        "reason": "stale blocked phase archive failed",
+                        "phase": phase,
+                        "chain": {},
+                        "created": [],
+                        "mode": mode,
+                    }
+            existing_phases.pop(phase, None)
+            current_row = {}
+            current_status = ""
         can_adjust_stale_phase = bool(
             state is not None
             and phase_order
@@ -905,27 +929,41 @@ class KanbanAdapter:
 
                 existing_state = await asyncio.to_thread(load_latest_state, external_ref)
                 expected_phase_names = {entry[0] for entry in _chain_for_issue(issue)}
-                if (
-                    existing_state is not None
-                    and existing_state.status == "todo"
-                    and existing_state.phase not in expected_phase_names
-                ):
-                    phases = {
-                        phase: row
-                        for phase, row in phases.items()
-                        if phase in expected_phase_names
-                    }
-                    if not phases:
+                if existing_state is not None and existing_state.status == "todo":
+                    stale_executor_phase = None
+                    stale_executor_status = None
+                    if existing_state.phase not in expected_phase_names:
+                        stale_executor_phase = existing_state.phase
+                        phases = {
+                            phase: row
+                            for phase, row in phases.items()
+                            if phase in expected_phase_names
+                        }
+                    else:
+                        current_row = phases.get(str(existing_state.phase or "")) or {}
+                        current_status = (current_row.get("status") or "").lower()
+                        if current_status == "blocked":
+                            stale_executor_phase = str(existing_state.phase or "")
+                            stale_executor_status = current_status
+                            phases = {
+                                phase: row
+                                for phase, row in phases.items()
+                                if phase != stale_executor_phase
+                            }
+                    if stale_executor_phase and (stale_executor_status == "blocked" or not phases):
+                        pipeline = {
+                            **pipeline_summary(existing_state),
+                            "stale_executor_phase": stale_executor_phase,
+                        }
+                        if stale_executor_status:
+                            pipeline["stale_executor_status"] = stale_executor_status
                         return {
                             "found": True,
                             "status": "partial",
-                            "phases": {},
+                            "phases": {phase: (row.get("status") or "") for phase, row in phases.items()},
                             "pr_url": None,
                             "blocker": None,
-                            "pipeline": {
-                                **pipeline_summary(existing_state),
-                                "stale_executor_phase": existing_state.phase,
-                            },
+                            "pipeline": pipeline,
                         }
             except Exception as exc:
                 logger.debug("kanban_adapter: stale phase filter skipped for %s: %s", external_ref, exc)

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -178,6 +178,79 @@ async def test_dispatch_does_not_parent_recovered_phase_to_terminal_like_prior_r
 
 
 @pytest.mark.asyncio
+async def test_dispatch_resumed_todo_archives_blocked_current_phase_before_retry():
+    from pipeline_evidence import PipelineState
+    from pipeline_store import save_state
+
+    state = PipelineState(
+        task_ref="multica:uuid-retry-current",
+        phase="implement",
+        status="todo",
+        attempts={"implement": 1},
+    )
+    save_state(state, event="operator_resumed")
+    rows = [_row("implement", "blocked", chain_version="v4", issue_id="uuid-retry-current")]
+    a = _FakeAdapter(list_rows=rows)
+    result = await a.dispatch(
+        {
+            "id": "uuid-retry-current",
+            "identifier": "ZOE-RETRY",
+            "title": "Harness: retry current phase",
+            "metadata": {"zoe_kind": "harness_fix", "acceptance_criteria": ["retry"]},
+        }
+    )
+
+    archives = [c for c in a.calls if c[0] == "archive"]
+    creates = [c for c in a.calls if c[0] == "create"]
+    assert archives == [["archive", "t_implement"]]
+    assert len(creates) == 1
+    assert creates[0][creates[0].index("--idempotency-key") + 1] == "multica:uuid-retry-current:implement"
+    assert result["ok"] is True
+    assert result["phase"] == "implement"
+    assert result["created"] == ["implement"]
+    assert result["chain"] == {"implement": "t_implement"}
+
+
+
+@pytest.mark.asyncio
+async def test_dispatch_resumed_todo_reports_archive_failure_without_create():
+    from pipeline_evidence import PipelineState
+    from pipeline_store import save_state
+
+    class ArchiveFailAdapter(_FakeAdapter):
+        async def _run(self, args, *, expect_json=False):
+            if args[0] == "archive":
+                self.calls.append(args)
+                raise ka.KanbanCLIError("archive failed")
+            return await super()._run(args, expect_json=expect_json)
+
+    state = PipelineState(
+        task_ref="multica:uuid-archive-fail",
+        phase="implement",
+        status="todo",
+        attempts={"implement": 1},
+    )
+    save_state(state, event="operator_resumed")
+    rows = [_row("implement", "blocked", chain_version="v4", issue_id="uuid-archive-fail")]
+    a = ArchiveFailAdapter(list_rows=rows)
+    result = await a.dispatch(
+        {
+            "id": "uuid-archive-fail",
+            "identifier": "ZOE-ARCHIVE",
+            "title": "Harness: retry current phase",
+            "metadata": {"zoe_kind": "harness_fix", "acceptance_criteria": ["retry"]},
+        }
+    )
+
+    assert [c for c in a.calls if c[0] == "archive"] == [["archive", "t_implement"]]
+    assert [c for c in a.calls if c[0] == "create"] == []
+    assert result["ok"] is False
+    assert result["reason"] == "stale blocked phase archive failed"
+    assert result["phase"] == "implement"
+
+
+
+@pytest.mark.asyncio
 async def test_dispatch_after_scout_evidence_creates_next_phase():
     from pipeline_store import bootstrap_state, save_state
     from pipeline_evidence import EvidenceItem, transition, with_evidence
@@ -1172,6 +1245,72 @@ async def test_poll_v4_running_pipeline_clears_stale_recovered_blocker():
     assert out["blocker"] is None
     assert out["pipeline"]["phase"] == "verify"
     assert out["pipeline"]["status"] == "running"
+
+
+@pytest.mark.asyncio
+async def test_poll_v4_resumed_todo_ignores_stale_blocked_current_phase():
+    from pipeline_evidence import PipelineState
+    from pipeline_store import save_state
+
+    state = PipelineState(
+        task_ref="multica:uuid-resume-current",
+        phase="implement",
+        status="todo",
+        attempts={"implement": 1},
+    )
+    save_state(state, event="operator_resumed")
+    rows = [_row("implement", "blocked", chain_version="v4", issue_id="uuid-resume-current")]
+    issue = {
+        "id": "uuid-resume-current",
+        "identifier": "ZOE-RESUME",
+        "title": "Harness: retry current phase",
+        "metadata": {"zoe_kind": "harness_fix", "acceptance_criteria": ["retry"]},
+    }
+    a = _FakeAdapter(list_rows=rows)
+    out = await a.poll("multica:uuid-resume-current", issue=issue)
+
+    assert out["status"] == "partial"
+    assert out["blocker"] is None
+    assert out["phases"] == {}
+    assert out["pipeline"]["phase"] == "implement"
+    assert out["pipeline"]["status"] == "todo"
+    assert out["pipeline"]["stale_executor_phase"] == "implement"
+    assert out["pipeline"]["stale_executor_status"] == "blocked"
+
+
+
+@pytest.mark.asyncio
+async def test_poll_v4_resumed_todo_ignores_stale_blocked_current_phase_with_prior_done():
+    from pipeline_evidence import PipelineState
+    from pipeline_store import save_state
+
+    state = PipelineState(
+        task_ref="multica:uuid-resume-after-scout",
+        phase="implement",
+        status="todo",
+        attempts={"scout": 1, "implement": 1},
+    )
+    save_state(state, event="operator_resumed")
+    rows = [
+        _row("scout", "done", chain_version="v4", issue_id="uuid-resume-after-scout"),
+        _row("implement", "blocked", chain_version="v4", issue_id="uuid-resume-after-scout"),
+    ]
+    issue = {
+        "id": "uuid-resume-after-scout",
+        "identifier": "ZOE-RESUME",
+        "title": "Code ticket after scout",
+    }
+    a = _FakeAdapter(list_rows=rows)
+    out = await a.poll("multica:uuid-resume-after-scout", issue=issue)
+
+    assert out["status"] == "partial"
+    assert out["blocker"] is None
+    assert out["phases"] == {"scout": "done"}
+    assert out["pipeline"]["phase"] == "implement"
+    assert out["pipeline"]["status"] == "todo"
+    assert out["pipeline"]["stale_executor_phase"] == "implement"
+    assert out["pipeline"]["stale_executor_status"] == "blocked"
+
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- treat explicitly resumed todo pipelines as retryable when the current Hermes phase row is stale blocked
- archive the stale blocked phase row before creating the replacement task so Hermes idempotency does not return the old task
- add adapter regression tests for poll and dispatch retry behavior

## Tests
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_kanban_adapter.py services/zoe-data/tests/test_multica_poll_dispatch.py