### PR TITLE
Ignore patch review diff in edit safety guard

### DIFF
--- a/services/zoe-data/kanban_phase_budget.py
+++ b/services/zoe-data/kanban_phase_budget.py
@@ -44,6 +44,7 @@ _PYTHON_CHECK_RE = re.compile(
     re.IGNORECASE,
 )
 _PATCH_STEP_RE = re.compile(r"^\s*(?:┊|\|)\s+\S+\s+patch\b", re.IGNORECASE)
+_PATCH_REVIEW_DIFF_RE = re.compile(r"^\s*(?:┊|\|)\s+review\s+diff\b", re.IGNORECASE)
 _TERMINAL_STEP_RE = re.compile(r"^\s*(?:┊|\|)\s+\S+\s+kanban_(?:complete|block)\b", re.IGNORECASE)
 _EXPLORE_STEP_RE = re.compile(r"^\s*(?:┊|\|)\s+\S+\s+(?:read|grep|find)\b", re.IGNORECASE)
 _READ_STEP_RE = re.compile(r"^\s*(?:┊|\|)\s+\S+\s+read\s+(?P<path>\S+)", re.IGNORECASE)
@@ -179,6 +180,8 @@ def implement_edit_safety_reason_from_log(task_id: str, phase: str, *, session: 
             pending_python_patch = True
             continue
         if not pending_python_patch:
+            continue
+        if _PATCH_REVIEW_DIFF_RE.search(line):
             continue
         if _PYTHON_CHECK_RE.search(line):
             pending_python_patch = False

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -1889,6 +1889,46 @@ def test_implement_edit_safety_allows_immediate_python_check(tmp_path, monkeypat
     assert kb.implement_edit_safety_reason_from_log("t_impl", "implement") is None
 
 
+def test_implement_edit_safety_ignores_patch_review_diff_before_check(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    log_dir = tmp_path / "kanban" / "logs"
+    log_dir.mkdir(parents=True)
+    (log_dir / "t_impl.log").write_text(
+        "Query: work kanban task t_impl\n"
+        "  ┊ 🔧 patch     /work/services/zoe-data/intent_router.py  5.9s\n"
+        "  ┊ review diff\n"
+        "a//work/services/zoe-data/intent_router.py → b//work/services/zoe-data/intent_router.py\n"
+        "@@ -410,7 +410,8 @@\n"
+        "-    r\"can you explain|set up (?:a )?new automation|what is happening in)\",\n"
+        "+    r\"can you explain|set up (?:a )?new automation|what is happening in|\"\n"
+        "+    r\"tell me (?:a|another) joke)\",\n"
+        "  ┊ 💻 $         python3 -m py_compile services/zoe-data/intent_router.py  0.2s\n",
+        encoding="utf-8",
+    )
+
+    assert kb.implement_edit_safety_reason_from_log("t_impl", "implement") is None
+
+
+def test_implement_edit_safety_blocks_explore_after_patch_review_diff(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    log_dir = tmp_path / "kanban" / "logs"
+    log_dir.mkdir(parents=True)
+    (log_dir / "t_impl.log").write_text(
+        "Query: work kanban task t_impl\n"
+        "  ┊ 🔧 patch     /work/services/zoe-data/intent_router.py  5.9s\n"
+        "  ┊ review diff\n"
+        "a//work/services/zoe-data/intent_router.py → b//work/services/zoe-data/intent_router.py\n"
+        "@@ -410,7 +410,8 @@\n"
+        "  ┊ 📖 read      /work/services/zoe-data/intent_router.py  0.1s\n",
+        encoding="utf-8",
+    )
+
+    reason = kb.implement_edit_safety_reason_from_log("t_impl", "implement")
+
+    assert reason is not None
+    assert "IMPLEMENT_EDIT_SAFETY" in reason
+
+
 def test_implement_edit_safety_ignores_non_step_patch_text(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     log_dir = tmp_path / "kanban" / "logs"


### PR DESCRIPTION
## Summary
- ignore Hermes patch-tool review diff lines while edit-safety is waiting for py_compile/focused tests
- preserve the blocker for real post-patch exploration before checks
- add a regression test using the live ZOE-5451 log shape

## Validation
- pending remote focused pytest/validators

## Production note
- dispatch remains paused; ZOE-5451 reached the intended patch but was blocked by this guard false positive
