### PR TITLE
Guide code audits through nginx header helper

### DIFF
--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -284,9 +284,39 @@ def _code_audit_implement_hint(issue: dict | None = None) -> str:
     meta = _ticket_metadata(issue)
     if not _is_code_audit_actionable(meta):
         return ""
+    issue = issue or {}
+    haystack = " ".join(
+        [
+            str(issue.get("title") or ""),
+            str(issue.get("description") or ""),
+            json.dumps(meta),
+        ]
+    ).lower()
+    nginx_security_header_hint = ""
+    nginx_header_terms = (
+        "security header",
+        "security-header",
+        "content-security-policy",
+        "x-frame-options",
+        "strict-transport-security",
+        "hsts",
+        "x-content-type-options",
+        "referrer-policy",
+        "permissions-policy",
+    )
+    nginx_context = "nginx" in haystack
+    if nginx_context and any(term in haystack for term in nginx_header_terms):
+        nginx_security_header_hint = (
+            "For nginx.conf security-header tickets, do not hand-patch repeated `server {}` "
+            "blocks. Run `python3 tools/audit/ensure_nginx_security_headers.py`, then "
+            "`python3 tools/audit/ensure_nginx_security_headers.py --check`, "
+            "then `python3 tools/audit/validate_structure.py`, "
+            "then use the chained ship command. "
+        )
     return (
         "- CODE-AUDIT FAST PATH: this is an actionable code-audit bug with acceptance criteria. "
         "Do not re-audit the whole repo, compare every possible helper, or search broadly for patterns. "
+        f"{nginx_security_header_hint}"
         "After `kanban_show`, inspect only the named vulnerable file/endpoint plus at most one nearest "
         "focused test file. Apply the smallest patch that satisfies the acceptance criteria before the "
         "8th model/tool step. If the ticket lists acceptable alternatives, choose the least invasive "

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -3716,6 +3716,106 @@ def test_implement_body_adds_code_audit_fast_path_for_actionable_bug():
     assert body.index("CODE-AUDIT FAST PATH") < body.index("Graphify map")
 
 
+def test_implement_body_points_nginx_security_headers_to_helper():
+    body = ka.KanbanAdapter()._build_body(
+        "implement",
+        {
+            "id": "uuid-code-audit-nginx",
+            "identifier": "ZOE-5355",
+            "title": "nginx.conf missing all HTTP security headers",
+            "metadata": {
+                "zoe_kind": "bug",
+                "source": "code_audit_p0_security",
+                "acceptance_criteria": [
+                    "Add CSP, X-Frame-Options, HSTS, nosniff, Referrer-Policy, and Permissions-Policy"
+                ],
+            },
+        },
+        "ZOE-5355",
+    )
+
+    assert "do not hand-patch repeated `server {}` blocks" in body
+    assert "tools/audit/ensure_nginx_security_headers.py" in body
+    assert "--check" in body
+    assert body.index("ensure_nginx_security_headers.py") < body.index("After `kanban_show`")
+
+
+def test_implement_body_points_nginx_named_headers_to_helper():
+    body = ka.KanbanAdapter()._build_body(
+        "implement",
+        {
+            "id": "uuid-code-audit-nginx-csp",
+            "identifier": "ZOE-5356",
+            "title": "nginx.conf: add X-Frame-Options, CSP, and HSTS",
+            "metadata": {
+                "zoe_kind": "bug",
+                "source": "code_audit_p0_security",
+                "acceptance_criteria": ["Add Content-Security-Policy and Strict-Transport-Security"],
+            },
+        },
+        "ZOE-5356",
+    )
+
+    assert "tools/audit/ensure_nginx_security_headers.py" in body
+
+
+def test_implement_body_points_nginx_header_terms_to_helper_without_p0_source():
+    body = ka.KanbanAdapter()._build_body(
+        "implement",
+        {
+            "id": "uuid-code-audit-nginx-header-term",
+            "identifier": "ZOE-5357",
+            "title": "nginx.conf: add Content-Security-Policy",
+            "metadata": {
+                "zoe_kind": "bug",
+                "source": "code_audit_scan",
+                "acceptance_criteria": ["Add Content-Security-Policy"],
+            },
+        },
+        "ZOE-5357",
+    )
+
+    assert "tools/audit/ensure_nginx_security_headers.py" in body
+
+
+def test_implement_body_points_nginx_security_ticket_without_conf_suffix_to_helper():
+    body = ka.KanbanAdapter()._build_body(
+        "implement",
+        {
+            "id": "uuid-code-audit-nginx-term",
+            "identifier": "ZOE-5358",
+            "title": "nginx: missing HSTS and CSP",
+            "metadata": {
+                "zoe_kind": "bug",
+                "source": "code_audit_scan",
+                "acceptance_criteria": ["Add HSTS and CSP"],
+            },
+        },
+        "ZOE-5358",
+    )
+
+    assert "tools/audit/ensure_nginx_security_headers.py" in body
+
+
+def test_implement_body_omits_nginx_header_helper_for_non_header_ticket():
+    body = ka.KanbanAdapter()._build_body(
+        "implement",
+        {
+            "id": "uuid-code-audit-nginx-cipher",
+            "identifier": "ZOE-5359",
+            "title": "nginx: tighten TLS cipher selection",
+            "metadata": {
+                "zoe_kind": "bug",
+                "source": "code_audit_p0_security",
+                "acceptance_criteria": ["Disable weak TLS ciphers"],
+            },
+        },
+        "ZOE-5359",
+    )
+
+    assert "tools/audit/ensure_nginx_security_headers.py" not in body
+
+
 def test_implement_body_omits_code_audit_fast_path_without_acceptance_criteria():
     body = ka.KanbanAdapter()._build_body(
         "implement",

--- a/services/zoe-data/tests/test_nginx_security_headers_helper.py
+++ b/services/zoe-data/tests/test_nginx_security_headers_helper.py
@@ -1,0 +1,462 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+HELPER_PATH = Path(__file__).resolve().parents[3] / "tools" / "audit" / "ensure_nginx_security_headers.py"
+spec = importlib.util.spec_from_file_location("ensure_nginx_security_headers", HELPER_PATH)
+if spec is None or spec.loader is None:
+    pytest.skip(f"cannot load nginx security-header helper at {HELPER_PATH}", allow_module_level=True)
+helper = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(helper)
+
+
+def test_ensure_headers_adds_managed_block_to_each_server():
+    config = """# Example only: server { should not be treated as an active block.
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+}
+
+server {
+    listen 80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location ~* \\.(js|css)$ {
+        add_header Cache-Control "no-cache, must-revalidate";
+        try_files $uri =404;
+    }
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}
+
+server {
+    listen 18790 ssl;
+    http2 on;
+    server_name _;
+
+    ssl_protocols TLSv1.2 TLSv1.3;
+
+    location / {
+        proxy_pass http://host.docker.internal:18789;
+    }
+}
+"""
+
+    updated = helper.ensure_headers(config)
+
+    assert updated.count(helper.BEGIN_MARKER) == 3
+    assert updated.count("location ~*") == 1
+    assert updated.count("add_header Content-Security-Policy") == 3
+    assert updated.count("add_header X-Frame-Options") == 3
+    assert updated.count("add_header Strict-Transport-Security") == 1
+    assert helper.missing_headers(updated) == []
+
+
+def test_ensure_headers_ignores_upstream_server_directives():
+    config = """upstream backend {
+    server 127.0.0.1:8080;
+}
+
+server {
+    listen 80;
+    server_name _;
+}
+"""
+
+    updated = helper.ensure_headers(config)
+
+    assert "upstream backend {\n    server 127.0.0.1:8080;\n}" in updated
+    assert updated.count(helper.BEGIN_MARKER) == 1
+    assert helper.missing_headers(updated) == []
+
+
+def test_ensure_headers_ignores_variable_named_server():
+    config = """map $uri $server {
+    default backend;
+}
+
+server {
+    listen 80;
+    server_name _;
+}
+"""
+
+    updated = helper.ensure_headers(config)
+
+    assert "map $uri $server {\n    default backend;\n}" in updated
+    assert updated.count(helper.BEGIN_MARKER) == 1
+    assert helper.missing_headers(updated) == []
+
+
+def test_ensure_headers_ignores_braces_inside_quoted_values():
+    config = """server {
+    listen 80;
+    server_name _;
+    add_header X-Custom "see /{path" always;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}
+"""
+
+    updated = helper.ensure_headers(config)
+
+    assert 'add_header X-Custom "see /{path" always;' in updated
+    assert updated.count(helper.BEGIN_MARKER) == 1
+    assert helper.missing_headers(updated) == []
+
+
+def test_ensure_headers_ignores_braces_inside_comment_lines():
+    config = """server {
+    listen 80;
+    server_name _;
+    # see /etc/nginx/conf.d/ {
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}
+"""
+
+    updated = helper.ensure_headers(config)
+
+    assert "# see /etc/nginx/conf.d/ {" in updated
+    assert updated.count(helper.BEGIN_MARKER) == 1
+    assert helper.missing_headers(updated) == []
+
+
+def test_ensure_headers_uses_existing_location_child_indent():
+    config = """server {
+  listen 443 ssl;
+  server_name _;
+
+  location ~* \\.(js|css)$ {
+    add_header Cache-Control "no-cache";
+    try_files $uri =404;
+  }
+}
+"""
+
+    updated = helper.ensure_headers(config)
+
+    assert "    # BEGIN ZOE MANAGED SECURITY HEADERS" in updated
+    assert "        # BEGIN ZOE MANAGED SECURITY HEADERS" not in updated
+    assert helper.missing_headers(updated) == []
+
+
+def test_ensure_headers_ignores_location_index_when_placing_server_headers():
+    config = """server {
+    listen 80;
+    server_name _;
+
+    location / {
+        index index.html;
+        try_files $uri $uri/ /index.html;
+    }
+}
+"""
+
+    updated = helper.ensure_headers(config)
+    server_marker = updated.index(helper.BEGIN_MARKER)
+    location_start = updated.index("    location /")
+    location_index = updated.index("        index index.html;")
+
+    assert server_marker < location_start
+    assert helper.BEGIN_MARKER not in updated[location_start:location_index]
+    assert helper.missing_headers(updated) == []
+
+
+def test_ensure_headers_places_server_headers_after_last_known_preamble_directive():
+    config = """server {
+    listen 80;
+    server_name _;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}
+"""
+
+    updated = helper.ensure_headers(config)
+
+    assert updated.index("server_name _;") < updated.index(helper.BEGIN_MARKER)
+    assert updated.index("listen 80;") < updated.index(helper.BEGIN_MARKER)
+
+
+def test_ensure_headers_places_server_headers_after_late_listen_when_index_comes_first():
+    config = """server {
+    index index.html;
+    listen 80;
+    server_name _;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}
+"""
+
+    updated = helper.ensure_headers(config)
+
+    assert updated.index("server_name _;") < updated.index(helper.BEGIN_MARKER)
+    assert updated.index("listen 80;") < updated.index(helper.BEGIN_MARKER)
+
+
+def test_ensure_headers_places_server_headers_after_tls_certificate_directives():
+    config = """server {
+    listen 443 ssl;
+    server_name _;
+    ssl_certificate /etc/ssl/cert.pem;
+    ssl_certificate_key /etc/ssl/key.pem;
+
+    location / {
+        proxy_pass http://127.0.0.1:8000;
+    }
+}
+"""
+
+    updated = helper.ensure_headers(config)
+
+    assert updated.index("ssl_certificate_key /etc/ssl/key.pem;") < updated.index(helper.BEGIN_MARKER)
+    assert "Strict-Transport-Security" in updated
+
+
+def test_ensure_headers_uses_listen_as_minimal_server_anchor():
+    config = """server {
+    listen 8080;
+
+    location / {
+        proxy_pass http://127.0.0.1:8000;
+    }
+}
+"""
+
+    updated = helper.ensure_headers(config)
+
+    assert updated.index("listen 8080;") < updated.index(helper.BEGIN_MARKER)
+    assert helper.missing_headers(updated) == []
+
+
+def test_ensure_headers_does_not_treat_ssl_comment_as_tls():
+    config = """server {
+    listen 80;
+    # redirect to ssl happens elsewhere
+
+    location / {
+        proxy_set_header X-Forwarded-Proto ssl;
+        proxy_pass http://127.0.0.1:8000;
+    }
+}
+"""
+
+    updated = helper.ensure_headers(config)
+
+    assert "Strict-Transport-Security" not in updated
+    assert helper.missing_headers(updated) == []
+
+
+def test_ensure_headers_adds_location_headers_when_location_defines_add_header():
+    config = """server {
+    listen 443 ssl;
+    server_name _;
+
+    location ~* \\.(js|css)$ {
+        add_header Cache-Control "no-cache, must-revalidate";
+        try_files $uri =404;
+    }
+}
+"""
+
+    updated = helper.ensure_headers(config)
+
+    assert updated.count(helper.BEGIN_MARKER) == 2
+    assert updated.count("add_header Content-Security-Policy") == 2
+    assert updated.count("add_header Strict-Transport-Security") == 2
+    assert helper.missing_headers(updated) == []
+
+
+def test_ensure_headers_ignores_commented_add_header_in_location():
+    config = """server {
+    listen 80;
+    server_name _;
+
+    location /assets/ {
+        # add_header Cache-Control "no-cache";
+        try_files $uri =404;
+    }
+}
+"""
+
+    updated = helper.ensure_headers(config)
+    location_start = updated.index("    location /assets/")
+    location = updated[location_start:]
+
+    assert updated.count(helper.BEGIN_MARKER) == 1
+    assert helper.BEGIN_MARKER not in location
+    assert helper.missing_headers(updated) == []
+
+
+def test_ensure_headers_is_idempotent_and_replaces_managed_blocks():
+    config = """server {
+    listen 80;
+    server_name _;
+
+    # BEGIN ZOE MANAGED SECURITY HEADERS
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    # END ZOE MANAGED SECURITY HEADERS
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}
+"""
+
+    once = helper.ensure_headers(config)
+    twice = helper.ensure_headers(once)
+
+    assert once == twice
+    assert "SAMEORIGIN" not in once
+    assert once.count(helper.BEGIN_MARKER) == 1
+    assert "Strict-Transport-Security" not in once
+    assert helper.missing_headers(once) == []
+
+
+def test_ensure_headers_is_idempotent_from_fresh_config_with_blank_before_location():
+    config = """server {
+    listen 80;
+    server_name _;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}
+"""
+
+    once = helper.ensure_headers(config)
+    twice = helper.ensure_headers(once)
+
+    assert once == twice
+    assert once.count(helper.BEGIN_MARKER) == 1
+    assert "\n\n    location /" in once
+    assert helper.missing_headers(once) == []
+
+
+def test_ensure_headers_is_idempotent_with_location_managed_blocks():
+    config = """server {
+    listen 443 ssl;
+    server_name _;
+
+    location ~* \\.(js|css)$ {
+        add_header Cache-Control "no-cache";
+        try_files $uri =404;
+    }
+}
+"""
+
+    once = helper.ensure_headers(config)
+    twice = helper.ensure_headers(once)
+
+    assert once == twice
+    assert once.count(helper.BEGIN_MARKER) == 2
+    assert helper.missing_headers(once) == []
+
+
+def test_missing_headers_reports_per_server_block():
+    config = """server {
+    listen 80;
+    server_name _;
+}
+"""
+
+    missing = helper.missing_headers(config)
+
+    assert "server[1]: Content-Security-Policy" in missing
+    assert "server[1]: Permissions-Policy" in missing
+
+
+def test_missing_headers_requires_server_level_headers_when_location_has_headers():
+    config = """server {
+    listen 80;
+
+    location ~* \\.(js|css)$ {
+        # BEGIN ZOE MANAGED SECURITY HEADERS
+        add_header Content-Security-Policy "default-src 'self'" always;
+        add_header X-Frame-Options "DENY" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+        # END ZOE MANAGED SECURITY HEADERS
+        add_header Cache-Control "no-cache";
+    }
+}
+"""
+
+    missing = helper.missing_headers(config)
+
+    assert "server[1]: Content-Security-Policy" in missing
+    assert "server[1].location[1]: Content-Security-Policy" not in missing
+
+
+def test_missing_headers_does_not_match_header_name_inside_another_value():
+    config = """server {
+    listen 80;
+    add_header X-Debug "add_header Content-Security-Policy removed" always;
+}
+"""
+
+    missing = helper.missing_headers(config)
+
+    assert "server[1]: Content-Security-Policy" in missing
+
+
+def test_main_writes_with_atomic_temp_path(tmp_path):
+    config_path = tmp_path / "nginx.conf"
+    config_path.write_text("server {\n    listen 80;\n}\n", encoding="utf-8")
+
+    result = helper.main(["--path", str(config_path)])
+
+    assert result == 0
+    assert helper.BEGIN_MARKER in config_path.read_text(encoding="utf-8")
+    assert not (tmp_path / ".nginx.conf.tmp").exists()
+
+
+def test_main_check_fails_when_no_server_blocks(tmp_path, capsys):
+    config_path = tmp_path / "nginx.conf"
+    config_path.write_text("events {}\n", encoding="utf-8")
+
+    result = helper.main(["--path", str(config_path), "--check"])
+    captured = capsys.readouterr()
+
+    assert result == 1
+    assert "no nginx server blocks found" in captured.err
+    assert "security headers present in 0 server block" not in captured.out
+
+
+def test_main_returns_clean_error_for_malformed_config(tmp_path, capsys):
+    config_path = tmp_path / "nginx.conf"
+    config_path.write_text("server {\n    listen 80;\n", encoding="utf-8")
+
+    result = helper.main(["--path", str(config_path)])
+    captured = capsys.readouterr()
+
+    assert result == 1
+    assert "error: unterminated nginx server block" in captured.err
+    assert "Traceback" not in captured.err
+
+
+def test_main_returns_clean_error_for_missing_file(tmp_path, capsys):
+    config_path = tmp_path / "missing-nginx.conf"
+
+    result = helper.main(["--path", str(config_path), "--check"])
+    captured = capsys.readouterr()
+
+    assert result == 1
+    assert "error: cannot read" in captured.err
+    assert str(config_path) in captured.err
+    assert "Traceback" not in captured.err

--- a/tools/audit/ensure_nginx_security_headers.py
+++ b/tools/audit/ensure_nginx_security_headers.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+"""Add or verify managed HTTP security headers in nginx server blocks.
+
+The helper targets Zoe's nginx config shape: top-level server blocks with
+direct child location blocks. It does not recursively rewrite nested location
+blocks, which Zoe's nginx.conf does not use.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_PATH = PROJECT_ROOT / "services" / "zoe-ui" / "nginx.conf"
+
+BEGIN_MARKER = "# BEGIN ZOE MANAGED SECURITY HEADERS"
+END_MARKER = "# END ZOE MANAGED SECURITY HEADERS"
+
+SECURITY_HEADERS: tuple[tuple[str, str], ...] = (
+    (
+        "Content-Security-Policy",
+        # The legacy Zoe SPA and proxied Multica surface still need inline/eval script
+        # compatibility. Keep this explicit so future security audits can tighten it.
+        "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; "
+        "style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; "
+        "font-src 'self'; connect-src 'self' ws: wss:; frame-ancestors 'none';",
+    ),
+    ("X-Frame-Options", "DENY"),
+    ("X-Content-Type-Options", "nosniff"),
+    ("Referrer-Policy", "strict-origin-when-cross-origin"),
+    ("Permissions-Policy", "camera=(), microphone=(), geolocation=()"),
+)
+HSTS_HEADER = ("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
+TLS_LISTEN_RE = re.compile(r"^\s*listen\b[^;]*\b(?:443|ssl)\b", re.MULTILINE)
+SSL_CERTIFICATE_RE = re.compile(r"^\s*ssl_certificate\b", re.MULTILINE)
+
+
+def _managed_block(indent: str = "    ", *, include_hsts: bool = False) -> str:
+    headers = SECURITY_HEADERS + ((HSTS_HEADER,) if include_hsts else ())
+    lines = [f"{indent}{BEGIN_MARKER}"]
+    for name, value in headers:
+        lines.append(f'{indent}add_header {name} "{value}" always;')
+    lines.append(f"{indent}{END_MARKER}")
+    return "\n".join(lines)
+
+
+def _line_is_commented(text: str, start: int) -> bool:
+    line_start = text.rfind("\n", 0, start) + 1
+    return text[line_start:start].lstrip().startswith("#")
+
+
+def _find_named_blocks(text: str, name: str) -> list[tuple[int, int]]:
+    blocks: list[tuple[int, int]] = []
+    index = 0
+    while True:
+        start = text.find(name, index)
+        if start == -1:
+            break
+        before = text[start - 1] if start else "\n"
+        after = text[start + len(name)] if start + len(name) < len(text) else ""
+        if (before.isalnum() or before in "_-$") or (after.isalnum() or after in "_-"):
+            index = start + len(name)
+            continue
+        if _line_is_commented(text, start):
+            index = start + len(name)
+            continue
+        brace = text.find("{", start + len(name))
+        candidate = text[start:brace] if brace != -1 else ""
+        if brace == -1 or ";" in candidate or not candidate.strip().startswith(name):
+            index = start + len(name)
+            continue
+        depth = 0
+        pos = brace
+        quote: str | None = None
+        escaped = False
+        while pos < len(text):
+            char = text[pos]
+            if quote:
+                if escaped:
+                    escaped = False
+                elif char == "\\":
+                    escaped = True
+                elif char == quote:
+                    quote = None
+                pos += 1
+                continue
+            if char in {'"', "'"}:
+                quote = char
+                pos += 1
+                continue
+            if char == "#":
+                newline = text.find("\n", pos)
+                if newline == -1:
+                    break
+                pos = newline + 1
+                continue
+            if char == "{":
+                depth += 1
+            elif char == "}":
+                depth -= 1
+                if depth == 0:
+                    blocks.append((start, pos + 1))
+                    index = pos + 1
+                    break
+            pos += 1
+        else:
+            raise ValueError(f"unterminated nginx {name} block")
+    return blocks
+
+
+def _find_server_blocks(text: str) -> list[tuple[int, int]]:
+    return _find_named_blocks(text, "server")
+
+
+def _strip_managed_block(block: str) -> str:
+    while True:
+        start = block.find(BEGIN_MARKER)
+        if start == -1:
+            return block
+        end = block.find(END_MARKER, start)
+        if end == -1:
+            raise ValueError("managed security header block is missing its end marker")
+        end += len(END_MARKER)
+        if end < len(block) and block[end] == "\n":
+            end += 1
+        line_start = block.rfind("\n", 0, start) + 1
+        if not block[line_start:start].strip():
+            start = line_start
+            if start > 0 and block[start - 1] == "\n":
+                start -= 1
+        block = block[:start] + block[end:]
+
+
+def _is_tls_block(block: str) -> bool:
+    return bool(TLS_LISTEN_RE.search(block) or SSL_CERTIFICATE_RE.search(block))
+
+
+def _directive_indent(line: str, fallback: str) -> str:
+    stripped = line.lstrip()
+    if not stripped:
+        return fallback
+    return line[: len(line) - len(stripped)]
+
+
+def _has_active_add_header(block: str) -> bool:
+    for line in block.splitlines():
+        stripped = line.lstrip()
+        if stripped.startswith("#"):
+            continue
+        if stripped.startswith("add_header "):
+            return True
+    return False
+
+
+def _has_active_header(block: str, name: str) -> bool:
+    needle = f"add_header {name} "
+    for line in block.splitlines():
+        stripped = line.lstrip()
+        if stripped.startswith("#"):
+            continue
+        if stripped.startswith(needle):
+            return True
+    return False
+
+
+def _insert_after_header(block: str, *, include_hsts: bool) -> str:
+    lines = block.splitlines()
+    location_blocks = _find_named_blocks(block, "location")
+    first_location_start = min((start for start, _end in location_blocks), default=len(block))
+    server_scope_line_count = len(block[:first_location_start].splitlines())
+    insert_after = None
+    indent = "    "
+    for idx, line in enumerate(lines[:server_scope_line_count]):
+        stripped = line.strip()
+        if stripped.startswith(
+            (
+                "index ",
+                "server_name ",
+                "ssl_certificate ",
+                "ssl_certificate_key ",
+                "ssl_prefer_server_ciphers ",
+                "ssl_protocols ",
+                "listen ",
+            )
+        ) and stripped.endswith(";"):
+            insert_after = idx
+            indent = _directive_indent(line, indent)
+    if insert_after is None:
+        insert_after = 0
+
+    lines.insert(insert_after + 1, "")
+    lines.insert(insert_after + 2, _managed_block(indent=indent, include_hsts=include_hsts))
+    return "\n".join(lines)
+
+
+def _insert_location_headers(block: str, *, include_hsts: bool) -> str:
+    location_blocks = _find_named_blocks(block, "location")
+    result: list[str] = []
+    cursor = 0
+    for start, end in location_blocks:
+        result.append(block[cursor:start])
+        location = block[start:end]
+        if not _has_active_add_header(location):
+            result.append(location)
+            cursor = end
+            continue
+        lines = location.splitlines()
+        insert_after = 0
+        location_indent = _directive_indent(lines[0], "    ")
+        child_indent = location_indent + "    "
+        for line in lines[1:]:
+            stripped = line.strip()
+            if stripped and not stripped.startswith("#"):
+                child_indent = _directive_indent(line, child_indent)
+                break
+        lines.insert(insert_after + 1, _managed_block(indent=child_indent, include_hsts=include_hsts))
+        lines.insert(insert_after + 2, "")
+        result.append("\n".join(lines))
+        cursor = end
+    result.append(block[cursor:])
+    return "".join(result)
+
+
+def ensure_headers(text: str) -> str:
+    blocks = _find_server_blocks(text)
+    if not blocks:
+        raise ValueError("no nginx server blocks found")
+    result: list[str] = []
+    cursor = 0
+    for start, end in blocks:
+        result.append(text[cursor:start])
+        block = _strip_managed_block(text[start:end])
+        include_hsts = _is_tls_block(block)
+        block = _insert_after_header(block, include_hsts=include_hsts)
+        block = _insert_location_headers(block, include_hsts=include_hsts)
+        result.append(block)
+        cursor = end
+    result.append(text[cursor:])
+    updated = "".join(result)
+    if text.endswith("\n") and not updated.endswith("\n"):
+        updated += "\n"
+    return updated
+
+
+def missing_headers(text: str) -> list[str]:
+    missing: list[str] = []
+    for index, (start, end) in enumerate(_find_server_blocks(text), start=1):
+        block = text[start:end]
+        headers = SECURITY_HEADERS + ((HSTS_HEADER,) if _is_tls_block(block) else ())
+        location_blocks = _find_named_blocks(block, "location")
+        first_location_start = min((loc_start for loc_start, _loc_end in location_blocks), default=len(block))
+        server_scope = block[:first_location_start]
+        for name, _value in headers:
+            if not _has_active_header(server_scope, name):
+                missing.append(f"server[{index}]: {name}")
+        for location_index, (loc_start, loc_end) in enumerate(location_blocks, start=1):
+            location = block[loc_start:loc_end]
+            if not _has_active_add_header(location):
+                continue
+            for name, _value in headers:
+                if not _has_active_header(location, name):
+                    missing.append(f"server[{index}].location[{location_index}]: {name}")
+    return missing
+
+
+def _write_text_atomic(path: Path, text: str) -> None:
+    tmp = path.with_name(f".{path.name}.tmp")
+    with tmp.open("w", encoding="utf-8") as handle:
+        handle.write(text)
+        handle.flush()
+        os.fsync(handle.fileno())
+    os.replace(tmp, path)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--path", type=Path, default=DEFAULT_PATH)
+    parser.add_argument("--check", action="store_true", help="verify headers without writing")
+    args = parser.parse_args(argv)
+
+    path = args.path
+    if not path.is_absolute():
+        path = PROJECT_ROOT / path
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        print(f"error: cannot read {path}: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        if args.check:
+            blocks = _find_server_blocks(text)
+            if not blocks:
+                print(f"error: no nginx server blocks found in {path}", file=sys.stderr)
+                return 1
+            missing = missing_headers(text)
+            if missing:
+                print("missing managed security headers:")
+                for item in missing:
+                    print(f"- {item}")
+                return 1
+            print(f"security headers present in {len(blocks)} server block(s)")
+            return 0
+
+        updated = ensure_headers(text)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    if updated == text:
+        print(f"security headers already present: {path}")
+        return 0
+    _write_text_atomic(path, updated)
+    print(f"updated nginx security headers: {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add an idempotent nginx security-header helper for repeated server blocks
- point nginx security-header code-audit tickets at the helper instead of ambiguous patches
- cover helper behavior and prompt routing with focused tests

## Tests
- python3 -m py_compile tools/audit/ensure_nginx_security_headers.py services/zoe-data/executors/kanban_adapter.py services/zoe-data/tests/test_kanban_adapter.py services/zoe-data/tests/test_nginx_security_headers_helper.py
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_nginx_security_headers_helper.py services/zoe-data/tests/test_kanban_adapter.py -q
- python3 tools/audit/validate_structure.py