### PR TITLE
Add Graphiti backend readiness probe

### DIFF
--- a/docs/architecture/zoe-graphiti-fixtures.md
+++ b/docs/architecture/zoe-graphiti-fixtures.md
@@ -11,9 +11,29 @@ This document records the first backend-neutral fixture set. It does not accept 
 Files:
 
 - `services/zoe-data/graphiti_bakeoff.py`
+- `services/zoe-data/graphiti_sidecar_probe.py`
+- `scripts/maintenance/graphiti_sidecar_probe.py`
 - `services/zoe-data/tests/test_graphiti_bakeoff.py`
+- `services/zoe-data/tests/test_graphiti_sidecar_probe.py`
 
 The fixtures define synthetic Zoe episodes and expected relationship questions before any FalkorDB or Neo4j service is started. Later runners should ingest the same episodes into Graphiti, query each evaluation question, and score returned answers with the same helper functions.
+
+The sidecar probe is read-only and should be run before any Graphiti ingestion bake-off:
+
+```bash
+PYTHONPATH=services/zoe-data python3 scripts/maintenance/graphiti_sidecar_probe.py --json
+```
+
+Probe statuses:
+
+- `disabled`: `GRAPHITI_ENABLED` is false; no backend TCP check, graph query, ingest, or writes.
+- `misconfigured`: offline-only policy or visible env parsing failed.
+- `offline`: enabled config is valid, but the selected backend TCP endpoint is not reachable.
+- `healthy`: enabled config is valid and the selected backend TCP endpoint accepts a connection.
+
+Probe payloads separate `ok` from `acceptable`. `ok` means the selected backend is actively reachable.
+`acceptable` means the operational state is allowed for the current rollout, so `disabled` is acceptable
+while Graphiti remains outside the chat hot path.
 
 Covered relationship topics:
 
@@ -38,3 +58,20 @@ The next Graphiti bake-off PR should:
 - mark the graph path async-only if p95 exceeds 2 seconds or Jetson footprint is too high.
 
 Graphiti must remain outside the normal chat hot path until those measurements exist.
+
+## Current Zoe-Host Check
+
+Date: 2026-06-09
+
+Environment:
+
+- Host: Zoe Jetson service host.
+- Default backend: FalkorDB at `127.0.0.1:6379`.
+- Runner mode: default disabled config, no graph ingest, no graph query, no writes.
+- Probe status: disabled with `GRAPHITI_ENABLED=false`.
+- Enabled FalkorDB preflight: `GRAPHITI_ENABLED=true` returned `offline`, `tcp_reachable=false`,
+  `reason="[Errno 111] Connection refused"`, exit code 2, and no process/container hits.
+
+This is not a Graphiti acceptance result. It is an availability baseline and a read-only preflight. The
+Graphiti bake-off remains incomplete until a local/offline FalkorDB sidecar is started and measured, then
+Neo4j is tested if feasible.

--- a/docs/strategy/zoe-evolution-harness-status.md
+++ b/docs/strategy/zoe-evolution-harness-status.md
@@ -32,7 +32,7 @@ Important non-complete truth:
 - Graphify has been refreshed from `origin/main` at `ad52f61d`; rerun it after subsequent code or architecture changes.
 - Tool/capability and memory read/write inventories now exist as cleanup gates; keep them updated as runtime paths change.
 - MemPalace now has a repeatable local baseline harness and first measured Zoe-host run; Hindsight now has a fixed measured runner, read-only sidecar probe, and Zoe-host availability baseline, but no live sidecar bake-off yet because no Hindsight process/container is running.
-- Graphiti/FalkorDB/Neo4j have not yet been measured for Zoe relational memory, but Zoe-specific Graphiti fixtures now define the first relationship eval set.
+- Graphiti/FalkorDB/Neo4j have not yet been measured for Zoe relational memory, but Zoe-specific Graphiti fixtures and a read-only backend probe now define the first relationship eval set and availability preflight.
 - The plan now names Zoe's missing north-star layer: capability profiles, trust/autonomy classes, candidate scouting, outcome evals, and hardware-aware promotion.
 - Zoe now has an executable capability profile contract and initial self-model for key chat, memory, graph, governance, escalation, Pi, and device-control surfaces.
 - Zoe now has candidate scoring for comparing Pi, MCP, GitHub, skill, API, local-service, and existing-Zoe options before adoption.
