### PR TITLE
Add code-audit implement fast path

### DIFF
--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -210,6 +210,15 @@ _AUDIT_NO_PR_RE = re.compile(
 )
 
 
+def _is_code_audit_actionable(meta: dict[str, Any]) -> bool:
+    """Return True for code-audit bug tickets that already have acceptance criteria."""
+    return (
+        str(meta.get("zoe_kind") or "").strip().lower() == "bug"
+        and str(meta.get("source") or "").strip().lower().startswith("code_audit_")
+        and bool(meta.get("acceptance_criteria"))
+    )
+
+
 def _skip_scout(issue: dict | None = None) -> bool:
     issue = issue or {}
     if str(os.environ.get("ZOE_KANBAN_SKIP_SCOUT", "")).strip().lower() in {"1", "true", "yes"}:
@@ -232,11 +241,7 @@ def _skip_scout(issue: dict | None = None) -> bool:
         and bool(meta.get("acceptance_criteria"))
     ):
         return True
-    if (
-        str(meta.get("zoe_kind") or "").strip().lower() == "bug"
-        and str(meta.get("source") or "").strip().lower().startswith("code_audit_")
-        and bool(meta.get("acceptance_criteria"))
-    ):
+    if _is_code_audit_actionable(meta):
         return True
     haystack = " ".join(
         [
@@ -246,6 +251,26 @@ def _skip_scout(issue: dict | None = None) -> bool:
         ]
     )
     return bool(_SKIP_SCOUT_TAG_RE.search(haystack))
+
+
+def _code_audit_implement_hint(issue: dict | None = None) -> str:
+    """Return extra bounded instructions for actionable code-audit tickets."""
+    meta = _ticket_metadata(issue)
+    if not _is_code_audit_actionable(meta):
+        return ""
+    return (
+        "- CODE-AUDIT FAST PATH: this is an actionable code-audit bug with acceptance criteria. "
+        "Do not re-audit the whole repo, compare every possible helper, or search broadly for patterns. "
+        "After `kanban_show`, inspect only the named vulnerable file/endpoint plus at most one nearest "
+        "focused test file. Apply the smallest patch that satisfies the acceptance criteria before the "
+        "8th model/tool step. If the ticket lists acceptable alternatives, choose the least invasive "
+        "in-process guard unless the acceptance criteria requires a different one. Spend no more than "
+        "3 tool calls hunting for tests; if no focused test is obvious, run `python3 tools/audit/validate_structure.py`, "
+        "commit the patch, run `git push -u origin HEAD`, open the PR, and report TESTS=validate_structure.py only. "
+        "If a product/security "
+        "decision is still missing after the named file is inspected, call `kanban_block` with "
+        "BLOCKER=IMPLEMENT_BUDGET and the missing decision.\n"
+    )
 
 
 def _audit_no_pr_issue(issue: dict | None = None) -> bool:
@@ -436,10 +461,12 @@ class KanbanAdapter:
             )
         if phase == "implement":
             overnight_hint = _overnight_implement_cost_hint() if mode == "overnight" else ""
+            code_audit_hint = _code_audit_implement_hint(issue)
             # Implement body intentionally omits full prior-phase logs; workers should
             # call kanban_show and read SCOUT_SUMMARY= from scout metadata when present.
             return common + overnight_hint + (
                 "You are the implementer (zoe-coder).\n"
+                f"{code_audit_hint}"
                 "- AUDIT/SMOKE FAST PATH: only if the title/body explicitly says audit-only, smoke test,"
                 " no code change, or uses trace/map with an audit/no-code qualifier, do not run Graphify"
                 " or repo exploration first. Complete in one bounded handoff with"

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -1850,6 +1850,68 @@ def test_closeout_body_defers_multica_done_until_retro():
     assert "MULTICA=<Zoe updates after retro; report blocker if any>" in body
 
 
+def test_implement_body_adds_code_audit_fast_path_for_actionable_bug():
+    body = ka.KanbanAdapter()._build_body(
+        "implement",
+        {
+            "id": "uuid-code-audit",
+            "identifier": "ZOE-5354",
+            "title": "GET /metrics endpoint is unauthenticated",
+            "metadata": {
+                "zoe_kind": "bug",
+                "source": "code_audit_p0_security",
+                "acceptance_criteria": ["Require admin or internal token on /metrics"],
+            },
+        },
+        "ZOE-5354",
+    )
+
+    assert "CODE-AUDIT FAST PATH" in body
+    assert "Do not re-audit the whole repo" in body
+    assert "Apply the smallest patch" in body
+    assert "Spend no more than 3 tool calls hunting for tests" in body
+    assert "git push -u origin HEAD" in body
+    assert body.index("CODE-AUDIT FAST PATH") < body.index("AUDIT/SMOKE FAST PATH")
+    assert body.index("CODE-AUDIT FAST PATH") < body.index("Graphify map")
+
+
+def test_implement_body_omits_code_audit_fast_path_without_acceptance_criteria():
+    body = ka.KanbanAdapter()._build_body(
+        "implement",
+        {
+            "id": "uuid-code-audit-open",
+            "identifier": "ZOE-OPEN",
+            "title": "Investigate unauthenticated endpoint",
+            "metadata": {
+                "zoe_kind": "bug",
+                "source": "code_audit_p0_security",
+            },
+        },
+        "ZOE-OPEN",
+    )
+
+    assert "CODE-AUDIT FAST PATH" not in body
+
+
+def test_implement_body_omits_code_audit_fast_path_for_non_code_audit():
+    body = ka.KanbanAdapter()._build_body(
+        "implement",
+        {
+            "id": "uuid-harness",
+            "identifier": "ZOE-5449",
+            "title": "Harness: follow up ITERATION_BUDGET",
+            "metadata": {
+                "zoe_kind": "harness_fix",
+                "source": "engineering_blocker_followup",
+                "acceptance_criteria": ["Focused tests cover blocker path"],
+            },
+        },
+        "ZOE-5449",
+    )
+
+    assert "CODE-AUDIT FAST PATH" not in body
+
+
 def test_implement_body_puts_bounded_fast_paths_before_graphify():
     body = ka.KanbanAdapter()._build_body(
         "implement",


### PR DESCRIPTION
## Summary
- add a scoped implement prompt fast path for actionable code-audit bug tickets with acceptance criteria
- instruct Hermes to patch the named vulnerable file/endpoint before broad helper/test hunting
- keep the guidance out of harness-fix and non-code-audit tickets

## Tests
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_kanban_adapter.py services/zoe-data/tests/test_multica_poll_dispatch.py