### PR TITLE
Enforce implement edit safety from logs

### DIFF
--- a/services/zoe-data/kanban_phase_budget.py
+++ b/services/zoe-data/kanban_phase_budget.py
@@ -38,6 +38,11 @@ _ITERATION_BUDGET_RE = re.compile(
     r"Iteration budget reached\s*\((?P<used>\d+)\s*/\s*(?P<limit>\d+)\)",
     re.IGNORECASE,
 )
+_PYTHON_PATCH_RE = re.compile(r"\bpatch\b.*\.py\b")
+_PYTHON_CHECK_RE = re.compile(
+    r"\b(py_compile|pytest|mypy|ruff|validate_structure|validate_critical_files)\b",
+    re.IGNORECASE,
+)
 _MARK_REVIEWED_VERDICT_RE = re.compile(
     r"\bmark-reviewed\b(?=.*--critical-count)(?=.*--summary)",
     re.IGNORECASE,
@@ -145,6 +150,37 @@ def phase_budget_reason_from_log(task_id: str, phase: str) -> str | None:
         f"BLOCKER=ITERATION_BUDGET: Hermes iteration budget reached during {phase} "
         f"(steps={match.group('used')}, limit={match.group('limit')})"
     )
+
+
+def implement_edit_safety_reason_from_log(task_id: str, phase: str) -> str | None:
+    """Block implement runs that patch Python then keep exploring before syntax checks.
+
+    Prompt instructions are not enough for cost control: a worker can apply a
+    malformed Python patch and spend the rest of its iteration budget reading and
+    grepping. Treat the latest task log as an enforceable event stream: after a
+    Python patch, the next tool step must be a narrow syntax/test check.
+    """
+    if phase != "implement":
+        return None
+    session = _latest_log_session(task_id, max_lines=0)
+    if not session:
+        return None
+
+    pending_python_patch = False
+    for line in session.splitlines():
+        if _PYTHON_PATCH_RE.search(line):
+            pending_python_patch = True
+            continue
+        if not pending_python_patch or not _STEP_LINE_RE.match(line):
+            continue
+        if _PYTHON_CHECK_RE.search(line):
+            pending_python_patch = False
+            continue
+        return (
+            "BLOCKER=IMPLEMENT_EDIT_SAFETY: Python patch was followed by more "
+            "exploration before py_compile/focused tests"
+        )
+    return None
 
 
 def review_wrapup_tool_grace(task_id: str, phase: str) -> int:
@@ -260,6 +296,9 @@ def phase_budget_reason(
             f"BLOCKER={phase.upper()}_BUDGET: code-enforced tool budget exceeded "
             f"(steps={tool_steps}, guidance_limit={tool_limit}, hard_limit={hard_limit})"
         )
+    edit_safety_reason = implement_edit_safety_reason_from_log(task_id, phase)
+    if edit_safety_reason:
+        return edit_safety_reason
     log_reason = phase_budget_reason_from_log(task_id, phase)
     if log_reason:
         return log_reason

--- a/services/zoe-data/kanban_phase_budget.py
+++ b/services/zoe-data/kanban_phase_budget.py
@@ -38,7 +38,7 @@ _ITERATION_BUDGET_RE = re.compile(
     r"Iteration budget reached\s*\((?P<used>\d+)\s*/\s*(?P<limit>\d+)\)",
     re.IGNORECASE,
 )
