### PR TITLE
Add harness worker repo map hint

### DIFF
--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -292,7 +292,8 @@ def _harness_implement_hint(issue: dict | None = None) -> str:
     source = str(meta.get("source") or "").lower()
     kind = str(meta.get("zoe_kind") or "").lower()
     harness_sources = {"retro_followup", "engineering_blocker_followup"}
-    if kind != "harness_fix" and "harness" not in title and source not in harness_sources:
+    harness_title = title.startswith(("harness:", "zoe harness", "hermes harness"))
+    if kind != "harness_fix" and not harness_title and source not in harness_sources:
         return ""
     return (
         "- HARNESS FAST PATH: this is a Zoe/Hermes harness ticket. Do not spend budget"

--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -284,6 +284,33 @@ def _code_audit_implement_hint(issue: dict | None = None) -> str:
     )
 
 
+def _harness_implement_hint(issue: dict | None = None) -> str:
+    """Return a small repo map for harness/self-improvement tickets."""
+    issue = issue or {}
+    meta = _ticket_metadata(issue)
+    title = str(issue.get("title") or "").lower()
+    source = str(meta.get("source") or "").lower()
+    kind = str(meta.get("zoe_kind") or "").lower()
+    if kind != "harness_fix" and "harness" not in title and not source.endswith("followup"):
+        return ""
+    return (
+        "- HARNESS FAST PATH: this is a Zoe/Hermes harness ticket. Do not spend budget"
+        " searching ~/.local, Hermes internals, or broad worktree inventories unless a named file"
+        " explicitly requires it. Start from this repo map:\n"
+        "  * phase prompt/dispatch/task creation: services/zoe-data/executors/kanban_adapter.py\n"
+        "  * task worktree creation and workspace_path pinning: services/zoe-data/worktree_bootstrap.py\n"
+        "  * phase handoff/evidence parsing: services/zoe-data/pipeline_handoff.py\n"
+        "  * journal/cache state: services/zoe-data/pipeline_store.py\n"
+        "  * Multica ticket metadata/progress: services/zoe-data/multica_ticket_contract.py and multica_client.py\n"
+        "  * poll/admission/blocked follow-ups: services/zoe-data/main.py, multica_admission.py,"
+        " multica_poll_dispatch.py\n"
+        "  For worktree-missing/retro fallback tickets, inspect kanban_adapter.py and"
+        " worktree_bootstrap.py first; decide whether the fix belongs before Hermes starts,"
+        " not inside the external Hermes worker. Start editing within 6 tool/model steps or"
+        " call `kanban_block` with BLOCKER=IMPLEMENT_BUDGET and the missing locator.\n"
+    )
+
+
 def _is_bounded_goal_phase(phase: str, issue: dict | None = None) -> bool:
     """Return True when this phase should run in bounded goal mode with one retry."""
     return phase == "implement" and _is_code_audit_actionable(_ticket_metadata(issue))
@@ -508,11 +535,13 @@ class KanbanAdapter:
         if phase == "implement":
             overnight_hint = _overnight_implement_cost_hint() if mode == "overnight" else ""
             code_audit_hint = _code_audit_implement_hint(issue)
