### PR TITLE
Clarify implement completion after PR creation

### DIFF
--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -532,6 +532,8 @@ class KanbanAdapter:
                 " `kanban_complete(summary=..., metadata={...})` OR `kanban_block(reason=...)`."
                 " Exiting without either is a protocol violation and the dispatcher will retry forever.\n"
                 "- Success: `kanban_complete` after push+PR with metadata including PR_URL, TESTS, SUMMARY.\n"
+                "  Security-sensitive changes still complete implement after the PR is opened; PR review/Greptile is the review gate.\n"
+                "  Do not call `kanban_block` merely because a human/security reviewer should inspect the PR.\n"
                 "- Failure/stuck: `kanban_block` with a clear reason (prefix BLOCKER= when applicable).\n\n"
                 "Summary text should still include:\n"
                 "PR_URL=<url or blank>\nBLOCKER=<reason or blank>\nTESTS=<checks run>\nSUMMARY=<short>\n"

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -1960,6 +1960,18 @@ def test_implement_body_omits_code_audit_fast_path_for_non_code_audit():
     assert "CODE-AUDIT FAST PATH" not in body
 
 
+def test_implement_body_always_completes_after_pr_creation_even_for_security_review():
+    body = ka.KanbanAdapter()._build_body(
+        "implement",
+        {"id": "uuid-generic", "identifier": "ZOE-GEN", "title": "Generic feature", "description": "Add a small endpoint"},
+        "ZOE-GEN",
+    )
+
+    assert "Security-sensitive changes still complete implement after the PR is opened" in body
+    assert "Do not call `kanban_block` merely because a human/security reviewer should inspect the PR" in body
+    assert "CODE-AUDIT FAST PATH" not in body
+
+
 def test_implement_body_puts_bounded_fast_paths_before_graphify():
     body = ka.KanbanAdapter()._build_body(
         "implement",


### PR DESCRIPTION
## Summary
- clarify implement workers should complete after opening a PR, including security-sensitive changes
- leave PR review and Greptile as downstream review gates instead of blocking implement for human review
- cover the prompt contract in the code-audit fast-path test

## Tests
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_kanban_adapter.py services/zoe-data/tests/test_multica_poll_dispatch.py