-_PYTHON_PATCH_RE = re.compile(r"\bpatch\b.*\.py\b")
+_PYTHON_PATCH_RE = re.compile(r"^\s*(?:┊|\|)\s+\S+\s+patch\s+.*\.py\b")
 _PYTHON_CHECK_RE = re.compile(
     r"\b(py_compile|pytest|mypy|ruff|validate_structure|validate_critical_files)\b",
     re.IGNORECASE,

--- a/services/zoe-data/kanban_phase_budget.py
+++ b/services/zoe-data/kanban_phase_budget.py
@@ -40,7 +40,7 @@ _ITERATION_BUDGET_RE = re.compile(
 )
 _PYTHON_PATCH_RE = re.compile(r"^\s*(?:┊|\|)\s+\S+\s+patch\s+.*\.py\b")
 _PYTHON_CHECK_RE = re.compile(
-    r"\b(py_compile|pytest|mypy|ruff|validate_structure|validate_critical_files)\b",
+    r"^\s*(?:┊|\|)\s+\S+\s+\$\s+.*\b(py_compile|pytest|mypy|ruff|validate_structure|validate_critical_files)\b",
     re.IGNORECASE,
 )
 _MARK_REVIEWED_VERDICT_RE = re.compile(

--- a/services/zoe-data/kanban_phase_budget.py
+++ b/services/zoe-data/kanban_phase_budget.py
@@ -160,7 +160,7 @@ def implement_edit_safety_reason_from_log(task_id: str, phase: str) -> str | Non
     grepping. Treat the latest task log as an enforceable event stream: after a
     Python patch, the next tool step must be a narrow syntax/test check.
     """
-    if phase != "implement":
+    if phase not in {"implement", "implement_revision"}:
         return None
     session = _latest_log_session(task_id, max_lines=0)
     if not session:
@@ -168,10 +168,12 @@ def implement_edit_safety_reason_from_log(task_id: str, phase: str) -> str | Non
 
     pending_python_patch = False
     for line in session.splitlines():
+        if not _STEP_LINE_RE.match(line):
+            continue
         if _PYTHON_PATCH_RE.search(line):
             pending_python_patch = True
             continue
-        if not pending_python_patch or not _STEP_LINE_RE.match(line):
+        if not pending_python_patch:
             continue
         if _PYTHON_CHECK_RE.search(line):
             pending_python_patch = False

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -1917,6 +1917,23 @@ def test_implement_edit_safety_ignores_patch_word_in_step_arguments(tmp_path, mo
     assert kb.implement_edit_safety_reason_from_log("t_impl", "implement") is None
 
 
+def test_implement_edit_safety_does_not_clear_on_check_word_in_step_arguments(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    log_dir = tmp_path / "kanban" / "logs"
+    log_dir.mkdir(parents=True)
+    (log_dir / "t_impl.log").write_text(
+        "Query: work kanban task t_impl\n"
+        "  ┊ 🔧 patch     /work/services/zoe-data/intent_router.py  5.9s\n"
+        "  ┊ 🔎 grep      validate_structure /work/services/zoe-data/main.py  0.1s\n",
+        encoding="utf-8",
+    )
+
+    reason = kb.implement_edit_safety_reason_from_log("t_impl", "implement")
+
+    assert reason is not None
+    assert "IMPLEMENT_EDIT_SAFETY" in reason
+
+
 def test_implement_edit_safety_covers_revision_phase(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     log_dir = tmp_path / "kanban" / "logs"

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -1855,6 +1855,40 @@ def test_phase_budget_reason_recovers_hermes_iteration_budget_log(tmp_path, monk
     )
 
 
+def test_implement_edit_safety_blocks_python_patch_without_immediate_check(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    log_dir = tmp_path / "kanban" / "logs"
+    log_dir.mkdir(parents=True)
+    (log_dir / "t_impl.log").write_text(
+        "Query: work kanban task t_impl\n"
+        "  ┊ 🔧 patch     /work/services/zoe-data/intent_router.py  5.9s\n"
+        "  ┊ 📖 read      /work/services/zoe-data/intent_router.py  0.1s\n",
+        encoding="utf-8",
+    )
+
+    reason = kb.implement_edit_safety_reason_from_log("t_impl", "implement")
+
+    assert reason == (
+        "BLOCKER=IMPLEMENT_EDIT_SAFETY: Python patch was followed by more "
+        "exploration before py_compile/focused tests"
+    )
+
+
+def test_implement_edit_safety_allows_immediate_python_check(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    log_dir = tmp_path / "kanban" / "logs"
+    log_dir.mkdir(parents=True)
+    (log_dir / "t_impl.log").write_text(
+        "Query: work kanban task t_impl\n"
+        "  ┊ 🔧 patch     /work/services/zoe-data/intent_router.py  5.9s\n"
+        "  ┊ 💻 $         python3 -m py_compile services/zoe-data/intent_router.py  0.2s\n"
+        "  ┊ 📖 read      /work/services/zoe-data/intent_router.py  0.1s\n",
+        encoding="utf-8",
+    )
+
+    assert kb.implement_edit_safety_reason_from_log("t_impl", "implement") is None
+
+
 def test_phase_budget_reason_ignores_stale_iteration_budget_log_session(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     log_dir = tmp_path / "kanban" / "logs"

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -1889,6 +1889,37 @@ def test_implement_edit_safety_allows_immediate_python_check(tmp_path, monkeypat
     assert kb.implement_edit_safety_reason_from_log("t_impl", "implement") is None
 
 
+def test_implement_edit_safety_ignores_non_step_patch_text(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    log_dir = tmp_path / "kanban" / "logs"
+    log_dir.mkdir(parents=True)
+    (log_dir / "t_impl.log").write_text(
+        "Query: work kanban task t_impl\n"
+        "Planning note: patch services/zoe-data/intent_router.py after locating the helper.\n"
+        "  ┊ 📖 read      /work/services/zoe-data/intent_router.py  0.1s\n",
+        encoding="utf-8",
+    )
+
+    assert kb.implement_edit_safety_reason_from_log("t_impl", "implement") is None
+
+
+def test_implement_edit_safety_covers_revision_phase(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    log_dir = tmp_path / "kanban" / "logs"
+    log_dir.mkdir(parents=True)
+    (log_dir / "t_revision.log").write_text(
+        "Query: work kanban task t_revision\n"
+        "  ┊ 🔧 patch     /work/services/zoe-data/intent_router.py  5.9s\n"
+        "  ┊ 🔎 grep      def execute_intent  0.1s\n",
+        encoding="utf-8",
+    )
+
+    reason = kb.implement_edit_safety_reason_from_log("t_revision", "implement_revision")
+
+    assert reason is not None
+    assert "IMPLEMENT_EDIT_SAFETY" in reason
+
+
 def test_phase_budget_reason_ignores_stale_iteration_budget_log_session(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     log_dir = tmp_path / "kanban" / "logs"

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -1903,6 +1903,20 @@ def test_implement_edit_safety_ignores_non_step_patch_text(tmp_path, monkeypatch
     assert kb.implement_edit_safety_reason_from_log("t_impl", "implement") is None
 
 
+def test_implement_edit_safety_ignores_patch_word_in_step_arguments(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    log_dir = tmp_path / "kanban" / "logs"
+    log_dir.mkdir(parents=True)
+    (log_dir / "t_impl.log").write_text(
+        "Query: work kanban task t_impl\n"
+        "  ┊ 🔎 grep      patch utils.py  0.1s\n"
+        "  ┊ 📖 read      /work/services/zoe-data/intent_router.py  0.1s\n",
+        encoding="utf-8",
+    )
+
+    assert kb.implement_edit_safety_reason_from_log("t_impl", "implement") is None
+
+
 def test_implement_edit_safety_covers_revision_phase(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     log_dir = tmp_path / "kanban" / "logs"


### PR DESCRIPTION
## Summary
- detect implement runs that patch Python and keep exploring before py_compile/focused checks
- return IMPLEMENT_EDIT_SAFETY from phase budget enforcement so Zoe blocks and terminates the worker
- add regression coverage for violating and compliant logs

## Validation
- python3 -m py_compile services/zoe-data/kanban_phase_budget.py services/zoe-data/tests/test_kanban_adapter.py
- remote adapter tests/validators pending