### PR TITLE
Add focused harness blocker follow-up prompt locator

### DIFF
--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -310,6 +310,33 @@ def _harness_implement_hint(issue: dict | None = None) -> str:
     harness_title = title.startswith(("harness:", "zoe harness", "hermes harness"))
     if kind != "harness_fix" and not harness_title and source not in harness_sources:
         return ""
+    blocker = str(meta.get("source_blocker") or "").upper()
+    blocker_followup_hint = ""
+    if source == "engineering_blocker_followup":
+        if blocker == "ITERATION_BUDGET":
+            focused_test = (
+                "services/zoe-data/tests/test_main_multica_poll.py::"
+                "test_record_blocked_multica_chain_creates_iteration_budget_followup"
+            )
+        elif blocker in {"IMPLEMENT_BUDGET", "IMPLEMENT_HANDOFF_DRIFT"}:
+            focused_test = (
+                "services/zoe-data/tests/test_main_multica_poll.py::"
+                "test_record_blocked_multica_chain_creates_budget_followup_once"
+            )
+        elif blocker == "PROTOCOL_VIOLATION":
+            focused_test = (
+                "services/zoe-data/tests/test_main_multica_poll.py::"
+                "test_record_blocked_multica_chain_creates_protocol_followup"
+            )
+        else:
+            focused_test = "services/zoe-data/tests/test_main_multica_poll.py"
+        blocker_followup_hint = (
+            "  For engineering_blocker_followup tickets, inspect only"
+            " services/zoe-data/main.py and services/zoe-data/tests/test_main_multica_poll.py"
+            f" first. Run focused test: `PYTHONPATH=services/zoe-data python3 -m pytest -q {focused_test}`."
+            " If that behavior is already covered and passing, make a small prompt/locator fix"
+            " instead of reworking blocker creation.\n"
+        )
     return (
         "- HARNESS FAST PATH: this is a Zoe/Hermes harness ticket. Do not spend budget"
         " searching ~/.local, Hermes internals, or broad worktree inventories unless a named file"
@@ -321,6 +348,7 @@ def _harness_implement_hint(issue: dict | None = None) -> str:
         "  * Multica ticket metadata/progress: services/zoe-data/multica_ticket_contract.py and multica_client.py\n"
         "  * poll/admission/blocked follow-ups: services/zoe-data/main.py, multica_admission.py,"
         " multica_poll_dispatch.py\n"
+        f"{blocker_followup_hint}"
         "  For worktree-missing/retro fallback tickets, inspect kanban_adapter.py and"
         " worktree_bootstrap.py first; decide whether the fix belongs before Hermes starts,"
         " not inside the external Hermes worker. Start editing within 6 tool/model steps or"

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -3011,7 +3011,7 @@ def test_implement_body_includes_harness_repo_map_for_blocker_followup_source():
             "description": """Fix the blocked harness run.
 
 ```zoe-ticket
-{"schema":1,"zoe_kind":"operator_task","source":"engineering_blocker_followup","acceptance_criteria":["small harness fix"],"evidence_expectations":["focused tests"]}
+{"schema":1,"zoe_kind":"operator_task","source":"engineering_blocker_followup","source_blocker":"ITERATION_BUDGET","acceptance_criteria":["small harness fix"],"evidence_expectations":["focused tests"]}
 ```""",
         },
         "ZOE-5454",
@@ -3020,6 +3020,58 @@ def test_implement_body_includes_harness_repo_map_for_blocker_followup_source():
     assert "HARNESS FAST PATH" in body
     assert "services/zoe-data/executors/kanban_adapter.py" in body
     assert "services/zoe-data/worktree_bootstrap.py" in body
+    assert "engineering_blocker_followup tickets" in body
+    assert "services/zoe-data/main.py" in body
+    assert "services/zoe-data/tests/test_main_multica_poll.py" in body
+    assert (
+        "PYTHONPATH=services/zoe-data python3 -m pytest -q "
+        "services/zoe-data/tests/test_main_multica_poll.py::"
+        "test_record_blocked_multica_chain_creates_iteration_budget_followup"
+    ) in body
+
+
+@pytest.mark.parametrize(
+    ("source_blocker", "expected_test"),
+    [
+        (
+            "IMPLEMENT_BUDGET",
+            "test_record_blocked_multica_chain_creates_budget_followup_once",
+        ),
+        (
+            "IMPLEMENT_HANDOFF_DRIFT",
+            "test_record_blocked_multica_chain_creates_budget_followup_once",
+        ),
+        (
+            "PROTOCOL_VIOLATION",
+            "test_record_blocked_multica_chain_creates_protocol_followup",
+        ),
+        (
+            "",
+            "services/zoe-data/tests/test_main_multica_poll.py`",
+        ),
+    ],
+)
+def test_implement_body_includes_harness_blocker_followup_focused_tests(
+    source_blocker, expected_test
+):
+    source_blocker_json = f',"source_blocker":"{source_blocker}"' if source_blocker else ""
+    body = ka.KanbanAdapter()._build_body(
+        "implement",
+        {
+            "id": "uuid-5454",
+            "identifier": "ZOE-5454",
+            "title": "Follow up harness blocker",
+            "description": f"""Fix the blocked harness run.
+
+```zoe-ticket
+{{"schema":1,"zoe_kind":"operator_task","source":"engineering_blocker_followup"{source_blocker_json},"acceptance_criteria":["small harness fix"],"evidence_expectations":["focused tests"]}}
+```""",
+        },
+        "ZOE-5454",
+    )
+
+    assert "engineering_blocker_followup tickets" in body
+    assert expected_test in body
 
 
 def test_implement_body_includes_harness_repo_map_for_harness_title():


### PR DESCRIPTION
## Summary
- add exact focused test guidance for engineering_blocker_followup harness tickets
- route ITERATION_BUDGET follow-ups to the correct test_main_multica_poll test
- lock the prompt body with adapter test coverage

## Validation
- python -m py_compile services/zoe-data/executors/kanban_adapter.py services/zoe-data/tests/test_kanban_adapter.py
- git diff --check