### PR TITLE
Add Zoe memory admission gates

### DIFF
--- a/docs/architecture/zoe-memory-admission-gates.md
+++ b/docs/architecture/zoe-memory-admission-gates.md
@@ -1,0 +1,34 @@
+# Zoe Memory Admission Gates
+
+Zoe memory admission is the contract between pending retain candidates and
+trusted durable memory. Reflection, extraction, and sidecar recall may propose
+memory, but they cannot silently promote it into truth.
+
+The executable contract lives in
+`services/zoe-data/zoe_memory_admission.py`.
+
+## Rules
+
+- Pending retain candidates may be kept for review.
+- Durable writes require approval evidence.
+- Durable writes require a successful admission or verification trace.
+- Failed or blocked traces prevent promotion.
+- Graphiti-style targets require a relationship or supersession edge.
+- Self-evolution memories require approved proposal context.
+- Trace `user_id` values must match the memory candidate user.
+
+## Current Scope
+
+This is a schema and decision contract only. It does not write to
+MemoryService, Hindsight, Graphiti, or Multica. Runtime wiring should happen in
+a later small PR after this contract is reviewed and tested.
+
+## Intended Flow
+
+1. Memory extraction or Hindsight reflection creates a pending candidate.
+2. Zoe records observation traces for recall, retain, admission, or
+   verification.
+3. Multica or a reviewer supplies approval evidence.
+4. `evaluate_memory_admission()` returns whether Zoe may keep the candidate
+   pending or write durable/trusted memory.
+5. The runtime writer uses the decision as a gate before touching any backend.

--- a/docs/strategy/zoe-evolution-harness-plan.md
+++ b/docs/strategy/zoe-evolution-harness-plan.md
@@ -211,6 +211,11 @@ Rules:
 - Auto-retain is gated.
 - Reflection may propose memories, but cannot silently create trusted truth.
 
+The executable admission gate lives in
+`services/zoe-data/zoe_memory_admission.py`. It keeps candidates pending until
+approval refs, successful admission/verification traces, scope/user checks, and
+proposal context for self-evolution memories allow durable writes.
+
 ## Memory Router
 
 The deterministic router lives in `services/zoe-data/zoe_memory_router.py`.
@@ -365,6 +370,8 @@ These evals should feed the same memory/evolution loop as test results. A failed
 6. Run Graphiti/FalkorDB and Graphiti/Neo4j bake-off.
 7. Add memory router behind a feature flag.
 8. Add retain-candidate admission through Multica/evidence gates.
+   - Status: foundation complete in `zoe_memory_admission.py`; runtime writers
+     still need to call it before durable backend writes.
 9. Add Zoe capability profiles and discovery/evaluation records.
 10. Add Zoe observation traces for recall, retain candidates, admission, contradiction, fallback, proposal, verification, outcome evals, and hardware fit.
 11. Clean Zoe main engine only after tests protect chat, memory gating, tool dispatch, capability profiles, and proposal records.

--- a/docs/strategy/zoe-evolution-harness-status.md
+++ b/docs/strategy/zoe-evolution-harness-status.md
@@ -38,8 +38,9 @@ Important non-complete truth:
 - Zoe now has candidate scoring for comparing Pi, MCP, GitHub, skill, API, local-service, and existing-Zoe options before adoption.
 - Zoe now has a self-evolution proposal contract that attaches signals, candidate scores, affected capabilities, approval gates, verification, rollback, and evidence before any execution.
 - Zoe now has an observation/evaluation trace schema for recall, retain candidates, admission, contradiction, fallback, proposals, verification, outcome evals, and hardware budget evidence.
+- Zoe now has an inert memory admission contract that keeps retain candidates pending until evidence, successful admission/verification traces, and approval refs allow durable/trusted memory writes.
 - The deterministic memory router is not yet wired into production chat behind a feature flag.
-- Retain-candidate admission is not yet fully governed through Multica approval.
+- Retain-candidate admission has a tested contract, but existing runtime writers are not yet wired to enforce it through Multica approval.
 - The full self-evolution loop is not yet implemented end to end; proposal records are now defined, but existing live proposal writers still need to emit them and Multica still needs to enforce admission.
 - Zoe main engine cleanup should not begin until the inventory, graph, and memory/evolution contracts have protective tests around the active surfaces.
 
