### PR TITLE
[codex] Improve Skybridge voice-first surface

### DIFF
--- a/services/zoe-data/tests/test_skybridge_static.py
+++ b/services/zoe-data/tests/test_skybridge_static.py
@@ -32,6 +32,32 @@ def test_skybridge_page_loads_required_modules_in_order():
     assert "window.confirm = function() { return true; }" not in html
 
 
+def test_skybridge_uses_login_orb_to_voice_pill_layout():
+    html = read(UI / "skybridge.html")
+
+    assert "Login-screen composition reset" in html
+    assert "<h1>Zoe</h1>" in html
+    assert "Skybridge is listening." in html
+    assert "#skyOrb" in html
+    assert "display: none !important" in html
+    assert ".sky-orb-panel::before" in html
+    assert "sky-login-breathe" in html
+    assert "body:not(.sky-empty) .sky-orb-panel::after" in html
+    assert "body:not(.sky-empty) .sky-listening-copy" in html
+    assert "body.sky-empty .sky-command" in html
+    assert "pointer-events: none" in html
+
+
+def test_skybridge_exposes_voice_transport_without_dashboard_header():
+    html = read(UI / "skybridge.html")
+
+    assert "sky-transport-toggle" in html
+    assert "data-mode=\"local\"" in html
+    assert "data-mode=\"livekit\"" in html
+    assert ".sky-stage-header" in html
+    assert "display: none" in html
+
+
 def test_skybridge_capability_registry_covers_core_touch_pages():
     registry = read(UI / "js" / "skybridge-capabilities.js")
 
@@ -80,6 +106,12 @@ def test_skybridge_voice_normalizes_both_transports():
     assert "this.ws.send(ab)" in voice
     assert "this.mode === 'livekit'" in voice
     assert "publishData(payload, { reliable: true })" in voice
+    assert "RoomEvent.TrackSubscribed" in voice
+    assert "RoomEvent.TrackUnsubscribed" in voice
+    assert "Track.Kind.Audio" in voice
+    assert "participant_identity" in voice
+    assert "/api/voice/livekit-cancel" in voice
+    assert "stopPlayback()" in voice
 
 
 def test_livekit_voice_router_accepts_text_commands():
@@ -104,6 +136,11 @@ def test_skybridge_uses_backend_status_contract():
     assert "Skybridge runtime ready" in app
     assert "route && route.startsWith('/')" in app
     assert "Unsupported card route" in app
+    assert "skybridge_voice_mode" in app
+    assert "localStorage.setItem('skybridge_voice_mode', mode)" in app
+    assert "currentUtterance" in app
+    assert "Heard: " in app
+    assert "voice.cancel()" in app
 
 
 def test_skybridge_is_registered_in_touch_menu():

--- a/services/zoe-data/tests/test_skybridge_static.py
+++ b/services/zoe-data/tests/test_skybridge_static.py
@@ -46,6 +46,7 @@ def test_skybridge_uses_login_orb_to_voice_pill_layout():
     assert "body:not(.sky-empty) .sky-listening-copy" in html
     assert "body.sky-empty .sky-command" in html
     assert "pointer-events: none" in html
+    assert "body.sky-empty .sky-command:hover" not in html
 
 
 def test_skybridge_exposes_voice_transport_without_dashboard_header():
@@ -112,6 +113,8 @@ def test_skybridge_voice_normalizes_both_transports():
     assert "participant_identity" in voice
     assert "/api/voice/livekit-cancel" in voice
     assert "stopPlayback()" in voice
+    assert "timeoutId = setTimeout" in voice
+    assert "clearTimeout(timeoutId)" in voice
 
 
 def test_livekit_voice_router_accepts_text_commands():
@@ -127,6 +130,8 @@ def test_skybridge_renderer_keeps_button_actions_functional():
 
     assert "Object.assign({}, props, { actions: cardActions })" in renderer
     assert "Object.assign({ status: risk }, props, { actions: settingActions })" in renderer
+    assert "function safeClassTokens" in renderer
+    assert "/^[a-z0-9-]+$/i.test(token)" in renderer
 
 
 def test_skybridge_uses_backend_status_contract():
@@ -141,6 +146,7 @@ def test_skybridge_uses_backend_status_contract():
     assert "currentUtterance" in app
     assert "Heard: " in app
     assert "voice.cancel()" in app
+    assert "Notice: " in app
 
 
 def test_skybridge_is_registered_in_touch_menu():

