### PR TITLE
Allow empty blocker handoffs to clear stale blockers

### DIFF
--- a/services/zoe-data/pipeline_handoff.py
+++ b/services/zoe-data/pipeline_handoff.py
@@ -84,7 +84,7 @@ def _parse_kv_fields(text: str) -> dict[str, str]:
     out: dict[str, str] = {}
     for match in _KV_RE.finditer(text or ""):
         key, value = match.group(1), match.group(2).strip()
-        if value:
+        if value or key == "BLOCKER":
             out[key] = value
     return out
 

--- a/services/zoe-data/tests/test_pipeline_handoff.py
+++ b/services/zoe-data/tests/test_pipeline_handoff.py
@@ -435,6 +435,24 @@ def test_infer_outcome_blocked_verify_loops():
     )
 
 
+def test_later_empty_blocker_clears_older_blocked_run():
+    detail = {
+        "latest_summary": "PR_URL=https://github.com/o/r/pull/213\nBLOCKER=\nTESTS=validate_structure.py passed",
+        "runs": [
+            {
+                "status": "blocked",
+                "summary": "BLOCKER=review-required: PR opened but worker blocked",
+            },
+            {
+                "status": "completed",
+                "summary": "PR_URL=https://github.com/o/r/pull/213\nBLOCKER=\nTESTS=validate_structure.py passed",
+            },
+        ],
+    }
+
+    assert infer_outcome("implement", "done", detail) == "complete"
+
+
 def test_infer_outcome_done_without_blocker_completes():
     assert infer_outcome("review", "done", {"latest_summary": "SUMMARY=approved", "comments": []}) == "complete"
 


### PR DESCRIPTION
## Summary
- preserve explicit empty BLOCKER= handoff fields
- allow a later completed run to clear an older blocked-run blocker
- add regression coverage for PR-producing implement recovery

## Tests
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_pipeline_handoff.py services/zoe-data/tests/test_pipeline_store.py