### PR TITLE
Add Zoe candidate scoring

### DIFF
--- a/docs/architecture/zoe-candidate-scoring.md
+++ b/docs/architecture/zoe-candidate-scoring.md
@@ -1,0 +1,46 @@
+# Zoe Candidate Scoring
+
+## Purpose
+
+Zoe should search and evaluate before she builds or installs. Candidate scoring gives Zoe a repeatable way to compare Pi packages, MCP servers, GitHub projects, local skills, APIs, local services, and existing Zoe capabilities.
+
+This is an evaluation contract only. It does not install, execute, or approve any candidate.
+
+## Harness
+
+Files:
+
+- `services/zoe-data/zoe_candidate_scoring.py`
+- `services/zoe-data/tests/test_zoe_candidate_scoring.py`
+
+Scoring dimensions are 0-5:
+
+- fit;
+- activity;
+- license;
+- offline viability;
+- security;
+- hardware/runtime footprint;
+- tests;
+- maintainability;
+- overlap with existing Zoe capabilities.
+
+The first example records compare:
+
+- keeping MemPalace as Zoe's measured offline baseline;
+- trying Graphiti with FalkorDB as a sidecar;
+- reviewing Pi runtime/package reuse before any install.
+
+## Adoption Gate
+
+The gate blocks candidates when:
+
+- license risk is incompatible or unknown;
+- offline viability is unavailable or unknown;
+- normalized score is below threshold.
+
+This makes the default future behavior conservative: Zoe can scout and propose broadly, but adoption still requires evidence, compatible licensing, offline/local viability, and a good enough score.
+
+## Next Use
+
+Future self-evolution proposal records should attach a candidate score before asking to install, integrate, or replace a capability.

--- a/docs/strategy/zoe-evolution-harness-status.md
+++ b/docs/strategy/zoe-evolution-harness-status.md
@@ -35,6 +35,7 @@ Important non-complete truth:
 - Graphiti/FalkorDB/Neo4j have not yet been measured for Zoe relational memory, but Zoe-specific Graphiti fixtures now define the first relationship eval set.
 - The plan now names Zoe's missing north-star layer: capability profiles, trust/autonomy classes, candidate scouting, outcome evals, and hardware-aware promotion.
 - Zoe now has an executable capability profile contract and initial self-model for key chat, memory, graph, governance, escalation, Pi, and device-control surfaces.
+- Zoe now has candidate scoring for comparing Pi, MCP, GitHub, skill, API, local-service, and existing-Zoe options before adoption.
 - The deterministic memory router is not yet wired into production chat behind a feature flag.
 - Retain-candidate admission is not yet fully governed through Multica approval.
 - The full self-evolution loop is not yet implemented end to end.
@@ -58,6 +59,7 @@ Important non-complete truth:
 | Memory read/write inventory | Complete foundation | `docs/architecture/zoe-memory-read-write-inventory.md` maps MemoryService operations, durable writes, prompt reads, MCP paths, Hindsight candidates, and metadata gaps. | Keep updated when memory write/read paths change. |
 | Zoe north-star layer | Complete foundation | `docs/strategy/zoe-evolution-harness-plan.md` and `docs/adr/ADR-zoe-north-star-layer.md` define capability profiles, trust/autonomy classes, discovery scoring, outcome evals, and hardware budgets. | Build capability profile inventory and candidate-scoring records. |
 | Capability profiles | Complete foundation | `services/zoe-data/zoe_capability_profile.py`, `services/zoe-data/tests/test_zoe_capability_profile.py`, and `docs/architecture/zoe-capability-profiles.md` define the first executable Zoe capability self-model. | Wire profiles into candidate scoring, self-evolution proposals, and cleanup gates. |
+| Candidate scoring | Complete foundation | `services/zoe-data/zoe_candidate_scoring.py`, `services/zoe-data/tests/test_zoe_candidate_scoring.py`, and `docs/architecture/zoe-candidate-scoring.md` define candidate scoring and adoption gates. | Attach candidate scores to self-evolution proposal records before installs or replacements. |
 | Observation/evaluation traces | Not started | Memory metrics exist for MemPalace but not full retrieval helpfulness/contradiction traces. | Add a trace schema for recall, retain candidate, admission, contradiction, and fallback events. |
 | Multica evidence gates | Partial | Implement completion now requires PR evidence for code/default profiles. | Add memory admission gates and explicit self-evolution proposal gates. |
 | Self-evolution loop | Partial | Multica, pipeline evidence, Greploop, Greptile, Hermes, and worktree bootstrap pieces exist. | Implement structured Notice -> Explain -> Search -> Evaluate -> Propose records before any automatic execution. |
