### PR TITLE
Add Zoe Hindsight memory harness

### DIFF
--- a/docs/adr/ADR-graphiti-bakeoff.md
+++ b/docs/adr/ADR-graphiti-bakeoff.md
@@ -1,0 +1,29 @@
+# ADR: Graphiti Bake-Off Second
+
+## Status
+
+Accepted for evaluation.
+
+## Context
+
+Graphiti is the strongest candidate for temporal relationship truth: entities, typed facts, validity windows, provenance episodes, and hybrid semantic/keyword/graph retrieval. It is heavier operationally than Postgres-native memory and must be measured before it enters Zoe's hot path.
+
+## Decision
+
+Evaluate Graphiti after the Hindsight bake-off.
+
+Defaults for the bake-off:
+
+- Test FalkorDB first for lighter operational footprint.
+- Test Neo4j if feasible as the mature graph baseline.
+- Keep graph retrieval out of normal chat until measured; relational enrichment should be async or explicit-query only.
+- Use Graphiti only for changing relationships: people, projects, promises, approvals, failures, fixes, supersession, and causality.
+- Require evidence-backed edges and supersession support.
+
+## Acceptance Criteria
+
+- Accurate multi-hop answers for people/tools/capabilities/failures/fixes/approvals/recurring tasks.
+- Superseded facts are preserved, not destructively overwritten.
+- Every relationship edge traces to evidence.
+- Query p95 is under 2s for relational lookups, or marked async-only.
+- Co-located Jetson memory usage is acceptable, or the service is sidecar/remote-only.

--- a/docs/adr/ADR-hindsight-bakeoff.md
+++ b/docs/adr/ADR-hindsight-bakeoff.md
@@ -1,0 +1,37 @@
+# ADR: Hindsight Bake-Off First
+
+## Status
+
+Accepted for evaluation.
+
+## Context
+
+Hindsight aligns with Zoe's continuity goal because it separates world facts, experiences, mental models, and reflection. It also fits Zoe's Postgres-centered architecture better than graph stacks that require another always-on database in the chat hot path. Zoe memory must be 100% offline, so any Hindsight evaluation must use a local model path only.
+
+## Decision
+
+Evaluate Hindsight before Graphiti as a runtime candidate.
+
+Defaults for the bake-off:
+
+- Run as an offline-only sidecar first; never make it required for normal chat or voice.
+- Use Hindsight built-in `llamacpp`, Zoe's local llama-server/OpenAI-compatible endpoint, Ollama/LM Studio on localhost/private network, or another operator-approved local endpoint.
+- Reject cloud LLM providers such as plain `openai`, `anthropic`, `gemini`, `groq`, `openrouter`, or `openai-codex` for Zoe memory.
+- Prefer controlled recall before any write integration; route only lesson/reflection queries through it.
+- Keep auto-retain off by default.
+- Route durable writes through retain candidates and evidence/admission gates.
+- Measure recall latency, write latency, memory pollution, scope isolation, evidence provenance, hallucination, contradiction, and fallback behavior.
+
+## Acceptance Criteria
+
+- Recall p95 under 600ms for low/mid budget on the selected offline model path.
+- Retain can run async without blocking chat.
+- Returned memories include evidence/source pointers.
+- Disputed/superseded memories behave correctly.
+- Missing or cross-user scope fails closed.
+- Zoe can disable Hindsight without breaking MemPalace recall.
+
+
+## Offline Guard
+
+`services/zoe-data/hindsight_memory.py` enforces `HINDSIGHT_OFFLINE_ONLY=true` by default. When enabled, the sidecar URL must be localhost/private, and visible Hindsight LLM provider settings must be local (`llamacpp`, `ollama`, `lmstudio`) or `openai` only with a localhost/private `HINDSIGHT_API_LLM_BASE_URL`.

--- a/docs/adr/ADR-zoe-memory-layer.md
+++ b/docs/adr/ADR-zoe-memory-layer.md
@@ -1,0 +1,31 @@
+# ADR: Zoe Memory Layer Direction
+
+## Status
+
+Accepted for staged implementation.
+
+## Context
+
+Zoe already has MemPalace through `MemoryService`, Graphify for code/system understanding, Multica for governed execution, and Gemma 4 as the local model path. The Zoe continuity goal requires more than semantic recall: Zoe needs scoped, evidence-backed, temporal relationships between people, tools, failures, fixes, approvals, recurring tasks, and capabilities.
+
+## Decision
+
+Use a layered memory architecture:
+
+- Keep Working Context short-lived and disposable for active conversation state.
+- Keep PostgreSQL as canonical state/truth for live app data and operational records.
+- Keep `MemoryService`/MemPalace as the episodic memory gatekeeper for fast personalization and exact remembered facts.
+- Add a portable Zoe memory contract before any new backend integration.
+- Evaluate Hindsight first as optional reflective memory for lessons, recurring patterns, failures/fixes, and experience summaries.
+- Evaluate Graphiti second only for temporal relational truth that changes over time.
+- Keep Graphify as code/system graph intelligence.
+- Keep Multica/review as the required governance layer for self-evolution writes and execution.
+- Add observation/evaluation traces so memory reads and writes can be judged by latency, helpfulness, hallucination, contradiction, and fallback behavior.
+
+## Consequences
+
+- Memory writes that create relational truth or self-evolution claims require evidence.
+- Auto-recall may be enabled; blind auto-retain remains disabled.
+- New backends are sidecars/bake-offs until measured.
+- Hindsight, Graphiti, and any new sidecar remain async, feature-flagged, timeout-bounded, and fallback-safe.
+- The current chat router is not modified by this ADR.

--- a/docs/strategy/zoe-evolution-harness-plan.md
+++ b/docs/strategy/zoe-evolution-harness-plan.md
@@ -1,0 +1,282 @@
+# Zoe Evolution Harness Plan
+
+## North Star
+
+Zoe's future architecture is a governed self-evolution harness, not a single memory product. Zoe should be able to notice needs, understand her own system, remember outcomes, discover capabilities, propose upgrades, execute safely, measure results, and retain what she learns.
+
+The product target is Zoe continuity: local-first presence, personal trust, system self-understanding, and the ability to improve without turning every reflection into unchecked truth.
+
+Naming discipline: use Zoe names for concrete modules, services, memory layers, prompts, ADRs, metrics, and runtime concepts. Treat external inspirations as product vision only, not system identity or implementation names.
+
+## Current Inventory
+
+As of the implementation pass on 2026-06-08, the canonical Zoe repo is `/home/zoe/assistant` on SSH target `zoe`, HEAD `1e60a976a785811900ce45c72a86bd0b613ed2e1`.
+
+Active production surfaces:
+
+- `services/zoe-data`: live web/chat API on host uvicorn port 8000.
+- `services/zoe-data/routers/chat.py`: production chat router.
+- `services/zoe-ui`: UI surface.
+- `services/zoe-auth`: auth surface.
+- Host-native `llama-server`: Gemma 4 E2B GGUF primary model path.
+- `MemoryService`: current memory read/write facade for MemPalace/Chroma-backed semantic memory. MemPalace remains the default offline recall layer because it is local-first, zero-API, and publishes strong reproducible retrieval recall numbers.
+- `Multica`: governed control plane for proposals, phase lanes, evidence, and execution admission.
+- `Graphify`: code/system graph intelligence in `graphify-out`.
+- Hermes/OpenClaw: escalation and execution surfaces, with Hermes preferred.
+
+Important current caveats:
+
+- `services/zoe-core` is retired reference code and must not be extended.
+- The existing Graphify report is stale: it was built from commit `b262ce99`, not current HEAD.
+- The worktree already had unrelated dirty files before this plan was implemented; this pass avoids modifying those files.
+- Live relational memory should remain Postgres-centered; do not introduce production SQLite memory paths.
+
+## Tool Decisions
+
+Keep existing Zoe strengths as the spine:
+
+- Gemma 4 remains Zoe's local primary model path.
+- Multica remains the governed execution/control plane.
+- Graphify remains Zoe's self/code understanding layer.
+- MemPalace remains the default fast offline associative/verbatim recall layer; do not replace it unless another offline system beats it on Zoe-specific tests.
+- Pi is used as an external agent/runtime/harness where useful, not rebuilt.
+- Hermes/OpenClaw remain escalation/execution surfaces, with Hermes preferred.
+
+Add measured memory/evolution layers:
+
+- Hindsight is the first offline-only sidecar bake-off because it fits Zoe's Postgres-centered stack and Zoe-style experience learning, but it must use local models only.
+- Graphiti is the second bake-off and the gold standard for temporal relational truth.
+- Create Context Graph and MemGraphRAG inform ontology/fact/evidence layering.
+
+
+## MemPalace Evidence
+
+MemPalace is not being demoted out of Zoe. Its published benchmark page reports 96.6% LongMemEval R@5 for raw vector search with no LLM, 98.4% held-out LongMemEval R@5 for hybrid v4 with no LLM, and 88.9% LoCoMo R@10 for hybrid v5. The project also explicitly describes local-first, zero-API operation. Zoe should keep MemPalace as the baseline offline recall layer and use the Hindsight bake-off to test experience/reflection workflow, not to replace MemPalace by default.
+
+## Memory Architecture
+
+Zoe memory is layered, not one magic database. The boring rule is that fast chat uses Working Context + Canonical State + Episodic Memory, while slow background jobs may enrich Reflective and Relational Memory.
+
+Layer responsibilities:
+
+- Working Context: short-lived per-turn/session context for current conversation, follow-ups, pronouns, and active task state. It is fast and disposable.
+- Canonical State: PostgreSQL remains truth for live app data, users, permissions, tasks, reminders, people, audit, and durable operational records. Do not move canonical app state into a memory framework.
+- Episodic Memory: `MemoryService`/MemPalace handles exact remembered facts, preferences, conversation-derived memories, and verbatim-ish recall. This is the fast personalization layer.
+- Reflective Memory: Hindsight is an optional offline sidecar for lessons, recurring patterns, failures/fixes, and experience summaries. It is not required for normal chat/voice and cannot blind auto-retain.
+- Relational / Temporal Memory: Graphiti-style graph memory is only for relationships that change over time: people, projects, promises, approvals, failures, fixes, supersession, and causality. Model the contract first and defer the service until measured.
+- Governance Layer: Zoe's memory contract plus Multica/review gates important writes. Relational, self-evolution, approval, fix/failure, and supersession memories require evidence and start as pending/candidate when untrusted.
+- Observation / Evaluation Layer: Phoenix/evals or Zoe eval traces measure whether retrieval helped, hallucinated, contradicted prior truth, or slowed the user path.
+
+Mental model:
+
+- Postgres = truth/state
+- MemoryService = gatekeeper
+- MemPalace = episodes/facts
+- Hindsight = lessons/reflection
+- Graphiti = changing relationships
+- Phoenix/evals = proof it works
+- Multica/review = governance
+
+The executable layer policy lives in `services/zoe-data/zoe_memory_layers.py`.
+
+```mermaid
+graph TD
+  Notice["Notice: misses, failures, user asks, recurring tasks"]
+  Trace["Trace: raw chat/tool/test evidence"]
+  Memory["Memory: Hindsight + MemPalace"]
+  Graph["Relational Graph: Graphiti-style truth"]
+  Proposal["Evolution Proposal"]
+  Multica["Multica Governance"]
+  Execute["Pi/Hermes/OpenClaw Execution"]
+  Verify["Tests, evidence, user outcome"]
+  Learn["Retain / Reflect / Supersede"]
+
+  Notice --> Trace
+  Trace --> Memory
+  Trace --> Graph
+  Memory --> Proposal
+  Graph --> Proposal
+  Proposal --> Multica
+  Multica --> Execute
+  Execute --> Verify
+  Verify --> Learn
+  Learn --> Memory
+  Learn --> Graph
+```
+
+## Memory Contract
+
+The executable contract lives in `services/zoe-data/zoe_memory_contract.py`.
+
+Minimum event fields:
+
+- `event_id`
+- `user_id`
+- `scope`: `personal`, `shared`, `ambient`, `system`, `project`
+- `source`: `chat`, `tool`, `test`, `trace`, `proposal`, `code`, `external`
+- `event_type`: `fact`, `preference`, `experience`, `failure`, `fix`, `capability`, `recurring_task`, `approval`
+- `content`
+- `entities`
+- `relationships`
+- `evidence_refs`
+- `confidence`
+- `status`: `active`, `disputed`, `superseded`, `archived`
+- `created_at`
+- `supersedes`
+- `retention_policy`
+
+Core relationship types:
+
+- `ASKED_FOR`
+- `USES`
+- `FAILED_ON`
+- `FIXED_BY`
+- `APPROVED_BY`
+- `TRUSTED_FOR`
+- `SUPERSEDES`
+- `RECURS_AS`
+- `CAUSED_BY`
+- `EVIDENCED_BY`
+- `BELONGS_TO_SCOPE`
+- `PROPOSED_CAPABILITY`
+- `MEASURED_BY`
+
+Rules:
+
+- No durable relational memory without evidence.
+- No self-modification memory without proposal/run/test evidence.
+- No unscoped writes.
+- Auto-recall is allowed.
+- Auto-retain is gated.
+- Reflection may propose memories, but cannot silently create trusted truth.
+
+## Memory Router
+
+The deterministic router lives in `services/zoe-data/zoe_memory_router.py`.
+
+Routing defaults:
+
+- Fast chat personalization: Working Context + PostgreSQL canonical state + MemoryService/MemPalace episodic recall.
+- Experience/lesson recall: Hindsight only when feature-flagged and timeout-bounded.
+- Relationship/causal/supersession queries: Graphiti-style graph as async/deferred relational enrichment until measured.
+- Code/system questions: Graphify.
+- Self-evolution proposals: Multica first, with Hindsight + Graphiti + Graphify evidence.
+
+Prompt-time policy:
+
+- Compile small memory packets, not raw dumps.
+- Include source/evidence IDs.
+- Prefer current facts over superseded facts.
+- Surface disputed memory as uncertain.
+- Never let memory override explicit user correction.
+
+Latency budgets:
+
+- 0-50ms: cached user/task facts.
+- 50-300ms: lightweight semantic recall.
+- 300-600ms: optional Hindsight recall when enabled; fallback-safe if unavailable.
+- 600ms-2s: graph relational lookup only for explicit relational questions, or async-only if slower.
+- Async only: retain, reflect, consolidate, conflict resolution, graph enrichment, eval traces.
+
+## Bake-Off Plan
+
+### Hindsight First
+
+Run Hindsight as an offline-only sidecar first, not embedded in hot chat or voice. Acceptable model modes are Hindsight built-in `llamacpp`, Zoe's local llama-server/OpenAI-compatible endpoint, Ollama/LM Studio on localhost/private network, or another operator-approved local endpoint. Cloud LLM providers are not allowed for Zoe memory. Enable controlled recall and keep blind auto-retain disabled. Durable writes should enter Zoe as retain candidates and become trusted only after evidence/admission gates.
+
+Acceptance criteria:
+
+- Recall p95 under 600ms for low/mid budget on the chosen offline model path.
+- Retain runs async without blocking chat.
+- Returned memories include evidence/source pointers.
+- Wrong memories can be disputed or superseded.
+- User/scope isolation tests pass.
+- Auto-retain is off by default.
+
+### Graphiti Second
+
+Evaluate Graphiti with FalkorDB first and Neo4j second if feasible. Keep it out of the normal chat hot path until measured. Use it only for changing relationships: people, projects, promises, approvals, failures, fixes, supersession, and causality; relational enrichment should be async or explicit-query only.
+
+Acceptance criteria:
+
+- Accurate multi-hop relationship answers.
+- Superseded facts are preserved, not overwritten destructively.
+- Every edge traces to raw evidence.
+- Relational query p95 under 2s, or marked async-only.
+- Co-located Jetson memory usage is acceptable, or the service is sidecar/remote-only.
+
+## Self-Evolution Harness
+
+Stages:
+
+1. Notice: detect misses, repeated failures, user requests, friction, tool gaps, stale capabilities.
+2. Explain: convert the signal into a structured problem statement with evidence.
+3. Search: look for existing tools, Pi packages, MCP servers, GitHub projects, skills, APIs.
+4. Evaluate: score candidates by fit, activity, stars, license, local viability, runtime cost, security, tests.
+5. Propose: create an evolution proposal with scope, risk, expected benefit, tests, rollback.
+6. Approve: require user/admin approval for privileged changes.
+7. Execute: use Pi/Hermes/OpenClaw/Multica lanes depending on task type.
+8. Verify: run tests, health checks, screenshots if UI, metrics if runtime.
+9. Learn: store outcome, evidence, failures, fixes, and updated capability trust.
+10. Retire: remove or archive unused tools and memories based on measured non-use or replacement.
+
+## Rollout Phases
+
+1. Document strategy and ADRs.
+2. Add executable memory contract and deterministic router tests.
+3. Build a synthetic Zoe memory evaluation dataset.
+4. Add observation/evaluation traces around memory reads and writes.
+5. Run Hindsight sidecar bake-off.
+6. Run Graphiti/FalkorDB and Graphiti/Neo4j bake-off.
+7. Add memory router behind a feature flag.
+8. Add retain-candidate admission through Multica/evidence gates.
+9. Clean Zoe main engine only after tests protect chat, memory gating, and tool dispatch.
+
+## Test Strategy
+
+Unit tests:
+
+- Memory event validation.
+- Scope/user enforcement.
+- Supersession logic.
+- Evidence-required writes.
+- Memory router decisions.
+- Tool/capability scoring.
+
+Integration tests:
+
+- Chat with MemPalace recall only.
+- Chat with Hindsight recall enabled.
+- Relational query with graph backend.
+- Self-evolution proposal creation.
+- Multica approval gate.
+- Failed tool run becomes pending memory, not trusted fact.
+- User correction supersedes old memory.
+
+Performance tests:
+
+- Baseline Zoe chat latency before changes.
+- Hindsight recall low/mid/high budget using offline-only model configuration.
+- Hindsight async retain.
+- Graphiti/FalkorDB query latency.
+- Graphiti/Neo4j query latency.
+- Jetson RAM/CPU under idle, chat, recall, retain, graph lookup.
+
+Safety tests:
+
+- Missing `user_id` fails closed.
+- Cross-user recall blocked.
+- Shared memory only appears in shared scope.
+- Disputed memory not injected as fact.
+- Auto-retain cannot write trusted memory directly.
+- Evolution proposal cannot execute without approval.
+
+## Success Metrics
+
+- Normal chat latency regression under 10%.
+- Prompt-time memory packet stays compact and cited.
+- Hindsight recall p95 under 600ms for normal use on offline-only model configuration.
+- Graph relationship queries accurate on the evaluation set.
+- 95%+ exact answers on synthetic relational memory eval.
+- Zero unscoped durable memory writes.
+- Every self-evolution change has proposal, evidence, verification, and retained outcome.

