### PR TITLE
Precheckout existing PR revisions before dispatch

### DIFF
--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -120,6 +120,12 @@ def _ticket_metadata(issue: dict | None = None) -> dict[str, Any]:
     return meta
 
 
+def _existing_pr_url(issue: dict | None = None) -> str:
+    issue = issue or {}
+    raw = issue.get("pr_url") or _ticket_metadata(issue).get("pr_url") or ""
+    return str(raw).strip()
+
+
 def _engineering_mode(issue: dict | None = None) -> str:
     """Resolve the engineering execution mode for a journaled phase run.
 
@@ -512,25 +518,23 @@ class KanbanAdapter:
                 " this is a revision task. Do not rediscover the original fix and do not create a new PR."
                 " This revision path takes precedence over all file inspection: after `kanban_show`,"
                 " do not read, grep, or edit files until the existing PR checkout below succeeds."
-                " Run `gh pr view <PR_URL> --json url,number,headRefName,"
+                " Zoe dispatch pre-checks this task worktree to the existing PR head before the worker"
+                " starts. Run `gh pr view <PR_URL> --json url,number,headRefName,headRefOid,"
                 f"headRepositoryOwner,mergeStateStatus,statusCheckRollup` and `{_greptile_mcp_bin()}"
                 " pr-comments --unaddressed-only jason-easyazz/zoe-ai-assistant <number>`."
                 " That Greptile command may exit nonzero when it prints unresolved comments; read stdout"
-                " as the action list instead of treating the nonzero exit alone as failure."
-                " Immediately check out a unique slash-free local copy of the PR with"
-                " `branch=pr-<number>-$(date +%s)-$$ && git checkout -B $branch &&"
-                " git fetch origin pull/<number>/head && git reset --hard FETCH_HEAD`; do not use"
-                " `gh pr checkout` because the PR head branch may already"
-                " be checked out in another worktree. Address only the"
-                " unresolved review/Greptile/CI action list, run focused tests plus validators, commit,"
+                " as the action list instead of treating the nonzero exit alone as failure. Run"
+                " `git rev-parse HEAD` and compare it to the gh `headRefOid`; if it does not match,"
+                " immediately call `kanban_block` with BLOCKER=PR_REVISION_CHECKOUT_FAILED."
+                " Do not run `gh pr checkout`, `git checkout`, `git fetch`, or `git reset` yourself"
+                " in this phase; if the pre-checked worktree is wrong, block instead of repairing it."
+                " Address only the unresolved review/Greptile/CI action list, run focused tests plus validators, commit,"
                 " `git push origin HEAD:<headRefName>` (use headRefName from the gh pr view output above),"
                 " and report the SAME PR_URL. Run Python tests with"
                 " `PYTHONPATH=services/zoe-data python3 -m pytest ...`. For tests involving module-level"
                 " env-derived constants, patch the module variable with monkeypatch/setattr after import;"
                 " do not set os.environ after importing the module and expect the already-loaded constant"
-                " to change. If checkout, fetch, or reset fails, immediately call `kanban_block` with"
-                " BLOCKER=PR_REVISION_CHECKOUT_FAILED; do not inspect or edit files on the original"
-                " worktree branch. If the action list is ambiguous, call `kanban_block` with"
+                " to change. If the action list is ambiguous, call `kanban_block` with"
                 " BLOCKER=PR_REVISION_BLOCKED.\n"
                 "- You already run on an isolated git worktree branch. Commit verified changes, then publish"
                 " the branch and open ONE small PR (do not merge) with EXACTLY these commands:\n"
@@ -951,9 +955,48 @@ class KanbanAdapter:
         if not (result or {}).get("deduplicated"):
             created.append(phase)
         if phase in {"implement", "verify"}:
-            from worktree_bootstrap import prepare_kanban_worktree
+            from worktree_bootstrap import prepare_existing_pr_revision_worktree, prepare_kanban_worktree
 
-            await asyncio.to_thread(prepare_kanban_worktree, str(task_id))
+            pr_url = _existing_pr_url(issue)
+            worktree_failure_reason = "kanban worktree preparation failed"
+            worktree_blocker = "BLOCKER=WORKTREE_PREPARATION_FAILED"
+            try:
+                if phase == "implement" and pr_url:
+                    worktree_failure_reason = "existing PR worktree preparation failed"
+                    worktree_blocker = "BLOCKER=PR_REVISION_CHECKOUT_FAILED"
+                    await asyncio.to_thread(
+                        prepare_existing_pr_revision_worktree,
+                        str(task_id),
+                        pr_url,
+                    )
+                else:
+                    await asyncio.to_thread(prepare_kanban_worktree, str(task_id))
+            except Exception as exc:  # noqa: BLE001
+                reason = f"{worktree_blocker}: {exc}"
+                logger.warning(
+                    "kanban_adapter: worktree preparation failed for %s (%s): %s",
+                    task_id,
+                    phase,
+                    exc,
+                )
+                try:
+                    await self._run(["block", str(task_id), reason[:1000]])
+                except KanbanCLIError as block_exc:
+                    logger.warning(
+                        "kanban_adapter: failed to block %s after worktree preparation failure: %s",
+                        task_id,
+                        block_exc,
+                    )
+                return {
+                    "ok": False,
+                    "external_ref": external_ref,
+                    "reason": worktree_failure_reason,
+                    "phase": phase,
+                    "chain": {phase: task_id},
+                    "created": created,
+                    "mode": mode,
+                    "ready_phase_only": True,
+                }
         if state is not None and state.status == "todo":
             try:
                 running = transition(state, "start")

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -15,6 +15,10 @@ def _mock_ensure_worktree(monkeypatch):
         "worktree_bootstrap.prepare_kanban_worktree",
         lambda task_id, **kwargs: Path(f"/tmp/worktrees/{task_id}"),
     )
+    monkeypatch.setattr(
+        "worktree_bootstrap.prepare_existing_pr_revision_worktree",
+        lambda task_id, pr_url, **kwargs: Path(f"/tmp/worktrees/{task_id}"),
+    )
 
 
 @pytest.fixture(autouse=True)
@@ -93,6 +97,87 @@ async def test_dispatch_refuses_to_create_without_pipeline_journal(monkeypatch):
     assert result["ok"] is False
     assert result["reason"] == "pipeline bootstrap failed"
     assert [c for c in a.calls if c[0] == "create"] == []
+
+
+@pytest.mark.asyncio
+async def test_dispatch_prepares_existing_pr_revision_worktree(monkeypatch):
+    monkeypatch.setenv("ZOE_KANBAN_SKIP_SCOUT", "1")
+    calls = []
+
+    def fake_prepare(task_id, pr_url, **kwargs):
+        calls.append((task_id, pr_url, kwargs))
+        return Path(f"/tmp/worktrees/{task_id}")
+
+    monkeypatch.setattr("worktree_bootstrap.prepare_existing_pr_revision_worktree", fake_prepare)
+    a = _FakeAdapter()
+    result = await a.dispatch(
+        {
+            "id": "uuid-pr-revision",
+            "identifier": "ZOE-5354",
+            "title": "Metrics auth revision",
+            "description": """```zoe-ticket
+{"pr_url":"https://github.com/jason-easyazz/zoe-ai-assistant/pull/213"}
+```""",
+        }
+    )
+
+    assert result["ok"] is True
+    assert result["phase"] == "implement"
+    assert calls == [
+        ("t_implement", "https://github.com/jason-easyazz/zoe-ai-assistant/pull/213", {})
+    ]
+
+
+@pytest.mark.asyncio
+async def test_dispatch_blocks_existing_pr_revision_when_precheckout_fails(monkeypatch):
+    monkeypatch.setenv("ZOE_KANBAN_SKIP_SCOUT", "1")
+
+    def fail_prepare(*args, **kwargs):
+        raise RuntimeError("fetch failed")
+
+    monkeypatch.setattr("worktree_bootstrap.prepare_existing_pr_revision_worktree", fail_prepare)
+    a = _FakeAdapter()
+    result = await a.dispatch(
+        {
+            "id": "uuid-pr-revision-fail",
+            "identifier": "ZOE-5354",
+            "title": "Metrics auth revision",
+            "description": """```zoe-ticket
+{"pr_url":"https://github.com/jason-easyazz/zoe-ai-assistant/pull/213"}
+```""",
+        }
+    )
+
+    assert result["ok"] is False
+    assert result["reason"] == "existing PR worktree preparation failed"
+    block_calls = [c for c in a.calls if c[0] == "block"]
+    assert len(block_calls) == 1
+    assert "BLOCKER=PR_REVISION_CHECKOUT_FAILED" in block_calls[0][2]
+
+
+@pytest.mark.asyncio
+async def test_dispatch_blocks_regular_worktree_failures_with_generic_reason(monkeypatch):
+    monkeypatch.setenv("ZOE_KANBAN_SKIP_SCOUT", "1")
+
+    def fail_prepare(*args, **kwargs):
+        raise RuntimeError("worktree add failed")
+
+    monkeypatch.setattr("worktree_bootstrap.prepare_kanban_worktree", fail_prepare)
+    a = _FakeAdapter()
+    result = await a.dispatch(
+        {
+            "id": "uuid-regular-worktree-fail",
+            "identifier": "ZOE-WT",
+            "title": "Regular implement task",
+        }
+    )
+
+    assert result["ok"] is False
+    assert result["reason"] == "kanban worktree preparation failed"
+    block_calls = [c for c in a.calls if c[0] == "block"]
+    assert len(block_calls) == 1
+    assert "BLOCKER=WORKTREE_PREPARATION_FAILED" in block_calls[0][2]
+    assert "PR_REVISION_CHECKOUT_FAILED" not in block_calls[0][2]
 
 
 
@@ -2199,18 +2284,15 @@ def test_implement_body_documents_existing_pr_revision_fast_path_before_new_pr_c
     assert "do not read, grep, or edit files until the existing PR checkout below succeeds" in body
     assert "/opt/zoe/greptile-mcp pr-comments --unaddressed-only" in body
     assert "may exit nonzero when it prints unresolved comments" in body
-    assert "branch=pr-<number>-$(date +%s)-$$" in body
-    assert "unique slash-free local copy" in body
-    assert "git checkout -B $branch" in body
-    assert "git fetch origin pull/<number>/head" in body
-    assert "git reset --hard FETCH_HEAD" in body
-    assert "do not use `gh pr checkout`" in body
+    assert "Zoe dispatch pre-checks this task worktree to the existing PR head" in body
+    assert "headRefOid" in body
+    assert "git rev-parse HEAD" in body
+    assert "Do not run `gh pr checkout`, `git checkout`, `git fetch`, or `git reset` yourself" in body
     assert "git push origin HEAD:<headRefName>" in body
     assert "report the SAME PR_URL" in body
     assert "PYTHONPATH=services/zoe-data python3 -m pytest" in body
     assert "patch the module variable with monkeypatch/setattr after import" in body
     assert "BLOCKER=PR_REVISION_CHECKOUT_FAILED" in body
-    assert "do not inspect or edit files on the original worktree branch" in body
     assert "BLOCKER=PR_REVISION_BLOCKED" in body
     assert body.index("BLOCKER=PR_REVISION_CHECKOUT_FAILED") < body.index("BLOCKER=PR_REVISION_BLOCKED")
     assert body.index("EXISTING PR REVISION FAST PATH") < body.index("open ONE small PR")

--- a/services/zoe-data/tests/test_worktree_bootstrap.py
+++ b/services/zoe-data/tests/test_worktree_bootstrap.py
@@ -87,6 +87,92 @@ def test_ensure_worktree_rejects_invalid_task_id():
         wb.ensure_worktree("../escape")
 
 
+def test_extract_pr_number():
+    assert wb._extract_pr_number("https://github.com/o/r/pull/213") == "213"
+    assert wb._extract_pr_number("https://github.com/o/r/pull/213/files") == "213"
+    with pytest.raises(ValueError, match="cannot extract"):
+        wb._extract_pr_number("https://github.com/o/r/issues/213")
+
+
+def test_prepare_existing_pr_revision_worktree_resets_to_pr_head(git_repo, tmp_path):
+    remote = tmp_path / "origin.git"
+    subprocess.run(["git", "init", "--bare", str(remote)], check=True, capture_output=True)
+    subprocess.run(["git", "remote", "add", "origin", str(remote)], cwd=git_repo, check=True)
+    subprocess.run(["git", "push", "-u", "origin", "main"], cwd=git_repo, check=True, capture_output=True)
+
+    (git_repo / "PR_ONLY.md").write_text("pr head\n", encoding="utf-8")
+    subprocess.run(["git", "add", "PR_ONLY.md"], cwd=git_repo, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "pr head"], cwd=git_repo, check=True, capture_output=True)
+    expected_head = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=git_repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    subprocess.run(
+        ["git", "push", "origin", "HEAD:refs/pull/213/head"],
+        cwd=git_repo,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(["git", "reset", "--hard", "HEAD~1"], cwd=git_repo, check=True, capture_output=True)
+
+    wt = wb.prepare_existing_pr_revision_worktree(
+        "t_pr_revision",
+        "https://github.com/o/r/pull/213",
+    )
+
+    assert (wt / "PR_ONLY.md").read_text(encoding="utf-8") == "pr head\n"
+    head = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=wt,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    assert head == expected_head
+    task_ref = subprocess.run(
+        ["git", "rev-parse", "refs/wt-pr/t_pr_revision"],
+        cwd=wt,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert task_ref.returncode != 0
+
+    (git_repo / "PR_ONLY.md").write_text("force-pushed pr head\n", encoding="utf-8")
+    subprocess.run(["git", "add", "PR_ONLY.md"], cwd=git_repo, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "--amend", "-m", "force-pushed pr head"], cwd=git_repo, check=True, capture_output=True)
+    force_pushed_head = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=git_repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    subprocess.run(
+        ["git", "push", "--force", "origin", "HEAD:refs/pull/213/head"],
+        cwd=git_repo,
+        check=True,
+        capture_output=True,
+    )
+
+    wt = wb.prepare_existing_pr_revision_worktree(
+        "t_pr_revision",
+        "https://github.com/o/r/pull/213",
+    )
+    head = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=wt,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    assert head == force_pushed_head
+    assert (wt / "PR_ONLY.md").read_text(encoding="utf-8") == "force-pushed pr head\n"
+
+
 def test_ensure_worktree_raises_when_repo_not_git(tmp_path, monkeypatch):
     monkeypatch.setenv("ZOE_REPO_ROOT", str(tmp_path / "not-git"))
     monkeypatch.setenv("ZOE_WORKTREE_ROOT", str(tmp_path / "worktrees"))

--- a/services/zoe-data/worktree_bootstrap.py
+++ b/services/zoe-data/worktree_bootstrap.py
@@ -14,6 +14,7 @@ from hermes_http import zoe_repo_root
 logger = logging.getLogger(__name__)
 
 _TASK_ID_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+_GITHUB_PR_RE = re.compile(r"/pull/(\d+)(?:\D|$)")
 
 
 def _run_git(args: list[str], *, cwd: str, timeout: int) -> subprocess.CompletedProcess[str]:
@@ -208,4 +209,62 @@ def prepare_kanban_worktree(task_id: str, *, base_branch: str = "main") -> Path:
             task_id,
             exc,
         )
+    return wt_path
+
+
+def _extract_pr_number(pr_url: str) -> str:
+    match = _GITHUB_PR_RE.search((pr_url or "").strip())
+    if not match:
+        raise ValueError(f"cannot extract GitHub PR number from {pr_url!r}")
+    return match.group(1)
+
+
+def prepare_existing_pr_revision_worktree(task_id: str, pr_url: str, *, base_branch: str = "main") -> Path:
+    """Create/pin a task worktree and reset it to the existing PR head.
+
+    Revision tasks must not rely on the worker prompt to check out the PR. Zoe
+    prepares the workspace before the Hermes worker is allowed to inspect files;
+    if the fetch/reset fails, dispatch can block the Kanban task without burning
+    a paid agent run on the wrong branch.
+    """
+    wt_path = prepare_kanban_worktree(task_id, base_branch=base_branch)
+    pr_number = _extract_pr_number(pr_url)
+    pr_ref = f"refs/wt-pr/{task_id}"
+
+    fetch = _run_git(
+        ["git", "fetch", "origin", f"+pull/{pr_number}/head:{pr_ref}"],
+        cwd=str(wt_path),
+        timeout=120,
+    )
+    if fetch.returncode != 0:
+        raise RuntimeError(
+            f"git fetch origin +pull/{pr_number}/head:{pr_ref} failed for {task_id}:"
+            f" {(fetch.stderr or fetch.stdout or '').strip() or 'unknown error'}"
+        )
+
+    reset = _run_git(
+        ["git", "reset", "--hard", pr_ref],
+        cwd=str(wt_path),
+        timeout=60,
+    )
+    if reset.returncode != 0:
+        raise RuntimeError(
+            f"git reset --hard {pr_ref} failed for {task_id}:"
+            f" {(reset.stderr or reset.stdout or '').strip() or 'unknown error'}"
+        )
+
+    cleanup = _run_git(["git", "update-ref", "-d", pr_ref], cwd=str(wt_path), timeout=30)
+    if cleanup.returncode != 0:
+        logger.warning(
+            "worktree_bootstrap: could not delete temporary PR ref %s for %s: %s",
+            pr_ref,
+            task_id,
+            (cleanup.stderr or cleanup.stdout or "").strip() or "unknown error",
+        )
+
+    logger.info(
+        "worktree_bootstrap: prepared existing PR revision workspace %s -> PR #%s",
+        task_id,
+        pr_number,
+    )
     return wt_path


### PR DESCRIPTION
## Summary
- prepare implement revision worktrees to the existing PR head before Hermes workers inspect files
- block the Kanban task if PR precheckout fails instead of relying on prompt compliance
- update revision prompt to verify the prechecked HEAD and stop if it is wrong

## Tests
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_kanban_adapter.py services/zoe-data/tests/test_worktree_bootstrap.py services/zoe-data/tests/test_multica_poll_dispatch.py services/zoe-data/tests/test_pipeline_handoff.py services/zoe-data/tests/test_pipeline_store.py