### PR TITLE
Add Hindsight sidecar readiness probe

### DIFF
--- a/docs/architecture/zoe-hindsight-bakeoff.md
+++ b/docs/architecture/zoe-hindsight-bakeoff.md
@@ -11,10 +11,31 @@ This document records the current bake-off runner and the first Zoe-host availab
 Files:
 
 - `services/zoe-data/hindsight_bakeoff.py`
+- `services/zoe-data/hindsight_sidecar_probe.py`
 - `scripts/maintenance/hindsight_bakeoff.py`
+- `scripts/maintenance/hindsight_sidecar_probe.py`
 - `services/zoe-data/tests/test_hindsight_bakeoff.py`
+- `services/zoe-data/tests/test_hindsight_sidecar_probe.py`
 
 The runner uses the synthetic Zoe memory events from `hindsight_bakeoff.py`, can optionally retain them into a configured Hindsight sidecar, then measures recall scores and p50/p95 latency across the evaluation queries.
+
+The sidecar probe is read-only and should be run before the bake-off:
+
+```bash
+PYTHONPATH=services/zoe-data python3 scripts/maintenance/hindsight_sidecar_probe.py --json
+```
+
+Probe statuses:
+
+- `disabled`: `HINDSIGHT_ENABLED` is false; no health call, retain, recall, or writes.
+- `misconfigured`: offline-only policy rejected the visible config.
+- `offline`: enabled config is valid, but the sidecar health call failed.
+- `unhealthy`: enabled config is valid and the sidecar responded, but not with an ok/healthy health body.
+- `healthy`: enabled config is valid and the sidecar health response reports ok/healthy.
+
+Probe payloads separate `ok` from `acceptable`. `ok` means the sidecar is actively healthy.
+`acceptable` means the operational state is allowed for the current rollout, so `disabled` is acceptable
+while bake-off runtime wiring remains off by default.
 
 Command:
 
@@ -41,6 +62,7 @@ Environment:
 - Sidecar status: not running; `curl --max-time 2 http://127.0.0.1:8888/health` returned connection refused.
 - Process/container status: no Hindsight process or container was running.
 - Runner mode: default disabled config, no retain, no writes.
+- Probe status: disabled with `HINDSIGHT_ENABLED=false`; no health call, retain, recall, or writes.
 
 Measured disabled-run result:
 

--- a/docs/strategy/zoe-evolution-harness-status.md
+++ b/docs/strategy/zoe-evolution-harness-status.md
@@ -31,7 +31,7 @@ Important non-complete truth:
 
 - Graphify has been refreshed from `origin/main` at `ad52f61d`; rerun it after subsequent code or architecture changes.
 - Tool/capability and memory read/write inventories now exist as cleanup gates; keep them updated as runtime paths change.
-- MemPalace now has a repeatable local baseline harness and first measured Zoe-host run; Hindsight now has a fixed measured runner and Zoe-host availability baseline, but no live sidecar bake-off yet because no Hindsight process/container is running.
+- MemPalace now has a repeatable local baseline harness and first measured Zoe-host run; Hindsight now has a fixed measured runner, read-only sidecar probe, and Zoe-host availability baseline, but no live sidecar bake-off yet because no Hindsight process/container is running.
 - Graphiti/FalkorDB/Neo4j have not yet been measured for Zoe relational memory, but Zoe-specific Graphiti fixtures now define the first relationship eval set.
 - The plan now names Zoe's missing north-star layer: capability profiles, trust/autonomy classes, candidate scouting, outcome evals, and hardware-aware promotion.
 - Zoe now has an executable capability profile contract and initial self-model for key chat, memory, graph, governance, escalation, Pi, and device-control surfaces.
@@ -55,7 +55,7 @@ Important non-complete truth:
 | Memory layer map | Complete foundation | `services/zoe-data/zoe_memory_layers.py` and `services/zoe-data/tests/test_zoe_memory_layers.py`. | Link layer decisions to runtime config and status endpoints. |
 | Memory router | Partial | `services/zoe-data/zoe_memory_router.py`, `services/zoe-data/zoe_memory_router_runtime.py`, `services/zoe-data/tests/test_zoe_memory_router.py`, `services/zoe-data/tests/test_zoe_memory_router_runtime.py`, and `/api/system/memory-router/status` expose disabled-by-default observe-only route decisions. | Add observation traces around route decisions, then wire prompt-time recall behind a second explicit feature flag with latency guards. |
 | MemPalace baseline | Complete foundation | `services/zoe-data/mempalace_baseline.py`, `scripts/maintenance/mempalace_baseline.py`, and `docs/architecture/zoe-mempalace-baseline.md` record a repeatable local benchmark; first run scored 1.0 avg with p95 200.90 ms and cleaned up 4 synthetic rows. | Expand with relational/supersession cases before comparing Graphiti-style backends. |