--- a/scripts/maintenance/hindsight_bakeoff.py
+++ b/scripts/maintenance/hindsight_bakeoff.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Run Zoe's Hindsight bake-off against a configured sidecar.
+
+This script is intentionally read/measure-oriented. It retains only the synthetic
+bake-off events and requires HINDSIGHT_ENABLED=true plus explicit
+--retain-synthetic to write to Hindsight.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+DATA = ROOT / "services" / "zoe-data"
+if str(DATA) not in sys.path:
+    sys.path.insert(0, str(DATA))
+
+from hindsight_bakeoff import EVAL_QUERIES, SYNTHETIC_EVENTS, score_recall_response  # noqa: E402
+from hindsight_memory import HindsightConfig, HindsightMemoryClient  # noqa: E402
+
+
+async def main() -> int:
+    parser = argparse.ArgumentParser(description="Run Zoe Hindsight synthetic bake-off")
+    parser.add_argument("--retain-synthetic", action="store_true", help="write synthetic events before recall")
+    parser.add_argument("--no-wait-retain", action="store_true", help="do not wait for async retain operations before recall")
+    parser.add_argument("--retain-timeout-seconds", type=float, default=180.0, help="max seconds to wait for each async retain operation")
+    parser.add_argument("--retain-poll-seconds", type=float, default=1.0, help="seconds between async retain status polls")
+    parser.add_argument("--json", action="store_true", help="emit JSON")
+    args = parser.parse_args()
+
+    client = HindsightMemoryClient(HindsightConfig.from_env())
+    output: dict[str, object] = {"status": client.enabled_status(), "retained": [], "operations": [], "scores": []}
+
+    if args.retain_synthetic:
+        retained = []
+        for event in SYNTHETIC_EVENTS:
+            retained.append(await client.retain_event(event, allow_auto=True))
+        output["retained"] = retained
+        if not args.no_wait_retain:
+            output["operations"] = await client.wait_for_retain_results(
+                retained,
+                timeout_seconds=args.retain_timeout_seconds,
+                poll_seconds=args.retain_poll_seconds,
+            )
+
+    scores = []
+    for query in EVAL_QUERIES:
+        response = await client.recall(
+            user_id=query.user_id,
+            scope=query.scope,
+            query=query.query,
+            budget=query.budget,
+            max_tokens=1024,
+        )
+        scores.append(score_recall_response(response, query))
+    output["scores"] = scores
+
+    if args.json:
+        print(json.dumps(output, indent=2, sort_keys=True))
+    else:
+        print(json.dumps(output["status"], indent=2, sort_keys=True))
+        for item in scores:
+            print(f"{item['name']}: score={item['score']:.2f} missing={item['missing']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/services/zoe-data/hindsight_bakeoff.py
+++ b/services/zoe-data/hindsight_bakeoff.py
@@ -1,0 +1,155 @@
+"""Synthetic Hindsight bake-off fixtures and scoring helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterable, Mapping
+
+from zoe_memory_contract import (
+    MemoryEvent,
+    MemoryEventType,
+    MemoryRelationship,
+    MemoryScope,
+    MemorySource,
+    RelationshipType,
+)
+
+
+@dataclass(frozen=True)
+class HindsightEvalQuery:
+    name: str
+    query: str
+    expected_terms: tuple[str, ...]
+    scope: str = MemoryScope.PROJECT.value
+    user_id: str = "jason"
+    budget: str = "mid"
+
+
+SYNTHETIC_EVENTS: tuple[MemoryEvent, ...] = (
+    MemoryEvent(
+        event_id="mem_evt_weather_failure_001",
+        user_id="jason",
+        scope=MemoryScope.PROJECT.value,
+        source=MemorySource.TRACE.value,
+        event_type=MemoryEventType.FAILURE.value,
+        content="The weather card failed on the mobile dashboard because the voice queue emitted duplicate weather responses.",
+        entities=("weather_card", "mobile_dashboard", "voice_queue"),
+        relationships=(
+            MemoryRelationship(RelationshipType.FAILED_ON.value, source="weather_card", target="mobile_dashboard_render"),
+            MemoryRelationship(RelationshipType.CAUSED_BY.value, source="weather_card_failure", target="duplicate_voice_queue_emit"),
+        ),
+        evidence_refs=("trace:weather-queue:001", "pytest:test_voice_weather_queue"),
+        confidence=0.86,
+    ),
+    MemoryEvent(
+        event_id="mem_evt_weather_fix_001",
+        user_id="jason",
+        scope=MemoryScope.PROJECT.value,
+        source=MemorySource.TEST.value,
+        event_type=MemoryEventType.FIX.value,
+        content="The voice queue guard fixed duplicate weather responses by allowing only one active weather card dispatch per request.",
+        entities=("voice_queue_guard", "weather_card"),
+        relationships=(
+            MemoryRelationship(RelationshipType.FIXED_BY.value, source="duplicate_weather_response", target="voice_queue_guard"),
+            MemoryRelationship(RelationshipType.MEASURED_BY.value, source="voice_queue_guard", target="pytest:test_voice_transcribe"),
+        ),
+        evidence_refs=("pytest:test_voice_transcribe", "commit:voice-queue-guard"),
+        confidence=0.9,
+    ),
+    MemoryEvent(
+        event_id="mem_evt_hindsight_preference_001",
+        user_id="jason",
+        scope=MemoryScope.PERSONAL.value,
+        source=MemorySource.CHAT.value,
+        event_type=MemoryEventType.PREFERENCE.value,
+        content="Jason prefers Hindsight as the first Zoe memory bake-off because it fits Postgres and self-evolving experience memory.",
+        entities=("hindsight", "postgres", "zoe_memory"),
+        relationships=(),
+        evidence_refs=("chat:2026-06-08:hindsight-first",),
+        confidence=0.8,
+    ),
+    MemoryEvent(
+        event_id="mem_evt_capability_approval_001",
+        user_id="jason",
+        scope=MemoryScope.PROJECT.value,
+        source=MemorySource.PROPOSAL.value,
+        event_type=MemoryEventType.APPROVAL.value,
+        content="Jason approved using Multica evidence gates before Zoe can persist self-evolution memories as trusted truth.",
+        entities=("multica", "evidence_gates", "self_evolution_memory"),
+        relationships=(
+            MemoryRelationship(RelationshipType.APPROVED_BY.value, source="evidence_gated_memory", target="jason"),
+            MemoryRelationship(RelationshipType.TRUSTED_FOR.value, source="multica", target="self_evolution_governance"),
+        ),
+        evidence_refs=("chat:2026-06-08:zoe-evolution-plan", "doc:ADR-zoe-memory-layer"),
+        confidence=0.88,
+    ),
+)
+
+EVAL_QUERIES: tuple[HindsightEvalQuery, ...] = (
+    HindsightEvalQuery(
+        name="recall_weather_failure",
+        query="What failed last time Zoe used the weather card?",
+        expected_terms=("weather", "duplicate", "voice"),
+    ),
+    HindsightEvalQuery(
+        name="recall_weather_fix",
+        query="What fix worked for the recurring weather response failure?",
+        expected_terms=("voice", "queue", "guard"),
+    ),
+    HindsightEvalQuery(
+        name="recall_user_preference",
+        query="What does Jason currently prefer for the first memory bake-off?",
+        expected_terms=("hindsight", "postgres"),
+        scope=MemoryScope.PERSONAL.value,
+    ),
+    HindsightEvalQuery(
+        name="recall_governance",
+        query="Which governance layer should gate Zoe self-evolution memory?",
+        expected_terms=("multica", "evidence"),
+    ),
+)
+
+
+def synthetic_retain_payloads() -> list[dict[str, Any]]:
+    return [event.to_dict() for event in SYNTHETIC_EVENTS]
+
+
+def score_recall_text(text: str, expected_terms: Iterable[str]) -> dict[str, Any]:
+    lowered = text.lower()
+    expected = tuple(term.lower() for term in expected_terms)
+    matched = tuple(term for term in expected if term in lowered)
+    return {
+        "matched": list(matched),
+        "missing": [term for term in expected if term not in matched],
+        "score": 1.0 if not expected else len(matched) / len(expected),
+    }
+
+
+def recall_response_text(response: Mapping[str, Any]) -> str:
+    results = response.get("results") or []
+    texts = []
+    for item in results:
+        if isinstance(item, Mapping):
+            texts.append(str(item.get("text") or item.get("content") or ""))
+        else:
+            texts.append(str(item))
+    if response.get("text"):
+        texts.append(str(response["text"]))
+    return "\n".join(part for part in texts if part)
+
+
+def score_recall_response(response: Mapping[str, Any], query: HindsightEvalQuery) -> dict[str, Any]:
+    text = recall_response_text(response)
+    score = score_recall_text(text, query.expected_terms)
+    return {"name": query.name, "query": query.query, "text": text, **score}
+
+
+__all__ = [
+    "EVAL_QUERIES",
+    "SYNTHETIC_EVENTS",
+    "HindsightEvalQuery",
+    "recall_response_text",
+    "score_recall_response",
+    "score_recall_text",
+    "synthetic_retain_payloads",
+]

--- a/services/zoe-data/hindsight_memory.py
+++ b/services/zoe-data/hindsight_memory.py
@@ -1,0 +1,372 @@
+"""Hindsight sidecar adapter for Zoe's memory bake-off.
+
+The adapter is disabled by default, never performs blind auto-retain, and is
+hardened for Zoe's offline-only memory rule. If enabled, the sidecar URL must be
+local/private and any visible Hindsight LLM provider config must use a local
+provider or a local OpenAI-compatible base URL.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import ipaddress
+import json
+import os
+import re
+from dataclasses import dataclass
+from typing import Any, Mapping
+from urllib.parse import urlparse
+
+import httpx
+
+from zoe_memory_contract import MemoryEvent, memory_event_from_mapping
+
+
+class HindsightMemoryError(RuntimeError):
+    """Raised when Hindsight is unavailable or returns an invalid response."""
+
+
+class HindsightOfflineConfigError(ValueError):
+    """Raised when Hindsight config would violate Zoe's offline-only rule."""
+
+
+_CLOUD_LLM_PROVIDERS = {
+    "anthropic",
+    "bedrock",
+    "claude-code",
+    "deepseek",
+    "fireworks",
+    "gemini",
+    "groq",
+    "litellm",
+    "litellmrouter",
+    "minimax",
+    "ollama-cloud",
+    "openai",
+    "openai-codex",
+    "openrouter",
+    "opencode-go",
+    "vertexai",
+    "volcano",
+    "zai",
+}
+
+_LOCAL_LLM_PROVIDERS = {
+    "llamacpp",
+    "llama.cpp",
+    "lmstudio",
+    "ollama",
+}
+
+
+@dataclass(frozen=True)
+class HindsightConfig:
+    enabled: bool = False
+    base_url: str = "http://127.0.0.1:8888"
+    auth_token: str | None = None
+    bank_prefix: str = "zoe"
+    timeout_seconds: float = 6.0
+    auto_retain: bool = False
+    async_retain: bool = True
+    offline_only: bool = True
+    llm_provider: str | None = None
+    llm_base_url: str | None = None
+
+    def __post_init__(self) -> None:
+        self.validate_offline_policy()
+
+    @classmethod
+    def from_env(cls, env: Mapping[str, str] | None = None) -> "HindsightConfig":
+        values = env or os.environ
+        return cls(
+            enabled=_env_bool(values.get("HINDSIGHT_ENABLED"), default=False),
+            base_url=(values.get("HINDSIGHT_BASE_URL") or "http://127.0.0.1:8888").rstrip("/"),
+            auth_token=values.get("HINDSIGHT_AUTH_TOKEN") or None,
+            bank_prefix=_slug(values.get("HINDSIGHT_BANK_PREFIX") or "zoe"),
+            timeout_seconds=float(values.get("HINDSIGHT_TIMEOUT_SECONDS") or 6.0),
+            auto_retain=_env_bool(values.get("HINDSIGHT_AUTO_RETAIN"), default=False),
+            async_retain=_env_bool(values.get("HINDSIGHT_ASYNC_RETAIN"), default=True),
+            offline_only=_env_bool(values.get("HINDSIGHT_OFFLINE_ONLY"), default=True),
+            llm_provider=(values.get("HINDSIGHT_API_LLM_PROVIDER") or values.get("HINDSIGHT_LLM_PROVIDER") or None),
+            llm_base_url=(values.get("HINDSIGHT_API_LLM_BASE_URL") or values.get("HINDSIGHT_LLM_BASE_URL") or None),
+        )
+
+    def bank_id(self, user_id: str, scope: str) -> str:
+        return "-".join((_slug(self.bank_prefix), _slug(scope), _slug(user_id)))
+
+    def validate_offline_policy(self) -> None:
+        if not self.enabled or not self.offline_only:
+            return
+        if not _is_local_or_private_url(self.base_url):
+            raise HindsightOfflineConfigError("HINDSIGHT_BASE_URL must be localhost or private network when offline_only is enabled")
+
+        provider = (self.llm_provider or "").strip().lower()
+        if not provider:
+            return
+        if provider in _LOCAL_LLM_PROVIDERS:
+            return
+        if provider == "openai" and self.llm_base_url and _is_local_or_private_url(self.llm_base_url):
+            return
+        if provider in _CLOUD_LLM_PROVIDERS:
+            raise HindsightOfflineConfigError(
+                f"Hindsight LLM provider {provider!r} is not allowed for Zoe offline memory; use llamacpp, ollama, lmstudio, or a local OpenAI-compatible base URL"
+            )
+        if self.llm_base_url and _is_local_or_private_url(self.llm_base_url):
+            return
+        raise HindsightOfflineConfigError(
+            f"Hindsight LLM provider {provider!r} is unrecognized for Zoe offline memory; set a localhost/private HINDSIGHT_API_LLM_BASE_URL or use llamacpp, ollama, or lmstudio"
+        )
+
+
+def _env_bool(value: str | None, *, default: bool) -> bool:
+    if value is None or str(value).strip() == "":
+        return default
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _slug(value: str) -> str:
+    slug = re.sub(r"[^a-zA-Z0-9_.-]+", "-", str(value).strip().lower()).strip("-")
+    return slug or "default"
+
+
+def _is_local_or_private_url(url: str | None) -> bool:
+    parsed = urlparse(str(url or ""))
+    host = parsed.hostname
+    if not host:
+        return False
+    if host in {"localhost", "zoe", "host.docker.internal"}:
+        return True
+    try:
+        ip = ipaddress.ip_address(host)
+    except ValueError:
+        return host.endswith(".local") or host.endswith(".lan")
+    return ip.is_loopback or ip.is_private or ip.is_link_local
+
+
+def event_to_hindsight_item(event: MemoryEvent) -> dict[str, Any]:
+    """Convert a validated Zoe memory event into a Hindsight retain item."""
+
+    event.validate()
+    tags = [
+        "zoe",
+        f"user:{_slug(event.user_id)}",
+        f"scope:{event.scope}",
+        f"type:{event.event_type}",
+        f"status:{event.status}",
+    ]
+    tags.extend(f"entity:{_slug(entity)}" for entity in event.entities[:8])
+    tags.extend(f"evidence:{_slug(ref)}" for ref in event.evidence_refs[:8])
+
+    context = {
+        "source": event.source,
+        "scope": event.scope,
+        "event_type": event.event_type,
+        "status": event.status,
+        "confidence": event.confidence,
+        "evidence_refs": list(event.evidence_refs),
+        "relationships": [relationship.to_dict() for relationship in event.relationships],
+        "supersedes": list(event.supersedes),
+        "retention_policy": event.retention_policy,
+    }
+
+    return {
+        "content": event.content,
+        "context": _compact_context(context),
+        "document_id": event.event_id,
+        "timestamp": event.created_at.isoformat(),
+        "tags": tags,
+    }
+
+
+def _compact_context(context: Mapping[str, Any]) -> str:
+    parts = []
+    for key, value in context.items():
+        if value in (None, "", [], {}):
+            continue
+        serialized = json.dumps(value, separators=(",", ":")) if isinstance(value, (list, dict)) else value
+        parts.append(f"{key}={serialized}")
+    return "; ".join(parts)
+
+
+class HindsightMemoryClient:
+    """Small async client for Hindsight's HTTP API."""
+
+    def __init__(self, config: HindsightConfig | None = None, *, client: httpx.AsyncClient | None = None):
+        self.config = config or HindsightConfig.from_env()
+        self._client = client
+
+    def enabled_status(self) -> dict[str, Any]:
+        return {
+            "enabled": self.config.enabled,
+            "base_url": self.config.base_url,
+            "bank_prefix": self.config.bank_prefix,
+            "auto_retain": self.config.auto_retain,
+            "async_retain": self.config.async_retain,
+            "offline_only": self.config.offline_only,
+            "llm_provider": self.config.llm_provider,
+            "llm_base_url": self.config.llm_base_url,
+        }
+
+    async def health(self) -> dict[str, Any]:
+        if not self.config.enabled:
+            return {"enabled": False, "healthy": False, "reason": "disabled"}
+        return await self._request("GET", "/health")
+
+    async def retain_event(self, event_or_payload: MemoryEvent | Mapping[str, Any], *, allow_auto: bool = False) -> dict[str, Any]:
+        """Submit an evidence-backed event to Hindsight.
+
+        By default this refuses to write unless the caller explicitly allows a
+        retain attempt and the Hindsight config is enabled. Zoe's normal path
+        should create retain candidates first, then call this only after an
+        evidence/admission gate.
+        """
+
+        event = event_or_payload if isinstance(event_or_payload, MemoryEvent) else memory_event_from_mapping(event_or_payload)
+        if not self.config.enabled:
+            return {"enabled": False, "retained": False, "reason": "disabled", "event_id": event.event_id}
+        if not allow_auto and not self.config.auto_retain:
+            return {"enabled": True, "retained": False, "reason": "auto_retain_disabled", "event_id": event.event_id}
+
+        bank_id = self.config.bank_id(event.user_id, event.scope)
+        payload = {"async": self.config.async_retain, "items": [event_to_hindsight_item(event)]}
+        result = await self._request("POST", f"/v1/default/banks/{bank_id}/memories", json=payload)
+        result.setdefault("event_id", event.event_id)
+        result.setdefault("bank_id", bank_id)
+        return result
+
+    async def operation_status(self, *, bank_id: str, operation_id: str) -> dict[str, Any]:
+        """Fetch a Hindsight async operation status."""
+
+        if not self.config.enabled:
+            return {"enabled": False, "status": "disabled", "reason": "disabled"}
+        return await self._request("GET", f"/v1/default/banks/{bank_id}/operations/{operation_id}")
+
+    async def wait_for_operation(
+        self,
+        *,
+        bank_id: str,
+        operation_id: str,
+        timeout_seconds: float = 120.0,
+        poll_seconds: float = 1.0,
+    ) -> dict[str, Any]:
+        """Poll a Hindsight async operation until it completes, fails, or times out."""
+
+        if not self.config.enabled:
+            return {"enabled": False, "status": "disabled", "reason": "disabled"}
+
+        deadline = asyncio.get_running_loop().time() + timeout_seconds
+        last_status: dict[str, Any] | None = None
+        while True:
+            last_status = await self.operation_status(bank_id=bank_id, operation_id=operation_id)
+            status = str(last_status.get("status") or "").lower()
+            if status in {"completed", "failed", "cancelled", "canceled"}:
+                return last_status
+            if asyncio.get_running_loop().time() >= deadline:
+                return {
+                    "operation_id": operation_id,
+                    "bank_id": bank_id,
+                    "status": "timeout",
+                    "last_status": last_status,
+                }
+            await asyncio.sleep(max(0.1, poll_seconds))
+
+    async def wait_for_retain_results(
+        self,
+        retained: list[Mapping[str, Any]],
+        *,
+        timeout_seconds: float = 120.0,
+        poll_seconds: float = 1.0,
+    ) -> list[dict[str, Any]]:
+        """Wait concurrently for all async retain operations that expose operation IDs."""
+
+        async def _poll_one(item: Mapping[str, Any]) -> dict[str, Any]:
+            operation_id = str(item.get("operation_id") or "").strip()
+            bank_id = str(item.get("bank_id") or "").strip()
+            if not operation_id or not bank_id:
+                return {"status": "not_async", "retain_result": dict(item)}
+            return await self.wait_for_operation(
+                bank_id=bank_id,
+                operation_id=operation_id,
+                timeout_seconds=timeout_seconds,
+                poll_seconds=poll_seconds,
+            )
+
+        return list(await asyncio.gather(*(_poll_one(item) for item in retained)))
+
+    async def recall(
+        self,
+        *,
+        user_id: str,
+        scope: str,
+        query: str,
+        budget: str = "mid",
+        max_tokens: int = 1024,
+        types: tuple[str, ...] = ("world", "experience"),
+        tags: tuple[str, ...] | None = None,
+    ) -> dict[str, Any]:
+        if not self.config.enabled:
+            return {"enabled": False, "results": [], "reason": "disabled"}
+        bank_id = self.config.bank_id(user_id, scope)
+        payload: dict[str, Any] = {
+            "query": query,
+            "budget": budget,
+            "max_tokens": max_tokens,
+            "types": list(types),
+            "trace": True,
+        }
+        if tags:
+            payload["tags"] = list(tags)
+            payload["tags_match"] = "all_strict"
+        result = await self._request("POST", f"/v1/default/banks/{bank_id}/memories/recall", json=payload)
+        result.setdefault("bank_id", bank_id)
+        return result
+
+    async def reflect(
+        self,
+        *,
+        user_id: str,
+        scope: str,
+        query: str,
+        budget: str = "low",
+        max_tokens: int = 1024,
+        include_facts: bool = True,
+    ) -> dict[str, Any]:
+        if not self.config.enabled:
+            return {"enabled": False, "text": "", "reason": "disabled"}
+        bank_id = self.config.bank_id(user_id, scope)
+        include = {"facts": {}} if include_facts else {}
+        payload = {"query": query, "budget": budget, "max_tokens": max_tokens, "include": include}
+        result = await self._request("POST", f"/v1/default/banks/{bank_id}/reflect", json=payload)
+        result.setdefault("bank_id", bank_id)
+        return result
+
+    async def _request(self, method: str, path: str, **kwargs: Any) -> dict[str, Any]:
+        url = f"{self.config.base_url}{path}"
+        headers = dict(kwargs.pop("headers", {}) or {})
+        if self.config.auth_token:
+            headers["Authorization"] = f"Bearer {self.config.auth_token}"
+        close_client = self._client is None
+        client = self._client or httpx.AsyncClient(timeout=self.config.timeout_seconds)
+        try:
+            response = await client.request(method, url, headers=headers, **kwargs)
+            response.raise_for_status()
+            data = response.json()
+            if not isinstance(data, dict):
+                return {"data": data}
+            return data
+        except httpx.HTTPError as exc:
+            raise HindsightMemoryError(f"Hindsight request failed: {method} {path}: {exc}") from exc
+        except ValueError as exc:
+            raise HindsightMemoryError(f"Hindsight response was not valid JSON: {method} {path}: {exc}") from exc
+        finally:
+            if close_client:
+                await client.aclose()
+
+
+__all__ = [
+    "HindsightConfig",
+    "HindsightMemoryClient",
+    "HindsightMemoryError",
+    "HindsightOfflineConfigError",
+    "event_to_hindsight_item",
+]

--- a/services/zoe-data/hindsight_retain_candidates.py
+++ b/services/zoe-data/hindsight_retain_candidates.py
@@ -1,0 +1,110 @@
+"""Hindsight retain-candidate admission helpers.
+
+Zoe should not let Hindsight reflection or extraction write trusted memory
+silently. These helpers create pending MemoryService rows that can be reviewed
+or admitted by Multica/evidence gates before any sidecar retain call occurs.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Mapping
+
+from zoe_memory_contract import MemoryEvent, memory_event_from_mapping
+
+
+HINDSIGHT_RETAIN_SOURCE = "hindsight_retain_candidate"
+
+
+def build_hindsight_retain_candidate(event_or_payload: MemoryEvent | Mapping[str, Any]) -> dict[str, Any]:
+    """Build a pending MemoryService ingest payload from a Zoe memory event."""
+
+    event = event_or_payload if isinstance(event_or_payload, MemoryEvent) else memory_event_from_mapping(event_or_payload)
+    event.validate()
+
+    tags = [
+        "zoe-memory",
+        "hindsight-retain-candidate",
+        f"scope:{event.scope}",
+        f"event:{event.event_type}",
+        f"status:{event.status}",
+    ]
+    tags.extend(f"entity:{entity}" for entity in event.entities[:6])
+    tags.extend(f"evidence:{ref}" for ref in event.evidence_refs[:6])
+    if event.relationships:
+        tags.append("relational")
+    if event.supersedes:
+        tags.append("supersession")
+
+    source_excerpt = event.content[:220]
+    if event.evidence_refs:
+        source_excerpt = f"{source_excerpt}\nEvidence: {', '.join(event.evidence_refs[:4])}"
+
+    context = {
+        "event_id": event.event_id,
+        "scope": event.scope,
+        "event_type": event.event_type,
+        "evidence_refs": list(event.evidence_refs),
+        "relationships": [relationship.to_dict() for relationship in event.relationships],
+        "supersedes": list(event.supersedes),
+        "retention_policy": event.retention_policy,
+    }
+
+    return {
+        "text": _candidate_text(event, context),
+        "user_id": event.user_id,
+        "source": HINDSIGHT_RETAIN_SOURCE,
+        "session_id": None,
+        "user_turn_id": event.event_id,
+        "memory_type": event.event_type,
+        "confidence": event.confidence,
+        "status": "pending",
+        "tags": tags,
+        "entity_type": "zoe_memory_event" if event.entities else None,
+        "entity_id": event.entities[0] if event.entities else event.event_id,
+        "source_excerpt": source_excerpt,
+        "metadata": context,
+    }
+
+
+def _candidate_text(event: MemoryEvent, context: Mapping[str, Any]) -> str:
+    structured = json.dumps(context, sort_keys=True, separators=(",", ":"))
+    return f"{event.content}\n\n[zoe_hindsight_retain_candidate] {structured}"
+
+
+async def create_hindsight_retain_candidate(
+    event_or_payload: MemoryEvent | Mapping[str, Any],
+    *,
+    memory_service: Any | None = None,
+) -> Any:
+    """Create a pending MemoryService row for later Hindsight admission."""
+
+    payload = build_hindsight_retain_candidate(event_or_payload)
+    svc = memory_service
+    if svc is None:
+        from memory_service import get_memory_service
+
+        svc = get_memory_service()
+
+    return await svc.ingest(
+        payload["text"],
+        user_id=payload["user_id"],
+        source=payload["source"],
+        session_id=payload["session_id"],
+        user_turn_id=payload["user_turn_id"],
+        memory_type=payload["memory_type"],
+        confidence=payload["confidence"],
+        status=payload["status"],
+        tags=payload["tags"],
+        entity_type=payload["entity_type"],
+        entity_id=payload["entity_id"],
+        source_excerpt=payload["source_excerpt"],
+        metadata=payload["metadata"],
+    )
+
+
+__all__ = [
+    "HINDSIGHT_RETAIN_SOURCE",
+    "build_hindsight_retain_candidate",
+    "create_hindsight_retain_candidate",
+]

--- a/services/zoe-data/memory_service.py
+++ b/services/zoe-data/memory_service.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 import asyncio
 import datetime
 import hashlib
+import json
 import logging
 import os
 import re
@@ -59,6 +60,12 @@ _MEMPALACE_DATA = os.environ.get(
 )
 
 _AUDIT_COLLECTION = os.environ.get("ZOE_MEMORY_AUDIT_COLLECTION", "mempalace_audit")
+
+
+def _metadata_value(value: Any) -> str | int | float | bool:
+    if isinstance(value, (str, int, float, bool)):
+        return value
+    return json.dumps(value, sort_keys=True, separators=(",", ":"))
 
 
 @dataclass(frozen=True)
@@ -163,6 +170,8 @@ class MemoryService:
         entity_type: Optional[str] = None,
         entity_id: Optional[str] = None,
         expires_at: Optional[str] = None,
+        source_excerpt: Optional[str] = None,
+        metadata: Optional[dict[str, Any]] = None,
         opt_out: bool = False,
     ) -> Optional[MemoryRef]:
         """Store a fact. Returns None when silently dropped."""
@@ -210,6 +219,8 @@ class MemoryService:
                 entity_type=entity_type,
                 entity_id=entity_id,
                 expires_at=expires_at,
+                source_excerpt=source_excerpt,
+                extra_metadata=metadata,
                 idem_key=idem_key,
             )
 
@@ -590,7 +601,9 @@ class MemoryService:
         entity_type: Optional[str],
         entity_id: Optional[str],
         expires_at: Optional[str],
-        idem_key: str,
+        source_excerpt: Optional[str] = None,
+        extra_metadata: Optional[dict[str, Any]] = None,
+        idem_key: str = "",
     ) -> dict[str, Any]:
         now = datetime.datetime.utcnow().isoformat() + "Z"
         md: dict[str, Any] = {
@@ -626,6 +639,13 @@ class MemoryService:
             md["entity_id"] = entity_id
         if expires_at:
             md["expires_at"] = expires_at
+        if source_excerpt:
+            md["source_excerpt"] = source_excerpt
+        for key, value in (extra_metadata or {}).items():
+            target_key = f"candidate_{key}"
+            if target_key in md or value is None:
+                continue
+            md[target_key] = _metadata_value(value)
         return md
 
     def _bump(self, status: str, source: str) -> None:

--- a/services/zoe-data/tests/test_hindsight_bakeoff.py
+++ b/services/zoe-data/tests/test_hindsight_bakeoff.py
@@ -1,0 +1,36 @@
+from hindsight_bakeoff import EVAL_QUERIES, SYNTHETIC_EVENTS, score_recall_response, synthetic_retain_payloads
+
+
+def test_synthetic_events_validate_and_include_required_cases():
+    payloads = synthetic_retain_payloads()
+
+    assert len(payloads) == len(SYNTHETIC_EVENTS) >= 4
+    assert {item["event_type"] for item in payloads} >= {"failure", "fix", "preference", "approval"}
+    assert all(item["user_id"] for item in payloads)
+    assert all(item["evidence_refs"] for item in payloads)
+
+
+def test_eval_queries_cover_plan_questions():
+    names = {query.name for query in EVAL_QUERIES}
+
+    assert names == {
+        "recall_weather_failure",
+        "recall_weather_fix",
+        "recall_user_preference",
+        "recall_governance",
+    }
+
+
+def test_score_recall_response_reports_missing_terms():
+    query = EVAL_QUERIES[0]
+    score = score_recall_response({"results": [{"text": "weather card had duplicate responses"}]}, query)
+
+    assert score["score"] == 2 / 3
+    assert score["missing"] == ["voice"]
+
+
+def test_synthetic_evidence_refs_are_tuples_not_strings():
+    for event in SYNTHETIC_EVENTS:
+        assert isinstance(event.evidence_refs, tuple)
+        assert all(isinstance(ref, str) for ref in event.evidence_refs)
+        assert all(len(ref) > 4 for ref in event.evidence_refs)

--- a/services/zoe-data/tests/test_hindsight_memory.py
+++ b/services/zoe-data/tests/test_hindsight_memory.py
@@ -1,0 +1,291 @@
+import json
+
+import httpx
+import pytest
+
+from hindsight_memory import (
+    HindsightConfig,
+    HindsightMemoryClient,
+    HindsightMemoryError,
+    HindsightOfflineConfigError,
+    event_to_hindsight_item,
+)
+from zoe_memory_contract import MemoryEvent, MemoryEventType, MemoryScope, MemorySource
+
+
+def _event():
+    return MemoryEvent(
+        event_id="mem_evt_test",
+        user_id="Jason B",
+        scope=MemoryScope.PROJECT.value,
+        source=MemorySource.TEST.value,
+        event_type=MemoryEventType.EXPERIENCE.value,
+        content="Zoe learned that Hindsight recall should be measured before live chat integration.",
+        entities=("Hindsight", "live chat"),
+        evidence_refs=("pytest:test_hindsight_memory",),
+    )
+
+
+def test_config_defaults_are_safe_and_offline_only():
+    config = HindsightConfig.from_env({})
+
+    assert config.enabled is False
+    assert config.auto_retain is False
+    assert config.async_retain is True
+    assert config.offline_only is True
+    assert config.bank_id("Jason B", "project") == "zoe-project-jason-b"
+
+
+def test_config_reads_local_env_without_enabling_auto_retain_by_accident():
+    config = HindsightConfig.from_env(
+        {
+            "HINDSIGHT_ENABLED": "true",
+            "HINDSIGHT_BASE_URL": "http://hindsight.local:8888/",
+            "HINDSIGHT_BANK_PREFIX": "Zoe Lab",
+            "HINDSIGHT_TIMEOUT_SECONDS": "2.5",
+            "HINDSIGHT_API_LLM_PROVIDER": "openai",
+            "HINDSIGHT_API_LLM_BASE_URL": "http://127.0.0.1:11434/v1",
+        }
+    )
+
+    assert config.enabled is True
+    assert config.base_url == "http://hindsight.local:8888"
+    assert config.bank_prefix == "zoe-lab"
+    assert config.timeout_seconds == 2.5
+    assert config.auto_retain is False
+    assert config.llm_provider == "openai"
+    assert config.llm_base_url == "http://127.0.0.1:11434/v1"
+
+
+def test_config_rejects_cloud_provider_when_enabled_offline_only():
+    with pytest.raises(HindsightOfflineConfigError, match="not allowed"):
+        HindsightConfig.from_env(
+            {
+                "HINDSIGHT_ENABLED": "true",
+                "HINDSIGHT_BASE_URL": "http://127.0.0.1:8888",
+                "HINDSIGHT_API_LLM_PROVIDER": "openai",
+            }
+        )
+
+
+def test_config_rejects_public_sidecar_url_when_enabled_offline_only():
+    with pytest.raises(HindsightOfflineConfigError, match="BASE_URL"):
+        HindsightConfig.from_env(
+            {
+                "HINDSIGHT_ENABLED": "true",
+                "HINDSIGHT_BASE_URL": "https://api.example.com",
+                "HINDSIGHT_API_LLM_PROVIDER": "llamacpp",
+            }
+        )
+
+
+def test_config_rejects_unknown_provider_without_local_base_url():
+    with pytest.raises(HindsightOfflineConfigError, match="unrecognized"):
+        HindsightConfig.from_env(
+            {
+                "HINDSIGHT_ENABLED": "true",
+                "HINDSIGHT_BASE_URL": "http://127.0.0.1:8888",
+                "HINDSIGHT_API_LLM_PROVIDER": "together",
+            }
+        )
+
+
+def test_config_allows_unknown_provider_with_local_base_url():
+    config = HindsightConfig.from_env(
+        {
+            "HINDSIGHT_ENABLED": "true",
+            "HINDSIGHT_BASE_URL": "http://127.0.0.1:8888",
+            "HINDSIGHT_API_LLM_PROVIDER": "vllm",
+            "HINDSIGHT_API_LLM_BASE_URL": "http://127.0.0.1:11434/v1",
+        }
+    )
+
+    assert config.llm_provider == "vllm"
+
+
+def test_config_allows_hindsight_builtin_llamacpp_provider():
+    config = HindsightConfig.from_env(
+        {
+            "HINDSIGHT_ENABLED": "true",
+            "HINDSIGHT_BASE_URL": "http://127.0.0.1:8888",
+            "HINDSIGHT_API_LLM_PROVIDER": "llamacpp",
+        }
+    )
+
+    assert config.enabled is True
+    assert config.llm_provider == "llamacpp"
+
+
+def test_event_to_hindsight_item_keeps_evidence_and_scope_tags():
+    item = event_to_hindsight_item(_event())
+
+    assert item["document_id"] == "mem_evt_test"
+    assert "user:jason-b" in item["tags"]
+    assert "scope:project" in item["tags"]
+    assert "evidence:pytest-test_hindsight_memory" in item["tags"]
+    assert "evidence_refs" in item["context"]
+
+
+@pytest.mark.asyncio
+async def test_retain_refuses_write_when_disabled():
+    client = HindsightMemoryClient(HindsightConfig(enabled=False))
+
+    result = await client.retain_event(_event(), allow_auto=True)
+
+    assert result == {"enabled": False, "retained": False, "reason": "disabled", "event_id": "mem_evt_test"}
+
+
+@pytest.mark.asyncio
+async def test_retain_refuses_auto_write_when_gate_closed():
+    client = HindsightMemoryClient(HindsightConfig(enabled=True, auto_retain=False))
+
+    result = await client.retain_event(_event())
+
+    assert result["retained"] is False
+    assert result["reason"] == "auto_retain_disabled"
+
+
+@pytest.mark.asyncio
+async def test_retain_posts_to_hindsight_memories_endpoint():
+    seen = {}
+
+    async def handler(request):
+        seen["method"] = request.method
+        seen["path"] = request.url.path
+        seen["payload"] = json.loads(request.read().decode())
+        return httpx.Response(200, json={"success": True, "items_count": 1, "async": True})
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as http_client:
+        client = HindsightMemoryClient(HindsightConfig(enabled=True, auto_retain=False), client=http_client)
+        result = await client.retain_event(_event(), allow_auto=True)
+
+    assert seen["method"] == "POST"
+    assert seen["path"] == "/v1/default/banks/zoe-project-jason-b/memories"
+    assert seen["payload"]["async"] is True
+    assert seen["payload"]["items"][0]["document_id"] == "mem_evt_test"
+    assert result["success"] is True
+    assert result["event_id"] == "mem_evt_test"
+
+
+@pytest.mark.asyncio
+async def test_operation_status_gets_hindsight_operation_endpoint():
+    seen = {}
+
+    async def handler(request):
+        seen["method"] = request.method
+        seen["path"] = request.url.path
+        return httpx.Response(200, json={"operation_id": "op_123", "status": "completed"})
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as http_client:
+        client = HindsightMemoryClient(HindsightConfig(enabled=True), client=http_client)
+        result = await client.operation_status(bank_id="zoe-project-jason", operation_id="op_123")
+
+    assert seen["method"] == "GET"
+    assert seen["path"] == "/v1/default/banks/zoe-project-jason/operations/op_123"
+    assert result["status"] == "completed"
+
+
+@pytest.mark.asyncio
+async def test_wait_for_operation_returns_immediately_when_disabled():
+    client = HindsightMemoryClient(HindsightConfig(enabled=False))
+
+    result = await client.wait_for_operation(
+        bank_id="zoe-project-jason",
+        operation_id="op_123",
+        timeout_seconds=120,
+        poll_seconds=120,
+    )
+
+    assert result == {"enabled": False, "status": "disabled", "reason": "disabled"}
+
+
+@pytest.mark.asyncio
+async def test_wait_for_retain_results_waits_for_async_operations():
+    async def handler(request):
+        return httpx.Response(200, json={"operation_id": "op_123", "status": "completed", "unit_ids_count": 1})
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as http_client:
+        client = HindsightMemoryClient(HindsightConfig(enabled=True), client=http_client)
+        result = await client.wait_for_retain_results(
+            [{"operation_id": "op_123", "bank_id": "zoe-project-jason"}],
+            timeout_seconds=1,
+            poll_seconds=0.1,
+        )
+
+    assert result == [{"operation_id": "op_123", "status": "completed", "unit_ids_count": 1}]
+
+
+@pytest.mark.asyncio
+async def test_wait_for_retain_results_skips_non_async_responses():
+    client = HindsightMemoryClient(HindsightConfig(enabled=True))
+
+    result = await client.wait_for_retain_results([{"success": True, "items_count": 1}])
+
+    assert result == [{"status": "not_async", "retain_result": {"success": True, "items_count": 1}}]
+
+
+@pytest.mark.asyncio
+async def test_recall_posts_trace_enabled_request():
+    seen = {}
+
+    async def handler(request):
+        seen["path"] = request.url.path
+        seen["payload"] = json.loads(request.read().decode())
+        return httpx.Response(200, json={"results": [{"text": "voice queue guard fixed weather"}]})
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as http_client:
+        client = HindsightMemoryClient(HindsightConfig(enabled=True), client=http_client)
+        result = await client.recall(user_id="Jason B", scope="project", query="What fixed weather?")
+
+    assert seen["path"] == "/v1/default/banks/zoe-project-jason-b/memories/recall"
+    assert seen["payload"]["trace"] is True
+    assert seen["payload"]["types"] == ["world", "experience"]
+    assert result["results"][0]["text"] == "voice queue guard fixed weather"
+
+
+def test_event_to_hindsight_item_serializes_structured_context_as_json():
+    item = event_to_hindsight_item(_event())
+
+    assert 'evidence_refs=["pytest:test_hindsight_memory"]' in item["context"]
+    assert "evidence_refs=['" not in item["context"]
+
+
+@pytest.mark.asyncio
+async def test_request_wraps_non_json_response():
+    async def handler(request):
+        return httpx.Response(200, text="not json")
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as http_client:
+        client = HindsightMemoryClient(HindsightConfig(enabled=True), client=http_client)
+        with pytest.raises(HindsightMemoryError, match="not valid JSON"):
+            await client.health()
+
+
+@pytest.mark.asyncio
+async def test_wait_for_retain_results_polls_async_operations_concurrently():
+    call_count = 0
+
+    async def handler(request):
+        nonlocal call_count
+        call_count += 1
+        return httpx.Response(200, json={"operation_id": request.url.path.rsplit("/", 1)[-1], "status": "completed"})
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as http_client:
+        client = HindsightMemoryClient(HindsightConfig(enabled=True), client=http_client)
+        result = await client.wait_for_retain_results(
+            [
+                {"operation_id": "op_1", "bank_id": "zoe-project-jason"},
+                {"operation_id": "op_2", "bank_id": "zoe-project-jason"},
+            ],
+            timeout_seconds=1,
+            poll_seconds=0.1,
+        )
+
+    assert [item["operation_id"] for item in result] == ["op_1", "op_2"]
+    assert call_count == 2

--- a/services/zoe-data/tests/test_hindsight_retain_candidates.py
+++ b/services/zoe-data/tests/test_hindsight_retain_candidates.py
@@ -1,0 +1,76 @@
+import pytest
+
+from hindsight_retain_candidates import (
+    HINDSIGHT_RETAIN_SOURCE,
+    build_hindsight_retain_candidate,
+    create_hindsight_retain_candidate,
+)
+from zoe_memory_contract import (
+    MemoryEvent,
+    MemoryEventType,
+    MemoryRelationship,
+    MemoryScope,
+    MemorySource,
+    RelationshipType,
+)
+
+
+def _event():
+    return MemoryEvent(
+        event_id="mem_evt_candidate",
+        user_id="jason",
+        scope=MemoryScope.PROJECT.value,
+        source=MemorySource.TRACE.value,
+        event_type=MemoryEventType.FAILURE.value,
+        content="The weather card failed because duplicate voice queue emits raced.",
+        entities=("weather_card", "voice_queue"),
+        relationships=(
+            MemoryRelationship(
+                relationship_type=RelationshipType.FAILED_ON.value,
+                source="weather_card",
+                target="mobile_dashboard_render",
+            ),
+        ),
+        evidence_refs=("trace:weather:001",),
+        confidence=0.81,
+    )
+
+
+def test_build_hindsight_retain_candidate_is_pending_and_evidence_tagged():
+    candidate = build_hindsight_retain_candidate(_event())
+
+    assert candidate["source"] == HINDSIGHT_RETAIN_SOURCE
+    assert candidate["status"] == "pending"
+    assert candidate["user_turn_id"] == "mem_evt_candidate"
+    assert "hindsight-retain-candidate" in candidate["tags"]
+    assert "evidence:trace:weather:001" in candidate["tags"]
+    assert "relational" in candidate["tags"]
+    assert candidate["metadata"]["relationships"][0]["relationship_type"] == "FAILED_ON"
+    assert "zoe_hindsight_retain_candidate" in candidate["text"]
+    assert '"relationship_type":"FAILED_ON"' in candidate["text"]
+    assert '"evidence_refs":["trace:weather:001"]' in candidate["text"]
+
+
+@pytest.mark.asyncio
+async def test_create_hindsight_retain_candidate_uses_memory_service_pending_ingest():
+    seen = {}
+
+    class FakeMemoryService:
+        async def ingest(self, text, **kwargs):
+            seen["text"] = text
+            seen.update(kwargs)
+            return {"id": "zoe_pending_mem"}
+
+    result = await create_hindsight_retain_candidate(_event(), memory_service=FakeMemoryService())
+
+    assert result == {"id": "zoe_pending_mem"}
+    assert seen["source"] == HINDSIGHT_RETAIN_SOURCE
+    assert "zoe_hindsight_retain_candidate" in seen["text"]
+    assert '"relationship_type":"FAILED_ON"' in seen["text"]
+    assert seen["status"] == "pending"
+    assert seen["memory_type"] == "failure"
+    assert seen["user_turn_id"] == "mem_evt_candidate"
+    assert seen["source_excerpt"].startswith("The weather card failed")
+    assert seen["metadata"]["relationships"][0]["relationship_type"] == "FAILED_ON"
+    assert seen["metadata"]["evidence_refs"] == ["trace:weather:001"]
+    assert "hindsight-retain-candidate" in seen["tags"]

--- a/services/zoe-data/tests/test_memory_service_metadata.py
+++ b/services/zoe-data/tests/test_memory_service_metadata.py
@@ -1,0 +1,53 @@
+from memory_service import MemoryService
+
+
+def test_build_metadata_preserves_candidate_source_excerpt_and_structured_metadata():
+    metadata = MemoryService._build_metadata(
+        user_id="jason",
+        source="hindsight_retain_candidate",
+        session_id=None,
+        user_turn_id="mem_evt_candidate",
+        memory_type="failure",
+        confidence=0.8,
+        status="pending",
+        tags=["relational"],
+        entity_type="zoe_memory_event",
+        entity_id="weather_card",
+        expires_at=None,
+        source_excerpt="Weather failed\nEvidence: trace:weather:001",
+        extra_metadata={
+            "event_id": "mem_evt_candidate",
+            "relationships": [{"relationship_type": "FAILED_ON"}],
+            "evidence_refs": ["trace:weather:001"],
+            "ignored": None,
+            "status": "candidate_pending",
+        },
+        idem_key="idem",
+    )
+
+    assert metadata["source_excerpt"].startswith("Weather failed")
+    assert metadata["candidate_event_id"] == "mem_evt_candidate"
+    assert metadata["candidate_relationships"] == "[{\"relationship_type\":\"FAILED_ON\"}]"
+    assert metadata["candidate_evidence_refs"] == "[\"trace:weather:001\"]"
+    assert "candidate_ignored" not in metadata
+    assert metadata["status"] == "pending"
+    assert metadata["candidate_status"] == "candidate_pending"
+
+
+def test_build_metadata_defaults_keep_review_edit_call_compatible():
+    metadata = MemoryService._build_metadata(
+        user_id="jason",
+        source="review_ui",
+        session_id=None,
+        user_turn_id=None,
+        memory_type="fact",
+        confidence=0.7,
+        status="approved",
+        tags=[],
+        entity_type=None,
+        entity_id=None,
+        expires_at=None,
+    )
+
+    assert metadata["source"] == "review_ui"
+    assert "source_excerpt" not in metadata

--- a/services/zoe-data/tests/test_zoe_memory_contract.py
+++ b/services/zoe-data/tests/test_zoe_memory_contract.py
@@ -1,0 +1,102 @@
+import pytest
+
+from zoe_memory_contract import (
+    MemoryContractError,
+    MemoryEvent,
+    MemoryEventType,
+    MemoryRelationship,
+    MemoryScope,
+    MemorySource,
+    RelationshipType,
+    memory_event_from_mapping,
+)
+
+
+def test_relational_memory_requires_evidence():
+    event = MemoryEvent(
+        user_id="jason",
+        scope=MemoryScope.PERSONAL.value,
+        source=MemorySource.TRACE.value,
+        event_type=MemoryEventType.FAILURE.value,
+        content="weather card failed during mobile render",
+        relationships=(
+            MemoryRelationship(
+                relationship_type=RelationshipType.FAILED_ON.value,
+                source="weather_card",
+                target="mobile_dashboard_render",
+            ),
+        ),
+        evidence_refs=(),
+    )
+
+    with pytest.raises(MemoryContractError, match="evidence_refs"):
+        event.validate()
+
+
+def test_valid_event_serializes_contract_fields():
+    event = MemoryEvent(
+        user_id="jason",
+        scope=MemoryScope.PROJECT.value,
+        source=MemorySource.TEST.value,
+        event_type=MemoryEventType.FIX.value,
+        content="voice queue guard fixed duplicate weather responses",
+        relationships=(
+            MemoryRelationship(
+                relationship_type=RelationshipType.FIXED_BY.value,
+                source="duplicate_weather_response",
+                target="voice_queue_guard",
+            ),
+        ),
+        evidence_refs=("pytest:services/zoe-data/tests/test_voice_transcribe.py",),
+        confidence=0.82,
+    )
+
+    payload = event.to_dict()
+
+    assert payload["user_id"] == "jason"
+    assert payload["status"] == "active"
+    assert payload["relationships"][0]["relationship_type"] == "FIXED_BY"
+    assert payload["evidence_refs"] == ["pytest:services/zoe-data/tests/test_voice_transcribe.py"]
+
+
+def test_mapping_rejects_unscoped_write():
+    with pytest.raises(MemoryContractError, match="user_id"):
+        memory_event_from_mapping(
+            {
+                "scope": "personal",
+                "source": "chat",
+                "event_type": "preference",
+                "content": "prefers concise answers",
+                "evidence_refs": [],
+            }
+        )
+
+
+def test_mapping_supports_supersession_with_evidence():
+    event = memory_event_from_mapping(
+        {
+            "user_id": "jason",
+            "scope": "personal",
+            "source": "chat",
+            "event_type": "fact",
+            "content": "Jason now prefers Hindsight-first bake-offs for Zoe memory.",
+            "evidence_refs": ["chat:2026-06-08:zoe-evolution-plan"],
+            "supersedes": ["mem_evt_old_graphiti_first"],
+        }
+    )
+
+    assert event.supersedes == ("mem_evt_old_graphiti_first",)
+
+
+def test_experience_memory_requires_evidence():
+    event = MemoryEvent(
+        user_id="jason",
+        scope=MemoryScope.PROJECT.value,
+        source=MemorySource.TRACE.value,
+        event_type=MemoryEventType.EXPERIENCE.value,
+        content="Zoe tried a Hindsight recall bake-off and learned from the outcome.",
+        evidence_refs=(),
+    )
+
+    with pytest.raises(MemoryContractError, match="evidence_refs"):
+        event.validate()

--- a/services/zoe-data/tests/test_zoe_memory_layers.py
+++ b/services/zoe-data/tests/test_zoe_memory_layers.py
@@ -1,0 +1,62 @@
+from zoe_memory_layers import (
+    ASYNC_ENRICHMENT_LAYERS,
+    FAST_CHAT_LAYERS,
+    LAYER_POLICIES,
+    MemoryLayer,
+    layer_policy,
+)
+from zoe_memory_router import MemoryBackend, route_memory_query
+
+
+def test_fast_chat_layers_are_boring_hot_path_only():
+    assert FAST_CHAT_LAYERS == (
+        MemoryLayer.WORKING_CONTEXT,
+        MemoryLayer.CANONICAL_STATE,
+        MemoryLayer.EPISODIC_MEMORY,
+    )
+    assert all(layer_policy(layer).hot_path for layer in FAST_CHAT_LAYERS)
+
+
+def test_sidecar_layers_are_async_enrichment_not_required_for_chat():
+    assert MemoryLayer.REFLECTIVE_MEMORY in ASYNC_ENRICHMENT_LAYERS
+    assert MemoryLayer.RELATIONAL_TEMPORAL_MEMORY in ASYNC_ENRICHMENT_LAYERS
+    assert not layer_policy(MemoryLayer.REFLECTIVE_MEMORY).hot_path
+    assert not layer_policy(MemoryLayer.RELATIONAL_TEMPORAL_MEMORY).hot_path
+
+
+def test_each_layer_has_failure_policy():
+    assert {policy.layer for policy in LAYER_POLICIES} == set(MemoryLayer)
+    assert all(policy.failure_policy for policy in LAYER_POLICIES)
+
+
+def test_default_chat_route_keeps_hindsight_and_graphiti_off_hot_path():
+    route = route_memory_query("What do I usually like for breakfast?")
+
+    assert route.primary == MemoryBackend.MEMPALACE
+    assert route.memory_layers == FAST_CHAT_LAYERS
+    assert MemoryBackend.HINDSIGHT not in route.secondary
+    assert MemoryBackend.GRAPHITI not in route.secondary
+    assert "never slow chat" in route.observation_policy
+
+
+def test_reflective_route_is_timeout_bounded_candidate_only():
+    route = route_memory_query("What did Zoe learn from that outcome pattern?")
+
+    assert route.primary == MemoryBackend.HINDSIGHT
+    assert MemoryLayer.OBSERVATION_EVALUATION in route.memory_layers
+    assert "candidate" in route.write_policy
+
+
+def test_failure_and_fix_queries_route_to_reflective_memory():
+    route = route_memory_query("What fix worked for the recurring weather failure?")
+
+    assert route.primary == MemoryBackend.HINDSIGHT
+    assert MemoryLayer.REFLECTIVE_MEMORY in route.memory_layers
+    assert MemoryBackend.GRAPHITI not in route.secondary
+
+
+def test_supersession_queries_route_to_relational_memory():
+    route = route_memory_query("Which fix superseded the old voice failure?")
+
+    assert route.primary == MemoryBackend.GRAPHITI
+    assert MemoryLayer.RELATIONAL_TEMPORAL_MEMORY in route.memory_layers

--- a/services/zoe-data/tests/test_zoe_memory_router.py
+++ b/services/zoe-data/tests/test_zoe_memory_router.py
@@ -1,0 +1,60 @@
+from zoe_memory_router import MemoryBackend, route_memory_query
+
+
+def test_default_chat_uses_mempalace_fast_path():
+    route = route_memory_query("What do I usually like for breakfast?")
+
+    assert route.primary == MemoryBackend.MEMPALACE
+    assert route.latency_budget_ms == 300
+
+
+def test_experience_queries_route_to_hindsight():
+    route = route_memory_query("What did Zoe learn from the last outcome?")
+
+    assert route.primary == MemoryBackend.HINDSIGHT
+    assert route.write_policy == "retain candidates only; auto-retain disabled by default"
+
+
+def test_relational_queries_route_to_graphiti():
+    route = route_memory_query("Which fix superseded the old voice failure?")
+
+    assert route.primary == MemoryBackend.GRAPHITI
+    assert MemoryBackend.HINDSIGHT in route.secondary
+    assert "evidence" in route.write_policy
+
+
+def test_mixed_code_noun_failure_queries_route_to_hindsight():
+    route = route_memory_query("What fix worked for the recurring service failure?")
+
+    assert route.primary == MemoryBackend.HINDSIGHT
+    assert route.latency_budget_ms == 600
+
+
+def test_code_questions_route_to_graphify():
+    route = route_memory_query("Which router owns chat in the Zoe repo?")
+
+    assert route.primary == MemoryBackend.GRAPHIFY
+    assert route.write_policy.startswith("read-only")
+
+
+def test_self_evolution_routes_through_multica():
+    route = route_memory_query("Create an upgrade proposal for a new capability")
+
+    assert route.primary == MemoryBackend.MULTICA
+    assert route.secondary == (
+        MemoryBackend.HINDSIGHT,
+        MemoryBackend.GRAPHITI,
+        MemoryBackend.GRAPHIFY,
+    )
+
+
+def test_router_uses_word_boundaries_for_slow_backend_terms():
+    examples = [
+        "What is the prefix for voice commands?",
+        "Show me fixture data",
+        "Can you encode this text?",
+        "Show this paragraph spacing",
+    ]
+
+    for query in examples:
+        assert route_memory_query(query).primary == MemoryBackend.MEMPALACE

--- a/services/zoe-data/zoe_memory_contract.py
+++ b/services/zoe-data/zoe_memory_contract.py
@@ -1,0 +1,237 @@
+"""Zoe memory contract for Zoe's governed self-evolution harness.
+
+This module defines the typed event/relationship shape that Hindsight,
+Graphiti-style graphs, MemPalace, Graphify, and Multica can share without
+making any one backend the source of truth during the bake-off phase.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Mapping
+from uuid import uuid4
+
+
+class MemoryContractError(ValueError):
+    """Raised when a memory event would violate Zoe's safety contract."""
+
+
+class MemoryScope(str, Enum):
+    PERSONAL = "personal"
+    SHARED = "shared"
+    AMBIENT = "ambient"
+    SYSTEM = "system"
+    PROJECT = "project"
+
+
+class MemorySource(str, Enum):
+    CHAT = "chat"
+    TOOL = "tool"
+    TEST = "test"
+    TRACE = "trace"
+    PROPOSAL = "proposal"
+    CODE = "code"
+    EXTERNAL = "external"
+
+
+class MemoryEventType(str, Enum):
+    FACT = "fact"
+    PREFERENCE = "preference"
+    EXPERIENCE = "experience"
+    FAILURE = "failure"
+    FIX = "fix"
+    CAPABILITY = "capability"
+    RECURRING_TASK = "recurring_task"
+    APPROVAL = "approval"
+
+
+class MemoryStatus(str, Enum):
+    ACTIVE = "active"
+    DISPUTED = "disputed"
+    SUPERSEDED = "superseded"
+    ARCHIVED = "archived"
+
+
+class RelationshipType(str, Enum):
+    ASKED_FOR = "ASKED_FOR"
+    USES = "USES"
+    FAILED_ON = "FAILED_ON"
+    FIXED_BY = "FIXED_BY"
+    APPROVED_BY = "APPROVED_BY"
+    TRUSTED_FOR = "TRUSTED_FOR"
+    SUPERSEDES = "SUPERSEDES"
+    RECURS_AS = "RECURS_AS"
+    CAUSED_BY = "CAUSED_BY"
+    EVIDENCED_BY = "EVIDENCED_BY"
+    BELONGS_TO_SCOPE = "BELONGS_TO_SCOPE"
+    PROPOSED_CAPABILITY = "PROPOSED_CAPABILITY"
+    MEASURED_BY = "MEASURED_BY"
+
+
+VALID_SCOPES = {item.value for item in MemoryScope}
+VALID_SOURCES = {item.value for item in MemorySource}
+VALID_EVENT_TYPES = {item.value for item in MemoryEventType}
+VALID_STATUSES = {item.value for item in MemoryStatus}
+VALID_RELATIONSHIPS = {item.value for item in RelationshipType}
+
+SELF_EVOLUTION_EVENT_TYPES = {
+    MemoryEventType.EXPERIENCE.value,
+    MemoryEventType.FAILURE.value,
+    MemoryEventType.FIX.value,
+    MemoryEventType.CAPABILITY.value,
+    MemoryEventType.APPROVAL.value,
+}
+
+
+@dataclass(frozen=True)
+class MemoryRelationship:
+    """A typed edge candidate for Zoe's relational memory graph."""
+
+    relationship_type: str
+    target: str
+    source: str | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def validate(self) -> None:
+        if self.relationship_type not in VALID_RELATIONSHIPS:
+            raise MemoryContractError(f"unsupported relationship_type: {self.relationship_type}")
+        if not str(self.target or "").strip():
+            raise MemoryContractError("relationship target is required")
+        if self.source is not None and not str(self.source).strip():
+            raise MemoryContractError("relationship source cannot be blank")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "relationship_type": self.relationship_type,
+            "source": self.source,
+            "target": self.target,
+            "metadata": dict(self.metadata or {}),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvent:
+    """Portable event shape for Zoe memory retain/graph-write candidates."""
+
+    user_id: str
+    scope: str
+    source: str
+    event_type: str
+    content: str
+    evidence_refs: tuple[str, ...]
+    event_id: str = field(default_factory=lambda: f"mem_evt_{uuid4().hex}")
+    entities: tuple[str, ...] = ()
+    relationships: tuple[MemoryRelationship, ...] = ()
+    confidence: float = 0.5
+    status: str = MemoryStatus.ACTIVE.value
+    created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    supersedes: tuple[str, ...] = ()
+    retention_policy: str = "standard"
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def validate(self) -> None:
+        if not str(self.event_id or "").strip():
+            raise MemoryContractError("event_id is required")
+        if not str(self.user_id or "").strip():
+            raise MemoryContractError("user_id is required")
+        if self.scope not in VALID_SCOPES:
+            raise MemoryContractError(f"unsupported scope: {self.scope}")
+        if self.source not in VALID_SOURCES:
+            raise MemoryContractError(f"unsupported source: {self.source}")
+        if self.event_type not in VALID_EVENT_TYPES:
+            raise MemoryContractError(f"unsupported event_type: {self.event_type}")
+        if not str(self.content or "").strip():
+            raise MemoryContractError("content is required")
+        if self.status not in VALID_STATUSES:
+            raise MemoryContractError(f"unsupported status: {self.status}")
+        if not 0.0 <= float(self.confidence) <= 1.0:
+            raise MemoryContractError("confidence must be between 0.0 and 1.0")
+        if self.event_id in set(self.supersedes or ()):  # defensive against loops
+            raise MemoryContractError("event cannot supersede itself")
+
+        for rel in self.relationships:
+            rel.validate()
+
+        has_relational_truth = bool(self.relationships or self.supersedes)
+        is_self_evolution = self.event_type in SELF_EVOLUTION_EVENT_TYPES or self.source == MemorySource.PROPOSAL.value
+        if (has_relational_truth or is_self_evolution) and not self.evidence_refs:
+            raise MemoryContractError("evidence_refs are required for relational or self-evolution memory")
+
+    def validated(self) -> "MemoryEvent":
+        self.validate()
+        return self
+
+    def to_dict(self) -> dict[str, Any]:
+        self.validate()
+        return {
+            "event_id": self.event_id,
+            "user_id": self.user_id,
+            "scope": self.scope,
+            "source": self.source,
+            "event_type": self.event_type,
+            "content": self.content,
+            "entities": list(self.entities),
+            "relationships": [rel.to_dict() for rel in self.relationships],
+            "evidence_refs": list(self.evidence_refs),
+            "confidence": float(self.confidence),
+            "status": self.status,
+            "created_at": self.created_at.isoformat(),
+            "supersedes": list(self.supersedes),
+            "retention_policy": self.retention_policy,
+            "metadata": dict(self.metadata or {}),
+        }
+
+
+def memory_event_from_mapping(payload: Mapping[str, Any]) -> MemoryEvent:
+    """Build and validate a MemoryEvent from an API/worker payload."""
+
+    relationships = tuple(
+        MemoryRelationship(
+            relationship_type=str(item.get("relationship_type") or item.get("type") or ""),
+            source=item.get("source"),
+            target=str(item.get("target") or ""),
+            metadata=item.get("metadata") or {},
+        )
+        for item in payload.get("relationships") or ()
+    )
+    created = payload.get("created_at")
+    if isinstance(created, str):
+        created_at = datetime.fromisoformat(created.replace("Z", "+00:00"))
+    elif isinstance(created, datetime):
+        created_at = created
+    else:
+        created_at = datetime.now(timezone.utc)
+
+    event = MemoryEvent(
+        event_id=str(payload.get("event_id") or f"mem_evt_{uuid4().hex}"),
+        user_id=str(payload.get("user_id") or ""),
+        scope=str(payload.get("scope") or ""),
+        source=str(payload.get("source") or ""),
+        event_type=str(payload.get("event_type") or ""),
+        content=str(payload.get("content") or ""),
+        entities=tuple(str(item) for item in payload.get("entities") or ()),
+        relationships=relationships,
+        evidence_refs=tuple(str(item) for item in payload.get("evidence_refs") or ()),
+        confidence=float(payload.get("confidence", 0.5)),
+        status=str(payload.get("status") or MemoryStatus.ACTIVE.value),
+        created_at=created_at,
+        supersedes=tuple(str(item) for item in payload.get("supersedes") or ()),
+        retention_policy=str(payload.get("retention_policy") or "standard"),
+        metadata=payload.get("metadata") or {},
+    )
+    return event.validated()
+
+
+__all__ = [
+    "MemoryContractError",
+    "MemoryEvent",
+    "MemoryEventType",
+    "MemoryRelationship",
+    "MemoryScope",
+    "MemorySource",
+    "MemoryStatus",
+    "RelationshipType",
+    "memory_event_from_mapping",
+]

--- a/services/zoe-data/zoe_memory_layers.py
+++ b/services/zoe-data/zoe_memory_layers.py
@@ -1,0 +1,124 @@
+"""Zoe memory layer policy for the evolution harness.
+
+This module names the memory layers so routes, docs, and future evals keep the
+same boring mental model: Postgres is truth, MemoryService gates writes,
+MemPalace recalls episodes, Hindsight reflects asynchronously, Graphiti models
+changing relationships, and Multica/review governs risky changes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class MemoryLayer(str, Enum):
+    WORKING_CONTEXT = "working_context"
+    CANONICAL_STATE = "canonical_state"
+    EPISODIC_MEMORY = "episodic_memory"
+    REFLECTIVE_MEMORY = "reflective_memory"
+    RELATIONAL_TEMPORAL_MEMORY = "relational_temporal_memory"
+    GOVERNANCE = "governance"
+    OBSERVATION_EVALUATION = "observation_evaluation"
+
+
+@dataclass(frozen=True)
+class MemoryLayerPolicy:
+    layer: MemoryLayer
+    owner: str
+    hot_path: bool
+    write_policy: str
+    failure_policy: str
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "layer": self.layer.value,
+            "owner": self.owner,
+            "hot_path": self.hot_path,
+            "write_policy": self.write_policy,
+            "failure_policy": self.failure_policy,
+        }
+
+
+LAYER_POLICIES: tuple[MemoryLayerPolicy, ...] = (
+    MemoryLayerPolicy(
+        MemoryLayer.WORKING_CONTEXT,
+        owner="chat/session runtime",
+        hot_path=True,
+        write_policy="short-lived per-turn/session state only",
+        failure_policy="discard and continue",
+    ),
+    MemoryLayerPolicy(
+        MemoryLayer.CANONICAL_STATE,
+        owner="PostgreSQL app tables",
+        hot_path=True,
+        write_policy="canonical app state, users, permissions, tasks, reminders, people, audit",
+        failure_policy="fail closed for required app state",
+    ),
+    MemoryLayerPolicy(
+        MemoryLayer.EPISODIC_MEMORY,
+        owner="MemoryService/MemPalace",
+        hot_path=True,
+        write_policy="exact facts, preferences, conversation-derived memories, verbatim-ish recall",
+        failure_policy="timeout-bounded fallback to working context and canonical state",
+    ),
+    MemoryLayerPolicy(
+        MemoryLayer.REFLECTIVE_MEMORY,
+        owner="Hindsight sidecar",
+        hot_path=False,
+        write_policy="pending/candidate lessons, recurring patterns, failures, fixes, experience summaries",
+        failure_policy="skip async enrichment; never block chat or voice",
+    ),
+    MemoryLayerPolicy(
+        MemoryLayer.RELATIONAL_TEMPORAL_MEMORY,
+        owner="Graphiti-style graph",
+        hot_path=False,
+        write_policy="evidence-backed changing relationships, supersession, causality, approvals",
+        failure_policy="defer graph enrichment; keep canonical and episodic paths usable",
+    ),
+    MemoryLayerPolicy(
+        MemoryLayer.GOVERNANCE,
+        owner="Zoe memory contract + Multica/review",
+        hot_path=False,
+        write_policy="evidence-gated admission for important memory and self-evolution writes",
+        failure_policy="leave memory as pending/candidate",
+    ),
+    MemoryLayerPolicy(
+        MemoryLayer.OBSERVATION_EVALUATION,
+        owner="Phoenix/evals or Zoe eval traces",
+        hot_path=False,
+        write_policy="record retrieval latency, helpfulness, hallucination, contradiction, and fallback outcomes",
+        failure_policy="drop eval trace before slowing user path",
+    ),
+)
+
+
+def layer_policy(layer: MemoryLayer) -> MemoryLayerPolicy:
+    for policy in LAYER_POLICIES:
+        if policy.layer == layer:
+            return policy
+    raise KeyError(layer)
+
+
+FAST_CHAT_LAYERS = (
+    MemoryLayer.WORKING_CONTEXT,
+    MemoryLayer.CANONICAL_STATE,
+    MemoryLayer.EPISODIC_MEMORY,
+)
+
+ASYNC_ENRICHMENT_LAYERS = (
+    MemoryLayer.REFLECTIVE_MEMORY,
+    MemoryLayer.RELATIONAL_TEMPORAL_MEMORY,
+    MemoryLayer.GOVERNANCE,
+    MemoryLayer.OBSERVATION_EVALUATION,
+)
+
+
+__all__ = [
+    "ASYNC_ENRICHMENT_LAYERS",
+    "FAST_CHAT_LAYERS",
+    "LAYER_POLICIES",
+    "MemoryLayer",
+    "MemoryLayerPolicy",
+    "layer_policy",
+]

--- a/services/zoe-data/zoe_memory_router.py
+++ b/services/zoe-data/zoe_memory_router.py
@@ -1,0 +1,194 @@
+"""Deterministic memory routing policy for Zoe's evolution harness."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import Enum
+
+from zoe_memory_layers import FAST_CHAT_LAYERS, MemoryLayer
+
+
+class MemoryBackend(str, Enum):
+    MEMPALACE = "mempalace"
+    HINDSIGHT = "hindsight"
+    GRAPHITI = "graphiti"
+    GRAPHIFY = "graphify"
+    MULTICA = "multica"
+
+
+@dataclass(frozen=True)
+class MemoryRoute:
+    primary: MemoryBackend
+    secondary: tuple[MemoryBackend, ...]
+    memory_layers: tuple[MemoryLayer, ...]
+    latency_budget_ms: int
+    prompt_policy: str
+    write_policy: str
+    observation_policy: str
+    reason: str
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "primary": self.primary.value,
+            "secondary": [item.value for item in self.secondary],
+            "memory_layers": [item.value for item in self.memory_layers],
+            "latency_budget_ms": self.latency_budget_ms,
+            "prompt_policy": self.prompt_policy,
+            "write_policy": self.write_policy,
+            "observation_policy": self.observation_policy,
+            "reason": self.reason,
+        }
+
+
+RELATIONAL_TERMS = {
+    "caused",
+    "cause",
+    "causality",
+    "superseded",
+    "supersedes",
+    "approved",
+    "approval",
+    "trusted",
+    "promise",
+    "promises",
+    "relationship",
+    "graph",
+    "evidence",
+}
+
+EXPERIENCE_TERMS = {
+    "learned",
+    "experience",
+    "outcome",
+    "worked",
+    "didn't work",
+    "failed",
+    "failure",
+    "fix",
+    "fixed",
+    "recurring",
+    "pattern",
+    "reflect",
+    "remember what happened",
+}
+
+CODE_TERMS = {
+    "code",
+    "service",
+    "dependency",
+    "router",
+    "module",
+    "function",
+    "graphify",
+    "repo",
+    "commit",
+}
+
+EVOLUTION_TERMS = {
+    "evolve",
+    "self-modify",
+    "self modify",
+    "upgrade",
+    "capability",
+    "proposal",
+    "multica",
+    "approve",
+    "harness",
+}
+
+
+def _contains_any(text: str, terms: set[str]) -> bool:
+    for term in terms:
+        pattern = r"(?<![\w])" + re.escape(term) + r"(?![\w])"
+        if re.search(pattern, text):
+            return True
+    return False
+
+
+def route_memory_query(query: str, *, purpose: str = "chat") -> MemoryRoute:
+    """Choose the memory backend policy without calling any backend.
+
+    The router is intentionally conservative: normal chat stays on working
+    context, canonical state, and episodic memory. Reflective and relational
+    layers are feature-flagged/async enrichment paths, and self-evolution goes
+    through Multica evidence.
+    """
+
+    text = f"{purpose} {query}".lower()
+
+    if _contains_any(text, EVOLUTION_TERMS):
+        return MemoryRoute(
+            primary=MemoryBackend.MULTICA,
+            secondary=(MemoryBackend.HINDSIGHT, MemoryBackend.GRAPHITI, MemoryBackend.GRAPHIFY),
+            memory_layers=(
+                MemoryLayer.GOVERNANCE,
+                MemoryLayer.REFLECTIVE_MEMORY,
+                MemoryLayer.RELATIONAL_TEMPORAL_MEMORY,
+                MemoryLayer.OBSERVATION_EVALUATION,
+            ),
+            latency_budget_ms=2000,
+            prompt_policy="compile evidence-backed proposal context only",
+            write_policy="proposal-gated; no trusted auto-retain",
+            observation_policy="trace proposal evidence, verification result, and retained outcome",
+            reason="self-evolution requires governance and evidence",
+        )
+
+    if _contains_any(text, RELATIONAL_TERMS):
+        return MemoryRoute(
+            primary=MemoryBackend.GRAPHITI,
+            secondary=(MemoryBackend.HINDSIGHT, MemoryBackend.MEMPALACE),
+            memory_layers=(
+                MemoryLayer.RELATIONAL_TEMPORAL_MEMORY,
+                MemoryLayer.REFLECTIVE_MEMORY,
+                MemoryLayer.EPISODIC_MEMORY,
+                MemoryLayer.OBSERVATION_EVALUATION,
+            ),
+            latency_budget_ms=2000,
+            prompt_policy="return compact current facts with evidence and supersession state",
+            write_policy="evidence-required graph candidate; async consolidation",
+            observation_policy="record latency, contradiction, supersession, and evidence coverage",
+            reason="relationship, causality, approval, or supersession query",
+        )
+
+    if _contains_any(text, EXPERIENCE_TERMS):
+        return MemoryRoute(
+            primary=MemoryBackend.HINDSIGHT,
+            secondary=(MemoryBackend.MEMPALACE,),
+            memory_layers=(
+                MemoryLayer.REFLECTIVE_MEMORY,
+                MemoryLayer.EPISODIC_MEMORY,
+                MemoryLayer.OBSERVATION_EVALUATION,
+            ),
+            latency_budget_ms=600,
+            prompt_policy="recall experiences and mental models with source pointers",
+            write_policy="retain candidates only; auto-retain disabled by default",
+            observation_policy="record recall latency, helpfulness, hallucination, and fallback outcome",
+            reason="experience or outcome memory query",
+        )
+
+    if _contains_any(text, CODE_TERMS):
+        return MemoryRoute(
+            primary=MemoryBackend.GRAPHIFY,
+            secondary=(MemoryBackend.MEMPALACE,),
+            memory_layers=(MemoryLayer.WORKING_CONTEXT, MemoryLayer.EPISODIC_MEMORY),
+            latency_budget_ms=2000,
+            prompt_policy="summarize code graph findings with file/source references",
+            write_policy="read-only unless routed through an evolution proposal",
+            observation_policy="record latency and whether code context changed the answer",
+            reason="code and system questions belong to Zoe self-understanding",
+        )
+
+    return MemoryRoute(
+        primary=MemoryBackend.MEMPALACE,
+        secondary=(),
+        memory_layers=FAST_CHAT_LAYERS,
+        latency_budget_ms=300,
+        prompt_policy="working context + canonical state + compact episodic recall",
+        write_policy="MemoryService gatekeeper; relationship writes require contract",
+        observation_policy="sample lightweight latency/helpfulness only; never slow chat",
+        reason="default chat personalization path",
+    )
+
+
+__all__ = ["MemoryBackend", "MemoryRoute", "route_memory_query"]


