### PR TITLE
Measure Hindsight bakeoff availability

### DIFF
--- a/docs/architecture/zoe-hindsight-bakeoff.md
+++ b/docs/architecture/zoe-hindsight-bakeoff.md
@@ -1,0 +1,68 @@
+# Zoe Hindsight Bake-Off
+
+## Purpose
+
+Hindsight remains an offline-only candidate for Zoe reflective memory: lessons, recurring failures, fixes, and experience summaries. It is not a replacement for MemPalace and it is not in the chat hot path.
+
+This document records the current bake-off runner and the first Zoe-host availability check.
+
+## Harness
+
+Files:
+
+- `services/zoe-data/hindsight_bakeoff.py`
+- `scripts/maintenance/hindsight_bakeoff.py`
+- `services/zoe-data/tests/test_hindsight_bakeoff.py`
+
+The runner uses the synthetic Zoe memory events from `hindsight_bakeoff.py`, can optionally retain them into a configured Hindsight sidecar, then measures recall scores and p50/p95 latency across the evaluation queries.
+
+Command:
+
+```bash
+PYTHONPATH=services/zoe-data python3 scripts/maintenance/hindsight_bakeoff.py --json
+```
+
+To write synthetic events, the operator must explicitly enable Hindsight and opt into writes:
+
+```bash
+HINDSIGHT_ENABLED=true PYTHONPATH=services/zoe-data python3 scripts/maintenance/hindsight_bakeoff.py --retain-synthetic --json
+```
+
+Zoe memory remains offline-only. `HindsightConfig` rejects public/cloud model providers unless an OpenAI-compatible provider points to a localhost/private base URL.
+
+## Current Zoe-Host Check
+
+Date: 2026-06-09
+
+Environment:
+
+- Host: Zoe Jetson service host.
+- Expected sidecar URL: `http://127.0.0.1:8888`.
+- Sidecar status: not running; `curl --max-time 2 http://127.0.0.1:8888/health` returned connection refused.
+- Process/container status: no Hindsight process or container was running.
+- Runner mode: default disabled config, no retain, no writes.
+
+Measured disabled-run result:
+
+| Metric | Value |
+| --- | --- |
+| Cases | 4 |
+| Average score | 0.0 |
+| Minimum score | 0.0 |
+| p50 latency | 0.0024 ms |
+| p95 latency | 0.0066 ms |
+| Sidecar writes | 0 |
+
+This is not a Hindsight acceptance result. It is an availability baseline and a fixed runner. The Hindsight bake-off remains incomplete until a local/offline sidecar is started and measured with synthetic retain/recall.
+
+## Acceptance Use
+
+Hindsight should not move into production recall until a measured sidecar run proves:
+
+- recall p95 under 600 ms for normal low/mid budget use, or an explicit async-only designation;
+- returned memories include evidence/source pointers;
+- retain can run async without blocking chat;
+- wrong, disputed, or superseded memories can be corrected;
+- user/scope isolation passes;
+- no cloud model provider is required;
+- Jetson CPU/RAM impact is acceptable or the service is marked sidecar/remote-only.

--- a/docs/strategy/zoe-evolution-harness-status.md
+++ b/docs/strategy/zoe-evolution-harness-status.md
@@ -31,7 +31,7 @@ Important non-complete truth:
 
 - Graphify has been refreshed from `origin/main` at `ad52f61d`; rerun it after subsequent code or architecture changes.
 - Tool/capability and memory read/write inventories now exist as cleanup gates; keep them updated as runtime paths change.
-- MemPalace now has a repeatable local baseline harness and first measured Zoe-host run; Hindsight has not yet been run as a measured live sidecar bake-off.
+- MemPalace now has a repeatable local baseline harness and first measured Zoe-host run; Hindsight now has a fixed measured runner and Zoe-host availability baseline, but no live sidecar bake-off yet because no Hindsight process/container is running.
 - Graphiti/FalkorDB/Neo4j have not yet been measured for Zoe relational memory.
 - The plan now names Zoe's missing north-star layer: capability profiles, trust/autonomy classes, candidate scouting, outcome evals, and hardware-aware promotion.
 - The deterministic memory router is not yet wired into production chat behind a feature flag.