@@ -63,7 +64,8 @@ Important non-complete truth:
 | Capability profiles | Complete foundation | `services/zoe-data/zoe_capability_profile.py`, `services/zoe-data/tests/test_zoe_capability_profile.py`, and `docs/architecture/zoe-capability-profiles.md` define the first executable Zoe capability self-model. | Wire profiles into candidate scoring, self-evolution proposals, and cleanup gates. |
 | Candidate scoring | Complete foundation | `services/zoe-data/zoe_candidate_scoring.py`, `services/zoe-data/tests/test_zoe_candidate_scoring.py`, and `docs/architecture/zoe-candidate-scoring.md` define candidate scoring and adoption gates. | Attach candidate scores to self-evolution proposal records before installs or replacements. |
 | Observation/evaluation traces | Complete foundation | `services/zoe-data/zoe_observation_trace.py`, `services/zoe-data/tests/test_zoe_observation_trace.py`, and `docs/architecture/zoe-observation-trace-schema.md` define trace records for recall, retain candidate, admission, contradiction, fallback, proposal, verification, outcome eval, and hardware-budget events. | Wire traces around memory router decisions, retain candidates, sidecar bake-offs, Multica admission, and capability promotion/retirement. |
-| Multica evidence gates | Partial | Implement completion now requires PR evidence for code/default profiles. | Add memory admission gates and explicit self-evolution proposal gates. |
+| Memory admission governance | Complete foundation | `services/zoe-data/zoe_memory_admission.py`, `services/zoe-data/tests/test_zoe_memory_admission.py`, and `docs/architecture/zoe-memory-admission-gates.md` define evidence, trace, approval, graph, and self-evolution proposal gates before durable memory writes. | Wire retain candidate workers and future graph/Hindsight writers through this decision before any backend write. |
+| Multica evidence gates | Partial | Implement completion now requires PR evidence for code/default profiles, and memory admission has a tested decision contract. | Connect the memory admission contract to Multica/review records and add explicit self-evolution execution gates. |
 | Self-evolution proposal records | Complete foundation | `services/zoe-data/zoe_evolution_proposal.py`, `services/zoe-data/tests/test_zoe_evolution_proposal.py`, and `docs/architecture/zoe-evolution-proposal-contract.md` define structured Notice -> Explain -> Search -> Evaluate -> Propose records. | Adapt existing live proposal writers to emit this payload and require it before installs/replacements. |
 | Self-evolution loop | Partial | Multica, pipeline evidence, Greploop, Greptile, Hermes, worktree bootstrap, candidate scoring, and proposal contract pieces exist. | Wire live proposal writers, Multica admission, execution approval, verification, retained outcomes, and retirement evidence. |
 | Main engine cleanup | Deferred | `zoe_agent.py` remains large and active. | Start only after inventories and chat/memory/tool dispatch tests are strong enough to prevent regressions. |
@@ -187,8 +189,9 @@ Keep each pull request small enough for Greptile and Zoe verification.
    - Wire deterministic routing into chat/agent recall in fallback-safe mode.
    - Add latency timeout and compact cited memory packets.
 8. Memory admission governance.
-   - Route retain candidates through Multica/review.
-   - Add evidence and scope gates for relational and self-evolution memory.
+   - Status: complete foundation.
+   - `zoe_memory_admission.py` now gates durable memory writes on approval refs, successful admission/verification traces, graph edge requirements, user/scope matching, and proposal context for self-evolution memories.
+   - Next: route retain candidate workers through the decision before any Hindsight, MemPalace, or Graphiti durable write.
 9. Self-evolution proposal records.
     - Implement Notice -> Explain -> Search -> Evaluate -> Propose records.
     - Keep execution approval-gated.

