### PR TITLE
Add Zoe memory router runtime status

### DIFF
--- a/docs/architecture/zoe-memory-router-runtime.md
+++ b/docs/architecture/zoe-memory-router-runtime.md
@@ -1,0 +1,30 @@
+# Zoe Memory Router Runtime Gate
+
+Zoe's deterministic memory router can now be inspected at runtime without
+changing chat behavior.
+
+The helper lives in `services/zoe-data/zoe_memory_router_runtime.py`.
+
+## Contract
+
+- Default is disabled: `ZOE_MEMORY_ROUTER_RUNTIME_ENABLED=false`.
+- Enabled mode is observe-only.
+- Chat hot-path prompt injection remains disabled.
+- Durable memory writes remain disabled.
+- Runtime status shows sample route decisions only when the runtime flag is enabled
+  or a test/operator call explicitly requests samples.
+- This slice does not call MemPalace, Hindsight, Graphiti, Graphify, or Multica.
+
+## Status Endpoint
+
+`GET /api/system/memory-router/status`
+
+The endpoint is admin-scoped through the existing system router and returns the
+feature flag, runtime mode, safety booleans, and sample route decisions.
+
+## Next Runtime Step
+
+The next PR may record observation traces around route decisions, still without
+injecting memory packets into prompts or writing durable memory. Prompt-time
+recall should remain a later feature flag after latency and safety evidence
+exist.

--- a/docs/strategy/zoe-evolution-harness-plan.md
+++ b/docs/strategy/zoe-evolution-harness-plan.md
@@ -219,6 +219,8 @@ proposal context for self-evolution memories allow durable writes.
 ## Memory Router
 
 The deterministic router lives in `services/zoe-data/zoe_memory_router.py`.
+Runtime inspection lives in `services/zoe-data/zoe_memory_router_runtime.py`
+and is disabled by default through `ZOE_MEMORY_ROUTER_RUNTIME_ENABLED`.
 
 Routing defaults:
 
@@ -227,6 +229,14 @@ Routing defaults:
 - Relationship/causal/supersession queries: Graphiti-style graph as async/deferred relational enrichment until measured.
 - Code/system questions: Graphify.
 - Self-evolution proposals: Multica first, with Hindsight + Graphiti + Graphify evidence.
+
+Runtime rules:
+
+- Default runtime mode is disabled.
+- Enabled runtime mode is observe-only until a later PR wires traces.
+- Prompt injection remains off.
+- Durable memory writes remain off.
+- `/api/system/memory-router/status` may expose sample route decisions for admin inspection.
 
 Prompt-time policy:
 

--- a/docs/strategy/zoe-evolution-harness-status.md
+++ b/docs/strategy/zoe-evolution-harness-status.md
@@ -39,7 +39,7 @@ Important non-complete truth:
 - Zoe now has a self-evolution proposal contract that attaches signals, candidate scores, affected capabilities, approval gates, verification, rollback, and evidence before any execution.
 - Zoe now has an observation/evaluation trace schema for recall, retain candidates, admission, contradiction, fallback, proposals, verification, outcome evals, and hardware budget evidence.
 - Zoe now has an inert memory admission contract that keeps retain candidates pending until evidence, successful admission/verification traces, and approval refs allow durable/trusted memory writes.
-- The deterministic memory router is not yet wired into production chat behind a feature flag.
+- The deterministic memory router now has a disabled-by-default runtime status gate; it is not yet used for prompt injection or backend recall in production chat.
 - Retain-candidate admission has a tested contract, but existing runtime writers are not yet wired to enforce it through Multica approval.
 - The full self-evolution loop is not yet implemented end to end; proposal records are now defined, but existing live proposal writers still need to emit them and Multica still needs to enforce admission.
 - Zoe main engine cleanup should not begin until the inventory, graph, and memory/evolution contracts have protective tests around the active surfaces.