@@ -50,7 +50,7 @@ Important non-complete truth:
 | Memory layer map | Complete foundation | `services/zoe-data/zoe_memory_layers.py` and `services/zoe-data/tests/test_zoe_memory_layers.py`. | Link layer decisions to runtime config and status endpoints. |
 | Memory router | Partial | `services/zoe-data/zoe_memory_router.py` and `services/zoe-data/tests/test_zoe_memory_router.py`. | Wire into chat/agent recall behind a disabled-by-default feature flag with latency guards. |
 | MemPalace baseline | Complete foundation | `services/zoe-data/mempalace_baseline.py`, `scripts/maintenance/mempalace_baseline.py`, and `docs/architecture/zoe-mempalace-baseline.md` record a repeatable local benchmark; first run scored 1.0 avg with p95 200.90 ms and cleaned up 4 synthetic rows. | Expand with relational/supersession cases before comparing Graphiti-style backends. |
-| Hindsight bake-off | Partial | Offline sidecar client, retain-candidate helpers, synthetic fixtures, and tests exist. | Run a measured sidecar bake-off with local models only and record p50/p95 latency, failures, and evidence quality. |
+| Hindsight bake-off | Partial | Offline sidecar client, retain-candidate helpers, synthetic fixtures, measured runner, availability doc, and tests exist; current Zoe-host check found no running Hindsight sidecar. | Start a local/offline sidecar, run retain/recall with synthetic events, and record p50/p95 latency, failures, evidence quality, and CPU/RAM use. |
 | Graphiti bake-off | Not started | ADR exists only. | Build Graphiti evaluation fixtures, then test FalkorDB first and Neo4j second if feasible. |
 | Graphify current map | Complete foundation | `graphify-out/GRAPH_REPORT.md` and `graphify-out/graph.json` were regenerated from `origin/main` at `ad52f61d`; `docs/architecture/zoe-harness-current-inventory.md` records the source-backed inventory. | Rerun Graphify after substantial code or architecture changes. |
 | Tool/capability inventory | Complete foundation | `docs/architecture/zoe-tool-capability-inventory.md` maps agent, MCP, Multica, Hermes, OpenClaw, and governance surfaces. | Keep updated when tool catalogs or execution lanes change. |
@@ -168,8 +168,9 @@ Keep each pull request small enough for Greptile and Zoe verification.
    - Repeatable benchmark and first Zoe-host p50/p95 run are documented in `docs/architecture/zoe-mempalace-baseline.md`.
    - Expand with memory footprint, relational, and supersession cases before backend replacement decisions.
 5. Hindsight sidecar bake-off.
-   - Run local/offline-only Hindsight.
-   - Produce measured results and gaps.
+   - Status: runner and availability baseline complete.
+   - Next: start local/offline-only Hindsight and run synthetic retain/recall.
+   - Produce measured p50/p95, evidence quality, CPU/RAM, and gaps.
    - Keep it out of production chat until feature-flagged and measured.
 6. Graphiti relational bake-off.
    - Add fixtures first.

--- a/scripts/maintenance/hindsight_bakeoff.py
+++ b/scripts/maintenance/hindsight_bakeoff.py
@@ -12,14 +12,14 @@ import argparse
 import asyncio
 import json
 import sys
+import time
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 DATA = ROOT / "services" / "zoe-data"
-if str(DATA) not in sys.path:
-    sys.path.insert(0, str(DATA))
+sys.path.insert(0, str(DATA))
 