### PR DESCRIPTION
## Summary
- document the Zoe evolution harness strategy and memory ADRs
- add the scoped/evidence-backed Zoe memory contract and deterministic Zoe memory router
- add explicit Zoe memory layer policy: Working Context, Canonical State, Episodic, Reflective, Relational/Temporal, Governance, Observation/Evaluation
- add disabled-by-default, offline-only Hindsight sidecar client, retain-candidate admission helper, synthetic bake-off fixtures, and maintenance runner
- keep MemPalace as Zoe default offline episodic recall layer; Hindsight is an optional reflective sidecar, not a replacement
- add Zoe naming discipline so concrete modules/services/memory layers use Zoe identity, while external inspirations remain product vision only

## Layering rule
- fast chat uses Working Context + PostgreSQL canonical state + MemoryService/MemPalace episodic recall
- Hindsight is only for feature-flagged, timeout-bounded lessons/reflection/failures/fixes/experience summaries
- Graphiti-style memory is only for changing relationships: people, projects, promises, approvals, failures, fixes, supersession, and causality
- Hindsight, Graphiti, and new sidecars must remain async, fallback-safe, and not required for normal chat/voice
- observation/eval policy records latency, helpfulness, hallucination, contradiction, and fallback outcomes without slowing the user path

## Offline memory rule
- HINDSIGHT_OFFLINE_ONLY defaults to true
- enabled Hindsight configs must use localhost/private sidecar URLs
- cloud LLM providers are rejected for Zoe memory unless using a local/private OpenAI-compatible base URL such as Zoe llama-server
- unknown provider names are rejected unless paired with a localhost/private LLM base URL
- auto-retain remains off by default; durable writes enter pending retain candidates first

