### PR TITLE
Define Zoe north star layer

### DIFF
--- a/docs/adr/ADR-zoe-north-star-layer.md
+++ b/docs/adr/ADR-zoe-north-star-layer.md
@@ -1,0 +1,49 @@
+# ADR: Zoe North Star Layer
+
+## Status
+
+Accepted.
+
+## Context
+
+The Zoe evolution harness already defines memory contracts, routing, bake-offs, evidence gates, and a self-evolution pipeline. That is the machinery. It does not fully define the product compass Zoe needs to become a coherent local-first assistant with continuity, useful initiative, and safe self-improvement.
+
+Without a north-star layer, Zoe can accumulate tools and memories without knowing which capabilities are trusted, which are expensive, which are duplicated, which improve user outcomes, and which should be retired.
+
+## Decision
+
+Add a Zoe north-star layer to the architecture. This is not a new runtime service yet. It is a required design layer that future PRs must make executable through small artifacts:
+
+- capability profiles for tools, routes, skills, agents, sidecars, devices, and execution lanes;
+- trust/autonomy classes for observe, recall, suggest, prepare, execute, and promote;
+- candidate discovery scoring for Pi, MCP, GitHub, local skills, APIs, and existing Zoe tools;
+- outcome evals for task completion, correction handling, continuity, friction, latency, trust, cleanup quality, and hardware fit;
+- hardware/runtime budgets for Jetson CPU, RAM, GPU, latency, model use, and local/offline viability;
+- promotion and retirement rules based on evidence.
+
+Concrete system identifiers must use Zoe names. External inspirations remain product vision and research inputs, not module or layer names.
+
+## Consequences
+
+Zoe's future cleanup work should not remove or replace active tools based only on intuition. It should use capability profiles, candidate comparisons, usage/failure evidence, and rollback plans.
+
+Zoe's self-evolution loop should prefer discovering and evaluating existing abilities before building new ones. Pi, MCP servers, GitHub projects, local skills, Hermes capabilities, OpenClaw fallback paths, and APIs should be scored with the same candidate record.
+
+Zoe may observe and suggest aggressively, but execution, durable trusted memory, privileged capability promotion, device control, secret use, installs, and cleanup remain approval-gated.
+
+## Acceptance Criteria
+
+- Every trusted capability has a profile with owner surface, trust level, approval requirement, offline mode, dependencies, tests, budget, evidence, known failures, and rollback.
+- Candidate adoption records include fit, project activity, stars, license, offline viability, security, footprint, test quality, maintenance burden, and overlap with existing Zoe abilities.
+- Outcome evals can show whether Zoe improves task completion, continuity, correction handling, trust, latency, cleanup quality, and hardware fit.
+- Failed outcome evals can become Notice records for the self-evolution loop.
+- Cleanup proposals include measured non-use, replacement, failure-rate, or maintenance-cost evidence.
+- No cloud model dependency is introduced for Zoe memory.
+
+## Initial PR Slices
+
+1. Add a generated or maintained capability profile inventory for active Zoe surfaces.
+2. Add a candidate-scoring template for Pi/MCP/GitHub/skill/API adoption.
+3. Add outcome eval trace schema.
+4. Wire recurring outcome failures into Notice records.
+5. Use capability profiles as a gate before main engine cleanup.

--- a/docs/strategy/zoe-evolution-harness-plan.md
+++ b/docs/strategy/zoe-evolution-harness-plan.md
@@ -8,9 +8,70 @@ The product target is Zoe continuity: local-first presence, personal trust, syst
 
 Naming discipline: use Zoe names for concrete modules, services, memory layers, prompts, ADRs, metrics, and runtime concepts. Treat external inspirations as product vision only, not system identity or implementation names.
 
