### PR TITLE
Add Graphiti relationship fixtures

### DIFF
--- a/docs/architecture/zoe-graphiti-fixtures.md
+++ b/docs/architecture/zoe-graphiti-fixtures.md
@@ -1,0 +1,40 @@
+# Zoe Graphiti Fixtures
+
+## Purpose
+
+Graphiti remains Zoe's candidate for temporal relational truth: people, tools, capabilities, failures, fixes, approvals, recurring tasks, causality, and superseded facts.
+
+This document records the first backend-neutral fixture set. It does not accept Graphiti for production use and does not place graph retrieval in chat.
+
+## Harness
+
+Files:
+
+- `services/zoe-data/graphiti_bakeoff.py`
+- `services/zoe-data/tests/test_graphiti_bakeoff.py`
+
+The fixtures define synthetic Zoe episodes and expected relationship questions before any FalkorDB or Neo4j service is started. Later runners should ingest the same episodes into Graphiti, query each evaluation question, and score returned answers with the same helper functions.
+
+Covered relationship topics:
+
+- weather failure -> cause -> fix -> test evidence;
+- memory preference supersession from an older Hindsight-first episode to a newer MemPalace-baseline episode;
+- Multica governance approval and trust conditions;
+- Hermes as the trusted planning/Greptile lane;
+- Graphify refresh as a recurring system-understanding task.
+
+## Acceptance Use
+
+The next Graphiti bake-off PR should:
+
+- run FalkorDB first;
+- run Neo4j second only if feasible;
+- ingest `GRAPHITI_EPISODES`;
+- query `GRAPHITI_EVAL_QUERIES`;
+- record p50/p95 latency;
+- record CPU/RAM footprint;
+- prove every returned edge or answer includes evidence;
+- verify superseded facts are preserved rather than destructively overwritten;
+- mark the graph path async-only if p95 exceeds 2 seconds or Jetson footprint is too high.
+
+Graphiti must remain outside the normal chat hot path until those measurements exist.

--- a/docs/strategy/zoe-evolution-harness-status.md
+++ b/docs/strategy/zoe-evolution-harness-status.md
@@ -32,7 +32,7 @@ Important non-complete truth:
 - Graphify has been refreshed from `origin/main` at `ad52f61d`; rerun it after subsequent code or architecture changes.
 - Tool/capability and memory read/write inventories now exist as cleanup gates; keep them updated as runtime paths change.
 - MemPalace now has a repeatable local baseline harness and first measured Zoe-host run; Hindsight now has a fixed measured runner and Zoe-host availability baseline, but no live sidecar bake-off yet because no Hindsight process/container is running.
-- Graphiti/FalkorDB/Neo4j have not yet been measured for Zoe relational memory.
+- Graphiti/FalkorDB/Neo4j have not yet been measured for Zoe relational memory, but Zoe-specific Graphiti fixtures now define the first relationship eval set.
 - The plan now names Zoe's missing north-star layer: capability profiles, trust/autonomy classes, candidate scouting, outcome evals, and hardware-aware promotion.
 - The deterministic memory router is not yet wired into production chat behind a feature flag.
 - Retain-candidate admission is not yet fully governed through Multica approval.
@@ -51,7 +51,7 @@ Important non-complete truth:
 | Memory router | Partial | `services/zoe-data/zoe_memory_router.py` and `services/zoe-data/tests/test_zoe_memory_router.py`. | Wire into chat/agent recall behind a disabled-by-default feature flag with latency guards. |
 | MemPalace baseline | Complete foundation | `services/zoe-data/mempalace_baseline.py`, `scripts/maintenance/mempalace_baseline.py`, and `docs/architecture/zoe-mempalace-baseline.md` record a repeatable local benchmark; first run scored 1.0 avg with p95 200.90 ms and cleaned up 4 synthetic rows. | Expand with relational/supersession cases before comparing Graphiti-style backends. |
 | Hindsight bake-off | Partial | Offline sidecar client, retain-candidate helpers, synthetic fixtures, measured runner, availability doc, and tests exist; current Zoe-host check found no running Hindsight sidecar. | Start a local/offline sidecar, run retain/recall with synthetic events, and record p50/p95 latency, failures, evidence quality, and CPU/RAM use. |
