### PR TITLE
[codex] Guard Hindsight offline embeddings

### DIFF
--- a/docs/architecture/zoe-hindsight-bakeoff.md
+++ b/docs/architecture/zoe-hindsight-bakeoff.md
@@ -49,7 +49,7 @@ To write synthetic events, the operator must explicitly enable Hindsight and opt
 HINDSIGHT_ENABLED=true PYTHONPATH=services/zoe-data python3 scripts/maintenance/hindsight_bakeoff.py --retain-synthetic --json
 ```
 
-Zoe memory remains offline-only. `HindsightConfig` rejects public/cloud model providers unless an OpenAI-compatible provider points to a localhost/private base URL.
+Zoe memory remains offline-only. `HindsightConfig` rejects public/cloud LLM and embedding providers unless an OpenAI-compatible or TEI endpoint points to a localhost/private base URL.
 
 ## Current Zoe-Host Check
 
@@ -63,6 +63,8 @@ Environment:
 - Process/container status: no Hindsight process or container was running.
 - Runner mode: default disabled config, no retain, no writes.
 - Probe status: disabled with `HINDSIGHT_ENABLED=false`; no health call, retain, recall, or writes.
+- Local image check: `ghcr.io/vectorize-io/hindsight:latest` exists on the Zoe host.
+- Offline start blocker: the image defaults its LLM provider to OpenAI unless Zoe overrides it, and the default local embedding model (`BAAI/bge-small-en-v1.5`) is not currently present in the host Hugging Face cache.
 
 Measured disabled-run result:
 
@@ -75,7 +77,7 @@ Measured disabled-run result:
 | p95 latency | 0.0066 ms |
 | Sidecar writes | 0 |
 
-This is not a Hindsight acceptance result. It is an availability baseline and a fixed runner. The Hindsight bake-off remains incomplete until a local/offline sidecar is started and measured with synthetic retain/recall.
+This is not a Hindsight acceptance result. It is an availability baseline and a fixed runner. The Hindsight bake-off remains incomplete until a local/offline sidecar is started and measured with synthetic retain/recall. A live run should not start until Zoe has either a cached local embedding model, an ONNX embedding model, a local TEI endpoint, or a local OpenAI-compatible embeddings endpoint.
 
 ## Acceptance Use
 

--- a/docs/strategy/zoe-evolution-harness-status.md
+++ b/docs/strategy/zoe-evolution-harness-status.md
@@ -31,7 +31,7 @@ Important non-complete truth:
 
 - Graphify has been refreshed from `origin/main` at `0ee19f03`; rerun it after subsequent code or architecture changes.
 - Tool/capability and memory read/write inventories now exist as cleanup gates; keep them updated as runtime paths change.
-- MemPalace now has a repeatable local baseline harness and first measured Zoe-host run; Hindsight now has a fixed measured runner, read-only sidecar probe, and Zoe-host availability baseline, but no live sidecar bake-off yet because no Hindsight process/container is running.
+- MemPalace now has a repeatable local baseline harness and first measured Zoe-host run; Hindsight now has a fixed measured runner, read-only sidecar probe, and Zoe-host availability baseline, but no live sidecar bake-off yet because no sidecar is running and the available image cannot be safely started until Zoe has a local/cached embedding model or local embeddings service configured.
 - Graphiti/FalkorDB/Neo4j have not yet been measured for Zoe relational memory, but Zoe-specific Graphiti fixtures and a read-only backend probe now define the first relationship eval set and availability preflight.
 - The plan now names Zoe's missing north-star layer: capability profiles, trust/autonomy classes, candidate scouting, outcome evals, and hardware-aware promotion.
 - Zoe now has an executable capability profile contract and initial self-model for key chat, memory, graph, governance, escalation, Pi, and device-control surfaces.
@@ -50,12 +50,12 @@ Important non-complete truth:
 | --- | --- | --- | --- |
 | Strategy and ADRs | Complete | `docs/strategy/zoe-evolution-harness-plan.md`, `docs/adr/ADR-zoe-memory-layer.md`, `docs/adr/ADR-hindsight-bakeoff.md`, `docs/adr/ADR-graphiti-bakeoff.md` | Keep updated only when decisions change. |
 | Zoe naming discipline | Complete for new harness docs/code | Strategy and ADRs use Zoe system names and keep external inspirations out of concrete identifiers. | Sweep future PRs for accidental non-Zoe module names. |
-| Offline-only memory rule | Partial | `HindsightConfig` rejects public/cloud memory model configuration by default. | Add a repository-wide memory/provider audit that flags cloud memory paths and exposed secrets. |
+| Offline-only memory rule | Partial | `HindsightConfig` rejects public/cloud memory LLM and embedding configuration by default. | Add runtime preflight evidence for a local embedding model/service before live Hindsight bake-off runs. |
 | Memory contract | Complete foundation | `services/zoe-data/zoe_memory_contract.py` and `services/zoe-data/tests/test_zoe_memory_contract.py`. | Extend only when a measured backend requires a new field or relationship. |
 | Memory layer map | Complete foundation | `services/zoe-data/zoe_memory_layers.py` and `services/zoe-data/tests/test_zoe_memory_layers.py`. | Link layer decisions to runtime config and status endpoints. |
 | Memory router | Partial | `services/zoe-data/zoe_memory_router.py`, `services/zoe-data/zoe_memory_router_runtime.py`, `services/zoe-data/tests/test_zoe_memory_router.py`, `services/zoe-data/tests/test_zoe_memory_router_runtime.py`, and `/api/system/memory-router/status` expose disabled-by-default observe-only route decisions. | Add observation traces around route decisions, then wire prompt-time recall behind a second explicit feature flag with latency guards. |
 | MemPalace baseline | Complete foundation | `services/zoe-data/mempalace_baseline.py`, `scripts/maintenance/mempalace_baseline.py`, and `docs/architecture/zoe-mempalace-baseline.md` record a repeatable local benchmark; first run scored 1.0 avg with p95 200.90 ms and cleaned up 4 synthetic rows. | Expand with relational/supersession cases before comparing Graphiti-style backends. |
-| Hindsight bake-off | Partial | Offline sidecar client, retain-candidate helpers, synthetic fixtures, measured runner, read-only sidecar probe, availability doc, and tests exist; current Zoe-host check found no running Hindsight sidecar. | Start a local/offline sidecar, run retain/recall with synthetic events, and record p50/p95 latency, failures, evidence quality, and CPU/RAM use. |
+| Hindsight bake-off | Partial | Offline sidecar client, retain-candidate helpers, synthetic fixtures, measured runner, read-only sidecar probe, availability doc, and tests exist; current Zoe-host check found no running Hindsight sidecar and no cached default embedding model. | Start a local/offline sidecar only after a local embedding model/service is present, run retain/recall with synthetic events, and record p50/p95 latency, failures, evidence quality, and CPU/RAM use. |
 | Graphiti bake-off | Partial | ADR plus `services/zoe-data/graphiti_bakeoff.py`, `services/zoe-data/graphiti_sidecar_probe.py`, `services/zoe-data/tests/test_graphiti_bakeoff.py`, `services/zoe-data/tests/test_graphiti_sidecar_probe.py`, and `docs/architecture/zoe-graphiti-fixtures.md` define the first relationship fixture set and read-only backend availability probe. | Start a local/offline FalkorDB sidecar, run the fixtures, then test Neo4j if feasible, and record latency, evidence quality, supersession behavior, and CPU/RAM use. |
 | Graphify current map | Complete foundation | `graphify-out/GRAPH_REPORT.md` and `graphify-out/graph.json` were regenerated from `origin/main` at `0ee19f03`; `docs/architecture/zoe-harness-current-inventory.md` records the source-backed inventory. | Rerun Graphify after substantial code or architecture changes. |
 | Tool/capability inventory | Complete foundation | `docs/architecture/zoe-tool-capability-inventory.md` maps agent, MCP, Multica, Hermes, OpenClaw, and governance surfaces. | Keep updated when tool catalogs or execution lanes change. |
@@ -178,7 +178,7 @@ Keep each pull request small enough for Greptile and Zoe verification.
    - Expand with memory footprint, relational, and supersession cases before backend replacement decisions.
 5. Hindsight sidecar bake-off.
    - Status: runner, read-only sidecar probe, and availability baseline complete.
-   - Next: start local/offline-only Hindsight and run synthetic retain/recall.
+   - Next: add or configure a local embedding model/service, then start local/offline-only Hindsight and run synthetic retain/recall.
    - Produce measured p50/p95, evidence quality, CPU/RAM, and gaps.
    - Keep it out of production chat until feature-flagged and measured.
 6. Graphiti relational bake-off.

--- a/services/zoe-data/hindsight_memory.py
+++ b/services/zoe-data/hindsight_memory.py
@@ -2,8 +2,8 @@
 
 The adapter is disabled by default, never performs blind auto-retain, and is
 hardened for Zoe's offline-only memory rule. If enabled, the sidecar URL must be
-local/private and any visible Hindsight LLM provider config must use a local
-provider or a local OpenAI-compatible base URL.
+local/private and any visible Hindsight LLM or embedding provider config must
+use a local provider or a local OpenAI-compatible base URL.
 """
 
 from __future__ import annotations
@@ -58,6 +58,23 @@ _LOCAL_LLM_PROVIDERS = {
     "ollama",
 }
 
+_CLOUD_EMBEDDINGS_PROVIDERS = {
+    "cohere",
+    "gemini",
+    "google",
+    "litellm",
+    "litellm-sdk",
+    "openai",
+    "openrouter",
+    "vertexai",
+    "zeroentropy",
+}
+
+_LOCAL_EMBEDDINGS_PROVIDERS = {
+    "local",
+    "onnx",
+}
+
 
 @dataclass(frozen=True)
 class HindsightConfig:
@@ -71,6 +88,9 @@ class HindsightConfig:
     offline_only: bool = True
     llm_provider: str | None = None
     llm_base_url: str | None = None
+    embeddings_provider: str = "local"
+    embeddings_model: str = "BAAI/bge-small-en-v1.5"
+    embeddings_base_url: str | None = None
 
     def __post_init__(self) -> None:
         self.validate_offline_policy()
@@ -89,6 +109,18 @@ class HindsightConfig:
             offline_only=_env_bool(values.get("HINDSIGHT_OFFLINE_ONLY"), default=True),
             llm_provider=(values.get("HINDSIGHT_API_LLM_PROVIDER") or values.get("HINDSIGHT_LLM_PROVIDER") or None),
             llm_base_url=(values.get("HINDSIGHT_API_LLM_BASE_URL") or values.get("HINDSIGHT_LLM_BASE_URL") or None),
+            embeddings_provider=(values.get("HINDSIGHT_API_EMBEDDINGS_PROVIDER") or "local"),
+            embeddings_model=(
+                values.get("HINDSIGHT_API_EMBEDDINGS_LOCAL_MODEL")
+                or values.get("HINDSIGHT_API_EMBEDDINGS_ONNX_MODEL_PATH")
+                or values.get("HINDSIGHT_API_EMBEDDINGS_ONNX_MODEL_ID")
+                or values.get("HINDSIGHT_API_EMBEDDINGS_OPENAI_MODEL")
+                or "BAAI/bge-small-en-v1.5"
+            ),
+            embeddings_base_url=_embeddings_base_url_from_env(
+                values,
+                values.get("HINDSIGHT_API_EMBEDDINGS_PROVIDER") or "local",
+            ),
         )
 
     def bank_id(self, user_id: str, scope: str) -> str:
@@ -100,6 +132,10 @@ class HindsightConfig:
         if not _is_local_or_private_url(self.base_url):
             raise HindsightOfflineConfigError("HINDSIGHT_BASE_URL must be localhost or private network when offline_only is enabled")
 
+        self._validate_llm_offline_policy()
+        self._validate_embeddings_offline_policy()
+
+    def _validate_llm_offline_policy(self) -> None:
         provider = (self.llm_provider or "").strip().lower()
         if not provider:
             return
@@ -117,11 +153,57 @@ class HindsightConfig:
             f"Hindsight LLM provider {provider!r} is unrecognized for Zoe offline memory; set a localhost/private HINDSIGHT_API_LLM_BASE_URL or use llamacpp, ollama, or lmstudio"
         )
 
+    def _validate_embeddings_offline_policy(self) -> None:
+        embeddings_provider = (self.embeddings_provider or "").strip().lower()
+        if not embeddings_provider:
+            raise HindsightOfflineConfigError("Hindsight embeddings provider must be set for Zoe offline memory")
+        if embeddings_provider in {"tei"}:
+            if self.embeddings_base_url and _is_local_or_private_url(self.embeddings_base_url):
+                return
+            raise HindsightOfflineConfigError("Hindsight TEI embeddings require a localhost/private HINDSIGHT_API_EMBEDDINGS_TEI_URL")
+        if embeddings_provider in _LOCAL_EMBEDDINGS_PROVIDERS:
+            return
+        if embeddings_provider == "openai" and self.embeddings_base_url and _is_local_or_private_url(self.embeddings_base_url):
+            return
+        if embeddings_provider in _CLOUD_EMBEDDINGS_PROVIDERS:
+            raise HindsightOfflineConfigError(
+                f"Hindsight embeddings provider {embeddings_provider!r} is not allowed for Zoe offline memory; use local, onnx, tei with a local URL, or a local OpenAI-compatible base URL"
+            )
+        if self.embeddings_base_url and _is_local_or_private_url(self.embeddings_base_url):
+            return
+        raise HindsightOfflineConfigError(
+            f"Hindsight embeddings provider {embeddings_provider!r} is unrecognized for Zoe offline memory; set a localhost/private embeddings base URL or use local/onnx/tei"
+        )
+
 
 def _env_bool(value: str | None, *, default: bool) -> bool:
     if value is None or str(value).strip() == "":
         return default
-    return str(value).strip().lower() in {"1", "true", "yes", "on"}
+    normalized = str(value).strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    raise ValueError(f"Unrecognized boolean env var value: {value!r}")
+
+
+def _embeddings_base_url_from_env(values: Mapping[str, str], provider: str) -> str | None:
+    normalized = str(provider or "").strip().lower()
+    if normalized == "tei":
+        return values.get("HINDSIGHT_API_EMBEDDINGS_TEI_URL") or None
+    if normalized == "openai":
+        return values.get("HINDSIGHT_API_EMBEDDINGS_OPENAI_BASE_URL") or None
+    if normalized == "litellm":
+        return values.get("HINDSIGHT_API_EMBEDDINGS_LITELLM_API_BASE") or None
+    if normalized == "litellm-sdk":
+        return values.get("HINDSIGHT_API_EMBEDDINGS_LITELLM_SDK_API_BASE") or None
+    return (
+        values.get("HINDSIGHT_API_EMBEDDINGS_OPENAI_BASE_URL")
+        or values.get("HINDSIGHT_API_EMBEDDINGS_TEI_URL")
+        or values.get("HINDSIGHT_API_EMBEDDINGS_LITELLM_API_BASE")
+        or values.get("HINDSIGHT_API_EMBEDDINGS_LITELLM_SDK_API_BASE")
+        or None
+    )
 
 
 def _slug(value: str) -> str:
@@ -205,6 +287,9 @@ class HindsightMemoryClient:
             "offline_only": self.config.offline_only,
             "llm_provider": self.config.llm_provider,
             "llm_base_url": self.config.llm_base_url,
+            "embeddings_provider": self.config.embeddings_provider,
+            "embeddings_model": self.config.embeddings_model,
+            "embeddings_base_url": self.config.embeddings_base_url,
         }
 
     async def health(self) -> dict[str, Any]:

--- a/services/zoe-data/hindsight_sidecar_probe.py
+++ b/services/zoe-data/hindsight_sidecar_probe.py
@@ -117,6 +117,7 @@ def _elapsed_ms(started: float) -> float:
 
 def _config_snapshot(env: Mapping[str, str] | None = None) -> dict[str, Any]:
     values = env or os.environ
+    embeddings_provider = values.get("HINDSIGHT_API_EMBEDDINGS_PROVIDER") or "local"
     return {
         "enabled": _env_bool_snapshot(values.get("HINDSIGHT_ENABLED"), default=False),
         "base_url": (values.get("HINDSIGHT_BASE_URL") or "http://127.0.0.1:8888").rstrip("/"),
@@ -126,13 +127,46 @@ def _config_snapshot(env: Mapping[str, str] | None = None) -> dict[str, Any]:
         "offline_only": _env_bool_snapshot(values.get("HINDSIGHT_OFFLINE_ONLY"), default=True),
         "llm_provider": values.get("HINDSIGHT_API_LLM_PROVIDER") or values.get("HINDSIGHT_LLM_PROVIDER") or None,
         "llm_base_url": values.get("HINDSIGHT_API_LLM_BASE_URL") or values.get("HINDSIGHT_LLM_BASE_URL") or None,
+        "embeddings_provider": embeddings_provider,
+        "embeddings_model": (
+            values.get("HINDSIGHT_API_EMBEDDINGS_LOCAL_MODEL")
+            or values.get("HINDSIGHT_API_EMBEDDINGS_ONNX_MODEL_PATH")
+            or values.get("HINDSIGHT_API_EMBEDDINGS_ONNX_MODEL_ID")
+            or values.get("HINDSIGHT_API_EMBEDDINGS_OPENAI_MODEL")
+            or "BAAI/bge-small-en-v1.5"
+        ),
+        "embeddings_base_url": _embeddings_base_url_snapshot(values, embeddings_provider),
     }
 
 
-def _env_bool_snapshot(value: str | None, *, default: bool) -> bool:
+def _env_bool_snapshot(value: str | None, *, default: bool) -> bool | str:
     if value is None or str(value).strip() == "":
         return default
-    return str(value).strip().lower() in {"1", "true", "yes", "on"}
+    normalized = str(value).strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    return str(value)
+
+
+def _embeddings_base_url_snapshot(values: Mapping[str, str], provider: str) -> str | None:
+    normalized = str(provider or "").strip().lower()
+    if normalized == "tei":
+        return values.get("HINDSIGHT_API_EMBEDDINGS_TEI_URL") or None
+    if normalized == "openai":
+        return values.get("HINDSIGHT_API_EMBEDDINGS_OPENAI_BASE_URL") or None
+    if normalized == "litellm":
+        return values.get("HINDSIGHT_API_EMBEDDINGS_LITELLM_API_BASE") or None
+    if normalized == "litellm-sdk":
+        return values.get("HINDSIGHT_API_EMBEDDINGS_LITELLM_SDK_API_BASE") or None
+    return (
+        values.get("HINDSIGHT_API_EMBEDDINGS_OPENAI_BASE_URL")
+        or values.get("HINDSIGHT_API_EMBEDDINGS_TEI_URL")
+        or values.get("HINDSIGHT_API_EMBEDDINGS_LITELLM_API_BASE")
+        or values.get("HINDSIGHT_API_EMBEDDINGS_LITELLM_SDK_API_BASE")
+        or None
+    )
 
 
 def _slug_snapshot(value: str) -> str:

--- a/services/zoe-data/tests/test_hindsight_memory.py
+++ b/services/zoe-data/tests/test_hindsight_memory.py
@@ -33,6 +33,8 @@ def test_config_defaults_are_safe_and_offline_only():
     assert config.auto_retain is False
     assert config.async_retain is True
     assert config.offline_only is True
+    assert config.embeddings_provider == "local"
+    assert config.embeddings_model == "BAAI/bge-small-en-v1.5"
     assert config.bank_id("Jason B", "project") == "zoe-project-jason-b"
 
 
@@ -45,6 +47,9 @@ def test_config_reads_local_env_without_enabling_auto_retain_by_accident():
             "HINDSIGHT_TIMEOUT_SECONDS": "2.5",
             "HINDSIGHT_API_LLM_PROVIDER": "openai",
             "HINDSIGHT_API_LLM_BASE_URL": "http://127.0.0.1:11434/v1",
+            "HINDSIGHT_API_EMBEDDINGS_PROVIDER": "openai",
+            "HINDSIGHT_API_EMBEDDINGS_OPENAI_BASE_URL": "http://127.0.0.1:11434/v1",
+            "HINDSIGHT_API_EMBEDDINGS_OPENAI_MODEL": "local-embedding",
         }
     )
 
@@ -55,6 +60,9 @@ def test_config_reads_local_env_without_enabling_auto_retain_by_accident():
     assert config.auto_retain is False
     assert config.llm_provider == "openai"
     assert config.llm_base_url == "http://127.0.0.1:11434/v1"
+    assert config.embeddings_provider == "openai"
+    assert config.embeddings_base_url == "http://127.0.0.1:11434/v1"
+    assert config.embeddings_model == "local-embedding"
 
 
 def test_config_rejects_cloud_provider_when_enabled_offline_only():
@@ -88,6 +96,103 @@ def test_config_rejects_unknown_provider_without_local_base_url():
                 "HINDSIGHT_API_LLM_PROVIDER": "together",
             }
         )
+
+
+def test_config_rejects_cloud_embeddings_provider_when_enabled_offline_only():
+    with pytest.raises(HindsightOfflineConfigError, match="embeddings provider"):
+        HindsightConfig.from_env(
+            {
+                "HINDSIGHT_ENABLED": "true",
+                "HINDSIGHT_BASE_URL": "http://127.0.0.1:8888",
+                "HINDSIGHT_API_LLM_PROVIDER": "llamacpp",
+                "HINDSIGHT_API_EMBEDDINGS_PROVIDER": "openai",
+            }
+        )
+
+
+def test_config_rejects_tei_embeddings_without_local_url():
+    with pytest.raises(HindsightOfflineConfigError, match="TEI embeddings"):
+        HindsightConfig.from_env(
+            {
+                "HINDSIGHT_ENABLED": "true",
+                "HINDSIGHT_BASE_URL": "http://127.0.0.1:8888",
+                "HINDSIGHT_API_LLM_PROVIDER": "llamacpp",
+                "HINDSIGHT_API_EMBEDDINGS_PROVIDER": "tei",
+            }
+        )
+
+
+def test_config_allows_tei_embeddings_with_local_url():
+    config = HindsightConfig.from_env(
+        {
+            "HINDSIGHT_ENABLED": "true",
+            "HINDSIGHT_BASE_URL": "http://127.0.0.1:8888",
+            "HINDSIGHT_API_LLM_PROVIDER": "llamacpp",
+            "HINDSIGHT_API_EMBEDDINGS_PROVIDER": "tei",
+            "HINDSIGHT_API_EMBEDDINGS_TEI_URL": "http://127.0.0.1:8080",
+        }
+    )
+
+    assert config.embeddings_provider == "tei"
+    assert config.embeddings_base_url == "http://127.0.0.1:8080"
+
+
+def test_config_rejects_tei_embeddings_when_only_openai_base_url_is_present():
+    with pytest.raises(HindsightOfflineConfigError, match="TEI embeddings"):
+        HindsightConfig.from_env(
+            {
+                "HINDSIGHT_ENABLED": "true",
+                "HINDSIGHT_BASE_URL": "http://127.0.0.1:8888",
+                "HINDSIGHT_API_LLM_PROVIDER": "llamacpp",
+                "HINDSIGHT_API_EMBEDDINGS_PROVIDER": "tei",
+                "HINDSIGHT_API_EMBEDDINGS_OPENAI_BASE_URL": "http://127.0.0.1:11434/v1",
+            }
+        )
+
+
+def test_config_rejects_tei_embeddings_with_cloud_tei_url_even_when_openai_base_url_is_local():
+    with pytest.raises(HindsightOfflineConfigError, match="TEI embeddings"):
+        HindsightConfig.from_env(
+            {
+                "HINDSIGHT_ENABLED": "true",
+                "HINDSIGHT_BASE_URL": "http://127.0.0.1:8888",
+                "HINDSIGHT_API_LLM_PROVIDER": "llamacpp",
+                "HINDSIGHT_API_EMBEDDINGS_PROVIDER": "tei",
+                "HINDSIGHT_API_EMBEDDINGS_TEI_URL": "https://tei.example.com",
+                "HINDSIGHT_API_EMBEDDINGS_OPENAI_BASE_URL": "http://127.0.0.1:11434/v1",
+            }
+        )
+
+
+def test_config_rejects_unknown_embeddings_provider_without_local_base_url():
+    with pytest.raises(HindsightOfflineConfigError, match="embeddings provider"):
+        HindsightConfig.from_env(
+            {
+                "HINDSIGHT_ENABLED": "true",
+                "HINDSIGHT_BASE_URL": "http://127.0.0.1:8888",
+                "HINDSIGHT_API_LLM_PROVIDER": "llamacpp",
+                "HINDSIGHT_API_EMBEDDINGS_PROVIDER": "mystery",
+            }
+        )
+
+
+def test_config_allows_unknown_embeddings_provider_with_local_base_url():
+    config = HindsightConfig.from_env(
+        {
+            "HINDSIGHT_ENABLED": "true",
+            "HINDSIGHT_BASE_URL": "http://127.0.0.1:8888",
+            "HINDSIGHT_API_LLM_PROVIDER": "llamacpp",
+            "HINDSIGHT_API_EMBEDDINGS_PROVIDER": "custom",
+            "HINDSIGHT_API_EMBEDDINGS_OPENAI_BASE_URL": "http://127.0.0.1:11434/v1",
+        }
+    )
+
+    assert config.embeddings_provider == "custom"
+
+
+def test_config_rejects_malformed_boolean_env():
+    with pytest.raises(ValueError, match="Unrecognized boolean"):
+        HindsightConfig.from_env({"HINDSIGHT_ENABLED": "enabled"})
 
 
 def test_config_allows_unknown_provider_with_local_base_url():
@@ -124,6 +229,23 @@ def test_event_to_hindsight_item_keeps_evidence_and_scope_tags():
     assert "scope:project" in item["tags"]
     assert "evidence:pytest-test_hindsight_memory" in item["tags"]
     assert "evidence_refs" in item["context"]
+
+
+def test_enabled_status_includes_embedding_config():
+    client = HindsightMemoryClient(
+        HindsightConfig(
+            enabled=True,
+            embeddings_provider="tei",
+            embeddings_base_url="http://127.0.0.1:8080",
+            embeddings_model="local-embedding",
+        )
+    )
+
+    status = client.enabled_status()
+
+    assert status["embeddings_provider"] == "tei"
+    assert status["embeddings_base_url"] == "http://127.0.0.1:8080"
+    assert status["embeddings_model"] == "local-embedding"
 
 
 @pytest.mark.asyncio

--- a/services/zoe-data/tests/test_hindsight_sidecar_probe.py
+++ b/services/zoe-data/tests/test_hindsight_sidecar_probe.py
@@ -31,7 +31,64 @@ async def test_probe_rejects_cloud_model_config():
     assert result.config["enabled"] is True
     assert result.config["base_url"] == "http://127.0.0.1:8888"
     assert result.config["llm_provider"] == "openai"
+    assert result.config["embeddings_provider"] == "local"
     assert "not allowed" in (result.reason or "")
+
+
+@pytest.mark.asyncio
+async def test_probe_rejects_cloud_embedding_config():
+    result = await probe_hindsight_sidecar(
+        env={
+            "HINDSIGHT_ENABLED": "true",
+            "HINDSIGHT_BASE_URL": "http://127.0.0.1:8888",
+            "HINDSIGHT_API_LLM_PROVIDER": "llamacpp",
+            "HINDSIGHT_API_EMBEDDINGS_PROVIDER": "openai",
+        },
+        include_process_scan=False,
+    )
+
+    assert result.status == "misconfigured"
+    assert result.acceptable is False
+    assert result.config["embeddings_provider"] == "openai"
+    assert "embeddings provider" in (result.reason or "")
+
+
+@pytest.mark.asyncio
+async def test_probe_snapshot_keeps_tei_url_from_openai_base_url():
+    result = await probe_hindsight_sidecar(
+        env={
+            "HINDSIGHT_ENABLED": "true",
+            "HINDSIGHT_BASE_URL": "http://127.0.0.1:8888",
+            "HINDSIGHT_API_LLM_PROVIDER": "llamacpp",
+            "HINDSIGHT_API_EMBEDDINGS_PROVIDER": "tei",
+            "HINDSIGHT_API_EMBEDDINGS_OPENAI_BASE_URL": "http://127.0.0.1:11434/v1",
+        },
+        include_process_scan=False,
+    )
+
+    assert result.status == "misconfigured"
+    assert result.config["embeddings_provider"] == "tei"
+    assert result.config["embeddings_base_url"] is None
+    assert "TEI embeddings" in (result.reason or "")
+
+
+@pytest.mark.asyncio
+async def test_probe_snapshot_prefers_tei_url_for_tei_provider():
+    result = await probe_hindsight_sidecar(
+        env={
+            "HINDSIGHT_ENABLED": "true",
+            "HINDSIGHT_BASE_URL": "http://127.0.0.1:8888",
+            "HINDSIGHT_API_LLM_PROVIDER": "llamacpp",
+            "HINDSIGHT_API_EMBEDDINGS_PROVIDER": "tei",
+            "HINDSIGHT_API_EMBEDDINGS_TEI_URL": "https://tei.example.com",
+            "HINDSIGHT_API_EMBEDDINGS_OPENAI_BASE_URL": "http://127.0.0.1:11434/v1",
+        },
+        include_process_scan=False,
+    )
+
+    assert result.status == "misconfigured"
+    assert result.config["embeddings_base_url"] == "https://tei.example.com"
+    assert "TEI embeddings" in (result.reason or "")
 
 
 @pytest.mark.asyncio
@@ -69,6 +126,19 @@ async def test_probe_reports_malformed_env_as_misconfigured():
     assert result.config["base_url"] == "http://127.0.0.1:8888"
     assert result.config["bank_prefix"] == "zoe"
     assert "could not convert string to float" in (result.reason or "")
+
+
+@pytest.mark.asyncio
+async def test_probe_reports_invalid_boolean_env_as_misconfigured():
+    result = await probe_hindsight_sidecar(
+        env={"HINDSIGHT_ENABLED": "enabled"},
+        include_process_scan=False,
+    )
+
+    assert result.status == "misconfigured"
+    assert result.acceptable is False
+    assert result.config["enabled"] == "enabled"
+    assert "Unrecognized boolean" in (result.reason or "")
 
 
 @pytest.mark.asyncio

--- a/tools/audit/validate_offline_memory.py
+++ b/tools/audit/validate_offline_memory.py
@@ -42,16 +42,24 @@ _CLOUD_PROVIDER_PATTERN = (
     r"(?:anthropic|gemini|groq|openrouter|bedrock|vertexai|ollama-cloud)[\"']?"
 )
 
+_CLOUD_EMBEDDINGS_PROVIDER_PATTERN = (
+    r"HINDSIGHT_API_EMBEDDINGS_PROVIDER\s*[:=]\s*[\"']?"
+    r"(?:cohere|gemini|google|litellm|openai|openrouter|vertexai|zeroentropy)[\"']?"
+)
+
 DENIED_MEMORY_PATTERNS = (
     re.compile(r"HINDSIGHT_OFFLINE_ONLY\s*[:=]\s*(?:false|0|no|off)", re.I),
     re.compile(r"HINDSIGHT_AUTO_RETAIN\s*[:=]\s*(?:true|1|yes|on)", re.I),
     re.compile(_CLOUD_PROVIDER_PATTERN, re.I),
+    re.compile(_CLOUD_EMBEDDINGS_PROVIDER_PATTERN, re.I),
     re.compile(r"(?:OPENAI|ANTHROPIC|GEMINI|GROQ|OPENROUTER)_API_KEY", re.I),
 )
 
 ALLOWED_CLOUD_KEY_CONTEXT = (
     "provider == \"openai\" and self.llm_base_url",
+    "embeddings_provider == \"openai\" and self.embeddings_base_url",
     "provider {provider!r} is not allowed",
+    "embeddings_provider {embeddings_provider!r} is not allowed",
 )
 
 
@@ -72,6 +80,8 @@ def _assert_hindsight_policy() -> list[str]:
         issues.append("Hindsight auto_retain must default to false")
     if default.base_url != "http://127.0.0.1:8888":
         issues.append("Hindsight default base_url must stay localhost")
+    if default.embeddings_provider != "local":
+        issues.append("Hindsight embeddings_provider must default to local")
 
     rejected_cases = [
         {
@@ -88,6 +98,18 @@ def _assert_hindsight_policy() -> list[str]:
             "HINDSIGHT_ENABLED": "true",
             "HINDSIGHT_BASE_URL": "https://memory.example.com",
             "HINDSIGHT_API_LLM_PROVIDER": "llamacpp",
+        },
+        {
+            "HINDSIGHT_ENABLED": "true",
+            "HINDSIGHT_BASE_URL": "http://127.0.0.1:8888",
+            "HINDSIGHT_API_LLM_PROVIDER": "llamacpp",
+            "HINDSIGHT_API_EMBEDDINGS_PROVIDER": "openai",
+        },
+        {
+            "HINDSIGHT_ENABLED": "true",
+            "HINDSIGHT_BASE_URL": "http://127.0.0.1:8888",
+            "HINDSIGHT_API_LLM_PROVIDER": "llamacpp",
+            "HINDSIGHT_API_EMBEDDINGS_PROVIDER": "tei",
         },
     ]
     for env in rejected_cases:
@@ -108,6 +130,26 @@ def _assert_hindsight_policy() -> list[str]:
             "HINDSIGHT_BASE_URL": "http://127.0.0.1:8888",
             "HINDSIGHT_API_LLM_PROVIDER": "openai",
             "HINDSIGHT_API_LLM_BASE_URL": "http://127.0.0.1:11434/v1",
+        },
+        {
+            "HINDSIGHT_ENABLED": "true",
+            "HINDSIGHT_BASE_URL": "http://127.0.0.1:8888",
+            "HINDSIGHT_API_LLM_PROVIDER": "llamacpp",
+            "HINDSIGHT_API_EMBEDDINGS_PROVIDER": "onnx",
+        },
+        {
+            "HINDSIGHT_ENABLED": "true",
+            "HINDSIGHT_BASE_URL": "http://127.0.0.1:8888",
+            "HINDSIGHT_API_LLM_PROVIDER": "llamacpp",
+            "HINDSIGHT_API_EMBEDDINGS_PROVIDER": "tei",
+            "HINDSIGHT_API_EMBEDDINGS_TEI_URL": "http://127.0.0.1:8080",
+        },
+        {
+            "HINDSIGHT_ENABLED": "true",
+            "HINDSIGHT_BASE_URL": "http://127.0.0.1:8888",
+            "HINDSIGHT_API_LLM_PROVIDER": "llamacpp",
+            "HINDSIGHT_API_EMBEDDINGS_PROVIDER": "openai",
+            "HINDSIGHT_API_EMBEDDINGS_OPENAI_BASE_URL": "http://127.0.0.1:11434/v1",
         },
     ]
     for env in accepted_cases:
@@ -155,10 +197,10 @@ def main() -> int:
             print(f"{RED}x{RESET} {issue}")
         return _fail(f"offline memory validation found {len(issues)} issue(s)")
 
-    print(f"{GREEN}ok{RESET} Hindsight defaults are disabled, offline-only, localhost, and no auto-retain")
+    print(f"{GREEN}ok{RESET} Hindsight defaults are disabled, offline-only, localhost, local embeddings, and no auto-retain")
     print(
-        f"{GREEN}ok{RESET} Public/cloud memory model providers are rejected "
-        "unless OpenAI-compatible points to local/private base URL"
+        f"{GREEN}ok{RESET} Public/cloud memory LLM and embedding providers are rejected "
+        "unless OpenAI-compatible/TEI points to local/private base URL"
     )
     print(f"{GREEN}ok{RESET} Active memory files contain no committed cloud-memory defaults or API-key dependencies")
     return 0


### PR DESCRIPTION
## Summary

- extend Hindsight offline policy to validate embedding providers independently from LLM providers
- expose embedding provider/model/base URL in Hindsight status and sidecar probe snapshots
- update the offline-memory audit and harness docs with the current live sidecar blocker: no local/cached embedding model or local embeddings service yet

## Why

Zoe memory must stay 100% offline. The existing Hindsight guard checked the sidecar URL and visible LLM provider, but embeddings could still be configured to a public/cloud provider or an uncached default without being surfaced clearly. This makes the live bake-off safer: Zoe can measure Hindsight only after a local embedding path exists.

## Validation

- `PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_hindsight_memory.py services/zoe-data/tests/test_hindsight_sidecar_probe.py services/zoe-data/tests/test_hindsight_bakeoff.py services/zoe-data/tests/test_hindsight_retain_candidates.py services/zoe-data/tests/test_zoe_memory_admission.py`
- `PYTHONPATH=services/zoe-data python3 scripts/maintenance/hindsight_sidecar_probe.py --json`
- `python3 tools/audit/validate_offline_memory.py`
- `python3 tools/audit/validate_structure.py`
- `python3 tools/audit/validate_critical_files.py`
- `git diff --check`
