### PR TITLE
Use bounded goal mode for code-audit implement tasks

### DIFF
--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -273,6 +273,13 @@ def _code_audit_implement_hint(issue: dict | None = None) -> str:
     )
 
 
+def _goal_mode_args(phase: str, issue: dict | None = None) -> list[str]:
+    """Return bounded Hermes goal-mode args for phases that benefit from one continuation."""
+    if phase == "implement" and _is_code_audit_actionable(_ticket_metadata(issue)):
+        return ["--goal", "--goal-max-turns", "2"]
+    return []
+
+
 def _audit_no_pr_issue(issue: dict | None = None) -> bool:
     issue = issue or {}
     meta = _ticket_metadata(issue)
@@ -870,6 +877,7 @@ class KanbanAdapter:
             # total attempt and zero automatic retries.
             "--max-retries",
             "1",
+            *_goal_mode_args(phase, issue),
             "--created-by",
             "zoe-bridge",
             "--body",

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -434,6 +434,52 @@ async def test_dispatch_keeps_scout_for_harness_fix_without_acceptance_criteria(
 
 
 @pytest.mark.asyncio
+async def test_dispatch_uses_bounded_goal_mode_for_actionable_code_audit_implement():
+    a = _FakeAdapter()
+    result = await a.dispatch(
+        {
+            "id": "uuid-code-audit-goal",
+            "identifier": "ZOE-5354",
+            "title": "GET /metrics endpoint is unauthenticated",
+            "metadata": {
+                "zoe_kind": "bug",
+                "source": "code_audit_p0_security",
+                "acceptance_criteria": ["Require admin or internal token on /metrics"],
+            },
+        }
+    )
+
+    creates = [c for c in a.calls if c[0] == "create"]
+    assert result["phase"] == "implement"
+    assert len(creates) == 1
+    assert "--goal" in creates[0]
+    assert creates[0][creates[0].index("--goal-max-turns") + 1] == "2"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_omits_goal_mode_for_non_code_audit_implement():
+    a = _FakeAdapter()
+    result = await a.dispatch(
+        {
+            "id": "uuid-harness-goal",
+            "identifier": "ZOE-5449",
+            "title": "Harness: follow up ITERATION_BUDGET",
+            "metadata": {
+                "zoe_kind": "harness_fix",
+                "source": "engineering_blocker_followup",
+                "acceptance_criteria": ["Focused tests cover blocker path"],
+            },
+        }
+    )
+
+    creates = [c for c in a.calls if c[0] == "create"]
+    assert result["phase"] == "implement"
+    assert len(creates) == 1
+    assert "--goal" not in creates[0]
+    assert "--goal-max-turns" not in creates[0]
+
+
+@pytest.mark.asyncio
 async def test_dispatch_skips_scout_for_code_audit_ticket_with_acceptance_criteria():
     a = _FakeAdapter()
     result = await a.dispatch(


### PR DESCRIPTION
## Summary
- run actionable code-audit implement tasks in bounded Hermes goal mode
- cap goal continuation at two turns so a first-turn investigation can continue once without an unbounded loop
- add dispatch tests for code-audit and non-code-audit implement tasks

## Tests
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_kanban_adapter.py services/zoe-data/tests/test_multica_poll_dispatch.py