### PR TITLE
Record pipeline completion after PR maintenance merge

### DIFF
--- a/scripts/maintenance/zoe_pr_maintenance.py
+++ b/scripts/maintenance/zoe_pr_maintenance.py
@@ -36,14 +36,14 @@ def _run_guard(pr: int, *, merge_when_ready: bool) -> dict:
     return parsed
 
 
-async def _record_issue_progress(issue_id: str | None, result: dict) -> None:
+async def _record_issue_progress(issue_id: str | None, result: dict) -> dict:
     if not issue_id:
-        return
+        return result
     from multica_client import get_multica_client
 
     client = get_multica_client()
     if not client.is_configured():
-        return
+        return result
     state = str(result.get("state") or "")
     status = "done" if state == "MERGED" else ("blocked" if state in {"BLOCKED", "ERROR"} else "in_review")
     blocker = None if status != "blocked" else str(result.get("reason") or result.get("output") or state)
@@ -56,6 +56,23 @@ async def _record_issue_progress(issue_id: str | None, result: dict) -> None:
         clear_blocker=status in {"done", "in_review"},
         status=status,
     )
+    if status == "done":
+        from pipeline_store import complete_pipeline_after_external_merge
+
+        try:
+            complete_pipeline_after_external_merge(
+                f"multica:{issue_id}",
+                pr_url=result.get("pr_url"),
+                merge_sha=result.get("merge_commit"),
+                greptile_status=str(result.get("greptile") or result.get("state") or ""),
+                reason="PR maintenance recorded merged PR",
+            )
+            result["journal_ok"] = True
+        except Exception as exc:  # noqa: BLE001 - keep maintenance output machine-readable.
+            result["journal_ok"] = False
+            result["journal_error"] = str(exc)
+            result["exit_code"] = 1
+    return result
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -66,9 +83,13 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     result = _run_guard(args.pr, merge_when_ready=args.merge_when_ready)
-    asyncio.run(_record_issue_progress(args.issue_id, result))
+    try:
+        result = asyncio.run(_record_issue_progress(args.issue_id, result))
+    except Exception as exc:  # noqa: BLE001 - command should print JSON even on progress failures.
+        result["progress_error"] = str(exc)
+        result["exit_code"] = 1
     print(json.dumps(result, sort_keys=True))
-    return 0 if result.get("ok") else 1
+    return 0 if result.get("ok") and not result.get("progress_error") and not result.get("journal_error") else 1
 
 
 if __name__ == "__main__":

