### PR TITLE
Add Zoe tool and memory inventories

### DIFF
--- a/docs/architecture/zoe-memory-read-write-inventory.md
+++ b/docs/architecture/zoe-memory-read-write-inventory.md
@@ -1,0 +1,95 @@
+# Zoe Memory Read Write Inventory
+
+## Purpose
+
+This inventory maps durable and prompt-time memory paths before Zoe adds Hindsight, Graphiti-style relational memory, or self-evolution memory admission. The goal is zero unscoped durable memory writes and no trusted relational or self-evolution memory without evidence.
+
+Source basis:
+
+- Inspected branch/head: `origin/main` at `a22f3de580de5c4842f22c2edbbbd4a3a5561615`.
+- Memory facade: `services/zoe-data/memory_service.py`.
+- Agent memory call sites: `services/zoe-data/zoe_agent.py`.
+- API memory router: `services/zoe-data/routers/memories.py`.
+- Derived memory paths: notes, journal, people, user profile, digest, extractor, portrait, MCP server.
+- Hindsight candidate path: `services/zoe-data/hindsight_retain_candidates.py`.
+
+## Memory Facade Contract
+
+`MemoryService` is the active read/write facade for MemPalace-backed Zoe memory.
+
+| Operation | Direction | Purpose | Required Evidence For Harness |
+| --- | --- | --- | --- |
+| `ingest` | Write | Add a memory row/fact. | user_id, source, memory_type, source id/turn, candidate/review status. |
+| `load_for_prompt` | Read | Load approved/user-scoped facts for prompt context. | user_id, limit, returned refs, latency. |
+| `search` | Read | Semantic search over user-scoped memory. | user_id, query, limit, returned refs, latency. |
+| `review` | Mutate | Approve/reject/edit pending memory. | memory_id, actor, decision, before/after for edits. |
+| `forget_last` | Mutate | Soft-delete most recent memory for correction. | user_id, actor/intent source, memory ref. |
+| `delete_user` | Delete | Admin right-to-be-forgotten path. | admin actor, target user_id, count removed. |
+| `archive_by_entity` | Mutate | Archive memories for deleted people/entities. | user_id, entity id, count/result. |
+| `export_user` | Read | Export user memory. | admin/user actor and target scope. |
+
+Harness rule: new memory backends should not bypass this facade unless the PR is explicitly changing the facade itself or adding a measured sidecar with no trusted direct writes.
+
+## Durable Write Paths
+
+| Path | File | Source | Current Write Shape | Gap Before Trusted Evolution Memory |
+| --- | --- | --- | --- | --- |
+| Agent direct add | `zoe_agent.py` `_mempalace_add` | Chat/tool call. | Calls `MemoryService.ingest`. | Needs Zoe memory event/scoped evidence packet before relational/self-evolution writes. |
+| Agent background extraction | `zoe_agent.py` background save -> `memory_extractor.py` | Chat turns. | Extracts candidates and calls `MemoryService.ingest`. | Candidate/admission mode needed for high-risk facts and corrections. |
+| Memory API proposal | `routers/memories.py` `/api/memories/proposals` | UI/API. | Calls `MemoryService.ingest` pending/review path. | Align review fields with Zoe memory contract. |
+| Memory API review | `routers/memories.py` review endpoint. | UI/API. | Calls `MemoryService.review`. | Ensure actor and before/after evidence are retained. |
+| Notes derived memory | `routers/notes.py` | Note create/update. | Calls `MemoryService.ingest`. | Add source note id and explicit evidence ref. |
+| Journal derived memory | `routers/journal.py` | Journal entries. | Calls `MemoryService.ingest`. | Add source journal id and explicit evidence ref. |
+| People derived memory | `routers/people.py` | Person records. | Calls `MemoryService.ingest`; archives by entity on delete. | Relationship facts should become Graphiti-style candidates with evidence. |
+| User profile memory | `routers/user_profile.py` | Profile update path. | Calls `MemoryService.ingest`. | Add structured source/evidence metadata. |
+| Person extractor | `person_extractor.py` | Extracted people/entities. | Calls `MemoryService.ingest`. | Needs candidate status for uncertain extraction. |
+| Memory digest | `memory_digest.py` | Chat/music/behavior consolidation. | Calls `search`, `review`, and `ingest`. | Needs source inventory per digest job and contradiction/supersession traces. |
+| MCP memory add | `mcp_server.py` `memory_add`. | MCP client/tool. | Calls `MemoryService.ingest`. | High-risk bridge; require explicit user/scope/evidence before self-evolution writes. |
+| MCP memory review/forget | `mcp_server.py` `memory_review`, `memory_forget`. | MCP client/tool. | Calls `MemoryService.review`. | Require actor, decision, before/after, audit link. |
+| Hindsight retain candidate | `hindsight_retain_candidates.py` | Reflective sidecar candidate. | Builds pending `MemoryService` payload. | Needs Multica/admission approval before trusted memory. |
+
+## Prompt And Recall Read Paths
+
+| Path | File | Purpose | Current Gate | Gap |
+| --- | --- | --- | --- | --- |
+| Agent prompt facts | `zoe_agent.py` `_load_user_facts_for_prompt`. | Prompt-time approved facts. | `MemoryService.load_for_prompt`. | Needs compact cited packet from `zoe_memory_router.py`. |
+| Agent semantic recall | `zoe_agent.py` `_mempalace_search`. | On-demand memory search. | `MemoryService.search` with timeout. | Route through memory router feature flag. |
+| Memory API search/list/export | `routers/memories.py`. | User/admin memory UI. | Auth dependency and `MemoryService`. | Add structured trace for query/result/helpfulness. |
+| Proactive morning check-in | `proactive/triggers/morning_checkin.py`. | Reads recent memory for proactive context. | `load_for_prompt`. | Must remain scoped and cancellation-aware. |
+| User portrait | `user_portrait.py`, `routers/portrait.py`. | Synthesizes profile context from memories. | `load_for_prompt`. | Needs trace and stale/superseded handling. |
+| Startup health probe | `main.py`. | Checks MemoryService readiness. | `load_for_prompt` and `search` against `family-admin`. | Keep read-only; do not write synthetic rows. |
+| Memory metrics | `memory_metrics.py`. | Counts/latency gauges. | `MemoryService` read helpers. | Extend to recall packet and admission metrics. |
+| OpenClaw context | `openclaw_ws.py`. | Supplies user facts to OpenClaw session. | User-scoped gateway session. | Use compact cited packet instead of broad raw memory dump. |
+| MCP memory search/list | `mcp_server.py`. | MCP memory read. | `MemoryService.search` and list/export helpers. | Trace actor/scope and result refs. |
+
+## Hindsight And Graphiti Readiness
+
+Hindsight is currently safe as an optional sidecar because:
+
+- `hindsight_memory.py` defaults to disabled, offline-only, localhost, and no auto-retain;
+- `tools/audit/validate_offline_memory.py` is enforced in CI;
+- `hindsight_retain_candidates.py` writes pending candidates instead of trusted memories.
+
+Graphiti-style relational memory is not yet implemented. Relationship facts from people, tools, failures, fixes, approvals, recurring tasks, and self-evolution outcomes should first become evidence-backed memory events or pending candidates, then be admitted to a graph backend only after the Graphiti bake-off proves latency, footprint, supersession, and source isolation.
+
+## Required Admission Metadata
+
+Every new durable memory write introduced by the Zoe harness should include or be derivable from:
+
+- `user_id`;
+- scope: personal, shared, ambient, system, or project;
+- source: chat, tool, test, trace, proposal, code, or external;
+- event type: fact, preference, experience, failure, fix, capability, recurring_task, or approval;
+- evidence refs: source turn, tool run, test, PR, proposal, or raw object id;
+- confidence and review status;
+- supersedes/disputed/archived state when correcting old memory.
+
+## Cleanup Rules
+
+Do not remove or merge memory paths until:
+
+- the path is mapped in this inventory;
+- focused tests cover user/scope isolation and write status;
+- high-risk writes go through pending/admission flow;
+- existing chat, voice, memories UI, MCP, and digest behavior still works;
+- MemPalace remains the measured offline baseline unless a replacement wins Zoe benchmarks.

