### PR TITLE
Block harness drift after focused tests

### DIFF
--- a/services/zoe-data/kanban_phase_budget.py
+++ b/services/zoe-data/kanban_phase_budget.py
@@ -48,6 +48,13 @@ _PATCH_REVIEW_DIFF_RE = re.compile(r"^\s*(?:┊|\|)\s+review\s+diff\b", re.IGNOR
 _TERMINAL_STEP_RE = re.compile(r"^\s*(?:┊|\|)\s+\S+\s+kanban_(?:complete|block)\b", re.IGNORECASE)
 _EXPLORE_STEP_RE = re.compile(r"^\s*(?:┊|\|)\s+\S+\s+(?:read|grep|find)\b", re.IGNORECASE)
 _READ_STEP_RE = re.compile(r"^\s*(?:┊|\|)\s+\S+\s+read\s+(?P<path>\S+)", re.IGNORECASE)
+_FOCUSED_HARNESS_TEST_RE = re.compile(
+    r"\bpython3\s+-m\s+pytest\b.*services/zoe-data/tests/\S+\.py::\S+",
+    re.IGNORECASE,
+)
+_ENGINEERING_BLOCKER_FOLLOWUP_SOURCE_RE = re.compile(
+    r'"source"\s*:\s*"engineering_blocker_followup"'
+)
 _MARK_REVIEWED_VERDICT_RE = re.compile(
     r"\bmark-reviewed\b(?=.*--critical-count)(?=.*--summary)",
     re.IGNORECASE,
@@ -211,7 +218,17 @@ def _read_path_key(raw_path: str) -> str:
     return re.sub(r":\d+(?:-\d+)?$", "", raw_path)
 
 
-def implement_pre_edit_drift_reason_from_log(task_id: str, phase: str, *, session: str | None = None) -> str | None:
+def _is_engineering_blocker_followup_body(body: str) -> bool:
+    return bool(_ENGINEERING_BLOCKER_FOLLOWUP_SOURCE_RE.search(body))
+
+
+def implement_pre_edit_drift_reason_from_log(
+    task_id: str,
+    phase: str,
+    *,
+    session: str | None = None,
+    task_body: str = "",
+) -> str | None:
     """Block implement runs that keep exploring before making any edit.
 
     Real production failures showed workers ignoring a narrow scout handoff and
@@ -228,18 +245,53 @@ def implement_pre_edit_drift_reason_from_log(task_id: str, phase: str, *, sessio
         return None
 
     step_lines = [line for line in session.splitlines() if _STEP_LINE_RE.match(line)]
-    if any(_PATCH_STEP_RE.search(line) or _TERMINAL_STEP_RE.search(line) for line in step_lines):
+    harness_followup = _is_engineering_blocker_followup_body(task_body)
+    focused_indexes = [
+        index
+        for index, line in enumerate(step_lines)
+        if harness_followup and _FOCUSED_HARNESS_TEST_RE.search(line)
+    ]
+    terminal_indexes = [
+        index
+        for index, line in enumerate(step_lines)
+        if _PATCH_STEP_RE.search(line) or _TERMINAL_STEP_RE.search(line)
+    ]
+    focused_harness_test_present = bool(focused_indexes)
+    if terminal_indexes and (
+        not focused_harness_test_present or terminal_indexes[0] < focused_indexes[0]
+    ):
         return None
 
     explore_budget = _pre_edit_explore_budget()
     repeat_read_budget = _pre_edit_repeat_read_budget()
     explore_steps = 0
+    focused_harness_test_seen = False
+    post_focus_adapter_read_allowed = True
     read_counts: dict[str, int] = {}
     for line in step_lines:
+        if _PATCH_STEP_RE.search(line) or _TERMINAL_STEP_RE.search(line):
+            return None
+        if harness_followup and _FOCUSED_HARNESS_TEST_RE.search(line):
+            focused_harness_test_seen = True
+            continue
         if not _EXPLORE_STEP_RE.search(line):
             continue
         explore_steps += 1
         read_match = _READ_STEP_RE.search(line)
+        if focused_harness_test_seen:
+            path = _read_path_key(read_match.group("path")) if read_match else ""
+            if (
+                post_focus_adapter_read_allowed
+                and path.endswith("services/zoe-data/executors/kanban_adapter.py")
+            ):
+                post_focus_adapter_read_allowed = False
+                continue
+            else:
+                return (
+                    "BLOCKER=IMPLEMENT_HANDOFF_DRIFT: engineering blocker follow-up kept "
+                    "exploring after focused test instead of editing kanban_adapter.py "
+                    "or blocking ALREADY_COVERED"
+                )
         if explore_steps > explore_budget:
             return (
                 "BLOCKER=IMPLEMENT_HANDOFF_DRIFT: pre-edit exploration exceeded "
@@ -373,7 +425,13 @@ def phase_budget_reason(
     edit_safety_reason = implement_edit_safety_reason_from_log(task_id, phase, session=session)
     if edit_safety_reason:
         return edit_safety_reason
-    pre_edit_drift_reason = implement_pre_edit_drift_reason_from_log(task_id, phase, session=session)
+    task = detail.get("task") if isinstance(detail.get("task"), dict) else {}
+    pre_edit_drift_reason = implement_pre_edit_drift_reason_from_log(
+        task_id,
+        phase,
+        session=session,
+        task_body=str(task.get("body") or ""),
+    )
     if pre_edit_drift_reason:
         return pre_edit_drift_reason
     log_reason = phase_budget_reason_from_log(task_id, phase)

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -2060,6 +2060,193 @@ def test_implement_pre_edit_drift_blocks_exploration_without_patch(tmp_path, mon
     assert "pre-edit exploration exceeded budget" in reason
 
 
+def test_implement_pre_edit_drift_blocks_harness_followup_after_focused_test(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("ZOE_KANBAN_IMPLEMENT_PRE_EDIT_EXPLORE_BUDGET", "12")
+    log_dir = tmp_path / "kanban" / "logs"
+    log_dir.mkdir(parents=True)
+    (log_dir / "t_impl.log").write_text(
+        "Query: work kanban task t_impl\n"
+        "  ┊ 📖 read      /work/services/zoe-data/main.py  0.1s\n"
+        "  ┊ 💻 $         cd /work && PYTHONPATH=services/zoe-data python3 -m pytest -v "
+        "services/zoe-data/tests/test_main_multica_poll.py::"
+        "test_record_blocked_multica_chain_creates_iteration_budget_followup -x  3.3s\n"
+        "  ┊ 📖 read      /work/services/zoe-data/executors/kanban_adapter.py  0.1s\n"
+        "  ┊ 🔎 grep      ITERATION_BUDGET  0.1s\n",
+        encoding="utf-8",
+    )
+
+    reason = kb.implement_pre_edit_drift_reason_from_log(
+        "t_impl",
+        "implement",
+        task_body='{"source":"engineering_blocker_followup"}',
+    )
+
+    assert reason is not None
+    assert "engineering blocker follow-up kept exploring after focused test" in reason
+
+
+def test_implement_pre_edit_drift_allows_harness_followup_adapter_read_after_focused_test(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    log_dir = tmp_path / "kanban" / "logs"
+    log_dir.mkdir(parents=True)
+    (log_dir / "t_impl.log").write_text(
+        "Query: work kanban task t_impl\n"
+        "  ┊ 💻 $         cd /work && PYTHONPATH=services/zoe-data python3 -m pytest -q "
+        "services/zoe-data/tests/test_main_multica_poll.py::"
+        "test_record_blocked_multica_chain_creates_iteration_budget_followup  3.3s\n"
+        "  ┊ 📖 read      /work/services/zoe-data/executors/kanban_adapter.py  0.1s\n",
+        encoding="utf-8",
+    )
+
+    reason = kb.implement_pre_edit_drift_reason_from_log(
+        "t_impl",
+        "implement",
+        task_body='{"source":"engineering_blocker_followup"}',
+    )
+
+    assert reason is None
+
+
+def test_implement_pre_edit_drift_does_not_charge_allowed_adapter_read_to_budget(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("ZOE_KANBAN_IMPLEMENT_PRE_EDIT_EXPLORE_BUDGET", "12")
+    log_dir = tmp_path / "kanban" / "logs"
+    log_dir.mkdir(parents=True)
+    pre_focus_explore = "\n".join(
+        f"  ┊ 🔎 grep      symbol_{index}  0.1s"
+        for index in range(12)
+    )
+    (log_dir / "t_impl.log").write_text(
+        "Query: work kanban task t_impl\n"
+        f"{pre_focus_explore}\n"
+        "  ┊ 💻 $         cd /work && PYTHONPATH=services/zoe-data python3 -m pytest -q "
+        "services/zoe-data/tests/test_main_multica_poll.py::"
+        "test_record_blocked_multica_chain_creates_iteration_budget_followup  3.3s\n"
+        "  ┊ 📖 read      /work/services/zoe-data/executors/kanban_adapter.py  0.1s\n",
+        encoding="utf-8",
+    )
+
+    reason = kb.implement_pre_edit_drift_reason_from_log(
+        "t_impl",
+        "implement",
+        task_body='{"source":"engineering_blocker_followup"}',
+    )
+
+    assert reason is None
+
+
+def test_implement_pre_edit_drift_covers_harness_followup_focused_tests_in_other_files(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    log_dir = tmp_path / "kanban" / "logs"
+    log_dir.mkdir(parents=True)
+    (log_dir / "t_impl.log").write_text(
+        "Query: work kanban task t_impl\n"
+        "  ┊ 💻 $         cd /work && PYTHONPATH=services/zoe-data python3 -m pytest -q "
+        "services/zoe-data/tests/test_kanban_adapter.py::"
+        "test_implement_body_includes_harness_blocker_followup_focused_tests  0.9s\n"
+        "  ┊ 🔎 grep      _ensure_blocker_followup_ticket  0.1s\n",
+        encoding="utf-8",
+    )
+
+    reason = kb.implement_pre_edit_drift_reason_from_log(
+        "t_impl",
+        "implement",
+        task_body='{"source":"engineering_blocker_followup"}',
+    )
+
+    assert reason is not None
+    assert "engineering blocker follow-up kept exploring after focused test" in reason
+
+
+def test_implement_pre_edit_drift_ignores_plain_followup_prompt_without_metadata(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("ZOE_KANBAN_IMPLEMENT_PRE_EDIT_EXPLORE_BUDGET", "12")
+    log_dir = tmp_path / "kanban" / "logs"
+    log_dir.mkdir(parents=True)
+    (log_dir / "t_impl.log").write_text(
+        "Query: work kanban task t_impl\n"
+        "  ┊ 💻 $         cd /work && PYTHONPATH=services/zoe-data python3 -m pytest -q "
+        "services/zoe-data/tests/test_kanban_adapter.py::"
+        "test_implement_body_includes_harness_blocker_followup_focused_tests  0.9s\n"
+        "  ┊ 🔎 grep      _ensure_blocker_followup_ticket  0.1s\n",
+        encoding="utf-8",
+    )
+
+    reason = kb.implement_pre_edit_drift_reason_from_log(
+        "t_impl",
+        "implement",
+        task_body="For engineering_blocker_followup tickets, inspect only the named files.",
+    )
+
+    assert reason is None
+
+
+def test_implement_pre_edit_drift_stands_down_for_harness_followup_patch_without_focused_test(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("ZOE_KANBAN_IMPLEMENT_PRE_EDIT_EXPLORE_BUDGET", "12")
+    log_dir = tmp_path / "kanban" / "logs"
+    log_dir.mkdir(parents=True)
+    pre_patch_explore = "\n".join(
+        f"  ┊ 🔎 grep      symbol_{index}  0.1s"
+        for index in range(13)
+    )
+    (log_dir / "t_impl.log").write_text(
+        "Query: work kanban task t_impl\n"
+        f"{pre_patch_explore}\n"
+        "  ┊ 🔧 patch     /work/services/zoe-data/executors/kanban_adapter.py  5.9s\n",
+        encoding="utf-8",
+    )
+
+    reason = kb.implement_pre_edit_drift_reason_from_log(
+        "t_impl",
+        "implement",
+        task_body='{"source":"engineering_blocker_followup"}',
+    )
+
+    assert reason is None
+
+
+def test_implement_pre_edit_drift_stands_down_for_patch_before_focused_test(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("ZOE_KANBAN_IMPLEMENT_PRE_EDIT_EXPLORE_BUDGET", "12")
+    log_dir = tmp_path / "kanban" / "logs"
+    log_dir.mkdir(parents=True)
+    pre_patch_explore = "\n".join(
+        f"  ┊ 🔎 grep      symbol_{index}  0.1s"
+        for index in range(13)
+    )
+    (log_dir / "t_impl.log").write_text(
+        "Query: work kanban task t_impl\n"
+        f"{pre_patch_explore}\n"
+        "  ┊ 🔧 patch     /work/services/zoe-data/executors/kanban_adapter.py  5.9s\n"
+        "  ┊ 💻 $         cd /work && PYTHONPATH=services/zoe-data python3 -m pytest -q "
+        "services/zoe-data/tests/test_main_multica_poll.py::"
+        "test_record_blocked_multica_chain_creates_iteration_budget_followup  3.3s\n",
+        encoding="utf-8",
+    )
+
+    reason = kb.implement_pre_edit_drift_reason_from_log(
+        "t_impl",
+        "implement",
+        task_body='{"source":"engineering_blocker_followup"}',
+    )
+
+    assert reason is None
+
+
 def test_implement_pre_edit_drift_prioritizes_explore_budget_when_both_trip(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     monkeypatch.setenv("ZOE_KANBAN_IMPLEMENT_PRE_EDIT_REPEAT_READ_BUDGET", "3")
@@ -2162,6 +2349,40 @@ def test_phase_budget_reason_blocks_pre_edit_handoff_drift(tmp_path, monkeypatch
 
     assert reason is not None
     assert "IMPLEMENT_HANDOFF_DRIFT" in reason
+
+
+def test_phase_budget_reason_passes_harness_followup_body_to_pre_edit_guard(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("ZOE_KANBAN_IMPLEMENT_PRE_EDIT_EXPLORE_BUDGET", "12")
+    log_dir = tmp_path / "kanban" / "logs"
+    log_dir.mkdir(parents=True)
+    (log_dir / "t_impl.log").write_text(
+        "Query: work kanban task t_impl\n"
+        "  ┊ 💻 $         cd /work && PYTHONPATH=services/zoe-data python3 -m pytest -q "
+        "services/zoe-data/tests/test_main_multica_poll.py::"
+        "test_record_blocked_multica_chain_creates_iteration_budget_followup  3.3s\n"
+        "  ┊ 📖 read      /work/services/zoe-data/executors/kanban_adapter.py  0.1s\n"
+        "  ┊ 🔎 grep      ITERATION_BUDGET  0.1s\n",
+        encoding="utf-8",
+    )
+
+    reason = kb.phase_budget_reason(
+        "t_impl",
+        "implement",
+        {
+            "task": {
+                "started_at": 100,
+                "body": '{"source":"engineering_blocker_followup"}',
+            },
+            "runs": [{"started_at": 100}],
+        },
+        now=120,
+    )
+
+    assert reason is not None
+    assert "engineering blocker follow-up kept exploring after focused test" in reason
 
 
 def test_phase_budget_reason_reuses_implement_log_session(monkeypatch):


### PR DESCRIPTION
## Summary
- add a code-enforced drift guard for engineering_blocker_followup implement runs after a focused pytest command
- allow one kanban_adapter.py read after the focused test, then require a patch or terminal block instead of further exploration
- cover the live ZOE-5456 failure shape, the allowed adapter-read path, the budget edge case, cross-file focused tests, and plain-text false-positive prevention

## Validation
- python3 -m py_compile services/zoe-data/kanban_phase_budget.py services/zoe-data/tests/test_kanban_adapter.py
- remote temp worktree: PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_kanban_adapter.py::test_implement_pre_edit_drift_blocks_harness_followup_after_focused_test services/zoe-data/tests/test_kanban_adapter.py::test_implement_pre_edit_drift_allows_harness_followup_adapter_read_after_focused_test services/zoe-data/tests/test_kanban_adapter.py::test_implement_pre_edit_drift_does_not_charge_allowed_adapter_read_to_budget services/zoe-data/tests/test_kanban_adapter.py::test_implement_pre_edit_drift_covers_harness_followup_focused_tests_in_other_files services/zoe-data/tests/test_kanban_adapter.py::test_implement_pre_edit_drift_ignores_plain_followup_prompt_without_metadata services/zoe-data/tests/test_kanban_adapter.py::test_implement_pre_edit_drift_blocks_exploration_without_patch services/zoe-data/tests/test_kanban_adapter.py::test_phase_budget_reason_blocks_pre_edit_handoff_drift