--- a/services/zoe-data/tests/test_zoe_memory_admission.py
+++ b/services/zoe-data/tests/test_zoe_memory_admission.py
@@ -1,0 +1,428 @@
+import pytest
+
+from zoe_candidate_scoring import CandidateEvaluation, CandidateScore
+from zoe_evolution_proposal import (
+    EvolutionSignal,
+    EvolutionSignalType,
+    ProposalRisk,
+    ProposalStatus,
+    TrustAutonomyClass,
+    build_evolution_proposal,
+)
+from zoe_memory_admission import (
+    MemoryAdmissionError,
+    MemoryAdmissionRequest,
+    MemoryAdmissionStatus,
+    evaluate_memory_admission,
+)
+from zoe_memory_contract import (
+    MemoryEvent,
+    MemoryEventType,
+    MemoryRelationship,
+    MemoryScope,
+    MemorySource,
+    RelationshipType,
+)
+from zoe_memory_router import MemoryBackend
+from zoe_observation_trace import ObservationOutcome, ObservationTrace, ObservationTraceType
+
+
+def _fact_event(**overrides):
+    values = {
+        "event_id": "mem_evt_pref",
+        "user_id": "jason",
+        "scope": MemoryScope.PERSONAL.value,
+        "source": MemorySource.CHAT.value,
+        "event_type": MemoryEventType.PREFERENCE.value,
+        "content": "Jason prefers Zoe memory to stay offline-only.",
+        "evidence_refs": ("chat:offline-memory",),
+        "confidence": 0.9,
+    }
+    values.update(overrides)
+    return MemoryEvent(**values)
+
+
+def _success_trace(**overrides):
+    values = {
+        "trace_id": "trace_admit_ok",
+        "trace_type": ObservationTraceType.ADMISSION.value,
+        "surface": "multica",
+        "scope": "personal",
+        "outcome": ObservationOutcome.SUCCESS.value,
+        "summary": "Memory candidate reviewed with evidence.",
+        "evidence_refs": ("multica:ZOE-123",),
+        "user_id": "jason",
+    }
+    values.update(overrides)
+    return ObservationTrace(**values)
+
+
+def _proposal(status=ProposalStatus.APPROVED.value):
+    signal = EvolutionSignal(
+        signal_id="signal_memory_gate",
+        signal_type=EvolutionSignalType.USER_REQUEST.value,
+        summary="User asked Zoe to retain a verified memory lesson.",
+        source="chat",
+        evidence_refs=("chat:memory-gate",),
+        user_id="jason",
+        scope="project",
+    )
+    candidate = CandidateEvaluation(
+        candidate_id="candidate_existing_zoe_memory",
+        name="Existing Zoe memory contract",
+        source="existing_zoe",
+        task="memory admission",
+        score=CandidateScore(
+            fit=5,
+            activity=4,
+            license=5,
+            offline=5,
+            security=4,
+            footprint=5,
+            tests=4,
+            maintainability=4,
+            overlap=5,
+        ),
+        evidence_refs=("docs:zoe-memory-contract",),
+        license_risk="compatible",
+        offline_viability="required",
+        recommendation="keep",
+    )
+    return build_evolution_proposal(
+        proposal_id="proposal_memory_gate",
+        title="Admit verified memory lesson",
+        problem_statement="Zoe needs to retain a verified self-evolution lesson.",
+        signals=(signal,),
+        candidate=candidate,
+        affected_capabilities=("memory",),
+        autonomy_class=TrustAutonomyClass.SUGGEST.value,
+        risk=ProposalRisk.MEDIUM.value,
+        expected_benefit="Retains evidence-backed improvement without blind auto-retain.",
+        verification_plan=("Focused memory admission tests pass.",),
+        rollback_plan="Leave the candidate pending and do not promote durable memory.",
+        approval_required=("memory_admission",),
+        status=status,
+    )
+
+
+def test_pending_candidate_cannot_write_durable_memory_without_approval():
+    request = MemoryAdmissionRequest(
+        admission_id="admit_pending",
+        candidate=_fact_event(),
+        requested_by="multica",
+        target_backends=(MemoryBackend.MEMPALACE.value,),
+        observation_traces=(),
+    )
+
+    decision = evaluate_memory_admission(request)
+
+    assert decision.status == MemoryAdmissionStatus.PENDING_REVIEW.value
+    assert decision.allowed_to_keep_pending is True
+    assert decision.allowed_to_write_durable is False
+    assert decision.allowed_backends == ()
+    assert decision.blockers == ("approval_required", "successful_admission_or_verification_trace_required")
+
+
+def test_approved_memory_with_successful_admission_trace_can_write_target_backend():
+    request = MemoryAdmissionRequest(
+        admission_id="admit_pref",
+        candidate=_fact_event(),
+        requested_by="multica",
+        target_backends=(MemoryBackend.MEMPALACE.value,),
+        observation_traces=(_success_trace(),),
+        approval_refs=("approval:multica:ZOE-123",),
+    )
+
+    decision = evaluate_memory_admission(request)
+
+    assert decision.status == MemoryAdmissionStatus.APPROVED.value
+    assert decision.allowed_to_write_durable is True
+    assert decision.allowed_backends == (MemoryBackend.MEMPALACE.value,)
+    assert decision.blockers == ()
+    assert decision.required_approvals == ("memory_admission",)
+    assert "chat:offline-memory" in decision.evidence_refs
+    assert "approval:multica:ZOE-123" in decision.evidence_refs
+
+
+def test_failed_or_blocked_trace_blocks_even_with_approval():
+    failed_trace = _success_trace(
+        trace_id="trace_failed",
+        outcome=ObservationOutcome.FAILED.value,
+        summary="The admission check contradicted current user preference.",
+    )
+    request = MemoryAdmissionRequest(
+        admission_id="admit_failed",
+        candidate=_fact_event(),
+        requested_by="multica",
+        target_backends=(MemoryBackend.MEMPALACE.value,),
+        observation_traces=(_success_trace(), failed_trace),
+        approval_refs=("approval:multica:ZOE-123",),
+    )
+
+    decision = evaluate_memory_admission(request)
+
+    assert decision.status == MemoryAdmissionStatus.BLOCKED.value
+    assert decision.allowed_to_write_durable is False
+    assert "failed_or_blocked_trace_present" in decision.blockers
+
+
+def test_failed_non_admission_trace_does_not_block_clean_admission():
+    failed_recall = _success_trace(
+        trace_id="trace_recall_miss",
+        trace_type=ObservationTraceType.RECALL.value,
+        surface="mempalace",
+        outcome=ObservationOutcome.FAILED.value,
+        summary="Recall did not find a useful prior memory.",
+        evidence_refs=(),
+    )
+    request = MemoryAdmissionRequest(
+        admission_id="admit_with_recall_miss",
+        candidate=_fact_event(),
+        requested_by="multica",
+        target_backends=(MemoryBackend.MEMPALACE.value,),
+        observation_traces=(_success_trace(), failed_recall),
+        approval_refs=("approval:multica:ZOE-123",),
+    )
+
+    decision = evaluate_memory_admission(request)
+
+    assert decision.status == MemoryAdmissionStatus.APPROVED.value
+    assert decision.allowed_to_write_durable is True
+    assert "failed_or_blocked_trace_present" not in decision.blockers
+
+
+def test_graphiti_target_requires_relationship_or_supersession():
+    request = MemoryAdmissionRequest(
+        admission_id="admit_graph_no_edge",
+        candidate=_fact_event(scope=MemoryScope.PROJECT.value),
+        requested_by="multica",
+        target_backends=(MemoryBackend.GRAPHITI.value,),
+        observation_traces=(_success_trace(scope="project"),),
+        approval_refs=("approval:multica:ZOE-123",),
+    )
+
+    decision = evaluate_memory_admission(request)
+
+    assert decision.status == MemoryAdmissionStatus.BLOCKED.value
+    assert decision.allowed_to_write_durable is False
+    assert "graphiti_target_requires_relationship_or_supersession" in decision.blockers
+    assert decision.required_approvals == ("memory_admission", "relational_truth")
+
+
+def test_relational_memory_can_be_approved_for_graphiti_with_evidence():
+    event = _fact_event(
+        scope=MemoryScope.PROJECT.value,
+        source=MemorySource.TRACE.value,
+        event_type=MemoryEventType.FACT.value,
+        relationships=(
+            MemoryRelationship(
+                relationship_type=RelationshipType.TRUSTED_FOR.value,
+                source="mempalace",
+                target="fast_chat_recall",
+            ),
+        ),
+        evidence_refs=("trace:mempalace-baseline",),
+    )
+    request = MemoryAdmissionRequest(
+        admission_id="admit_graph_edge",
+        candidate=event,
+        requested_by="multica",
+        target_backends=(MemoryBackend.GRAPHITI.value,),
+        observation_traces=(_success_trace(scope="project"),),
+        approval_refs=("approval:multica:ZOE-124",),
+    )
+
+    decision = evaluate_memory_admission(request)
+
+    assert decision.allowed_to_write_durable is True
+    assert decision.allowed_backends == (MemoryBackend.GRAPHITI.value,)
+
+
+def test_trace_user_must_match_candidate_user():
+    request = MemoryAdmissionRequest(
+        admission_id="admit_cross_user",
+        candidate=_fact_event(),
+        requested_by="multica",
+        target_backends=(MemoryBackend.MEMPALACE.value,),
+        observation_traces=(_success_trace(user_id="someone_else"),),
+        approval_refs=("approval:multica:ZOE-123",),
+    )
+
+    with pytest.raises(MemoryAdmissionError, match="user_id must match"):
+        evaluate_memory_admission(request)
+
+
+def test_trace_user_id_is_required_even_for_project_scope_traces():
+    request = MemoryAdmissionRequest(
+        admission_id="admit_trace_missing_user",
+        candidate=_fact_event(),
+        requested_by="multica",
+        target_backends=(MemoryBackend.MEMPALACE.value,),
+        observation_traces=(_success_trace(scope="project", user_id=None),),
+        approval_refs=("approval:multica:ZOE-123",),
+    )
+
+    with pytest.raises(MemoryAdmissionError, match="user_id must match"):
+        evaluate_memory_admission(request)
+
+
+def test_read_only_or_governance_backends_are_not_admitted_write_targets():
+    request = MemoryAdmissionRequest(
+        admission_id="admit_read_only_backend",
+        candidate=_fact_event(),
+        requested_by="multica",
+        target_backends=(MemoryBackend.GRAPHIFY.value,),
+        observation_traces=(_success_trace(),),
+        approval_refs=("approval:multica:ZOE-123",),
+    )
+
+    with pytest.raises(MemoryAdmissionError, match="not admitted write targets"):
+        evaluate_memory_admission(request)
+
+
+def test_invalid_candidate_errors_are_wrapped_as_memory_admission_error():
+    request = MemoryAdmissionRequest(
+        admission_id="admit_bad_candidate",
+        candidate=_fact_event(scope="unknown_scope"),
+        requested_by="multica",
+        target_backends=(MemoryBackend.MEMPALACE.value,),
+        observation_traces=(_success_trace(),),
+        approval_refs=("approval:multica:ZOE-123",),
+    )
+
+    with pytest.raises(MemoryAdmissionError, match="candidate is invalid"):
+        evaluate_memory_admission(request)
+
+
+def test_invalid_trace_errors_are_wrapped_as_memory_admission_error():
+    request = MemoryAdmissionRequest(
+        admission_id="admit_bad_trace",
+        candidate=_fact_event(),
+        requested_by="multica",
+        target_backends=(MemoryBackend.MEMPALACE.value,),
+        observation_traces=(_success_trace(trace_type="unknown_trace_type"),),
+        approval_refs=("approval:multica:ZOE-123",),
+    )
+
+    with pytest.raises(MemoryAdmissionError, match="trace trace_admit_ok is invalid"):
+        evaluate_memory_admission(request)
+
+
+def test_self_evolution_memory_requires_approved_proposal_context():
+    event = _fact_event(
+        event_id="mem_evt_self_evolution_fix",
+        scope=MemoryScope.PROJECT.value,
+        source=MemorySource.TRACE.value,
+        event_type=MemoryEventType.FIX.value,
+        content="The memory admission gate fixed blind durable retain promotion.",
+        evidence_refs=("pytest:test_zoe_memory_admission",),
+    )
+    request = MemoryAdmissionRequest(
+        admission_id="admit_self_evolution_no_proposal",
+        candidate=event,
+        requested_by="multica",
+        target_backends=(MemoryBackend.HINDSIGHT.value,),
+        observation_traces=(_success_trace(scope="project"),),
+        approval_refs=("approval:multica:ZOE-125",),
+    )
+
+    decision = evaluate_memory_admission(request)
+
+    assert decision.status == MemoryAdmissionStatus.BLOCKED.value
+    assert decision.allowed_to_write_durable is False
+    assert "self_evolution_memory_requires_proposal_context" in decision.blockers
+    assert decision.required_approvals == ("memory_admission", "self_evolution_proposal")
+
+
+def test_proposal_sourced_memory_requires_proposal_context_even_for_fact_type():
+    event = _fact_event(
+        event_id="mem_evt_proposal_fact",
+        scope=MemoryScope.PROJECT.value,
+        source=MemorySource.PROPOSAL.value,
+        event_type=MemoryEventType.FACT.value,
+        content="A proposal-sourced fact still needs proposal context.",
+        evidence_refs=("proposal:memory-fact",),
+    )
+    request = MemoryAdmissionRequest(
+        admission_id="admit_proposal_source_no_context",
+        candidate=event,
+        requested_by="multica",
+        target_backends=(MemoryBackend.HINDSIGHT.value,),
+        observation_traces=(_success_trace(scope="project"),),
+        approval_refs=("approval:multica:ZOE-126",),
+    )
+
+    decision = evaluate_memory_admission(request)
+
+    assert decision.status == MemoryAdmissionStatus.BLOCKED.value
+    assert "self_evolution_memory_requires_proposal_context" in decision.blockers
+
+
+def test_self_evolution_memory_can_be_admitted_with_approved_memory_proposal():
+    event = _fact_event(
+        event_id="mem_evt_self_evolution_fix",
+        scope=MemoryScope.PROJECT.value,
+        source=MemorySource.TRACE.value,
+        event_type=MemoryEventType.FIX.value,
+        content="The memory admission gate fixed blind durable retain promotion.",
+        evidence_refs=("pytest:test_zoe_memory_admission",),
+    )
+    request = MemoryAdmissionRequest(
+        admission_id="admit_self_evolution",
+        candidate=event,
+        requested_by="multica",
+        target_backends=(MemoryBackend.HINDSIGHT.value,),
+        observation_traces=(_success_trace(scope="project"),),
+        approval_refs=("approval:multica:ZOE-125",),
+        proposal=_proposal(),
+    )
+
+    decision = evaluate_memory_admission(request)
+
+    assert decision.allowed_to_write_durable is True
+    assert decision.allowed_backends == (MemoryBackend.HINDSIGHT.value,)
+    assert decision.blockers == ()
+
+
+def test_pending_optional_proposal_does_not_block_non_self_evolution_memory():
+    request = MemoryAdmissionRequest(
+        admission_id="admit_pref_with_optional_pending_proposal",
+        candidate=_fact_event(),
+        requested_by="multica",
+        target_backends=(MemoryBackend.MEMPALACE.value,),
+        observation_traces=(_success_trace(),),
+        approval_refs=("approval:multica:ZOE-123",),
+        proposal=_proposal(status=ProposalStatus.PENDING_APPROVAL.value),
+    )
+
+    decision = evaluate_memory_admission(request)
+
+    assert decision.status == MemoryAdmissionStatus.APPROVED.value
+    assert decision.allowed_to_write_durable is True
+    assert "proposal_must_be_approved_or_verified" not in decision.blockers
+
+
+def test_self_evolution_memory_blocks_unapproved_proposal_context():
+    event = _fact_event(
+        event_id="mem_evt_self_evolution_draft",
+        scope=MemoryScope.PROJECT.value,
+        source=MemorySource.TRACE.value,
+        event_type=MemoryEventType.FIX.value,
+        content="Draft proposal should not promote trusted memory.",
+        evidence_refs=("pytest:test_zoe_memory_admission",),
+    )
+    request = MemoryAdmissionRequest(
+        admission_id="admit_self_evolution_draft",
+        candidate=event,
+        requested_by="multica",
+        target_backends=(MemoryBackend.HINDSIGHT.value,),
+        observation_traces=(_success_trace(scope="project"),),
+        approval_refs=("approval:multica:ZOE-125",),
+        proposal=_proposal(status=ProposalStatus.PENDING_APPROVAL.value),
+    )
+
+    decision = evaluate_memory_admission(request)
+
+    assert decision.status == MemoryAdmissionStatus.BLOCKED.value
+    assert decision.allowed_to_write_durable is False
+    assert "proposal_must_be_approved_or_verified" in decision.blockers

