### PR TITLE
Guard harness workers against test environment detours

### DIFF
--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -334,6 +334,11 @@ def _harness_implement_hint(issue: dict | None = None) -> str:
             "  For engineering_blocker_followup tickets, inspect only"
             " services/zoe-data/main.py and services/zoe-data/tests/test_main_multica_poll.py"
             f" first. Run focused test: `PYTHONPATH=services/zoe-data python3 -m pytest -q {focused_test}`."
+            " Use the existing repo/runtime environment only: do not create `.venv`, run `pip install`,"
+            " or install missing Python packages from inside a worker. If that exact command reports"
+            " a missing dependency/import that is not fixed by `PYTHONPATH=services/zoe-data`, call"
+            " `kanban_block` with BLOCKER=TEST_ENVIRONMENT and the first import error instead of"
+            " spending turns on environment repair."
             " If that behavior is already covered and passing, make a small prompt/locator fix"
             " instead of reworking blocker creation.\n"
         )

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -3028,6 +3028,8 @@ def test_implement_body_includes_harness_repo_map_for_blocker_followup_source():
         "services/zoe-data/tests/test_main_multica_poll.py::"
         "test_record_blocked_multica_chain_creates_iteration_budget_followup"
     ) in body
+    assert "do not create `.venv`, run `pip install`" in body
+    assert "BLOCKER=TEST_ENVIRONMENT" in body
 
 
 @pytest.mark.parametrize(
@@ -3072,6 +3074,7 @@ def test_implement_body_includes_harness_blocker_followup_focused_tests(
 
     assert "engineering_blocker_followup tickets" in body
     assert expected_test in body
+    assert "Use the existing repo/runtime environment only" in body
 
 
 def test_implement_body_includes_harness_repo_map_for_harness_title():


### PR DESCRIPTION
## Summary
- tell harness blocker-followup workers to use the existing repo/runtime test environment only
- forbid ad hoc .venv creation or pip installs inside worker turns
- require BLOCKER=TEST_ENVIRONMENT when PYTHONPATH-focused tests reveal a true missing dependency

## Validation
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_kanban_adapter.py::test_implement_body_includes_harness_repo_map_for_blocker_followup_source services/zoe-data/tests/test_kanban_adapter.py::test_implement_body_includes_harness_blocker_followup_focused_tests
- python3 -m py_compile services/zoe-data/executors/kanban_adapter.py services/zoe-data/tests/test_kanban_adapter.py
- python3 tools/audit/validate_structure.py