### PR TITLE
Add Zoe evolution proposal contract

### DIFF
--- a/docs/architecture/zoe-evolution-proposal-contract.md
+++ b/docs/architecture/zoe-evolution-proposal-contract.md
@@ -1,0 +1,42 @@
+# Zoe Evolution Proposal Contract
+
+## Purpose
+
+Zoe's self-evolution loop needs a structured proposal record before it changes code, installs tools, starts sidecars, writes trusted memory, or promotes a capability. The contract in `services/zoe-data/zoe_evolution_proposal.py` defines that record without executing it.
+
+This is the bridge between the harness plan and Multica:
+
+- Notice: an evidence-backed signal is captured.
+- Explain: the signal becomes a problem statement.
+- Search: a candidate is selected from Pi, MCP, GitHub, skills, APIs, local services, or existing Zoe surfaces.
+- Evaluate: the candidate carries Zoe's score, license, offline viability, security, footprint, and overlap evidence.
+- Propose: the proposal records affected capabilities, risk, expected benefit, verification, rollback, and approval requirements.
+
+## Contract Rules
+
+- Every signal requires evidence.
+- Every proposal requires at least one signal.
+- Every proposal requires a scored candidate.
+- Every proposal requires affected capabilities, verification, rollback, and evidence.
+- Execute and promote proposals require explicit approvals.
+- High-risk and privileged proposals require approval.
+- The proposal contract never grants execution by itself.
+
+`approval_gate.allowed_to_execute` is intentionally always false. A valid proposal can be prepared and handed to Multica or review, but privileged execution must happen through the governed runtime path.
+
+## Why This Matters
+
+This gives Zoe a durable, testable shape for self-improvement before the runtime loop becomes more autonomous. It prevents a user request, reflection, or failed tool run from becoming an unchecked install, trusted memory, or code change.
+
+It also attaches candidate scoring to proposals, so Zoe can compare existing Pi/MCP/GitHub/local options before building new bespoke code.
+
+## Current Scope
+
+This slice is contract-only:
+
+- no production table migration;
+- no automatic execution;
+- no automatic memory promotion;
+- no chat hot-path change.
+
+The next slices should adapt existing `evolution_proposals` writes to include this contract payload, then add Multica admission rules for memory and capability promotion.

--- a/docs/strategy/zoe-evolution-harness-plan.md
+++ b/docs/strategy/zoe-evolution-harness-plan.md
@@ -274,7 +274,7 @@ Stages:
 2. Explain: convert the signal into a structured problem statement with evidence.
 3. Search: look for existing tools, Pi packages, MCP servers, GitHub projects, skills, APIs.
 4. Evaluate: score candidates by fit, activity, stars, license, local viability, runtime cost, security, tests.
-5. Propose: create an evolution proposal with scope, risk, expected benefit, tests, rollback.
+5. Propose: create an evolution proposal with scope, scored candidate, affected capabilities, risk, expected benefit, tests, rollback, and approval requirements.
 6. Approve: require user/admin approval for privileged changes.
 7. Execute: use Pi/Hermes/OpenClaw/Multica lanes depending on task type.
 8. Verify: run tests, health checks, screenshots if UI, metrics if runtime.

--- a/docs/strategy/zoe-evolution-harness-status.md
+++ b/docs/strategy/zoe-evolution-harness-status.md
@@ -36,9 +36,10 @@ Important non-complete truth:
 - The plan now names Zoe's missing north-star layer: capability profiles, trust/autonomy classes, candidate scouting, outcome evals, and hardware-aware promotion.
 - Zoe now has an executable capability profile contract and initial self-model for key chat, memory, graph, governance, escalation, Pi, and device-control surfaces.
 - Zoe now has candidate scoring for comparing Pi, MCP, GitHub, skill, API, local-service, and existing-Zoe options before adoption.
+- Zoe now has a self-evolution proposal contract that attaches signals, candidate scores, affected capabilities, approval gates, verification, rollback, and evidence before any execution.
 - The deterministic memory router is not yet wired into production chat behind a feature flag.
 - Retain-candidate admission is not yet fully governed through Multica approval.
