### PR TITLE
Guard implement handoff drift

### DIFF
--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -324,6 +324,33 @@ def _harness_implement_hint(issue: dict | None = None) -> str:
     )
 
 
+def _intent_gap_implement_hint(issue: dict | None = None, *, phase: str = "implement") -> str:
+    issue = issue or {}
+    haystack = " ".join(
+        [
+            str(issue.get("identifier") or ""),
+            str(issue.get("title") or ""),
+            str(issue.get("description") or ""),
+        ]
+    ).lower()
+    if "intent gap" not in haystack and "intent-gap" not in haystack:
+        return ""
+    edit_deadline = (
+        " Start editing within 4 tool/model steps after `kanban_show`.\n"
+        if phase == "implement"
+        else " After the existing-PR checkout checks succeed, start the focused revision edit within 4 tool/model steps.\n"
+    )
+    return (
+        "- INTENT-GAP IMPLEMENT FAST PATH: this ticket is already scoped by scout as"
+        " a routing/intent gap. Do not re-scout the repo. Start from"
+        " services/zoe-data/intent_router.py and the nearest intent_router tests;"
+        " inspect each at most once, then patch the intent route and focused tests."
+        " If those files are not the right location, call `kanban_block` with"
+        " BLOCKER=IMPLEMENT_BUDGET and the missing locator instead of exploring."
+        f"{edit_deadline}"
+    )
+
+
 def _is_bounded_goal_phase(phase: str, issue: dict | None = None) -> bool:
     """Return True when this phase should run in bounded goal mode with one retry."""
     return phase == "implement" and _is_code_audit_actionable(_ticket_metadata(issue))
@@ -552,16 +579,18 @@ class KanbanAdapter:
                 " BLOCKER=SCOUT_BUDGET and the missing information instead of exploring further.\n"
                 "- TERMINAL PROTOCOL: end with `kanban_complete` or `kanban_block` (no silent exit)."
             )
-        if phase == "implement":
+        if phase in {"implement", "implement_revision"}:
             overnight_hint = _overnight_implement_cost_hint() if mode == "overnight" else ""
             code_audit_hint = _code_audit_implement_hint(issue)
             harness_hint = _harness_implement_hint(issue)
+            intent_gap_hint = _intent_gap_implement_hint(issue, phase=phase)
             # Implement body intentionally omits full prior-phase logs; workers should
             # call kanban_show and read SCOUT_SUMMARY= from scout metadata when present.
             return common + overnight_hint + (
                 "You are the implementer (zoe-coder).\n"
                 f"{code_audit_hint}"
                 f"{harness_hint}"
+                f"{intent_gap_hint}"
                 "- AUDIT/SMOKE FAST PATH: only if the title/body explicitly says audit-only, smoke test,"
                 " no code change, or uses trace/map with an audit/no-code qualifier, do not run Graphify"
                 " or repo exploration first. Complete in one bounded handoff with"

--- a/services/zoe-data/kanban_phase_budget.py
+++ b/services/zoe-data/kanban_phase_budget.py
@@ -43,6 +43,10 @@ _PYTHON_CHECK_RE = re.compile(
     r"^\s*(?:┊|\|)\s+\S+\s+\$\s+.*\b(py_compile|pytest|mypy|ruff|validate_structure|validate_critical_files)\b",
     re.IGNORECASE,
 )
+_PATCH_STEP_RE = re.compile(r"^\s*(?:┊|\|)\s+\S+\s+patch\b", re.IGNORECASE)
+_TERMINAL_STEP_RE = re.compile(r"^\s*(?:┊|\|)\s+\S+\s+kanban_(?:complete|block)\b", re.IGNORECASE)
+_EXPLORE_STEP_RE = re.compile(r"^\s*(?:┊|\|)\s+\S+\s+(?:read|grep|find)\b", re.IGNORECASE)
+_READ_STEP_RE = re.compile(r"^\s*(?:┊|\|)\s+\S+\s+read\s+(?P<path>\S+)", re.IGNORECASE)
 _MARK_REVIEWED_VERDICT_RE = re.compile(
     r"\bmark-reviewed\b(?=.*--critical-count)(?=.*--summary)",
     re.IGNORECASE,
@@ -152,7 +156,7 @@ def phase_budget_reason_from_log(task_id: str, phase: str) -> str | None:
     )
 
 
-def implement_edit_safety_reason_from_log(task_id: str, phase: str) -> str | None:
+def implement_edit_safety_reason_from_log(task_id: str, phase: str, *, session: str | None = None) -> str | None:
     """Block implement runs that patch Python then keep exploring before syntax checks.
 
     Prompt instructions are not enough for cost control: a worker can apply a
@@ -162,7 +166,8 @@ def implement_edit_safety_reason_from_log(task_id: str, phase: str) -> str | Non
     """
     if phase not in {"implement", "implement_revision"}:
         return None
-    session = _latest_log_session(task_id, max_lines=0)
+    if session is None:
+        session = _latest_log_session(task_id, max_lines=0)
     if not session:
         return None
 
@@ -182,6 +187,69 @@ def implement_edit_safety_reason_from_log(task_id: str, phase: str) -> str | Non
             "BLOCKER=IMPLEMENT_EDIT_SAFETY: Python patch was followed by more "
             "exploration before py_compile/focused tests"
         )
