### PR TITLE
[codex] Keep Skybridge query projection offline

### DIFF
--- a/services/zoe-ui/dist/touch/js/skybridge.js
+++ b/services/zoe-ui/dist/touch/js/skybridge.js
@@ -28,7 +28,7 @@
         if (typeof TouchMenu !== 'undefined') TouchMenu.init({ page: 'skybridge' });
         const initialQuery = new URLSearchParams(location.search).get('q');
         if (initialQuery) {
-            setTimeout(() => submitCommand(initialQuery), 120);
+            setTimeout(() => projectCommand(initialQuery), 120);
         }
     }
 
@@ -126,10 +126,16 @@
     function submitCommand(text) {
         const query = String(text || '').trim();
         if (!query) return;
+        projectCommand(query);
+        if (voice) voice.sendText(query);
+    }
+
+    function projectCommand(text) {
+        const query = String(text || '').trim();
+        if (!query) return;
         currentUtterance = 'Heard: ' + query;
         els.copy.textContent = currentUtterance;
         projectCards(query);
-        if (voice) voice.sendText(query);
     }
 
     function projectCards(query) {


### PR DESCRIPTION
## Summary
- keeps Skybridge URL query projection local to the visual/card surface
- prevents `?q=` screenshot/deep-link renders from sending text into the voice transport
- preserves normal typed/voice command behavior through `submitCommand`

## Validation
- `python3 -m pytest services/zoe-data/tests/test_skybridge_static.py services/zoe-data/tests/test_skybridge_status.py services/zoe-data/tests/test_card_service.py -q` -> 22 passed
- `node --check services/zoe-ui/dist/touch/js/skybridge.js` from Mac environment -> passed
- live screenshot confirmed `?q=security` shows `Heard: security` and renders cards without a transport error