-| Hindsight bake-off | Partial | Offline sidecar client, retain-candidate helpers, synthetic fixtures, measured runner, availability doc, and tests exist; current Zoe-host check found no running Hindsight sidecar. | Start a local/offline sidecar, run retain/recall with synthetic events, and record p50/p95 latency, failures, evidence quality, and CPU/RAM use. |
+| Hindsight bake-off | Partial | Offline sidecar client, retain-candidate helpers, synthetic fixtures, measured runner, read-only sidecar probe, availability doc, and tests exist; current Zoe-host check found no running Hindsight sidecar. | Start a local/offline sidecar, run retain/recall with synthetic events, and record p50/p95 latency, failures, evidence quality, and CPU/RAM use. |
 | Graphiti bake-off | Partial | ADR plus `services/zoe-data/graphiti_bakeoff.py`, `services/zoe-data/tests/test_graphiti_bakeoff.py`, and `docs/architecture/zoe-graphiti-fixtures.md` define the first relationship fixture set. | Run the fixtures against FalkorDB first, then Neo4j if feasible, and record latency, evidence quality, supersession behavior, and CPU/RAM use. |
 | Graphify current map | Complete foundation | `graphify-out/GRAPH_REPORT.md` and `graphify-out/graph.json` were regenerated from `origin/main` at `ad52f61d`; `docs/architecture/zoe-harness-current-inventory.md` records the source-backed inventory. | Rerun Graphify after substantial code or architecture changes. |
 | Tool/capability inventory | Complete foundation | `docs/architecture/zoe-tool-capability-inventory.md` maps agent, MCP, Multica, Hermes, OpenClaw, and governance surfaces. | Keep updated when tool catalogs or execution lanes change. |
@@ -177,7 +177,7 @@ Keep each pull request small enough for Greptile and Zoe verification.
    - Repeatable benchmark and first Zoe-host p50/p95 run are documented in `docs/architecture/zoe-mempalace-baseline.md`.
    - Expand with memory footprint, relational, and supersession cases before backend replacement decisions.
 5. Hindsight sidecar bake-off.
-   - Status: runner and availability baseline complete.
+   - Status: runner, read-only sidecar probe, and availability baseline complete.
    - Next: start local/offline-only Hindsight and run synthetic retain/recall.
    - Produce measured p50/p95, evidence quality, CPU/RAM, and gaps.
    - Keep it out of production chat until feature-flagged and measured.