## Greptile fixes
- retain candidates now pass `source_excerpt` and structured `metadata` through `MemoryService.ingest`
- `MemoryService` stores extra candidate metadata as queryable `candidate_*` fields with non-scalar values JSON-serialized for Chroma-safe metadata
- Hindsight context strings now serialize list/dict values as JSON rather than Python repr
- unknown Hindsight LLM providers now fail closed unless a local/private base URL is configured
- Hindsight non-JSON sidecar responses are wrapped in `HindsightMemoryError`
- async retain polling now uses concurrent polling instead of sequential waits
- router precedence now sends mixed failure/fix/lesson queries that mention code nouns, such as service failure, to Hindsight rather than Graphify while preserving Graphiti for supersession/relationship queries
- candidate metadata collision handling now preserves prefixed fields such as `candidate_status` alongside base fields such as `status`
- disabled Hindsight operation polling now returns immediately instead of waiting until timeout

## Tests
- python3 -m pytest -q services/zoe-data/tests/test_hindsight_memory.py services/zoe-data/tests/test_hindsight_bakeoff.py services/zoe-data/tests/test_hindsight_retain_candidates.py services/zoe-data/tests/test_memory_service_metadata.py services/zoe-data/tests/test_zoe_memory_contract.py services/zoe-data/tests/test_zoe_memory_router.py services/zoe-data/tests/test_zoe_memory_layers.py services/zoe-data/tests/test_memory_candidates.py services/zoe-data/tests/test_memory_capture_lockdown.py services/zoe-data/tests/test_memory_digest_postgres_sql.py
- 52 passed in 1.59s
- python3 scripts/maintenance/hindsight_bakeoff.py --json
- python3 -m py_compile services/zoe-data/memory_service.py services/zoe-data/zoe_memory_layers.py services/zoe-data/zoe_memory_contract.py services/zoe-data/zoe_memory_router.py services/zoe-data/hindsight_memory.py services/zoe-data/hindsight_bakeoff.py services/zoe-data/hindsight_retain_candidates.py scripts/maintenance/hindsight_bakeoff.py
- python3 tools/audit/validate_structure.py
- python3 tools/audit/validate_critical_files.py
- git diff --check

## Live offline bake-off
- Fresh temporary Hindsight sidecar using Zoe local Gemma llama-server only: HINDSIGHT_API_LLM_BASE_URL=http://127.0.0.1:11434/v1
- 4/4 async retain operations completed with extraction_errors_count=0
- 4/4 synthetic recall queries scored 1.0
- Recall timings from Hindsight logs were approximately 0.327s, 0.434s, 0.501s, and 0.566s
- Sidecar memory after run was approximately 865 MiB
- Temporary bake-off container and volume were removed after testing

## Notes
- This PR does not wire Hindsight or Graphiti into live chat.
- A live Hindsight performance bake-off should use pre-provisioned offline models only.