--- a/docs/architecture/zoe-tool-capability-inventory.md
+++ b/docs/architecture/zoe-tool-capability-inventory.md
@@ -1,0 +1,85 @@
+# Zoe Tool And Capability Inventory
+
+## Purpose
+
+This inventory maps Zoe's active tool and capability surfaces before the self-evolution harness starts modifying, adding, or retiring abilities. It is a cleanup gate: a tool should not be removed, replaced, or made autonomous unless its owner, risk, evidence needs, and runtime surface are understood.
+
+Source basis:
+
+- Inspected branch/head: `origin/main` at `a22f3de580de5c4842f22c2edbbbd4a3a5561615`.
+- Agent catalog: `services/zoe-data/zoe_agent.py`.
+- MCP bridge: `services/zoe-data/mcp_server.py`.
+- Multica/pipeline execution: `services/zoe-data/multica_*.py`, `services/zoe-data/pipeline_*.py`, `services/zoe-data/executors/kanban_adapter.py`.
+- Current architecture inventory: `docs/architecture/zoe-harness-current-inventory.md`.
+
+## Agent Tool Catalog
+
+`services/zoe-data/zoe_agent.py` currently exposes these callable tools to the Gemma-backed Zoe agent loop.
+
+| Tool | Capability | Primary Owner | Risk | Harness Evidence Needed |
+| --- | --- | --- | --- | --- |
+| `mempalace_search` | Search user-scoped MemPalace facts. | `MemoryService` / MemPalace. | Medium: prompt influence and privacy scope. | user_id, query, result refs, latency, scope. |
+| `mempalace_add` | Store a user memory fact. | `MemoryService` / MemPalace. | High: durable memory write. | user_id, source turn, evidence/candidate status, review/admission path. |
+| `memory_update` | Update/review memory-like state. | Zoe agent + `MemoryService` paths. | High: durable memory mutation. | memory id, actor, decision, before/after, audit entry. |
+| `ha_control` | Home Assistant control. | HA bridge / data router. | High: physical-world action. | user_id, entity, action, risk approval where needed, HA result. |
+| `calendar_today` | Read today's calendar. | Calendar router/service. | Low/medium: personal data read. | user_id, source, read scope. |
+| `calendar_list_events` | Read calendar event range. | Calendar router/service. | Low/medium: personal data read. | user_id, date range, read scope. |
+| `calendar_create_event` | Create calendar event. | Calendar router/service. | Medium/high: external state write. | user_id, event payload, confirmation/approval, result id. |
+| `reminder_create` | Create reminder. | Reminders router/service. | Medium: durable task write. | user_id, reminder payload, due time, result id. |
+| `reminder_list` | Read reminders. | Reminders router/service. | Low/medium: personal data read. | user_id, query scope. |
+| `list_add_item` | Add list item. | Lists router/service. | Medium: durable list write. | user_id, list id/name, item, result. |
+| `list_get_items` | Read list items. | Lists router/service. | Low/medium: personal data read. | user_id, list id/name. |
+| `weather_current` | Current weather lookup. | Weather/router tool. | Low. | location source, result. |
+| `weather_forecast` | Forecast lookup. | Weather/router tool. | Low. | location source, result. |
+| `open_touch_page` | Open/navigate local touch UI page. | UI/router surface. | Medium: user-visible UI action. | target page, actor, result. |
+| `bash` | Shell execution. | Zoe agent execution lane. | Critical: arbitrary command execution. | approval/risk gate, command, working dir, stdout/stderr summary, rollback if mutating. |
+| `web_search` | Fast DuckDuckGo/CloakBrowser search. | Zoe agent research helpers. | Medium: external data and network. | query, sources, timestamp. |
+| `deep_web_research` | Multi-source browser research. | Zoe agent + CloakBrowser. | Medium/high: network/browser state. | query, visited sources, screenshots/evidence when available. |
+| `escalate_to_openclaw` | Escalate task to OpenClaw. | OpenClaw gateway/router. | High: external execution surface. | reason, task scope, user approval where needed, result. |
+| `escalate_to_hermes` | Escalate planning/code/reasoning task to Hermes. | Hermes operator skills. | High: implementation/execution surface. | proposal/task id, worktree, tests, PR/evidence for code. |
+| `show_map` | Render map panel. | AG-UI/panel tooling. | Low/medium: UI output. | location/source and panel result. |
+| `show_chart` | Render chart panel. | AG-UI/panel tooling. | Low/medium: UI output. | data source and panel result. |
+| `show_action_menu` | Render action menu. | AG-UI/panel tooling. | Medium: can prompt follow-up actions. | actions, actor, chosen result. |
+| `list_openclaw_plugins` | Inspect OpenClaw plugins. | OpenClaw. | Low read, medium if used for execution planning. | plugin list and timestamp. |
+| `list_openclaw_skills` | Inspect OpenClaw skills. | OpenClaw. | Low read, medium if used for execution planning. | skill list and timestamp. |
+| `setup_telegram` | Telegram integration setup helper. | Integration/setup surface. | High: external account/config. | explicit approval, config status, no secret leakage. |
+| `proactive_schedule` | Schedule proactive behavior. | Proactive router/scheduler. | Medium/high: future autonomous action. | user_id, schedule, scope, cancellation path. |
+| `report_issue` | Create/report an issue or operational finding. | Zoe issue/reporting lane. | Medium: task creation/noise. | source turn, issue scope, resulting task/id. |
+
+## Voice Tool Allowlist
+
+Voice mode uses a smaller set of tools for latency and safety. Current voice allowlist includes memory search/add, HA, calendar, reminders, lists, weather, page opening, web search, Hermes/OpenClaw escalation, map/chart display, OpenClaw skill listing, and issue reporting. Voice always keeps Hermes escalation available for complex tasks.
+
+Harness implication: voice tools need stricter latency and interruption behavior than chat tools. Any self-evolution change that expands the voice allowlist must include voice-specific tests or a manual voice smoke check.
+
+## MCP Tool Surface
+
+`services/zoe-data/mcp_server.py` exposes broader tool access for clients and execution surfaces.
+
+| MCP Area | Representative Tools / Paths | Risk | Harness Evidence Needed |
+| --- | --- | --- | --- |
+| Memory | `memory_add`, `memory_search`, `memory_list`, `memory_review`, `memory_forget`. | High for writes/review/delete. | user_id, actor, memory id/ref, decision, source evidence. |
+| People/notes/journal bridges | Calls `_store_person_memory`, `_store_note_memory`, `_store_journal_memory`. | High for derived memory writes. | source object id, user_id, MemoryService ref. |
+| Graphify | Graphify search/query helpers. | Low/medium read; high if used to justify cleanup. | graph commit/report date, query, cited nodes. |
+| Operational tools | System, UI, browser, integration, and maintenance tools. | Varies; many are privileged. | command/action log, approval where mutating. |
+
+## Execution And Governance Lanes
+
+| Lane | Files | Purpose | Required Before Autonomy |
+| --- | --- | --- | --- |
+| Multica proposal/control | `multica_client.py`, `multica_operator.py`, `multica_admission.py`. | Governed task/proposal control plane. | Structured proposal, risk, expected benefit, approval state. |
+| Pipeline evidence | `pipeline_evidence.py`, `pipeline_store.py`, `pipeline_validators.py`. | Phase transition gates and evidence profiles. | Evidence requirements for memory admission and self-evolution proposals. |
+| Greptile/Grep loop | `greptile_client.py`, `greploop_guard.py`. | Review and bounded repair loop. | Review state, confidence/gates, no unresolved actionable comments. |
+| Worktree bootstrap | `worktree_bootstrap.py`. | Isolated code-producing work. | Branch/worktree id, PR evidence, rollback path. |
+| Hermes | `executors/kanban_adapter.py` plus operator skills. | Preferred planning/code/reasoning lane. | Task packet, scoped context, tests, PR/Greptile evidence for code. |
+| OpenClaw | `routers/openclaw.py`, `openclaw_ws.py`. | Manual/fallback browser/execution lane. | Explicit routing reason and result evidence. |
+
+## Retirement Rules
+
+A tool can be retired only when:
+
+- it has a named replacement or measured non-use;
+- active call sites are removed or redirected;
+- user-facing chat/voice affordances still work;
+- memory, external state, or physical-world side effects are covered by tests or manual verification;
+- the retirement is reviewed in a small PR with Greptile and local validation.

