### PR TITLE
Surface Hermes iteration budget blockers

### DIFF
--- a/services/zoe-data/main.py
+++ b/services/zoe-data/main.py
@@ -168,7 +168,7 @@ def _blocker_followup_marker(phase: str, blocker: str) -> str | None:
     if phase != "implement":
         return None
     upper = blocker.upper()
-    for marker in ("IMPLEMENT_BUDGET", "PROTOCOL_VIOLATION"):
+    for marker in ("IMPLEMENT_BUDGET", "ITERATION_BUDGET", "PROTOCOL_VIOLATION"):
         if marker in upper:
             return marker
     return None

--- a/services/zoe-data/pipeline_handoff.py
+++ b/services/zoe-data/pipeline_handoff.py
@@ -41,7 +41,7 @@ _LOG_TOOL_MARKERS = (
 _STABLE_BLOCKER_RE = re.compile(
     r"\b(?:WORKTREE_NOT_READY|GATE_BLOCKED|PROTOCOL_VIOLATION|MERGE_BLOCKED|"
     r"VERIFICATION_FAILED|HTTP_402|PAYMENT_REQUIRED|CREDITS_EXHAUSTED|"
-    r"TURN_BUDGET|CONTEXT_LIMIT|TOKEN_LIMIT|SCOPE_SPLIT_REQUIRED|NEEDS_SPLIT)\b",
+    r"TURN_BUDGET|ITERATION_BUDGET|CONTEXT_LIMIT|TOKEN_LIMIT|SCOPE_SPLIT_REQUIRED|NEEDS_SPLIT)\b",
     re.I,
 )
 
@@ -61,6 +61,22 @@ def _haystacks(detail: dict[str, Any]) -> list[str]:
     logs = detail.get("logs") or detail.get("log") or detail.get("log_tail")
     if logs:
         parts.append(logs if isinstance(logs, str) else json.dumps(logs))
+    for run in detail.get("runs") or []:
+        if not isinstance(run, dict):
+            continue
+        run_error = run.get("error")
+        if run_error:
+            parts.append(
+                f"ITERATION_BUDGET: {run_error}"
+                if "iteration budget" in str(run_error).lower()
+                else str(run_error)
+            )
+        run_summary = run.get("summary")
+        if run_summary:
+            parts.append(str(run_summary))
+        run_metadata = run.get("metadata")
+        if run_metadata:
+            parts.append(json.dumps(run_metadata))
     return parts
 
 
@@ -182,14 +198,6 @@ def _retro_followup_metadata(fields: dict[str, str]) -> dict[str, Any]:
         "description": description[:2000] or title[:500],
         "source": "retro",
     }
-
-
-def _log_tail_snippet(detail: dict[str, Any], *, max_lines: int = 8) -> str:
-    for chunk in reversed(_haystacks(detail)):
-        lines = [ln.strip() for ln in chunk.splitlines() if ln.strip()]
-        if lines:
-            return "\n".join(lines[-max_lines:])
-    return ""
 
 
 def _stable_block_reason_from_text(text: str) -> str:
@@ -546,9 +554,8 @@ def block_reason_from_handoff(detail: dict[str, Any], *, row_block_reason: str |
     reason = (fields.get("BLOCKER") or row_block_reason or "").strip()
     if reason:
         return reason
-    tail = _log_tail_snippet(detail)
-    if tail:
-        stable = _stable_block_reason_from_text(tail)
+    for chunk in _haystacks(detail):
+        stable = _stable_block_reason_from_text(chunk)
         if stable:
             return stable
     return ""

--- a/services/zoe-data/tests/test_main_multica_poll.py
+++ b/services/zoe-data/tests/test_main_multica_poll.py
@@ -269,6 +269,43 @@ async def test_record_blocked_multica_chain_records_terminal_block_metadata():
 
 
 @pytest.mark.asyncio
+async def test_record_blocked_multica_chain_creates_iteration_budget_followup():
+    from main import _record_blocked_multica_chain
+    from multica_ticket_contract import parse_ticket_block
+
+    client = RecordingClient()
+    client.issues["parent-iteration"] = {
+        "id": "parent-iteration",
+        "identifier": "ZOE-ITER",
+        "status": "blocked",
+        "description": "Parent description",
+        "assignee_id": "agent-1",
+        "assignee_type": "agent",
+        "project_id": "project-1",
+    }
+
+    blocker = await _record_blocked_multica_chain(
+        client,
+        "parent-iteration",
+        {
+            "pipeline": {"phase": "implement", "block_reason": "ITERATION_BUDGET"},
+        },
+    )
+
+    assert blocker == "ITERATION_BUDGET"
+    assert len(client.created) == 1
+    child = client.created[0]
+    metadata = parse_ticket_block(child["description"])
+    assert child["title"] == "Harness: follow up ITERATION_BUDGET for ZOE-ITER"
+    assert metadata["source"] == "engineering_blocker_followup"
+    assert metadata["source_blocker"] == "ITERATION_BUDGET"
+    assert metadata["parent_issue_id"] == "parent-iteration"
+    assert ("child-1", "harness-fix") in client.labels
+    assert ("child-1", "iteration-budget") in client.labels
+    assert client.notes == [("parent-iteration", "Harness follow-up created for ITERATION_BUDGET: ZOE-C1")]
+
+
+@pytest.mark.asyncio
 async def test_record_blocked_multica_chain_uses_non_terminal_block_reason_without_prefix():
     from main import _record_blocked_multica_chain
 

--- a/services/zoe-data/tests/test_pipeline_handoff.py
+++ b/services/zoe-data/tests/test_pipeline_handoff.py
@@ -474,6 +474,24 @@ def test_block_reason_from_handoff_ignores_dynamic_log_tail():
     assert reason == "WORKTREE_NOT_READY"
 
 
+def test_block_reason_from_handoff_extracts_iteration_budget_from_run_error():
+    from pipeline_handoff import block_reason_from_handoff
+
+    detail = {
+        "latest_summary": "",
+        "comments": [],
+        "runs": [
+            {
+                "outcome": "gave_up",
+                "error": "Iteration budget exhausted (22/22) — task could not complete within the allowed iterations",
+                "metadata": {"trigger_outcome": "timed_out"},
+            }
+        ],
+    }
+
+    assert block_reason_from_handoff(detail) == "ITERATION_BUDGET"
+
+
 def test_block_reason_ignores_dynamic_log_tail_without_stable_token():
     from pipeline_handoff import block_reason_from_handoff
 


### PR DESCRIPTION
## Summary
- include Hermes run errors/metadata in handoff parsing so iteration-limit failures are not collapsed to a generic block
- classify ITERATION_BUDGET as a stable harness blocker and create Multica follow-up tickets for implement-phase iteration budget blocks
- add focused parser and Multica blocker follow-up tests

## Tests
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_pipeline_handoff.py services/zoe-data/tests/test_main_multica_poll.py services/zoe-data/tests/test_kanban_adapter.py services/zoe-data/tests/test_multica_poll_dispatch.py