### PR TITLE
Allow one retry for bounded code-audit goal tasks

### DIFF
--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -273,11 +273,24 @@ def _code_audit_implement_hint(issue: dict | None = None) -> str:
     )
 
 
+def _is_bounded_goal_phase(phase: str, issue: dict | None = None) -> bool:
+    """Return True when this phase should run in bounded goal mode with one retry."""
+    return phase == "implement" and _is_code_audit_actionable(_ticket_metadata(issue))
+
+
 def _goal_mode_args(phase: str, issue: dict | None = None) -> list[str]:
     """Return bounded Hermes goal-mode args for phases that benefit from one continuation."""
-    if phase == "implement" and _is_code_audit_actionable(_ticket_metadata(issue)):
+    if _is_bounded_goal_phase(phase, issue):
         return ["--goal", "--goal-max-turns", "2"]
     return []
+
+
+def _max_retries_for_phase(phase: str, issue: dict | None = None) -> str:
+    """Return the Hermes consecutive-failure limit for this task."""
+    if _is_bounded_goal_phase(phase, issue):
+        # Goal mode gives these tickets one bounded continuation in the same worktree.
+        return "2"
+    return "1"
 
 
 def _audit_no_pr_issue(issue: dict | None = None) -> bool:
@@ -874,9 +887,11 @@ class KanbanAdapter:
             "--max-runtime",
             _max_runtime(mode),
             # Hermes trips the circuit breaker on the Nth failure; 1 means one
-            # total attempt and zero automatic retries.
+            # total attempt and zero automatic retries. Code-audit goal tasks get
+            # one same-worktree continuation so a first turn that made a patch can
+            # still commit/push instead of starting over.
             "--max-retries",
-            "1",
+            _max_retries_for_phase(phase, issue),
             *_goal_mode_args(phase, issue),
             "--created-by",
             "zoe-bridge",

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -454,6 +454,7 @@ async def test_dispatch_uses_bounded_goal_mode_for_actionable_code_audit_impleme
     assert len(creates) == 1
     assert "--goal" in creates[0]
     assert creates[0][creates[0].index("--goal-max-turns") + 1] == "2"
+    assert creates[0][creates[0].index("--max-retries") + 1] == "2"
 
 
 @pytest.mark.asyncio
@@ -477,6 +478,7 @@ async def test_dispatch_omits_goal_mode_for_non_code_audit_implement():
     assert len(creates) == 1
     assert "--goal" not in creates[0]
     assert "--goal-max-turns" not in creates[0]
+    assert creates[0][creates[0].index("--max-retries") + 1] == "1"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- give actionable code-audit implement tasks one same-worktree retry when running in bounded goal mode
- keep every other task at max-retries=1
- assert both positive and negative dispatch behavior in tests

## Tests
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_kanban_adapter.py services/zoe-data/tests/test_multica_poll_dispatch.py