--- a/docs/architecture/zoe-tool-capability-inventory.md
+++ b/docs/architecture/zoe-tool-capability-inventory.md
@@ -16,41 +16,74 @@ Source basis:
 
 `services/zoe-data/zoe_agent.py` currently exposes these callable tools to the Gemma-backed Zoe agent loop.
 
-| Tool | Capability | Primary Owner | Risk | Harness Evidence Needed |
-| --- | --- | --- | --- | --- |
-| `mempalace_search` | Search user-scoped MemPalace facts. | `MemoryService` / MemPalace. | Medium: prompt influence and privacy scope. | user_id, query, result refs, latency, scope. |
-| `mempalace_add` | Store a user memory fact. | `MemoryService` / MemPalace. | High: durable memory write. | user_id, source turn, evidence/candidate status, review/admission path. |
-| `memory_update` | Update/review memory-like state. | Zoe agent + `MemoryService` paths. | High: durable memory mutation. | memory id, actor, decision, before/after, audit entry. |
-| `ha_control` | Home Assistant control. | HA bridge / data router. | High: physical-world action. | user_id, entity, action, risk approval where needed, HA result. |
-| `calendar_today` | Read today's calendar. | Calendar router/service. | Low/medium: personal data read. | user_id, source, read scope. |
-| `calendar_list_events` | Read calendar event range. | Calendar router/service. | Low/medium: personal data read. | user_id, date range, read scope. |
-| `calendar_create_event` | Create calendar event. | Calendar router/service. | Medium/high: external state write. | user_id, event payload, confirmation/approval, result id. |
-| `reminder_create` | Create reminder. | Reminders router/service. | Medium: durable task write. | user_id, reminder payload, due time, result id. |
-| `reminder_list` | Read reminders. | Reminders router/service. | Low/medium: personal data read. | user_id, query scope. |
-| `list_add_item` | Add list item. | Lists router/service. | Medium: durable list write. | user_id, list id/name, item, result. |
-| `list_get_items` | Read list items. | Lists router/service. | Low/medium: personal data read. | user_id, list id/name. |
-| `weather_current` | Current weather lookup. | Weather/router tool. | Low. | location source, result. |
-| `weather_forecast` | Forecast lookup. | Weather/router tool. | Low. | location source, result. |
-| `open_touch_page` | Open/navigate local touch UI page. | UI/router surface. | Medium: user-visible UI action. | target page, actor, result. |
-| `bash` | Shell execution. | Zoe agent execution lane. | Critical: arbitrary command execution. | approval/risk gate, command, working dir, stdout/stderr summary, rollback if mutating. |
-| `web_search` | Fast DuckDuckGo/CloakBrowser search. | Zoe agent research helpers. | Medium: external data and network. | query, sources, timestamp. |
-| `deep_web_research` | Multi-source browser research. | Zoe agent + CloakBrowser. | Medium/high: network/browser state. | query, visited sources, screenshots/evidence when available. |
-| `escalate_to_openclaw` | Escalate task to OpenClaw. | OpenClaw gateway/router. | High: external execution surface. | reason, task scope, user approval where needed, result. |
-| `escalate_to_hermes` | Escalate planning/code/reasoning task to Hermes. | Hermes operator skills. | High: implementation/execution surface. | proposal/task id, worktree, tests, PR/evidence for code. |
-| `show_map` | Render map panel. | AG-UI/panel tooling. | Low/medium: UI output. | location/source and panel result. |
-| `show_chart` | Render chart panel. | AG-UI/panel tooling. | Low/medium: UI output. | data source and panel result. |
-| `show_action_menu` | Render action menu. | AG-UI/panel tooling. | Medium: can prompt follow-up actions. | actions, actor, chosen result. |
-| `list_openclaw_plugins` | Inspect OpenClaw plugins. | OpenClaw. | Low read, medium if used for execution planning. | plugin list and timestamp. |
-| `list_openclaw_skills` | Inspect OpenClaw skills. | OpenClaw. | Low read, medium if used for execution planning. | skill list and timestamp. |
-| `setup_telegram` | Telegram integration setup helper. | Integration/setup surface. | High: external account/config. | explicit approval, config status, no secret leakage. |
-| `proactive_schedule` | Schedule proactive behavior. | Proactive router/scheduler. | Medium/high: future autonomous action. | user_id, schedule, scope, cancellation path. |
-| `report_issue` | Create/report an issue or operational finding. | Zoe issue/reporting lane. | Medium: task creation/noise. | source turn, issue scope, resulting task/id. |
+| Tool | Status | Confidence | Capability | Primary Owner | Risk | Harness Evidence Needed |
+| --- | --- | --- | --- | --- | --- | --- |
+| `mempalace_search` | Active | High | Search user-scoped MemPalace facts. | `MemoryService` / MemPalace. | Medium: prompt influence and privacy scope. | user_id, query, result refs, latency, scope. |
+| `mempalace_add` | Active | High | Store a user memory fact. | `MemoryService` / MemPalace. | High: durable memory write. | user_id, source turn, evidence/candidate status, review/admission path. |
+| `memory_update` | Active | High | Update/review memory-like state. | Zoe agent + `MemoryService` paths. | High: durable memory mutation. | memory id, actor, decision, before/after, audit entry. |
+| `ha_control` | Active | High | Home Assistant control. | HA bridge / data router. | High: physical-world action. | user_id, entity, action, risk approval where needed, HA result. |
+| `calendar_today` | Active | High | Read today's calendar. | Calendar router/service. | Low/medium: personal data read. | user_id, source, read scope. |
+| `calendar_list_events` | Active | High | Read calendar event range. | Calendar router/service. | Low/medium: personal data read. | user_id, date range, read scope. |
+| `calendar_create_event` | Active | High | Create calendar event. | Calendar router/service. | Medium/high: external state write. | user_id, event payload, confirmation/approval, result id. |
+| `reminder_create` | Active | High | Create reminder. | Reminders router/service. | Medium: durable task write. | user_id, reminder payload, due time, result id. |
+| `reminder_list` | Active | High | Read reminders. | Reminders router/service. | Low/medium: personal data read. | user_id, query scope. |
+| `list_add_item` | Active | High | Add list item. | Lists router/service. | Medium: durable list write. | user_id, list id/name, item, result. |
+| `list_get_items` | Active | High | Read list items. | Lists router/service. | Low/medium: personal data read. | user_id, list id/name. |
+| `weather_current` | Active | High | Current weather lookup. | Weather/router tool. | Low. | location source, result. |
+| `weather_forecast` | Active | High | Forecast lookup. | Weather/router tool. | Low. | location source, result. |
+| `open_touch_page` | Active | High | Open/navigate local touch UI page. | UI/router surface. | Medium: user-visible UI action. | target page, actor, result. |
+| `bash` | Active | High | Shell execution. | Zoe agent execution lane. | Critical: arbitrary command execution. | approval/risk gate, command, working dir, stdout/stderr summary, rollback if mutating. |
+| `web_search` | Active | High | Fast DuckDuckGo/CloakBrowser search. | Zoe agent research helpers. | Medium: external data and network. | query, sources, timestamp. |
+| `deep_web_research` | Active | High | Multi-source browser research. | Zoe agent + CloakBrowser. | Medium/high: network/browser state. | query, visited sources, screenshots/evidence when available. |
+| `escalate_to_openclaw` | Active | High | Escalate task to OpenClaw. | OpenClaw gateway/router. | High: external execution surface. | reason, task scope, user approval where needed, result. |
+| `escalate_to_hermes` | Active | High | Escalate planning/code/reasoning task to Hermes. | Hermes operator skills. | High: implementation/execution surface. | proposal/task id, worktree, tests, PR/evidence for code. |
+| `show_map` | Active | High | Render map panel. | AG-UI/panel tooling. | Low/medium: UI output. | location/source and panel result. |
+| `show_chart` | Active | High | Render chart panel. | AG-UI/panel tooling. | Low/medium: UI output. | data source and panel result. |
+| `show_action_menu` | Active | High | Render action menu. | AG-UI/panel tooling. | Medium: can prompt follow-up actions. | actions, actor, chosen result. |
+| `list_openclaw_plugins` | Active | High | Inspect OpenClaw plugins. | OpenClaw. | Low read, medium if used for execution planning. | plugin list and timestamp. |
+| `list_openclaw_skills` | Active | High | Inspect OpenClaw skills. | OpenClaw. | Low read, medium if used for execution planning. | skill list and timestamp. |
+| `setup_telegram` | Active | High | Telegram integration setup helper. | Integration/setup surface. | High: external account/config. | explicit approval, config status, no secret leakage. |
+| `proactive_schedule` | Active | High | Schedule proactive behavior. | Proactive router/scheduler. | Medium/high: future autonomous action. | user_id, schedule, scope, cancellation path. |
+| `report_issue` | Active | High | Create/report an issue or operational finding. | Zoe issue/reporting lane. | Medium: task creation/noise. | source turn, issue scope, resulting task/id. |
 
 ## Voice Tool Allowlist
 
