### PR TITLE
Give verify PR validation more headroom

### DIFF
--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -548,6 +548,10 @@ class KanbanAdapter:
                 " `kanban_show`, compare the implementer handoff to the Multica acceptance criteria,"
                 " then call `kanban_complete` in this turn with TESTS=not applicable/audit evidence,"
                 " VALIDATORS=not applicable/audit-only, PR_URL= blank, and a short pass/fail summary.\n"
+                "- PR_URL FAST PATH: if `kanban_show` or the ticket block includes PR_URL, do not"
+                " hunt branches or commits. Use `gh pr view <url> --json url,headRefName,headRefOid,"
+                "mergeStateStatus,statusCheckRollup` and inspect the PR diff/checks directly, then"
+                " run the validators below and complete/block from that evidence.\n"
                 "- Start with `kanban_show` to read the implementer handoff and PR_URL.\n"
                 "- Do not redesign or refactor. Run the declared tests and the minimum extra checks needed"
                 " for the touched surface.\n"
@@ -558,7 +562,12 @@ class KanbanAdapter:
                 " PR_URL, and a pass/fail summary. Include exact commands and outcomes.\n"
                 "- If tests fail, evidence is missing, the PR is absent for a code task, or the task needs"
                 " product clarification, call `kanban_block` with BLOCKER= and the failing output.\n"
-                "- If you cannot reach a pass/block decision within 8 tool/model steps, call"
+                "- If Greptile/CI has unresolved comments or failures, call `kanban_block` with"
+                " BLOCKER=PR_REVIEW_REQUIRED, PR_URL, and a concise action list; do not spend this"
+                " phase rewriting the PR.\n"
+                "- If you cannot reach a pass/block decision within 14 tool/model steps, call"
+                # Keep in sync with _TOOL_DEFAULTS["verify"] - terminal grace
+                # in kanban_phase_budget.py.
                 " `kanban_block` with BLOCKER=VERIFY_BUDGET and the missing evidence.\n"
                 "- TERMINAL PROTOCOL: end with `kanban_complete` or `kanban_block` (no silent exit)."
             )

--- a/services/zoe-data/kanban_phase_budget.py
+++ b/services/zoe-data/kanban_phase_budget.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 _TOOL_DEFAULTS = {
     "scout": 8,
     "implement": 24,
-    "verify": 10,
+    "verify": 16,
     "review": 10,
     "closeout": 12,
     "retro": 8,

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -1025,6 +1025,20 @@ async def test_verify_body_requires_evidence_gate():
 
 
 @pytest.mark.asyncio
+async def test_verify_body_uses_pr_url_fast_path_before_generic_work():
+    body = ka.KanbanAdapter()._build_body(
+        "verify",
+        {"id": "uuid-1", "identifier": "ZOE-9", "title": "Fix thing", "description": ""},
+        "ZOE-9",
+    )
+    assert "PR_URL FAST PATH" in body
+    assert "do not hunt branches or commits" in body
+    assert "gh pr view <url>" in body
+    assert "PR_REVIEW_REQUIRED" in body
+    assert body.index("PR_URL FAST PATH") < body.index("Start with `kanban_show`")
+
+
+@pytest.mark.asyncio
 async def test_review_body_requires_verify_evidence():
     body = ka.KanbanAdapter()._build_body(
         "review",
@@ -1636,6 +1650,35 @@ def test_phase_budget_reason_enforces_tool_and_runtime_limits(tmp_path, monkeypa
     )
     assert reason is not None
     assert "runtime budget exceeded" in reason
+
+
+def test_verify_phase_budget_allows_pr_validation_headroom(tmp_path, monkeypatch):
+    log_path = tmp_path / "task.log"
+    monkeypatch.setattr(kb, "_log_path", lambda _task_id: log_path)
+    monkeypatch.delenv("ZOE_KANBAN_VERIFY_TOOL_BUDGET", raising=False)
+
+    log_path.write_text("\n".join(["  ┊ tool call"] * 17), encoding="utf-8")
+    reason = kb.phase_budget_reason(
+        "t_verify",
+        "verify",
+        {"task": {"started_at": 100}},
+        now=110,
+    )
+
+    assert reason is None
+
+    log_path.write_text("\n".join(["  ┊ tool call"] * 19), encoding="utf-8")
+    reason = kb.phase_budget_reason(
+        "t_verify",
+        "verify",
+        {"task": {"started_at": 100}},
+        now=110,
+    )
+
+    assert reason is not None
+    assert "VERIFY_BUDGET" in reason
+    assert "guidance_limit=16" in reason
+    assert "hard_limit=18" in reason
 
 
 def test_phase_budget_accepts_iso_timestamp_and_ascii_step_logs(tmp_path, monkeypatch):


### PR DESCRIPTION
## What changed
- Adds a verify PR_URL fast path so Hermes validates the known PR directly instead of rediscovering branches/commits.
- Raises the default verify tool budget from 10 to 16 so required PR checks and validators can finish without a false terminal block.
- Adds tests for the fast path and verify budget headroom.

## Why
The live ZOE-5354 run reached verify but hit VERIFY_BUDGET at 14 steps before it could complete the PR validation path. The system failed closed, which protected spend, but the budget was too tight for real PR validation.

## Validation
- `PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_kanban_adapter.py services/zoe-data/tests/test_multica_poll_dispatch.py services/zoe-data/tests/test_pipeline_handoff.py services/zoe-data/tests/test_pipeline_store.py`
- 198 passed
