### PR TITLE
[codex] Attach proposal contract to MCP evolution writes

### DIFF
--- a/docs/architecture/zoe-evolution-proposal-contract.md
+++ b/docs/architecture/zoe-evolution-proposal-contract.md
@@ -32,11 +32,22 @@ It also attaches candidate scoring to proposals, so Zoe can compare existing Pi/
 
 ## Current Scope
 
-This slice is contract-only:
+The foundation contract is now wired into the MCP `create_evolution_proposal`
+writer:
 
-- no production table migration;
+- the legacy `evolution_proposals` row shape remains unchanged for current UI,
+  Multica, and review routes;
+- a validated `zoe_evolution_proposal` contract snapshot is stored as JSON in
+  the existing `target_patterns` field;
+- proposal creation remains review-only and never grants execution;
+- `approval_gate.allowed_to_execute` remains false.
+
+This still avoids:
+
 - no automatic execution;
 - no automatic memory promotion;
 - no chat hot-path change.
 
-The next slices should adapt existing `evolution_proposals` writes to include this contract payload, then add Multica admission rules for memory and capability promotion.
+The next slices should adapt remaining `evolution_proposals` writers to include
+this contract payload, then add Multica admission rules for memory and capability
+promotion.

--- a/docs/architecture/zoe-evolution-proposal-contract.md
+++ b/docs/architecture/zoe-evolution-proposal-contract.md
@@ -39,6 +39,8 @@ writer:
   Multica, and review routes;
 - a validated `zoe_evolution_proposal` contract snapshot is stored as JSON in
   the existing `target_patterns` field;
+- `multica_issue_id` remains authoritative in the legacy column; the stored
+  contract snapshot is not rewritten just to mirror that live sync field;
 - proposal creation remains review-only and never grants execution;
 - `approval_gate.allowed_to_execute` remains false.
 

--- a/docs/strategy/zoe-evolution-harness-status.md
+++ b/docs/strategy/zoe-evolution-harness-status.md
@@ -42,7 +42,7 @@ Important non-complete truth:
 - Zoe now has a read-only Pi runtime probe and policy contract; actual Pi execution is still blocked until Node/npm/Pi and local/offline model configuration are present and approved.
 - The deterministic memory router now has a disabled-by-default runtime status gate, optional non-persistent observation trace packets, and a governed non-persistent trace collector; it is not yet used for prompt injection or backend recall in production chat.
 - Retain-candidate admission has a tested contract, but existing runtime writers are not yet wired to enforce it through Multica approval.
-- The full self-evolution loop is not yet implemented end to end; proposal records are now defined, but existing live proposal writers still need to emit them and Multica still needs to enforce admission.
+- The full self-evolution loop is not yet implemented end to end; the MCP `create_evolution_proposal` writer now stores a validated Zoe proposal contract snapshot in the legacy `target_patterns` field, but other live proposal writers still need to emit it and Multica still needs to enforce admission.
 - Zoe main engine cleanup should not begin until the inventory, graph, and memory/evolution contracts have protective tests around the active surfaces.
 
 ## Phase Ledger
@@ -68,7 +68,7 @@ Important non-complete truth:
 | Observation/evaluation traces | Complete foundation | `services/zoe-data/zoe_observation_trace.py`, `services/zoe-data/zoe_observation_trace_collector.py`, tests, `docs/architecture/zoe-observation-trace-schema.md`, and `docs/architecture/zoe-observation-trace-collector.md` define trace records and non-persistent collection gates for memory route decisions, recall, retain candidate, admission, contradiction, fallback, proposal, verification, outcome eval, and hardware-budget events. | Wire runtime callers through the collector, then add governed collection around retain candidates, sidecar bake-offs, Multica admission, and capability promotion/retirement. |
 | Memory admission governance | Complete foundation | `services/zoe-data/zoe_memory_admission.py`, `services/zoe-data/hindsight_retain_candidates.py`, tests, and `docs/architecture/zoe-memory-admission-gates.md` define evidence, trace, approval, graph, and self-evolution proposal gates before durable memory writes; Hindsight retain candidates can now build/evaluate admission requests before promotion. | Wire future graph/Hindsight durable writers through this decision before any backend write. |
 | Multica evidence gates | Partial | Implement completion now requires PR evidence for code/default profiles, and memory admission has a tested decision contract. | Connect the memory admission contract to Multica/review records and add explicit self-evolution execution gates. |
