### PR TITLE
Add MemPalace baseline harness

### DIFF
--- a/docs/architecture/zoe-mempalace-baseline.md
+++ b/docs/architecture/zoe-mempalace-baseline.md
@@ -1,0 +1,67 @@
+# Zoe MemPalace Baseline
+
+## Purpose
+
+MemPalace remains Zoe's offline baseline memory layer until another offline system beats it on Zoe-specific recall, latency, footprint, and governance tests. This document records the repeatable baseline harness and the first measured run from the Zoe host.
+
+## Harness
+
+Files:
+
+- `services/zoe-data/mempalace_baseline.py`
+- `scripts/maintenance/mempalace_baseline.py`
+- `services/zoe-data/tests/test_mempalace_baseline.py`
+
+The runner uses `MemoryService`, writes four synthetic benchmark memories for the synthetic user `zoe-mempalace-baseline`, runs scoped recall queries, scores expected terms, reports latency, and deletes the synthetic user rows by default.
+
+Command:
+
+```bash
+PYTHONPATH=services/zoe-data python3 scripts/maintenance/mempalace_baseline.py --timeout 3.0
+```
+
+Use `--keep` only when intentionally inspecting benchmark rows.
+
+## Baseline Run
+
+Date: 2026-06-09
+
+Environment:
+
+- Host: Zoe Jetson service host.
+- Memory path: `MemoryService` -> MemPalace.
+- Models: offline/local memory stack; no cloud model provider required.
+- Cleanup: default cleanup removed 4 synthetic rows.
+
+Results:
+
+| Metric | Value |
+| --- | --- |
+| Cases | 4 |
+| Average score | 1.0 |
+| Minimum score | 1.0 |
+| p50 latency | 112.77 ms |
+| p95 latency | 200.90 ms |
+| Cleanup removed | 4 rows |
+
+Case results:
+
+| Case | Hit Count | Score | Latency |
+| --- | --- | --- | --- |
+| `weather_failure_fix` | 1 | 1.0 | 51.29 ms |
+| `memory_preference` | 2 | 1.0 | 73.71 ms |
+| `governance_approval` | 3 | 1.0 | 209.56 ms |
+| `tool_capability` | 4 | 1.0 | 151.83 ms |
+
+## Acceptance Use
+
+This baseline does not prove MemPalace is perfect. It gives Zoe a repeatable local measurement before Hindsight and Graphiti comparisons. Future memory backends should be compared against the same cases plus expanded relational/supersession cases.
+
+A replacement should not displace MemPalace unless it wins on the Zoe benchmark set while preserving:
+
+- offline operation;
+- user/scope isolation;
+- compact cited recall packets;
+- correction/supersession behavior;
+- acceptable Jetson CPU/RAM use;
+- normal chat latency regression under 10%.

--- a/docs/strategy/zoe-evolution-harness-status.md
+++ b/docs/strategy/zoe-evolution-harness-status.md
@@ -31,7 +31,7 @@ Important non-complete truth:
 
 - Graphify has been refreshed from `origin/main` at `ad52f61d`; rerun it after subsequent code or architecture changes.
 - Tool/capability and memory read/write inventories now exist as cleanup gates; keep them updated as runtime paths change.
-- Hindsight has not yet been run as a measured live sidecar bake-off.
+- MemPalace now has a repeatable local baseline harness and first measured Zoe-host run; Hindsight has not yet been run as a measured live sidecar bake-off.
 - Graphiti/FalkorDB/Neo4j have not yet been measured for Zoe relational memory.
 - The deterministic memory router is not yet wired into production chat behind a feature flag.
 - Retain-candidate admission is not yet fully governed through Multica approval.
@@ -48,7 +48,7 @@ Important non-complete truth:
 | Memory contract | Complete foundation | `services/zoe-data/zoe_memory_contract.py` and `services/zoe-data/tests/test_zoe_memory_contract.py`. | Extend only when a measured backend requires a new field or relationship. |
 | Memory layer map | Complete foundation | `services/zoe-data/zoe_memory_layers.py` and `services/zoe-data/tests/test_zoe_memory_layers.py`. | Link layer decisions to runtime config and status endpoints. |
 | Memory router | Partial | `services/zoe-data/zoe_memory_router.py` and `services/zoe-data/tests/test_zoe_memory_router.py`. | Wire into chat/agent recall behind a disabled-by-default feature flag with latency guards. |
