### PR TITLE
Tighten harness already-covered guard

### DIFF
--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -339,8 +339,11 @@ def _harness_implement_hint(issue: dict | None = None) -> str:
             " a missing dependency/import that is not fixed by `PYTHONPATH=services/zoe-data`, call"
             " `kanban_block` with BLOCKER=TEST_ENVIRONMENT and the first import error instead of"
             " spending turns on environment repair."
-            " If that behavior is already covered and passing, make a small prompt/locator fix"
-            " instead of reworking blocker creation.\n"
+            " If the focused test passes before any edit, do not inspect more blocker code:"
+            " edit services/zoe-data/executors/kanban_adapter.py within 2 more tool/model"
+            " steps with the smallest prompt/locator guard, or call `kanban_block` with"
+            " BLOCKER=ALREADY_COVERED and the passing test output. Do not rework blocker"
+            " creation after a passing focused test.\n"
         )
     return (
         "- HARNESS FAST PATH: this is a Zoe/Hermes harness ticket. Do not spend budget"

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -3030,6 +3030,9 @@ def test_implement_body_includes_harness_repo_map_for_blocker_followup_source():
     ) in body
     assert "do not create `.venv`, run `pip install`" in body
     assert "BLOCKER=TEST_ENVIRONMENT" in body
+    assert "If the focused test passes before any edit, do not inspect more blocker code" in body
+    assert "edit services/zoe-data/executors/kanban_adapter.py within 2 more tool/model steps" in body
+    assert "BLOCKER=ALREADY_COVERED" in body
 
 
 @pytest.mark.parametrize(
@@ -3075,6 +3078,9 @@ def test_implement_body_includes_harness_blocker_followup_focused_tests(
     assert "engineering_blocker_followup tickets" in body
     assert expected_test in body
     assert "Use the existing repo/runtime environment only" in body
+    assert "If the focused test passes before any edit, do not inspect more blocker code" in body
+    assert "edit services/zoe-data/executors/kanban_adapter.py within 2 more tool/model steps" in body
+    assert "BLOCKER=ALREADY_COVERED" in body
 
 
 def test_implement_body_includes_harness_repo_map_for_harness_title():


### PR DESCRIPTION
## Summary
- tighten the engineering blocker follow-up prompt so a passing focused test stops broad blocker-code exploration
- require a tiny kanban_adapter prompt/locator edit within two steps or a clean BLOCKER=ALREADY_COVERED
- add adapter test assertions for the new cost-control guidance

## Validation
- python3 -m py_compile services/zoe-data/executors/kanban_adapter.py
- remote temp worktree: PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_kanban_adapter.py::test_implement_body_includes_harness_repo_map_for_blocker_followup_source services/zoe-data/tests/test_kanban_adapter.py::test_implement_body_includes_harness_blocker_followup_focused_tests