### PR TITLE
Prevent recursive harness follow-up tickets

### DIFF
--- a/services/zoe-data/main.py
+++ b/services/zoe-data/main.py
@@ -192,6 +192,14 @@ async def _ensure_blocker_followup_ticket(client, issue_id: str, chain: dict, bl
         parent = await client.get_issue(issue_id)
         if not parent.get("id"):
             return {}
+        parent_metadata = parse_ticket_block(parent.get("description") or "")
+        if parent_metadata.get("source") == "engineering_blocker_followup":
+            logger.info(
+                "multica_poll: not creating recursive harness follow-up for %s (%s)",
+                parent.get("identifier") or issue_id,
+                marker,
+            )
+            return {}
         parent_ident = parent.get("identifier") or issue_id
         for status in ("backlog", "todo", "in_progress", "blocked", "in_review"):
             for candidate in await client.list_issues(status=status, limit=1000) or []:

--- a/services/zoe-data/tests/test_main_multica_poll.py
+++ b/services/zoe-data/tests/test_main_multica_poll.py
@@ -388,6 +388,46 @@ async def test_record_blocked_multica_chain_creates_budget_followup_once():
 
 
 @pytest.mark.asyncio
+async def test_record_blocked_multica_chain_does_not_create_recursive_harness_followup():
+    from main import _record_blocked_multica_chain
+    from multica_ticket_contract import describe_ticket
+
+    client = RecordingClient()
+    client.issues["issue-budget"] = {
+        "id": "issue-budget",
+        "identifier": "ZOE-5448",
+        "description": describe_ticket(
+            "Existing harness follow-up",
+            zoe_kind="harness_fix",
+            source="engineering_blocker_followup",
+            parent_issue_id="parent-root",
+            acceptance_criteria=["Focused tests cover blocker path"],
+            evidence_expectations=["Focused tests", "PR URL"],
+        ),
+        "assignee_id": "hermes",
+        "assignee_type": "agent",
+        "project_id": "project-1",
+    }
+
+    blocker = await _record_blocked_multica_chain(
+        client,
+        "issue-budget",
+        {
+            "pipeline": {
+                "phase": "implement",
+                "block_reason": "ITERATION_BUDGET: Hermes iteration budget reached",
+            }
+        },
+    )
+
+    assert blocker == "ITERATION_BUDGET: Hermes iteration budget reached"
+    assert client.calls[0][1]["dispatch_approved"] is False
+    assert client.created == []
+    assert client.labels == []
+    assert client.notes == []
+
+
+@pytest.mark.asyncio
 async def test_record_blocked_multica_chain_reuses_existing_in_progress_budget_followup():
     from main import _record_blocked_multica_chain
     from multica_ticket_contract import describe_ticket, parse_ticket_block, write_ticket_block


### PR DESCRIPTION
## Summary
- stop blocked harness follow-up tickets from creating another harness follow-up child
- keep the parent blocked and dispatch_approved=false so the single-ticket lane does not recurse
- add regression coverage for recursive blocker follow-up suppression

## Tests
- remote: PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_main_multica_poll.py services/zoe-data/tests/test_multica_admission.py services/zoe-data/tests/test_multica_poll_dispatch.py (40 passed)
- local: python3 -m py_compile services/zoe-data/main.py services/zoe-data/tests/test_main_multica_poll.py
- local+remote: python3 tools/audit/validate_structure.py
- local+remote: python3 tools/audit/validate_critical_files.py