--- a/services/zoe-ui/dist/touch/js/skybridge-renderer.js
+++ b/services/zoe-ui/dist/touch/js/skybridge-renderer.js
@@ -24,11 +24,12 @@
     function cardFrame(props, body, options) {
         const wide = options && options.wide ? ' wide' : '';
         const compact = options && options.compact ? ' compact' : '';
+        const tone = options && options.tone ? ' ' + options.tone : '';
         const actions = Array.isArray(props.actions) && props.actions.length
             ? '<div class="sky-actions">' + props.actions.map(buttonHtml).join('') + '</div>'
             : '';
         return [
-            '<article class="sky-card' + wide + compact + '" data-card-id="' + escapeHtml(props.id || '') + '">',
+            '<article class="sky-card' + wide + compact + tone + '" data-card-id="' + escapeHtml(props.id || '') + '">',
             '<div class="sky-card-header">',
             '<div>',
             props.kicker ? '<p class="sky-card-kicker">' + escapeHtml(props.kicker) + '</p>' : '',
@@ -43,20 +44,19 @@
     }
 
     function renderStatus(props) {
-        return cardFrame(props, '<div class="sky-card-body">' + escapeHtml(props.body || props.message || '') + '</div>', { wide: !!props.wide });
+        return cardFrame(props, '<div class="sky-card-body">' + escapeHtml(props.body || props.message || '') + '</div>', { wide: !!props.wide, tone: props.tone || '' });
     }
 
     function renderPage(props) {
         const fields = [
-            ['Route', props.route || ''],
-            ['Kind', props.kind || 'page'],
-            ['Actions', (props.actions || []).join(', ')]
+            ['What opens', props.title || 'Page'],
+            ['Best for', props.summary || 'Zoe context']
         ].map(pair => '<div class="sky-field"><span>' + escapeHtml(pair[0]) + '</span><strong>' + escapeHtml(pair[1]) + '</strong></div>').join('');
         var cardActions = [
             { label: 'Open page', route: props.route, type: 'open' },
             { label: 'Show related settings', query: props.title + ' settings' }
         ];
-        return cardFrame(Object.assign({}, props, { actions: cardActions }), '<div class="sky-card-body">' + escapeHtml(props.summary || '') + '</div><div class="sky-card-grid">' + fields + '</div>', { wide: true });
+        return cardFrame(Object.assign({}, props, { actions: cardActions }), '<div class="sky-card-body">' + escapeHtml(props.summary || '') + '</div><div class="sky-card-grid">' + fields + '</div>', { wide: false, tone: 'page-card' });
     }
 
     function renderSetting(props) {
@@ -64,33 +64,32 @@
         const changeLabel = risk === 'critical' ? 'Prepare change' : 'Change setting';
         const fields = [
             ['Risk', risk],
-            ['Domain', props.domain || 'settings'],
-            ['Section', props.id || '']
+            ['Control area', props.domain || 'settings']
         ].map(pair => '<div class="sky-field"><span>' + escapeHtml(pair[0]) + '</span><strong>' + escapeHtml(pair[1]) + '</strong></div>').join('');
         var settingActions = [
             { label: 'Open settings', route: props.route, type: 'open' },
             { label: changeLabel, query: 'change ' + props.title, kind: risk === 'critical' ? 'warn' : 'normal' }
         ];
-        return cardFrame(Object.assign({ status: risk }, props, { actions: settingActions }), '<div class="sky-card-body">' + escapeHtml(props.summary || '') + '</div><div class="sky-card-grid">' + fields + '</div>', { wide: true });
+        return cardFrame(Object.assign({ status: risk }, props, { actions: settingActions }), '<div class="sky-card-body">' + escapeHtml(props.summary || '') + '</div><div class="sky-card-grid">' + fields + '</div>', { wide: false, tone: 'setting-card' });
     }
 
     function renderPageGrid(props) {
-        const items = (props.items || []).map(item => {
+        const items = (props.items || []).slice(0, 4).map(item => {
             return '<div class="sky-field"><span>' + escapeHtml(item.title) + '</span><strong>' + escapeHtml(item.summary) + '</strong></div>';
         }).join('');
-        return cardFrame(props, '<div class="sky-card-grid">' + items + '</div>', { wide: true });
+        return cardFrame(props, '<div class="sky-card-grid">' + items + '</div>', { wide: true, tone: 'map-card' });
     }
 
     function renderSettingsOverview(props) {
-        const items = (props.items || []).map(item => {
+        const items = (props.items || []).slice(0, 4).map(item => {
             return '<div class="sky-field"><span>' + escapeHtml(item.title) + ' · ' + escapeHtml(item.risk) + '</span><strong>' + escapeHtml(item.summary) + '</strong></div>';
         }).join('');
-        return cardFrame(props, '<div class="sky-card-grid">' + items + '</div>', { wide: true });
+        return cardFrame(props, '<div class="sky-card-grid">' + items + '</div>', { wide: true, tone: 'map-card' });
     }
 
     function renderList(props) {
-        const rows = (props.items || []).map(item => '<div class="sky-field"><strong>' + escapeHtml(typeof item === 'string' ? item : item.title || item.text || JSON.stringify(item)) + '</strong></div>').join('');
-        return cardFrame(props, '<div class="sky-card-grid">' + rows + '</div>', { wide: true });
+        const rows = (props.items || []).slice(0, 3).map(item => '<div class="sky-field"><strong>' + escapeHtml(typeof item === 'string' ? item : item.title || item.text || JSON.stringify(item)) + '</strong></div>').join('');
+        return cardFrame(props, '<div class="sky-card-grid">' + rows + '</div>', { wide: false, tone: 'list-card' });
     }
 
     function normalizeCard(card) {

--- a/services/zoe-ui/dist/touch/js/skybridge-renderer.js
+++ b/services/zoe-ui/dist/touch/js/skybridge-renderer.js
@@ -21,10 +21,18 @@
         return '<button type="button" class="' + kind.trim() + '" data-sky-action="' + escapeHtml(action.type || 'query') + '" data-query="' + query + '" data-route="' + route + '">' + label + '</button>';
     }
 
+    function safeClassTokens(value) {
+        return String(value || '')
+            .split(/\s+/)
+            .filter(token => /^[a-z0-9-]+$/i.test(token))
+            .join(' ');
+    }
+
     function cardFrame(props, body, options) {
         const wide = options && options.wide ? ' wide' : '';
         const compact = options && options.compact ? ' compact' : '';
-        const tone = options && options.tone ? ' ' + options.tone : '';
+        const safeTone = options && options.tone ? safeClassTokens(options.tone) : '';
+        const tone = safeTone ? ' ' + safeTone : '';
         const actions = Array.isArray(props.actions) && props.actions.length
             ? '<div class="sky-actions">' + props.actions.map(buttonHtml).join('') + '</div>'
             : '';

--- a/services/zoe-ui/dist/touch/js/skybridge-voice.js
+++ b/services/zoe-ui/dist/touch/js/skybridge-voice.js
@@ -149,15 +149,20 @@
                         this.emit({ type: 'error', message: 'LiveKit disconnected' });
                     }
                 });
-                await Promise.race([
-                    room.connect(data.url, data.token),
-                    new Promise((_, reject) => {
-                        setTimeout(() => {
-                            try { room.disconnect(); } catch (_) {}
-                            reject(new Error('LiveKit timeout'));
-                        }, 7000);
-                    })
-                ]);
+                let timeoutId = null;
+                try {
+                    await Promise.race([
+                        room.connect(data.url, data.token),
+                        new Promise((_, reject) => {
+                            timeoutId = setTimeout(() => {
+                                try { room.disconnect(); } catch (_) {}
+                                reject(new Error('LiveKit timeout'));
+                            }, 7000);
+                        })
+                    ]);
+                } finally {
+                    if (timeoutId) clearTimeout(timeoutId);
+                }
                 this.room = room;
                 this.emit({ type: 'ready', mode: 'livekit' });
             } catch (err) {

--- a/services/zoe-ui/dist/touch/js/skybridge-voice.js
+++ b/services/zoe-ui/dist/touch/js/skybridge-voice.js
@@ -18,6 +18,8 @@
             this.onEvent = options.onEvent;
             this.ws = null;
             this.room = null;
+            this.remoteAudioEls = [];
+            this.currentAudio = null;
             this.micStream = null;
             this.mediaRecorder = null;
             this.audioChunks = [];
@@ -61,6 +63,7 @@
             this.audioChunks = [];
             if (this.ws) this.ws.close();
             if (this.room) this.room.disconnect();
+            this.stopPlayback();
             if (this.micStream) this.micStream.getTracks().forEach(track => track.stop());
             this.ws = null;
             this.room = null;
@@ -125,6 +128,8 @@
                     return;
                 }
                 const room = new LivekitClient.Room({ adaptiveStream: true, dynacast: true });
+                room.on(LivekitClient.RoomEvent.TrackSubscribed, track => this.handleLiveKitTrack(track));
+                room.on(LivekitClient.RoomEvent.TrackUnsubscribed, track => this.detachLiveKitTrack(track));
                 room.on(LivekitClient.RoomEvent.DataReceived, payload => {
                     try {
                         const text = new TextDecoder().decode(payload);
@@ -134,7 +139,25 @@
                         this.emit({ type: 'error', message: 'Malformed server event' });
                     }
                 });
-                await room.connect(data.url, data.token);
+                room.on(LivekitClient.RoomEvent.Disconnected, () => {
+                    this.room = null;
+                    this.serverBusy = false;
+                    this.speaking = false;
+                    this.stopPlayback();
+                    this.emit({ type: 'state', state: 'ambient' });
+                    if (!this.stopped && this.mode === 'livekit') {
+                        this.emit({ type: 'error', message: 'LiveKit disconnected' });
+                    }
+                });
+                await Promise.race([
+                    room.connect(data.url, data.token),
+                    new Promise((_, reject) => {
+                        setTimeout(() => {
+                            try { room.disconnect(); } catch (_) {}
+                            reject(new Error('LiveKit timeout'));
+                        }, 7000);
+                    })
+                ]);
                 this.room = room;
                 this.emit({ type: 'ready', mode: 'livekit' });
             } catch (err) {
@@ -142,6 +165,73 @@
                 this.mode = 'local';
                 this.connectLocal();
             }
+        }
+
+        handleLiveKitTrack(track) {
+            if (typeof LivekitClient === 'undefined' || track.kind !== LivekitClient.Track.Kind.Audio) return;
+            const audioEl = track.attach();
+            audioEl.autoplay = true;
+            audioEl.dataset.skybridgeAudio = '1';
+            document.body.appendChild(audioEl);
+            this.remoteAudioEls.push({ track, audioEl });
+            this.speaking = true;
+            this.emit({ type: 'state', state: 'responding' });
+            const cleanup = () => {
+                this.detachLiveKitTrack(track, audioEl);
+                if (!this.remoteAudioEls.length) {
+                    this.speaking = false;
+                    this.emit({ type: 'state', state: 'ambient' });
+                }
+            };
+            audioEl.addEventListener('ended', cleanup, { once: true });
+            audioEl.addEventListener('error', cleanup, { once: true });
+            audioEl.play().catch(cleanup);
+        }
+
+        detachLiveKitTrack(track, audioEl) {
+            this.remoteAudioEls = this.remoteAudioEls.filter(item => {
+                const match = item.track === track || item.audioEl === audioEl;
+                if (match) {
+                    try { item.track.detach(item.audioEl); } catch (_) {}
+                    try { item.audioEl.remove(); } catch (_) {}
+                }
+                return !match;
+            });
+            if (!this.remoteAudioEls.length) this.speaking = false;
+        }
+
+        stopPlayback() {
+            if (this.currentAudio) {
+                try { this.currentAudio.pause(); } catch (_) {}
+                this.currentAudio = null;
+            }
+            this.remoteAudioEls.forEach(item => {
+                try { item.track.detach(item.audioEl); } catch (_) {}
+                try { item.audioEl.remove(); } catch (_) {}
+            });
+            this.remoteAudioEls = [];
+            this.speaking = false;
+        }
+
+        async cancel() {
+            this.stopPlayback();
+            this.serverBusy = false;
+            clearTimeout(this.autoListenTimer);
+            if (this.mode === 'livekit' && this.room) {
+                try {
+                    await fetch('/api/voice/livekit-cancel', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json', 'X-Session-ID': getSessionId() },
+                        body: JSON.stringify({
+                            participant_identity: this.room.localParticipant && this.room.localParticipant.identity || '',
+                            session_id: getSessionId()
+                        })
+                    });
+                } catch (_) {}
+            } else if (this.ws && this.ws.readyState === WebSocket.OPEN) {
+                this.ws.send(JSON.stringify({ type: 'cancel' }));
+            }
+            this.emit({ type: 'state', state: 'ambient' });
         }
 
         handleServerEvent(msg) {
@@ -256,12 +346,14 @@
                 const form = new FormData();
                 form.append('audio', blob, 'skybridge.webm');
                 form.append('session_id', getSessionId());
+                form.append('participant_identity', this.room && this.room.localParticipant ? this.room.localParticipant.identity || '' : '');
                 try {
                     const resp = await fetch('/api/voice/livekit-audio', {
                         method: 'POST',
                         headers: { 'X-Session-ID': getSessionId() },
                         body: form
                     });
+                    if (!resp.ok) throw new Error('LiveKit audio upload failed');
                     const data = await resp.json();
                     if (data.transcript) this.emit({ type: 'transcript', role: 'user', text: data.transcript });
                     if (data.response_text) this.emit({ type: 'transcript', role: 'zoe', text: data.response_text });
@@ -295,10 +387,12 @@
                 for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
                 const url = URL.createObjectURL(new Blob([bytes], { type: contentType }));
                 const audio = new Audio(url);
+                this.currentAudio = audio;
                 this.speaking = true;
                 this.emit({ type: 'state', state: 'responding' });
                 audio.onended = () => {
                     URL.revokeObjectURL(url);
+                    if (this.currentAudio === audio) this.currentAudio = null;
                     this.speaking = false;
                     this.emit({ type: 'state', state: 'ambient' });
                 };

--- a/services/zoe-ui/dist/touch/js/skybridge.js
+++ b/services/zoe-ui/dist/touch/js/skybridge.js
@@ -4,10 +4,12 @@
 (function () {
     const els = {};
     let voice = null;
-    let mode = new URLSearchParams(location.search).get('mode') || 'local';
+    let mode = new URLSearchParams(location.search).get('mode') || localStorage.getItem('skybridge_voice_mode') || 'local';
     let orbState = 'ambient';
     let phase = 0;
     let animationFrame = null;
+    let cardSequence = 0;
+    let currentUtterance = '';
 
     const colors = {
         ambient: ['#5fc6ff', '#66d19e'],
@@ -24,6 +26,10 @@
         loadBackendStatus();
         setMode(mode);
         if (typeof TouchMenu !== 'undefined') TouchMenu.init({ page: 'skybridge' });
+        const initialQuery = new URLSearchParams(location.search).get('q');
+        if (initialQuery) {
+            setTimeout(() => submitCommand(initialQuery), 120);
+        }
     }
 
     async function loadBackendStatus() {
@@ -66,6 +72,8 @@
             if (!voice) return;
             if (voice.isRecording) {
                 voice.stopRecording();
+            } else if (voice.speaking || voice.serverBusy) {
+                voice.cancel().catch(err => showError(err.message || 'Cancel failed'));
             } else {
                 voice.startRecording().catch(err => showError(err.message || 'Microphone unavailable'));
             }
@@ -88,6 +96,7 @@
 
     function setMode(nextMode) {
         mode = nextMode || 'local';
+        localStorage.setItem('skybridge_voice_mode', mode);
         document.querySelectorAll('[data-mode]').forEach(btn => {
             btn.classList.toggle('active', btn.dataset.mode === mode);
         });
@@ -117,6 +126,8 @@
     function submitCommand(text) {
         const query = String(text || '').trim();
         if (!query) return;
+        currentUtterance = 'Heard: ' + query;
+        els.copy.textContent = currentUtterance;
         projectCards(query);
         if (voice) voice.sendText(query);
     }
@@ -124,17 +135,20 @@
     function projectCards(query) {
         const matches = window.SkybridgeCapabilities.find(query);
         if (!matches.length) {
+            clearCards();
             addCard({
                 component: 'status',
                 props: {
                     title: 'I can work from here',
                     kicker: 'No exact page match',
                     body: 'I will keep the conversation here. If this needs a page or setting, Skybridge can add a new capability mapping for it.',
-                    status: 'General'
+                    status: 'General',
+                    tone: 'hero'
                 }
             }, true);
             return;
         }
+        clearCards();
         const top = matches[0];
         if (top.kind === 'setting') {
             setContext('Settings', top.title + ' is active for follow-up commands.');
@@ -152,25 +166,42 @@
                     items: matches.slice(1, 5).map(item => item.title + ' - ' + item.summary),
                     actions: matches.slice(1, 3).map(item => ({ label: item.title, query: item.title }))
                 }
-            });
+            }, false, 120);
         }
     }
 
     function renderHome() {
-        setContext('Home surface', 'Cards appear here as Zoe understands the request.');
-        els.cards.innerHTML = '';
-        window.SkybridgeCapabilities.getHomeCards().forEach(card => addCard(card));
+        document.body.classList.add('sky-empty');
+        currentUtterance = '';
+        setContext('Listening', 'The surface will build itself when Zoe understands what you need.');
+        clearCards();
+        els.copy.textContent = 'Listening. Ask Zoe for anything.';
+        requestAnimationFrame(resizeOrb);
     }
 
-    function addCard(card, prepend) {
+    function clearCards() {
+        cardSequence = 0;
+        els.cards.innerHTML = '';
+        document.body.classList.add('sky-empty');
+        requestAnimationFrame(resizeOrb);
+    }
+
+    function addCard(card, prepend, delayMs) {
+        document.body.classList.remove('sky-empty');
+        requestAnimationFrame(resizeOrb);
         const wrapper = document.createElement('div');
         wrapper.innerHTML = window.SkybridgeRenderer.render(card);
         const node = wrapper.firstElementChild;
         if (!node) return;
+        node.style.animationDelay = ((delayMs == null ? cardSequence * 90 : delayMs) / 1000) + 's';
+        cardSequence += 1;
         if (prepend && els.cards.firstChild) {
             els.cards.insertBefore(node, els.cards.firstChild);
         } else {
             els.cards.appendChild(node);
+        }
+        while (els.cards.children.length > 8) {
+            els.cards.removeChild(els.cards.lastElementChild);
         }
     }
 
@@ -181,6 +212,8 @@
 
     function addTranscript(role, text) {
         if (!text) return;
+        currentUtterance = (role === 'user' ? 'Heard: ' : 'Zoe: ') + text;
+        els.copy.textContent = currentUtterance;
         const line = document.createElement('div');
         line.className = 'sky-line';
         line.innerHTML = '<strong>' + (role === 'user' ? 'You' : 'Zoe') + ':</strong> ' + window.SkybridgeRenderer.escapeHtml(text);
@@ -194,15 +227,9 @@
 
     function showError(message) {
         setStatus(message || 'Something needs attention');
-        addCard({
-            component: 'status',
-            props: {
-                title: 'Skybridge notice',
-                kicker: 'Runtime',
-                body: message || 'Something needs attention.',
-                status: 'Notice'
-            }
-        }, true);
+        if (!document.body.classList.contains('sky-empty') && !currentUtterance) {
+            els.copy.textContent = message || 'Something needs attention.';
+        }
     }
 
     function setState(state) {
@@ -214,7 +241,9 @@
             thinking: 'Finding the right page, data, or card...',
             responding: 'Zoe is speaking. You can interrupt when needed.'
         };
-        els.copy.textContent = copy[state] || copy.ambient;
+        if (document.body.classList.contains('sky-empty') || !currentUtterance) {
+            els.copy.textContent = copy[state] || copy.ambient;
+        }
         setStatus(state.charAt(0).toUpperCase() + state.slice(1));
     }
 
@@ -236,24 +265,56 @@
             ctx.clearRect(0, 0, w, h);
             const cx = w / 2;
             const cy = h / 2;
-            const base = Math.min(w, h) * 0.22;
+            const empty = document.body.classList.contains('sky-empty');
+            const base = Math.min(w, h) * (empty ? 0.26 : 0.24);
             const pulse = 1 + (orbState === 'listening' ? 0.06 : orbState === 'responding' ? 0.08 : 0.025) * Math.sin(phase * 2);
             const r = base * pulse;
             const pair = colors[orbState] || colors.ambient;
+            const outer = ctx.createRadialGradient(cx, cy, r * 0.1, cx, cy, r * 2.55);
+            outer.addColorStop(0, pair[0] + '42');
+            outer.addColorStop(0.35, pair[1] + '22');
+            outer.addColorStop(1, 'transparent');
+            ctx.fillStyle = outer;
+            ctx.beginPath();
+            ctx.arc(cx, cy, r * 2.55, 0, Math.PI * 2);
+            ctx.fill();
+
             const glow = ctx.createRadialGradient(cx, cy, r * 0.2, cx, cy, r * 2.4);
-            glow.addColorStop(0, pair[0] + '88');
-            glow.addColorStop(0.55, pair[1] + '33');
+            glow.addColorStop(0, pair[0] + 'aa');
+            glow.addColorStop(0.52, pair[1] + '42');
             glow.addColorStop(1, 'transparent');
             ctx.fillStyle = glow;
             ctx.beginPath();
             ctx.arc(cx, cy, r * 2.4, 0, Math.PI * 2);
             ctx.fill();
+
+            ctx.save();
+            ctx.globalAlpha = empty ? 0.24 : 0.16;
+            ctx.strokeStyle = pair[1] + '66';
+            ctx.lineWidth = Math.max(1, r * 0.012);
+            for (let i = 0; i < 3; i += 1) {
+                const ring = r * (1.26 + i * 0.23 + Math.sin(phase + i) * 0.018);
+                ctx.beginPath();
+                ctx.arc(cx, cy, ring, 0, Math.PI * 2);
+                ctx.stroke();
+            }
+            ctx.restore();
+
             const orb = ctx.createRadialGradient(cx - r * 0.3, cy - r * 0.35, r * 0.1, cx, cy, r);
             orb.addColorStop(0, '#ffffff');
-            orb.addColorStop(0.15, pair[0]);
-            orb.addColorStop(0.75, pair[1]);
-            orb.addColorStop(1, '#070910');
+            orb.addColorStop(0.17, '#c9f8ff');
+            orb.addColorStop(0.48, pair[0]);
+            orb.addColorStop(1, pair[1]);
             ctx.fillStyle = orb;
+            ctx.beginPath();
+            ctx.arc(cx, cy, r, 0, Math.PI * 2);
+            ctx.fill();
+
+            const sheen = ctx.createLinearGradient(cx - r, cy - r, cx + r, cy + r);
+            sheen.addColorStop(0, 'rgba(255,255,255,0.24)');
+            sheen.addColorStop(0.35, 'rgba(255,255,255,0.05)');
+            sheen.addColorStop(1, 'rgba(255,255,255,0)');
+            ctx.fillStyle = sheen;
             ctx.beginPath();
             ctx.arc(cx, cy, r, 0, Math.PI * 2);
             ctx.fill();

--- a/services/zoe-ui/dist/touch/js/skybridge.js
+++ b/services/zoe-ui/dist/touch/js/skybridge.js
@@ -226,9 +226,20 @@
     }
 
     function showError(message) {
-        setStatus(message || 'Something needs attention');
-        if (!document.body.classList.contains('sky-empty') && !currentUtterance) {
-            els.copy.textContent = message || 'Something needs attention.';
+        const text = message || 'Something needs attention.';
+        setStatus(text);
+        if (!document.body.classList.contains('sky-empty')) {
+            const previous = currentUtterance;
+            els.copy.textContent = 'Notice: ' + text;
+            if (previous) {
+                setTimeout(() => {
+                    if (!document.body.classList.contains('sky-empty') && currentUtterance === previous) {
+                        els.copy.textContent = previous;
+                    }
+                }, 4500);
+            }
+        } else {
+            els.copy.textContent = text;
         }
     }
 

--- a/services/zoe-ui/dist/touch/skybridge.html
+++ b/services/zoe-ui/dist/touch/skybridge.html
@@ -1156,11 +1156,6 @@
             opacity: 0.72;
         }
 
-        body.sky-empty .sky-command:hover,
-        body.sky-empty .sky-command:focus-within {
-            opacity: 1;
-        }
-
         body:not(.sky-empty) .sky-transcript {
             border-top: 1px solid rgba(255,255,255,0.08);
             border-radius: 18px;

--- a/services/zoe-ui/dist/touch/skybridge.html
+++ b/services/zoe-ui/dist/touch/skybridge.html
@@ -462,6 +462,1188 @@
             }
             .sky-card.compact { grid-column: span 12; }
         }