--- a/scripts/maintenance/hindsight_sidecar_probe.py
+++ b/scripts/maintenance/hindsight_sidecar_probe.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Probe Zoe's Hindsight sidecar without writes."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+DATA = ROOT / "services" / "zoe-data"
+sys.path.insert(0, str(DATA))
+
+from hindsight_sidecar_probe import probe_hindsight_sidecar_sync  # noqa: E402
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Probe Zoe Hindsight sidecar readiness")
+    parser.add_argument("--no-process-scan", action="store_true", help="skip ps/docker process discovery")
+    parser.add_argument("--json", action="store_true", help="emit JSON")
+    args = parser.parse_args()
+
+    result = probe_hindsight_sidecar_sync(include_process_scan=not args.no_process_scan)
+    if args.json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        print(
+            f"status={result['status']} ok={result['ok']} "
+            f"acceptable={result['acceptable']} latency_ms={result['latency_ms']:.2f}"
+        )
+        if result.get("reason"):
+            print(f"reason={result['reason']}")
+    return 0 if result["acceptable"] else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/zoe-data/hindsight_sidecar_probe.py
+++ b/services/zoe-data/hindsight_sidecar_probe.py
@@ -1,0 +1,211 @@
+"""Read-only Hindsight sidecar readiness probe for Zoe."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import re
+import subprocess
+import time
+from dataclasses import dataclass
+from typing import Any, Mapping, Sequence
+
+from hindsight_memory import HindsightConfig, HindsightMemoryClient, HindsightMemoryError, HindsightOfflineConfigError
+
+
+@dataclass(frozen=True)
+class HindsightSidecarProbeResult:
+    ok: bool
+    acceptable: bool
+    status: str
+    config: dict[str, Any]
+    health: dict[str, Any]
+    process_hits: tuple[str, ...]
+    container_hits: tuple[str, ...]
+    latency_ms: float
+    reason: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "ok": self.ok,
+            "acceptable": self.acceptable,
+            "status": self.status,
+            "config": self.config,
+            "health": self.health,
+            "process_hits": list(self.process_hits),
+            "container_hits": list(self.container_hits),
+            "latency_ms": self.latency_ms,
+            "reason": self.reason,
+        }
+
+
+async def probe_hindsight_sidecar(
+    *,
+    env: Mapping[str, str] | None = None,
+    include_process_scan: bool = True,
+) -> HindsightSidecarProbeResult:
+    """Probe Hindsight readiness without retain, recall, or memory writes."""
+
+    started = time.perf_counter()
+    process_hits: tuple[str, ...] = ()
+    container_hits: tuple[str, ...] = ()
+    if include_process_scan:
+        process_hits, container_hits = await _scan_runtime()
+
+    try:
+        config = HindsightConfig.from_env(env)
+    except (HindsightOfflineConfigError, ValueError) as exc:
+        return HindsightSidecarProbeResult(
+            ok=False,
+            acceptable=False,
+            status="misconfigured",
+            config=_config_snapshot(env),
+            health={},
+            process_hits=process_hits,
+            container_hits=container_hits,
+            latency_ms=_elapsed_ms(started),
+            reason=str(exc),
+        )
+
+    client = HindsightMemoryClient(config)
+
+    if not config.enabled:
+        return HindsightSidecarProbeResult(
+            ok=False,
+            acceptable=True,
+            status="disabled",
+            config=client.enabled_status(),
+            health={"enabled": False, "healthy": False, "reason": "disabled"},
+            process_hits=process_hits,
+            container_hits=container_hits,
+            latency_ms=_elapsed_ms(started),
+            reason="HINDSIGHT_ENABLED is false",
+        )
+
+    try:
+        health = await client.health()
+    except HindsightMemoryError as exc:
+        return HindsightSidecarProbeResult(
+            ok=False,
+            acceptable=False,
+            status="offline",
+            config=client.enabled_status(),
+            health={},
+            process_hits=process_hits,
+            container_hits=container_hits,
+            latency_ms=_elapsed_ms(started),
+            reason=str(exc),
+        )
+
+    healthy = bool(health.get("ok") or health.get("healthy") or health.get("status") in {"ok", "healthy"})
+    return HindsightSidecarProbeResult(
+        ok=healthy,
+        acceptable=healthy,
+        status="healthy" if healthy else "unhealthy",
+        config=client.enabled_status(),
+        health=health,
+        process_hits=process_hits,
+        container_hits=container_hits,
+        latency_ms=_elapsed_ms(started),
+        reason=None if healthy else "health response did not report ok/healthy",
+    )
+
+
+def _elapsed_ms(started: float) -> float:
+    return (time.perf_counter() - started) * 1000
+
+
+def _config_snapshot(env: Mapping[str, str] | None = None) -> dict[str, Any]:
+    values = env or os.environ
+    return {
+        "enabled": _env_bool_snapshot(values.get("HINDSIGHT_ENABLED"), default=False),
+        "base_url": (values.get("HINDSIGHT_BASE_URL") or "http://127.0.0.1:8888").rstrip("/"),
+        "bank_prefix": _slug_snapshot(values.get("HINDSIGHT_BANK_PREFIX") or "zoe"),
+        "auto_retain": _env_bool_snapshot(values.get("HINDSIGHT_AUTO_RETAIN"), default=False),
+        "async_retain": _env_bool_snapshot(values.get("HINDSIGHT_ASYNC_RETAIN"), default=True),
+        "offline_only": _env_bool_snapshot(values.get("HINDSIGHT_OFFLINE_ONLY"), default=True),
+        "llm_provider": values.get("HINDSIGHT_API_LLM_PROVIDER") or values.get("HINDSIGHT_LLM_PROVIDER") or None,
+        "llm_base_url": values.get("HINDSIGHT_API_LLM_BASE_URL") or values.get("HINDSIGHT_LLM_BASE_URL") or None,
+    }
+
+
+def _env_bool_snapshot(value: str | None, *, default: bool) -> bool:
+    if value is None or str(value).strip() == "":
+        return default
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _slug_snapshot(value: str) -> str:
+    slug = re.sub(r"[^a-zA-Z0-9_.-]+", "-", str(value).strip().lower()).strip("-")
+    return slug or "default"
+
+
+async def _scan_runtime() -> tuple[tuple[str, ...], tuple[str, ...]]:
+    process_hits, container_hits = await asyncio.gather(
+        asyncio.to_thread(_scan_processes, ("hindsight",)),
+        asyncio.to_thread(_scan_containers, ("hindsight",)),
+    )
+    return tuple(process_hits), tuple(container_hits)
+
+
+def _scan_processes(markers: Sequence[str]) -> list[str]:
+    try:
+        proc = subprocess.run(
+            ["ps", "-eo", "pid=,comm=,args="],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return []
+    if proc.returncode != 0:
+        return []
+    return _matching_lines(proc.stdout.splitlines(), markers)
+
+
+def _scan_containers(markers: Sequence[str]) -> list[str]:
+    try:
+        proc = subprocess.run(
+            ["docker", "ps", "--format", "{{.Names}} {{.Image}} {{.Status}}"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return []
+    if proc.returncode != 0:
+        return []
+    return _matching_lines(proc.stdout.splitlines(), markers)
+
+
+def _matching_lines(lines: Sequence[str], markers: Sequence[str]) -> list[str]:
+    lowered_markers = tuple(marker.lower() for marker in markers)
+    matches = []
+    for line in lines:
+        lowered = line.lower()
+        if "hindsight_sidecar_probe.py" in lowered or " -m hindsight_sidecar_probe" in lowered:
+            continue
+        if any(marker in lowered for marker in lowered_markers):
+            matches.append(" ".join(line.split())[:240])
+    return matches
+
+
+def probe_hindsight_sidecar_sync(
+    *,
+    env: Mapping[str, str] | None = None,
+    include_process_scan: bool = True,
+) -> dict[str, Any]:
+    """CLI-only sync wrapper; async service callers should await probe_hindsight_sidecar."""
+
+    return asyncio.run(
+        probe_hindsight_sidecar(env=env, include_process_scan=include_process_scan)
+    ).to_dict()
+
+
+__all__ = [
+    "HindsightSidecarProbeResult",
+    "probe_hindsight_sidecar",
+    "probe_hindsight_sidecar_sync",
+]

--- a/services/zoe-data/tests/test_hindsight_sidecar_probe.py
+++ b/services/zoe-data/tests/test_hindsight_sidecar_probe.py
@@ -1,0 +1,160 @@
+import pytest
+
+from hindsight_sidecar_probe import _matching_lines, probe_hindsight_sidecar, probe_hindsight_sidecar_sync
+
+
+@pytest.mark.asyncio
+async def test_probe_reports_disabled_without_health_request():
+    result = await probe_hindsight_sidecar(env={}, include_process_scan=False)
+
+    payload = result.to_dict()
+    assert payload["ok"] is False
+    assert payload["acceptable"] is True
+    assert payload["status"] == "disabled"
+    assert payload["reason"] == "HINDSIGHT_ENABLED is false"
+    assert payload["health"]["reason"] == "disabled"
+
+
+@pytest.mark.asyncio
+async def test_probe_rejects_cloud_model_config():
+    result = await probe_hindsight_sidecar(
+        env={
+            "HINDSIGHT_ENABLED": "true",
+            "HINDSIGHT_BASE_URL": "http://127.0.0.1:8888",
+            "HINDSIGHT_API_LLM_PROVIDER": "openai",
+        },
+        include_process_scan=False,
+    )
+
+    assert result.status == "misconfigured"
+    assert result.acceptable is False
+    assert result.config["enabled"] is True
+    assert result.config["base_url"] == "http://127.0.0.1:8888"
+    assert result.config["llm_provider"] == "openai"
+    assert "not allowed" in (result.reason or "")
+
+
+@pytest.mark.asyncio
+async def test_probe_reports_process_hits_when_config_is_invalid(monkeypatch):
+    monkeypatch.setattr("hindsight_sidecar_probe._scan_processes", lambda markers: ["456 hindsight-server"])
+    monkeypatch.setattr("hindsight_sidecar_probe._scan_containers", lambda markers: ["hindsight-sidecar image"])
+
+    result = await probe_hindsight_sidecar(
+        env={
+            "HINDSIGHT_ENABLED": "true",
+            "HINDSIGHT_BASE_URL": "http://127.0.0.1:8888",
+            "HINDSIGHT_API_LLM_PROVIDER": "openai",
+        },
+        include_process_scan=True,
+    )
+
+    assert result.status == "misconfigured"
+    assert result.process_hits == ("456 hindsight-server",)
+    assert result.container_hits == ("hindsight-sidecar image",)
+
+
+@pytest.mark.asyncio
+async def test_probe_reports_malformed_env_as_misconfigured():
+    result = await probe_hindsight_sidecar(
+        env={
+            "HINDSIGHT_ENABLED": "true",
+            "HINDSIGHT_BASE_URL": "http://127.0.0.1:8888",
+            "HINDSIGHT_TIMEOUT_SECONDS": "not-a-number",
+        },
+        include_process_scan=False,
+    )
+
+    assert result.status == "misconfigured"
+    assert result.acceptable is False
+    assert result.config["base_url"] == "http://127.0.0.1:8888"
+    assert result.config["bank_prefix"] == "zoe"
+    assert "could not convert string to float" in (result.reason or "")
+
+
+@pytest.mark.asyncio
+async def test_probe_reports_healthy_sidecar(monkeypatch):
+    async def fake_health(self):
+        return {"status": "ok", "version": "test"}
+
+    monkeypatch.setattr("hindsight_sidecar_probe.HindsightMemoryClient.health", fake_health)
+
+    result = await probe_hindsight_sidecar(
+        env={
+            "HINDSIGHT_ENABLED": "true",
+            "HINDSIGHT_BASE_URL": "http://127.0.0.1:8888",
+            "HINDSIGHT_API_LLM_PROVIDER": "llamacpp",
+        },
+        include_process_scan=False,
+    )
+
+    assert result.ok is True
+    assert result.acceptable is True
+    assert result.status == "healthy"
+    assert result.health["status"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_probe_reports_unhealthy_sidecar_response(monkeypatch):
+    async def fake_health(self):
+        return {"status": "starting"}
+
+    monkeypatch.setattr("hindsight_sidecar_probe.HindsightMemoryClient.health", fake_health)
+
+    result = await probe_hindsight_sidecar(
+        env={
+            "HINDSIGHT_ENABLED": "true",
+            "HINDSIGHT_BASE_URL": "http://127.0.0.1:8888",
+            "HINDSIGHT_API_LLM_PROVIDER": "llamacpp",
+        },
+        include_process_scan=False,
+    )
+
+    assert result.ok is False
+    assert result.acceptable is False
+    assert result.status == "unhealthy"
+    assert result.reason == "health response did not report ok/healthy"
+
+
+@pytest.mark.asyncio
+async def test_probe_reports_offline_sidecar(monkeypatch):
+    async def fake_health(self):
+        from hindsight_memory import HindsightMemoryError
+
+        raise HindsightMemoryError("connection refused")
+
+    monkeypatch.setattr("hindsight_sidecar_probe.HindsightMemoryClient.health", fake_health)
+
+    result = await probe_hindsight_sidecar(
+        env={
+            "HINDSIGHT_ENABLED": "true",
+            "HINDSIGHT_BASE_URL": "http://127.0.0.1:8888",
+            "HINDSIGHT_API_LLM_PROVIDER": "llamacpp",
+        },
+        include_process_scan=False,
+    )
+
+    assert result.ok is False
+    assert result.acceptable is False
+    assert result.status == "offline"
+    assert "connection refused" in (result.reason or "")
+
+
+def test_probe_sync_wrapper_returns_dict():
+    payload = probe_hindsight_sidecar_sync(env={}, include_process_scan=False)
+
+    assert payload["status"] == "disabled"
+    assert payload["acceptable"] is True
+    assert isinstance(payload["latency_ms"], float)
+
+
+def test_process_scan_ignores_probe_process_itself():
+    matches = _matching_lines(
+        [
+            "123 python3 scripts/maintenance/hindsight_sidecar_probe.py --json",
+            "124 python3 -m hindsight_sidecar_probe",
+            "456 hindsight-server --host 127.0.0.1",
+        ],
+        ("hindsight",),
+    )
+
+    assert matches == ["456 hindsight-server --host 127.0.0.1"]


### PR DESCRIPTION
## Summary\n- add a read-only Hindsight sidecar readiness probe with disabled/misconfigured/offline/healthy statuses\n- add a maintenance CLI that performs no retain, recall, or writes\n- update the Hindsight bake-off docs and harness ledger with the probe path\n\n## Current Zoe-host probe\n- status=disabled\n- reason=HINDSIGHT_ENABLED is false\n- process_hits=[]\n- container_hits=[]\n- writes=0\n\n## Tests\n- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_hindsight_sidecar_probe.py services/zoe-data/tests/test_hindsight_bakeoff.py services/zoe-data/tests/test_hindsight_memory.py services/zoe-data/tests/test_hindsight_retain_candidates.py services/zoe-data/tests/test_zoe_memory_admission.py\n- PYTHONPATH=services/zoe-data python3 scripts/maintenance/hindsight_sidecar_probe.py --json\n- python3 tools/audit/validate_structure.py\n- python3 tools/audit/validate_critical_files.py\n- python3 tools/audit/validate_offline_memory.py\n- git diff --check