+    return None
+
+
+def _pre_edit_explore_budget() -> int:
+    try:
+        return max(1, int(os.environ.get("ZOE_KANBAN_IMPLEMENT_PRE_EDIT_EXPLORE_BUDGET", "12")))
+    except ValueError:
+        return 12
+
+
+def _pre_edit_repeat_read_budget() -> int:
+    try:
+        return max(1, int(os.environ.get("ZOE_KANBAN_IMPLEMENT_PRE_EDIT_REPEAT_READ_BUDGET", "6")))
+    except ValueError:
+        return 6
+
+
+def _read_path_key(raw_path: str) -> str:
+    return re.sub(r":\d+(?:-\d+)?$", "", raw_path)
+
+
+def implement_pre_edit_drift_reason_from_log(task_id: str, phase: str, *, session: str | None = None) -> str | None:
+    """Block implement runs that keep exploring before making any edit.
+
+    Real production failures showed workers ignoring a narrow scout handoff and
+    repeatedly reading/grepping the same files until Hermes' full iteration
+    budget was gone. This guard cuts that loop off earlier. Once a patch or a
+    terminal Kanban call appears, this pre-edit guard stands down and the normal
+    edit-safety / evidence gates take over.
+    """
+    if phase not in {"implement", "implement_revision"}:
+        return None
+    if session is None:
+        session = _latest_log_session(task_id, max_lines=0)
+    if not session:
+        return None
+
+    step_lines = [line for line in session.splitlines() if _STEP_LINE_RE.match(line)]
+    if any(_PATCH_STEP_RE.search(line) or _TERMINAL_STEP_RE.search(line) for line in step_lines):
+        return None
+
+    explore_budget = _pre_edit_explore_budget()
+    repeat_read_budget = _pre_edit_repeat_read_budget()
+    explore_steps = 0
+    read_counts: dict[str, int] = {}
+    for line in step_lines:
+        if not _EXPLORE_STEP_RE.search(line):
+            continue
+        explore_steps += 1
+        read_match = _READ_STEP_RE.search(line)
+        if explore_steps > explore_budget:
+            return (
+                "BLOCKER=IMPLEMENT_HANDOFF_DRIFT: pre-edit exploration exceeded "
+                f"budget without patch (steps={explore_steps}, limit={explore_budget})"
+            )
+        if read_match:
+            path = _read_path_key(read_match.group("path"))
+            read_counts[path] = read_counts.get(path, 0) + 1
+            if read_counts[path] > repeat_read_budget:
+                return (
+                    "BLOCKER=IMPLEMENT_HANDOFF_DRIFT: repeated pre-edit reads "
+                    f"without patch (file={path}, reads={read_counts[path]})"
+                )
     return None
 
 