@@ -192,8 +194,9 @@ Keep each pull request small enough for Greptile and Zoe verification.
     - Expand profiles for voice, MCP, calendars, reminders, lists, search, maps/charts, proactive scheduling, and setup flows.
     - Use trust level, approval class, tests, budget, dependencies, rollback, and known failures as proposal/cleanup gates.
 11. Candidate discovery scoring.
-    - Add records/templates that compare Pi, MCP, GitHub, local skills, APIs, and existing Zoe capabilities.
-    - Include activity, stars, license, offline viability, security, hardware footprint, test quality, and overlap.
+    - Status: complete foundation.
+    - Candidate records now compare Pi, MCP, GitHub, local skills, APIs, local services, and existing Zoe capabilities.
+    - Next: attach scores to self-evolution proposals and require them before installs/replacements.
 12. Outcome eval trace schema.
     - Track task completion, correction handling, continuity, friction, latency, trust, cleanup quality, and hardware fit.
     - Convert recurring failures into Notice records.

--- a/services/zoe-data/tests/test_zoe_candidate_scoring.py
+++ b/services/zoe-data/tests/test_zoe_candidate_scoring.py
@@ -1,0 +1,104 @@
+import pytest
+
+from zoe_candidate_scoring import (
+    EXAMPLE_CANDIDATES,
+    CandidateEvaluation,
+    CandidateScore,
+    adoption_gate,
+    rank_candidates,
+)
+
+
+def test_candidate_score_validates_range_and_normalizes():
+    score = CandidateScore(fit=5, activity=4, license=3, offline=5, security=4, footprint=3, tests=4, maintainability=4, overlap=5)
+
+    assert score.total() == 37
+    assert score.normalized() == 37 / 45
+
+
+def test_candidate_score_rejects_out_of_range_values():
+    score = CandidateScore(fit=6, activity=4, license=3, offline=5, security=4, footprint=3, tests=4, maintainability=4, overlap=5)
+
+    with pytest.raises(ValueError, match="fit score must be between 0 and 5"):
+        score.validate()
+
+
+def test_example_candidates_validate_and_rank_mempalace_first():
+    ranked = rank_candidates(EXAMPLE_CANDIDATES)
+
+    assert ranked[0].candidate_id == "existing_mempalace"
+    assert all(candidate.evidence_refs for candidate in ranked)
+
+
+def test_adoption_gate_allows_strong_compatible_candidate():
+    candidate = EXAMPLE_CANDIDATES[0]
+
+    gate = adoption_gate(candidate)
+
+    assert gate["allowed"] is True
+    assert gate["blockers"] == []
+
+
+def test_adoption_gate_blocks_unknown_offline_candidate():
+    candidate = EXAMPLE_CANDIDATES[2]
+
+    gate = adoption_gate(candidate)
+
+    assert gate["allowed"] is False
+    assert "offline:unknown" in gate["blockers"]
+
+
+def test_adoption_gate_blocks_incompatible_license():
+    candidate = CandidateEvaluation(
+        candidate_id="bad_license",
+        name="Bad license candidate",
+        source="github",
+        task="test",
+        score=CandidateScore(fit=5, activity=5, license=0, offline=5, security=5, footprint=5, tests=5, maintainability=5, overlap=5),
+        evidence_refs=("test:evidence",),
+        license_risk="incompatible",
+        offline_viability="required",
+        recommendation="reject",
+    )
+
+    gate = adoption_gate(candidate)
+
+    assert gate["allowed"] is False
+    assert "license:incompatible" in gate["blockers"]
+
+
+def test_candidate_validation_requires_evidence_refs():
+    candidate = CandidateEvaluation(
+        candidate_id="no_evidence",
+        name="No evidence candidate",
+        source="github",
+        task="test",
+        score=CandidateScore(fit=3, activity=3, license=3, offline=3, security=3, footprint=3, tests=3, maintainability=3, overlap=3),
+        evidence_refs=(),
+    )
+
+    with pytest.raises(ValueError, match="evidence_refs are required"):
+        candidate.validate()
+
+
+def test_candidate_validation_rejects_unknown_recommendation():
+    candidate = CandidateEvaluation(
+        candidate_id="bad_recommendation",
+        name="Bad recommendation candidate",
+        source="github",
+        task="test",
+        score=CandidateScore(fit=3, activity=3, license=3, offline=3, security=3, footprint=3, tests=3, maintainability=3, overlap=3),
+        evidence_refs=("test:evidence",),
+        recommendation="trail_sidecar",
+    )
+
+    with pytest.raises(ValueError, match="unknown recommendation"):
+        candidate.validate()
+
+
+def test_candidate_to_dict_includes_total_and_normalized_score():
+    payload = EXAMPLE_CANDIDATES[1].to_dict()
+
+    assert payload["total_score"] == EXAMPLE_CANDIDATES[1].score.total()
+    assert payload["normalized_score"] == EXAMPLE_CANDIDATES[1].score.normalized()
+    assert payload["overlaps_existing"] == ["graphiti_relational_memory"]