@@ -56,7 +56,7 @@ Important non-complete truth:
 | Memory router | Partial | `services/zoe-data/zoe_memory_router.py`, `services/zoe-data/zoe_memory_router_runtime.py`, `services/zoe-data/tests/test_zoe_memory_router.py`, `services/zoe-data/tests/test_zoe_memory_router_runtime.py`, and `/api/system/memory-router/status` expose disabled-by-default observe-only route decisions. | Add observation traces around route decisions, then wire prompt-time recall behind a second explicit feature flag with latency guards. |
 | MemPalace baseline | Complete foundation | `services/zoe-data/mempalace_baseline.py`, `scripts/maintenance/mempalace_baseline.py`, and `docs/architecture/zoe-mempalace-baseline.md` record a repeatable local benchmark; first run scored 1.0 avg with p95 200.90 ms and cleaned up 4 synthetic rows. | Expand with relational/supersession cases before comparing Graphiti-style backends. |
 | Hindsight bake-off | Partial | Offline sidecar client, retain-candidate helpers, synthetic fixtures, measured runner, read-only sidecar probe, availability doc, and tests exist; current Zoe-host check found no running Hindsight sidecar. | Start a local/offline sidecar, run retain/recall with synthetic events, and record p50/p95 latency, failures, evidence quality, and CPU/RAM use. |
-| Graphiti bake-off | Partial | ADR plus `services/zoe-data/graphiti_bakeoff.py`, `services/zoe-data/tests/test_graphiti_bakeoff.py`, and `docs/architecture/zoe-graphiti-fixtures.md` define the first relationship fixture set. | Run the fixtures against FalkorDB first, then Neo4j if feasible, and record latency, evidence quality, supersession behavior, and CPU/RAM use. |
+| Graphiti bake-off | Partial | ADR plus `services/zoe-data/graphiti_bakeoff.py`, `services/zoe-data/graphiti_sidecar_probe.py`, `services/zoe-data/tests/test_graphiti_bakeoff.py`, `services/zoe-data/tests/test_graphiti_sidecar_probe.py`, and `docs/architecture/zoe-graphiti-fixtures.md` define the first relationship fixture set and read-only backend availability probe. | Start a local/offline FalkorDB sidecar, run the fixtures, then test Neo4j if feasible, and record latency, evidence quality, supersession behavior, and CPU/RAM use. |
 | Graphify current map | Complete foundation | `graphify-out/GRAPH_REPORT.md` and `graphify-out/graph.json` were regenerated from `origin/main` at `ad52f61d`; `docs/architecture/zoe-harness-current-inventory.md` records the source-backed inventory. | Rerun Graphify after substantial code or architecture changes. |
 | Tool/capability inventory | Complete foundation | `docs/architecture/zoe-tool-capability-inventory.md` maps agent, MCP, Multica, Hermes, OpenClaw, and governance surfaces. | Keep updated when tool catalogs or execution lanes change. |
 | Memory read/write inventory | Complete foundation | `docs/architecture/zoe-memory-read-write-inventory.md` maps MemoryService operations, durable writes, prompt reads, MCP paths, Hindsight candidates, and metadata gaps. | Keep updated when memory write/read paths change. |
@@ -182,8 +182,8 @@ Keep each pull request small enough for Greptile and Zoe verification.
    - Produce measured p50/p95, evidence quality, CPU/RAM, and gaps.
    - Keep it out of production chat until feature-flagged and measured.
 6. Graphiti relational bake-off.
-   - Status: fixture foundation complete.
-   - Next: test FalkorDB, then Neo4j if feasible.
+   - Status: fixture foundation and read-only backend probe complete.
+   - Next: start local/offline FalkorDB, run fixture ingest/query measurements, then test Neo4j if feasible.
    - Decide sidecar/remote/hot-path eligibility from evidence.
 7. Runtime memory router feature flag.
    - Status: observe-only runtime status foundation complete.