--- a/services/zoe-data/pipeline_store.py
+++ b/services/zoe-data/pipeline_store.py
@@ -15,6 +15,7 @@ from pipeline_evidence import (
     EvidenceItem,
     PipelinePhase,
     PipelineState,
+    TransitionRecord,
     block_fingerprint,
     build_scope_split_packet,
     can_complete_phase,
@@ -264,6 +265,109 @@ def skip_blocked_implementation(
                 skipped,
                 event="operator_skipped_implementation",
                 extra={"reason": reason, "from_phase": "implement", "to_phase": "verify"},
+            )
+        except PipelineStateConflict:
+            if attempt:
+                raise
+    raise AssertionError("unreachable")
+
+
+def complete_pipeline_after_external_merge(
+    task_ref: str,
+    *,
+    pr_url: str | None = None,
+    merge_sha: str | None = None,
+    greptile_status: str | None = None,
+    reason: str = "external PR merge recorded",
+) -> PipelineState | None:
+    """Journal a completed run when PR maintenance recovers a worker publish gap."""
+    for attempt in range(2):
+        state = load_latest_state(task_ref)
+        if state is None:
+            return None
+        if state.status == "done":
+            return state
+        evidence = list(state.evidence)
+        if pr_url and not any(item.kind == "pr" and item.artifact == pr_url for item in evidence):
+            evidence.append(
+                EvidenceItem(
+                    kind="pr",
+                    summary=pr_url[:500],
+                    artifact=pr_url,
+                    passed=True,
+                    metadata={"source": "pr_maintenance", "phase": "implement"},
+                )
+            )
+        if not any(
+            item.kind == "greptile"
+            and item.metadata.get("source") == "pr_maintenance"
+            and item.metadata.get("phase") == "closeout"
+            and item.metadata.get("merge_sha") == merge_sha
+            for item in evidence
+        ):
+            evidence.append(
+                EvidenceItem(
+                    kind="greptile",
+                    summary=(greptile_status or "MERGED")[:500],
+                    artifact=pr_url,
+                    passed=True,
+                    metadata={
+                        "source": "pr_maintenance",
+                        "phase": "closeout",
+                        "merge_sha": merge_sha,
+                    },
+                )
+            )
+        if not any(
+            item.kind == "log"
+            and item.metadata.get("source") == "pr_maintenance"
+            and item.metadata.get("phase") == "retro"
+            and item.metadata.get("merge_sha") == merge_sha
+            for item in evidence
+        ):
+            evidence.append(
+                EvidenceItem(
+                    kind="log",
+                    summary=reason[:500],
+                    artifact=pr_url,
+                    passed=True,
+                    metadata={
+                        "source": "pr_maintenance",
+                        "phase": "retro",
+                        "merge_sha": merge_sha,
+                    },
+                )
+            )
+        completed = state.model_copy(
+            update={
+                "phase": "retro",
+                "status": "done",
+                "evidence": evidence,
+                "last_block_fingerprint": None,
+                "repeated_block_count": 0,
+                "block_classification": None,
+                "split_packet": None,
+                "history": [
+                    *state.history,
+                    TransitionRecord(
+                        from_phase=state.phase,
+                        to_phase="retro",
+                        outcome="complete",
+                        reason=reason,
+                    ),
+                ],
+            }
+        )
+        try:
+            return save_state(
+                completed,
+                event="external_merge_completed",
+                extra={
+                    "reason": reason,
+                    "pr_url": pr_url,
+                    "merge_sha": merge_sha,
+                    "greptile_status": greptile_status,
+                },
             )
         except PipelineStateConflict:
             if attempt:

--- a/services/zoe-data/tests/test_pipeline_store.py
+++ b/services/zoe-data/tests/test_pipeline_store.py
@@ -129,6 +129,56 @@ def test_resume_pipeline_retries_after_conflict(isolated_store, monkeypatch):
     assert resumed.status == "todo"
 
 
+def test_complete_pipeline_after_external_merge_journals_done(isolated_store):
+    state = PipelineState(task_ref="multica:merged", phase="implement", status="blocked")
+    state = with_evidence(
+        state,
+        EvidenceItem(
+            kind="greptile",
+            summary="5/5",
+            passed=True,
+            metadata={"source": "pr_maintenance", "phase": "closeout", "merge_sha": "deadbeef"},
+        ),
+        EvidenceItem(
+            kind="log",
+            summary="PR maintenance recorded merged PR",
+            passed=True,
+            metadata={"source": "pr_maintenance", "phase": "retro", "merge_sha": "deadbeef"},
+        ),
+    )
+    store.save_state(state, event="blocked")
+
+    completed = store.complete_pipeline_after_external_merge(
+        "multica:merged",
+        pr_url="https://github.com/o/r/pull/9",
+        merge_sha="deadbeef",
+        greptile_status="5/5",
+    )
+
+    assert completed is not None
+    assert completed.phase == "retro"
+    assert completed.status == "done"
+    assert completed.block_classification is None
+    assert completed.split_packet is None
+    assert completed.history[-1].from_phase == "implement"
+    assert completed.history[-1].to_phase == "retro"
+    assert any(item.kind == "pr" and item.artifact == "https://github.com/o/r/pull/9" for item in completed.evidence)
+    assert any(item.kind == "greptile" and item.metadata.get("merge_sha") == "deadbeef" for item in completed.evidence)
+    assert any(item.kind == "log" and item.metadata.get("phase") == "retro" for item in completed.evidence)
+    assert sum(
+        1
+        for item in completed.evidence
+        if item.kind == "greptile" and item.metadata.get("source") == "pr_maintenance"
+    ) == 1
+    assert sum(
+        1
+        for item in completed.evidence
+        if item.kind == "log" and item.metadata.get("source") == "pr_maintenance"
+    ) == 1
+    last = json.loads(isolated_store.read_text(encoding="utf-8").strip().splitlines()[-1])
+    assert last["event"] == "external_merge_completed"
+
+
 def test_concurrent_evidence_merge_deduplicates_created_at_only(isolated_store):
     initial = store.save_state(
         PipelineState(task_ref="multica:evidence-dedup"),

--- a/services/zoe-data/tests/test_zoe_pr_maintenance.py
+++ b/services/zoe-data/tests/test_zoe_pr_maintenance.py
@@ -1,4 +1,5 @@
 import importlib.util
+import asyncio
 import sys
 import types
 from pathlib import Path
@@ -46,3 +47,101 @@ def test_run_guard_calls_merge_guard(monkeypatch):
     result = _load_module()._run_guard(141, merge_when_ready=True)
     assert result == {"ok": True, "state": "MERGED", "pr": 141, "exit_code": 0}
 
+
+def test_record_issue_progress_marks_pipeline_done_on_merge(monkeypatch):
+    calls = []
+
+    class Client:
+        def is_configured(self):
+            return True
+
+        async def record_progress(self, issue_id, **kwargs):
+            calls.append(("progress", issue_id, kwargs))
+
+    def complete_pipeline_after_external_merge(task_ref, **kwargs):
+        calls.append(("complete", task_ref, kwargs))
+
+    monkeypatch.setitem(
+        sys.modules,
+        "multica_client",
+        types.SimpleNamespace(get_multica_client=lambda: Client()),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "pipeline_store",
+        types.SimpleNamespace(
+            complete_pipeline_after_external_merge=complete_pipeline_after_external_merge
+        ),
+    )
+
+    result = asyncio.run(
+        _load_module()._record_issue_progress(
+            "issue-1",
+            {
+                "state": "MERGED",
+                "greptile": "5/5",
+                "merge_commit": "deadbeef",
+                "pr_url": "https://github.com/o/r/pull/9",
+            },
+        )
+    )
+
+    assert result["journal_ok"] is True
+    assert calls[0] == (
+        "progress",
+        "issue-1",
+        {
+            "phase": "closeout",
+            "greptile_status": "5/5",
+            "merge_sha": "deadbeef",
+            "blocker": None,
+            "clear_blocker": True,
+            "status": "done",
+        },
+    )
+    assert calls[1] == (
+        "complete",
+        "multica:issue-1",
+        {
+            "pr_url": "https://github.com/o/r/pull/9",
+            "merge_sha": "deadbeef",
+            "greptile_status": "5/5",
+            "reason": "PR maintenance recorded merged PR",
+        },
+    )
+
+
+def test_record_issue_progress_preserves_json_contract_on_journal_error(monkeypatch):
+    class Client:
+        def is_configured(self):
+            return True
+
+        async def record_progress(self, issue_id, **kwargs):
+            return {}
+
+    def complete_pipeline_after_external_merge(task_ref, **kwargs):
+        raise RuntimeError("journal unavailable")
+
+    monkeypatch.setitem(
+        sys.modules,
+        "multica_client",
+        types.SimpleNamespace(get_multica_client=lambda: Client()),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "pipeline_store",
+        types.SimpleNamespace(
+            complete_pipeline_after_external_merge=complete_pipeline_after_external_merge
+        ),
+    )
+
+    result = asyncio.run(
+        _load_module()._record_issue_progress(
+            "issue-1",
+            {"ok": True, "state": "MERGED", "merge_commit": "deadbeef"},
+        )
+    )
+
+    assert result["journal_ok"] is False
+    assert result["journal_error"] == "journal unavailable"
+    assert result["exit_code"] == 1


### PR DESCRIPTION
## Summary
- add a pipeline journal recovery helper for PRs merged through PR maintenance
- have zoe_pr_maintenance mark the Multica pipeline done after a guarded MERGED result
- cover the helper and wrapper behavior with focused tests

## Validation
- python -m py_compile services/zoe-data/pipeline_store.py scripts/maintenance/zoe_pr_maintenance.py services/zoe-data/tests/test_pipeline_store.py services/zoe-data/tests/test_zoe_pr_maintenance.py
- git diff --check

Note: local pytest is unavailable in the Codex macOS runtime; focused pytest will run in CI/remote validation.