@@ -53,7 +53,7 @@ Important non-complete truth:
 | Offline-only memory rule | Partial | `HindsightConfig` rejects public/cloud memory model configuration by default. | Add a repository-wide memory/provider audit that flags cloud memory paths and exposed secrets. |
 | Memory contract | Complete foundation | `services/zoe-data/zoe_memory_contract.py` and `services/zoe-data/tests/test_zoe_memory_contract.py`. | Extend only when a measured backend requires a new field or relationship. |
 | Memory layer map | Complete foundation | `services/zoe-data/zoe_memory_layers.py` and `services/zoe-data/tests/test_zoe_memory_layers.py`. | Link layer decisions to runtime config and status endpoints. |
-| Memory router | Partial | `services/zoe-data/zoe_memory_router.py` and `services/zoe-data/tests/test_zoe_memory_router.py`. | Wire into chat/agent recall behind a disabled-by-default feature flag with latency guards. |
+| Memory router | Partial | `services/zoe-data/zoe_memory_router.py`, `services/zoe-data/zoe_memory_router_runtime.py`, `services/zoe-data/tests/test_zoe_memory_router.py`, `services/zoe-data/tests/test_zoe_memory_router_runtime.py`, and `/api/system/memory-router/status` expose disabled-by-default observe-only route decisions. | Add observation traces around route decisions, then wire prompt-time recall behind a second explicit feature flag with latency guards. |
 | MemPalace baseline | Complete foundation | `services/zoe-data/mempalace_baseline.py`, `scripts/maintenance/mempalace_baseline.py`, and `docs/architecture/zoe-mempalace-baseline.md` record a repeatable local benchmark; first run scored 1.0 avg with p95 200.90 ms and cleaned up 4 synthetic rows. | Expand with relational/supersession cases before comparing Graphiti-style backends. |
 | Hindsight bake-off | Partial | Offline sidecar client, retain-candidate helpers, synthetic fixtures, measured runner, availability doc, and tests exist; current Zoe-host check found no running Hindsight sidecar. | Start a local/offline sidecar, run retain/recall with synthetic events, and record p50/p95 latency, failures, evidence quality, and CPU/RAM use. |
 | Graphiti bake-off | Partial | ADR plus `services/zoe-data/graphiti_bakeoff.py`, `services/zoe-data/tests/test_graphiti_bakeoff.py`, and `docs/architecture/zoe-graphiti-fixtures.md` define the first relationship fixture set. | Run the fixtures against FalkorDB first, then Neo4j if feasible, and record latency, evidence quality, supersession behavior, and CPU/RAM use. |
@@ -186,8 +186,9 @@ Keep each pull request small enough for Greptile and Zoe verification.
    - Next: test FalkorDB, then Neo4j if feasible.
    - Decide sidecar/remote/hot-path eligibility from evidence.
 7. Runtime memory router feature flag.
-   - Wire deterministic routing into chat/agent recall in fallback-safe mode.
-   - Add latency timeout and compact cited memory packets.
+   - Status: observe-only runtime status foundation complete.
+   - `zoe_memory_router_runtime.py` and `/api/system/memory-router/status` expose disabled-by-default route decisions without prompt injection or writes.
+   - Next: add observation traces around route decisions, then wire prompt-time recall in fallback-safe mode with latency timeout and compact cited memory packets.
 8. Memory admission governance.
    - Status: complete foundation.
    - `zoe_memory_admission.py` now gates durable memory writes on approval refs, successful admission/verification traces, graph edge requirements, user/scope matching, and proposal context for self-evolution memories.

--- a/services/zoe-data/routers/system.py
+++ b/services/zoe-data/routers/system.py
@@ -165,6 +165,14 @@ async def get_system_status(
     }
 
 
+@router.get("/memory-router/status")
+async def get_memory_router_status(user: dict = Depends(require_admin)):
+    """Read-only status for Zoe's disabled-by-default memory router runtime."""
+    from zoe_memory_router_runtime import memory_router_runtime_status
+
+    return memory_router_runtime_status()
+
+
 def _load_skills_and_cron():
     skills = []
     skills_dir = os.path.expanduser("~/.openclaw/workspace/skills")