--- a/scripts/maintenance/graphiti_sidecar_probe.py
+++ b/scripts/maintenance/graphiti_sidecar_probe.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Probe Zoe's Graphiti graph backend without writes."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+DATA = ROOT / "services" / "zoe-data"
+sys.path.insert(0, str(DATA))
+
+from graphiti_sidecar_probe import probe_graphiti_sidecar_sync  # noqa: E402
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Probe Zoe Graphiti backend readiness")
+    parser.add_argument("--no-process-scan", action="store_true", help="skip ps/docker process discovery")
+    parser.add_argument("--json", action="store_true", help="emit JSON")
+    args = parser.parse_args()
+
+    result = probe_graphiti_sidecar_sync(include_process_scan=not args.no_process_scan)
+    if args.json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        print(
+            f"status={result['status']} ok={result['ok']} "
+            f"acceptable={result['acceptable']} latency_ms={result['latency_ms']:.2f}"
+        )
+        if result.get("reason"):
+            print(f"reason={result['reason']}")
+    return 0 if result["acceptable"] else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/zoe-data/graphiti_sidecar_probe.py
+++ b/services/zoe-data/graphiti_sidecar_probe.py
@@ -1,0 +1,318 @@
+"""Read-only Graphiti graph-backend readiness probe for Zoe."""
+
+from __future__ import annotations
+
+import asyncio
+import ipaddress
+import os
+import socket
+import subprocess
+import time
+from dataclasses import dataclass
+from typing import Any, Mapping, Sequence
+
+
+class GraphitiProbeConfigError(ValueError):
+    """Raised when visible Graphiti probe config is invalid or non-local."""
+
+
+@dataclass(frozen=True)
+class GraphitiProbeConfig:
+    enabled: bool = False
+    backend: str = "falkordb"
+    falkordb_host: str = "127.0.0.1"
+    falkordb_port: int = 6379
+    neo4j_host: str = "127.0.0.1"
+    neo4j_bolt_port: int = 7687
+    offline_only: bool = True
+    timeout_seconds: float = 1.0
+
+    @classmethod
+    def from_env(cls, env: Mapping[str, str] | None = None) -> "GraphitiProbeConfig":
+        config = cls(**_config_values(env, tolerant=False))
+        config.validate()
+        return config
+
+    @classmethod
+    def snapshot_from_env(cls, env: Mapping[str, str] | None = None) -> dict[str, Any]:
+        return _config_values(env, tolerant=True)
+
+    def validate(self) -> None:
+        if self.backend not in {"falkordb", "neo4j"}:
+            raise GraphitiProbeConfigError("GRAPHITI_BACKEND must be falkordb or neo4j")
+        if (
+            self.falkordb_port <= 0
+            or self.falkordb_port > 65535
+            or self.neo4j_bolt_port <= 0
+            or self.neo4j_bolt_port > 65535
+        ):
+            raise GraphitiProbeConfigError("Graphiti backend ports must be integers in range 1-65535")
+        if self.timeout_seconds <= 0:
+            raise GraphitiProbeConfigError("GRAPHITI_PROBE_TIMEOUT_SECONDS must be positive")
+        if not self.offline_only:
+            return
+        for host in (self.falkordb_host, self.neo4j_host):
+            if not _is_local_or_private_host(host):
+                raise GraphitiProbeConfigError("Graphiti backend hosts must be localhost or private network when offline_only is enabled")
+
+    def target(self) -> tuple[str, int]:
+        if self.backend == "neo4j":
+            return self.neo4j_host, self.neo4j_bolt_port
+        return self.falkordb_host, self.falkordb_port
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "enabled": self.enabled,
+            "backend": self.backend,
+            "falkordb_host": self.falkordb_host,
+            "falkordb_port": self.falkordb_port,
+            "neo4j_host": self.neo4j_host,
+            "neo4j_bolt_port": self.neo4j_bolt_port,
+            "offline_only": self.offline_only,
+            "timeout_seconds": self.timeout_seconds,
+        }
+
+
+@dataclass(frozen=True)
+class GraphitiSidecarProbeResult:
+    ok: bool
+    acceptable: bool
+    status: str
+    config: dict[str, Any]
+    health: dict[str, Any]
+    process_hits: tuple[str, ...]
+    container_hits: tuple[str, ...]
+    latency_ms: float
+    reason: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "ok": self.ok,
+            "acceptable": self.acceptable,
+            "status": self.status,
+            "config": self.config,
+            "health": self.health,
+            "process_hits": list(self.process_hits),
+            "container_hits": list(self.container_hits),
+            "latency_ms": self.latency_ms,
+            "reason": self.reason,
+        }
+
+
+async def probe_graphiti_sidecar(
+    *,
+    env: Mapping[str, str] | None = None,
+    include_process_scan: bool = True,
+) -> GraphitiSidecarProbeResult:
+    """Probe Graphiti backend readiness without ingesting episodes or writing graph data."""
+
+    started = time.perf_counter()
+    process_hits: tuple[str, ...] = ()
+    container_hits: tuple[str, ...] = ()
+    if include_process_scan:
+        process_hits, container_hits = await _scan_runtime()
+
+    try:
+        config = GraphitiProbeConfig.from_env(env)
+    except (GraphitiProbeConfigError, ValueError) as exc:
+        return GraphitiSidecarProbeResult(
+            ok=False,
+            acceptable=False,
+            status="misconfigured",
+            config=GraphitiProbeConfig.snapshot_from_env(env),
+            health={},
+            process_hits=process_hits,
+            container_hits=container_hits,
+            latency_ms=_elapsed_ms(started),
+            reason=str(exc),
+        )
+
+    if not config.enabled:
+        return GraphitiSidecarProbeResult(
+            ok=False,
+            acceptable=True,
+            status="disabled",
+            config=config.to_dict(),
+            health={"enabled": False, "healthy": False, "reason": "disabled"},
+            process_hits=process_hits,
+            container_hits=container_hits,
+            latency_ms=_elapsed_ms(started),
+            reason="GRAPHITI_ENABLED is false",
+        )
+
+    host, port = config.target()
+    reachable, reason = await asyncio.to_thread(_tcp_check, host, port, config.timeout_seconds)
+    health = {
+        "backend": config.backend,
+        "host": host,
+        "port": port,
+        "tcp_reachable": reachable,
+    }
+    return GraphitiSidecarProbeResult(
+        ok=reachable,
+        acceptable=reachable,
+        status="healthy" if reachable else "offline",
+        config=config.to_dict(),
+        health=health,
+        process_hits=process_hits,
+        container_hits=container_hits,
+        latency_ms=_elapsed_ms(started),
+        reason=None if reachable else reason,
+    )
+
+
+def _elapsed_ms(started: float) -> float:
+    return (time.perf_counter() - started) * 1000
+
+
+def _config_values(env: Mapping[str, str] | None = None, *, tolerant: bool) -> dict[str, Any]:
+    values = env or os.environ
+    bool_reader = _env_bool_snapshot if tolerant else _env_bool
+    port_reader = _env_int_snapshot if tolerant else _env_int
+    timeout_reader = _env_float_snapshot if tolerant else _env_float
+    return {
+        "enabled": bool_reader(values.get("GRAPHITI_ENABLED"), default=False),
+        "backend": (values.get("GRAPHITI_BACKEND") or "falkordb").strip().lower(),
+        "falkordb_host": (values.get("GRAPHITI_FALKORDB_HOST") or "127.0.0.1").strip(),
+        "falkordb_port": port_reader(values.get("GRAPHITI_FALKORDB_PORT"), default=6379),
+        "neo4j_host": (values.get("GRAPHITI_NEO4J_HOST") or "127.0.0.1").strip(),
+        "neo4j_bolt_port": port_reader(values.get("GRAPHITI_NEO4J_BOLT_PORT"), default=7687),
+        "offline_only": bool_reader(values.get("GRAPHITI_OFFLINE_ONLY"), default=True),
+        "timeout_seconds": timeout_reader(values.get("GRAPHITI_PROBE_TIMEOUT_SECONDS"), default=1.0),
+    }
+
+
+async def _scan_runtime() -> tuple[tuple[str, ...], tuple[str, ...]]:
+    process_hits, container_hits = await asyncio.gather(
+        asyncio.to_thread(_scan_processes, ("graphiti", "falkordb", "neo4j")),
+        asyncio.to_thread(_scan_containers, ("graphiti", "falkordb", "neo4j")),
+    )
+    return tuple(process_hits), tuple(container_hits)
+
+
+def _tcp_check(host: str, port: int, timeout_seconds: float) -> tuple[bool, str | None]:
+    try:
+        with socket.create_connection((host, port), timeout=timeout_seconds):
+            return True, None
+    except OSError as exc:
+        return False, str(exc)
+
+
+def _scan_processes(markers: Sequence[str]) -> list[str]:
+    try:
+        proc = subprocess.run(
+            ["ps", "-eo", "pid=,comm=,args="],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return []
+    if proc.returncode != 0:
+        return []
+    return _matching_lines(proc.stdout.splitlines(), markers)
+
+
+def _scan_containers(markers: Sequence[str]) -> list[str]:
+    try:
+        proc = subprocess.run(
+            ["docker", "ps", "--format", "{{.Names}} {{.Image}} {{.Status}}"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return []
+    if proc.returncode != 0:
+        return []
+    return _matching_lines(proc.stdout.splitlines(), markers)
+
+
+def _matching_lines(lines: Sequence[str], markers: Sequence[str]) -> list[str]:
+    lowered_markers = tuple(marker.lower() for marker in markers)
+    matches = []
+    for line in lines:
+        lowered = line.lower()
+        if "graphiti_sidecar_probe.py" in lowered or " -m graphiti_sidecar_probe" in lowered:
+            continue
+        if any(marker in lowered for marker in lowered_markers):
+            matches.append(" ".join(line.split())[:240])
+    return matches
+
+
+def _env_bool(value: str | None, *, default: bool) -> bool:
+    if value is None or str(value).strip() == "":
+        return default
+    normalized = str(value).strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    raise ValueError(f"Unrecognized boolean env var value: {value!r}")
+
+
+def _env_bool_snapshot(value: str | None, *, default: bool) -> bool | str:
+    try:
+        return _env_bool(value, default=default)
+    except ValueError:
+        return str(value)
+
+
+def _env_int(value: str | None, *, default: int) -> int:
+    if value is None or str(value).strip() == "":
+        return default
+    return int(str(value).strip())
+
+
+def _env_float(value: str | None, *, default: float) -> float:
+    if value is None or str(value).strip() == "":
+        return default
+    return float(str(value).strip())
+
+
+def _env_int_snapshot(value: str | None, *, default: int) -> int | str:
+    try:
+        return _env_int(value, default=default)
+    except ValueError:
+        return str(value)
+
+
+def _env_float_snapshot(value: str | None, *, default: float) -> float | str:
+    try:
+        return _env_float(value, default=default)
+    except ValueError:
+        return str(value)
+
+
+def _is_local_or_private_host(host: str | None) -> bool:
+    if not host:
+        return False
+    normalized = str(host).strip().lower()
+    if normalized in {"localhost", "zoe", "host.docker.internal"}:
+        return True
+    try:
+        ip = ipaddress.ip_address(normalized)
+    except ValueError:
+        return normalized.endswith(".local") or normalized.endswith(".lan")
+    return ip.is_loopback or ip.is_private or ip.is_link_local
+
+
+def probe_graphiti_sidecar_sync(
+    *,
+    env: Mapping[str, str] | None = None,
+    include_process_scan: bool = True,
+) -> dict[str, Any]:
+    """CLI-only sync wrapper; async service callers should await probe_graphiti_sidecar."""
+
+    return asyncio.run(probe_graphiti_sidecar(env=env, include_process_scan=include_process_scan)).to_dict()
+
+
+__all__ = [
+    "GraphitiProbeConfig",
+    "GraphitiProbeConfigError",
+    "GraphitiSidecarProbeResult",
+    "probe_graphiti_sidecar",
+    "probe_graphiti_sidecar_sync",
+]

--- a/services/zoe-data/tests/test_graphiti_sidecar_probe.py
+++ b/services/zoe-data/tests/test_graphiti_sidecar_probe.py
@@ -1,0 +1,217 @@
+import pytest
+
+from graphiti_sidecar_probe import (
+    GraphitiProbeConfig,
+    _matching_lines,
+    probe_graphiti_sidecar,
+    probe_graphiti_sidecar_sync,
+)
+
+
+@pytest.mark.asyncio
+async def test_probe_reports_disabled_without_tcp_check(monkeypatch):
+    def fail_tcp_check(host, port, timeout_seconds):
+        raise AssertionError("disabled probe should not connect")
+
+    monkeypatch.setattr("graphiti_sidecar_probe._tcp_check", fail_tcp_check)
+
+    result = await probe_graphiti_sidecar(env={}, include_process_scan=False)
+
+    payload = result.to_dict()
+    assert payload["ok"] is False
+    assert payload["acceptable"] is True
+    assert payload["status"] == "disabled"
+    assert payload["reason"] == "GRAPHITI_ENABLED is false"
+    assert payload["health"]["reason"] == "disabled"
+
+
+@pytest.mark.asyncio
+async def test_probe_rejects_public_backend_host():
+    result = await probe_graphiti_sidecar(
+        env={
+            "GRAPHITI_ENABLED": "true",
+            "GRAPHITI_BACKEND": "falkordb",
+            "GRAPHITI_FALKORDB_HOST": "graph.example.com",
+        },
+        include_process_scan=False,
+    )
+
+    assert result.status == "misconfigured"
+    assert result.acceptable is False
+    assert result.config["falkordb_host"] == "graph.example.com"
+    assert "localhost or private network" in (result.reason or "")
+
+
+@pytest.mark.asyncio
+async def test_probe_rejects_unknown_backend():
+    result = await probe_graphiti_sidecar(
+        env={
+            "GRAPHITI_ENABLED": "true",
+            "GRAPHITI_BACKEND": "remotegraph",
+        },
+        include_process_scan=False,
+    )
+
+    assert result.status == "misconfigured"
+    assert result.acceptable is False
+    assert "GRAPHITI_BACKEND" in (result.reason or "")
+
+
+@pytest.mark.asyncio
+async def test_probe_reports_malformed_port_as_misconfigured():
+    result = await probe_graphiti_sidecar(
+        env={
+            "GRAPHITI_ENABLED": "true",
+            "GRAPHITI_FALKORDB_PORT": "not-a-port",
+        },
+        include_process_scan=False,
+    )
+
+    assert result.status == "misconfigured"
+    assert result.acceptable is False
+    assert result.config["falkordb_port"] == "not-a-port"
+    assert "invalid literal" in (result.reason or "")
+
+
+@pytest.mark.asyncio
+async def test_probe_reports_unrecognized_boolean_as_misconfigured():
+    result = await probe_graphiti_sidecar(
+        env={
+            "GRAPHITI_ENABLED": "enabled",
+        },
+        include_process_scan=False,
+    )
+
+    assert result.status == "misconfigured"
+    assert result.acceptable is False
+    assert result.config["enabled"] == "enabled"
+    assert "Unrecognized boolean" in (result.reason or "")
+
+
+@pytest.mark.asyncio
+async def test_probe_reports_out_of_range_port_as_misconfigured():
+    result = await probe_graphiti_sidecar(
+        env={
+            "GRAPHITI_ENABLED": "true",
+            "GRAPHITI_FALKORDB_PORT": "99999",
+        },
+        include_process_scan=False,
+    )
+
+    assert result.status == "misconfigured"
+    assert result.acceptable is False
+    assert result.config["falkordb_port"] == 99999
+    assert "1-65535" in (result.reason or "")
+
+
+@pytest.mark.asyncio
+async def test_probe_reports_healthy_falkordb_backend(monkeypatch):
+    monkeypatch.setattr("graphiti_sidecar_probe._tcp_check", lambda host, port, timeout: (True, None))
+
+    result = await probe_graphiti_sidecar(
+        env={
+            "GRAPHITI_ENABLED": "true",
+            "GRAPHITI_BACKEND": "falkordb",
+            "GRAPHITI_FALKORDB_HOST": "127.0.0.1",
+            "GRAPHITI_FALKORDB_PORT": "6379",
+        },
+        include_process_scan=False,
+    )
+
+    assert result.ok is True
+    assert result.acceptable is True
+    assert result.status == "healthy"
+    assert result.health == {
+        "backend": "falkordb",
+        "host": "127.0.0.1",
+        "port": 6379,
+        "tcp_reachable": True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_probe_reports_healthy_neo4j_backend(monkeypatch):
+    monkeypatch.setattr("graphiti_sidecar_probe._tcp_check", lambda host, port, timeout: (True, None))
+
+    result = await probe_graphiti_sidecar(
+        env={
+            "GRAPHITI_ENABLED": "true",
+            "GRAPHITI_BACKEND": "neo4j",
+            "GRAPHITI_NEO4J_HOST": "127.0.0.1",
+            "GRAPHITI_NEO4J_BOLT_PORT": "7687",
+        },
+        include_process_scan=False,
+    )
+
+    assert result.ok is True
+    assert result.status == "healthy"
+    assert result.health["backend"] == "neo4j"
+    assert result.health["port"] == 7687
+
+
+@pytest.mark.asyncio
+async def test_probe_reports_offline_backend(monkeypatch):
+    monkeypatch.setattr("graphiti_sidecar_probe._tcp_check", lambda host, port, timeout: (False, "connection refused"))
+
+    result = await probe_graphiti_sidecar(
+        env={
+            "GRAPHITI_ENABLED": "true",
+            "GRAPHITI_BACKEND": "falkordb",
+        },
+        include_process_scan=False,
+    )
+
+    assert result.ok is False
+    assert result.acceptable is False
+    assert result.status == "offline"
+    assert result.reason == "connection refused"
+
+
+@pytest.mark.asyncio
+async def test_probe_reports_process_hits_when_config_is_invalid(monkeypatch):
+    monkeypatch.setattr("graphiti_sidecar_probe._scan_processes", lambda markers: ["456 falkordb-server"])
+    monkeypatch.setattr("graphiti_sidecar_probe._scan_containers", lambda markers: ["neo4j graph image"])
+
+    result = await probe_graphiti_sidecar(
+        env={
+            "GRAPHITI_ENABLED": "true",
+            "GRAPHITI_BACKEND": "remotegraph",
+        },
+        include_process_scan=True,
+    )
+
+    assert result.status == "misconfigured"
+    assert result.process_hits == ("456 falkordb-server",)
+    assert result.container_hits == ("neo4j graph image",)
+
+
+def test_probe_sync_wrapper_returns_dict():
+    payload = probe_graphiti_sidecar_sync(env={}, include_process_scan=False)
+
+    assert payload["status"] == "disabled"
+    assert payload["acceptable"] is True
+    assert isinstance(payload["latency_ms"], float)
+
+
+def test_process_scan_ignores_probe_process_itself():
+    matches = _matching_lines(
+        [
+            "123 python3 scripts/maintenance/graphiti_sidecar_probe.py --json",
+            "124 python3 -m graphiti_sidecar_probe",
+            "456 falkordb-server --port 6379",
+            "789 neo4j console",
+        ],
+        ("graphiti", "falkordb", "neo4j"),
+    )
+
+    assert matches == ["456 falkordb-server --port 6379", "789 neo4j console"]
+
+
+def test_config_defaults_to_falkordb_offline_localhost():
+    config = GraphitiProbeConfig.from_env({})
+
+    assert config.enabled is False
+    assert config.backend == "falkordb"
+    assert config.falkordb_host == "127.0.0.1"
+    assert config.falkordb_port == 6379
+    assert config.offline_only is True


### PR DESCRIPTION
## Summary
- add a read-only Graphiti backend readiness probe for FalkorDB/Neo4j availability preflight
- add a maintenance CLI and tests for disabled, misconfigured, offline, and healthy paths
- document current Zoe-host Graphiti availability baseline and update the harness ledger

## Verification
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_graphiti_sidecar_probe.py services/zoe-data/tests/test_graphiti_bakeoff.py services/zoe-data/tests/test_zoe_memory_admission.py services/zoe-data/tests/test_zoe_memory_router.py services/zoe-data/tests/test_zoe_memory_router_runtime.py
- PYTHONPATH=services/zoe-data python3 scripts/maintenance/graphiti_sidecar_probe.py --json
- GRAPHITI_ENABLED=true PYTHONPATH=services/zoe-data python3 scripts/maintenance/graphiti_sidecar_probe.py --json; expected exit 2 while FalkorDB is not running
- python3 tools/audit/validate_structure.py
- python3 tools/audit/validate_critical_files.py
- python3 tools/audit/validate_offline_memory.py
- git diff --check