+## Zoe North Star Layer
+
+The earlier harness plan describes how Zoe can remember, propose, execute, verify, and learn. That is necessary, but not enough. Zoe also needs a durable product compass that answers what she should become and how she knows she is getting better.
+
+Zoe's north-star layer is a governed agency loop:
+
+1. Sense the user's world: messages, voice turns, tools, devices, routines, failures, preferences, home state, recurring tasks, and operator notes.
+2. Maintain a living self-model: current capabilities, unavailable capabilities, confidence, costs, latency, hardware limits, owners, tests, and trusted execution lanes.
+3. Maintain a living user/world model: people, places, projects, commitments, permissions, relationship context, unresolved promises, and changing facts.
+4. Scout for abilities: Pi packages, MCP servers, GitHub projects, local skills, device APIs, open-source agents, and Zoe's own prior fixes.
+5. Evaluate candidates before adoption: usefulness, activity, stars, license, local/offline viability, security, memory footprint, CPU/GPU cost, tests, maintainability, and fit with Zoe's identity.
+6. Ask for approval when trust or privilege changes: new tools, new durable memory classes, external access, device control, secret access, code execution, and self-modification remain gated.
+7. Prove improvement: every adopted capability needs an eval, a rollback path, an owner, and evidence that it improved user outcomes without exceeding latency or hardware budgets.
+8. Retire deliberately: stale tools, failing skills, misleading memories, and duplicate routes should be retired only after non-use or replacement is measured.
+
+This layer is deliberately Zoe-named. The ambition is Samantha-like continuity and usefulness, but concrete system identity, modules, prompts, docs, and metrics should stay Zoe-specific to avoid confusing inspiration with implementation.
+
+## Missing Design Axes
+
+The harness should track these axes explicitly before major cleanup:
+
+| Axis | Why It Matters | First Concrete Artifact |
+| --- | --- | --- |
+| Capability self-model | Zoe cannot improve herself if she cannot inspect what she can currently do, what failed, what is trusted, and what is expensive. | `zoe_capability_profile` records or a JSON/DB-backed inventory generated from tools, routes, skills, and proposals. |
+| User/world continuity | Personal intelligence depends on relationships, promises, routines, corrections, and context that changes over time. | Graphiti-style temporal fixtures plus scoped memory contract events for people, projects, promises, and supersession. |
+| Trust calibration | Self-evolution should increase user trust, not create surprising autonomy. | Explicit approval classes for recall, retain, execute, device-control, secret-use, install, code-change, and cleanup. |
+| Hardware/runtime budget | Zoe lives on constrained local hardware; a brilliant backend that starves chat is a failed backend. | Per-capability CPU/RAM/GPU/latency measurements recorded next to benchmark results. |
+| Capability scouting | Zoe should find existing abilities before writing bespoke code. | Search/evaluate records that score Pi, MCP, GitHub, local skills, and APIs by activity, stars, fit, license, and offline viability. |
+| Product taste | Zoe should become more helpful and coherent, not just bigger. | Outcome evals that rate task completion, interruption cost, correction handling, and user delight/friction. |
+| Embodiment and devices | Zoe's world includes Home Assistant, voice, UI, and local hardware, not only text. | Device/action capability profiles with safety class, required approval, and rollback/undo behavior. |
+| Learning quality | Reflection can create confident nonsense unless measured. | Retrieval helpfulness, contradiction, correction, and supersession traces. |
+| Cleanup economics | Removing tools should be based on evidence, not aesthetic discomfort. | Non-use, replacement, failure-rate, and maintenance-cost metrics before retirement PRs. |
+
+## Zoe Capability Profile
+
+Every meaningful Zoe ability should eventually have a profile. This can start as a generated document or JSON file before becoming a table.
+
+Minimum fields:
+
+- `capability_id`
+- `name`
+- `owner_surface`: chat, voice, UI, Hermes, OpenClaw, Multica, MCP, Pi, skill, local service, external API
+- `task_types`
+- `trust_level`: experimental, assisted, trusted, privileged, retired
+- `approval_required`
+- `offline_mode`: required, supported, unavailable, unknown
+- `model_dependencies`
+- `device_dependencies`
+- `memory_dependencies`
+- `latency_budget_ms`
+- `cpu_budget`
+- `ram_budget_mb`
+- `gpu_budget`
+- `evidence_refs`
+- `tests`
+- `last_verified_at`
+- `known_failures`
+- `rollback`
+
+These profiles become the substrate for self-evolution: Zoe can compare a user request against known abilities, decide whether she already has the capability, propose a candidate when she does not, and retire or downgrade abilities that repeatedly fail.
+
 ## Current Inventory
 