+            harness_hint = _harness_implement_hint(issue)
             # Implement body intentionally omits full prior-phase logs; workers should
             # call kanban_show and read SCOUT_SUMMARY= from scout metadata when present.
             return common + overnight_hint + (
                 "You are the implementer (zoe-coder).\n"
                 f"{code_audit_hint}"
+                f"{harness_hint}"
                 "- AUDIT/SMOKE FAST PATH: only if the title/body explicitly says audit-only, smoke test,"
                 " no code change, or uses trace/map with an audit/no-code qualifier, do not run Graphify"
                 " or repo exploration first. Complete in one bounded handoff with"

--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -291,7 +291,8 @@ def _harness_implement_hint(issue: dict | None = None) -> str:
     title = str(issue.get("title") or "").lower()
     source = str(meta.get("source") or "").lower()
     kind = str(meta.get("zoe_kind") or "").lower()
-    if kind != "harness_fix" and "harness" not in title and not source.endswith("followup"):
+    harness_sources = {"retro_followup", "engineering_blocker_followup"}
+    if kind != "harness_fix" and "harness" not in title and source not in harness_sources:
         return ""
     return (
         "- HARNESS FAST PATH: this is a Zoe/Hermes harness ticket. Do not spend budget"

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -2601,6 +2601,27 @@ def test_implement_body_includes_harness_repo_map_for_harness_tickets():
     assert body.index("HARNESS FAST PATH") < body.index("Graphify map")
 
 
+def test_implement_body_includes_harness_repo_map_for_blocker_followup_source():
+    body = ka.KanbanAdapter()._build_body(
+        "implement",
+        {
+            "id": "uuid-5454",
+            "identifier": "ZOE-5454",
+            "title": "Follow up iteration budget",
+            "description": """Fix the blocked harness run.
+
+```zoe-ticket
+{"schema":1,"zoe_kind":"operator_task","source":"engineering_blocker_followup","acceptance_criteria":["small harness fix"],"evidence_expectations":["focused tests"]}
+```""",
+        },
+        "ZOE-5454",
+    )
+
+    assert "HARNESS FAST PATH" in body
+    assert "services/zoe-data/executors/kanban_adapter.py" in body
+    assert "services/zoe-data/worktree_bootstrap.py" in body
+
+
 def test_implement_body_omits_harness_repo_map_for_generic_tickets():
     body = ka.KanbanAdapter()._build_body(
         "implement",

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -2628,7 +2628,7 @@ def test_implement_body_includes_harness_repo_map_for_harness_title():
         {
             "id": "uuid-title",
             "identifier": "ZOE-TITLE",
-            "title": "Fix harness worktree path",
+            "title": "Harness: fix worktree path",
             "description": """Small operator task.
 
 ```zoe-ticket
@@ -2640,6 +2640,21 @@ def test_implement_body_includes_harness_repo_map_for_harness_title():
 
     assert "HARNESS FAST PATH" in body
     assert "services/zoe-data/executors/kanban_adapter.py" in body
+
+
+def test_implement_body_omits_harness_repo_map_for_unrelated_harness_word():
+    body = ka.KanbanAdapter()._build_body(
+        "implement",
+        {
+            "id": "uuid-test-harness",
+            "identifier": "ZOE-TEST",
+            "title": "Fix CI test harness timeout",
+            "description": "Update a product test fixture timeout.",
+        },
+        "ZOE-TEST",
+    )
+
+    assert "HARNESS FAST PATH" not in body
 
 
 def test_implement_body_omits_harness_repo_map_for_generic_tickets():

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -2577,6 +2577,46 @@ def test_implement_body_puts_bounded_fast_paths_before_graphify():
     assert body.index("SMALL EXPLICIT CODE FAST PATH") < body.index("Graphify map")
 
 
+def test_implement_body_includes_harness_repo_map_for_harness_tickets():
+    body = ka.KanbanAdapter()._build_body(
+        "implement",
+        {
+            "id": "uuid-5435",
+            "identifier": "ZOE-5435",
+            "title": "retro-fallback-when-worktree-missing",
+            "description": """Fix the missing worktree retro fallback.
+
+```zoe-ticket
+{"schema":1,"zoe_kind":"harness_fix","source":"retro_followup","acceptance_criteria":["small harness fix"],"evidence_expectations":["focused tests"]}
+```""",
+        },
+        "ZOE-5435",
+    )
+
+    assert "HARNESS FAST PATH" in body
+    assert "services/zoe-data/executors/kanban_adapter.py" in body
+    assert "services/zoe-data/worktree_bootstrap.py" in body
+    assert "For worktree-missing/retro fallback tickets" in body
+    assert "Start editing within 6 tool/model steps" in body
+    assert body.index("HARNESS FAST PATH") < body.index("Graphify map")
+
+
+def test_implement_body_omits_harness_repo_map_for_generic_tickets():
+    body = ka.KanbanAdapter()._build_body(
+        "implement",
+        {
+            "id": "uuid-generic",
+            "identifier": "ZOE-GEN",
+            "title": "Generic feature",
+            "description": "Add a small user setting.",
+        },
+        "ZOE-GEN",
+    )
+
+    assert "HARNESS FAST PATH" not in body
+    assert "For worktree-missing/retro fallback tickets" not in body
+
+
 def test_scout_body_has_child_followup_fast_path():
     body = ka.KanbanAdapter()._build_body(
         "scout",

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -2622,6 +2622,26 @@ def test_implement_body_includes_harness_repo_map_for_blocker_followup_source():
     assert "services/zoe-data/worktree_bootstrap.py" in body
 
 
+def test_implement_body_includes_harness_repo_map_for_harness_title():
+    body = ka.KanbanAdapter()._build_body(
+        "implement",
+        {
+            "id": "uuid-title",
+            "identifier": "ZOE-TITLE",
+            "title": "Fix harness worktree path",
+            "description": """Small operator task.
+
+```zoe-ticket
+{"schema":1,"zoe_kind":"operator_task","source":"manual","acceptance_criteria":["small fix"],"evidence_expectations":["focused tests"]}
+```""",
+        },
+        "ZOE-TITLE",
+    )
+
+    assert "HARNESS FAST PATH" in body
+    assert "services/zoe-data/executors/kanban_adapter.py" in body
+
+
 def test_implement_body_omits_harness_repo_map_for_generic_tickets():
     body = ka.KanbanAdapter()._build_body(
         "implement",


### PR DESCRIPTION
## Summary
- adds a conditional harness-ticket repo map to implement-phase Hermes prompts
- points harness/worktree tickets at kanban_adapter.py, worktree_bootstrap.py, pipeline state/evidence modules, and Multica helpers before generic exploration
- keeps the hint out of generic implement tickets

## Why
A real-ticket validation run for ZOE-5435 blocked at ITERATION_BUDGET after spending most of its budget rediscovering the harness/wrapper location. This applies the Case/Babysitter/OpenJarvis lesson: use measured trace evidence to reduce search cost instead of raising budgets.

## Tests
- python3 -m py_compile services/zoe-data/executors/kanban_adapter.py services/zoe-data/tests/test_kanban_adapter.py
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_kanban_adapter.py services/zoe-data/tests/test_pipeline_handoff.py services/zoe-data/tests/test_pipeline_store.py services/zoe-data/tests/test_multica_poll_dispatch.py
- python3 tools/audit/validate_structure.py
- python3 tools/audit/validate_critical_files.py