### PR TITLE
Recover pipeline evidence from Kanban run metadata

### DIFF
--- a/services/zoe-data/pipeline_handoff.py
+++ b/services/zoe-data/pipeline_handoff.py
@@ -46,15 +46,16 @@ _STABLE_BLOCKER_RE = re.compile(
 )
 
 
+def _task_body(detail: dict[str, Any]) -> str:
+    task = detail.get("task") if isinstance(detail.get("task"), dict) else {}
+    return str(task.get("body") or "")
+
+
 def _haystacks(detail: dict[str, Any]) -> list[str]:
     parts: list[str] = []
     summary = detail.get("latest_summary")
     if summary:
         parts.append(summary if isinstance(summary, str) else json.dumps(summary))
-    task = detail.get("task") if isinstance(detail.get("task"), dict) else {}
-    task_body = task.get("body") or ""
-    if task_body:
-        parts.append(str(task_body))
     for comment in detail.get("comments") or []:
         body = comment.get("body") or comment.get("text") or ""
         if body:
@@ -295,8 +296,7 @@ def _test_from_run_metadata(detail: dict[str, Any], *, phase: PipelinePhase) -> 
 
 
 def _pr_url_from_ticket_block(detail: dict[str, Any]) -> str:
-    task = detail.get("task") if isinstance(detail.get("task"), dict) else {}
-    body = str(task.get("body") or "") if isinstance(task, dict) else ""
+    body = _task_body(detail)
     if not body:
         return ""
     try:
@@ -480,6 +480,9 @@ def evidence_from_handoff(
     text_fields: dict[str, str] = {}
     for chunk in _haystacks(detail):
         text_fields.update(_parse_kv_fields(chunk))
+    task_body = _task_body(detail)
+    if task_body:
+        text_fields.update(_parse_kv_fields(task_body))
     fields = dict(text_fields)
     fields.update(_structured_handoff_fields(detail))
 
@@ -559,6 +562,8 @@ def evidence_from_handoff(
             if review_item:
                 items.append(review_item)
 
+    ticket_pr_url = _pr_url_from_ticket_block(detail)
+
     if phase == "closeout":
         summary_raw = fields.get("SUMMARY") or fields.get("CLOSEOUT") or ""
         audit_only = (fields.get("AUDIT_ONLY") or "").strip().lower() in {"1", "true", "yes"}
@@ -568,7 +573,7 @@ def evidence_from_handoff(
             summary_raw
             and "audit" in summary_raw.lower()
             and not (fields.get("PR_URL") or "").strip()
-            and not _pr_url_from_ticket_block(detail)
+            and not ticket_pr_url
         )
         if audit_only or inferred_audit:
             items.append(
@@ -591,7 +596,7 @@ def evidence_from_handoff(
             metadata["follow_up"] = follow_up
         items.append(EvidenceItem(kind="log", summary=retro_raw[:500], passed=True, metadata=metadata))
 
-    pr_url = fields.get("PR_URL") or _pr_url_from_ticket_block(detail)
+    pr_url = fields.get("PR_URL") or ticket_pr_url
     if pr_url and phase in {"implement", "verify", "closeout"}:
         items.append(EvidenceItem(kind="pr", summary=pr_url[:500], artifact=pr_url, passed=True))
 

--- a/services/zoe-data/pipeline_handoff.py
+++ b/services/zoe-data/pipeline_handoff.py
@@ -51,6 +51,10 @@ def _haystacks(detail: dict[str, Any]) -> list[str]:
     summary = detail.get("latest_summary")
     if summary:
         parts.append(summary if isinstance(summary, str) else json.dumps(summary))
+    task = detail.get("task") if isinstance(detail.get("task"), dict) else {}
+    task_body = task.get("body") or ""
+    if task_body:
+        parts.append(str(task_body))
     for comment in detail.get("comments") or []:
         body = comment.get("body") or comment.get("text") or ""
         if body:
@@ -250,6 +254,60 @@ def _tool_from_log_markers(detail: dict[str, Any]) -> EvidenceItem | None:
                 metadata={"source": "log_markers"},
             )
     return None
+
+
+def _test_from_run_metadata(detail: dict[str, Any], *, phase: PipelinePhase) -> EvidenceItem | None:
+    if phase not in {"implement", "verify"}:
+        return None
+    latest: tuple[Any, Any] | None = None
+    for run in detail.get("runs") or []:
+        if not isinstance(run, dict):
+            continue
+        metadata = run.get("metadata") or {}
+        if not isinstance(metadata, dict):
+            continue
+        tests_run = metadata.get("tests_run")
+        tests_passed = metadata.get("tests_passed")
+        if tests_run in (None, "", 0, "0"):
+            continue
+        latest = (tests_run, tests_passed)
+    if latest is not None:
+        tests_run, tests_passed = latest
+        passed = False
+        if tests_passed is True:
+            passed = True
+        elif tests_passed is False:
+            passed = False
+        else:
+            try:
+                passed = int(tests_passed) >= int(tests_run)
+            except (TypeError, ValueError):
+                passed = str(tests_passed or "").strip().lower() in {"true", "yes", "pass", "passed"}
+        summary = f"kanban run metadata: tests_run={tests_run}, tests_passed={tests_passed}"
+        return EvidenceItem(
+            kind="test",
+            summary=summary[:500],
+            content_hash=content_hash(summary),
+            passed=passed,
+            metadata={"source": "kanban_run_metadata", "phase": phase},
+        )
+    return None
+
+
+def _pr_url_from_ticket_block(detail: dict[str, Any]) -> str:
+    task = detail.get("task") if isinstance(detail.get("task"), dict) else {}
+    body = str(task.get("body") or "") if isinstance(task, dict) else ""
+    if not body:
+        return ""
+    try:
+        from multica_ticket_contract import parse_ticket_block
+
+        metadata = parse_ticket_block(body)
+    except Exception:  # noqa: BLE001
+        metadata = {}
+    if isinstance(metadata, dict):
+        return str(metadata.get("pr_url") or "").strip()
+    return ""
 
 
 def _review_metadata_candidates(detail: dict[str, Any]) -> list[tuple[str, dict[str, Any]]]:
@@ -471,6 +529,10 @@ def evidence_from_handoff(
                 metadata={"source": "handoff"},
             )
         )
+    elif phase in {"implement", "verify"}:
+        metadata_test = _test_from_run_metadata(detail, phase=phase)
+        if metadata_test:
+            items.append(metadata_test)
 
     validators_raw = fields.get("VALIDATORS") or ""
     if validators_raw and phase in {"implement", "verify"}:
@@ -503,7 +565,10 @@ def evidence_from_handoff(
         # Some audit/no-code closeout workers omit AUDIT_ONLY but still report an
         # audit-only summary and no PR. Treat only that explicit audit wording as inferred audit.
         inferred_audit = bool(
-            summary_raw and "audit" in summary_raw.lower() and not (fields.get("PR_URL") or "").strip()
+            summary_raw
+            and "audit" in summary_raw.lower()
+            and not (fields.get("PR_URL") or "").strip()
+            and not _pr_url_from_ticket_block(detail)
         )
         if audit_only or inferred_audit:
             items.append(
@@ -526,7 +591,7 @@ def evidence_from_handoff(
             metadata["follow_up"] = follow_up
         items.append(EvidenceItem(kind="log", summary=retro_raw[:500], passed=True, metadata=metadata))
 
-    pr_url = fields.get("PR_URL") or ""
+    pr_url = fields.get("PR_URL") or _pr_url_from_ticket_block(detail)
     if pr_url and phase in {"implement", "verify", "closeout"}:
         items.append(EvidenceItem(kind="pr", summary=pr_url[:500], artifact=pr_url, passed=True))
 

--- a/services/zoe-data/pipeline_handoff.py
+++ b/services/zoe-data/pipeline_handoff.py
@@ -480,9 +480,9 @@ def evidence_from_handoff(
     text_fields: dict[str, str] = {}
     for chunk in _haystacks(detail):
         text_fields.update(_parse_kv_fields(chunk))
-    task_body = _task_body(detail)
-    if task_body:
-        text_fields.update(_parse_kv_fields(task_body))
+    task_fields = _parse_kv_fields(_task_body(detail))
+    if task_fields.get("PR_URL") and not text_fields.get("PR_URL"):
+        text_fields["PR_URL"] = task_fields["PR_URL"]
     fields = dict(text_fields)
     fields.update(_structured_handoff_fields(detail))
 

--- a/services/zoe-data/pipeline_handoff.py
+++ b/services/zoe-data/pipeline_handoff.py
@@ -562,7 +562,11 @@ def evidence_from_handoff(
             if review_item:
                 items.append(review_item)
 
-    ticket_pr_url = _pr_url_from_ticket_block(detail)
+    ticket_pr_url = (
+        _pr_url_from_ticket_block(detail)
+        if phase in {"implement", "verify", "closeout"}
+        else ""
+    )
 
     if phase == "closeout":
         summary_raw = fields.get("SUMMARY") or fields.get("CLOSEOUT") or ""

--- a/services/zoe-data/tests/test_pipeline_handoff.py
+++ b/services/zoe-data/tests/test_pipeline_handoff.py
@@ -86,6 +86,32 @@ PR_URL=https://github.com/jason-easyazz/zoe-ai-assistant/pull/213
     assert any(item.kind == "pr" for item in items)
 
 
+def test_task_body_tests_do_not_override_run_metadata_recovery():
+    detail = {
+        "latest_summary": "Fixed the requested implementation.",
+        "task": {
+            "body": """Multica issue: ZOE-5354
+TESTS=old ticket template says pending
+PR_URL=https://github.com/jason-easyazz/zoe-ai-assistant/pull/213"""
+        },
+        "runs": [
+            {
+                "metadata": {
+                    "tests_run": 2,
+                    "tests_passed": 2,
+                },
+            }
+        ],
+    }
+
+    items = evidence_from_handoff("implement", detail, skills=())
+
+    test_item = next(item for item in items if item.kind == "test")
+    assert test_item.passed is True
+    assert test_item.metadata.get("source") == "kanban_run_metadata"
+    assert "tests_run=2" in test_item.summary
+
+
 def test_run_metadata_test_evidence_requires_all_tests_to_pass():
     detail = {
         "runs": [

--- a/services/zoe-data/tests/test_pipeline_handoff.py
+++ b/services/zoe-data/tests/test_pipeline_handoff.py
@@ -59,6 +59,33 @@ def test_implement_evidence_recovers_live_run_metadata_and_ticket_pr_url():
     )
 
 
+def test_task_body_does_not_create_tool_evidence_without_logs_or_skills():
+    detail = {
+        "latest_summary": "Fixed the requested implementation.",
+        "task": {
+            "body": """Multica issue: ZOE-5354
+PR_URL=https://github.com/jason-easyazz/zoe-ai-assistant/pull/213
+```zoe-ticket
+{"pr_url":"https://github.com/jason-easyazz/zoe-ai-assistant/pull/213"}
+```"""
+        },
+        "runs": [
+            {
+                "metadata": {
+                    "tests_run": 1,
+                    "tests_passed": 1,
+                },
+            }
+        ],
+    }
+
+    items = evidence_from_handoff("implement", detail, skills=())
+
+    assert not any(item.kind == "tool" for item in items)
+    assert any(item.kind == "test" and item.passed is True for item in items)
+    assert any(item.kind == "pr" for item in items)
+
+
 def test_run_metadata_test_evidence_requires_all_tests_to_pass():
     detail = {
         "runs": [

--- a/services/zoe-data/tests/test_pipeline_handoff.py
+++ b/services/zoe-data/tests/test_pipeline_handoff.py
@@ -19,6 +19,109 @@ def test_evidence_from_implement_handoff_parses_tools_and_tests():
     assert "pr" in kinds
 
 
+def test_implement_evidence_recovers_live_run_metadata_and_ticket_pr_url():
+    detail = {
+        "latest_summary": (
+            "Fixed timing-attack vulnerability in auth.py token comparison — "
+            "replaced vulnerable == with hmac.compare_digest for constant-time security."
+        ),
+        "task": {
+            "body": """Multica issue: ZOE-5354
+```zoe-ticket
+{"pr_url":"https://github.com/jason-easyazz/zoe-ai-assistant/pull/213"}
+```"""
+        },
+        "runs": [
+            {
+                "summary": "Fixed timing-attack vulnerability in auth.py token comparison.",
+                "metadata": {
+                    "changed_files": ["services/zoe-data/auth.py"],
+                    "tests_run": 1,
+                    "tests_passed": 1,
+                },
+            }
+        ],
+    }
+
+    items = evidence_from_handoff("implement", detail, skills=("zoe-engineering",))
+
+    assert any(item.kind == "tool" and item.passed is True for item in items)
+    assert any(
+        item.kind == "test"
+        and item.passed is True
+        and item.metadata.get("source") == "kanban_run_metadata"
+        for item in items
+    )
+    assert any(
+        item.kind == "pr"
+        and item.artifact == "https://github.com/jason-easyazz/zoe-ai-assistant/pull/213"
+        for item in items
+    )
+
+
+def test_run_metadata_test_evidence_requires_all_tests_to_pass():
+    detail = {
+        "runs": [
+            {
+                "metadata": {
+                    "tests_run": 5,
+                    "tests_passed": 3,
+                }
+            }
+        ],
+    }
+
+    items = evidence_from_handoff("implement", detail, skills=("zoe-engineering",))
+    test_item = next(item for item in items if item.kind == "test")
+    assert test_item.passed is False
+
+
+def test_run_metadata_test_evidence_uses_latest_qualifying_run():
+    detail = {
+        "runs": [
+            {
+                "metadata": {
+                    "tests_run": 1,
+                    "tests_passed": 1,
+                }
+            },
+            {
+                "metadata": {
+                    "tests_run": 5,
+                    "tests_passed": 3,
+                }
+            },
+        ],
+    }
+
+    items = evidence_from_handoff("implement", detail, skills=("zoe-engineering",))
+    test_item = next(item for item in items if item.kind == "test")
+    assert test_item.passed is False
+    assert "tests_run=5" in test_item.summary
+    assert "tests_passed=3" in test_item.summary
+
+
+def test_closeout_ticket_pr_url_prevents_inferred_audit_only_evidence():
+    detail = {
+        "latest_summary": "SUMMARY=audit closeout completed without prose PR field",
+        "task": {
+            "body": """Multica issue: ZOE-5354
+```zoe-ticket
+{"pr_url":"https://github.com/jason-easyazz/zoe-ai-assistant/pull/213"}
+```"""
+        },
+    }
+
+    items = evidence_from_handoff("closeout", detail)
+
+    assert any(item.kind == "pr" for item in items)
+    assert not any(
+        item.kind == "log"
+        and item.metadata.get("audit_only") is True
+        for item in items
+    )
+
+
 def test_implementation_required_from_structured_scout_handoff():
     detail = {
         "runs": [

--- a/services/zoe-data/tests/test_pipeline_store.py
+++ b/services/zoe-data/tests/test_pipeline_store.py
@@ -395,7 +395,13 @@ async def test_sync_pipeline_advances_with_live_run_metadata_recovery(isolated_s
 
     assert state.phase == "verify"
     assert state.status == "todo"
-    assert any(item.kind == "tool" and item.passed is True for item in state.evidence)
+    assert "zoe-engineering" in store._PHASE_SKILLS["implement"]
+    assert any(
+        item.kind == "tool"
+        and item.passed is True
+        and item.metadata.get("source") == "skills"
+        for item in state.evidence
+    )
     assert any(item.kind == "test" and item.passed is True for item in state.evidence)
     assert any(
         item.kind == "pr"

--- a/services/zoe-data/tests/test_pipeline_store.py
+++ b/services/zoe-data/tests/test_pipeline_store.py
@@ -358,6 +358,53 @@ async def test_sync_pipeline_advances_on_complete_handoff(isolated_store):
 
 
 @pytest.mark.asyncio
+async def test_sync_pipeline_advances_with_live_run_metadata_recovery(isolated_store):
+    await store.bootstrap_state("multica:sync-live-metadata")
+
+    async def fetch_detail(_task_id: str):
+        return {
+            "latest_summary": (
+                "Fixed timing-attack vulnerability in auth.py token comparison — "
+                "replaced vulnerable == with hmac.compare_digest."
+            ),
+            "task": {
+                "body": """Multica issue: ZOE-5354
+```zoe-ticket
+{"pr_url":"https://github.com/jason-easyazz/zoe-ai-assistant/pull/213"}
+```"""
+            },
+            "runs": [
+                {
+                    "summary": "Fixed timing-attack vulnerability in auth.py token comparison.",
+                    "metadata": {
+                        "changed_files": ["services/zoe-data/auth.py"],
+                        "tests_run": 1,
+                        "tests_passed": 1,
+                    },
+                }
+            ],
+            "comments": [],
+        }
+
+    phases = {"implement": {"id": "t_live", "status": "archived"}}
+    state = await store.sync_pipeline_from_chain(
+        "multica:sync-live-metadata",
+        phases,
+        fetch_detail,
+    )
+
+    assert state.phase == "verify"
+    assert state.status == "todo"
+    assert any(item.kind == "tool" and item.passed is True for item in state.evidence)
+    assert any(item.kind == "test" and item.passed is True for item in state.evidence)
+    assert any(
+        item.kind == "pr"
+        and item.artifact == "https://github.com/jason-easyazz/zoe-ai-assistant/pull/213"
+        for item in state.evidence
+    )
+
+
+@pytest.mark.asyncio
 async def test_sync_pipeline_retries_a_concurrent_transition_write(
     isolated_store, monkeypatch
 ):


### PR DESCRIPTION
## Summary
- include task body/ticket metadata when parsing Kanban handoffs
- recover test evidence from lowercase Kanban run metadata such as tests_run/tests_passed
- recover PR evidence from the ticket pr_url when Hermes omits PR_URL= in the prose summary

## Tests
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_pipeline_handoff.py services/zoe-data/tests/test_pipeline_store.py services/zoe-data/tests/test_kanban_adapter.py services/zoe-data/tests/test_multica_poll_dispatch.py