-As of the implementation pass on 2026-06-08, the canonical Zoe repo is `/home/zoe/assistant` on SSH target `zoe`, HEAD `1e60a976a785811900ce45c72a86bd0b613ed2e1`.
+As of the north-star update on 2026-06-09, the canonical Zoe repo is `/home/zoe/assistant` on SSH target `zoe`, with `origin/main` at `5d45a50bb1187ae6064f0a1d9ffdf45a41d47534`.
 
 Active production surfaces:
 
@@ -27,7 +88,7 @@ Active production surfaces:
 Important current caveats:
 
 - `services/zoe-core` is retired reference code and must not be extended.
-- The existing Graphify report is stale: it was built from commit `b262ce99`, not current HEAD.
+- The existing Graphify report is stale after newer harness PRs: it was last refreshed from `ad52f61d`, not current `origin/main`.
 - The worktree already had unrelated dirty files before this plan was implemented; this pass avoids modifying those files.
 - Live relational memory should remain Postgres-centered; do not introduce production SQLite memory paths.
 
@@ -220,6 +281,80 @@ Stages:
 9. Learn: store outcome, evidence, failures, fixes, and updated capability trust.
 10. Retire: remove or archive unused tools and memories based on measured non-use or replacement.
 
+## Capability Discovery And Adoption
+
+Zoe should search before she builds. The adoption path for a requested or discovered ability is:
+
+```mermaid
+graph TD
+  Need["Need: user ask, repeated failure, missing ability"]
+  Profile["Capability Profile Lookup"]
+  Scout["Scout: Pi, MCP, GitHub, skills, APIs, local tools"]
+  Score["Score: fit, activity, stars, license, offline, cost, risk"]
+  Trial["Sandbox Trial"]
+  Proposal["Multica Proposal"]
+  Approval["Approval Gate"]
+  Integrate["Small PR Integration"]
+  Verify["Tests, evals, health, hardware budget"]
+  Promote["Promote / Trust / Retire"]
+
+  Need --> Profile
+  Profile --> Scout
+  Scout --> Score
+  Score --> Trial
+  Trial --> Proposal
+  Proposal --> Approval
+  Approval --> Integrate
+  Integrate --> Verify
+  Verify --> Promote
+```
+
+Candidate scoring should include:
+
+- task fit and user value;
+- project activity, stars, release recency, issue health, and maintainer signals;
+- license compatibility;
+- local/offline viability and whether cloud calls are optional or mandatory;
+- Jetson CPU/RAM/GPU footprint;
+- security posture, secret handling, sandboxability, and dependency risk;
+- tests, examples, docs, and integration surface;
+- rollback/removal cost;
+- overlap with existing Zoe capabilities.
+
+Pi should be treated as a source of existing runtime/tooling ability, not as something Zoe rebuilds. MCP servers, local skills, Hermes capabilities, OpenClaw fallback surfaces, and GitHub projects should be evaluated through the same profile/scoring record.
+
+## Trust And Autonomy Classes
+
+Zoe's autonomy should increase only where evidence says it is safe.
+
+| Class | Zoe May Do | Gate |
+| --- | --- | --- |
+| Observe | Collect traces, errors, latency, non-secret tool outcomes, and user-visible misses. | Scoped logging policy. |
+| Recall | Retrieve scoped memories and capability profiles into compact cited packets. | User/scope isolation and latency timeout. |
+| Suggest | Propose memories, fixes, tools, cleanup, or capability additions. | Evidence required. |
+| Prepare | Create draft plans, branches, tests, docs, and non-privileged local experiments. | Worktree and review policy. |
+| Execute | Modify code, install tools, access devices, use secrets, or change durable runtime behavior. | Multica/user/admin approval according to risk. |
+| Promote | Mark a capability trusted, create trusted memory, or retire a subsystem. | Verification evidence and review. |
+
+This trust model prevents Zoe from confusing self-awareness with permission. She can notice and propose aggressively, but she earns execution and promotion through evidence.
+
+## Outcome Evals
+
+The self-evolution harness needs product evals, not only unit tests.
+
+Minimum recurring eval categories:
+
+- task completion: did Zoe actually finish the user's requested outcome?
+- correction handling: did Zoe accept and retain corrections without arguing or reintroducing stale facts?
+- continuity: did Zoe remember active projects, people, commitments, and preferences in the right scope?
+- friction: did Zoe ask for permission only when needed and avoid unnecessary clarification?
+- latency: did memory/tool routing stay within budget for chat and voice?
+- trust: did privileged actions require approval and produce audit evidence?
+- cleanup quality: did removed or retired paths have measured replacement/non-use evidence?
+- hardware fit: did the adopted capability stay within Jetson CPU/RAM/GPU budgets?
+
+These evals should feed the same memory/evolution loop as test results. A failed eval should create a pending experience/failure memory and, when recurring, a Notice record for self-evolution.
+
 ## Rollout Phases
 
 1. Document strategy and ADRs.