-| MemPalace baseline | Partial | `MemoryService` remains the live memory facade; MemPalace integration tests exist. | Add a current MemPalace read/write inventory and latency baseline. |
+| MemPalace baseline | Complete foundation | `services/zoe-data/mempalace_baseline.py`, `scripts/maintenance/mempalace_baseline.py`, and `docs/architecture/zoe-mempalace-baseline.md` record a repeatable local benchmark; first run scored 1.0 avg with p95 200.90 ms and cleaned up 4 synthetic rows. | Expand with relational/supersession cases before comparing Graphiti-style backends. |
 | Hindsight bake-off | Partial | Offline sidecar client, retain-candidate helpers, synthetic fixtures, and tests exist. | Run a measured sidecar bake-off with local models only and record p50/p95 latency, failures, and evidence quality. |
 | Graphiti bake-off | Not started | ADR exists only. | Build Graphiti evaluation fixtures, then test FalkorDB first and Neo4j second if feasible. |
 | Graphify current map | Complete foundation | `graphify-out/GRAPH_REPORT.md` and `graphify-out/graph.json` were regenerated from `origin/main` at `ad52f61d`; `docs/architecture/zoe-harness-current-inventory.md` records the source-backed inventory. | Rerun Graphify after substantial code or architecture changes. |
@@ -141,9 +141,9 @@ Keep each pull request small enough for Greptile and Zoe verification.
    - Keep `docs/architecture/zoe-tool-capability-inventory.md` and `docs/architecture/zoe-memory-read-write-inventory.md` updated as runtime paths change.
    - Use the inventories as cleanup and self-evolution admission gates.
 4. MemPalace baseline evaluation.
-   - Add repeatable local benchmark fixtures.
-   - Measure current p50/p95 and memory footprint.
-   - Keep MemPalace as baseline unless another offline option wins.
+   - Status: complete foundation.
+   - Repeatable benchmark and first Zoe-host p50/p95 run are documented in `docs/architecture/zoe-mempalace-baseline.md`.
+   - Expand with memory footprint, relational, and supersession cases before backend replacement decisions.
 5. Hindsight sidecar bake-off.
    - Run local/offline-only Hindsight.
    - Produce measured results and gaps.

