### PR TITLE
Run retro tasks from main repo workspace

### DIFF
--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -91,6 +91,17 @@ def _board() -> str:
     return os.environ.get("ZOE_KANBAN_BOARD", "default")
 
 
+def _workspace_for_phase(phase: str) -> str:
+    """Choose the Hermes workspace for a phase.
+
+    Retro is read-only orchestration/learning work. Running it from the main
+    repo avoids phantom task worktrees after closeout has already merged.
+    """
+    if phase == "retro":
+        return f"dir:{zoe_repo_root()}"
+    return "worktree"
+
+
 def _greptile_mcp_bin() -> str:
     """Locate the operator-local greptile MCP CLI; honour GREPTILE_MCP_BIN override.
 
@@ -494,13 +505,14 @@ class KanbanAdapter:
         issue_id = str(issue.get("id") or "").strip()
         escalation = _model_escalation_active(issue, mode)
         escalation_marker = "zoe-model-escalation: true\n" if escalation else ""
+        workspace_label = "main repo checkout" if phase == "retro" else "git worktree"
         common = (
             f"Multica issue: {identifier} (id {issue_id})\n"
             f"zoe-ref: multica:{issue_id}:{phase}\n"
             f"zoe-chain: v4\n"
             f"{escalation_marker}"
             f"{mode_note}"
-            f"Repo: {zoe_repo_root()}  |  Base branch: main  |  Workspace: git worktree\n\n"
+            f"Repo: {zoe_repo_root()}  |  Base branch: main  |  Workspace: {workspace_label}\n\n"
             f"Title: {title}\n\n{description}\n\n"
         )
         if phase == "scout":
@@ -976,7 +988,7 @@ class KanbanAdapter:
             "--assignee",
             assignee,
             "--workspace",
-            "worktree",
+            _workspace_for_phase(phase),
             "--idempotency-key",
             f"{external_ref}:{phase}",
             "--max-runtime",

--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -505,7 +505,8 @@ class KanbanAdapter:
         issue_id = str(issue.get("id") or "").strip()
         escalation = _model_escalation_active(issue, mode)
         escalation_marker = "zoe-model-escalation: true\n" if escalation else ""
-        workspace_label = "main repo checkout" if phase == "retro" else "git worktree"
+        workspace = _workspace_for_phase(phase)
+        workspace_label = "main repo checkout" if workspace.startswith("dir:") else "git worktree"
         common = (
             f"Multica issue: {identifier} (id {issue_id})\n"
             f"zoe-ref: multica:{issue_id}:{phase}\n"

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -180,6 +180,33 @@ async def test_dispatch_blocks_regular_worktree_failures_with_generic_reason(mon
     assert "PR_REVISION_CHECKOUT_FAILED" not in block_calls[0][2]
 
 
+@pytest.mark.asyncio
+async def test_dispatch_retro_uses_main_repo_workspace():
+    from pipeline_evidence import PipelineState
+    from pipeline_store import save_state
+
+    state = PipelineState(
+        task_ref="multica:uuid-retro-workspace",
+        phase="retro",
+        status="todo",
+        attempts={"implement": 1, "verify": 1, "review": 1, "closeout": 1},
+    )
+    save_state(state, event="operator_resumed")
+    a = _FakeAdapter()
+    result = await a.dispatch(
+        {
+            "id": "uuid-retro-workspace",
+            "identifier": "ZOE-RETRO",
+            "title": "Retro fallback",
+        }
+    )
+
+    assert result["ok"] is True
+    assert result["phase"] == "retro"
+    create = [c for c in a.calls if c[0] == "create"][0]
+    assert create[create.index("--workspace") + 1] == f"dir:{ka.zoe_repo_root()}"
+
+
 
 
 @pytest.mark.asyncio
@@ -2719,6 +2746,7 @@ def test_retro_body_has_post_closeout_fast_path():
         "ZOE-9",
     )
 
+    assert "Workspace: main repo checkout" in body
     assert "POST-CLOSEOUT FAST PATH" in body
     assert "PR_URL, MERGE_SHA" in body
     assert "GREPTILE/greptile_status=5/5 or already_merged" in body


### PR DESCRIPTION
## Summary
- dispatches retro-phase Hermes tasks with --workspace dir:<repo> instead of synthetic worktree
- updates retro prompt body to say Workspace: main repo checkout
- preserves worktree isolation for implement/verify and other phases

## Why
Real-ticket validation of ZOE-5435 showed Hermes repeatedly searching for a nonexistent shell wrapper and blocking on iteration budget. The actual missing-worktree risk is in handing read-only retro work a worktree workspace. Running retro from the main checkout removes the phantom worktree class without raising budgets.

## Tests
- python3 -m py_compile services/zoe-data/executors/kanban_adapter.py services/zoe-data/tests/test_kanban_adapter.py
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_kanban_adapter.py services/zoe-data/tests/test_pipeline_handoff.py services/zoe-data/tests/test_pipeline_store.py services/zoe-data/tests/test_multica_poll_dispatch.py
- python3 tools/audit/validate_structure.py
- python3 tools/audit/validate_critical_files.py