@@ -230,7 +365,9 @@ Stages:
 6. Run Graphiti/FalkorDB and Graphiti/Neo4j bake-off.
 7. Add memory router behind a feature flag.
 8. Add retain-candidate admission through Multica/evidence gates.
-9. Clean Zoe main engine only after tests protect chat, memory gating, and tool dispatch.
+9. Add Zoe capability profiles and discovery/evaluation records.
+10. Add outcome eval traces for task completion, correction handling, continuity, trust, and hardware fit.
+11. Clean Zoe main engine only after tests protect chat, memory gating, tool dispatch, capability profiles, and proposal records.
 
 ## Test Strategy
 
@@ -242,6 +379,9 @@ Unit tests:
 - Evidence-required writes.
 - Memory router decisions.
 - Tool/capability scoring.
+- Capability profile validation.
+- Candidate scoring for Pi/MCP/GitHub/skill/API adoption.
+- Trust/autonomy class gates.
 
 Integration tests:
 
@@ -252,6 +392,8 @@ Integration tests:
 - Multica approval gate.
 - Failed tool run becomes pending memory, not trusted fact.
 - User correction supersedes old memory.
+- User asks for a missing capability and Zoe creates a proposal, not an unchecked install.
+- Capability promotion requires verification evidence.
 
 Performance tests:
 
@@ -261,6 +403,7 @@ Performance tests:
 - Graphiti/FalkorDB query latency.
 - Graphiti/Neo4j query latency.
 - Jetson RAM/CPU under idle, chat, recall, retain, graph lookup.
+- Per-capability budget checks for adopted local tools.
 
 Safety tests:
 
@@ -270,6 +413,8 @@ Safety tests:
 - Disputed memory not injected as fact.
 - Auto-retain cannot write trusted memory directly.
 - Evolution proposal cannot execute without approval.
+- Privileged capability profile cannot move to trusted without verification.
+- Cleanup/retirement proposal cannot proceed without non-use or replacement evidence.
 
 ## Success Metrics
 
@@ -280,3 +425,4 @@ Safety tests:
 - 95%+ exact answers on synthetic relational memory eval.
 - Zero unscoped durable memory writes.
 - Every self-evolution change has proposal, evidence, verification, and retained outcome.
