### PR TITLE
ZOE-5451: Route joke requests to open-domain agent

### DIFF
--- a/scripts/maintenance/zoe_apply_intent_gap_contract.py
+++ b/scripts/maintenance/zoe_apply_intent_gap_contract.py
@@ -8,7 +8,7 @@ import json
 from pathlib import Path
 
 
-JOKE_PATTERN = r"tell me (?:a|another) joke|make me laugh|got any jokes"
+JOKE_PATTERN = r"tell me (?:a|another) joke|make me laugh|(?:do you |have you )?(?:got|have) any jokes|know any (?:good )?jokes"
 JOKE_TEST = '''"""Open-domain creative intent routing."""
 
 import pytest

--- a/scripts/maintenance/zoe_apply_intent_gap_contract.py
+++ b/scripts/maintenance/zoe_apply_intent_gap_contract.py
@@ -16,7 +16,7 @@ import pytest
 from intent_router import detect_intent
 
 
-@pytest.mark.parametrize("text", ["Tell me a joke.", "Tell me a joke", "Tell me another joke."])
+@pytest.mark.parametrize("text", ["Tell me a joke.", "Tell me a joke", "Tell me another joke.", "make me laugh", "do you have any jokes?", "have you got any jokes?", "know any good jokes?"])
 def test_joke_requests_route_to_open_domain_agent(text: str):
     intent = detect_intent(text)
 

--- a/services/zoe-data/intent_router.py
+++ b/services/zoe-data/intent_router.py
@@ -411,7 +411,7 @@ _AGENT_CHAT_RE = re.compile(
     r"^(?:tell me about|what(?:'s| is) the (?:capital|weather)|"
     r"search the web|write me (?:an? )?(?:email|haiku|poem)|"
     r"can you explain|set up (?:a )?new automation|what is happening in|"
-    r"tell me (?:a|another) joke|make me laugh|got any jokes)",
+    r"tell me (?:a|another) joke|make me laugh|(?:do you |have you )?(?:got|have) any jokes|know any (?:good )?jokes)",
     re.IGNORECASE,
 )
 

--- a/services/zoe-data/intent_router.py
+++ b/services/zoe-data/intent_router.py
@@ -410,7 +410,8 @@ _GREETING_RE = re.compile(
 _AGENT_CHAT_RE = re.compile(
     r"^(?:tell me about|what(?:'s| is) the (?:capital|weather)|"
     r"search the web|write me (?:an? )?(?:email|haiku|poem)|"
-    r"can you explain|set up (?:a )?new automation|what is happening in)",
+    r"can you explain|set up (?:a )?new automation|what is happening in|"
+    r"tell me (?:a|another) joke|make me laugh|got any jokes)",
     re.IGNORECASE,
 )
 

--- a/services/zoe-data/tests/test_intent_gap_contract_helper.py
+++ b/services/zoe-data/tests/test_intent_gap_contract_helper.py
@@ -35,7 +35,7 @@ def test_apply_joke_contract_patches_router_and_adds_test(tmp_path):
     router = router_path.read_text(encoding="utf-8")
     generated_test = tmp_path / "services/zoe-data/tests/test_intent_open_domain.py"
     assert result["idempotent"] is False
-    assert "tell me (?:a|another) joke|make me laugh|got any jokes" in router
+    assert "tell me (?:a|another) joke|make me laugh|(?:do you |have you )?(?:got|have) any jokes|know any (?:good )?jokes" in router
     assert generated_test.exists()
     assert "test_joke_requests_route_to_open_domain_agent" in generated_test.read_text(encoding="utf-8")
 
@@ -76,3 +76,18 @@ def test_apply_joke_contract_fails_cleanly_when_router_missing(tmp_path):
         assert "intent_router.py not found" in str(exc)
     else:
         raise AssertionError("expected SystemExit for missing intent_router.py")
+
+
+def test_apply_joke_contract_is_idempotent_with_current_router_pattern(tmp_path):
+    helper = _load_helper()
+    router_path = tmp_path / "services/zoe-data/intent_router.py"
+    router_path.parent.mkdir(parents=True)
+    router_path.write_text(
+        '    r"tell me (?:a|another) joke|make me laugh|(?:do you |have you )?(?:got|have) any jokes|know any (?:good )?jokes)",\n',
+        encoding="utf-8",
+    )
+
+    result = helper.apply_joke_contract(tmp_path)
+
+    assert result["changed"] == ["services/zoe-data/tests/test_intent_open_domain.py"]
+    assert "tell me (?:a|another) joke|make me laugh|(?:do you |have you )?(?:got|have) any jokes|know any (?:good )?jokes" in router_path.read_text(encoding="utf-8")

--- a/services/zoe-data/tests/test_intent_open_domain.py
+++ b/services/zoe-data/tests/test_intent_open_domain.py
@@ -5,7 +5,7 @@ import pytest
 from intent_router import detect_intent
 
 
-@pytest.mark.parametrize("text", ["Tell me a joke.", "Tell me a joke", "Tell me another joke."])
+@pytest.mark.parametrize("text", ["Tell me a joke.", "Tell me a joke", "Tell me another joke.", "make me laugh", "do you have any jokes?", "have you got any jokes?", "know any good jokes?"])
 def test_joke_requests_route_to_open_domain_agent(text: str):
     intent = detect_intent(text)
 

--- a/services/zoe-data/tests/test_intent_open_domain.py
+++ b/services/zoe-data/tests/test_intent_open_domain.py
@@ -1,0 +1,14 @@
+"""Open-domain creative intent routing."""
+
+import pytest
+
+from intent_router import detect_intent
+
+
+@pytest.mark.parametrize("text", ["Tell me a joke.", "Tell me a joke", "Tell me another joke."])
+def test_joke_requests_route_to_open_domain_agent(text: str):
+    intent = detect_intent(text)
+
+    assert intent is not None
+    assert intent.name == "extend_capability"
+    assert intent.slots == {"raw": text}


### PR DESCRIPTION
## Summary
- route joke/open-domain prompts through _AGENT_CHAT_RE to extend_capability
- add focused tests for Tell me a joke variants

## Validation
- python3 -m py_compile services/zoe-data/intent_router.py
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_intent_open_domain.py
- python3 tools/audit/validate_structure.py

## Recovery note
Hermes produced commit 3f168a2 but hit its iteration budget before push/PR, so Codex published the worker commit without modifying it.