### PR TITLE
Surface verify budget blockers without revision

### DIFF
--- a/services/zoe-data/pipeline_handoff.py
+++ b/services/zoe-data/pipeline_handoff.py
@@ -44,6 +44,14 @@ _STABLE_BLOCKER_RE = re.compile(
     r"TURN_BUDGET|ITERATION_BUDGET|CONTEXT_LIMIT|TOKEN_LIMIT|SCOPE_SPLIT_REQUIRED|NEEDS_SPLIT)\b",
     re.I,
 )
+_SURFACED_BLOCKER_RE = re.compile(
+    r"\b(?:VERIFY_BUDGET|REVIEW_BUDGET|CLOSEOUT_BUDGET|IMPLEMENT_BUDGET|"
+    r"PR_REVIEW_REQUIRED|PR_REVISION_BLOCKED|PR_REVISION_CHECKOUT_FAILED|"
+    r"WORKTREE_PREPARATION_FAILED|WORKTREE_NOT_READY|PROTOCOL_VIOLATION|"
+    r"TURN_BUDGET|ITERATION_BUDGET|CONTEXT_LIMIT|TOKEN_LIMIT|"
+    r"HTTP_402|PAYMENT_REQUIRED|CREDITS_EXHAUSTED)\b",
+    re.I,
+)
 
 
 def _task_body(detail: dict[str, Any]) -> str:
@@ -638,7 +646,14 @@ def block_reason_from_handoff(detail: dict[str, Any], *, row_block_reason: str |
 def infer_outcome(phase: PipelinePhase, row_status: str, detail: dict[str, Any]) -> str | None:
     """Map a terminal Kanban row to a pipeline transition outcome when inferrable."""
     status = (row_status or "").lower()
+    fields: dict[str, str] = {}
+    for chunk in _haystacks(detail):
+        fields.update(_parse_kv_fields(chunk))
+    blocker = fields.get("BLOCKER") or block_reason_from_handoff(detail) or ""
+
     if status == "blocked":
+        if _SURFACED_BLOCKER_RE.search(blocker):
+            return "block"
         if phase == "verify":
             return "verification_failed"
         if phase == "review":
@@ -649,11 +664,9 @@ def infer_outcome(phase: PipelinePhase, row_status: str, detail: dict[str, Any])
     if status not in {"done", "archived"}:
         return None
 
-    fields: dict[str, str] = {}
-    for chunk in _haystacks(detail):
-        fields.update(_parse_kv_fields(chunk))
-    blocker = fields.get("BLOCKER") or ""
     if blocker:
+        if _SURFACED_BLOCKER_RE.search(blocker):
+            return "block"
         if phase == "verify":
             return "verification_failed"
         if phase == "review":

--- a/services/zoe-data/pipeline_handoff.py
+++ b/services/zoe-data/pipeline_handoff.py
@@ -38,20 +38,43 @@ _LOG_TOOL_MARKERS = (
     "validate_structure",
     "validate_critical_files",
 )
-_STABLE_BLOCKER_RE = re.compile(
-    r"\b(?:WORKTREE_NOT_READY|GATE_BLOCKED|PROTOCOL_VIOLATION|MERGE_BLOCKED|"
-    r"VERIFICATION_FAILED|HTTP_402|PAYMENT_REQUIRED|CREDITS_EXHAUSTED|"
-    r"TURN_BUDGET|ITERATION_BUDGET|CONTEXT_LIMIT|TOKEN_LIMIT|SCOPE_SPLIT_REQUIRED|NEEDS_SPLIT)\b",
-    re.I,
+_STABLE_BLOCKER_TOKENS = (
+    "WORKTREE_NOT_READY",
+    "GATE_BLOCKED",
+    "PROTOCOL_VIOLATION",
+    "MERGE_BLOCKED",
+    "VERIFICATION_FAILED",
+    "HTTP_402",
+    "PAYMENT_REQUIRED",
+    "CREDITS_EXHAUSTED",
+    "TURN_BUDGET",
+    "ITERATION_BUDGET",
+    "CONTEXT_LIMIT",
+    "TOKEN_LIMIT",
+    "SCOPE_SPLIT_REQUIRED",
+    "NEEDS_SPLIT",
 )
-_SURFACED_BLOCKER_RE = re.compile(
-    r"\b(?:VERIFY_BUDGET|REVIEW_BUDGET|CLOSEOUT_BUDGET|IMPLEMENT_BUDGET|"
-    r"PR_REVIEW_REQUIRED|PR_REVISION_BLOCKED|PR_REVISION_CHECKOUT_FAILED|"
-    r"WORKTREE_PREPARATION_FAILED|WORKTREE_NOT_READY|PROTOCOL_VIOLATION|"
-    r"TURN_BUDGET|ITERATION_BUDGET|CONTEXT_LIMIT|TOKEN_LIMIT|"
-    r"HTTP_402|PAYMENT_REQUIRED|CREDITS_EXHAUSTED)\b",
-    re.I,
+_SURFACED_BLOCKER_TOKENS = (
+    "VERIFY_BUDGET",
+    "REVIEW_BUDGET",
+    "CLOSEOUT_BUDGET",
+    "IMPLEMENT_BUDGET",
+    "PR_REVIEW_REQUIRED",
+    "PR_REVISION_BLOCKED",
+    "PR_REVISION_CHECKOUT_FAILED",
+    "WORKTREE_PREPARATION_FAILED",
+    "WORKTREE_NOT_READY",
+    "PROTOCOL_VIOLATION",
+    "TURN_BUDGET",
+    "ITERATION_BUDGET",
+    "CONTEXT_LIMIT",
+    "TOKEN_LIMIT",
+    "HTTP_402",
+    "PAYMENT_REQUIRED",
+    "CREDITS_EXHAUSTED",
 )
+_STABLE_BLOCKER_RE = re.compile(rf"\b(?:{'|'.join(_STABLE_BLOCKER_TOKENS)})\b", re.I)
+_SURFACED_BLOCKER_RE = re.compile(rf"\b(?:{'|'.join(_SURFACED_BLOCKER_TOKENS)})\b", re.I)
 
 
 def _task_body(detail: dict[str, Any]) -> str:
@@ -649,7 +672,13 @@ def infer_outcome(phase: PipelinePhase, row_status: str, detail: dict[str, Any])
     fields: dict[str, str] = {}
     for chunk in _haystacks(detail):
         fields.update(_parse_kv_fields(chunk))
-    blocker = fields.get("BLOCKER") or block_reason_from_handoff(detail) or ""
+    explicit_blocker = (fields.get("BLOCKER") or "").strip()
+    blocker = explicit_blocker
+    if status == "blocked" and not blocker:
+        for chunk in _haystacks(detail):
+            blocker = _stable_block_reason_from_text(chunk)
+            if blocker:
+                break
 
     if status == "blocked":
         if _SURFACED_BLOCKER_RE.search(blocker):
@@ -664,7 +693,7 @@ def infer_outcome(phase: PipelinePhase, row_status: str, detail: dict[str, Any])
     if status not in {"done", "archived"}:
         return None
 
-    if blocker:
+    if explicit_blocker:
         if _SURFACED_BLOCKER_RE.search(blocker):
             return "block"
         if phase == "verify":

--- a/services/zoe-data/pipeline_handoff.py
+++ b/services/zoe-data/pipeline_handoff.py
@@ -694,7 +694,7 @@ def infer_outcome(phase: PipelinePhase, row_status: str, detail: dict[str, Any])
         return None
 
     if explicit_blocker:
-        if _SURFACED_BLOCKER_RE.search(blocker):
+        if _SURFACED_BLOCKER_RE.search(explicit_blocker):
             return "block"
         if phase == "verify":
             return "verification_failed"

--- a/services/zoe-data/tests/test_pipeline_handoff.py
+++ b/services/zoe-data/tests/test_pipeline_handoff.py
@@ -591,6 +591,45 @@ def test_infer_outcome_blocked_verify_loops():
     )
 
 
+def test_infer_outcome_verify_budget_surfaces_block():
+    assert (
+        infer_outcome(
+            "verify",
+            "blocked",
+            {"latest_summary": "BLOCKER=VERIFY_BUDGET: code-enforced tool budget exceeded", "comments": []},
+        )
+        == "block"
+    )
+
+
+def test_infer_outcome_pr_review_required_surfaces_block():
+    assert (
+        infer_outcome(
+            "verify",
+            "blocked",
+            {
+                "latest_summary": (
+                    "BLOCKER=PR_REVIEW_REQUIRED: Greptile has unresolved comments\n"
+                    "PR_URL=https://github.com/o/r/pull/213"
+                ),
+                "comments": [],
+            },
+        )
+        == "block"
+    )
+
+
+def test_infer_outcome_done_with_verify_budget_surfaces_block():
+    assert (
+        infer_outcome(
+            "verify",
+            "done",
+            {"latest_summary": "BLOCKER=VERIFY_BUDGET: exceeded\nTESTS=not completed", "comments": []},
+        )
+        == "block"
+    )
+
+
 def test_later_empty_blocker_clears_older_blocked_run():
     detail = {
         "latest_summary": "PR_URL=https://github.com/o/r/pull/213\nBLOCKER=\nTESTS=validate_structure.py passed",

--- a/services/zoe-data/tests/test_pipeline_handoff.py
+++ b/services/zoe-data/tests/test_pipeline_handoff.py
@@ -602,6 +602,17 @@ def test_infer_outcome_verify_budget_surfaces_block():
     )
 
 
+def test_infer_outcome_freeform_verify_budget_surfaces_block():
+    assert (
+        infer_outcome(
+            "verify",
+            "blocked",
+            {"latest_summary": "VERIFY_BUDGET: code-enforced tool budget exceeded", "comments": []},
+        )
+        == "block"
+    )
+
+
 def test_infer_outcome_pr_review_required_surfaces_block():
     assert (
         infer_outcome(

--- a/services/zoe-data/tests/test_pipeline_handoff.py
+++ b/services/zoe-data/tests/test_pipeline_handoff.py
@@ -630,6 +630,23 @@ def test_infer_outcome_done_with_verify_budget_surfaces_block():
     )
 
 
+def test_infer_outcome_done_ignores_freeform_stable_blocker_text():
+    assert (
+        infer_outcome(
+            "verify",
+            "done",
+            {
+                "latest_summary": (
+                    "SUMMARY=verification completed\n"
+                    "Log excerpt: GATE_BLOCKED: old text from a previous attempt"
+                ),
+                "comments": [],
+            },
+        )
+        == "complete"
+    )
+
+
 def test_later_empty_blocker_clears_older_blocked_run():
     detail = {
         "latest_summary": "PR_URL=https://github.com/o/r/pull/213\nBLOCKER=\nTESTS=validate_structure.py passed",

--- a/services/zoe-data/tests/test_pipeline_handoff.py
+++ b/services/zoe-data/tests/test_pipeline_handoff.py
@@ -619,6 +619,28 @@ def test_infer_outcome_pr_review_required_surfaces_block():
     )
 
 
+def test_infer_outcome_review_budget_surfaces_block():
+    assert (
+        infer_outcome(
+            "review",
+            "blocked",
+            {"latest_summary": "BLOCKER=REVIEW_BUDGET: reviewer exceeded budget", "comments": []},
+        )
+        == "block"
+    )
+
+
+def test_infer_outcome_closeout_budget_surfaces_block():
+    assert (
+        infer_outcome(
+            "closeout",
+            "blocked",
+            {"latest_summary": "BLOCKER=CLOSEOUT_BUDGET: closeout exceeded budget", "comments": []},
+        )
+        == "block"
+    )
+
+
 def test_infer_outcome_done_with_verify_budget_surfaces_block():
     assert (
         infer_outcome(

--- a/services/zoe-data/tests/test_pipeline_store.py
+++ b/services/zoe-data/tests/test_pipeline_store.py
@@ -808,6 +808,26 @@ async def test_sync_pipeline_blocked_records_reason_in_history(isolated_store):
 
 
 @pytest.mark.asyncio
+async def test_sync_pipeline_verify_budget_blocks_without_revision(isolated_store):
+    state = PipelineState(task_ref="multica:verify-budget", phase="verify", status="running")
+    store.save_state(state, event="effect_requested")
+
+    async def fetch_detail(_task_id: str):
+        return {
+            "latest_summary": "BLOCKER=VERIFY_BUDGET: code-enforced tool budget exceeded",
+            "comments": [],
+        }
+
+    phases = {"verify": {"id": "t_verify", "status": "blocked"}}
+    state = await store.sync_pipeline_from_chain("multica:verify-budget", phases, fetch_detail)
+
+    assert state.phase == "verify"
+    assert state.status == "blocked"
+    assert state.history[-1].outcome == "block"
+    assert "VERIFY_BUDGET" in (state.history[-1].reason or "")
+
+
+@pytest.mark.asyncio
 async def test_sync_pipeline_auto_validators_on_implement_done(isolated_store, monkeypatch):
     await store.bootstrap_state("multica:val")
 


### PR DESCRIPTION
## Summary
- classify harness/control blockers such as VERIFY_BUDGET and PR_REVIEW_REQUIRED as surfaced blocks instead of verification-failed revisions
- keep ordinary verify test failures on the existing revision path
- add handoff and pipeline-store regression tests for the live duplicate-implement loop

## Tests
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_pipeline_handoff.py services/zoe-data/tests/test_pipeline_store.py services/zoe-data/tests/test_kanban_adapter.py services/zoe-data/tests/test_multica_poll_dispatch.py