@@ -298,9 +366,13 @@ def phase_budget_reason(
             f"BLOCKER={phase.upper()}_BUDGET: code-enforced tool budget exceeded "
             f"(steps={tool_steps}, guidance_limit={tool_limit}, hard_limit={hard_limit})"
         )
-    edit_safety_reason = implement_edit_safety_reason_from_log(task_id, phase)
+    session = _latest_log_session(task_id, max_lines=0) if phase in {"implement", "implement_revision"} else None
+    edit_safety_reason = implement_edit_safety_reason_from_log(task_id, phase, session=session)
     if edit_safety_reason:
         return edit_safety_reason
+    pre_edit_drift_reason = implement_pre_edit_drift_reason_from_log(task_id, phase, session=session)
+    if pre_edit_drift_reason:
+        return pre_edit_drift_reason
     log_reason = phase_budget_reason_from_log(task_id, phase)
     if log_reason:
         return log_reason

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -1951,6 +1951,199 @@ def test_implement_edit_safety_covers_revision_phase(tmp_path, monkeypatch):
     assert "IMPLEMENT_EDIT_SAFETY" in reason
 
 
+def test_implement_pre_edit_drift_blocks_repeated_reads_without_patch(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("ZOE_KANBAN_IMPLEMENT_PRE_EDIT_REPEAT_READ_BUDGET", "6")
+    log_dir = tmp_path / "kanban" / "logs"
+    log_dir.mkdir(parents=True)
+    repeated_reads = "\n".join(
+        "  ┊ 📖 read      /work/services/zoe-data/intent_router.py  0.1s"
+        for _ in range(7)
+    )
+    (log_dir / "t_impl.log").write_text(
+        "Query: work kanban task t_impl\n"
+        "  ┊ ⚡ kanban_sh   0.0s\n"
+        "  ┊ 💻 $         cd /work && git status  0.1s\n"
+        f"{repeated_reads}\n",
+        encoding="utf-8",
+    )
+
+    reason = kb.implement_pre_edit_drift_reason_from_log("t_impl", "implement")
+
+    assert reason is not None
+    assert "IMPLEMENT_HANDOFF_DRIFT" in reason
+    assert "repeated pre-edit reads" in reason
+
+
+def test_implement_pre_edit_drift_normalizes_read_range_suffixes(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("ZOE_KANBAN_IMPLEMENT_PRE_EDIT_REPEAT_READ_BUDGET", "3")
+    monkeypatch.setenv("ZOE_KANBAN_IMPLEMENT_PRE_EDIT_EXPLORE_BUDGET", "20")
+    log_dir = tmp_path / "kanban" / "logs"
+    log_dir.mkdir(parents=True)
+    ranged_reads = "\n".join(
+        f"  ┊ 📖 read      /work/services/zoe-data/intent_router.py:{index}-{index + 20}  0.1s"
+        for index in [1, 40, 80, 120]
+    )
+    (log_dir / "t_impl.log").write_text(
+        "Query: work kanban task t_impl\n"
+        f"{ranged_reads}\n",
+        encoding="utf-8",
+    )
+
+    reason = kb.implement_pre_edit_drift_reason_from_log("t_impl", "implement")
+
+    assert reason is not None
+    assert "repeated pre-edit reads" in reason
+    assert "file=/work/services/zoe-data/intent_router.py" in reason
+
+
+def test_implement_pre_edit_drift_blocks_exploration_without_patch(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("ZOE_KANBAN_IMPLEMENT_PRE_EDIT_EXPLORE_BUDGET", "12")
+    log_dir = tmp_path / "kanban" / "logs"
+    log_dir.mkdir(parents=True)
+    explore = "\n".join(
+        f"  ┊ 🔎 grep      symbol_{index}  0.1s"
+        for index in range(13)
+    )
+    (log_dir / "t_impl.log").write_text(
+        "Query: work kanban task t_impl\n"
+        "  ┊ ⚡ kanban_sh   0.0s\n"
+        f"{explore}\n",
+        encoding="utf-8",
+    )
+
+    reason = kb.implement_pre_edit_drift_reason_from_log("t_impl", "implement")
+
+    assert reason is not None
+    assert "pre-edit exploration exceeded budget" in reason
+
+
+def test_implement_pre_edit_drift_prioritizes_explore_budget_when_both_trip(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("ZOE_KANBAN_IMPLEMENT_PRE_EDIT_REPEAT_READ_BUDGET", "3")
+    monkeypatch.setenv("ZOE_KANBAN_IMPLEMENT_PRE_EDIT_EXPLORE_BUDGET", "3")
+    log_dir = tmp_path / "kanban" / "logs"
+    log_dir.mkdir(parents=True)
+    repeated_reads = "\n".join(
+        "  ┊ 📖 read      /work/services/zoe-data/intent_router.py  0.1s"
+        for _ in range(4)
+    )
+    (log_dir / "t_impl.log").write_text(
+        "Query: work kanban task t_impl\n"
+        f"{repeated_reads}\n",
+        encoding="utf-8",
+    )
+
+    reason = kb.implement_pre_edit_drift_reason_from_log("t_impl", "implement")
+
+    assert reason is not None
+    assert "pre-edit exploration exceeded budget" in reason
+
+
+def test_implement_pre_edit_drift_stands_down_after_patch(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    log_dir = tmp_path / "kanban" / "logs"
+    log_dir.mkdir(parents=True)
+    (log_dir / "t_impl.log").write_text(
+        "Query: work kanban task t_impl\n"
+        "  ┊ 📖 read      /work/services/zoe-data/intent_router.py  0.1s\n"
+        "  ┊ 📖 read      /work/services/zoe-data/intent_router.py  0.1s\n"
+        "  ┊ 🔧 patch     /work/services/zoe-data/intent_router.py  5.9s\n"
+        "  ┊ 📖 read      /work/services/zoe-data/intent_router.py  0.1s\n",
+        encoding="utf-8",
+    )
+
+    assert kb.implement_pre_edit_drift_reason_from_log("t_impl", "implement") is None
+
+
+def test_implement_pre_edit_drift_stands_down_after_terminal_call(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("ZOE_KANBAN_IMPLEMENT_PRE_EDIT_EXPLORE_BUDGET", "12")
+    log_dir = tmp_path / "kanban" / "logs"
+    log_dir.mkdir(parents=True)
+    explore = "\n".join(
+        f"  ┊ 🔎 grep      symbol_{index}  0.1s"
+        for index in range(13)
+    )
+    (log_dir / "t_impl.log").write_text(
+        "Query: work kanban task t_impl\n"
+        f"{explore}\n"
+        "  ┊ ✅ kanban_block  0.1s\n",
+        encoding="utf-8",
+    )
+
+    assert kb.implement_pre_edit_drift_reason_from_log("t_impl", "implement") is None
+
+
+def test_implement_pre_edit_drift_covers_revision_phase(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("ZOE_KANBAN_IMPLEMENT_PRE_EDIT_EXPLORE_BUDGET", "12")
+    log_dir = tmp_path / "kanban" / "logs"
+    log_dir.mkdir(parents=True)
+    explore = "\n".join(
+        f"  ┊ 🔎 grep      stale_comment_{index}  0.1s"
+        for index in range(13)
+    )
+    (log_dir / "t_revision.log").write_text(
+        "Query: work kanban task t_revision\n"
+        f"{explore}\n",
+        encoding="utf-8",
+    )
+
+    reason = kb.implement_pre_edit_drift_reason_from_log("t_revision", "implement_revision")
+
+    assert reason is not None
+    assert "IMPLEMENT_HANDOFF_DRIFT" in reason
+
+
+def test_phase_budget_reason_blocks_pre_edit_handoff_drift(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("ZOE_KANBAN_IMPLEMENT_PRE_EDIT_EXPLORE_BUDGET", "12")
+    log_dir = tmp_path / "kanban" / "logs"
+    log_dir.mkdir(parents=True)
+    explore = "\n".join(
+        f"  ┊ 🔎 grep      symbol_{index}  0.1s"
+        for index in range(13)
+    )
+    (log_dir / "t_impl.log").write_text(
+        "Query: work kanban task t_impl\n"
+        f"{explore}\n",
+        encoding="utf-8",
+    )
+
+    reason = kb.phase_budget_reason(
+        "t_impl",
+        "implement",
+        {"task": {"started_at": 100}, "runs": [{"started_at": 100}]},
+        now=120,
+    )
+
+    assert reason is not None
+    assert "IMPLEMENT_HANDOFF_DRIFT" in reason
+
+
+def test_phase_budget_reason_reuses_implement_log_session(monkeypatch):
+    monkeypatch.setattr(kb, "tool_step_count", lambda *args, **kwargs: 1)
+    monkeypatch.setattr(kb, "_started_timestamp", lambda detail: None)
+    calls = []
+
+    def fake_latest(task_id, *, max_lines=120):
+        calls.append(max_lines)
+        if max_lines == 0:
+            return (
+                "Query: work kanban task t_impl\n"
+                "  ┊ 📖 read      /work/services/zoe-data/intent_router.py  0.1s\n"
+            )
+        return ""
+
+    monkeypatch.setattr(kb, "_latest_log_session", fake_latest)
+
+    assert kb.phase_budget_reason("t_impl", "implement", {"task": {}, "runs": []}) is None
+    assert calls.count(0) == 1
+
+
 def test_phase_budget_reason_ignores_stale_iteration_budget_log_session(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     log_dir = tmp_path / "kanban" / "logs"
@@ -2918,6 +3111,44 @@ def test_implement_body_includes_unconditional_scout_handoff_fast_path():
     assert "intent-gap tickets" in body
     assert "start editing within 4 tool/model steps" in body
     assert body.index("SCOUT HANDOFF FAST PATH") < body.index("SMALL EXPLICIT CODE FAST PATH")
+
+
+def test_implement_body_includes_intent_gap_fast_path():
+    body = ka.KanbanAdapter()._build_body(
+        "implement",
+        {
+            "id": "uuid-intent",
+            "identifier": "ZOE-5451",
+            "title": "Intent gap: 'Tell me a joke.'",
+            "description": "SCOUT_SUMMARY says services/zoe-data/intent_router.py needs a narrow route.",
+        },
+        "ZOE-5451",
+    )
+
+    assert "INTENT-GAP IMPLEMENT FAST PATH" in body
+    assert "services/zoe-data/intent_router.py" in body
+    assert "nearest intent_router tests" in body
+    assert "Start editing within 4 tool/model steps after `kanban_show`" in body
+    assert body.index("INTENT-GAP IMPLEMENT FAST PATH") < body.index("AUDIT/SMOKE FAST PATH")
+
+
+def test_implement_revision_body_includes_intent_gap_fast_path():
+    body = ka.KanbanAdapter()._build_body(
+        "implement_revision",
+        {
+            "id": "uuid-intent",
+            "identifier": "ZOE-5451",
+            "title": "Intent-gap revision: 'Tell me a joke.'",
+            "description": "Existing PR still needs a focused intent_router.py revision.",
+        },
+        "ZOE-5451",
+    )
+
+    assert "INTENT-GAP IMPLEMENT FAST PATH" in body
+    assert "services/zoe-data/intent_router.py" in body
+    assert "EXISTING PR REVISION FAST PATH" in body
+    assert "After the existing-PR checkout checks succeed" in body
+    assert "Start editing within 4 tool/model steps after `kanban_show`" not in body
 
 
 def test_retro_body_has_post_closeout_fast_path():


### PR DESCRIPTION
## Summary\n- add an intent-gap implement fast path that starts from intent_router.py and nearby tests\n- add a code-enforced IMPLEMENT_HANDOFF_DRIFT guard for repeated pre-edit read/grep loops\n- cover the ZOE-5451 over-read failure with regression tests\n\n## Tests\n- python3 -m py_compile services/zoe-data/executors/kanban_adapter.py services/zoe-data/kanban_phase_budget.py services/zoe-data/tests/test_kanban_adapter.py\n- remote focused pytest/validators pending