### PR TITLE
Recover Hermes iteration budget blockers from logs

### DIFF
--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -28,7 +28,12 @@ from pathlib import Path
 from typing import Any
 
 from hermes_http import hermes_bin, zoe_repo_root
-from kanban_phase_budget import phase_budget_reason, terminate_running_workers
+from kanban_phase_budget import (
+    phase_budget_reason,
+    phase_budget_reason_from_log,
+    task_log_tail,
+    terminate_running_workers,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -335,6 +340,21 @@ def _protocol_violation_count(detail: dict[str, Any]) -> int:
     return sum(
         1 for event in events if isinstance(event, dict) and event.get("kind") == "protocol_violation"
     )
+
+
+def _with_recovered_log_budget(task_id: str, phase: str, detail: dict[str, Any]) -> dict[str, Any]:
+    """Attach Hermes log evidence when a silent exit was really a budget stop."""
+    reason = phase_budget_reason_from_log(task_id, phase)
+    if not reason:
+        return detail
+    enriched = dict(detail)
+    latest = str(enriched.get("latest_summary") or "").strip()
+    enriched["latest_summary"] = f"{latest}\n{reason}".strip() if latest else reason
+    if not (enriched.get("logs") or enriched.get("log") or enriched.get("log_tail")):
+        tail = task_log_tail(task_id)
+        if tail:
+            enriched["log_tail"] = tail
+    return enriched
 
 
 def _expected_phases(phases: dict[str, dict]) -> set[str]:
@@ -1118,6 +1138,7 @@ class KanbanAdapter:
             except KanbanCLIError as exc:
                 logger.debug("kanban_adapter: show failed for %s: %s", task_id, exc)
                 continue
+            detail = _with_recovered_log_budget(task_id, phase, detail)
             detail_cache[task_id] = detail
             if await self._maybe_auto_block_phase_budget(task_id, phase, row, detail):
                 phases[phase] = row
@@ -1160,6 +1181,12 @@ class KanbanAdapter:
                 if cached is not None:
                     return cached
                 detail = await self._run(["show", task_id, "--json"], expect_json=True)
+                phase = next(
+                    (phase for phase, row in phases.items() if row.get("id") == task_id),
+                    "",
+                )
+                if phase:
+                    detail = _with_recovered_log_budget(task_id, phase, detail)
                 detail_cache[task_id] = detail
                 return detail
 

--- a/services/zoe-data/kanban_phase_budget.py
+++ b/services/zoe-data/kanban_phase_budget.py
@@ -34,6 +34,10 @@ _RUNTIME_DEFAULTS = {
 }
 _STEP_LINE_RE = re.compile(r"^\s*(?:┊|\|)\s+\S")
 _FALLBACK_STEP_RE = re.compile(r"^\s*\S.*\s+\d+(?:\.\d+)?s(?:\s+\[.*\])?\s*$")
+_ITERATION_BUDGET_RE = re.compile(
+    r"Iteration budget reached\s*\((?P<used>\d+)\s*/\s*(?P<limit>\d+)\)",
+    re.IGNORECASE,
+)
 _ZERO_STEP_WARNED: set[str] = set()
 
 
@@ -64,6 +68,17 @@ def _log_path(task_id: str) -> Path:
     return hermes_home / "kanban" / "logs" / f"{task_id}.log"
 
 
+def task_log_tail(task_id: str, *, max_lines: int = 80) -> str:
+    """Return the latest Hermes Kanban task log lines for evidence recovery."""
+    try:
+        lines = _log_path(task_id).read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        return ""
+    if max_lines <= 0:
+        return "\n".join(lines)
+    return "\n".join(lines[-max_lines:])
+
+
 def tool_step_count(task_id: str, *, since: float | None = None) -> int:
     path = _log_path(task_id)
     try:
@@ -92,6 +107,31 @@ def tool_step_count(task_id: str, *, since: float | None = None) -> int:
             task_id,
         )
     return count
+
+
+def phase_budget_reason_from_log(task_id: str, phase: str) -> str | None:
+    """Recover Hermes' own iteration-budget stop from a task log.
+
+    Hermes can exit with rc=0 after printing "Iteration budget reached" before it
+    calls kanban_block. That used to look like a generic protocol violation and
+    hid the useful cost-control signal from the pipeline. Treat the log line as
+    explicit blocker evidence so Zoe can stop/recover without redispatch loops.
+    """
+    tail = task_log_tail(task_id, max_lines=120)
+    if not tail:
+        return None
+    lines = tail.splitlines()
+    query_starts = [index for index, line in enumerate(lines) if line.startswith("Query:")]
+    if query_starts:
+        tail = "\n".join(lines[query_starts[-1]:])
+    matches = list(_ITERATION_BUDGET_RE.finditer(tail))
+    if not matches:
+        return None
+    match = matches[-1]
+    return (
+        f"BLOCKER=ITERATION_BUDGET: Hermes iteration budget reached during {phase} "
+        f"(steps={match.group('used')}, limit={match.group('limit')})"
+    )
 
 
 def _is_expected_worker(pid: int) -> bool:
@@ -185,6 +225,9 @@ def phase_budget_reason(
             f"BLOCKER={phase.upper()}_BUDGET: code-enforced tool budget exceeded "
             f"(steps={tool_steps}, guidance_limit={tool_limit}, hard_limit={hard_limit})"
         )
+    log_reason = phase_budget_reason_from_log(task_id, phase)
+    if log_reason:
+        return log_reason
 
     if started_ts is None:
         return None

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -1781,6 +1781,85 @@ def test_protocol_violation_count():
     assert ka._protocol_violation_count(detail) == 2
 
 
+def test_phase_budget_reason_recovers_hermes_iteration_budget_log(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    log_dir = tmp_path / "kanban" / "logs"
+    log_dir.mkdir(parents=True)
+    (log_dir / "t_impl.log").write_text(
+        "Query: work kanban task t_impl\n"
+        "  ┊ 📖 read      services/zoe-data/main.py  0.1s\n"
+        "⚠ Iteration budget reached (22/22) — response may be incomplete\n",
+        encoding="utf-8",
+    )
+
+    reason = kb.phase_budget_reason_from_log("t_impl", "implement")
+
+    assert reason == (
+        "BLOCKER=ITERATION_BUDGET: Hermes iteration budget reached during implement "
+        "(steps=22, limit=22)"
+    )
+
+
+def test_phase_budget_reason_ignores_stale_iteration_budget_log_session(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    log_dir = tmp_path / "kanban" / "logs"
+    log_dir.mkdir(parents=True)
+    (log_dir / "t_impl.log").write_text(
+        "Query: work kanban task t_impl\n"
+        "⚠ Iteration budget reached (22/22) — response may be incomplete\n"
+        "Query: work kanban task t_impl\n"
+        "  ┊ ✅ kanban_block  0.1s\n",
+        encoding="utf-8",
+    )
+
+    assert kb.phase_budget_reason_from_log("t_impl", "implement") is None
+
+
+@pytest.mark.asyncio
+async def test_poll_v4_blocked_protocol_violation_recovers_iteration_budget_from_log(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    log_dir = tmp_path / "kanban" / "logs"
+    log_dir.mkdir(parents=True)
+    (log_dir / "t_implement.log").write_text(
+        "Query: work kanban task t_implement\n"
+        "  ┊ 🔎 grep      ITERATION_BUDGET  0.1s\n"
+        "⚠ Iteration budget reached (22/22) — response may be incomplete\n",
+        encoding="utf-8",
+    )
+    rows = [_row("implement", "blocked", chain_version="v4")]
+    show = {
+        "t_implement": {
+            "latest_summary": "",
+            "comments": [],
+            "events": [{"kind": "protocol_violation", "payload": {"exit_code": 0}}],
+            "runs": [
+                {
+                    "status": "crashed",
+                    "outcome": "crashed",
+                    "error": "worker exited cleanly without calling kanban_complete",
+                }
+            ],
+        }
+    }
+    a = _FakeAdapter(list_rows=rows, show_map=show)
+
+    out = await a.poll("multica:uuid-9")
+
+    assert out["status"] == "blocked"
+    assert out["blocker"] == (
+        "ITERATION_BUDGET: Hermes iteration budget reached during implement "
+        "(steps=22, limit=22)"
+    )
+    assert out["pipeline"]["status"] == "blocked"
+    assert out["pipeline"]["block_reason"] == (
+        "ITERATION_BUDGET: Hermes iteration budget reached during implement "
+        "(steps=22, limit=22)"
+    )
+
+
 def test_phase_budget_reason_enforces_tool_and_runtime_limits(tmp_path, monkeypatch):
     log_path = tmp_path / "task.log"
     log_path.write_text("\n".join(["  ┊ tool call"] * 9), encoding="utf-8")


### PR DESCRIPTION
## Summary
- recover Hermes Iteration budget reached log lines as explicit ITERATION_BUDGET blockers
- enrich Kanban poll details so blocked protocol-violation rows sync a useful budget reason into the pipeline
- add regression coverage for log-only iteration budget recovery

## Tests
- remote: PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_kanban_adapter.py services/zoe-data/tests/test_pipeline_handoff.py services/zoe-data/tests/test_pipeline_store.py services/zoe-data/tests/test_multica_poll_dispatch.py (223 passed)
- local: python3 -m py_compile services/zoe-data/kanban_phase_budget.py services/zoe-data/executors/kanban_adapter.py services/zoe-data/tests/test_kanban_adapter.py
- local+remote: python3 tools/audit/validate_structure.py
- local+remote: python3 tools/audit/validate_critical_files.py