-Voice mode uses a smaller set of tools for latency and safety. Current voice allowlist includes memory search/add, HA, calendar, reminders, lists, weather, page opening, web search, Hermes/OpenClaw escalation, map/chart display, OpenClaw skill listing, and issue reporting. Voice always keeps Hermes escalation available for complex tasks.
+Voice mode uses a smaller set of tools for latency and safety. Current source
+inspection shows this allowlist baseline:
 
-Harness implication: voice tools need stricter latency and interruption behavior than chat tools. Any self-evolution change that expands the voice allowlist must include voice-specific tests or a manual voice smoke check.
+| Tool | Voice Allowed | Voice Note |
+| --- | --- | --- |
+| `mempalace_search` | Yes | Memory recall is allowed in voice. |
+| `mempalace_add` | Yes | Memory add is allowed, but durable writes still need admission rules for high-risk facts. |
+| `memory_update` | No | Keep review/update flows out of low-latency voice until explicitly designed. |
+| `ha_control` | Yes | Physical-world action; must preserve HA risk/confirmation behavior. |
+| `calendar_today` | Yes | Read-only calendar helper. |
+| `calendar_list_events` | Yes | Read-only calendar helper. |
+| `calendar_create_event` | Yes | Durable external write; keep confirmation behavior. |
+| `reminder_create` | Yes | Durable reminder write. |
+| `reminder_list` | Yes | Read-only reminder helper. |
+| `list_add_item` | Yes | Durable list write. |
+| `list_get_items` | Yes | Read-only list helper. |
+| `weather_current` | Yes | Low-risk weather read. |
+| `weather_forecast` | Yes | Low-risk weather read. |
+| `open_touch_page` | Yes | User-visible UI action. |
+| `bash` | No | Shell execution must not be voice-fast-path. |
+| `web_search` | Yes | Fast search allowed. |
+| `deep_web_research` | No | Long-running research should escalate/background rather than block voice. |
+| `escalate_to_openclaw` | Yes | Explicit escalation allowed. |
+| `escalate_to_hermes` | Yes | Always available for complex voice tasks. |
+| `show_map` | Yes | Panel display allowed. |
+| `show_chart` | Yes | Panel display allowed. |
+| `show_action_menu` | No | Interactive action menus need separate voice design. |
+| `list_openclaw_plugins` | No | Plugin inventory is not in the voice allowlist. |
+| `list_openclaw_skills` | Yes | Skill listing is allowed. |
+| `setup_telegram` | No | Account setup should not be voice-fast-path. |
+| `proactive_schedule` | No | Future autonomous scheduling needs explicit approval flow. |
+| `report_issue` | Yes | Issue reporting is allowed. |
+
+Harness implication: any self-evolution change that expands the voice allowlist
+must update this table and include voice-specific tests or a manual voice smoke
+check.
 
 ## MCP Tool Surface
 