-| Self-evolution proposal records | Complete foundation | `services/zoe-data/zoe_evolution_proposal.py`, `services/zoe-data/tests/test_zoe_evolution_proposal.py`, and `docs/architecture/zoe-evolution-proposal-contract.md` define structured Notice -> Explain -> Search -> Evaluate -> Propose records. | Adapt existing live proposal writers to emit this payload and require it before installs/replacements. |
+| Self-evolution proposal records | Partial runtime wiring | `services/zoe-data/zoe_evolution_proposal.py`, `services/zoe-data/zoe_evolution_proposal_adapter.py`, tests, and `docs/architecture/zoe-evolution-proposal-contract.md` define structured Notice -> Explain -> Search -> Evaluate -> Propose records. The MCP `create_evolution_proposal` writer now stores a validated contract snapshot while preserving the legacy row shape. | Adapt remaining live proposal writers to emit this payload and require it before installs/replacements. |
 | Self-evolution loop | Partial | Multica, pipeline evidence, Greploop, Greptile, Hermes, worktree bootstrap, candidate scoring, and proposal contract pieces exist. | Wire live proposal writers, Multica admission, execution approval, verification, retained outcomes, and retirement evidence. |
 | Main engine cleanup | Deferred | `zoe_agent.py` remains large and active. | Start only after inventories and chat/memory/tool dispatch tests are strong enough to prevent regressions. |
 
@@ -199,7 +199,8 @@ Keep each pull request small enough for Greptile and Zoe verification.
    - Hindsight retain candidates can now build and evaluate admission requests before any durable promotion.
    - Next: route future Hindsight, MemPalace, and Graphiti durable writers through the decision before backend writes.
 9. Self-evolution proposal records.
-    - Implement Notice -> Explain -> Search -> Evaluate -> Propose records.
+    - Status: foundation complete and MCP `create_evolution_proposal` runtime writer now emits a validated contract snapshot into `target_patterns`.
+    - Next: adapt remaining live proposal writers and require the contract before installs/replacements.
     - Keep execution approval-gated.
 10. Zoe capability profile inventory.
     - Status: complete foundation for key active and candidate surfaces.

--- a/services/zoe-data/evolution_notice.py
+++ b/services/zoe-data/evolution_notice.py
@@ -334,6 +334,20 @@ async def record_user_issue(message: str, user_id: str) -> None:
 _MEASURE_WINDOW_S = 48 * 3600  # 48-hour monitoring window post-deployment
 
 
+def _load_target_patterns(raw: str | None) -> list[str]:
+    """Load legacy target pattern arrays without crashing on contract envelopes."""
+
+    if not raw:
+        return []
+    try:
+        payload = json.loads(raw)
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return []
+    if not isinstance(payload, list):
+        return []
+    return [str(item) for item in payload if item is not None]
+
+
 async def run_measure_phase() -> dict:
     """MEASURE: close monitoring window for deployed proposals.
 
@@ -361,7 +375,7 @@ async def run_measure_phase() -> dict:
 
         for row in rows:
             proposal_id = row["id"]
-            target_patterns: list[str] = json.loads(row["target_patterns"] or "[]")
+            target_patterns = _load_target_patterns(row["target_patterns"])
 
             # Heuristic: count intent misses for the target patterns in the 48h
             # BEFORE deploy vs the 48h AFTER deploy. If miss count dropped by

--- a/services/zoe-data/mcp_server.py
+++ b/services/zoe-data/mcp_server.py
@@ -2992,6 +2992,7 @@ async def _execute_tool(db, name: str, args: dict):
     elif name == "create_evolution_proposal":
         try:
             from multica_client import sync_evolution_proposal_to_multica  # type: ignore[import]
+            from zoe_evolution_proposal_adapter import dump_mcp_evolution_proposal_contract  # type: ignore[import]
             import time as _time
             title = (args.get("title") or "").strip()
             description = (args.get("description") or "").strip()
@@ -3000,11 +3001,19 @@ async def _execute_tool(db, name: str, args: dict):
             evidence = (args.get("evidence") or "").strip()
             proposal_type = args.get("proposal_type", "intent_pattern")
             prop_id = str(uuid.uuid4()).replace("-", "")
+            contract_snapshot = dump_mcp_evolution_proposal_contract(
+                proposal_id=prop_id,
+                title=title,
+                description=description,
+                evidence=evidence,
+                proposal_type=proposal_type,
+                user_id=args.get("_user_id") or args.get("user_id"),
+            )
             await db.execute(
                 """INSERT INTO evolution_proposals
-                   (id, title, description, evidence, type, status, proposed_at)
-                   VALUES ($1,$2,$3,$4,$5,'pending',$6)""",
-                prop_id, title, description, evidence, proposal_type, _time.time(),
+                   (id, title, description, evidence, target_patterns, type, status, proposed_at)
+                   VALUES ($1,$2,$3,$4,$5,$6,'pending',$7)""",
+                prop_id, title, description, evidence, contract_snapshot, proposal_type, _time.time(),
             )
             multica_id = await sync_evolution_proposal_to_multica(
                 proposal_id=prop_id,
@@ -3014,11 +3023,25 @@ async def _execute_tool(db, name: str, args: dict):
                 proposal_type=proposal_type,
             )
             if multica_id:
-                await db.execute(
-                    "UPDATE evolution_proposals SET multica_issue_id=$1 WHERE id=$2",
-                    multica_id, prop_id,
+                contract_snapshot = dump_mcp_evolution_proposal_contract(
+                    proposal_id=prop_id,
+                    title=title,
+                    description=description,
+                    evidence=evidence,
+                    proposal_type=proposal_type,
+                    user_id=args.get("_user_id") or args.get("user_id"),
+                    multica_issue_id=multica_id,
                 )
-            return {"ok": True, "proposal_id": prop_id, "multica_issue_id": multica_id}
+                await db.execute(
+                    "UPDATE evolution_proposals SET multica_issue_id=$1, target_patterns=$2 WHERE id=$3",
+                    multica_id, contract_snapshot, prop_id,
+                )
+            return {
+                "ok": True,
+                "proposal_id": prop_id,
+                "multica_issue_id": multica_id,
+                "contract_schema": "zoe_evolution_proposal",
+            }
         except Exception as exc:
             return {"error": f"create_evolution_proposal failed: {exc}"}
 

--- a/services/zoe-data/mcp_server.py
+++ b/services/zoe-data/mcp_server.py
@@ -2992,14 +2992,17 @@ async def _execute_tool(db, name: str, args: dict):
     elif name == "create_evolution_proposal":
         try:
             from multica_client import sync_evolution_proposal_to_multica  # type: ignore[import]
-            from zoe_evolution_proposal_adapter import dump_mcp_evolution_proposal_contract  # type: ignore[import]
+            from zoe_evolution_proposal_adapter import (  # type: ignore[import]
+                dump_mcp_evolution_proposal_contract,
+                normalize_mcp_evolution_proposal_type,
+            )
             import time as _time
             title = (args.get("title") or "").strip()
             description = (args.get("description") or "").strip()
             if not title or not description:
                 return {"error": "title and description required"}
             evidence = (args.get("evidence") or "").strip()
-            proposal_type = args.get("proposal_type", "intent_pattern")
+            proposal_type = normalize_mcp_evolution_proposal_type(args.get("proposal_type", "intent_pattern"))
             prop_id = str(uuid.uuid4()).replace("-", "")
             contract_snapshot = dump_mcp_evolution_proposal_contract(
                 proposal_id=prop_id,

--- a/services/zoe-data/mcp_server.py
+++ b/services/zoe-data/mcp_server.py
@@ -3023,18 +3023,9 @@ async def _execute_tool(db, name: str, args: dict):
                 proposal_type=proposal_type,
             )
             if multica_id:
-                contract_snapshot = dump_mcp_evolution_proposal_contract(
-                    proposal_id=prop_id,
-                    title=title,
-                    description=description,
-                    evidence=evidence,
-                    proposal_type=proposal_type,
-                    user_id=args.get("_user_id") or args.get("user_id"),
-                    multica_issue_id=multica_id,
-                )
                 await db.execute(
-                    "UPDATE evolution_proposals SET multica_issue_id=$1, target_patterns=$2 WHERE id=$3",
-                    multica_id, contract_snapshot, prop_id,
+                    "UPDATE evolution_proposals SET multica_issue_id=$1 WHERE id=$2",
+                    multica_id, prop_id,
                 )
             return {
                 "ok": True,

--- a/services/zoe-data/tests/test_evolution_notice_measure.py
+++ b/services/zoe-data/tests/test_evolution_notice_measure.py
@@ -1,0 +1,87 @@
+import json
+import sys
+import types
+
+import pytest
+
+import evolution_notice
+from zoe_evolution_proposal_adapter import dump_mcp_evolution_proposal_contract
+
+
+class _Db:
+    def __init__(self, rows):
+        self.rows = rows
+        self.fetch_calls = []
+        self.execute_calls = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def fetch(self, sql, *args):
+        self.fetch_calls.append((sql, args))
+        if "FROM evolution_proposals" in sql and "status='deployed'" in sql:
+            return self.rows
+        if "SELECT multica_issue_id FROM evolution_proposals" in sql:
+            return [{"multica_issue_id": None}]
+        if "FROM chat_messages" in sql:
+            return [{"cnt": 0}]
+        return []
+
+    async def execute(self, sql, *args):
+        self.execute_calls.append((sql, args))
+
+
+@pytest.mark.asyncio
+async def test_measure_phase_treats_contract_target_patterns_as_no_patterns(monkeypatch):
+    contract = dump_mcp_evolution_proposal_contract(
+        proposal_id="prop_contract",
+        title="Contract proposal",
+        description="Contract envelopes in target_patterns should not crash measure phase.",
+        evidence="trace:contract",
+        proposal_type="code_improvement",
+    )
+    db = _Db(
+        [
+            {
+                "id": "prop_contract",
+                "type": "code_improvement",
+                "title": "Contract proposal",
+                "target_patterns": contract,
+                "deployed_at": 1000.0,
+            }
+        ]
+    )
+
+    monkeypatch.setattr(evolution_notice.time, "time", lambda: 1000.0 + evolution_notice._MEASURE_WINDOW_S + 1)
+    monkeypatch.setitem(sys.modules, "db_pool", types.SimpleNamespace(get_db_ctx=lambda: db))
+
+    async def fake_update_multica_issue_on_proposal_status_change(*_args, **_kwargs):
+        raise AssertionError("no linked Multica issue should be updated")
+
+    monkeypatch.setitem(
+        sys.modules,
+        "multica_client",
+        types.SimpleNamespace(update_multica_issue_on_proposal_status_change=fake_update_multica_issue_on_proposal_status_change),
+    )
+
+    result = await evolution_notice.run_measure_phase()
+
+    assert result == {"evaluated": 1, "validated": 1, "failed": 0}
+    assert len(db.execute_calls) == 1
+    update_sql, update_args = db.execute_calls[0]
+    assert "validation_result" in update_sql
+    validation_result = json.loads(update_args[1])
+    assert validation_result["miss_before_48h"] == 0
+    assert validation_result["miss_after_48h"] == 0
+    assert validation_result["verdict"] == "validated"
+    assert not any("FROM chat_messages" in sql for sql, _args in db.fetch_calls)
+
+
+def test_load_target_patterns_accepts_only_legacy_arrays():
+    assert evolution_notice._load_target_patterns('["a", "b"]') == ["a", "b"]
+    assert evolution_notice._load_target_patterns('{"schema":"zoe_evolution_proposal"}') == []
+    assert evolution_notice._load_target_patterns("not-json") == []
+    assert evolution_notice._load_target_patterns(None) == []

--- a/services/zoe-data/tests/test_panel_mcp_tools.py
+++ b/services/zoe-data/tests/test_panel_mcp_tools.py
@@ -110,15 +110,49 @@ async def test_create_evolution_proposal_stores_contract_snapshot(monkeypatch):
     insert_sql, insert_args = db.calls[0]
     update_sql, update_args = db.calls[1]
     assert "target_patterns" in insert_sql
-    assert "target_patterns" in update_sql
+    assert "target_patterns" not in update_sql
 
     insert_contract = json.loads(insert_args[4])
-    update_contract = json.loads(update_args[1])
     assert insert_contract["schema"] == "zoe_evolution_proposal"
     assert insert_contract["proposal"]["status"] == "pending_approval"
+    assert insert_contract["proposal"]["multica_issue_id"] is None
     assert insert_contract["proposal"]["signals"][0]["signal_type"] == "repeated_failure"
     assert insert_contract["proposal"]["approval_gate"]["allowed_to_execute"] is False
-    assert update_contract["proposal"]["multica_issue_id"] == "multica-issue-123"
+    assert update_args == ("multica-issue-123", result["proposal_id"])
+
+
+@pytest.mark.asyncio
+async def test_create_evolution_proposal_keeps_contract_when_multica_unconfigured(monkeypatch):
+    async def fake_sync_evolution_proposal_to_multica(**_kwargs):
+        return None
+
+    monkeypatch.setitem(
+        sys.modules,
+        "multica_client",
+        types.SimpleNamespace(sync_evolution_proposal_to_multica=fake_sync_evolution_proposal_to_multica),
+    )
+    db = _RecordingDb()
+
+    result = await mcp_server._execute_tool(
+        db=db,
+        name="create_evolution_proposal",
+        args={
+            "title": "Review missing proposal path",
+            "description": "Zoe should keep a contract snapshot even when Multica is unavailable.",
+            "proposal_type": "code_improvement",
+        },
+    )
+
+    assert result["ok"] is True
+    assert result["multica_issue_id"] is None
+    assert result["contract_schema"] == "zoe_evolution_proposal"
+    assert len(db.calls) == 1
+    insert_sql, insert_args = db.calls[0]
+    assert "target_patterns" in insert_sql
+    contract = json.loads(insert_args[4])
+    assert contract["schema"] == "zoe_evolution_proposal"
+    assert contract["proposal"]["multica_issue_id"] is None
+    assert contract["proposal"]["signals"][0]["signal_type"] == "tool_gap"
 
 
 class _Cursor:

--- a/services/zoe-data/tests/test_panel_mcp_tools.py
+++ b/services/zoe-data/tests/test_panel_mcp_tools.py
@@ -4,6 +4,7 @@ import asyncio
 import sys
 import os
 import json
+import types
 
 import pytest
 
@@ -67,6 +68,57 @@ def test_all_panel_tools_have_descriptions():
     assert len(panel_tools) >= 6, f"Expected at least 6 panel tools, got {len(panel_tools)}"
     for t in panel_tools:
         assert t.get("description"), f"Tool {t['name']} is missing a description"
+
+
+class _RecordingDb:
+    def __init__(self):
+        self.calls = []
+
+    async def execute(self, sql, *args):
+        self.calls.append((sql, args))
+        return _Cursor(None)
+
+
+@pytest.mark.asyncio
+async def test_create_evolution_proposal_stores_contract_snapshot(monkeypatch):
+    async def fake_sync_evolution_proposal_to_multica(**_kwargs):
+        return "multica-issue-123"
+
+    monkeypatch.setitem(
+        sys.modules,
+        "multica_client",
+        types.SimpleNamespace(sync_evolution_proposal_to_multica=fake_sync_evolution_proposal_to_multica),
+    )
+    db = _RecordingDb()
+
+    result = await mcp_server._execute_tool(
+        db=db,
+        name="create_evolution_proposal",
+        args={
+            "_user_id": "jason",
+            "title": "Improve recurring task recall",
+            "description": "Zoe missed a recurring task twice and should create a reviewed improvement proposal.",
+            "evidence": "chat:recurring-task-miss",
+            "proposal_type": "intent_pattern",
+        },
+    )
+
+    assert result["ok"] is True
+    assert result["multica_issue_id"] == "multica-issue-123"
+    assert result["contract_schema"] == "zoe_evolution_proposal"
+    assert len(db.calls) == 2
+    insert_sql, insert_args = db.calls[0]
+    update_sql, update_args = db.calls[1]
+    assert "target_patterns" in insert_sql
+    assert "target_patterns" in update_sql
+
+    insert_contract = json.loads(insert_args[4])
+    update_contract = json.loads(update_args[1])
+    assert insert_contract["schema"] == "zoe_evolution_proposal"
+    assert insert_contract["proposal"]["status"] == "pending_approval"
+    assert insert_contract["proposal"]["signals"][0]["signal_type"] == "repeated_failure"
+    assert insert_contract["proposal"]["approval_gate"]["allowed_to_execute"] is False
+    assert update_contract["proposal"]["multica_issue_id"] == "multica-issue-123"
 
 
 class _Cursor:

--- a/services/zoe-data/tests/test_panel_mcp_tools.py
+++ b/services/zoe-data/tests/test_panel_mcp_tools.py
@@ -151,6 +151,8 @@ async def test_create_evolution_proposal_keeps_contract_when_multica_unconfigure
     assert "target_patterns" in insert_sql
     contract = json.loads(insert_args[4])
     assert contract["schema"] == "zoe_evolution_proposal"
+    assert insert_args[5] == "code_improvement"
+    assert contract["proposal"]["metadata"]["legacy_proposal_type"] == "code_improvement"
     assert contract["proposal"]["multica_issue_id"] is None
     assert contract["proposal"]["signals"][0]["signal_type"] == "tool_gap"
 

--- a/services/zoe-data/tests/test_zoe_evolution_proposal_adapter.py
+++ b/services/zoe-data/tests/test_zoe_evolution_proposal_adapter.py
@@ -88,3 +88,4 @@ def test_loader_rejects_legacy_non_contract_payloads():
     assert load_proposal_contract_snapshot(None) is None
     assert load_proposal_contract_snapshot("not json") is None
     assert load_proposal_contract_snapshot('{"legacy": true}') is None
+    assert load_proposal_contract_snapshot('["pattern1", "pattern2"]') is None

--- a/services/zoe-data/tests/test_zoe_evolution_proposal_adapter.py
+++ b/services/zoe-data/tests/test_zoe_evolution_proposal_adapter.py
@@ -1,0 +1,84 @@
+import json
+
+from zoe_evolution_proposal_adapter import (
+    build_mcp_evolution_proposal_contract,
+    dump_mcp_evolution_proposal_contract,
+    load_proposal_contract_snapshot,
+)
+
+
+def test_mcp_contract_snapshot_is_valid_and_review_only():
+    payload = build_mcp_evolution_proposal_contract(
+        proposal_id="prop123",
+        title="Improve weather fallback",
+        description="Weather fallback failed twice and needs a measured fix.",
+        evidence="tool_run:weather:failed twice",
+        proposal_type="agent_health",
+        user_id="jason",
+    )
+
+    proposal = payload["proposal"]
+
+    assert payload["schema"] == "zoe_evolution_proposal"
+    assert proposal["status"] == "pending_approval"
+    assert proposal["autonomy_class"] == "suggest"
+    assert proposal["approval_gate"]["allowed_to_execute"] is False
+    assert proposal["signals"][0]["signal_type"] == "outcome_eval_failure"
+    assert proposal["signals"][0]["scope"] == "personal"
+    assert "agent_runtime" in proposal["affected_capabilities"]
+    assert "mcp:create_evolution_proposal:prop123" in proposal["evidence_refs"]
+    assert "evidence:mcp:create_evolution_proposal:prop123" in proposal["evidence_refs"]
+
+
+def test_mcp_contract_snapshot_has_source_evidence_when_freeform_evidence_is_empty():
+    payload = build_mcp_evolution_proposal_contract(
+        proposal_id="prop_no_evidence",
+        title="Review an intent gap",
+        description="Zoe missed a repeated natural language intent.",
+        evidence="",
+        proposal_type="intent_pattern",
+    )
+
+    proposal = payload["proposal"]
+
+    assert proposal["signals"][0]["signal_type"] == "repeated_failure"
+    assert proposal["evidence_refs"] == ["mcp:create_evolution_proposal:prop_no_evidence"]
+    assert proposal["signals"][0]["scope"] == "system"
+
+
+def test_unknown_legacy_type_falls_back_to_intent_pattern():
+    payload = build_mcp_evolution_proposal_contract(
+        proposal_id="prop_unknown",
+        title="Unknown proposal type",
+        description="Unknown legacy types should not bypass the proposal contract.",
+        evidence="manual observation",
+        proposal_type="surprise",
+    )
+
+    proposal = payload["proposal"]
+
+    assert proposal["metadata"]["legacy_proposal_type"] == "intent_pattern"
+    assert proposal["signals"][0]["signal_type"] == "repeated_failure"
+
+
+def test_dump_and_load_contract_snapshot_round_trip():
+    raw = dump_mcp_evolution_proposal_contract(
+        proposal_id="prop_round_trip",
+        title="Round trip",
+        description="Contract payload should survive target_patterns JSON storage.",
+        evidence="trace:round-trip",
+        proposal_type="code_improvement",
+        multica_issue_id="issue-123",
+    )
+
+    payload = load_proposal_contract_snapshot(raw)
+
+    assert payload is not None
+    assert json.loads(raw)["proposal"]["multica_issue_id"] == "issue-123"
+    assert payload["proposal"]["signals"][0]["signal_type"] == "tool_gap"
+
+
+def test_loader_rejects_legacy_non_contract_payloads():
+    assert load_proposal_contract_snapshot(None) is None
+    assert load_proposal_contract_snapshot("not json") is None
+    assert load_proposal_contract_snapshot('{"legacy": true}') is None

--- a/services/zoe-data/tests/test_zoe_evolution_proposal_adapter.py
+++ b/services/zoe-data/tests/test_zoe_evolution_proposal_adapter.py
@@ -4,6 +4,7 @@ from zoe_evolution_proposal_adapter import (
     build_mcp_evolution_proposal_contract,
     dump_mcp_evolution_proposal_contract,
     load_proposal_contract_snapshot,
+    normalize_mcp_evolution_proposal_type,
 )
 
 
@@ -59,6 +60,11 @@ def test_unknown_legacy_type_falls_back_to_intent_pattern():
 
     assert proposal["metadata"]["legacy_proposal_type"] == "intent_pattern"
     assert proposal["signals"][0]["signal_type"] == "repeated_failure"
+
+
+def test_normalize_mcp_evolution_proposal_type_matches_contract_fallback():
+    assert normalize_mcp_evolution_proposal_type("code_improvement") == "code_improvement"
+    assert normalize_mcp_evolution_proposal_type("surprise") == "intent_pattern"
 
 
 def test_dump_and_load_contract_snapshot_round_trip():

--- a/services/zoe-data/zoe_evolution_proposal_adapter.py
+++ b/services/zoe-data/zoe_evolution_proposal_adapter.py
@@ -55,7 +55,7 @@ def build_mcp_evolution_proposal_contract(
     legacy proposal row as evidence for later Multica/review gates.
     """
 
-    normalized_type = _normalize_proposal_type(proposal_type)
+    normalized_type = normalize_mcp_evolution_proposal_type(proposal_type)
     source_ref = f"mcp:create_evolution_proposal:{proposal_id}"
     evidence_refs = _evidence_refs(source_ref, evidence)
     signal = EvolutionSignal(
@@ -153,7 +153,9 @@ def load_proposal_contract_snapshot(raw: str | bytes | Mapping[str, Any] | None)
     return payload
 
 
-def _normalize_proposal_type(proposal_type: str | None) -> str:
+def normalize_mcp_evolution_proposal_type(proposal_type: str | None) -> str:
+    """Normalize legacy MCP proposal types before DB and contract storage."""
+
     normalized = (proposal_type or "intent_pattern").strip().lower()
     if normalized not in _SIGNAL_BY_LEGACY_TYPE:
         return "intent_pattern"
@@ -172,4 +174,5 @@ __all__ = [
     "build_mcp_evolution_proposal_contract",
     "dump_mcp_evolution_proposal_contract",
     "load_proposal_contract_snapshot",
+    "normalize_mcp_evolution_proposal_type",
 ]

--- a/services/zoe-data/zoe_evolution_proposal_adapter.py
+++ b/services/zoe-data/zoe_evolution_proposal_adapter.py
@@ -1,0 +1,175 @@
+"""Adapters that bridge legacy Zoe proposal writers to the proposal contract.
+
+The live `evolution_proposals` table predates `zoe_evolution_proposal.py` and is
+still read by existing UI, Multica, and review routes. These helpers keep that
+legacy shape intact while attaching a validated contract snapshot to
+`target_patterns` for future gates.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Mapping
+
+from zoe_candidate_scoring import CandidateEvaluation, CandidateScore
+from zoe_evolution_proposal import (
+    EvolutionSignal,
+    EvolutionSignalType,
+    ProposalRisk,
+    ProposalStatus,
+    TrustAutonomyClass,
+    build_evolution_proposal,
+)
+
+CONTRACT_ENVELOPE_VERSION = 1
+
+_SIGNAL_BY_LEGACY_TYPE = {
+    "intent_pattern": EvolutionSignalType.REPEATED_FAILURE.value,
+    "agent_health": EvolutionSignalType.OUTCOME_EVAL_FAILURE.value,
+    "user_frustration": EvolutionSignalType.USER_REQUEST.value,
+    "code_improvement": EvolutionSignalType.TOOL_GAP.value,
+}
+
+_AFFECTED_CAPABILITIES_BY_TYPE = {
+    "intent_pattern": ("intent_router", "chat_router", "observation_trace"),
+    "agent_health": ("agent_runtime", "multica_governance", "observation_trace"),
+    "user_frustration": ("chat_experience", "memory_router", "observation_trace"),
+    "code_improvement": ("zoe_codebase", "multica_governance", "verification"),
+}
+
+
+def build_mcp_evolution_proposal_contract(
+    *,
+    proposal_id: str,
+    title: str,
+    description: str,
+    evidence: str = "",
+    proposal_type: str = "intent_pattern",
+    user_id: str | None = None,
+    multica_issue_id: str | None = None,
+) -> dict[str, Any]:
+    """Build a validated contract snapshot for the MCP proposal writer.
+
+    The returned dict is JSON-serializable and intentionally does not execute,
+    approve, install, or write memory. It is safe to store beside the existing
+    legacy proposal row as evidence for later Multica/review gates.
+    """
+
+    normalized_type = _normalize_proposal_type(proposal_type)
+    source_ref = f"mcp:create_evolution_proposal:{proposal_id}"
+    evidence_refs = _evidence_refs(source_ref, evidence)
+    signal = EvolutionSignal(
+        signal_id=f"signal_{proposal_id}",
+        signal_type=_SIGNAL_BY_LEGACY_TYPE[normalized_type],
+        summary=description,
+        source="mcp:create_evolution_proposal",
+        evidence_refs=evidence_refs,
+        user_id=user_id,
+        scope="system" if not user_id else "personal",
+        metadata={
+            "legacy_proposal_type": normalized_type,
+            "evidence_excerpt": evidence[:500],
+        },
+    )
+    candidate = CandidateEvaluation(
+        candidate_id=f"existing_zoe_{normalized_type}",
+        name="Existing Zoe proposal path",
+        source="existing_zoe",
+        task=title,
+        score=CandidateScore(
+            fit=4,
+            activity=4,
+            license=5,
+            offline=5,
+            security=4,
+            footprint=5,
+            tests=3,
+            maintainability=4,
+            overlap=5,
+        ),
+        evidence_refs=evidence_refs,
+        license_risk="compatible",
+        offline_viability="required",
+        runtime_notes="Legacy MCP proposal writer creates review-only proposals; no execution is granted by this contract.",
+        overlaps_existing=("evolution_proposals", "multica_governance"),
+        recommendation="needs_review",
+        metadata={"legacy_proposal_type": normalized_type},
+    )
+    proposal = build_evolution_proposal(
+        proposal_id=proposal_id,
+        title=title,
+        problem_statement=description,
+        signals=(signal,),
+        candidate=candidate,
+        affected_capabilities=_AFFECTED_CAPABILITIES_BY_TYPE[normalized_type],
+        autonomy_class=TrustAutonomyClass.SUGGEST.value,
+        risk=ProposalRisk.MEDIUM.value,
+        expected_benefit="Create a reviewable Zoe improvement proposal with evidence before any implementation work.",
+        verification_plan=(
+            "human_or_multica_review_required_before_approval",
+            "implementation_pr_must_attach_tests_and_evidence_before_completion",
+        ),
+        rollback_plan="Reject or defer the proposal; no runtime change has been made by proposal creation.",
+        status=ProposalStatus.PENDING_APPROVAL.value,
+        multica_issue_id=multica_issue_id,
+        metadata={
+            "legacy_table": "evolution_proposals",
+            "legacy_status": "pending",
+            "legacy_proposal_type": normalized_type,
+            "created_by": "mcp:create_evolution_proposal",
+        },
+    )
+    return {
+        "version": CONTRACT_ENVELOPE_VERSION,
+        "schema": "zoe_evolution_proposal",
+        "legacy_writer": "mcp:create_evolution_proposal",
+        "proposal": proposal.to_dict(),
+    }
+
+
+def dump_mcp_evolution_proposal_contract(**kwargs: Any) -> str:
+    """Return a stable JSON string for the legacy `target_patterns` column."""
+
+    return json.dumps(build_mcp_evolution_proposal_contract(**kwargs), sort_keys=True, separators=(",", ":"))
+
+
+def load_proposal_contract_snapshot(raw: str | bytes | Mapping[str, Any] | None) -> dict[str, Any] | None:
+    """Best-effort loader for rows that may or may not carry a contract snapshot."""
+
+    if raw is None:
+        return None
+    if isinstance(raw, Mapping):
+        payload = dict(raw)
+    else:
+        try:
+            payload = json.loads(raw.decode("utf-8") if isinstance(raw, bytes) else str(raw))
+        except (TypeError, ValueError, json.JSONDecodeError):
+            return None
+    if payload.get("schema") != "zoe_evolution_proposal":
+        return None
+    proposal = payload.get("proposal")
+    if not isinstance(proposal, Mapping):
+        return None
+    return payload
+
+
+def _normalize_proposal_type(proposal_type: str | None) -> str:
+    normalized = (proposal_type or "intent_pattern").strip().lower()
+    if normalized not in _SIGNAL_BY_LEGACY_TYPE:
+        return "intent_pattern"
+    return normalized
+
+
+def _evidence_refs(source_ref: str, evidence: str) -> tuple[str, ...]:
+    refs = [source_ref]
+    if evidence.strip():
+        refs.append(f"evidence:{source_ref}")
+    return tuple(refs)
+
+
+__all__ = [
+    "CONTRACT_ENVELOPE_VERSION",
+    "build_mcp_evolution_proposal_contract",
+    "dump_mcp_evolution_proposal_contract",
+    "load_proposal_contract_snapshot",
+]

--- a/services/zoe-data/zoe_evolution_proposal_adapter.py
+++ b/services/zoe-data/zoe_evolution_proposal_adapter.py
@@ -145,7 +145,7 @@ def load_proposal_contract_snapshot(raw: str | bytes | Mapping[str, Any] | None)
             payload = json.loads(raw.decode("utf-8") if isinstance(raw, bytes) else str(raw))
         except (TypeError, ValueError, json.JSONDecodeError):
             return None
-    if payload.get("schema") != "zoe_evolution_proposal":
+    if not isinstance(payload, Mapping) or payload.get("schema") != "zoe_evolution_proposal":
         return None
     proposal = payload.get("proposal")
     if not isinstance(proposal, Mapping):


### PR DESCRIPTION
## Summary

- add a Zoe evolution proposal adapter for legacy MCP proposal writes
- store a validated `zoe_evolution_proposal` contract snapshot in the existing `evolution_proposals.target_patterns` field
- keep the legacy row shape, Multica sync, and review UI behavior intact
- document that MCP proposal creation is now contract-backed but still review-only and never grants execution

## Why

The harness already had a structured self-evolution proposal contract, but the live MCP `create_evolution_proposal` writer still created loose legacy rows. This bridges that gap without a schema migration and without changing execution behavior.

## Validation

- `PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_zoe_evolution_proposal_adapter.py services/zoe-data/tests/test_zoe_evolution_proposal.py services/zoe-data/tests/test_panel_mcp_tools.py`
- `python3 -m py_compile services/zoe-data/zoe_evolution_proposal_adapter.py services/zoe-data/mcp_server.py`
- `python3 tools/audit/validate_structure.py`
- `python3 tools/audit/validate_critical_files.py`
- `python3 tools/audit/validate_offline_memory.py`
- `git diff --check`