-| Graphiti bake-off | Not started | ADR exists only. | Build Graphiti evaluation fixtures, then test FalkorDB first and Neo4j second if feasible. |
+| Graphiti bake-off | Partial | ADR plus `services/zoe-data/graphiti_bakeoff.py`, `services/zoe-data/tests/test_graphiti_bakeoff.py`, and `docs/architecture/zoe-graphiti-fixtures.md` define the first relationship fixture set. | Run the fixtures against FalkorDB first, then Neo4j if feasible, and record latency, evidence quality, supersession behavior, and CPU/RAM use. |
 | Graphify current map | Complete foundation | `graphify-out/GRAPH_REPORT.md` and `graphify-out/graph.json` were regenerated from `origin/main` at `ad52f61d`; `docs/architecture/zoe-harness-current-inventory.md` records the source-backed inventory. | Rerun Graphify after substantial code or architecture changes. |
 | Tool/capability inventory | Complete foundation | `docs/architecture/zoe-tool-capability-inventory.md` maps agent, MCP, Multica, Hermes, OpenClaw, and governance surfaces. | Keep updated when tool catalogs or execution lanes change. |
 | Memory read/write inventory | Complete foundation | `docs/architecture/zoe-memory-read-write-inventory.md` maps MemoryService operations, durable writes, prompt reads, MCP paths, Hindsight candidates, and metadata gaps. | Keep updated when memory write/read paths change. |
@@ -173,8 +173,8 @@ Keep each pull request small enough for Greptile and Zoe verification.
    - Produce measured p50/p95, evidence quality, CPU/RAM, and gaps.
    - Keep it out of production chat until feature-flagged and measured.
 6. Graphiti relational bake-off.
-   - Add fixtures first.
-   - Test FalkorDB, then Neo4j if feasible.
+   - Status: fixture foundation complete.
+   - Next: test FalkorDB, then Neo4j if feasible.
    - Decide sidecar/remote/hot-path eligibility from evidence.
 7. Runtime memory router feature flag.
    - Wire deterministic routing into chat/agent recall in fallback-safe mode.