-- The full self-evolution loop is not yet implemented end to end.
+- The full self-evolution loop is not yet implemented end to end; proposal records are now defined, but existing live proposal writers still need to emit them and Multica still needs to enforce admission.
 - Zoe main engine cleanup should not begin until the inventory, graph, and memory/evolution contracts have protective tests around the active surfaces.
 
 ## Phase Ledger
@@ -62,7 +63,8 @@ Important non-complete truth:
 | Candidate scoring | Complete foundation | `services/zoe-data/zoe_candidate_scoring.py`, `services/zoe-data/tests/test_zoe_candidate_scoring.py`, and `docs/architecture/zoe-candidate-scoring.md` define candidate scoring and adoption gates. | Attach candidate scores to self-evolution proposal records before installs or replacements. |
 | Observation/evaluation traces | Not started | Memory metrics exist for MemPalace but not full retrieval helpfulness/contradiction traces. | Add a trace schema for recall, retain candidate, admission, contradiction, and fallback events. |
 | Multica evidence gates | Partial | Implement completion now requires PR evidence for code/default profiles. | Add memory admission gates and explicit self-evolution proposal gates. |
-| Self-evolution loop | Partial | Multica, pipeline evidence, Greploop, Greptile, Hermes, and worktree bootstrap pieces exist. | Implement structured Notice -> Explain -> Search -> Evaluate -> Propose records before any automatic execution. |
+| Self-evolution proposal records | Complete foundation | `services/zoe-data/zoe_evolution_proposal.py`, `services/zoe-data/tests/test_zoe_evolution_proposal.py`, and `docs/architecture/zoe-evolution-proposal-contract.md` define structured Notice -> Explain -> Search -> Evaluate -> Propose records. | Adapt existing live proposal writers to emit this payload and require it before installs/replacements. |
+| Self-evolution loop | Partial | Multica, pipeline evidence, Greploop, Greptile, Hermes, worktree bootstrap, candidate scoring, and proposal contract pieces exist. | Wire live proposal writers, Multica admission, execution approval, verification, retained outcomes, and retirement evidence. |
 | Main engine cleanup | Deferred | `zoe_agent.py` remains large and active. | Start only after inventories and chat/memory/tool dispatch tests are strong enough to prevent regressions. |
 
 ## Missing Work By Capability