--- a/services/zoe-data/zoe_memory_admission.py
+++ b/services/zoe-data/zoe_memory_admission.py
@@ -1,0 +1,211 @@
+"""Governed memory admission decisions for Zoe.
+
+This module is intentionally inert. It evaluates whether a memory candidate
+has enough scope, evidence, observation traces, and approval context to move
+from "pending candidate" toward durable/trusted memory. It does not write to
+MemoryService, Hindsight, Graphiti, or Multica.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Mapping, Sequence
+
+from zoe_evolution_proposal import EvolutionProposal, ProposalStatus
+from zoe_memory_contract import SELF_EVOLUTION_EVENT_TYPES, MemoryEvent, MemorySource
+from zoe_memory_router import MemoryBackend
+from zoe_observation_trace import ObservationOutcome, ObservationTrace, ObservationTraceType
+
+
+class MemoryAdmissionError(ValueError):
+    """Raised when a memory admission request is malformed."""
+
+
+class MemoryAdmissionStatus(str, Enum):
+    PENDING_REVIEW = "pending_review"
+    BLOCKED = "blocked"
+    APPROVED = "approved"
+
+
+ADMITTED_WRITE_BACKENDS = {
+    MemoryBackend.MEMPALACE.value,
+    MemoryBackend.HINDSIGHT.value,
+    MemoryBackend.GRAPHITI.value,
+}
+
+@dataclass(frozen=True)
+class MemoryAdmissionRequest:
+    admission_id: str
+    candidate: MemoryEvent
+    requested_by: str
+    target_backends: tuple[str, ...]
+    observation_traces: tuple[ObservationTrace, ...]
+    approval_refs: tuple[str, ...] = ()
+    proposal: EvolutionProposal | None = None
+    metadata: Mapping[str, Any] | None = None
+
+    def validate(self) -> None:
+        if not self.admission_id:
+            raise MemoryAdmissionError("admission_id is required")
+        if not self.requested_by:
+            raise MemoryAdmissionError(f"{self.admission_id}: requested_by is required")
+        try:
+            self.candidate.validate()
+        except ValueError as exc:
+            raise MemoryAdmissionError(f"{self.admission_id}: candidate is invalid: {exc}") from exc
+        if not self.target_backends:
+            raise MemoryAdmissionError(f"{self.admission_id}: target_backends are required")
+        unsupported = set(self.target_backends) - ADMITTED_WRITE_BACKENDS
+        if unsupported:
+            raise MemoryAdmissionError(
+                f"{self.admission_id}: target_backends are not admitted write targets: {sorted(unsupported)}"
+            )
+        for trace in self.observation_traces:
+            try:
+                trace.validate()
+            except ValueError as exc:
+                raise MemoryAdmissionError(f"{self.admission_id}: trace {trace.trace_id} is invalid: {exc}") from exc
+            if trace.user_id != self.candidate.user_id:
+                raise MemoryAdmissionError(
+                    f"{self.admission_id}: trace {trace.trace_id} user_id must match candidate user_id"
+                )
+        if self.proposal is not None:
+            try:
+                self.proposal.validate()
+            except ValueError as exc:
+                raise MemoryAdmissionError(f"{self.admission_id}: proposal is invalid: {exc}") from exc
+            if "memory_admission" not in self.proposal.approval_required:
+                raise MemoryAdmissionError(
+                    f"{self.admission_id}: proposal context must require memory_admission approval"
+                )
+
+    def evidence_refs(self) -> tuple[str, ...]:
+        refs: list[str] = list(self.candidate.evidence_refs)
+        for trace in self.observation_traces:
+            refs.extend(trace.evidence_refs)
+        if self.proposal is not None:
+            refs.extend(self.proposal.evidence_refs)
+        refs.extend(self.approval_refs)
+        return tuple(dict.fromkeys(refs))
+
+
+@dataclass(frozen=True)
+class MemoryAdmissionDecision:
+    admission_id: str
+    status: str
+    allowed_to_keep_pending: bool
+    allowed_to_write_durable: bool
+    allowed_backends: tuple[str, ...]
+    blockers: tuple[str, ...]
+    required_approvals: tuple[str, ...]
+    evidence_refs: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "admission_id": self.admission_id,
+            "status": self.status,
+            "allowed_to_keep_pending": self.allowed_to_keep_pending,
+            "allowed_to_write_durable": self.allowed_to_write_durable,
+            "allowed_backends": list(self.allowed_backends),
+            "blockers": list(self.blockers),
+            "required_approvals": list(self.required_approvals),
+            "evidence_refs": list(self.evidence_refs),
+        }
+
+
+def evaluate_memory_admission(request: MemoryAdmissionRequest) -> MemoryAdmissionDecision:
+    """Return Zoe's memory admission decision without writing memory."""
+
+    request.validate()
+    blockers = _admission_blockers(request)
+    allowed_to_write = not blockers
+    status = MemoryAdmissionStatus.APPROVED.value if allowed_to_write else MemoryAdmissionStatus.BLOCKED.value
+    soft_blockers = {"approval_required", "successful_admission_or_verification_trace_required"}
+    if blockers and set(blockers).issubset(soft_blockers):
+        status = MemoryAdmissionStatus.PENDING_REVIEW.value
+
+    return MemoryAdmissionDecision(
+        admission_id=request.admission_id,
+        status=status,
+        allowed_to_keep_pending=True,
+        allowed_to_write_durable=allowed_to_write,
+        allowed_backends=request.target_backends if allowed_to_write else (),
+        blockers=tuple(blockers),
+        required_approvals=tuple(_required_approvals(request)),
+        evidence_refs=request.evidence_refs(),
+    )
+
+
+def _admission_blockers(request: MemoryAdmissionRequest) -> list[str]:
+    blockers: list[str] = []
+    if not request.approval_refs:
+        blockers.append("approval_required")
+
+    if not _has_successful_trace(
+        request.observation_traces,
+        ObservationTraceType.ADMISSION.value,
+        ObservationTraceType.VERIFICATION.value,
+    ):
+        blockers.append("successful_admission_or_verification_trace_required")
+
+    if _has_failed_trace(
+        request.observation_traces,
+        ObservationTraceType.ADMISSION.value,
+        ObservationTraceType.VERIFICATION.value,
+    ):
+        blockers.append("failed_or_blocked_trace_present")
+
+    if MemoryBackend.GRAPHITI.value in request.target_backends and not (
+        request.candidate.relationships or request.candidate.supersedes
+    ):
+        blockers.append("graphiti_target_requires_relationship_or_supersession")
+
+    requires_proposal = _requires_proposal_context(request.candidate)
+    if requires_proposal and request.proposal is None:
+        blockers.append("self_evolution_memory_requires_proposal_context")
+
+    if request.proposal is not None and requires_proposal:
+        if request.proposal.status not in {ProposalStatus.APPROVED.value, ProposalStatus.VERIFIED.value}:
+            blockers.append("proposal_must_be_approved_or_verified")
+
+    return list(dict.fromkeys(blockers))
+
+
+def _required_approvals(request: MemoryAdmissionRequest) -> list[str]:
+    approvals = ["memory_admission"]
+    if _requires_proposal_context(request.candidate):
+        approvals.append("self_evolution_proposal")
+    if MemoryBackend.GRAPHITI.value in request.target_backends:
+        approvals.append("relational_truth")
+    return approvals
+
+
+def _has_successful_trace(traces: Sequence[ObservationTrace], *trace_types: str) -> bool:
+    return any(
+        trace.trace_type in trace_types and trace.outcome == ObservationOutcome.SUCCESS.value
+        for trace in traces
+    )
+
+
+def _has_failed_trace(traces: Sequence[ObservationTrace], *trace_types: str) -> bool:
+    return any(
+        trace.trace_type in trace_types
+        and trace.outcome in {ObservationOutcome.FAILED.value, ObservationOutcome.BLOCKED.value}
+        for trace in traces
+    )
+
+
+def _requires_proposal_context(candidate: MemoryEvent) -> bool:
+    if candidate.source == MemorySource.PROPOSAL.value:
+        return True
+    return candidate.event_type in SELF_EVOLUTION_EVENT_TYPES
+
+
+__all__ = [
+    "MemoryAdmissionDecision",
+    "MemoryAdmissionError",
+    "MemoryAdmissionRequest",
+    "MemoryAdmissionStatus",
+    "evaluate_memory_admission",
+]


### PR DESCRIPTION
## Summary\n- add an inert Zoe memory admission decision contract for pending vs durable memory writes\n- gate durable writes on approvals, successful admission/verification traces, graph edge requirements, matching user scope, and proposal context for self-evolution memories\n- document the gate and update the harness status ledger\n\n## Tests\n- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_zoe_memory_admission.py services/zoe-data/tests/test_hindsight_retain_candidates.py services/zoe-data/tests/test_zoe_memory_contract.py services/zoe-data/tests/test_zoe_observation_trace.py services/zoe-data/tests/test_zoe_evolution_proposal.py services/zoe-data/tests/test_zoe_memory_router.py\n- python3 tools/audit/validate_structure.py\n- python3 tools/audit/validate_critical_files.py\n- python3 tools/audit/validate_offline_memory.py\n- git diff --check