--- a/services/zoe-data/tests/test_zoe_memory_router_runtime.py
+++ b/services/zoe-data/tests/test_zoe_memory_router_runtime.py
@@ -1,0 +1,98 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from auth import require_admin
+from routers.system import router as system_router
+from zoe_memory_router import MemoryBackend
+from zoe_memory_router_runtime import (
+    FEATURE_FLAG,
+    memory_router_runtime_enabled,
+    memory_router_runtime_status,
+    route_memory_for_runtime,
+)
+
+
+def test_memory_router_runtime_is_disabled_by_default(monkeypatch):
+    monkeypatch.delenv(FEATURE_FLAG, raising=False)
+
+    status = memory_router_runtime_status(include_samples=False)
+
+    assert memory_router_runtime_enabled() is False
+    assert status["enabled"] is False
+    assert status["mode"] == "disabled"
+    assert status["default_enabled"] is False
+    assert status["chat_hot_path_enabled"] is False
+    assert status["prompt_injection_enabled"] is False
+    assert status["durable_writes_enabled"] is False
+
+
+def test_memory_router_runtime_enabled_is_observe_only(monkeypatch):
+    monkeypatch.setenv(FEATURE_FLAG, "true")
+
+    decision = route_memory_for_runtime("What fix worked for this recurring failure?")
+
+    assert decision["enabled"] is True
+    assert decision["mode"] == "observe_only"
+    assert decision["route"]["primary"] == MemoryBackend.HINDSIGHT.value
+    assert decision["can_inject_prompt"] is False
+    assert decision["can_write_memory"] is False
+
+
+def test_status_can_include_sample_route_decisions(monkeypatch):
+    monkeypatch.setenv(FEATURE_FLAG, "true")
+
+    status = memory_router_runtime_status(
+        samples=(("self_evolution", "Create an upgrade proposal for a new capability."),)
+    )
+
+    assert status["sample_routes"][0]["id"] == "self_evolution"
+    assert status["sample_routes"][0]["decision"]["route"]["primary"] == MemoryBackend.MULTICA.value
+    assert status["sample_routes"][0]["decision"]["can_write_memory"] is False
+
+
+def test_disabled_runtime_does_not_compute_route_decision(monkeypatch):
+    monkeypatch.delenv(FEATURE_FLAG, raising=False)
+
+    decision = route_memory_for_runtime("Create an upgrade proposal for a new capability.")
+    status = memory_router_runtime_status()
+
+    assert decision["route"] is None
+    assert status["sample_routes"] == []
+
+
+def test_system_memory_router_status_endpoint_is_admin_scoped(monkeypatch):
+    monkeypatch.delenv(FEATURE_FLAG, raising=False)
+    app = FastAPI()
+    app.include_router(system_router)
+
+    async def fake_admin():
+        return {"user_id": "admin", "role": "family-admin"}
+
+    app.dependency_overrides[require_admin] = fake_admin
+
+    resp = TestClient(app).get("/api/system/memory-router/status")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["surface"] == "zoe_memory_router"
+    assert data["enabled"] is False
+    assert data["prompt_injection_enabled"] is False
+    assert data["durable_writes_enabled"] is False
+    assert data["sample_routes"] == []
+
+
+def test_system_memory_router_status_endpoint_rejects_non_admin(monkeypatch):
+    monkeypatch.delenv(FEATURE_FLAG, raising=False)
+    app = FastAPI()
+    app.include_router(system_router)
+
+    async def fake_non_admin():
+        from fastapi import HTTPException
+
+        raise HTTPException(status_code=403, detail="Admin access required")
+
+    app.dependency_overrides[require_admin] = fake_non_admin
+
+    resp = TestClient(app).get("/api/system/memory-router/status")
+
+    assert resp.status_code == 403