+- Every trusted capability has a current profile, owner surface, budget, tests, and rollback.

--- a/docs/strategy/zoe-evolution-harness-status.md
+++ b/docs/strategy/zoe-evolution-harness-status.md
@@ -33,6 +33,7 @@ Important non-complete truth:
 - Tool/capability and memory read/write inventories now exist as cleanup gates; keep them updated as runtime paths change.
 - MemPalace now has a repeatable local baseline harness and first measured Zoe-host run; Hindsight has not yet been run as a measured live sidecar bake-off.
 - Graphiti/FalkorDB/Neo4j have not yet been measured for Zoe relational memory.
+- The plan now names Zoe's missing north-star layer: capability profiles, trust/autonomy classes, candidate scouting, outcome evals, and hardware-aware promotion.
 - The deterministic memory router is not yet wired into production chat behind a feature flag.
 - Retain-candidate admission is not yet fully governed through Multica approval.
 - The full self-evolution loop is not yet implemented end to end.
@@ -54,6 +55,7 @@ Important non-complete truth:
 | Graphify current map | Complete foundation | `graphify-out/GRAPH_REPORT.md` and `graphify-out/graph.json` were regenerated from `origin/main` at `ad52f61d`; `docs/architecture/zoe-harness-current-inventory.md` records the source-backed inventory. | Rerun Graphify after substantial code or architecture changes. |
 | Tool/capability inventory | Complete foundation | `docs/architecture/zoe-tool-capability-inventory.md` maps agent, MCP, Multica, Hermes, OpenClaw, and governance surfaces. | Keep updated when tool catalogs or execution lanes change. |
 | Memory read/write inventory | Complete foundation | `docs/architecture/zoe-memory-read-write-inventory.md` maps MemoryService operations, durable writes, prompt reads, MCP paths, Hindsight candidates, and metadata gaps. | Keep updated when memory write/read paths change. |
+| Zoe north-star layer | Complete foundation | `docs/strategy/zoe-evolution-harness-plan.md` and `docs/adr/ADR-zoe-north-star-layer.md` define capability profiles, trust/autonomy classes, discovery scoring, outcome evals, and hardware budgets. | Build capability profile inventory and candidate-scoring records. |
 | Observation/evaluation traces | Not started | Memory metrics exist for MemPalace but not full retrieval helpfulness/contradiction traces. | Add a trace schema for recall, retain candidate, admission, contradiction, and fallback events. |
 | Multica evidence gates | Partial | Implement completion now requires PR evidence for code/default profiles. | Add memory admission gates and explicit self-evolution proposal gates. |
 | Self-evolution loop | Partial | Multica, pipeline evidence, Greploop, Greptile, Hermes, and worktree bootstrap pieces exist. | Implement structured Notice -> Explain -> Search -> Evaluate -> Propose records before any automatic execution. |
@@ -124,6 +126,27 @@ Acceptance evidence:
 - Failed execution produces a pending memory candidate, not a trusted fact.
 - Successful execution updates capability trust only after verification.
 
+### Zoe Product Intelligence
+
+The missing plan layer is not another database. It is a product and agency model that keeps Zoe pointed at the right kind of intelligence: local-first continuity, useful initiative, safe capability growth, and measured improvement.
+
+Required slices:
+
+- define capability profiles for current Zoe tools, routes, skills, sidecars, and execution lanes;
+- classify each capability by trust level, approval requirement, offline viability, model/device dependency, tests, rollback, and hardware budget;
+- create candidate-scoring records for Pi, MCP, GitHub, local skills, APIs, and existing Zoe tools before adopting or replacing anything;
+- add trust/autonomy classes so Zoe can observe, recall, suggest, prepare, execute, and promote under different gates;
+- add outcome eval traces for task completion, correction handling, continuity, friction, latency, trust, cleanup quality, and hardware fit;
+- treat user-visible coherence and relationship continuity as first-class success metrics alongside latency and test pass rate.
+
+Acceptance evidence:
+
+- every trusted capability has a profile with tests, owner surface, budget, and rollback;
+- candidate adoption decisions record activity, stars, license, offline viability, security, footprint, and fit;
+- privileged execution cannot occur merely because a capability exists;
+- outcome evals can create Notice records when Zoe repeatedly fails or regresses;
+- cleanup proposals include non-use, replacement, failure-rate, or maintenance-cost evidence.
+
 ## Recommended PR Order
 
 Keep each pull request small enough for Greptile and Zoe verification.
