### PR TITLE
ZOE-5354: Authenticate /metrics endpoint

### DIFF
--- a/services/zoe-data/auth.py
+++ b/services/zoe-data/auth.py
@@ -6,6 +6,7 @@ import os
 import time
 import logging
 import httpx
+import hmac
 from fastapi import Request, HTTPException, Depends
 from typing import Any, Optional, Dict, Tuple
 
@@ -295,7 +296,7 @@ async def require_internal_token(request: Request) -> None:
         return
     if _ZOE_INTERNAL_TOKEN:
         provided = request.headers.get("X-Internal-Token", "")
-        if provided and provided == _ZOE_INTERNAL_TOKEN:
+        if provided and hmac.compare_digest(provided, _ZOE_INTERNAL_TOKEN):
             return
     raise HTTPException(
         status_code=403,

--- a/services/zoe-data/main.py
+++ b/services/zoe-data/main.py
@@ -920,7 +920,7 @@ async def app_settings():
 
 
 @app.get("/metrics")
-async def prometheus_metrics():
+async def prometheus_metrics(_: None = Depends(require_internal_token)):
     """Prometheus scrape endpoint.
 
     Exposes counters/gauges from `memory_metrics.REGISTRY` (MemPalace ingest,


### PR DESCRIPTION
Adds  to  endpoint to prevent unauthenticated scrapes of per-user memory and routing metrics.\n\nFixes ZOE-5354.\n\n## Tests\n- Ran 
[94mLoading manifest...[0m
[94mScanning project files...[0m
[94mCategorizing files...[0m

[94m================================================================================[0m
[94mPROJECT STRUCTURE VALIDATION[0m
[94m================================================================================[0m

Total files analyzed: 1608
[92mCritical files: 47[0m
[92mApproved files: 1561[0m
[93mSafe to delete: 0[0m
[91mProhibited in root: 0[0m
[91mOrphan files: 0[0m

[92m✓ Root .md files: 10/10[0m

[94m================================================================================[0m
[92m✅ VALIDATION PASSED[0m
[92mProject structure is clean[0m\n- No existing focused test for /metrics endpoint; existing auth pattern matches other internal endpoints.\n\n## Changes\n- : added  dependency to  endpoint.