@@ -73,6 +106,14 @@ Harness implication: voice tools need stricter latency and interruption behavior
 | Worktree bootstrap | `worktree_bootstrap.py`. | Isolated code-producing work. | Branch/worktree id, PR evidence, rollback path. |
 | Hermes | `executors/kanban_adapter.py` plus operator skills. | Preferred planning/code/reasoning lane. | Task packet, scoped context, tests, PR/Greptile evidence for code. |
 | OpenClaw | `routers/openclaw.py`, `openclaw_ws.py`. | Manual/fallback browser/execution lane. | Explicit routing reason and result evidence. |
+
+## Retired And Reference Surfaces
+
+| Surface | Status | Confidence | Owner / Notes | Cleanup Rule |
+| --- | --- | --- | --- | --- |
+| `services/zoe-core/` | Retired reference | High | Historical Zoe core code; project rules say do not extend it for new features. | Do not use as a source for new runtime behavior; archive/delete only through cleanup safety. |
+| `docs/archive/retired-services/` | Retired reference | High | Archived service documentation and code snapshots. | Read for history only; do not wire into production paths. |
+| `services/zoe-ui/dist/js/_archive/` | Archived UI reference | Medium | UI archive files retained in manifest. | Do not revive without a dedicated PR and current UI tests. |
 
 ## Retirement Rules
 