--- a/services/zoe-data/zoe_candidate_scoring.py
+++ b/services/zoe-data/zoe_candidate_scoring.py
@@ -1,0 +1,197 @@
+"""Candidate scoring for Zoe capability adoption.
+
+Zoe should evaluate existing Pi, MCP, GitHub, skill, API, and local-service
+options before building or installing a new capability.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Sequence
+
+
+CANDIDATE_SOURCES = {"pi", "mcp", "github", "skill", "api", "local_service", "existing_zoe"}
+LICENSE_RISKS = {"compatible", "review", "incompatible", "unknown"}
+OFFLINE_VIABILITY = {"required", "supported", "partial", "unavailable", "unknown"}
+RECOMMENDATIONS = {"keep", "trial_sidecar", "needs_review", "reject"}
+
+
+@dataclass(frozen=True)
+class CandidateScore:
+    fit: int
+    activity: int
+    license: int
+    offline: int
+    security: int
+    footprint: int
+    tests: int
+    maintainability: int
+    overlap: int
+
+    def validate(self) -> None:
+        for field_name, value in self.to_dict().items():
+            if not 0 <= value <= 5:
+                raise ValueError(f"{field_name} score must be between 0 and 5")
+
+    def total(self) -> int:
+        self.validate()
+        return sum(self.to_dict().values())
+
+    def normalized(self) -> float:
+        return self.total() / 45
+
+    def to_dict(self) -> dict[str, int]:
+        return {
+            "fit": self.fit,
+            "activity": self.activity,
+            "license": self.license,
+            "offline": self.offline,
+            "security": self.security,
+            "footprint": self.footprint,
+            "tests": self.tests,
+            "maintainability": self.maintainability,
+            "overlap": self.overlap,
+        }
+
+
+@dataclass(frozen=True)
+class CandidateEvaluation:
+    candidate_id: str
+    name: str
+    source: str
+    task: str
+    score: CandidateScore
+    evidence_refs: tuple[str, ...]
+    license_risk: str = "unknown"
+    offline_viability: str = "unknown"
+    stars: int | None = None
+    last_activity: str | None = None
+    runtime_notes: str | None = None
+    security_notes: str | None = None
+    overlaps_existing: tuple[str, ...] = ()
+    recommendation: str = "needs_review"
+    metadata: Mapping[str, Any] | None = None
+
+    def validate(self) -> None:
+        if not self.candidate_id:
+            raise ValueError("candidate_id is required")
+        if not self.name:
+            raise ValueError(f"{self.candidate_id}: name is required")
+        if self.source not in CANDIDATE_SOURCES:
+            raise ValueError(f"{self.candidate_id}: unknown source {self.source!r}")
+        if self.license_risk not in LICENSE_RISKS:
+            raise ValueError(f"{self.candidate_id}: unknown license_risk {self.license_risk!r}")
+        if self.offline_viability not in OFFLINE_VIABILITY:
+            raise ValueError(f"{self.candidate_id}: unknown offline_viability {self.offline_viability!r}")
+        if self.recommendation not in RECOMMENDATIONS:
+            raise ValueError(f"{self.candidate_id}: unknown recommendation {self.recommendation!r}")
+        if not self.evidence_refs:
+            raise ValueError(f"{self.candidate_id}: evidence_refs are required")
+        if self.stars is not None and self.stars < 0:
+            raise ValueError(f"{self.candidate_id}: stars must be non-negative")
+        self.score.validate()
+
+    def to_dict(self) -> dict[str, Any]:
+        self.validate()
+        score = self.score.to_dict()
+        total_score = sum(score.values())
+        normalized_score = total_score / 45
+        return {
+            "candidate_id": self.candidate_id,
+            "name": self.name,
+            "source": self.source,
+            "task": self.task,
+            "score": score,
+            "total_score": total_score,
+            "normalized_score": normalized_score,
+            "evidence_refs": list(self.evidence_refs),
+            "license_risk": self.license_risk,
+            "offline_viability": self.offline_viability,
+            "stars": self.stars,
+            "last_activity": self.last_activity,
+            "runtime_notes": self.runtime_notes,
+            "security_notes": self.security_notes,
+            "overlaps_existing": list(self.overlaps_existing),
+            "recommendation": self.recommendation,
+            "metadata": dict(self.metadata or {}),
+        }
+
+
+def rank_candidates(candidates: Sequence[CandidateEvaluation]) -> list[CandidateEvaluation]:
+    for candidate in candidates:
+        candidate.validate()
+    return sorted(candidates, key=lambda candidate: (candidate.score.total(), candidate.score.fit), reverse=True)
+
+
+def adoption_gate(candidate: CandidateEvaluation, *, minimum_score: float = 0.72) -> dict[str, Any]:
+    candidate.validate()
+    blockers = []
+    if candidate.license_risk in {"incompatible", "unknown"}:
+        blockers.append(f"license:{candidate.license_risk}")
+    if candidate.offline_viability in {"unavailable", "unknown"}:
+        blockers.append(f"offline:{candidate.offline_viability}")
+    if candidate.score.normalized() < minimum_score:
+        blockers.append("score_below_threshold")
+    return {
+        "candidate_id": candidate.candidate_id,
+        "allowed": not blockers,
+        "blockers": blockers,
+        "normalized_score": candidate.score.normalized(),
+        "recommendation": candidate.recommendation,
+    }
+
+
+EXAMPLE_CANDIDATES: tuple[CandidateEvaluation, ...] = (
+    CandidateEvaluation(
+        candidate_id="existing_mempalace",
+        name="Keep MemPalace as Zoe baseline",
+        source="existing_zoe",
+        task="offline episodic memory recall",
+        score=CandidateScore(fit=5, activity=4, license=4, offline=5, security=4, footprint=4, tests=5, maintainability=4, overlap=5),
+        evidence_refs=("docs/architecture/zoe-mempalace-baseline.md",),
+        license_risk="compatible",
+        offline_viability="required",
+        runtime_notes="Measured p95 under current Zoe local baseline.",
+        overlaps_existing=("mempalace_memory",),
+        recommendation="keep",
+    ),
+    CandidateEvaluation(
+        candidate_id="graphiti_falkordb_trial",
+        name="Graphiti with FalkorDB",
+        source="github",
+        task="temporal relationship memory",
+        score=CandidateScore(fit=4, activity=4, license=3, offline=4, security=3, footprint=2, tests=3, maintainability=3, overlap=2),
+        evidence_refs=("docs/architecture/zoe-graphiti-fixtures.md", "docs/adr/ADR-graphiti-bakeoff.md"),
+        license_risk="review",
+        offline_viability="supported",
+        runtime_notes="Needs Jetson CPU/RAM measurement before any hot-path use.",
+        overlaps_existing=("graphiti_relational_memory",),
+        recommendation="trial_sidecar",
+    ),
+    CandidateEvaluation(
+        candidate_id="pi_runtime_reuse",
+        name="Pi runtime/package reuse",
+        source="pi",
+        task="external capability discovery and reuse",
+        score=CandidateScore(fit=4, activity=3, license=2, offline=2, security=2, footprint=2, tests=2, maintainability=3, overlap=3),
+        evidence_refs=("docs/strategy/zoe-evolution-harness-plan.md",),
+        license_risk="review",
+        offline_viability="unknown",
+        runtime_notes="Must be scored per package/runtime before install.",
+        overlaps_existing=("pi_external_runtime",),
+        recommendation="needs_review",
+    ),
+)
+
+
+__all__ = [
+    "CANDIDATE_SOURCES",
+    "EXAMPLE_CANDIDATES",
+    "LICENSE_RISKS",
+    "OFFLINE_VIABILITY",
+    "RECOMMENDATIONS",
+    "CandidateEvaluation",
+    "CandidateScore",
+    "adoption_gate",
+    "rank_candidates",
+]


### PR DESCRIPTION
## Summary
- add candidate scoring contract for Pi/MCP/GitHub/skill/API/local-service/existing-Zoe options
- add adoption gate blockers for license risk, offline viability, and low normalized score
- document candidate scoring as the required evidence path before installs or replacements

## Verification
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_zoe_candidate_scoring.py
- python3 tools/audit/validate_structure.py
- python3 tools/audit/validate_critical_files.py
- python3 tools/audit/validate_offline_memory.py
- python3 -m py_compile services/zoe-data/zoe_candidate_scoring.py
- git diff --check