--- a/services/zoe-data/graphiti_bakeoff.py
+++ b/services/zoe-data/graphiti_bakeoff.py
@@ -1,0 +1,221 @@
+"""Zoe Graphiti bake-off fixtures and scoring helpers.
+
+These fixtures are backend-neutral. A later runner can feed the episodes into
+Graphiti backed by FalkorDB or Neo4j, then score returned answers against the
+same relationship questions.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from statistics import median
+from typing import Any, Iterable, Mapping, Sequence
+
+
+@dataclass(frozen=True)
+class GraphitiEvalEpisode:
+    episode_id: str
+    name: str
+    body: str
+    source_description: str
+    evidence_refs: tuple[str, ...]
+    reference_time: str
+
+
+@dataclass(frozen=True)
+class GraphitiEvalQuery:
+    name: str
+    question: str
+    expected_terms: tuple[str, ...]
+    expected_relationship_path: tuple[str, ...]
+
+
+GRAPHITI_EPISODES: tuple[GraphitiEvalEpisode, ...] = (
+    GraphitiEvalEpisode(
+        episode_id="graphiti_weather_failure_fix",
+        name="Weather failure fixed by voice queue guard",
+        body=(
+            "Zoe weather_card FAILED_ON mobile_dashboard_render because duplicate_voice_queue_emit CAUSED_BY "
+            "voice_queue. The fix duplicate_weather_response FIXED_BY voice_queue_guard was MEASURED_BY "
+            "pytest:test_voice_transcribe. Evidence trace:weather-queue:001 and commit:voice-queue-guard."
+        ),
+        source_description="Zoe synthetic failure/fix trace",
+        evidence_refs=("trace:weather-queue:001", "commit:voice-queue-guard", "pytest:test_voice_transcribe"),
+        reference_time="2026-06-09T00:00:00Z",
+    ),
+    GraphitiEvalEpisode(
+        episode_id="graphiti_memory_preference_old",
+        name="Old Hindsight-first memory preference",
+        body=(
+            "Jason preferred Hindsight as Zoe's first memory bake-off because it fits Postgres and "
+            "self-evolving experience memory. Evidence chat:2026-06-08:hindsight-first."
+        ),
+        source_description="Zoe synthetic old preference episode",
+        evidence_refs=("chat:2026-06-08:hindsight-first",),
+        reference_time="2026-06-08T00:00:00Z",
+    ),
+    GraphitiEvalEpisode(
+        episode_id="graphiti_memory_preference_current",
+        name="Current MemPalace-baseline memory preference",
+        body=(
+            "Jason corrected the plan: MemPalace remains Zoe's offline baseline memory until another offline "
+            "system beats it on Zoe-specific latency, recall, and governance tests. The MemPalace baseline "
+            "preference SUPERSEDES chat:2026-06-08:hindsight-first and is EVIDENCED_BY "
+            "chat:2026-06-09:mempalace-baseline."
+        ),
+        source_description="Zoe synthetic current preference episode",
+        evidence_refs=("chat:2026-06-09:mempalace-baseline",),
+        reference_time="2026-06-09T00:00:00Z",
+    ),
+    GraphitiEvalEpisode(
+        episode_id="graphiti_governance_approval",
+        name="Self-evolution memory governance",
+        body=(
+            "Jason APPROVED_BY Multica evidence gates for Zoe self_evolution_memory. Multica is TRUSTED_FOR "
+            "self_evolution_governance only when proposal evidence, tests, and PR evidence exist. "
+            "Evidence doc:ADR-zoe-memory-layer and pr:231."
+        ),
+        source_description="Zoe synthetic governance approval",
+        evidence_refs=("doc:ADR-zoe-memory-layer", "pr:231"),
+        reference_time="2026-06-09T00:00:00Z",
+    ),
+    GraphitiEvalEpisode(
+        episode_id="graphiti_capability_lane",
+        name="Hermes trusted capability lane",
+        body=(
+            "Hermes USES Greptile review loops and Grep loop repair packets. Hermes is TRUSTED_FOR planning, "
+            "architecture analysis, implementation repair, and review-loop execution. OpenClaw remains manual "
+            "fallback, not the default planning lane. Evidence docs:zoe-tool-capability-inventory."
+        ),
+        source_description="Zoe synthetic capability lane",
+        evidence_refs=("docs:zoe-tool-capability-inventory",),
+        reference_time="2026-06-09T00:00:00Z",
+    ),
+    GraphitiEvalEpisode(
+        episode_id="graphiti_recurring_task",
+        name="Graphify recurring refresh task",
+        body=(
+            "Graphify BELONGS_TO_SCOPE system understanding. Graphify graph report RECURS_AS refresh_after_substantial_code_change. "
+            "Stale graph reports should CAUSE Notice records before cleanup or architecture decisions. "
+            "Evidence docs:zoe-harness-current-inventory and graphify-out:GRAPH_REPORT."
+        ),
+        source_description="Zoe synthetic recurring task",
+        evidence_refs=("docs:zoe-harness-current-inventory", "graphify-out:GRAPH_REPORT"),
+        reference_time="2026-06-09T00:00:00Z",
+    ),
+)
+
+
+GRAPHITI_EVAL_QUERIES: tuple[GraphitiEvalQuery, ...] = (
+    GraphitiEvalQuery(
+        name="multi_hop_failure_fix",
+        question="What fixed the weather card failure and what measured it?",
+        expected_terms=("weather", "voice_queue_guard", "pytest"),
+        expected_relationship_path=("weather_card", "FAILED_ON", "mobile_dashboard_render", "FIXED_BY", "voice_queue_guard", "MEASURED_BY"),
+    ),
+    GraphitiEvalQuery(
+        name="superseded_memory_preference",
+        question="What is Jason's current memory baseline preference and what old fact did it supersede?",
+        expected_terms=("mempalace", "offline", "supersedes", "hindsight"),
+        expected_relationship_path=("mempalace", "SUPERSEDES", "hindsight-first"),
+    ),
+    GraphitiEvalQuery(
+        name="governance_trust",
+        question="Which governance layer is trusted for Zoe self-evolution memory and under what evidence condition?",
+        expected_terms=("multica", "trusted", "proposal", "tests"),
+        expected_relationship_path=("multica", "TRUSTED_FOR", "self_evolution_governance", "EVIDENCED_BY"),
+    ),
+    GraphitiEvalQuery(
+        name="capability_lane",
+        question="Which lane should Zoe use for planning and Greptile review loops?",
+        expected_terms=("hermes", "greptile", "planning"),
+        expected_relationship_path=("hermes", "USES", "greptile", "TRUSTED_FOR", "planning"),
+    ),
+    GraphitiEvalQuery(
+        name="recurring_graphify_refresh",
+        question="When should Graphify refresh recur and what should stale reports cause?",
+        expected_terms=("refresh", "substantial", "notice", "cleanup"),
+        expected_relationship_path=("graphify", "RECURS_AS", "refresh_after_substantial_code_change", "CAUSE", "Notice"),
+    ),
+)
+
+
+def graphiti_episode_payloads() -> list[dict[str, Any]]:
+    return [
+        {
+            "episode_id": episode.episode_id,
+            "name": episode.name,
+            "episode_body": episode.body,
+            "source_description": episode.source_description,
+            "reference_time": episode.reference_time,
+            "evidence_refs": list(episode.evidence_refs),
+        }
+        for episode in GRAPHITI_EPISODES
+    ]
+
+
+def score_answer_text(text: str, expected_terms: Iterable[str]) -> dict[str, Any]:
+    lowered = text.lower()
+    expected = tuple(term.lower() for term in expected_terms)
+    matched = tuple(term for term in expected if term in lowered)
+    return {
+        "matched": list(matched),
+        "missing": [term for term in expected if term not in matched],
+        "score": 1.0 if not expected else len(matched) / len(expected),
+    }
+
+
+def score_graphiti_answer(answer: Mapping[str, Any] | str, query: GraphitiEvalQuery) -> dict[str, Any]:
+    if isinstance(answer, Mapping):
+        raw = answer.get("text") if answer.get("text") is not None else answer.get("answer")
+        text = str(raw) if raw is not None else str(answer)
+    else:
+        text = str(answer)
+    score = score_answer_text(text, query.expected_terms)
+    return {
+        "name": query.name,
+        "question": query.question,
+        "expected_relationship_path": list(query.expected_relationship_path),
+        "text": text,
+        **score,
+    }
+
+
+def percentile(values: Sequence[float], percentile_value: float) -> float:
+    if not 0.0 <= percentile_value <= 1.0:
+        raise ValueError("percentile_value must be between 0.0 and 1.0")
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return ordered[0]
+    rank = (len(ordered) - 1) * percentile_value
+    lower = int(rank)
+    upper = min(lower + 1, len(ordered) - 1)
+    weight = rank - lower
+    return ordered[lower] * (1 - weight) + ordered[upper] * weight
+
+
+def summarize_graphiti_scores(scores: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    score_values = [float(item.get("score") or 0.0) for item in scores]
+    latencies = [float(item.get("latency_ms") or 0.0) for item in scores if "latency_ms" in item]
+    return {
+        "case_count": len(scores),
+        "avg_score": sum(score_values) / len(score_values) if score_values else 0.0,
+        "min_score": min(score_values) if score_values else 0.0,
+        "p50_latency_ms": median(latencies) if latencies else 0.0,
+        "p95_latency_ms": percentile(latencies, 0.95),
+    }
+
+
+__all__ = [
+    "GRAPHITI_EPISODES",
+    "GRAPHITI_EVAL_QUERIES",
+    "GraphitiEvalEpisode",
+    "GraphitiEvalQuery",
+    "graphiti_episode_payloads",
+    "percentile",
+    "score_answer_text",
+    "score_graphiti_answer",
+    "summarize_graphiti_scores",
+]

--- a/services/zoe-data/tests/test_graphiti_bakeoff.py
+++ b/services/zoe-data/tests/test_graphiti_bakeoff.py
@@ -1,0 +1,91 @@
+import pytest
+
+from graphiti_bakeoff import (
+    GRAPHITI_EPISODES,
+    GRAPHITI_EVAL_QUERIES,
+    graphiti_episode_payloads,
+    percentile,
+    score_graphiti_answer,
+    summarize_graphiti_scores,
+)
+
+
+def test_graphiti_episodes_cover_zoe_relationship_topics():
+    ids = {episode.episode_id for episode in GRAPHITI_EPISODES}
+
+    assert ids == {
+        "graphiti_weather_failure_fix",
+        "graphiti_memory_preference_old",
+        "graphiti_memory_preference_current",
+        "graphiti_governance_approval",
+        "graphiti_capability_lane",
+        "graphiti_recurring_task",
+    }
+    assert all(episode.evidence_refs for episode in GRAPHITI_EPISODES)
+
+
+def test_graphiti_queries_cover_multi_hop_and_supersession():
+    names = {query.name for query in GRAPHITI_EVAL_QUERIES}
+
+    assert names == {
+        "multi_hop_failure_fix",
+        "superseded_memory_preference",
+        "governance_trust",
+        "capability_lane",
+        "recurring_graphify_refresh",
+    }
+    assert all(query.expected_relationship_path for query in GRAPHITI_EVAL_QUERIES)
+
+
+def test_graphiti_episode_payloads_include_evidence():
+    payloads = graphiti_episode_payloads()
+
+    assert len(payloads) == len(GRAPHITI_EPISODES)
+    assert all(payload["episode_id"] for payload in payloads)
+    assert all(payload["episode_body"] for payload in payloads)
+    assert all(payload["evidence_refs"] for payload in payloads)
+
+
+def test_graphiti_supersession_payloads_have_temporal_order():
+    payloads = {payload["episode_id"]: payload for payload in graphiti_episode_payloads()}
+
+    assert payloads["graphiti_memory_preference_old"]["reference_time"] < payloads["graphiti_memory_preference_current"]["reference_time"]
+    assert "SUPERSEDES" in payloads["graphiti_memory_preference_current"]["episode_body"]
+
+
+def test_score_graphiti_answer_reports_missing_terms():
+    query = GRAPHITI_EVAL_QUERIES[0]
+    score = score_graphiti_answer("weather fixed by voice_queue_guard", query)
+
+    assert score["score"] == 2 / 3
+    assert score["missing"] == ["pytest"]
+    assert score["expected_relationship_path"] == list(query.expected_relationship_path)
+
+
+def test_score_graphiti_answer_respects_empty_text_field():
+    query = GRAPHITI_EVAL_QUERIES[0]
+    score = score_graphiti_answer({"text": ""}, query)
+
+    assert score["text"] == ""
+    assert score["score"] == 0.0
+
+
+def test_summarize_graphiti_scores_reports_latency():
+    summary = summarize_graphiti_scores(
+        [
+            {"score": 1.0, "latency_ms": 100.0},
+            {"score": 0.5, "latency_ms": 200.0},
+            {"score": 0.0, "latency_ms": 300.0},
+        ]
+    )
+
+    assert summary["case_count"] == 3
+    assert summary["avg_score"] == 0.5
+    assert summary["min_score"] == 0.0
+    assert summary["p50_latency_ms"] == 200.0
+    assert summary["p95_latency_ms"] == 290.0
+
+
+def test_percentile_rejects_out_of_range_values():
+    with pytest.raises(ValueError, match="between 0.0 and 1.0"):
+        percentile([1, 2, 3], 95)


### PR DESCRIPTION
## Summary
- add Zoe-specific Graphiti relationship fixtures for failures/fixes, supersession, governance, capability trust, and recurring Graphify refresh
- add backend-neutral scoring and latency summary helpers for future FalkorDB/Neo4j runs
- document how the fixtures should be used before Graphiti enters any chat path

## Verification
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_graphiti_bakeoff.py
- python3 tools/audit/validate_structure.py
- python3 tools/audit/validate_critical_files.py
- python3 tools/audit/validate_offline_memory.py
- python3 -m py_compile services/zoe-data/graphiti_bakeoff.py
- git diff --check