--- a/docs/strategy/zoe-evolution-harness-status.md
+++ b/docs/strategy/zoe-evolution-harness-status.md
@@ -30,8 +30,7 @@ Current merged foundation:
 Important non-complete truth:
 
 - Graphify has been refreshed from `origin/main` at `ad52f61d`; rerun it after subsequent code or architecture changes.
-- Zoe does not yet have a complete active-vs-retired tool inventory.
-- Zoe does not yet have a complete memory read/write inventory.
+- Tool/capability and memory read/write inventories now exist as cleanup gates; keep them updated as runtime paths change.
 - Hindsight has not yet been run as a measured live sidecar bake-off.
 - Graphiti/FalkorDB/Neo4j have not yet been measured for Zoe relational memory.
 - The deterministic memory router is not yet wired into production chat behind a feature flag.
@@ -53,8 +52,8 @@ Important non-complete truth:
 | Hindsight bake-off | Partial | Offline sidecar client, retain-candidate helpers, synthetic fixtures, and tests exist. | Run a measured sidecar bake-off with local models only and record p50/p95 latency, failures, and evidence quality. |
 | Graphiti bake-off | Not started | ADR exists only. | Build Graphiti evaluation fixtures, then test FalkorDB first and Neo4j second if feasible. |
 | Graphify current map | Complete foundation | `graphify-out/GRAPH_REPORT.md` and `graphify-out/graph.json` were regenerated from `origin/main` at `ad52f61d`; `docs/architecture/zoe-harness-current-inventory.md` records the source-backed inventory. | Rerun Graphify after substantial code or architecture changes. |