--- a/services/zoe-data/tests/test_zoe_evolution_proposal.py
+++ b/services/zoe-data/tests/test_zoe_evolution_proposal.py
@@ -1,0 +1,277 @@
+import pytest
+
+from zoe_candidate_scoring import CandidateEvaluation, CandidateScore
+from zoe_evolution_proposal import (
+    EvolutionSignal,
+    EvolutionSignalType,
+    ProposalRisk,
+    ProposalStatus,
+    TrustAutonomyClass,
+    build_evolution_proposal,
+)
+
+
+def _candidate(**overrides):
+    defaults = {
+        "candidate_id": "mcp_calendar_candidate",
+        "name": "Calendar MCP candidate",
+        "source": "mcp",
+        "task": "calendar sync",
+        "score": CandidateScore(
+            fit=5,
+            activity=4,
+            license=4,
+            offline=5,
+            security=4,
+            footprint=4,
+            tests=4,
+            maintainability=4,
+            overlap=4,
+        ),
+        "evidence_refs": ("github:mcp/calendar", "docs/architecture/zoe-tool-capability-inventory.md"),
+        "license_risk": "compatible",
+        "offline_viability": "required",
+        "stars": 1200,
+        "last_activity": "2026-06-01",
+        "recommendation": "trial_sidecar",
+    }
+    defaults.update(overrides)
+    return CandidateEvaluation(**defaults)
+
+
+def _signal(**overrides):
+    defaults = {
+        "signal_id": "sig_calendar_gap",
+        "signal_type": EvolutionSignalType.USER_REQUEST.value,
+        "summary": "User asked Zoe to improve calendar sync reliability.",
+        "source": "chat",
+        "evidence_refs": ("chat:calendar-sync-request",),
+        "user_id": "jason",
+        "scope": "project",
+    }
+    defaults.update(overrides)
+    return EvolutionSignal(**defaults)
+
+
+def test_build_proposal_collects_signal_and_candidate_evidence():
+    proposal = build_evolution_proposal(
+        proposal_id="prop_calendar_mcp",
+        title="Trial calendar MCP sidecar",
+        problem_statement="Zoe needs a measured existing calendar capability before building a bespoke sync path.",
+        signals=(_signal(),),
+        candidate=_candidate(),
+        affected_capabilities=("chat_router", "calendar_sync"),
+        autonomy_class=TrustAutonomyClass.PREPARE.value,
+        risk=ProposalRisk.MEDIUM.value,
+        expected_benefit="Reduce bespoke calendar sync code and improve reliability.",
+        verification_plan=("pytest:tests/integration/test_chat_interface.py", "live:/api/system/status"),
+        rollback_plan="Disable the sidecar profile and keep existing calendar routes.",
+    )
+
+    payload = proposal.to_dict()
+
+    assert payload["proposal_id"] == "prop_calendar_mcp"
+    assert payload["candidate"]["total_score"] == _candidate().score.total()
+    assert payload["evidence_refs"] == [
+        "chat:calendar-sync-request",
+        "github:mcp/calendar",
+        "docs/architecture/zoe-tool-capability-inventory.md",
+    ]
+    assert payload["approval_gate"]["allowed_to_prepare"] is True
+    assert payload["approval_gate"]["allowed_to_execute"] is False
+
+
+def test_signal_requires_evidence():
+    signal = _signal(evidence_refs=())
+
+    with pytest.raises(ValueError, match="evidence_refs are required"):
+        signal.validate()
+
+
+def test_execute_proposal_requires_approval():
+    with pytest.raises(ValueError, match="execute/promote proposals require approval_required"):
+        build_evolution_proposal(
+            proposal_id="prop_exec",
+            title="Execute install",
+            problem_statement="Install a candidate.",
+            signals=(_signal(),),
+            candidate=_candidate(),
+            affected_capabilities=("calendar_sync",),
+            autonomy_class=TrustAutonomyClass.EXECUTE.value,
+            risk=ProposalRisk.MEDIUM.value,
+            expected_benefit="Test install.",
+            verification_plan=("pytest:tests/integration/test_chat_interface.py",),
+            rollback_plan="Remove the install.",
+        )
+
+
+def test_execute_gate_requires_pr_evidence_even_with_approval():
+    with pytest.raises(ValueError, match="execute/promote proposals require pr_evidence approval"):
+        build_evolution_proposal(
+            proposal_id="prop_exec_missing_pr",
+            title="Execute install",
+            problem_statement="Install a candidate.",
+            signals=(_signal(),),
+            candidate=_candidate(),
+            affected_capabilities=("calendar_sync",),
+            autonomy_class=TrustAutonomyClass.EXECUTE.value,
+            risk=ProposalRisk.MEDIUM.value,
+            expected_benefit="Test install.",
+            verification_plan=("pytest:tests/integration/test_chat_interface.py",),
+            rollback_plan="Remove the install.",
+            approval_required=("install_or_runtime_change",),
+        )
+
+
+def test_promote_proposal_can_prepare_with_pr_evidence_but_never_execute():
+    proposal = build_evolution_proposal(
+        proposal_id="prop_promote_calendar",
+        title="Promote calendar candidate",
+        problem_statement="Promote the measured candidate after verification.",
+        signals=(_signal(signal_type=EvolutionSignalType.OUTCOME_EVAL_FAILURE.value),),
+        candidate=_candidate(),
+        affected_capabilities=("calendar_sync",),
+        autonomy_class=TrustAutonomyClass.PROMOTE.value,
+        risk=ProposalRisk.MEDIUM.value,
+        expected_benefit="Make the measured capability trusted after review.",
+        verification_plan=("pytest:tests/integration/test_chat_interface.py",),
+        rollback_plan="Demote the capability profile to assisted.",
+        approval_required=("pr_evidence",),
+    )
+    gate = proposal.approval_gate()
+
+    assert gate["allowed_to_prepare"] is True
+    assert gate["allowed_to_execute"] is False
+    assert gate["blockers"] == []
+
+
+def test_high_risk_proposal_requires_approval():
+    with pytest.raises(ValueError, match="high-risk proposals require approval_required"):
+        build_evolution_proposal(
+            proposal_id="prop_high_no_approval",
+            title="High risk proposal",
+            problem_statement="Start a sidecar that changes runtime behavior.",
+            signals=(_signal(signal_type=EvolutionSignalType.TOOL_GAP.value),),
+            candidate=_candidate(),
+            affected_capabilities=("calendar_sync",),
+            autonomy_class=TrustAutonomyClass.SUGGEST.value,
+            risk=ProposalRisk.HIGH.value,
+            expected_benefit="Improve reliability.",
+            verification_plan=("pytest:tests/integration/test_chat_interface.py",),
+            rollback_plan="Disable the sidecar.",
+        )
+
+
+def test_high_risk_requires_user_or_admin_approval():
+    with pytest.raises(ValueError, match="high-risk proposals require user_or_admin_for_privileged_execution approval"):
+        build_evolution_proposal(
+            proposal_id="prop_high_missing_user",
+            title="High risk proposal",
+            problem_statement="Start a sidecar that changes runtime behavior.",
+            signals=(_signal(signal_type=EvolutionSignalType.TOOL_GAP.value),),
+            candidate=_candidate(),
+            affected_capabilities=("calendar_sync",),
+            autonomy_class=TrustAutonomyClass.SUGGEST.value,
+            risk=ProposalRisk.HIGH.value,
+            expected_benefit="Improve reliability.",
+            verification_plan=("pytest:tests/integration/test_chat_interface.py",),
+            rollback_plan="Disable the sidecar.",
+            approval_required=("sidecar_start",),
+        )
+
+
+def test_high_risk_proposal_can_prepare_with_user_or_admin_approval():
+    proposal = build_evolution_proposal(
+        proposal_id="prop_high_with_user",
+        title="High risk proposal",
+        problem_statement="Start a sidecar that changes runtime behavior.",
+        signals=(_signal(signal_type=EvolutionSignalType.TOOL_GAP.value),),
+        candidate=_candidate(),
+        affected_capabilities=("calendar_sync",),
+        autonomy_class=TrustAutonomyClass.SUGGEST.value,
+        risk=ProposalRisk.HIGH.value,
+        expected_benefit="Improve reliability.",
+        verification_plan=("pytest:tests/integration/test_chat_interface.py",),
+        rollback_plan="Disable the sidecar.",
+        approval_required=("sidecar_start", "user_or_admin_for_privileged_execution"),
+    )
+    gate = proposal.approval_gate()
+
+    assert gate["allowed_to_prepare"] is True
+    assert gate["blockers"] == []
+
+
+def test_approved_status_requires_approval_gate():
+    with pytest.raises(ValueError, match="approved/verified proposals require approval evidence gates"):
+        build_evolution_proposal(
+            proposal_id="prop_approved_without_gate",
+            title="Approved without gate",
+            problem_statement="This status should not be accepted without approvals.",
+            signals=(_signal(),),
+            candidate=_candidate(),
+            affected_capabilities=("calendar_sync",),
+            autonomy_class=TrustAutonomyClass.SUGGEST.value,
+            risk=ProposalRisk.LOW.value,
+            expected_benefit="Improve reliability.",
+            verification_plan=("pytest:tests/integration/test_chat_interface.py",),
+            rollback_plan="No-op.",
+            status=ProposalStatus.APPROVED.value,
+        )
+
+
+def test_unknown_approval_class_is_rejected():
+    with pytest.raises(ValueError, match="unknown approval class"):
+        build_evolution_proposal(
+            proposal_id="prop_bad_approval_class",
+            title="Bad approval class",
+            problem_statement="Typoed approval classes should fail at construction.",
+            signals=(_signal(),),
+            candidate=_candidate(),
+            affected_capabilities=("calendar_sync",),
+            autonomy_class=TrustAutonomyClass.SUGGEST.value,
+            risk=ProposalRisk.LOW.value,
+            expected_benefit="Catch approval typos early.",
+            verification_plan=("pytest:tests/integration/test_chat_interface.py",),
+            rollback_plan="No-op.",
+            approval_required=("pr-evidence",),
+        )
+
+
+def test_candidate_gate_blocks_unknown_offline_candidate():
+    proposal = build_evolution_proposal(
+        proposal_id="prop_pi_unknown",
+        title="Review Pi package",
+        problem_statement="Pi package needs review before adoption.",
+        signals=(_signal(signal_type=EvolutionSignalType.TOOL_GAP.value),),
+        candidate=_candidate(
+            candidate_id="pi_unknown",
+            name="Unknown Pi package",
+            source="pi",
+            score=CandidateScore(
+                fit=4,
+                activity=3,
+                license=2,
+                offline=1,
+                security=2,
+                footprint=2,
+                tests=2,
+                maintainability=3,
+                overlap=3,
+            ),
+            license_risk="review",
+            offline_viability="unknown",
+            recommendation="needs_review",
+        ),
+        affected_capabilities=("pi_external_runtime",),
+        autonomy_class=TrustAutonomyClass.SUGGEST.value,
+        risk=ProposalRisk.MEDIUM.value,
+        expected_benefit="Reuse existing Pi capability if it is safe and offline-capable.",
+        verification_plan=("candidate scoring review",),
+        rollback_plan="Do not install the package.",
+    )
+
+    gate = proposal.approval_gate()
+
+    assert gate["allowed_to_prepare"] is False
+    assert "offline:unknown" in gate["blockers"]
+    assert "score_below_threshold" in gate["blockers"]