--- a/services/zoe-data/zoe_memory_router_runtime.py
+++ b/services/zoe-data/zoe_memory_router_runtime.py
@@ -1,0 +1,97 @@
+"""Runtime feature-flag wrapper for Zoe memory routing.
+
+The deterministic router can be inspected safely before it participates in
+chat prompt construction or memory writes. This module keeps that runtime
+contract explicit: disabled by default, observe-only when enabled, and never a
+writer.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Sequence
+
+from zoe_memory_router import route_memory_query
+
+
+FEATURE_FLAG = "ZOE_MEMORY_ROUTER_RUNTIME_ENABLED"
+DEFAULT_SAMPLE_QUERIES = (
+    ("default_chat", "What do I usually like for breakfast?"),
+    ("experience", "What fix worked for the recurring service failure?"),
+    ("relational", "Which approval superseded the old tool trust?"),
+    ("self_evolution", "Create an upgrade proposal for a new capability."),
+)
+
+
+def memory_router_runtime_enabled(env: dict[str, str] | None = None) -> bool:
+    values = os.environ if env is None else env
+    return str(values.get(FEATURE_FLAG, "false")).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def route_memory_for_runtime(
+    query: str,
+    *,
+    purpose: str = "chat",
+    env: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    enabled = memory_router_runtime_enabled(env)
+    if not enabled:
+        return {
+            "enabled": False,
+            "mode": "disabled",
+            "route": None,
+            "can_inject_prompt": False,
+            "can_write_memory": False,
+            "reason": "runtime flag disabled",
+        }
+    route = route_memory_query(query, purpose=purpose)
+    return {
+        "enabled": True,
+        "mode": "observe_only",
+        "route": route.to_dict(),
+        "can_inject_prompt": False,
+        "can_write_memory": False,
+        "reason": "runtime flag enabled for observation only",
+    }
+
+
+def memory_router_runtime_status(
+    *,
+    env: dict[str, str] | None = None,
+    include_samples: bool | None = None,
+    samples: Sequence[tuple[str, str]] = DEFAULT_SAMPLE_QUERIES,
+) -> dict[str, Any]:
+    enabled = memory_router_runtime_enabled(env)
+    sample_routes = []
+    if include_samples is None:
+        include_samples = enabled
+    if include_samples:
+        for sample_id, query in samples:
+            sample_routes.append(
+                {
+                    "id": sample_id,
+                    "query": query,
+                    "decision": route_memory_for_runtime(query, env=env),
+                }
+            )
+    return {
+        "ok": True,
+        "surface": "zoe_memory_router",
+        "feature_flag": FEATURE_FLAG,
+        "enabled": enabled,
+        "mode": "observe_only" if enabled else "disabled",
+        "default_enabled": False,
+        "chat_hot_path_enabled": False,
+        "prompt_injection_enabled": False,
+        "durable_writes_enabled": False,
+        "sample_routes": sample_routes,
+    }
+
+
+__all__ = [
+    "DEFAULT_SAMPLE_QUERIES",
+    "FEATURE_FLAG",
+    "memory_router_runtime_enabled",
+    "memory_router_runtime_status",
+    "route_memory_for_runtime",
+]


### PR DESCRIPTION
## Summary
- add a disabled-by-default observe-only runtime wrapper for Zoe memory route decisions
- expose an admin /api/system/memory-router/status endpoint without prompt injection or memory writes
- document the runtime gate and update the harness ledger

## Tests
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_zoe_memory_router_runtime.py services/zoe-data/tests/test_zoe_memory_router.py services/zoe-data/tests/test_zoe_memory_admission.py services/zoe-data/tests/test_zoe_observation_trace.py services/zoe-data/tests/test_zoe_evolution_proposal.py
- python3 tools/audit/validate_structure.py
- python3 tools/audit/validate_critical_files.py
- python3 tools/audit/validate_offline_memory.py
- git diff --check