-| Tool/capability inventory | Not started | Current plan names surfaces but does not provide a full inventory. | Generate a tool/capability map with owner, runtime surface, evidence requirements, and retirement status. |
-| Memory read/write inventory | Not started | Existing code uses `MemoryService`, MemPalace, digest, MCP, chat, notes, people, and journal paths, but no single inventory exists. | Produce an inventory of every durable memory read/write and whether it has user, scope, evidence, and review state. |
+| Tool/capability inventory | Complete foundation | `docs/architecture/zoe-tool-capability-inventory.md` maps agent, MCP, Multica, Hermes, OpenClaw, and governance surfaces. | Keep updated when tool catalogs or execution lanes change. |
+| Memory read/write inventory | Complete foundation | `docs/architecture/zoe-memory-read-write-inventory.md` maps MemoryService operations, durable writes, prompt reads, MCP paths, Hindsight candidates, and metadata gaps. | Keep updated when memory write/read paths change. |
 | Observation/evaluation traces | Not started | Memory metrics exist for MemPalace but not full retrieval helpfulness/contradiction traces. | Add a trace schema for recall, retain candidate, admission, contradiction, and fallback events. |
 | Multica evidence gates | Partial | Implement completion now requires PR evidence for code/default profiles. | Add memory admission gates and explicit self-evolution proposal gates. |
 | Self-evolution loop | Partial | Multica, pipeline evidence, Greploop, Greptile, Hermes, and worktree bootstrap pieces exist. | Implement structured Notice -> Explain -> Search -> Evaluate -> Propose records before any automatic execution. |