--- a/scripts/maintenance/mempalace_baseline.py
+++ b/scripts/maintenance/mempalace_baseline.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Run Zoe's MemPalace baseline against the local MemoryService.
+
+This script uses a synthetic benchmark user and deletes that user's rows by
+default after the run so the baseline does not pollute real user memory.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+ZOE_DATA = ROOT / "services" / "zoe-data"
+sys.path.insert(0, str(ZOE_DATA))
+
+from mempalace_baseline import run_mempalace_baseline  # noqa: E402
+from memory_service import get_memory_service  # noqa: E402
+
+
+async def _main() -> int:
+    parser = argparse.ArgumentParser(description="Run Zoe MemPalace baseline")
+    parser.add_argument("--user-id", default="zoe-mempalace-baseline")
+    parser.add_argument("--keep", action="store_true", help="keep synthetic benchmark rows")
+    parser.add_argument("--timeout", type=float, default=2.0)
+    args = parser.parse_args()
+
+    service = get_memory_service()
+    try:
+        summary = await run_mempalace_baseline(service, user_id=args.user_id, timeout_s=args.timeout)
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    finally:
+        if not args.keep:
+            removed = await service.delete_user(args.user_id, actor="mempalace_baseline")
+            print(json.dumps({"cleanup_removed": removed, "user_id": args.user_id}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(_main()))

--- a/services/zoe-data/mempalace_baseline.py
+++ b/services/zoe-data/mempalace_baseline.py
@@ -1,0 +1,161 @@
+"""Repeatable MemPalace baseline fixtures and scoring helpers.
+
+The baseline is intentionally backend-light: tests can run with a fake service,
+while the maintenance runner can use Zoe's real `MemoryService` on the Jetson.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from statistics import median
+from typing import Any, Iterable, Protocol, Sequence
+
+
+@dataclass(frozen=True)
+class MemPalaceBaselineCase:
+    case_id: str
+    text: str
+    query: str
+    expected_terms: tuple[str, ...]
+    memory_type: str
+    user_id: str = "zoe-mempalace-baseline"
+
+
+class MemPalaceBaselineService(Protocol):
+    async def ingest(self, text: str, **kwargs: Any) -> Any: ...
+
+    async def search(self, query: str, **kwargs: Any) -> Sequence[Any]: ...
+
+
+BASELINE_CASES: tuple[MemPalaceBaselineCase, ...] = (
+    MemPalaceBaselineCase(
+        case_id="weather_failure_fix",
+        text="The mobile weather card failed because duplicate voice queue dispatches emitted two weather responses; the voice queue guard fixed it.",
+        query="What failed last time Zoe used the weather card and what fixed it?",
+        expected_terms=("weather", "duplicate", "voice", "guard"),
+        memory_type="experience",
+    ),
+    MemPalaceBaselineCase(
+        case_id="memory_preference",
+        text="Jason prefers MemPalace to remain Zoe's offline baseline memory until another offline system beats it on Zoe-specific latency and recall tests.",
+        query="What does Jason prefer as Zoe's offline baseline memory?",
+        expected_terms=("mempalace", "offline", "baseline"),
+        memory_type="preference",
+    ),
+    MemPalaceBaselineCase(
+        case_id="governance_approval",
+        text="Zoe self-evolution memory must pass through Multica evidence gates before it can become trusted durable truth.",
+        query="Which governance layer gates Zoe self-evolution memory?",
+        expected_terms=("multica", "evidence", "trusted"),
+        memory_type="approval",
+    ),
+    MemPalaceBaselineCase(
+        case_id="tool_capability",
+        text="Hermes is Zoe's preferred escalation lane for planning, architecture analysis, implementation repair, and Greptile review loops.",
+        query="Which lane should Zoe prefer for planning and Greptile repair loops?",
+        expected_terms=("hermes", "planning", "greptile"),
+        memory_type="capability",
+    ),
+)
+
+
+def recall_text_from_results(results: Sequence[Any]) -> str:
+    parts: list[str] = []
+    for item in results:
+        if isinstance(item, str):
+            parts.append(item)
+            continue
+        text = getattr(item, "text", None)
+        if text:
+            parts.append(str(text))
+            continue
+        if isinstance(item, dict):
+            parts.append(str(item.get("text") or item.get("content") or ""))
+    return "\n".join(part for part in parts if part)
+
+
+def score_recall_text(text: str, expected_terms: Iterable[str]) -> dict[str, Any]:
+    lowered = text.lower()
+    expected = tuple(term.lower() for term in expected_terms)
+    matched = tuple(term for term in expected if term in lowered)
+    return {
+        "matched": list(matched),
+        "missing": [term for term in expected if term not in matched],
+        "score": 1.0 if not expected else len(matched) / len(expected),
+    }
+
+
+def percentile(values: Sequence[float], percentile_value: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return ordered[0]
+    rank = (len(ordered) - 1) * percentile_value
+    lower = int(rank)
+    upper = min(lower + 1, len(ordered) - 1)
+    weight = rank - lower
+    return ordered[lower] * (1 - weight) + ordered[upper] * weight
+
+
+async def run_mempalace_baseline(
+    service: MemPalaceBaselineService,
+    *,
+    cases: Sequence[MemPalaceBaselineCase] = BASELINE_CASES,
+    user_id: str = "zoe-mempalace-baseline",
+    search_limit: int = 5,
+    timeout_s: float = 2.0,
+) -> dict[str, Any]:
+    results: list[dict[str, Any]] = []
+    for case in cases:
+        await service.ingest(
+            case.text,
+            user_id=user_id,
+            source="mempalace_baseline",
+            user_turn_id=f"baseline:{case.case_id}",
+            memory_type=case.memory_type,
+            confidence=0.95,
+            status="approved",
+            tags=["mempalace_baseline", case.case_id],
+        )
+        started = time.perf_counter()
+        hits = await service.search(
+            case.query,
+            user_id=user_id,
+            limit=search_limit,
+            timeout_s=timeout_s,
+        )
+        latency_ms = (time.perf_counter() - started) * 1000
+        recalled = recall_text_from_results(hits)
+        score = score_recall_text(recalled, case.expected_terms)
+        results.append(
+            {
+                "case_id": case.case_id,
+                "query": case.query,
+                "latency_ms": latency_ms,
+                "hit_count": len(hits),
+                **score,
+            }
+        )
+
+    latencies = [item["latency_ms"] for item in results]
+    scores = [item["score"] for item in results]
+    return {
+        "case_count": len(results),
+        "avg_score": sum(scores) / len(scores) if scores else 0.0,
+        "min_score": min(scores) if scores else 0.0,
+        "p50_latency_ms": median(latencies) if latencies else 0.0,
+        "p95_latency_ms": percentile(latencies, 0.95),
+        "results": results,
+    }
+
+
+__all__ = [
+    "BASELINE_CASES",
+    "MemPalaceBaselineCase",
+    "recall_text_from_results",
+    "run_mempalace_baseline",
+    "score_recall_text",
+    "percentile",
+]

--- a/services/zoe-data/tests/test_mempalace_baseline.py
+++ b/services/zoe-data/tests/test_mempalace_baseline.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+from mempalace_baseline import (
+    BASELINE_CASES,
+    percentile,
+    recall_text_from_results,
+    run_mempalace_baseline,
+    score_recall_text,
+)
+
+
+@dataclass
+class FakeRef:
+    text: str
+
+
+class FakeMemoryService:
+    def __init__(self):
+        self.rows = []
+
+    async def ingest(self, text: str, **kwargs):
+        self.rows.append({"text": text, "kwargs": kwargs})
+        return FakeRef(text=text)
+
+    async def search(self, query: str, **kwargs):
+        query_terms = {part.strip("?.,'").lower() for part in query.split()}
+        ranked = []
+        for row in self.rows:
+            text = row["text"]
+            overlap = sum(1 for term in query_terms if term and term in text.lower())
+            ranked.append((overlap, text))
+        ranked.sort(reverse=True)
+        return [FakeRef(text=text) for overlap, text in ranked[: kwargs.get("limit", 5)] if overlap > 0]
+
+
+def test_baseline_cases_cover_memory_plan_topics():
+    ids = {case.case_id for case in BASELINE_CASES}
+
+    assert ids == {
+        "weather_failure_fix",
+        "memory_preference",
+        "governance_approval",
+        "tool_capability",
+    }
+    assert all(case.expected_terms for case in BASELINE_CASES)
+
+
+def test_score_recall_text_reports_missing_terms():
+    score = score_recall_text("weather card duplicate response", ("weather", "duplicate", "voice"))
+
+    assert score["score"] == 2 / 3
+    assert score["missing"] == ["voice"]
+
+
+def test_recall_text_from_results_supports_refs_dicts_and_strings():
+    text = recall_text_from_results([FakeRef("alpha"), {"content": "beta"}, "gamma"])
+
+    assert text.splitlines() == ["alpha", "beta", "gamma"]
+
+
+def test_percentile_interpolates():
+    assert percentile([10, 20, 30], 0.5) == 20
+    assert percentile([10, 20, 30], 0.95) == pytest.approx(29)
+
+
+@pytest.mark.asyncio
+async def test_run_mempalace_baseline_scores_fake_service():
+    summary = await run_mempalace_baseline(FakeMemoryService(), timeout_s=0.1)
+
+    assert summary["case_count"] == len(BASELINE_CASES)
+    assert summary["avg_score"] >= 0.75
+    assert summary["p95_latency_ms"] >= summary["p50_latency_ms"]
+    assert all(result["hit_count"] >= 1 for result in summary["results"])
+
+
+@pytest.mark.asyncio
+async def test_maintenance_runner_cleans_up_after_baseline_failure(monkeypatch, capsys):
+    script_path = Path(__file__).resolve().parents[3] / "scripts" / "maintenance" / "mempalace_baseline.py"
+    spec = importlib.util.spec_from_file_location("mempalace_baseline_runner", script_path)
+    assert spec and spec.loader
+    runner = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(runner)
+
+    class FailingService:
+        def __init__(self):
+            self.deleted = []
+
+        async def delete_user(self, user_id: str, *, actor: str):
+            self.deleted.append((user_id, actor))
+            return 7
+
+    service = FailingService()
+
+    async def fail_baseline(*args, **kwargs):
+        raise RuntimeError("baseline failed")
+
+    monkeypatch.setattr(runner, "get_memory_service", lambda: service)
+    monkeypatch.setattr(runner, "run_mempalace_baseline", fail_baseline)
+    monkeypatch.setattr(runner.sys, "argv", ["mempalace_baseline.py"])
+
+    with pytest.raises(RuntimeError, match="baseline failed"):
+        await runner._main()
+
+    assert service.deleted == [("zoe-mempalace-baseline", "mempalace_baseline")]
+    assert '"cleanup_removed": 7' in capsys.readouterr().out


### PR DESCRIPTION
## Summary
- add repeatable MemPalace baseline fixtures and scoring helpers
- add a maintenance runner that measures local MemoryService/MemPalace recall and cleans up synthetic rows by default
- document the first Zoe-host baseline run and update the harness status ledger

## Baseline evidence
- live runner scored 4/4 cases at avg_score 1.0 and min_score 1.0
- p50 latency: 112.77 ms
- p95 latency: 200.90 ms
- cleanup removed 4 synthetic rows for user zoe-mempalace-baseline

## Verification
- python3 tools/audit/validate_structure.py
- python3 tools/audit/validate_critical_files.py
- python3 tools/audit/validate_offline_memory.py
- python3 -m py_compile services/zoe-data/mempalace_baseline.py scripts/maintenance/mempalace_baseline.py
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_mempalace_baseline.py services/zoe-data/tests/test_mempalace_integration.py
- PYTHONPATH=services/zoe-data python3 scripts/maintenance/mempalace_baseline.py --timeout 3.0
- git diff --check
