### PR TITLE
Add review verdict wrap-up budget grace

### DIFF
--- a/services/zoe-data/kanban_phase_budget.py
+++ b/services/zoe-data/kanban_phase_budget.py
@@ -38,6 +38,10 @@ _ITERATION_BUDGET_RE = re.compile(
     r"Iteration budget reached\s*\((?P<used>\d+)\s*/\s*(?P<limit>\d+)\)",
     re.IGNORECASE,
 )
+_MARK_REVIEWED_VERDICT_RE = re.compile(
+    r"\bmark-reviewed\b(?=.*--critical-count)(?=.*--summary)",
+    re.IGNORECASE,
+)
 _ZERO_STEP_WARNED: set[str] = set()
 
 
@@ -79,6 +83,17 @@ def task_log_tail(task_id: str, *, max_lines: int = 80) -> str:
     return "\n".join(lines[-max_lines:])
 
 
+def _latest_log_session(task_id: str, *, max_lines: int = 120) -> str:
+    tail = task_log_tail(task_id, max_lines=max_lines)
+    if not tail:
+        return ""
+    lines = tail.splitlines()
+    query_starts = [index for index, line in enumerate(lines) if line.startswith("Query:")]
+    if query_starts:
+        lines = lines[query_starts[-1]:]
+    return "\n".join(lines)
+
+
 def tool_step_count(task_id: str, *, since: float | None = None) -> int:
     path = _log_path(task_id)
     try:
@@ -117,13 +132,9 @@ def phase_budget_reason_from_log(task_id: str, phase: str) -> str | None:
     hid the useful cost-control signal from the pipeline. Treat the log line as
     explicit blocker evidence so Zoe can stop/recover without redispatch loops.
     """
-    tail = task_log_tail(task_id, max_lines=120)
+    tail = _latest_log_session(task_id, max_lines=120)
     if not tail:
         return None
-    lines = tail.splitlines()
-    query_starts = [index for index, line in enumerate(lines) if line.startswith("Query:")]
-    if query_starts:
-        tail = "\n".join(lines[query_starts[-1]:])
     matches = list(_ITERATION_BUDGET_RE.finditer(tail))
     if not matches:
         return None
@@ -132,6 +143,25 @@ def phase_budget_reason_from_log(task_id: str, phase: str) -> str | None:
         f"BLOCKER=ITERATION_BUDGET: Hermes iteration budget reached during {phase} "
         f"(steps={match.group('used')}, limit={match.group('limit')})"
     )
+
+
+def review_wrapup_tool_grace(task_id: str, phase: str) -> int:
+    """Grant review terminal headroom only after a verdict marker is written."""
+    if phase != "review":
+        return 0
+    session = _latest_log_session(task_id, max_lines=160)
+    if not session:
+        return 0
+    for line in session.splitlines():
+        lowered = line.lower()
+        if "mark-reviewed" not in lowered or "--help" in lowered:
+            continue
+        if _MARK_REVIEWED_VERDICT_RE.search(line):
+            try:
+                return max(0, int(os.environ.get("ZOE_KANBAN_REVIEW_WRAPUP_TOOL_GRACE", "3")))
+            except ValueError:
+                return 3
+    return 0
 
 
 def _is_expected_worker(pid: int) -> bool:
@@ -219,7 +249,8 @@ def phase_budget_reason(
         )
     except ValueError:
         terminal_grace = _TERMINAL_GRACE_DEFAULT
-    hard_limit = tool_limit + terminal_grace
+    wrapup_grace = review_wrapup_tool_grace(task_id, phase)
+    hard_limit = tool_limit + terminal_grace + wrapup_grace
     if tool_steps > hard_limit:
         return (
             f"BLOCKER={phase.upper()}_BUDGET: code-enforced tool budget exceeded "

--- a/services/zoe-data/kanban_phase_budget.py
+++ b/services/zoe-data/kanban_phase_budget.py
@@ -84,13 +84,15 @@ def task_log_tail(task_id: str, *, max_lines: int = 80) -> str:
 
 
 def _latest_log_session(task_id: str, *, max_lines: int = 120) -> str:
-    tail = task_log_tail(task_id, max_lines=max_lines)
-    if not tail:
+    try:
+        lines = _log_path(task_id).read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
         return ""
-    lines = tail.splitlines()
     query_starts = [index for index, line in enumerate(lines) if line.startswith("Query:")]
     if query_starts:
         lines = lines[query_starts[-1]:]
+    if max_lines > 0:
+        lines = lines[-max_lines:]
     return "\n".join(lines)
 
 
@@ -149,7 +151,7 @@ def review_wrapup_tool_grace(task_id: str, phase: str) -> int:
     """Grant review terminal headroom only after a verdict marker is written."""
     if phase != "review":
         return 0
-    session = _latest_log_session(task_id, max_lines=160)
+    session = _latest_log_session(task_id, max_lines=0)
     if not session:
         return 0
     for line in session.splitlines():

--- a/services/zoe-data/kanban_phase_budget.py
+++ b/services/zoe-data/kanban_phase_budget.py
@@ -155,6 +155,8 @@ def review_wrapup_tool_grace(task_id: str, phase: str) -> int:
     if not session:
         return 0
     for line in session.splitlines():
+        if not _STEP_LINE_RE.match(line):
+            continue
         lowered = line.lower()
         if "mark-reviewed" not in lowered or "--help" in lowered:
             continue

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -1925,6 +1925,77 @@ def test_review_budget_gets_wrapup_grace_after_mark_reviewed_verdict(tmp_path, m
     assert reason is None
 
 
+def test_review_budget_finds_verdict_in_verbose_session(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    log_dir = tmp_path / "kanban" / "logs"
+    log_dir.mkdir(parents=True)
+    lines = ["Query: work kanban task t_review"]
+    lines.extend(f"  ┊ pre-verdict tool call {idx}  0.1s" for idx in range(8))
+    lines.append(
+        "  ┊ 💻 $ python3 services/zoe-data/pipeline_evidence_commands.py "
+        "mark-reviewed multica:issue --critical-count 0 --summary approved  0.1s"
+    )
+    lines.extend(f"verbose review output line {idx}" for idx in range(220))
+    lines.extend(f"  ┊ post-verdict tool call {idx}  0.1s" for idx in range(5))
+    (log_dir / "t_review.log").write_text("\n".join(lines), encoding="utf-8")
+
+    reason = kb.phase_budget_reason(
+        "t_review",
+        "review",
+        {"task": {"started_at": 100}},
+        now=110,
+    )
+
+    assert kb.tool_step_count("t_review") == 14
+    assert kb.review_wrapup_tool_grace("t_review", "review") == 3
+    assert reason is None
+
+
+def test_review_budget_wrapup_grace_env_override(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("ZOE_KANBAN_REVIEW_WRAPUP_TOOL_GRACE", "5")
+    log_dir = tmp_path / "kanban" / "logs"
+    log_dir.mkdir(parents=True)
+    lines = ["Query: work kanban task t_review"]
+    lines.append(
+        "  ┊ 💻 $ python3 services/zoe-data/pipeline_evidence_commands.py "
+        "mark-reviewed multica:issue --critical-count 0 --summary approved  0.1s"
+    )
+    (log_dir / "t_review.log").write_text("\n".join(lines), encoding="utf-8")
+
+    assert kb.review_wrapup_tool_grace("t_review", "review") == 5
+
+
+def test_review_budget_wrapup_grace_zero_override(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("ZOE_KANBAN_REVIEW_WRAPUP_TOOL_GRACE", "0")
+    log_dir = tmp_path / "kanban" / "logs"
+    log_dir.mkdir(parents=True)
+    lines = ["Query: work kanban task t_review"]
+    lines.append(
+        "  ┊ 💻 $ python3 services/zoe-data/pipeline_evidence_commands.py "
+        "mark-reviewed multica:issue --critical-count 0 --summary approved  0.1s"
+    )
+    (log_dir / "t_review.log").write_text("\n".join(lines), encoding="utf-8")
+
+    assert kb.review_wrapup_tool_grace("t_review", "review") == 0
+
+
+def test_review_budget_wrapup_grace_bad_override_falls_back(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("ZOE_KANBAN_REVIEW_WRAPUP_TOOL_GRACE", "soon")
+    log_dir = tmp_path / "kanban" / "logs"
+    log_dir.mkdir(parents=True)
+    lines = ["Query: work kanban task t_review"]
+    lines.append(
+        "  ┊ 💻 $ python3 services/zoe-data/pipeline_evidence_commands.py "
+        "mark-reviewed multica:issue --critical-count 0 --summary approved  0.1s"
+    )
+    (log_dir / "t_review.log").write_text("\n".join(lines), encoding="utf-8")
+
+    assert kb.review_wrapup_tool_grace("t_review", "review") == 3
+
+
 def test_review_budget_without_verdict_still_blocks_at_normal_limit(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     log_dir = tmp_path / "kanban" / "logs"

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -1900,6 +1900,77 @@ def test_phase_budget_reason_enforces_tool_and_runtime_limits(tmp_path, monkeypa
     assert "runtime budget exceeded" in reason
 
 
+def test_review_budget_gets_wrapup_grace_after_mark_reviewed_verdict(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    log_dir = tmp_path / "kanban" / "logs"
+    log_dir.mkdir(parents=True)
+    lines = ["Query: work kanban task t_review"]
+    lines.extend(f"  ┊ tool call {idx}  0.1s" for idx in range(13))
+    lines.append(
+        "  ┊ 💻 $ PYTHONPATH=services/zoe-data python3 "
+        "services/zoe-data/pipeline_evidence_commands.py mark-reviewed "
+        "multica:issue --critical-count 0 --summary approved  0.1s"
+    )
+    (log_dir / "t_review.log").write_text("\n".join(lines), encoding="utf-8")
+
+    reason = kb.phase_budget_reason(
+        "t_review",
+        "review",
+        {"task": {"started_at": 100}},
+        now=110,
+    )
+
+    assert kb.tool_step_count("t_review") == 14
+    assert kb.review_wrapup_tool_grace("t_review", "review") == 3
+    assert reason is None
+
+
+def test_review_budget_without_verdict_still_blocks_at_normal_limit(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    log_dir = tmp_path / "kanban" / "logs"
+    log_dir.mkdir(parents=True)
+    (log_dir / "t_review.log").write_text(
+        "Query: work kanban task t_review\n"
+        + "\n".join(f"  ┊ tool call {idx}  0.1s" for idx in range(13)),
+        encoding="utf-8",
+    )
+
+    reason = kb.phase_budget_reason(
+        "t_review",
+        "review",
+        {"task": {"started_at": 100}},
+        now=110,
+    )
+
+    assert reason is not None
+    assert "BLOCKER=REVIEW_BUDGET" in reason
+    assert "hard_limit=12" in reason
+
+
+def test_review_budget_does_not_treat_mark_reviewed_help_as_verdict(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    log_dir = tmp_path / "kanban" / "logs"
+    log_dir.mkdir(parents=True)
+    lines = ["Query: work kanban task t_review"]
+    lines.extend(f"  ┊ tool call {idx}  0.1s" for idx in range(13))
+    lines.append(
+        "  ┊ 💻 $ python3 services/zoe-data/pipeline_evidence_commands.py "
+        "mark-reviewed --help  0.1s"
+    )
+    (log_dir / "t_review.log").write_text("\n".join(lines), encoding="utf-8")
+
+    reason = kb.phase_budget_reason(
+        "t_review",
+        "review",
+        {"task": {"started_at": 100}},
+        now=110,
+    )
+
+    assert kb.review_wrapup_tool_grace("t_review", "review") == 0
+    assert reason is not None
+    assert "BLOCKER=REVIEW_BUDGET" in reason
+
+
 def test_verify_phase_budget_allows_pr_validation_headroom(tmp_path, monkeypatch):
     log_path = tmp_path / "task.log"
     monkeypatch.setattr(kb, "_log_path", lambda _task_id: log_path)

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -2042,6 +2042,33 @@ def test_review_budget_does_not_treat_mark_reviewed_help_as_verdict(tmp_path, mo
     assert "BLOCKER=REVIEW_BUDGET" in reason
 
 
+def test_review_budget_does_not_treat_help_output_as_verdict(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    log_dir = tmp_path / "kanban" / "logs"
+    log_dir.mkdir(parents=True)
+    lines = ["Query: work kanban task t_review"]
+    lines.extend(f"  ┊ tool call {idx}  0.1s" for idx in range(13))
+    lines.append(
+        "  ┊ 💻 $ python3 services/zoe-data/pipeline_evidence_commands.py "
+        "mark-reviewed --help  0.1s"
+    )
+    lines.append(
+        "usage: mark-reviewed multica:issue --critical-count 0 --summary approved"
+    )
+    (log_dir / "t_review.log").write_text("\n".join(lines), encoding="utf-8")
+
+    reason = kb.phase_budget_reason(
+        "t_review",
+        "review",
+        {"task": {"started_at": 100}},
+        now=110,
+    )
+
+    assert kb.review_wrapup_tool_grace("t_review", "review") == 0
+    assert reason is not None
+    assert "BLOCKER=REVIEW_BUDGET" in reason
+
+
 def test_verify_phase_budget_allows_pr_validation_headroom(tmp_path, monkeypatch):
     log_path = tmp_path / "task.log"
     monkeypatch.setattr(kb, "_log_path", lambda _task_id: log_path)


### PR DESCRIPTION
## Summary
- grants a small review-phase wrap-up tool grace only after a real mark-reviewed verdict command is observed
- keeps normal review budget blocking for exploration and mark-reviewed --help sessions
- reuses latest-log-session trimming so stale Hermes sessions cannot grant budget headroom

## Tests
- python3 -m py_compile services/zoe-data/kanban_phase_budget.py services/zoe-data/tests/test_kanban_adapter.py
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_kanban_adapter.py services/zoe-data/tests/test_pipeline_handoff.py services/zoe-data/tests/test_pipeline_store.py services/zoe-data/tests/test_multica_poll_dispatch.py
- python3 tools/audit/validate_structure.py
- python3 tools/audit/validate_critical_files.py