### PR TITLE
Ignore stale terminal rows for revision phases

### DIFF
--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -788,14 +788,19 @@ class KanbanAdapter:
         entry = next((plan_entry for plan_entry in plan if plan_entry[0] == phase), None)
         current_row = existing_phases.get(phase) or {}
         current_status = (current_row.get("status") or "").lower()
-        if state is not None and state.status == "todo" and current_status == "blocked":
+        if (
+            state is not None
+            and state.status == "todo"
+            and (current_status == "blocked" or current_status in _TERMINAL_KANBAN_STATUSES)
+        ):
             task_id = current_row.get("id")
             if task_id:
                 try:
                     await self._run(["archive", str(task_id)])
                 except KanbanCLIError as exc:
                     logger.warning(
-                        "kanban_adapter: archive of stale blocked task %s failed for %s: %s",
+                        "kanban_adapter: archive of stale %s task %s failed for %s: %s",
+                        current_status,
                         task_id,
                         external_ref,
                         exc,
@@ -803,7 +808,7 @@ class KanbanAdapter:
                     return {
                         "ok": False,
                         "external_ref": external_ref,
-                        "reason": "stale blocked phase archive failed",
+                        "reason": "stale phase archive failed",
                         "phase": phase,
                         "chain": {},
                         "created": [],
@@ -1003,7 +1008,7 @@ class KanbanAdapter:
                     else:
                         current_row = phases.get(str(existing_state.phase or "")) or {}
                         current_status = (current_row.get("status") or "").lower()
-                        if current_status == "blocked":
+                        if current_status == "blocked" or current_status in _TERMINAL_KANBAN_STATUSES:
                             stale_executor_phase = str(existing_state.phase or "")
                             stale_executor_status = current_status
                             phases = {
@@ -1011,7 +1016,11 @@ class KanbanAdapter:
                                 for phase, row in phases.items()
                                 if phase != stale_executor_phase
                             }
-                    if stale_executor_phase and (stale_executor_status == "blocked" or not phases):
+                    if stale_executor_phase and (
+                        stale_executor_status == "blocked"
+                        or stale_executor_status in _TERMINAL_KANBAN_STATUSES
+                        or not phases
+                    ):
                         pipeline = {
                             **pipeline_summary(existing_state),
                             "stale_executor_phase": stale_executor_phase,

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -245,7 +245,7 @@ async def test_dispatch_resumed_todo_reports_archive_failure_without_create():
     assert [c for c in a.calls if c[0] == "archive"] == [["archive", "t_implement"]]
     assert [c for c in a.calls if c[0] == "create"] == []
     assert result["ok"] is False
-    assert result["reason"] == "stale blocked phase archive failed"
+    assert result["reason"] == "stale phase archive failed"
     assert result["phase"] == "implement"
 
 
@@ -554,6 +554,48 @@ async def test_dispatch_keeps_scout_for_non_bug_code_audit_ticket():
         }
     )
     assert set(result["chain"]) == {"scout"}
+
+
+@pytest.mark.asyncio
+async def test_dispatch_archives_stale_terminal_revision_phase_row():
+    from pipeline_evidence import PipelineState
+    from pipeline_store import load_latest_state, save_state
+
+    save_state(
+        PipelineState(
+            task_ref="multica:uuid-revision-terminal",
+            phase="implement",
+            status="todo",
+            evidence_profile="code",
+        ),
+        event="verification_failed",
+    )
+    rows = [
+        _row("implement", "done", chain_version="v4", issue_id="uuid-revision-terminal"),
+        _row("verify", "blocked", chain_version="v4", issue_id="uuid-revision-terminal"),
+    ]
+    a = _FakeAdapter(list_rows=rows)
+
+    result = await a.dispatch(
+        {
+            "id": "uuid-revision-terminal",
+            "identifier": "ZOE-5354",
+            "title": "Fix metrics auth",
+            "metadata": {
+                "zoe_kind": "bug",
+                "source": "code_audit_p0_security",
+                "acceptance_criteria": ["Require internal token"],
+            },
+        }
+    )
+
+    assert result["ok"] is True
+    assert result["phase"] == "implement"
+    assert result["created"] == ["implement"]
+    assert ["archive", "t_implement"] in a.calls
+    latest = load_latest_state("multica:uuid-revision-terminal")
+    assert latest.phase == "implement"
+    assert latest.status == "running"
 
 
 @pytest.mark.asyncio
@@ -1223,6 +1265,48 @@ async def test_poll_v4_done_phase_with_ready_next_phase_is_partial():
     assert out["status"] == "partial"
     assert out["pipeline"]["phase"] == "implement"
     assert out["pipeline"]["status"] == "todo"
+
+
+@pytest.mark.asyncio
+async def test_poll_ignores_stale_terminal_row_for_revision_phase():
+    from pipeline_evidence import PipelineState
+    from pipeline_store import save_state
+
+    save_state(
+        PipelineState(
+            task_ref="multica:uuid-revision-poll",
+            phase="implement",
+            status="todo",
+            evidence_profile="code",
+        ),
+        event="verification_failed",
+    )
+    rows = [
+        _row("implement", "done", chain_version="v4", issue_id="uuid-revision-poll"),
+        _row("verify", "blocked", chain_version="v4", issue_id="uuid-revision-poll"),
+    ]
+    a = _FakeAdapter(list_rows=rows)
+
+    out = await a.poll(
+        "multica:uuid-revision-poll",
+        issue={
+            "id": "uuid-revision-poll",
+            "identifier": "ZOE-5354",
+            "title": "Fix metrics auth",
+            "metadata": {
+                "zoe_kind": "bug",
+                "source": "code_audit_p0_security",
+                "acceptance_criteria": ["Require internal token"],
+            },
+        },
+    )
+
+    assert out["status"] == "partial"
+    assert out["pipeline"]["phase"] == "implement"
+    assert out["pipeline"]["status"] == "todo"
+    assert out["pipeline"]["stale_executor_phase"] == "implement"
+    assert out["pipeline"]["stale_executor_status"] == "done"
+    assert out["blocker"] is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What changed
- Treat terminal Kanban rows for a journal `todo` phase as stale, not as the current phase effect.
- Archive stale terminal rows during dispatch so a fresh revision task can be created.
- Return `partial` from poll when stale terminal rows are filtered, allowing the one-ticket dispatcher to re-dispatch safely.
- Adds regression tests for the ZOE-5354 verify-to-implement revision path.

## Why
The live ZOE-5354 verify task correctly blocked with `PR_REVIEW_REQUIRED`, but the next poll saw the old completed implement row for the same `zoe-ref` and advanced the journal back to verify. That caused an immediate duplicate block/fingerprint abort instead of creating the revision task.

## Validation
- `PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_kanban_adapter.py services/zoe-data/tests/test_multica_poll_dispatch.py services/zoe-data/tests/test_pipeline_handoff.py services/zoe-data/tests/test_pipeline_store.py`
- 200 passed