--- a/services/zoe-data/zoe_evolution_proposal.py
+++ b/services/zoe-data/zoe_evolution_proposal.py
@@ -1,0 +1,264 @@
+"""Zoe self-evolution proposal contract.
+
+This module keeps the Notice -> Explain -> Search -> Evaluate -> Propose
+record boring and reviewable before any code execution or tool install occurs.
+It deliberately does not execute proposals; it only validates that a proposal
+has enough evidence, candidate scoring, approval gates, tests, and rollback
+context to be handed to Multica or a human reviewer.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Mapping, Sequence
+
+from zoe_candidate_scoring import CandidateEvaluation, adoption_gate
+
+
+class EvolutionSignalType(str, Enum):
+    USER_REQUEST = "user_request"
+    REPEATED_FAILURE = "repeated_failure"
+    TOOL_GAP = "tool_gap"
+    STALE_CAPABILITY = "stale_capability"
+    OUTCOME_EVAL_FAILURE = "outcome_eval_failure"
+    OPERATOR_NOTE = "operator_note"
+
+
+class TrustAutonomyClass(str, Enum):
+    OBSERVE = "observe"
+    RECALL = "recall"
+    SUGGEST = "suggest"
+    PREPARE = "prepare"
+    EXECUTE = "execute"
+    PROMOTE = "promote"
+
+
+class ProposalRisk(str, Enum):
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+    PRIVILEGED = "privileged"
+
+
+class ProposalStatus(str, Enum):
+    DRAFT = "draft"
+    PENDING_APPROVAL = "pending_approval"
+    APPROVED = "approved"
+    REJECTED = "rejected"
+    VERIFIED = "verified"
+    FAILED = "failed"
+    RETIRED = "retired"
+
+
+PRIVILEGED_APPROVAL_CLASSES = {
+    "device_action_confirmation",
+    "install_or_runtime_change",
+    "license_review",
+    "memory_admission",
+    "pr_evidence",
+    "secret_access",
+    "security_review",
+    "sidecar_start",
+    "user_or_admin_for_privileged_execution",
+}
+
+
+@dataclass(frozen=True)
+class EvolutionSignal:
+    signal_id: str
+    signal_type: str
+    summary: str
+    source: str
+    evidence_refs: tuple[str, ...]
+    user_id: str | None = None
+    scope: str = "system"
+    metadata: Mapping[str, Any] | None = None
+
+    def validate(self) -> None:
+        if not self.signal_id:
+            raise ValueError("signal_id is required")
+        if self.signal_type not in {item.value for item in EvolutionSignalType}:
+            raise ValueError(f"{self.signal_id}: unknown signal_type {self.signal_type!r}")
+        if not self.summary:
+            raise ValueError(f"{self.signal_id}: summary is required")
+        if not self.source:
+            raise ValueError(f"{self.signal_id}: source is required")
+        if not self.scope:
+            raise ValueError(f"{self.signal_id}: scope is required")
+        if not self.evidence_refs:
+            raise ValueError(f"{self.signal_id}: evidence_refs are required")
+
+    def to_dict(self) -> dict[str, Any]:
+        self.validate()
+        return {
+            "signal_id": self.signal_id,
+            "signal_type": self.signal_type,
+            "summary": self.summary,
+            "source": self.source,
+            "evidence_refs": list(self.evidence_refs),
+            "user_id": self.user_id,
+            "scope": self.scope,
+            "metadata": dict(self.metadata or {}),
+        }
+
+
+@dataclass(frozen=True)
+class EvolutionProposal:
+    proposal_id: str
+    title: str
+    problem_statement: str
+    signals: tuple[EvolutionSignal, ...]
+    candidate: CandidateEvaluation
+    affected_capabilities: tuple[str, ...]
+    autonomy_class: str
+    risk: str
+    expected_benefit: str
+    verification_plan: tuple[str, ...]
+    rollback_plan: str
+    evidence_refs: tuple[str, ...]
+    approval_required: tuple[str, ...] = ()
+    status: str = ProposalStatus.DRAFT.value
+    multica_issue_id: str | None = None
+    metadata: Mapping[str, Any] | None = None
+
+    def validate(self) -> None:
+        if not self.proposal_id:
+            raise ValueError("proposal_id is required")
+        if not self.title:
+            raise ValueError(f"{self.proposal_id}: title is required")
+        if not self.problem_statement:
+            raise ValueError(f"{self.proposal_id}: problem_statement is required")
+        if not self.signals:
+            raise ValueError(f"{self.proposal_id}: at least one signal is required")
+        for signal in self.signals:
+            signal.validate()
+        self.candidate.validate()
+        if not self.affected_capabilities:
+            raise ValueError(f"{self.proposal_id}: affected_capabilities are required")
+        if self.autonomy_class not in {item.value for item in TrustAutonomyClass}:
+            raise ValueError(f"{self.proposal_id}: unknown autonomy_class {self.autonomy_class!r}")
+        if self.risk not in {item.value for item in ProposalRisk}:
+            raise ValueError(f"{self.proposal_id}: unknown risk {self.risk!r}")
+        if self.status not in {item.value for item in ProposalStatus}:
+            raise ValueError(f"{self.proposal_id}: unknown status {self.status!r}")
+        if not self.expected_benefit:
+            raise ValueError(f"{self.proposal_id}: expected_benefit is required")
+        if not self.verification_plan:
+            raise ValueError(f"{self.proposal_id}: verification_plan is required")
+        if not self.rollback_plan:
+            raise ValueError(f"{self.proposal_id}: rollback_plan is required")
+        if not self.evidence_refs:
+            raise ValueError(f"{self.proposal_id}: evidence_refs are required")
+        unknown_classes = set(self.approval_required) - PRIVILEGED_APPROVAL_CLASSES
+        if unknown_classes:
+            raise ValueError(
+                f"{self.proposal_id}: unknown approval class(es) in approval_required: {sorted(unknown_classes)}"
+            )
+        if self.autonomy_class in {TrustAutonomyClass.EXECUTE.value, TrustAutonomyClass.PROMOTE.value}:
+            if not self.approval_required:
+                raise ValueError(f"{self.proposal_id}: execute/promote proposals require approval_required")
+            if "pr_evidence" not in self.approval_required:
+                raise ValueError(f"{self.proposal_id}: execute/promote proposals require pr_evidence approval")
+        if self.risk in {ProposalRisk.HIGH.value, ProposalRisk.PRIVILEGED.value}:
+            if not self.approval_required:
+                raise ValueError(f"{self.proposal_id}: high-risk proposals require approval_required")
+            if "user_or_admin_for_privileged_execution" not in self.approval_required:
+                raise ValueError(
+                    f"{self.proposal_id}: high-risk proposals require user_or_admin_for_privileged_execution approval"
+                )
+        if self.status in {ProposalStatus.APPROVED.value, ProposalStatus.VERIFIED.value}:
+            if not self.approval_required:
+                raise ValueError(f"{self.proposal_id}: approved/verified proposals require approval evidence gates")
+
+    def approval_gate(self) -> dict[str, Any]:
+        self.validate()
+        candidate_gate = adoption_gate(self.candidate)
+        blockers = list(candidate_gate["blockers"])
+        return {
+            "proposal_id": self.proposal_id,
+            "allowed_to_prepare": candidate_gate["allowed"] and not blockers,
+            "allowed_to_execute": False,
+            "blockers": blockers,
+            "candidate_gate": candidate_gate,
+            "approval_required": list(self.approval_required),
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        approval_gate = self.approval_gate()
+        return {
+            "proposal_id": self.proposal_id,
+            "title": self.title,
+            "problem_statement": self.problem_statement,
+            "signals": [signal.to_dict() for signal in self.signals],
+            "candidate": self.candidate.to_dict(),
+            "affected_capabilities": list(self.affected_capabilities),
+            "autonomy_class": self.autonomy_class,
+            "risk": self.risk,
+            "expected_benefit": self.expected_benefit,
+            "verification_plan": list(self.verification_plan),
+            "rollback_plan": self.rollback_plan,
+            "evidence_refs": list(self.evidence_refs),
+            "approval_required": list(self.approval_required),
+            "status": self.status,
+            "multica_issue_id": self.multica_issue_id,
+            "approval_gate": approval_gate,
+            "metadata": dict(self.metadata or {}),
+        }
+
+
+def build_evolution_proposal(
+    *,
+    proposal_id: str,
+    title: str,
+    problem_statement: str,
+    signals: Sequence[EvolutionSignal],
+    candidate: CandidateEvaluation,
+    affected_capabilities: Sequence[str],
+    autonomy_class: str,
+    risk: str,
+    expected_benefit: str,
+    verification_plan: Sequence[str],
+    rollback_plan: str,
+    approval_required: Sequence[str] = (),
+    status: str = ProposalStatus.DRAFT.value,
+    multica_issue_id: str | None = None,
+    metadata: Mapping[str, Any] | None = None,
+) -> EvolutionProposal:
+    evidence_refs: list[str] = []
+    for signal in signals:
+        evidence_refs.extend(signal.evidence_refs)
+    evidence_refs.extend(candidate.evidence_refs)
+
+    proposal = EvolutionProposal(
+        proposal_id=proposal_id,
+        title=title,
+        problem_statement=problem_statement,
+        signals=tuple(signals),
+        candidate=candidate,
+        affected_capabilities=tuple(affected_capabilities),
+        autonomy_class=autonomy_class,
+        risk=risk,
+        expected_benefit=expected_benefit,
+        verification_plan=tuple(verification_plan),
+        rollback_plan=rollback_plan,
+        evidence_refs=tuple(dict.fromkeys(evidence_refs)),
+        approval_required=tuple(approval_required),
+        status=status,
+        multica_issue_id=multica_issue_id,
+        metadata=metadata,
+    )
+    proposal.validate()
+    return proposal
+
+
+__all__ = [
+    "EvolutionProposal",
+    "EvolutionSignal",
+    "EvolutionSignalType",
+    "PRIVILEGED_APPROVAL_CLASSES",
+    "ProposalRisk",
+    "ProposalStatus",
+    "TrustAutonomyClass",
+    "build_evolution_proposal",
+]


### PR DESCRIPTION
## Summary\n- add a tested Zoe evolution proposal contract for Notice -> Explain -> Search -> Evaluate -> Propose records\n- attach signals, candidate scores, affected capabilities, approval gates, verification plans, rollback, and evidence refs\n- document the proposal contract and update the harness plan/status ledger\n\n## Validation\n- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_zoe_evolution_proposal.py services/zoe-data/tests/test_zoe_candidate_scoring.py services/zoe-data/tests/test_zoe_capability_profile.py\n- python3 tools/audit/validate_structure.py\n- python3 tools/audit/validate_critical_files.py\n- python3 tools/audit/validate_offline_memory.py\n- git diff --check