@@ -159,9 +182,18 @@ Keep each pull request small enough for Greptile and Zoe verification.
    - Route retain candidates through Multica/review.
    - Add evidence and scope gates for relational and self-evolution memory.
 9. Self-evolution proposal records.
-   - Implement Notice -> Explain -> Search -> Evaluate -> Propose records.
-   - Keep execution approval-gated.
-10. Main engine cleanup.
+    - Implement Notice -> Explain -> Search -> Evaluate -> Propose records.
+    - Keep execution approval-gated.
+10. Zoe capability profile inventory.
+    - Add profiles for active chat, voice, memory, Graphify, Multica, Hermes, OpenClaw, MCP, Pi, and local service capabilities.
+    - Include trust level, approval class, tests, budget, dependencies, rollback, and known failures.
+11. Candidate discovery scoring.
+    - Add records/templates that compare Pi, MCP, GitHub, local skills, APIs, and existing Zoe capabilities.
+    - Include activity, stars, license, offline viability, security, hardware footprint, test quality, and overlap.
+12. Outcome eval trace schema.
+    - Track task completion, correction handling, continuity, friction, latency, trust, cleanup quality, and hardware fit.
+    - Convert recurring failures into Notice records.
+13. Main engine cleanup.
     - Split only protected, well-understood areas in `zoe_agent.py`.
     - Remove duplicate or retired memory paths only after inventory and tests.
 
@@ -173,6 +205,7 @@ Do not start major Zoe main engine cleanup if any of these are true:
 - Active-vs-retired surfaces are not labeled.
 - Memory writes cannot be traced to user, scope, evidence, and review state.
 - Chat, memory gating, tool dispatch, and Multica evidence tests are missing.
+- Capability profiles and outcome evals are missing for the surface being cleaned or replaced.
 - A proposed change would bypass PR review, Greptile, or protected-branch policy.
 - A memory backend requires cloud models for Zoe memory.
 
@@ -188,4 +221,6 @@ The Zoe evolution harness is done only when:
 - no durable memory write is unscoped;
 - no trusted relational/self-evolution memory lacks evidence;
 - every code-producing self-evolution change has proposal, approval when privileged, PR evidence, verification, and retained outcome;
+- every trusted Zoe capability has a profile, budget, tests, approval class, known failure list, and rollback path;
+- outcome evals can show Zoe is improving task completion, continuity, correction handling, trust, latency, and hardware fit;
 - stale tools and memory paths can be retired through measured, reviewable cleanup rather than intuition.


### PR DESCRIPTION
## Summary
- add a Zoe north-star layer to the evolution harness plan
- define capability profiles, trust/autonomy classes, capability scouting, outcome evals, hardware/runtime budgets, and promotion/retirement rules
- add an ADR so future implementation can build capability inventories and scoring records from an accepted decision

## Why
Jason called out that the previous plan still felt incomplete. This fills the gap between memory/governance plumbing and the actual Zoe product intelligence goal: Zoe should know what she can do, what she should learn, what is trusted, what is expensive, and whether a change made her more useful.

## Verification
- python3 tools/audit/validate_structure.py
- python3 tools/audit/validate_critical_files.py
- python3 tools/audit/validate_offline_memory.py
- git diff --check