-from hindsight_bakeoff import EVAL_QUERIES, SYNTHETIC_EVENTS, score_recall_response  # noqa: E402
+from hindsight_bakeoff import EVAL_QUERIES, SYNTHETIC_EVENTS, score_recall_response, summarize_bakeoff_scores  # noqa: E402
 from hindsight_memory import HindsightConfig, HindsightMemoryClient  # noqa: E402
 
 
@@ -33,7 +33,7 @@ async def main() -> int:
     args = parser.parse_args()
 
     client = HindsightMemoryClient(HindsightConfig.from_env())
-    output: dict[str, object] = {"status": client.enabled_status(), "retained": [], "operations": [], "scores": []}
+    output: dict[str, object] = {"status": client.enabled_status(), "retained": [], "operations": [], "scores": [], "summary": {}}
 
     if args.retain_synthetic:
         retained = []
@@ -49,6 +49,7 @@ async def main() -> int:
 
     scores = []
     for query in EVAL_QUERIES:
+        started = time.perf_counter()
         response = await client.recall(
             user_id=query.user_id,
             scope=query.scope,
@@ -56,15 +57,23 @@ async def main() -> int:
             budget=query.budget,
             max_tokens=1024,
         )
-        scores.append(score_recall_response(response, query))
+        latency_ms = (time.perf_counter() - started) * 1000
+        score = score_recall_response(response, query)
+        score["latency_ms"] = latency_ms
+        score["bank_id"] = response.get("bank_id")
+        score["enabled"] = response.get("enabled", client.config.enabled)
+        score["reason"] = response.get("reason")
+        scores.append(score)
     output["scores"] = scores
+    output["summary"] = summarize_bakeoff_scores(scores)
 
     if args.json:
         print(json.dumps(output, indent=2, sort_keys=True))
     else:
         print(json.dumps(output["status"], indent=2, sort_keys=True))
+        print(json.dumps(output["summary"], indent=2, sort_keys=True))
         for item in scores:
-            print(f"{item['name']}: score={item['score']:.2f} missing={item['missing']}")
+            print(f"{item['name']}: score={item['score']:.2f} latency_ms={item['latency_ms']:.2f} missing={item['missing']}")
     return 0
 
 