+
+        /* Skybridge presentation layer: voice-first, cinematic, card-native. */
+        html, body {
+            background:
+                radial-gradient(circle at 20% 30%, rgba(95, 198, 255, 0.22), transparent 34%),
+                radial-gradient(circle at 78% 18%, rgba(102, 209, 158, 0.18), transparent 28%),
+                radial-gradient(circle at 70% 86%, rgba(247, 191, 95, 0.1), transparent 26%),
+                linear-gradient(145deg, #080a10 0%, #11151d 42%, #07080c 100%);
+        }
+
+        body::before {
+            content: "";
+            position: fixed;
+            inset: 64px 0 0;
+            pointer-events: none;
+            background-image:
+                linear-gradient(rgba(255,255,255,0.04) 1px, transparent 1px),
+                linear-gradient(90deg, rgba(255,255,255,0.035) 1px, transparent 1px);
+            background-size: 72px 72px;
+            mask-image: radial-gradient(circle at 50% 42%, black 0%, transparent 72%);
+            opacity: 0.22;
+        }
+
+        .sky-topbar {
+            padding: 20px 34px 10px;
+        }
+
+        .sky-heading h1 {
+            font-size: clamp(30px, 4vw, 54px);
+            font-weight: 760;
+        }
+
+        .sky-heading p {
+            font-size: 15px;
+            color: rgba(246,248,251,0.72);
+        }
+
+        .sky-status {
+            border-color: rgba(255,255,255,0.14);
+            background: rgba(255,255,255,0.075);
+            box-shadow: inset 0 1px 0 rgba(255,255,255,0.1);
+        }
+
+        .sky-shell {
+            grid-template-columns: minmax(360px, 40vw) minmax(0, 1fr);
+            gap: 26px;
+            padding: 12px 34px 20px;
+        }
+
+        .sky-orb-panel,
+        .sky-stage {
+            border-color: rgba(255,255,255,0.12);
+            background:
+                linear-gradient(180deg, rgba(255,255,255,0.11), rgba(255,255,255,0.035)),
+                rgba(7, 9, 14, 0.62);
+            border-radius: 18px;
+            box-shadow:
+                0 28px 90px rgba(0,0,0,0.44),
+                inset 0 1px 0 rgba(255,255,255,0.09);
+        }
+
+        .sky-orb-panel {
+            min-height: 0;
+        }
+
+        #skyOrb {
+            min-height: 520px;
+            filter: saturate(1.1);
+        }
+
+        .sky-listening-copy {
+            bottom: 92px;
+            max-width: 360px;
+            margin: 0 auto;
+            font-size: 18px;
+            color: rgba(246,248,251,0.72);
+        }
+
+        .sky-transcript {
+            max-height: 118px;
+            background: rgba(0,0,0,0.22);
+        }
+
+        .sky-stage-header {
+            padding: 22px 24px;
+            background: linear-gradient(90deg, rgba(255,255,255,0.075), transparent);
+        }
+
+        .sky-context h2 {
+            font-size: clamp(28px, 3.2vw, 44px);
+            line-height: 1;
+        }
+
+        .sky-context p {
+            font-size: 15px;
+            color: rgba(246,248,251,0.7);
+        }
+
+        .sky-mode-toggle {
+            border-radius: 12px;
+        }
+
+        .sky-mode-toggle button {
+            border-radius: 10px;
+            font-weight: 700;
+        }
+
+        .sky-card-stack {
+            position: relative;
+            padding: 24px;
+            gap: 16px;
+            align-content: start;
+            scrollbar-width: thin;
+        }
+
+        .sky-card-stack::before {
+            content: "";
+            position: sticky;
+            top: -24px;
+            grid-column: 1 / -1;
+            height: 0;
+            z-index: 2;
+            box-shadow: 0 0 68px 44px rgba(7,9,14,0.55);
+            pointer-events: none;
+        }
+
+        .sky-card {
+            position: relative;
+            overflow: hidden;
+            min-height: 0;
+            border-radius: 16px;
+            border-color: rgba(255,255,255,0.13);
+            background:
+                linear-gradient(145deg, rgba(255,255,255,0.12), rgba(255,255,255,0.045)),
+                rgba(17, 21, 29, 0.74);
+            box-shadow:
+                0 18px 48px rgba(0,0,0,0.28),
+                inset 0 1px 0 rgba(255,255,255,0.08);
+            opacity: 0;
+            transform: translateY(18px) scale(0.985);
+            animation: sky-materialize 620ms cubic-bezier(0.2, 0.9, 0.2, 1) forwards;
+        }
+
+        .sky-card::after {
+            content: "";
+            position: absolute;
+            inset: 0;
+            background: radial-gradient(circle at 18% 10%, rgba(95,198,255,0.16), transparent 38%);
+            pointer-events: none;
+            opacity: 0.9;
+        }
+
+        .sky-card > * {
+            position: relative;
+            z-index: 1;
+        }
+
+        .sky-card.hero {
+            min-height: 230px;
+            padding: 24px;
+            background:
+                radial-gradient(circle at 10% 0%, rgba(95,198,255,0.28), transparent 38%),
+                linear-gradient(145deg, rgba(255,255,255,0.14), rgba(255,255,255,0.045)),
+                rgba(12, 16, 24, 0.86);
+        }
+
+        .sky-card.hero .sky-card-title {
+            font-size: clamp(28px, 3vw, 42px);
+            line-height: 1.03;
+        }
+
+        .sky-card.hero .sky-card-body {
+            max-width: 58ch;
+            font-size: 16px;
+        }
+
+        .sky-card.wide {
+            grid-column: span 12;
+        }
+
+        .sky-card.page-card,
+        .sky-card.setting-card {
+            grid-column: span 6;
+        }
+
+        .sky-card-title {
+            font-size: 22px;
+            line-height: 1.12;
+        }
+
+        .sky-card-kicker {
+            letter-spacing: 0.08em;
+            color: rgba(246,248,251,0.6);
+        }
+
+        .sky-card-body {
+            font-size: 15px;
+            color: rgba(246,248,251,0.78);
+        }
+
+        .sky-card-grid {
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+            gap: 10px;
+        }
+
+        .sky-card.page-card .sky-card-grid,
+        .sky-card.setting-card .sky-card-grid,
+        .sky-card.list-card .sky-card-grid {
+            grid-template-columns: 1fr;
+        }
+
+        .sky-field {
+            border-color: rgba(255,255,255,0.1);
+            background: rgba(0,0,0,0.18);
+            border-radius: 12px;
+        }
+
+        .sky-actions button,
+        .sky-command button {
+            border-radius: 12px;
+            font-weight: 720;
+        }
+
+        .sky-actions button.primary,
+        .sky-command .primary {
+            background: linear-gradient(135deg, #6bd6ff, #73e0aa);
+        }
+
+        .sky-command {
+            padding: 14px 34px max(20px, env(safe-area-inset-bottom, 20px));
+            background: rgba(5, 7, 10, 0.84);
+        }
+
+        .sky-command input {
+            min-height: 56px;
+            border-radius: 16px;
+            font-size: 17px;
+        }
+
+        body.sky-empty {
+            grid-template-rows: auto 1fr auto;
+        }
+
+        body.sky-empty .sky-topbar {
+            grid-template-columns: 1fr;
+            justify-items: center;
+            padding-top: clamp(28px, 5vh, 64px);
+        }
+
+        body.sky-empty .sky-title {
+            flex-direction: column;
+            text-align: center;
+            gap: 16px;
+        }
+
+        body.sky-empty .sky-mark {
+            width: 54px;
+            height: 54px;
+        }
+
+        body.sky-empty .sky-heading h1 {
+            font-size: clamp(42px, 7vw, 82px);
+        }
+
+        body.sky-empty .sky-heading p {
+            max-width: min(620px, 84vw);
+            white-space: normal;
+            font-size: 17px;
+        }
+
+        body.sky-empty .sky-status {
+            position: fixed;
+            right: 34px;
+            top: calc(var(--ta-nav-h, 64px) + 24px);
+            z-index: 4;
+        }
+
+        body.sky-empty .sky-shell {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding-top: 0;
+            padding-bottom: 28px;
+        }
+
+        body.sky-empty .sky-orb-panel {
+            width: min(900px, calc(100vw - 68px));
+            min-height: min(58vh, 620px);
+            border-color: transparent;
+            background: transparent;
+            box-shadow: none;
+        }
+
+        body.sky-empty #skyOrb {
+            min-height: min(58vh, 620px);
+        }
+
+        body.sky-empty .sky-listening-copy {
+            bottom: 44px;
+            font-size: clamp(20px, 3vw, 34px);
+            line-height: 1.18;
+            max-width: 720px;
+            color: rgba(246,248,251,0.82);
+            text-shadow: 0 10px 40px rgba(0,0,0,0.45);
+        }
+
+        body.sky-empty .sky-transcript,
+        body.sky-empty .sky-stage {
+            display: none;
+        }
+
+        body.sky-empty .sky-command {
+            max-width: min(860px, calc(100vw - 48px));
+            width: 100%;
+            justify-self: center;
+            margin: 0 auto max(18px, env(safe-area-inset-bottom, 18px));
+            border: 1px solid rgba(255,255,255,0.12);
+            border-radius: 22px;
+            background: rgba(12, 15, 22, 0.82);
+            box-shadow: 0 24px 80px rgba(0,0,0,0.42);
+        }
+
+        @keyframes sky-materialize {
+            0% { opacity: 0; transform: translateY(22px) scale(0.975); filter: blur(10px); }
+            55% { opacity: 1; filter: blur(0); }
+            100% { opacity: 1; transform: translateY(0) scale(1); filter: blur(0); }
+        }
+
+        @media (max-width: 980px) {
+            .sky-shell {
+                grid-template-columns: 1fr;
+            }
+            #skyOrb {
+                min-height: 360px;
+            }
+            .sky-card.page-card,
+            .sky-card.setting-card {
+                grid-column: span 12;
+            }
+        }
+
+        @media (max-width: 640px) {
+            .sky-topbar {
+                padding-top: 16px;
+            }
+            .sky-heading h1 {
+                font-size: 32px;
+            }
+            .sky-shell {
+                gap: 16px;
+            }
+            .sky-card-stack {
+                padding: 14px;
+            }
+            .sky-card-grid {
+                grid-template-columns: 1fr;
+            }
+            body.sky-empty .sky-status {
+                position: static;
+                justify-self: stretch;
+            }
+            body.sky-empty .sky-shell {
+                padding-top: 0;
+            }
+            body.sky-empty .sky-orb-panel {
+                width: calc(100vw - 28px);
+                min-height: 440px;
+            }
+            body.sky-empty #skyOrb {
+                min-height: 420px;
+            }
+            body.sky-empty .sky-command {
+                grid-template-columns: 1fr;
+                max-width: calc(100vw - 28px);
+            }
+        }
+
+        /* Final Skybridge visual language: Zoe login calm, dynamic card surface. */
+        html,
+        body {
+            padding-top: 0 !important;
+            background:
+                radial-gradient(circle at 50% 34%, rgba(123, 97, 255, 0.18), transparent 34%),
+                radial-gradient(circle at 54% 42%, rgba(90, 224, 224, 0.12), transparent 30%),
+                linear-gradient(135deg, #1a1a2e 0%, #16213e 50%, #0f3460 100%);
+        }
+
+        body {
+            position: relative;
+        }
+
+        #ztm-nav {
+            display: none !important;
+        }
+
+        body::before {
+            inset: 0;
+            background:
+                radial-gradient(circle at 50% 42%, rgba(123, 97, 255, 0.18), transparent 25%),
+                radial-gradient(circle at 50% 42%, rgba(90, 224, 224, 0.08), transparent 42%);
+            mask-image: none;
+            opacity: 1;
+        }
+
+        body::after {
+            content: "";
+            position: fixed;
+            inset: 0;
+            pointer-events: none;
+            background:
+                linear-gradient(180deg, rgba(255,255,255,0.035), transparent 20%, transparent 78%, rgba(0,0,0,0.18)),
+                radial-gradient(ellipse at center, transparent 42%, rgba(5, 7, 18, 0.28) 100%);
+            z-index: 0;
+        }
+
+        .sky-topbar,
+        .sky-shell,
+        .sky-command {
+            position: relative;
+            z-index: 1;
+        }
+
+        .sky-topbar {
+            position: fixed;
+            top: max(18px, env(safe-area-inset-top, 18px));
+            left: 28px;
+            right: 28px;
+            padding: 0;
+            z-index: 5;
+        }
+
+        .sky-title {
+            gap: 12px;
+        }
+
+        .sky-mark {
+            width: 36px;
+            height: 36px;
+            background: linear-gradient(135deg, #7B61FF, #5AE0E0);
+            box-shadow: 0 0 34px rgba(90, 224, 224, 0.24);
+        }
+
+        .sky-heading h1 {
+            font-size: 22px;
+            font-weight: 400;
+            background: linear-gradient(135deg, #ffffff, #5AE0E0);
+            -webkit-background-clip: text;
+            background-clip: text;
+            color: transparent;
+        }
+
+        .sky-heading p {
+            margin-top: 4px;
+            color: rgba(255,255,255,0.48);
+            font-size: 13px;
+        }
+
+        .sky-status {
+            display: none;
+            min-height: 38px;
+            border-radius: 999px;
+            border-color: rgba(255,255,255,0.1);
+            background: rgba(255,255,255,0.055);
+            box-shadow: none;
+        }
+
+        .sky-transport-toggle {
+            position: fixed;
+            top: 96px;
+            right: max(30px, calc((100vw - min(1040px, calc(100vw - 64px))) / 2));
+            display: flex;
+            gap: 6px;
+            padding: 5px;
+            border-radius: 999px;
+            border: 1px solid rgba(255,255,255,0.1);
+            background: rgba(9, 13, 27, 0.48);
+            backdrop-filter: blur(18px);
+            -webkit-backdrop-filter: blur(18px);
+            z-index: 6;
+        }
+
+        .sky-transport-toggle button {
+            min-height: 34px;
+            border: 0;
+            border-radius: 999px;
+            padding: 0 12px;
+            color: rgba(255,255,255,0.62);
+            background: transparent;
+            font: inherit;
+            font-size: 13px;
+            font-weight: 700;
+            cursor: pointer;
+        }
+
+        .sky-transport-toggle button.active {
+            color: #081016;
+            background: linear-gradient(135deg, #7B61FF, #5AE0E0);
+        }
+
+        .sky-shell {
+            height: 100%;
+            padding: 112px clamp(28px, 4vw, 60px) 104px;
+            grid-template-columns: minmax(310px, 34vw) minmax(420px, 1fr);
+            align-items: stretch;
+        }
+
+        .sky-orb-panel {
+            border: 0;
+            background: transparent;
+            box-shadow: none;
+        }
+
+        #skyOrb {
+            min-height: 420px;
+        }
+
+        .sky-listening-copy {
+            bottom: 44px;
+            font-size: 18px;
+            color: rgba(255,255,255,0.6);
+        }
+
+        .sky-stage {
+            border: 1px solid rgba(255,255,255,0.11);
+            border-radius: 22px;
+            background: rgba(7, 10, 22, 0.32);
+            box-shadow:
+                0 30px 90px rgba(0,0,0,0.28),
+                inset 0 1px 0 rgba(255,255,255,0.08);
+        }
+
+        .sky-stage-header {
+            border-bottom-color: rgba(255,255,255,0.08);
+            background: linear-gradient(90deg, rgba(255,255,255,0.07), rgba(255,255,255,0.015));
+        }
+
+        .sky-context h2 {
+            font-weight: 400;
+            background: linear-gradient(135deg, #ffffff, #78f0f0);
+            -webkit-background-clip: text;
+            background-clip: text;
+            color: transparent;
+        }
+
+        .sky-mode-toggle {
+            border: 1px solid rgba(255,255,255,0.1);
+            background: rgba(0,0,0,0.16);
+        }
+
+        .sky-card-stack {
+            grid-template-columns: repeat(6, minmax(0, 1fr));
+            padding: 26px;
+        }
+
+        .sky-card,
+        .sky-card.page-card,
+        .sky-card.setting-card,
+        .sky-card.list-card {
+            grid-column: span 3;
+            padding: 22px;
+            border-radius: 20px;
+            border: 1px solid rgba(255,255,255,0.12);
+            background:
+                radial-gradient(circle at 18% 0%, rgba(90, 224, 224, 0.16), transparent 40%),
+                linear-gradient(145deg, rgba(255,255,255,0.13), rgba(255,255,255,0.045)),
+                rgba(10, 14, 28, 0.74);
+        }
+
+        .sky-card:first-child {
+            grid-column: span 4;
+            min-height: 260px;
+        }
+
+        .sky-card.wide,
+        .sky-card.hero {
+            grid-column: span 6;
+        }
+
+        .sky-card-title {
+            font-size: clamp(24px, 2.4vw, 36px);
+            font-weight: 500;
+        }
+
+        .sky-card-body {
+            font-size: 16px;
+        }
+
+        .sky-field {
+            padding: 12px;
+            border-radius: 14px;
+            background: rgba(255,255,255,0.045);
+        }
+
+        .sky-command {
+            position: fixed;
+            left: 50%;
+            bottom: max(22px, env(safe-area-inset-bottom, 22px));
+            width: min(860px, calc(100vw - 48px));
+            transform: translateX(-50%);
+            padding: 10px;
+            border: 1px solid rgba(255,255,255,0.12);
+            border-radius: 28px;
+            background: rgba(9, 13, 27, 0.72);
+            backdrop-filter: blur(22px);
+            -webkit-backdrop-filter: blur(22px);
+            box-shadow: 0 26px 90px rgba(0,0,0,0.42);
+        }
+
+        .sky-command input {
+            min-height: 54px;
+            border: 0;
+            border-radius: 22px;
+            background: rgba(255,255,255,0.065);
+        }
+
+        .sky-command button {
+            min-height: 54px;
+            border-radius: 20px;
+        }
+
+        body.sky-empty .sky-topbar {
+            position: fixed;
+            top: 0;
+            bottom: 0;
+            left: 0;
+            right: 0;
+            display: grid;
+            align-content: center;
+            justify-items: center;
+            padding: 0 24px;
+            pointer-events: none;
+        }
+
+        body.sky-empty .sky-title {
+            transform: translateY(180px);
+            gap: 12px;
+        }
+
+        body.sky-empty .sky-mark {
+            display: none;
+        }
+
+        body.sky-empty .sky-heading h1 {
+            font-size: clamp(48px, 6vw, 76px);
+            font-weight: 300;
+        }
+
+        body.sky-empty .sky-heading p {
+            margin-top: 12px;
+            font-size: clamp(16px, 1.6vw, 22px);
+            color: rgba(255,255,255,0.18);
+        }
+
+        body.sky-empty .sky-status {
+            position: fixed;
+            top: max(22px, env(safe-area-inset-top, 22px));
+            right: 28px;
+            pointer-events: auto;
+        }
+
+        body.sky-empty .sky-shell {
+            height: 100dvh;
+            padding: 0;
+            display: grid;
+            place-items: center;
+        }
+
+        body.sky-empty .sky-orb-panel {
+            width: min(760px, 92vw);
+            height: min(680px, 78vh);
+            display: grid;
+            place-items: center;
+        }
+
+        body.sky-empty #skyOrb {
+            width: 100%;
+            height: 100%;
+            min-height: 0;
+            filter: saturate(1.15);
+        }
+
+        body.sky-empty .sky-listening-copy {
+            bottom: max(62px, 7vh);
+            max-width: 620px;
+            font-size: clamp(17px, 2vw, 26px);
+            color: rgba(255,255,255,0.34);
+        }
+
+        body.sky-empty .sky-command {
+            width: min(720px, calc(100vw - 56px));
+            grid-template-columns: auto minmax(0, 1fr) auto auto;
+            opacity: 0.72;
+        }
+
+        body.sky-empty .sky-command:hover,
+        body.sky-empty .sky-command:focus-within {
+            opacity: 1;
+        }
+
+        body:not(.sky-empty) .sky-transcript {
+            border-top: 1px solid rgba(255,255,255,0.08);
+            border-radius: 18px;
+            margin: 0 20px 20px;
+            background: rgba(255,255,255,0.045);
+        }
+
+        @media (max-width: 980px) {
+            .sky-shell {
+                height: auto;
+                min-height: 100dvh;
+                grid-template-columns: 1fr;
+                padding-bottom: 116px;
+                overflow-y: auto;
+            }
+
+            .sky-card,
+            .sky-card.page-card,
+            .sky-card.setting-card,
+            .sky-card.list-card,
+            .sky-card:first-child {
+                grid-column: span 6;
+            }
+        }
+
+        @media (max-width: 640px) {
+            .sky-topbar {
+                left: 16px;
+                right: 16px;
+            }
+
+            .sky-status {
+                display: none;
+            }
+
+            .sky-shell {
+                padding: 88px 14px 118px;
+            }
+
+            .sky-card-stack {
+                grid-template-columns: 1fr;
+                padding: 14px;
+            }
+
+            .sky-card,
+            .sky-card.page-card,
+            .sky-card.setting-card,
+            .sky-card.list-card,
+            .sky-card:first-child,
+            .sky-card.wide,
+            .sky-card.hero {
+                grid-column: 1;
+            }
+
+            .sky-command,
+            body.sky-empty .sky-command {
+                width: calc(100vw - 24px);
+                grid-template-columns: 1fr auto;
+                border-radius: 22px;
+            }
+
+            .sky-command #skyHomeBtn,
+            .sky-command .primary {
+                display: none;
+            }
+
+            body.sky-empty .sky-title {
+                transform: translateY(132px);
+            }
+        }
+        /* Login-screen composition reset: one Zoe surface, cards materialize inside it. */
+        #skyOrb {
+            display: none !important;
+        }
+
+        .sky-shell {
+            display: block !important;
+            height: 100dvh;
+            min-height: 100dvh;
+            padding: 0 !important;
+            overflow: hidden;
+        }
+
+        .sky-orb-panel {
+            position: fixed !important;
+            inset: 0 !important;
+            width: 100vw !important;
+            height: 100dvh !important;
+            min-height: 0 !important;
+            border: 0 !important;
+            background: transparent !important;
+            box-shadow: none !important;
+            pointer-events: none;
+            overflow: visible;
+        }
+
+        .sky-orb-panel::before {
+            content: "";
+            position: fixed;
+            left: 50%;
+            top: 38%;
+            width: clamp(250px, 26vw, 350px);
+            height: clamp(250px, 26vw, 350px);
+            transform: translate(-50%, -50%);
+            border-radius: 50%;
+            background: linear-gradient(135deg, #7B61FF 0%, #5AE0E0 100%);
+            box-shadow:
+                0 0 80px rgba(123, 97, 255, 0.34),
+                0 0 140px rgba(90, 224, 224, 0.18);
+            animation: sky-login-breathe 4s ease-in-out infinite;
+        }
+
+        .sky-orb-panel::after {
+            content: "";
+            position: fixed;
+            left: 50%;
+            top: 38%;
+            width: clamp(310px, 34vw, 470px);
+            height: clamp(310px, 34vw, 470px);
+            transform: translate(-50%, -50%);
+            border-radius: 50%;
+            background: radial-gradient(circle, rgba(123, 97, 255, 0.13), transparent 68%);
+            animation: sky-login-halo 4s ease-in-out infinite;
+        }
+
+        .sky-listening-copy {
+            position: fixed !important;
+            left: 50% !important;
+            right: auto !important;
+            top: calc(38% + clamp(248px, 23vw, 315px));
+            bottom: auto !important;
+            width: min(620px, 86vw);
+            transform: translateX(-50%) !important;
+            margin: 0;
+            text-align: center;
+            color: rgba(255,255,255,0.18) !important;
+            font-size: clamp(15px, 1.35vw, 20px) !important;
+            line-height: 1.4;
+        }
+
+        .sky-topbar {
+            display: grid;
+            grid-template-columns: 1fr auto;
+            align-items: start;
+        }
+
+        .sky-title {
+            justify-self: center;
+            flex-direction: column;
+            gap: 0;
+            text-align: center;
+        }
+
+        .sky-mark {
+            display: none;
+        }
+
+        .sky-heading h1 {
+            font-size: clamp(46px, 5vw, 64px);
+            font-weight: 300;
+            line-height: 1;
+        }
+
+        .sky-heading p {
+            max-width: none;
+            color: rgba(255,255,255,0.18);
+            font-size: clamp(15px, 1.4vw, 20px);
+            white-space: normal;
+        }
+
+        body.sky-empty .sky-topbar {
+            top: calc(38% + clamp(165px, 16vw, 220px));
+            bottom: auto;
+            align-content: start;
+            pointer-events: none;
+        }
+
+        body.sky-empty .sky-title {
+            transform: none;
+        }
+
+        body.sky-empty .sky-status {
+            opacity: 0;
+            pointer-events: none;
+        }
+
+        body.sky-empty .sky-command {
+            opacity: 0;
+            pointer-events: none;
+            transform: translateX(-50%) translateY(18px);
+        }
+
+        body.sky-empty .sky-transport-toggle {
+            opacity: 0;
+            pointer-events: none;
+        }
+
+        .sky-stage {
+            position: fixed;
+            left: 50%;
+            right: auto;
+            bottom: 112px;
+            width: min(1040px, calc(100vw - 64px));
+            max-height: 52vh;
+            transform: translateX(-50%);
+            border: 0;
+            border-radius: 0;
+            background: transparent;
+            box-shadow: none;
+            overflow: visible;
+        }
+
+        .sky-stage-header {
+            display: none;
+        }
+
+        .sky-card-stack {
+            display: grid;
+            grid-template-columns: repeat(12, minmax(0, 1fr));
+            gap: 14px;
+            max-height: 52vh;
+            padding: 0;
+            overflow: auto;
+            align-content: end;
+            scrollbar-width: none;
+        }
+
+        .sky-card-stack::-webkit-scrollbar,
+        .sky-card-stack::before {
+            display: none;
+        }
+
+        .sky-card,
+        .sky-card.page-card,
+        .sky-card.setting-card,
+        .sky-card.list-card,
+        .sky-card:first-child {
+            grid-column: span 6;
+            min-height: 190px;
+            border-radius: 18px;
+            background:
+                radial-gradient(circle at 12% 0%, rgba(123, 97, 255, 0.15), transparent 44%),
+                linear-gradient(145deg, rgba(255,255,255,0.14), rgba(255,255,255,0.045)),
+                rgba(17, 24, 46, 0.72);
+            box-shadow:
+                0 26px 80px rgba(0,0,0,0.36),
+                inset 0 1px 0 rgba(255,255,255,0.08);
+            backdrop-filter: blur(24px);
+            -webkit-backdrop-filter: blur(24px);
+        }
+
+        .sky-card:first-child {
+            grid-column: span 7;
+        }
+
+        .sky-card.list-card {
+            grid-column: span 5;
+        }
+
+        .sky-card-title {
+            font-weight: 500;
+        }
+
+        .sky-command {
+            width: min(780px, calc(100vw - 56px));
+            background: rgba(9, 13, 27, 0.58);
+        }
+
+        body:not(.sky-empty) .sky-orb-panel::before {
+            top: 104px;
+            left: calc(50% - 330px);
+            width: 58px;
+            height: 58px;
+            opacity: 0.78;
+            z-index: 4;
+        }
+
+        body:not(.sky-empty) .sky-orb-panel::after {
+            top: 104px;
+            left: 50%;
+            width: min(780px, calc(100vw - 56px));
+            height: 76px;
+            border-radius: 999px;
+            background:
+                linear-gradient(145deg, rgba(255,255,255,0.14), rgba(255,255,255,0.055)),
+                rgba(9, 13, 27, 0.76);
+            border: 1px solid rgba(255,255,255,0.12);
+            box-shadow:
+                0 24px 90px rgba(0,0,0,0.42),
+                inset 0 1px 0 rgba(255,255,255,0.08);
+            backdrop-filter: blur(24px);
+            -webkit-backdrop-filter: blur(24px);
+            opacity: 1;
+            z-index: 3;
+        }
+
+        body:not(.sky-empty) .sky-topbar {
+            top: 26px;
+            left: 30px;
+            right: 30px;
+        }
+
+        body:not(.sky-empty) .sky-title {
+            justify-self: start;
+            align-items: flex-start;
+            text-align: left;
+        }
+
+        body:not(.sky-empty) .sky-heading h1 {
+            font-size: 28px;
+            font-weight: 400;
+        }
+
+        body:not(.sky-empty) .sky-heading p {
+            font-size: 13px;
+            color: rgba(255,255,255,0.5);
+        }
+
+        body:not(.sky-empty) .sky-listening-copy,
+        body:not(.sky-empty) .sky-transcript {
+            display: none;
+        }
+
+        body:not(.sky-empty) .sky-listening-copy {
+            display: block;
+            top: 104px !important;
+            left: calc(50% - 254px) !important;
+            width: min(590px, calc(100vw - 230px));
+            height: 76px;
+            transform: none !important;
+            text-align: left;
+            color: rgba(255,255,255,0.78) !important;
+            font-size: clamp(16px, 1.4vw, 20px) !important;
+            line-height: 76px;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+            z-index: 5;
+        }
+
+        body:not(.sky-empty) .sky-stage {
+            top: 188px;
+            bottom: 104px;
+            max-height: none;
+        }
+
+        body:not(.sky-empty) .sky-card-stack {
+            max-height: calc(100dvh - 292px);
+            align-content: start;
+        }
+
+        body:not(.sky-empty) .sky-command {
+            opacity: 0.28;
+        }
+
+        body:not(.sky-empty) .sky-command:focus-within,
+        body:not(.sky-empty) .sky-command:hover {
+            opacity: 1;
+        }
+
+        @keyframes sky-login-breathe {
+            0%, 100% {
+                transform: translate(-50%, -50%) scale(1);
+                box-shadow:
+                    0 0 80px rgba(123, 97, 255, 0.34),
+                    0 0 140px rgba(90, 224, 224, 0.18);
+            }
+            50% {
+                transform: translate(-50%, -50%) scale(1.035);
+                box-shadow:
+                    0 0 105px rgba(123, 97, 255, 0.44),
+                    0 0 170px rgba(90, 224, 224, 0.24);
+            }
+        }
+
+        @keyframes sky-login-halo {
+            0%, 100% { opacity: 0.82; transform: translate(-50%, -50%) scale(1); }
+            50% { opacity: 1; transform: translate(-50%, -50%) scale(1.04); }
+        }
+
+        @media (max-width: 780px) {
+            html,
+            body {
+                width: 100vw;
+                max-width: 100vw;
+                overflow-x: hidden;
+            }
+
+            .sky-stage {
+                left: 14px !important;
+                right: auto !important;
+                width: 76vw !important;
+                max-width: 76vw !important;
+                max-height: none;
+                top: 238px !important;
+                bottom: 98px;
+                transform: none !important;
+                overflow: hidden;
+            }
+
+            .sky-card:first-child,
+            .sky-card.setting-card:first-child,
+            .sky-card.page-card:first-child {
+                min-height: 330px !important;
+            }
+
+            .sky-card,
+            .sky-card.page-card,
+            .sky-card.setting-card,
+            .sky-card.list-card,
+            .sky-card:first-child {
+                grid-column: span 12;
+            }
+
+            body:not(.sky-empty) .sky-orb-panel::before,
+            body:not(.sky-empty) .sky-orb-panel::after {
+                top: 150px;
+            }
+
+            .sky-transport-toggle {
+                top: 86px;
+                left: 30px;
+                right: auto;
+                max-width: calc(100vw - 60px);
+            }
+
+            body:not(.sky-empty) .sky-orb-panel::before {
+                left: 54px;
+                width: 52px;
+                height: 52px;
+            }
+
+            body:not(.sky-empty) .sky-orb-panel::after {
+                left: 14px;
+                width: 76vw;
+                height: 68px;
+                transform: none !important;
+            }
+
+            body:not(.sky-empty) .sky-listening-copy {
+                top: 150px !important;
+                left: 92px !important;
+                width: calc(76vw - 78px);
+                height: 68px;
+                line-height: 68px;
+                font-size: 16px !important;
+            }
+
+            .sky-card-stack {
+                grid-template-columns: minmax(0, 1fr) !important;
+                max-height: calc(100dvh - 314px) !important;
+                width: 100% !important;
+                overflow-x: hidden !important;
+            }
+
+            .sky-card,
+            .sky-card.page-card,
+            .sky-card.setting-card,
+            .sky-card.list-card,
+            .sky-card:first-child {
+                grid-column: 1 / -1 !important;
+                width: 100%;
+                max-width: 100%;
+                min-width: 0;
+                padding: 20px;
+                height: auto !important;
+                overflow: hidden;
+            }
+
+            .sky-badge {
+                display: none;
+            }
+
+            .sky-card-title,
+            .sky-card-body,
+            .sky-field,
+            .sky-field strong,
+            .sky-field span {
+                min-width: 0;
+                overflow-wrap: anywhere;
+                white-space: normal;
+            }
+        }
     </style>
 </head>
 <body>
@@ -469,13 +1651,17 @@
         <div class="sky-title">
             <div class="sky-mark" aria-hidden="true"></div>
             <div class="sky-heading">
-                <h1>Skybridge</h1>
-                <p id="skySubtitle">Voice-first control for Zoe's pages, settings, and live cards.</p>
+                <h1>Zoe</h1>
+                <p id="skySubtitle">Skybridge is listening.</p>
             </div>
         </div>
         <div class="sky-status" aria-live="polite">
             <span class="sky-status-dot" id="skyStatusDot"></span>
             <span class="sky-status-text" id="skyStatusText">Starting</span>
+        </div>
+        <div class="sky-transport-toggle" aria-label="Voice transport">
+            <button type="button" data-mode="local">Local</button>
+            <button type="button" data-mode="livekit">LiveKit</button>
         </div>
     </header>
 


### PR DESCRIPTION
## Summary
- replaces the rough Skybridge dashboard-style surface with a Zoe login-style idle orb
- collapses the orb into a voice pill after a command and renders Skybridge cards into the main canvas
- adds Local/LiveKit transport selection, persistence, and Speak-to-interrupt behavior
- ports fuller LiveKit voice behavior into Skybridge: remote audio track playback, participant identity uploads, cancel signaling, disconnect cleanup, timeout cleanup, and playback cleanup
- adds static tests for the orb-to-pill design contract, safe card tone classes, active-state runtime notices, and LiveKit transport behavior

## Validation
- `python3 -m pytest services/zoe-data/tests/test_skybridge_static.py services/zoe-data/tests/test_skybridge_status.py services/zoe-data/tests/test_card_service.py -q` -> 22 passed
- `python3 tools/audit/validate_structure.py` -> passed
- `python3 tools/audit/validate_critical_files.py` -> passed
- `node --check` for `skybridge.js`, `skybridge-voice.js`, and `skybridge-renderer.js` from the Mac environment -> passed
- live `/touch/skybridge.html`, Skybridge JS assets, and `/api/skybridge/status` returned 200 after the hotfix files were deployed
- screenshots captured from the live surface for idle, active card, and mobile card states

## Greptile
- Greptile MCP review was triggered for PR #291.
- Initial findings were addressed in commit `43c0282`: LiveKit timeout cleanup, tone class sanitization, visible active-state notices, and dead hover rule removal.
- A fresh Greptile review was requested after the follow-up commit.

## Notes
- The authenticated LiveKit token flow could not be fully exercised from the synthetic curl session; unauthenticated token requests correctly returned 401.
- The PR branch Skybridge assets match the live verified assets byte-for-byte after the hotfix sync for the main HTML/app/voice/renderer files.
