### PR TITLE
Tighten intent gap edit contract

### DIFF
--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -70,6 +70,10 @@ _PROTOCOL_VIOLATION_LIMIT = max(
 # task body at dispatch. Anchored to the start of a line so it never collides with
 # prose elsewhere in the body.
 _REF_MARKER_RE = re.compile(r"^zoe-ref:\s*(\S+)", re.MULTILINE)
+_JOKE_INTENT_GAP_TITLE_RE = re.compile(
+    r"\bintent[- ]gap\b.*['\"]?(?:tell\s+me\s+(?:another\s+)?joke|joke)['\"]?",
+    re.IGNORECASE,
+)
 
 
 def _row_ref_key(row: dict) -> str:
@@ -326,10 +330,11 @@ def _harness_implement_hint(issue: dict | None = None) -> str:
 
 def _intent_gap_implement_hint(issue: dict | None = None, *, phase: str = "implement") -> str:
     issue = issue or {}
+    title = str(issue.get("title") or "")
     haystack = " ".join(
         [
             str(issue.get("identifier") or ""),
-            str(issue.get("title") or ""),
+            title,
             str(issue.get("description") or ""),
         ]
     ).lower()
@@ -340,6 +345,17 @@ def _intent_gap_implement_hint(issue: dict | None = None, *, phase: str = "imple
         if phase == "implement"
         else " After the existing-PR checkout checks succeed, start the focused revision edit within 4 tool/model steps.\n"
     )
+    joke_contract = ""
+    if _JOKE_INTENT_GAP_TITLE_RE.search(title):
+        joke_contract = (
+            " Concrete edit contract for this joke gap: update `_AGENT_CHAT_RE` so"
+            " `Tell me a joke.`, `Tell me a joke`, and `Tell me another joke.` route"
+            " to `extend_capability` through the existing open-domain/creative branch."
+            " Add or extend the focused detect_intent test coverage for those examples;"
+            " the expected result is `Intent(\"extend_capability\", {\"raw\": <original text>})`."
+            " Do not add a joke bank or a brittle per-joke executor in this ticket; the"
+            " acceptance goal is routing the creative request to the agent path.\n"
+        )
     return (
         "- INTENT-GAP IMPLEMENT FAST PATH: this ticket is already scoped by scout as"
         " a routing/intent gap. Do not re-scout the repo. Start from"
@@ -350,6 +366,7 @@ def _intent_gap_implement_hint(issue: dict | None = None, *, phase: str = "imple
         " `detect_intent`. Your first search should be one of those anchors;"
         " do not grep `_CALCULATE_`, `_execute_`, or unrelated domain sections"
         " for creative intent gaps."
+        f"{joke_contract}"
         " If those files are not the right location, call `kanban_block` with"
         " BLOCKER=IMPLEMENT_BUDGET and the missing locator instead of exploring."
         f"{edit_deadline}"

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -3131,8 +3131,28 @@ def test_implement_body_includes_intent_gap_fast_path():
     assert "`_AGENT_CHAT_RE`" in body
     assert "Open-domain Q&A / creative" in body
     assert "do not grep `_CALCULATE_`, `_execute_`" in body
+    assert "`Tell me a joke.`, `Tell me a joke`, and `Tell me another joke.`" in body
+    assert "Intent(\"extend_capability\", {\"raw\": <original text>})" in body
+    assert "Do not add a joke bank or a brittle per-joke executor" in body
     assert "Start editing within 4 tool/model steps after `kanban_show`" in body
     assert body.index("INTENT-GAP IMPLEMENT FAST PATH") < body.index("AUDIT/SMOKE FAST PATH")
+
+
+def test_implement_body_does_not_add_joke_contract_for_other_intent_gaps():
+    body = ka.KanbanAdapter()._build_body(
+        "implement",
+        {
+            "id": "uuid-intent-weather",
+            "identifier": "ZOE-5450",
+            "title": "Intent gap: 'Can you tell me about me?'",
+            "description": "This is no joke; the routing is broken for profile questions.",
+        },
+        "ZOE-5450",
+    )
+
+    assert "INTENT-GAP IMPLEMENT FAST PATH" in body
+    assert "Concrete edit contract for this joke gap" not in body
+    assert "`Tell me a joke.`, `Tell me a joke`, and `Tell me another joke.`" not in body
 
 
 def test_implement_revision_body_includes_intent_gap_fast_path():
@@ -3152,6 +3172,9 @@ def test_implement_revision_body_includes_intent_gap_fast_path():
     assert "`_AGENT_CHAT_RE`" in body
     assert "Open-domain Q&A / creative" in body
     assert "do not grep `_CALCULATE_`, `_execute_`" in body
+    assert "`Tell me a joke.`, `Tell me a joke`, and `Tell me another joke.`" in body
+    assert "Intent(\"extend_capability\", {\"raw\": <original text>})" in body
+    assert "Do not add a joke bank or a brittle per-joke executor" in body
     assert "EXISTING PR REVISION FAST PATH" in body
     assert "After the existing-PR checkout checks succeed" in body
     assert "Start editing within 4 tool/model steps after `kanban_show`" not in body


### PR DESCRIPTION
## Summary
- add a concrete edit contract for joke intent-gap tickets in the Hermes implement prompt
- tell workers to route joke prompts through the existing creative/open-domain branch instead of inventing a joke subsystem
- cover the implement and implement_revision prompt contract with focused tests

## Validation
- pending remote focused pytest/validators

## Production note
- dispatch remains paused after ZOE-5451 hit IMPLEMENT_HANDOFF_DRIFT on the previous retry