@@ -138,9 +137,9 @@ Keep each pull request small enough for Greptile and Zoe verification.
    - Keep Graphify refreshed after substantial code or architecture changes.
    - Reconcile future generated reports against `docs/architecture/zoe-harness-current-inventory.md`.
 3. Tool and memory inventory.
-   - Add `docs/architecture/zoe-tool-capability-inventory.md`.
-   - Add `docs/architecture/zoe-memory-read-write-inventory.md`.
-   - Include active, retired, owner, scope, evidence, and risk columns.
+   - Status: complete foundation.
+   - Keep `docs/architecture/zoe-tool-capability-inventory.md` and `docs/architecture/zoe-memory-read-write-inventory.md` updated as runtime paths change.
+   - Use the inventories as cleanup and self-evolution admission gates.
 4. MemPalace baseline evaluation.
    - Add repeatable local benchmark fixtures.
    - Measure current p50/p95 and memory footprint.


### PR DESCRIPTION
## Summary
- add source-backed Zoe tool/capability inventory for agent tools, MCP surfaces, execution lanes, and retirement gates
- add memory read/write inventory for MemoryService operations, durable writes, prompt reads, MCP paths, and Hindsight candidates
- update the harness status ledger so tool and memory inventory are complete foundation items

## Verification
- python3 tools/audit/validate_structure.py
- python3 tools/audit/validate_critical_files.py
- python3 tools/audit/validate_offline_memory.py
- git diff --check
- checked new docs for accidental non-Zoe system naming