--- a/services/zoe-data/hindsight_bakeoff.py
+++ b/services/zoe-data/hindsight_bakeoff.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Iterable, Mapping
+from statistics import median
+from typing import Any, Iterable, Mapping, Sequence
 
 from zoe_memory_contract import (
     MemoryEvent,
@@ -125,6 +126,33 @@ def score_recall_text(text: str, expected_terms: Iterable[str]) -> dict[str, Any
     }
 
 
+def percentile(values: Sequence[float], percentile_value: float) -> float:
+    if not 0.0 <= percentile_value <= 1.0:
+        raise ValueError("percentile_value must be between 0.0 and 1.0")
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return ordered[0]
+    rank = (len(ordered) - 1) * percentile_value
+    lower = int(rank)
+    upper = min(lower + 1, len(ordered) - 1)
+    weight = rank - lower
+    return ordered[lower] * (1 - weight) + ordered[upper] * weight
+
+
+def summarize_bakeoff_scores(scores: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    score_values = [float(item.get("score") or 0.0) for item in scores]
+    latencies = [float(item.get("latency_ms") or 0.0) for item in scores if "latency_ms" in item]
+    return {
+        "case_count": len(scores),
+        "avg_score": sum(score_values) / len(score_values) if score_values else 0.0,
+        "min_score": min(score_values) if score_values else 0.0,
+        "p50_latency_ms": median(latencies) if latencies else 0.0,
+        "p95_latency_ms": percentile(latencies, 0.95),
+    }
+
+
 def recall_response_text(response: Mapping[str, Any]) -> str:
     results = response.get("results") or []
     texts = []
@@ -148,8 +176,10 @@ __all__ = [
     "EVAL_QUERIES",
     "SYNTHETIC_EVENTS",
     "HindsightEvalQuery",
+    "percentile",
     "recall_response_text",
     "score_recall_response",
     "score_recall_text",
+    "summarize_bakeoff_scores",
     "synthetic_retain_payloads",
 ]

--- a/services/zoe-data/tests/test_hindsight_bakeoff.py
+++ b/services/zoe-data/tests/test_hindsight_bakeoff.py
@@ -1,4 +1,15 @@
-from hindsight_bakeoff import EVAL_QUERIES, SYNTHETIC_EVENTS, score_recall_response, synthetic_retain_payloads
+import importlib.util
+import sys
+from pathlib import Path
+
+from hindsight_bakeoff import (
+    EVAL_QUERIES,
+    SYNTHETIC_EVENTS,
+    percentile,
+    score_recall_response,
+    summarize_bakeoff_scores,
+    synthetic_retain_payloads,
+)
 
 
 def test_synthetic_events_validate_and_include_required_cases():
@@ -34,3 +45,43 @@ def test_synthetic_evidence_refs_are_tuples_not_strings():
         assert isinstance(event.evidence_refs, tuple)
         assert all(isinstance(ref, str) for ref in event.evidence_refs)
         assert all(len(ref) > 4 for ref in event.evidence_refs)
+
+
+def test_summarize_bakeoff_scores_reports_score_and_latency():
+    summary = summarize_bakeoff_scores(
+        [
+            {"score": 1.0, "latency_ms": 20.0},
+            {"score": 0.5, "latency_ms": 10.0},
+            {"score": 0.0, "latency_ms": 30.0},
+        ]
+    )
+
+    assert summary["case_count"] == 3
+    assert summary["avg_score"] == 0.5
+    assert summary["min_score"] == 0.0
+    assert summary["p50_latency_ms"] == 20.0
+    assert summary["p95_latency_ms"] == 29.0
+
+
+def test_percentile_rejects_out_of_range_values():
+    try:
+        percentile([1, 2, 3], 95)
+    except ValueError as exc:
+        assert "between 0.0 and 1.0" in str(exc)
+    else:
+        raise AssertionError("percentile accepted an out-of-range value")
+
+
+def test_maintenance_runner_imports_real_bakeoff_module():
+    script_path = Path(__file__).resolve().parents[3] / "scripts" / "maintenance" / "hindsight_bakeoff.py"
+    spec = importlib.util.spec_from_file_location("hindsight_bakeoff_runner", script_path)
+    assert spec and spec.loader
+    runner = importlib.util.module_from_spec(spec)
+    original_sys_path = list(sys.path)
+    try:
+        spec.loader.exec_module(runner)
+    finally:
+        sys.path[:] = original_sys_path
+
+    assert len(runner.EVAL_QUERIES) == len(EVAL_QUERIES)
+    assert runner.summarize_bakeoff_scores([{"score": 1, "latency_ms": 1}])["case_count"] == 1


### PR DESCRIPTION
## Summary
- fix the Hindsight bake-off runner import shadowing bug so it can run from `scripts/maintenance`
- add p50/p95 summary metrics for Hindsight recall evaluation scores
- document the current Zoe-host availability baseline: no Hindsight sidecar process/container is running yet

## Evidence
- `curl --max-time 2 http://127.0.0.1:8888/health` returns connection refused
- no Hindsight process or container is running on the Zoe host
- disabled/default runner mode executes with no retain writes and reports 4 cases, avg_score 0.0, min_score 0.0

## Verification
- python3 tools/audit/validate_structure.py
- python3 tools/audit/validate_critical_files.py
- python3 tools/audit/validate_offline_memory.py
- python3 -m py_compile services/zoe-data/hindsight_bakeoff.py scripts/maintenance/hindsight_bakeoff.py
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_hindsight_bakeoff.py services/zoe-data/tests/test_hindsight_memory.py services/zoe-data/tests/test_hindsight_retain_candidates.py
- PYTHONPATH=services/zoe-data python3 scripts/maintenance/hindsight_bakeoff.py --json
- git diff --check
