### PR TITLE
Gate code implement completion on PR evidence

### DIFF
--- a/services/zoe-data/greploop_guard.py
+++ b/services/zoe-data/greploop_guard.py
@@ -696,6 +696,15 @@ async def run_guard_once(
         status = await get_pr_status(repo=DEFAULT_REPO, pr_number=pr_number, default_branch=DEFAULT_BASE_BRANCH)
         comments = await list_pr_comments(repo=DEFAULT_REPO, pr_number=pr_number, default_branch=DEFAULT_BASE_BRANCH)
         findings = comments.get("findings") or []
+        if status.get("reviewIsRunning"):
+            state["greptile"] = {
+                "status": status.get("reviewCompleteness") or "review_running",
+                "confidence": status.get("confidenceScore"),
+                "unaddressed_count": len(findings),
+            }
+            state["terminal_state"] = "WAITING_GREPTILE"
+            _write_json(pr_number, "status.json", state)
+            return {"ok": True, "state": "WAITING_GREPTILE", "greptile": status}
         progress_key = f"{status.get('headSha')}:{status.get('confidenceScore')}:{len(findings)}"
         blocked = _update_circuit_breakers(pr_number, state, progress_key)
         if blocked:
@@ -709,10 +718,6 @@ async def run_guard_once(
             "unaddressed_count": len(findings),
         }
         _write_json(pr_number, "status.json", state)
-        if status.get("reviewIsRunning"):
-            state["terminal_state"] = "WAITING_GREPTILE"
-            _write_json(pr_number, "status.json", state)
-            return {"ok": True, "state": "WAITING_GREPTILE", "greptile": status}
         if (status.get("confidenceScore") or 0) >= int(task.get("target_confidence") or 5) and not findings:
             state["terminal_state"] = "READY_TO_MERGE"
             _write_json(pr_number, "status.json", state)

--- a/services/zoe-data/greploop_guard.py
+++ b/services/zoe-data/greploop_guard.py
@@ -697,14 +697,22 @@ async def run_guard_once(
         comments = await list_pr_comments(repo=DEFAULT_REPO, pr_number=pr_number, default_branch=DEFAULT_BASE_BRANCH)
         findings = comments.get("findings") or []
         if status.get("reviewIsRunning"):
+            wait_count = int(state.get("waiting_greptile_count") or 0) + 1
+            state["waiting_greptile_count"] = wait_count
             state["greptile"] = {
                 "status": status.get("reviewCompleteness") or "review_running",
                 "confidence": status.get("confidenceScore"),
                 "unaddressed_count": len(findings),
             }
+            if wait_count > MAX_ITERATIONS:
+                state["terminal_state"] = "BLOCKED_GREPTILE_STUCK"
+                _write_json(pr_number, "status.json", state)
+                _record_guardrail(pr_number, "Greptile review stayed active past wait limit")
+                return {"ok": False, "state": "BLOCKED_GREPTILE_STUCK", "greptile": status}
             state["terminal_state"] = "WAITING_GREPTILE"
             _write_json(pr_number, "status.json", state)
             return {"ok": True, "state": "WAITING_GREPTILE", "greptile": status}
+        state["waiting_greptile_count"] = 0
         progress_key = f"{status.get('headSha')}:{status.get('confidenceScore')}:{len(findings)}"
         blocked = _update_circuit_breakers(pr_number, state, progress_key)
         if blocked:

--- a/services/zoe-data/greptile_client.py
+++ b/services/zoe-data/greptile_client.py
@@ -79,7 +79,16 @@ def review_is_running(status: dict[str, Any]) -> bool:
     for review in status.get("codeReviews") or []:
         if isinstance(review, dict):
             candidates.extend([review.get("status"), review.get("state"), review.get("conclusion")])
-    return any(str(value).lower() in {"running", "queued", "pending", "in_progress", "in-progress"} for value in candidates if value)
+    running_states = {
+        "running",
+        "queued",
+        "pending",
+        "in_progress",
+        "in-progress",
+        "reviewing_files",
+        "reviewing-files",
+    }
+    return any(str(value).lower() in running_states for value in candidates if value)
 
 
 def _load_api_key() -> str:

--- a/services/zoe-data/pipeline_evidence.py
+++ b/services/zoe-data/pipeline_evidence.py
@@ -48,6 +48,7 @@ _REQUIRED_EVIDENCE: dict[PipelinePhase, set[EvidenceKind]] = {
 }
 
 _EVIDENCE_PROFILES: dict[EvidenceProfile, dict[PipelinePhase, set[EvidenceKind]]] = {
+    # Default is the normal code-producing path, so implement completion needs PR evidence.
     "default": _REQUIRED_EVIDENCE,
     "code": _REQUIRED_EVIDENCE,
     "audit": {

--- a/services/zoe-data/pipeline_evidence.py
+++ b/services/zoe-data/pipeline_evidence.py
@@ -40,7 +40,7 @@ PHASE_ORDER: tuple[PipelinePhase, ...] = (
 
 _REQUIRED_EVIDENCE: dict[PipelinePhase, set[EvidenceKind]] = {
     "scout": {"tool"},
-    "implement": {"tool"},
+    "implement": {"tool", "pr"},
     "verify": {"test", "validator"},
     "review": {"human"},
     "closeout": {"greptile"},

--- a/services/zoe-data/pipeline_store.py
+++ b/services/zoe-data/pipeline_store.py
@@ -249,6 +249,7 @@ def skip_blocked_implementation(
             raise ValueError(
                 f"pipeline lacks passed scout/tool evidence required for a no-code skip: {task_ref}"
             )
+        state = state.model_copy(update={"evidence_profile": "audit"})
         skipped = transition(state, "skip_implementation", reason=reason)
         skipped = skipped.model_copy(
             update={
@@ -604,6 +605,12 @@ async def _sync_pipeline_from_chain_once(
             }
             if state.phase == "verify" and not verify_validator_hash_matches(state):
                 extra["validator_hash_mismatch"] = True
+            block_reason = "GATE_BLOCKED: missing required evidence " + ",".join(extra["missing"])
+            state, _should_abort = record_block_fingerprint(
+                state,
+                block_fingerprint(phase, block_reason),  # type: ignore[arg-type]
+            )
+            state = transition(state, "block", reason=block_reason)
             state = await _run_io(
                 partial(
                     save_state,

--- a/services/zoe-data/pipeline_store.py
+++ b/services/zoe-data/pipeline_store.py
@@ -603,9 +603,15 @@ async def _sync_pipeline_from_chain_once(
                 "row_phase": phase,
                 "missing": sorted(missing_required_evidence(state)),
             }
-            if state.phase == "verify" and not verify_validator_hash_matches(state):
+            validator_hash_mismatch = state.phase == "verify" and not verify_validator_hash_matches(state)
+            if validator_hash_mismatch:
                 extra["validator_hash_mismatch"] = True
-            block_reason = "GATE_BLOCKED: missing required evidence " + ",".join(extra["missing"])
+            if extra["missing"]:
+                block_reason = "GATE_BLOCKED: missing required evidence " + ",".join(extra["missing"])
+            elif validator_hash_mismatch:
+                block_reason = "GATE_BLOCKED: validator hash mismatch"
+            else:
+                block_reason = "GATE_BLOCKED: phase completion evidence invalid"
             state, _should_abort = record_block_fingerprint(
                 state,
                 block_fingerprint(phase, block_reason),  # type: ignore[arg-type]

--- a/services/zoe-data/pipeline_store.py
+++ b/services/zoe-data/pipeline_store.py
@@ -611,7 +611,10 @@ async def _sync_pipeline_from_chain_once(
             elif validator_hash_mismatch:
                 block_reason = "GATE_BLOCKED: validator hash mismatch"
             else:
-                block_reason = "GATE_BLOCKED: phase completion evidence invalid"
+                raise AssertionError(
+                    "can_complete_phase returned False with no diagnosable gate reason "
+                    f"(phase={state.phase!r}, evidence={[item.kind for item in state.evidence]!r})"
+                )
             state, _should_abort = record_block_fingerprint(
                 state,
                 block_fingerprint(phase, block_reason),  # type: ignore[arg-type]

--- a/services/zoe-data/pipeline_store.py
+++ b/services/zoe-data/pipeline_store.py
@@ -610,6 +610,8 @@ async def _sync_pipeline_from_chain_once(
                 state,
                 block_fingerprint(phase, block_reason),  # type: ignore[arg-type]
             )
+            # A gate block is already terminal for this phase until operator action
+            # changes the state, so repeated-fingerprint escalation would be noise.
             state = transition(state, "block", reason=block_reason)
             state = await _run_io(
                 partial(

--- a/services/zoe-data/tests/test_greploop_guard.py
+++ b/services/zoe-data/tests/test_greploop_guard.py
@@ -276,6 +276,35 @@ async def test_run_guard_once_active_review_does_not_trip_no_progress(tmp_path, 
 
 
 @pytest.mark.asyncio
+async def test_run_guard_once_blocks_permanently_active_review(tmp_path, monkeypatch):
+    async def fake_status(**_kwargs):
+        return {
+            "confidenceScore": None,
+            "reviewIsRunning": True,
+            "headSha": "abc",
+            "reviewCompleteness": "No Greptile review comments",
+            "codeReviews": [{"status": "REVIEWING_FILES"}],
+        }
+
+    async def fake_comments(**_kwargs):
+        return {"findings": []}
+
+    monkeypatch.setattr(greploop_guard, "STATE_ROOT", tmp_path)
+    monkeypatch.setattr("greptile_client.get_pr_status", fake_status)
+    monkeypatch.setattr("greptile_client.list_pr_comments", fake_comments)
+
+    out = {}
+    for _ in range(greploop_guard.MAX_ITERATIONS + 1):
+        out = await greploop_guard.run_guard_once(66)
+
+    assert out["ok"] is False
+    assert out["state"] == "BLOCKED_GREPTILE_STUCK"
+    state = greploop_guard.read_guard_state(66)
+    assert state["terminal_state"] == "BLOCKED_GREPTILE_STUCK"
+    assert state["no_progress_count"] == 0
+
+
+@pytest.mark.asyncio
 async def test_merge_pr_when_ready_merges_when_assessment_passes(tmp_path, monkeypatch):
     async def fake_assess(_pr_number, **_kwargs):
         return {"ready": True, "blockers": [], "greptile": {}, "gh": {"ok": True}}

--- a/services/zoe-data/tests/test_greploop_guard.py
+++ b/services/zoe-data/tests/test_greploop_guard.py
@@ -243,6 +243,36 @@ async def test_run_guard_once_does_not_retrigger_active_reviewing_files(tmp_path
     assert out["state"] == "WAITING_GREPTILE"
     state = greploop_guard.read_guard_state(66)
     assert state["terminal_state"] == "WAITING_GREPTILE"
+    assert state["iteration"] == 0
+
+
+@pytest.mark.asyncio
+async def test_run_guard_once_active_review_does_not_trip_no_progress(tmp_path, monkeypatch):
+    async def fake_status(**_kwargs):
+        return {
+            "confidenceScore": None,
+            "reviewIsRunning": True,
+            "headSha": None,
+            "reviewCompleteness": "No Greptile review comments",
+            "codeReviews": [{"status": "REVIEWING_FILES"}],
+        }
+
+    async def fake_comments(**_kwargs):
+        return {"findings": []}
+
+    monkeypatch.setattr(greploop_guard, "STATE_ROOT", tmp_path)
+    monkeypatch.setattr("greptile_client.get_pr_status", fake_status)
+    monkeypatch.setattr("greptile_client.list_pr_comments", fake_comments)
+
+    for _ in range(greploop_guard.NO_PROGRESS_LIMIT + 1):
+        out = await greploop_guard.run_guard_once(66)
+        assert out["ok"] is True
+        assert out["state"] == "WAITING_GREPTILE"
+
+    state = greploop_guard.read_guard_state(66)
+    assert state["terminal_state"] == "WAITING_GREPTILE"
+    assert state["iteration"] == 0
+    assert state["no_progress_count"] == 0
 
 
 @pytest.mark.asyncio

--- a/services/zoe-data/tests/test_greploop_guard.py
+++ b/services/zoe-data/tests/test_greploop_guard.py
@@ -216,6 +216,36 @@ async def test_assess_merge_readiness_blocks_low_confidence(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_run_guard_once_does_not_retrigger_active_reviewing_files(tmp_path, monkeypatch):
+    async def fake_status(**_kwargs):
+        return {
+            "confidenceScore": None,
+            "reviewIsRunning": True,
+            "headSha": "abc",
+            "reviewCompleteness": "No Greptile review comments",
+            "codeReviews": [{"status": "REVIEWING_FILES"}],
+        }
+
+    async def fake_comments(**_kwargs):
+        return {"findings": []}
+
+    async def fail_trigger(**_kwargs):
+        raise AssertionError("active Greptile reviews must not be retriggered")
+
+    monkeypatch.setattr(greploop_guard, "STATE_ROOT", tmp_path)
+    monkeypatch.setattr("greptile_client.get_pr_status", fake_status)
+    monkeypatch.setattr("greptile_client.list_pr_comments", fake_comments)
+    monkeypatch.setattr("greptile_client.trigger_review", fail_trigger)
+
+    out = await greploop_guard.run_guard_once(66)
+
+    assert out["ok"] is True
+    assert out["state"] == "WAITING_GREPTILE"
+    state = greploop_guard.read_guard_state(66)
+    assert state["terminal_state"] == "WAITING_GREPTILE"
+
+
+@pytest.mark.asyncio
 async def test_merge_pr_when_ready_merges_when_assessment_passes(tmp_path, monkeypatch):
     async def fake_assess(_pr_number, **_kwargs):
         return {"ready": True, "blockers": [], "greptile": {}, "gh": {"ok": True}}

--- a/services/zoe-data/tests/test_greptile_client.py
+++ b/services/zoe-data/tests/test_greptile_client.py
@@ -33,4 +33,5 @@ def test_normalize_pr_comment_maps_common_fields():
 
 def test_review_is_running_detects_pending_states():
     assert greptile_client.review_is_running({"reviewCompleteness": "in_progress"}) is True
+    assert greptile_client.review_is_running({"codeReviews": [{"status": "REVIEWING_FILES"}]}) is True
     assert greptile_client.review_is_running({"reviewCompleteness": "reviewed"}) is False

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -1380,6 +1380,34 @@ async def test_poll_v4_done_phase_with_ready_next_phase_is_partial():
 
 
 @pytest.mark.asyncio
+async def test_poll_v4_blocks_code_implement_done_without_pr():
+    rows = [_row("implement", "done", chain_version="v4", issue_id="uuid-no-pr")]
+    show = {
+        "t_implement": {
+            "latest_summary": "TOOLS_USED=graphify\nTESTS=validate_structure.py passed\nSUMMARY=investigated only",
+            "comments": [],
+        }
+    }
+    a = _FakeAdapter(list_rows=rows, show_map=show)
+    out = await a.poll(
+        "multica:uuid-no-pr",
+        issue={
+            "id": "uuid-no-pr",
+            "identifier": "ZOE-NO-PR",
+            "title": "Harness fix must produce a PR",
+            "metadata": {"evidence_profile": "code"},
+        },
+    )
+
+    assert out["found"] is True
+    assert out["status"] == "blocked"
+    assert out["pipeline"]["phase"] == "implement"
+    assert out["pipeline"]["status"] == "blocked"
+    assert out["pipeline"]["missing_evidence"] == ["pr"]
+    assert out["blocker"] == "GATE_BLOCKED: missing required evidence pr"
+
+
+@pytest.mark.asyncio
 async def test_poll_ignores_stale_terminal_row_for_revision_phase():
     from pipeline_evidence import PipelineState
     from pipeline_store import save_state

--- a/services/zoe-data/tests/test_pipeline_store.py
+++ b/services/zoe-data/tests/test_pipeline_store.py
@@ -436,6 +436,29 @@ async def test_sync_pipeline_blocks_code_implement_without_pr(isolated_store):
 
 
 @pytest.mark.asyncio
+async def test_sync_pipeline_blocks_default_implement_without_pr(isolated_store):
+    await store.bootstrap_state("multica:no-pr-default")
+
+    async def fetch_detail(_task_id: str):
+        return {
+            "latest_summary": "TOOLS_USED=graphify\nSUMMARY=investigated only",
+            "comments": [],
+        }
+
+    state = await store.sync_pipeline_from_chain(
+        "multica:no-pr-default",
+        {"implement": {"id": "t_impl", "status": "done"}},
+        fetch_detail,
+    )
+
+    assert state.evidence_profile == "default"
+    assert state.phase == "implement"
+    assert state.status == "blocked"
+    assert state.history[-1].reason == "GATE_BLOCKED: missing required evidence pr"
+    assert store.pipeline_summary(state)["missing_evidence"] == ["pr"]
+
+
+@pytest.mark.asyncio
 async def test_sync_pipeline_reports_validator_hash_mismatch_gate(isolated_store):
     state = PipelineState(
         task_ref="multica:verify-hash-mismatch",

--- a/services/zoe-data/tests/test_pipeline_store.py
+++ b/services/zoe-data/tests/test_pipeline_store.py
@@ -436,6 +436,53 @@ async def test_sync_pipeline_blocks_code_implement_without_pr(isolated_store):
 
 
 @pytest.mark.asyncio
+async def test_sync_pipeline_reports_validator_hash_mismatch_gate(isolated_store):
+    state = PipelineState(
+        task_ref="multica:verify-hash-mismatch",
+        phase="verify",
+        status="todo",
+        evidence=[
+            EvidenceItem(kind="test", summary="pytest passed", passed=True),
+            EvidenceItem(
+                kind="validator",
+                summary="implement validator",
+                passed=True,
+                content_hash="a" * 64,
+                metadata={"phase": "implement", "source": "handoff"},
+            ),
+            EvidenceItem(
+                kind="validator",
+                summary="verify validator",
+                passed=True,
+                content_hash="b" * 64,
+                metadata={"phase": "verify", "source": "handoff"},
+            ),
+        ],
+    )
+    store.save_state(state, event="verify_ready")
+
+    async def fetch_detail(_task_id: str):
+        return {
+            "latest_summary": "TESTS=pytest passed\nVALIDATORS=validate_structure.py passed",
+            "comments": [],
+        }
+
+    state = await store.sync_pipeline_from_chain(
+        "multica:verify-hash-mismatch",
+        {"verify": {"id": "t_verify", "status": "done"}},
+        fetch_detail,
+    )
+
+    assert state.phase == "verify"
+    assert state.status == "blocked"
+    assert state.history[-1].reason == "GATE_BLOCKED: validator hash mismatch"
+    last = json.loads(isolated_store.read_text(encoding="utf-8").strip().splitlines()[-1])
+    assert last["event"] == "gate_blocked"
+    assert last["meta"]["missing"] == []
+    assert last["meta"]["validator_hash_mismatch"] is True
+
+
+@pytest.mark.asyncio
 async def test_sync_pipeline_advances_with_live_run_metadata_recovery(isolated_store):
     await store.bootstrap_state("multica:sync-live-metadata")
 

--- a/services/zoe-data/tests/test_pipeline_store.py
+++ b/services/zoe-data/tests/test_pipeline_store.py
@@ -358,6 +358,29 @@ async def test_sync_pipeline_advances_on_complete_handoff(isolated_store):
 
 
 @pytest.mark.asyncio
+async def test_sync_pipeline_blocks_code_implement_without_pr(isolated_store):
+    await store.bootstrap_state("multica:no-pr-code", issue={"metadata": {"evidence_profile": "code"}})
+
+    async def fetch_detail(_task_id: str):
+        return {
+            "latest_summary": "TOOLS_USED=graphify\nTESTS=validate_structure.py passed\nSUMMARY=investigated only",
+            "comments": [],
+        }
+
+    phases = {"implement": {"id": "t_impl", "status": "done"}}
+    state = await store.sync_pipeline_from_chain("multica:no-pr-code", phases, fetch_detail)
+
+    assert state.phase == "implement"
+    assert state.status == "blocked"
+    assert state.history[-1].reason == "GATE_BLOCKED: missing required evidence pr"
+    assert store.pipeline_summary(state)["missing_evidence"] == ["pr"]
+    last = json.loads(isolated_store.read_text(encoding="utf-8").strip().splitlines()[-1])
+    assert last["event"] == "gate_blocked"
+    assert last["meta"]["row_phase"] == "implement"
+    assert last["meta"]["missing"] == ["pr"]
+
+
+@pytest.mark.asyncio
 async def test_sync_pipeline_advances_with_live_run_metadata_recovery(isolated_store):
     await store.bootstrap_state("multica:sync-live-metadata")
 

--- a/services/zoe-data/tests/test_pipeline_store.py
+++ b/services/zoe-data/tests/test_pipeline_store.py
@@ -337,6 +337,61 @@ def test_skip_blocked_implementation_requires_tool_evidence(isolated_store):
 
 
 @pytest.mark.asyncio
+async def test_skip_blocked_code_implementation_allows_validator_only_verify(isolated_store):
+    from pipeline_evidence import TransitionRecord
+
+    state = PipelineState(
+        task_ref="multica:code-gate-no-code-skip",
+        phase="implement",
+        status="blocked",
+        evidence_profile="code",
+        history=[
+            TransitionRecord(
+                from_phase="implement",
+                to_phase="implement",
+                outcome="block",
+                reason="GATE_BLOCKED: missing required evidence pr",
+            )
+        ],
+        evidence=[
+            EvidenceItem(
+                kind="tool",
+                summary="scout proved acceptance is already satisfied by merged work",
+                passed=True,
+            )
+        ],
+    )
+    store.save_state(state, event="gate_blocked", extra={"missing": ["pr"]})
+
+    skipped = store.skip_blocked_implementation(
+        "multica:code-gate-no-code-skip",
+        reason="operator confirmed no code change is needed",
+    )
+
+    assert skipped.phase == "verify"
+    assert skipped.status == "todo"
+    assert skipped.evidence_profile == "audit"
+
+    async def fetch_detail(_task_id: str):
+        return {
+            "latest_summary": "VALIDATORS=validate_structure.py passed",
+            "comments": [],
+        }
+
+    verified = await store.sync_pipeline_from_chain(
+        "multica:code-gate-no-code-skip",
+        {"verify": {"id": "t_verify", "status": "done"}},
+        fetch_detail,
+    )
+
+    assert verified.phase == "review"
+    assert verified.status == "todo"
+    assert verified.evidence_profile == "audit"
+    assert verified.history[-1].outcome == "complete"
+    assert verified.history[-1].reason != "GATE_BLOCKED: missing required evidence test"
+
+
+@pytest.mark.asyncio
 async def test_sync_pipeline_advances_on_complete_handoff(isolated_store):
     await store.bootstrap_state("multica:sync")
 


### PR DESCRIPTION
## Summary
- require PR evidence before code-profile implement phases can advance to verify
- convert missing phase evidence into an explicit `GATE_BLOCKED` pipeline block
- keep operator-confirmed no-code implementation skips on the audit evidence profile

## Why
A real Multica ticket (ZOE-5423) exposed that an implement worker could mark itself done after investigation only. The pipeline then created a verify task, which correctly blocked because there was no PR. This PR moves that stop condition into Zoe's deterministic evidence gate so Hermes cannot spend another phase verifying nothing.

## Validation
- `PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_pipeline_store.py services/zoe-data/tests/test_kanban_adapter.py services/zoe-data/tests/test_pipeline_handoff.py` on 192.168.1.218: 227 passed
- `python3 tools/audit/validate_structure.py`
- `python3 tools/audit/validate_critical_files.py`
