### PR TITLE
[codex] Attach proposal contracts to notice writers

### DIFF
--- a/docs/architecture/zoe-evolution-proposal-contract.md
+++ b/docs/architecture/zoe-evolution-proposal-contract.md
@@ -32,13 +32,16 @@ It also attaches candidate scoring to proposals, so Zoe can compare existing Pi/
 
 ## Current Scope
 
-The foundation contract is now wired into the MCP `create_evolution_proposal`
-writer:
+The foundation contract is now wired into Zoe's live proposal writers:
 
 - the legacy `evolution_proposals` row shape remains unchanged for current UI,
   Multica, and review routes;
 - a validated `zoe_evolution_proposal` contract snapshot is stored as JSON in
   the existing `target_patterns` field;
+- nightly NOTICE proposals, MCP-created proposals, user-frustration proposals,
+  and explicit user issue reports all emit the snapshot;
+- MEASURE still supports legacy target-pattern behavior by reading
+  `legacy_target_patterns` from contract metadata;
 - `multica_issue_id` remains authoritative in the legacy column; the stored
   contract snapshot is not rewritten just to mirror that live sync field;
 - proposal creation remains review-only and never grants execution;
@@ -50,6 +53,6 @@ This still avoids:
 - no automatic memory promotion;
 - no chat hot-path change.
 
-The next slices should adapt remaining `evolution_proposals` writers to include
-this contract payload, then add Multica admission rules for memory and capability
+The next slices should require this contract payload before installs or
+replacements, then add Multica admission rules for memory and capability
 promotion.

--- a/docs/strategy/zoe-evolution-harness-status.md
+++ b/docs/strategy/zoe-evolution-harness-status.md
@@ -42,7 +42,7 @@ Important non-complete truth:
 - Zoe now has a read-only Pi runtime probe and policy contract; actual Pi execution is still blocked until Node/npm/Pi and local/offline model configuration are present and approved.
 - The deterministic memory router now has a disabled-by-default runtime status gate, optional non-persistent observation trace packets, and a governed non-persistent trace collector; it is not yet used for prompt injection or backend recall in production chat.
 - Retain-candidate admission has a tested contract, but existing runtime writers are not yet wired to enforce it through Multica approval.
-- The full self-evolution loop is not yet implemented end to end; the MCP `create_evolution_proposal` writer now stores a validated Zoe proposal contract snapshot in the legacy `target_patterns` field, but other live proposal writers still need to emit it and Multica still needs to enforce admission.
+- The full self-evolution loop is not yet implemented end to end; live proposal writers now store validated Zoe proposal contract snapshots in the legacy `target_patterns` field, but Multica still needs to enforce admission and execution gates.
 - Zoe main engine cleanup should not begin until the inventory, graph, and memory/evolution contracts have protective tests around the active surfaces.
 
 ## Phase Ledger
@@ -68,7 +68,7 @@ Important non-complete truth:
 | Observation/evaluation traces | Complete foundation | `services/zoe-data/zoe_observation_trace.py`, `services/zoe-data/zoe_observation_trace_collector.py`, tests, `docs/architecture/zoe-observation-trace-schema.md`, and `docs/architecture/zoe-observation-trace-collector.md` define trace records and non-persistent collection gates for memory route decisions, recall, retain candidate, admission, contradiction, fallback, proposal, verification, outcome eval, and hardware-budget events. | Wire runtime callers through the collector, then add governed collection around retain candidates, sidecar bake-offs, Multica admission, and capability promotion/retirement. |
 | Memory admission governance | Complete foundation | `services/zoe-data/zoe_memory_admission.py`, `services/zoe-data/hindsight_retain_candidates.py`, tests, and `docs/architecture/zoe-memory-admission-gates.md` define evidence, trace, approval, graph, and self-evolution proposal gates before durable memory writes; Hindsight retain candidates can now build/evaluate admission requests before promotion. | Wire future graph/Hindsight durable writers through this decision before any backend write. |
 | Multica evidence gates | Partial | Implement completion now requires PR evidence for code/default profiles, and memory admission has a tested decision contract. | Connect the memory admission contract to Multica/review records and add explicit self-evolution execution gates. |
-| Self-evolution proposal records | Partial runtime wiring | `services/zoe-data/zoe_evolution_proposal.py`, `services/zoe-data/zoe_evolution_proposal_adapter.py`, tests, and `docs/architecture/zoe-evolution-proposal-contract.md` define structured Notice -> Explain -> Search -> Evaluate -> Propose records. The MCP `create_evolution_proposal` writer now stores a validated contract snapshot while preserving the legacy row shape. | Adapt remaining live proposal writers to emit this payload and require it before installs/replacements. |
+| Self-evolution proposal records | Runtime writers wired | `services/zoe-data/zoe_evolution_proposal.py`, `services/zoe-data/zoe_evolution_proposal_adapter.py`, tests, and `docs/architecture/zoe-evolution-proposal-contract.md` define structured Notice -> Explain -> Search -> Evaluate -> Propose records. MCP proposal creation, nightly NOTICE proposals, user-frustration proposals, and explicit user issue reports now store validated contract snapshots while preserving the legacy row shape and MEASURE target patterns. | Require the contract before installs/replacements and connect it to Multica admission/execution gates. |
 | Self-evolution loop | Partial | Multica, pipeline evidence, Greploop, Greptile, Hermes, worktree bootstrap, candidate scoring, and proposal contract pieces exist. | Wire live proposal writers, Multica admission, execution approval, verification, retained outcomes, and retirement evidence. |
 | Main engine cleanup | Deferred | `zoe_agent.py` remains large and active. | Start only after inventories and chat/memory/tool dispatch tests are strong enough to prevent regressions. |
 
@@ -199,8 +199,8 @@ Keep each pull request small enough for Greptile and Zoe verification.
    - Hindsight retain candidates can now build and evaluate admission requests before any durable promotion.
    - Next: route future Hindsight, MemPalace, and Graphiti durable writers through the decision before backend writes.
 9. Self-evolution proposal records.
-    - Status: foundation complete and MCP `create_evolution_proposal` runtime writer now emits a validated contract snapshot into `target_patterns`.
-    - Next: adapt remaining live proposal writers and require the contract before installs/replacements.
+    - Status: foundation complete and live proposal writers now emit validated contract snapshots into `target_patterns`.
+    - Next: require the contract before installs/replacements and connect it to Multica execution gates.
     - Keep execution approval-gated.
 10. Zoe capability profile inventory.
     - Status: complete foundation for key active and candidate surfaces.

--- a/services/zoe-data/evolution_notice.py
+++ b/services/zoe-data/evolution_notice.py
@@ -92,6 +92,7 @@ async def run_evolution_notice() -> dict:
     """Run the NOTICE phase — returns summary dict."""
     from db_pool import get_db_ctx
     from multica_client import sync_evolution_proposal_to_multica
+    from zoe_evolution_proposal_adapter import dump_legacy_evolution_proposal_contract
 
     created = 0
     skipped = 0
@@ -121,7 +122,16 @@ async def run_evolution_notice() -> dict:
                 "miss_count": len(members),
                 "examples": members[:5],
             })
-            target_patterns = json.dumps(members[:20])
+            target_members = members[:20]
+            target_patterns = dump_legacy_evolution_proposal_contract(
+                proposal_id=prop_id,
+                title=title,
+                description=description,
+                evidence=evidence,
+                proposal_type=prop_type,
+                legacy_writer="evolution_notice:intent_miss_cluster",
+                target_patterns=target_members,
+            )
             await db.execute(
                 """INSERT INTO evolution_proposals
                    (id, type, title, description, evidence, target_patterns, status, proposed_at)
@@ -183,14 +193,23 @@ async def run_evolution_notice() -> dict:
             prop_id = uuid.uuid4().hex
             description = f"{tier} had {errors}/{total} ({int(100*errors/total)}%) slow/error calls in 24h."
             evidence_data = json.dumps({"agent_tier": tier, "total": total, "errors": errors})
+            target_patterns = dump_legacy_evolution_proposal_contract(
+                proposal_id=prop_id,
+                title=title,
+                description=description,
+                evidence=evidence_data,
+                proposal_type="agent_health",
+                legacy_writer="evolution_notice:agent_health",
+            )
             await db.execute(
                 """INSERT INTO evolution_proposals
-                   (id, type, title, description, evidence, status, proposed_at)
-                   VALUES ($1,'agent_health',$2,$3,$4,'pending',$5)""",
+                   (id, type, title, description, evidence, target_patterns, status, proposed_at)
+                   VALUES ($1,'agent_health',$2,$3,$4,$5,'pending',$6)""",
                 prop_id,
                 title,
                 description,
                 evidence_data,
+                target_patterns,
                 time.time(),
             )
             created += 1
@@ -221,6 +240,7 @@ async def record_frustration_signal(
     """Write a user frustration proposal (called from chat.py inline)."""
     from db_pool import get_db_ctx
     from multica_client import sync_evolution_proposal_to_multica
+    from zoe_evolution_proposal_adapter import dump_legacy_evolution_proposal_contract
 
     title = f"User frustration: '{normalized_message[:60]}'"
     async with get_db_ctx() as db:
@@ -244,6 +264,16 @@ async def record_frustration_signal(
             "repeat_count": repeat_count,
             "message": normalized_message,
         })
+        target_patterns = dump_legacy_evolution_proposal_contract(
+            proposal_id=prop_id,
+            title=title,
+            description=description,
+            evidence=evidence,
+            proposal_type="user_frustration",
+            legacy_writer="evolution_notice:user_frustration",
+            user_id=user_id,
+            target_patterns=(normalized_message,),
+        )
         await db.execute(
             """INSERT INTO evolution_proposals
                (id, type, title, description, evidence, target_patterns, status, proposed_at)
@@ -252,7 +282,7 @@ async def record_frustration_signal(
             title,
             description,
             evidence,
-            json.dumps([normalized_message]),
+            target_patterns,
             time.time(),
         )
         logger.info(
@@ -284,6 +314,7 @@ async def record_user_issue(message: str, user_id: str) -> None:
     """
     from db_pool import get_db_ctx
     from multica_client import sync_evolution_proposal_to_multica
+    from zoe_evolution_proposal_adapter import dump_legacy_evolution_proposal_contract
 
     title = f"User report: '{message[:60]}'"
     async with get_db_ctx() as db:
@@ -299,6 +330,16 @@ async def record_user_issue(message: str, user_id: str) -> None:
         prop_id = uuid.uuid4().hex
         description = f"User {user_id} explicitly reported a problem: {message}"
         evidence = json.dumps({"user_id": user_id, "message": message})
+        target_patterns = dump_legacy_evolution_proposal_contract(
+            proposal_id=prop_id,
+            title=title,
+            description=description,
+            evidence=evidence,
+            proposal_type="user_issue_report",
+            legacy_writer="evolution_notice:user_issue_report",
+            user_id=user_id,
+            target_patterns=(message,),
+        )
         await db.execute(
             """INSERT INTO evolution_proposals
                (id, type, title, description, evidence, target_patterns, status, proposed_at)
@@ -307,7 +348,7 @@ async def record_user_issue(message: str, user_id: str) -> None:
             title,
             description,
             evidence,
-            json.dumps([message]),
+            target_patterns,
             time.time(),
         )
         logger.info(
@@ -335,7 +376,7 @@ _MEASURE_WINDOW_S = 48 * 3600  # 48-hour monitoring window post-deployment
 
 
 def _load_target_patterns(raw: str | None) -> list[str]:
-    """Load legacy target pattern arrays without crashing on contract envelopes."""
+    """Load target patterns from legacy arrays or proposal contract envelopes."""
 
     if not raw:
         return []
@@ -343,9 +384,15 @@ def _load_target_patterns(raw: str | None) -> list[str]:
         payload = json.loads(raw)
     except (TypeError, ValueError, json.JSONDecodeError):
         return []
-    if not isinstance(payload, list):
-        return []
-    return [str(item) for item in payload if item is not None]
+    if isinstance(payload, list):
+        return [str(item) for item in payload if item is not None]
+    if isinstance(payload, dict) and payload.get("schema") == "zoe_evolution_proposal":
+        proposal = payload.get("proposal")
+        metadata = proposal.get("metadata") if isinstance(proposal, dict) else None
+        target_patterns = metadata.get("legacy_target_patterns") if isinstance(metadata, dict) else None
+        if isinstance(target_patterns, list):
+            return [str(item) for item in target_patterns if item is not None]
+    return []
 
 
 async def run_measure_phase() -> dict:

--- a/services/zoe-data/tests/test_evolution_notice_measure.py
+++ b/services/zoe-data/tests/test_evolution_notice_measure.py
@@ -5,7 +5,7 @@ import types
 import pytest
 
 import evolution_notice
-from zoe_evolution_proposal_adapter import dump_mcp_evolution_proposal_contract
+from zoe_evolution_proposal_adapter import dump_legacy_evolution_proposal_contract, dump_mcp_evolution_proposal_contract
 
 
 class _Db:
@@ -32,6 +32,33 @@ class _Db:
 
     async def execute(self, sql, *args):
         self.execute_calls.append((sql, args))
+
+
+class _WriterDb:
+    def __init__(self):
+        self.fetch_calls = []
+        self.execute_calls = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def fetch(self, sql, *args):
+        self.fetch_calls.append((sql, args))
+        return []
+
+    async def execute(self, sql, *args):
+        self.execute_calls.append((sql, args))
+
+
+class _NoticeDb(_WriterDb):
+    async def fetch(self, sql, *args):
+        self.fetch_calls.append((sql, args))
+        if "FROM llm_call_log" in sql:
+            return [{"agent_tier": "gemma4", "total": 20, "errors": 3}]
+        return []
 
 
 @pytest.mark.asyncio
@@ -85,3 +112,118 @@ def test_load_target_patterns_accepts_only_legacy_arrays():
     assert evolution_notice._load_target_patterns('{"schema":"zoe_evolution_proposal"}') == []
     assert evolution_notice._load_target_patterns("not-json") == []
     assert evolution_notice._load_target_patterns(None) == []
+
+
+def test_load_target_patterns_extracts_contract_metadata():
+    raw = dump_legacy_evolution_proposal_contract(
+        proposal_id="prop_patterns",
+        title="Intent gap",
+        description="Contract envelopes should preserve measurement patterns.",
+        evidence="trace:patterns",
+        proposal_type="intent_pattern",
+        legacy_writer="evolution_notice:intent_miss_cluster",
+        target_patterns=("turn lights on", "switch lights on"),
+    )
+
+    assert evolution_notice._load_target_patterns(raw) == ["turn lights on", "switch lights on"]
+
+
+@pytest.mark.asyncio
+async def test_record_frustration_signal_stores_contract_snapshot(monkeypatch):
+    db = _WriterDb()
+
+    monkeypatch.setitem(sys.modules, "db_pool", types.SimpleNamespace(get_db_ctx=lambda: db))
+
+    async def fake_sync_evolution_proposal_to_multica(**_kwargs):
+        return None
+
+    monkeypatch.setitem(
+        sys.modules,
+        "multica_client",
+        types.SimpleNamespace(sync_evolution_proposal_to_multica=fake_sync_evolution_proposal_to_multica),
+    )
+
+    await evolution_notice.record_frustration_signal(
+        user_id="jason",
+        normalized_message="why can't you remember the bins",
+        session_id="sess-1",
+        repeat_count=3,
+    )
+
+    assert len(db.execute_calls) == 1
+    insert_sql, insert_args = db.execute_calls[0]
+    assert "target_patterns" in insert_sql
+    contract = json.loads(insert_args[4])
+    assert contract["schema"] == "zoe_evolution_proposal"
+    assert contract["legacy_writer"] == "evolution_notice:user_frustration"
+    assert contract["proposal"]["metadata"]["legacy_target_patterns"] == ["why can't you remember the bins"]
+    assert contract["proposal"]["signals"][0]["scope"] == "personal"
+
+
+@pytest.mark.asyncio
+async def test_record_user_issue_stores_contract_snapshot(monkeypatch):
+    db = _WriterDb()
+
+    monkeypatch.setitem(sys.modules, "db_pool", types.SimpleNamespace(get_db_ctx=lambda: db))
+
+    async def fake_sync_evolution_proposal_to_multica(**_kwargs):
+        return None
+
+    monkeypatch.setitem(
+        sys.modules,
+        "multica_client",
+        types.SimpleNamespace(sync_evolution_proposal_to_multica=fake_sync_evolution_proposal_to_multica),
+    )
+
+    await evolution_notice.record_user_issue("weather failed again", "jason")
+
+    assert len(db.execute_calls) == 1
+    insert_sql, insert_args = db.execute_calls[0]
+    assert "target_patterns" in insert_sql
+    contract = json.loads(insert_args[4])
+    assert insert_args[1] == "User report: 'weather failed again'"
+    assert contract["schema"] == "zoe_evolution_proposal"
+    assert contract["legacy_writer"] == "evolution_notice:user_issue_report"
+    assert contract["proposal"]["metadata"]["legacy_proposal_type"] == "user_issue_report"
+    assert contract["proposal"]["metadata"]["legacy_target_patterns"] == ["weather failed again"]
+
+
+@pytest.mark.asyncio
+async def test_run_evolution_notice_stores_contract_snapshots(monkeypatch):
+    db = _NoticeDb()
+
+    monkeypatch.setattr(
+        evolution_notice,
+        "_load_recent_misses",
+        lambda: ["turn on kitchen lights", "turn on kitchen lights", "turn on kitchen lights"],
+    )
+    monkeypatch.setitem(sys.modules, "db_pool", types.SimpleNamespace(get_db_ctx=lambda: db))
+
+    async def fake_sync_evolution_proposal_to_multica(**_kwargs):
+        return None
+
+    monkeypatch.setitem(
+        sys.modules,
+        "multica_client",
+        types.SimpleNamespace(sync_evolution_proposal_to_multica=fake_sync_evolution_proposal_to_multica),
+    )
+
+    result = await evolution_notice.run_evolution_notice()
+
+    assert result == {"created": 2, "skipped_dedup": 0, "clusters": 1}
+    assert len(db.execute_calls) == 2
+    intent_sql, intent_args = db.execute_calls[0]
+    health_sql, health_args = db.execute_calls[1]
+    assert "target_patterns" in intent_sql
+    assert "target_patterns" in health_sql
+
+    intent_contract = json.loads(intent_args[5])
+    health_contract = json.loads(health_args[4])
+    assert intent_contract["legacy_writer"] == "evolution_notice:intent_miss_cluster"
+    assert intent_contract["proposal"]["metadata"]["legacy_target_patterns"] == [
+        "turn on kitchen lights",
+        "turn on kitchen lights",
+        "turn on kitchen lights",
+    ]
+    assert health_contract["legacy_writer"] == "evolution_notice:agent_health"
+    assert health_contract["proposal"]["metadata"]["legacy_proposal_type"] == "agent_health"

--- a/services/zoe-data/tests/test_zoe_evolution_proposal_adapter.py
+++ b/services/zoe-data/tests/test_zoe_evolution_proposal_adapter.py
@@ -1,7 +1,9 @@
 import json
 
 from zoe_evolution_proposal_adapter import (
+    build_legacy_evolution_proposal_contract,
     build_mcp_evolution_proposal_contract,
+    dump_legacy_evolution_proposal_contract,
     dump_mcp_evolution_proposal_contract,
     load_proposal_contract_snapshot,
     normalize_mcp_evolution_proposal_type,
@@ -82,6 +84,46 @@ def test_dump_and_load_contract_snapshot_round_trip():
     assert payload is not None
     assert json.loads(raw)["proposal"]["multica_issue_id"] == "issue-123"
     assert payload["proposal"]["signals"][0]["signal_type"] == "tool_gap"
+
+
+def test_legacy_contract_snapshot_preserves_target_patterns_and_writer():
+    payload = build_legacy_evolution_proposal_contract(
+        proposal_id="prop_notice",
+        title="Intent gap",
+        description="Zoe missed related intent messages.",
+        evidence="trace:intent-gap",
+        proposal_type="intent_pattern",
+        legacy_writer="evolution_notice:intent_miss_cluster",
+        target_patterns=("one", "two"),
+    )
+
+    proposal = payload["proposal"]
+
+    assert payload["legacy_writer"] == "evolution_notice:intent_miss_cluster"
+    assert proposal["metadata"]["legacy_target_patterns"] == ["one", "two"]
+    assert proposal["signals"][0]["metadata"]["legacy_target_patterns"] == ["one", "two"]
+    assert proposal["candidate"]["metadata"]["legacy_target_patterns"] == ["one", "two"]
+
+
+def test_legacy_contract_snapshot_supports_user_issue_report():
+    raw = dump_legacy_evolution_proposal_contract(
+        proposal_id="prop_user_issue",
+        title="User report",
+        description="User explicitly reported a problem.",
+        evidence="trace:user-report",
+        proposal_type="user_issue_report",
+        legacy_writer="evolution_notice:user_issue_report",
+        user_id="jason",
+        target_patterns=("reported problem",),
+    )
+
+    payload = load_proposal_contract_snapshot(raw)
+
+    assert payload is not None
+    proposal = payload["proposal"]
+    assert proposal["metadata"]["legacy_proposal_type"] == "user_issue_report"
+    assert proposal["signals"][0]["signal_type"] == "user_request"
+    assert proposal["signals"][0]["scope"] == "personal"
 
 
 def test_loader_rejects_legacy_non_contract_payloads():

--- a/services/zoe-data/zoe_evolution_proposal_adapter.py
+++ b/services/zoe-data/zoe_evolution_proposal_adapter.py
@@ -9,7 +9,7 @@ legacy shape intact while attaching a validated contract snapshot to
 from __future__ import annotations
 
 import json
-from typing import Any, Mapping
+from typing import Any, Mapping, Sequence
 
 from zoe_candidate_scoring import CandidateEvaluation, CandidateScore
 from zoe_evolution_proposal import (
@@ -27,6 +27,7 @@ _SIGNAL_BY_LEGACY_TYPE = {
     "intent_pattern": EvolutionSignalType.REPEATED_FAILURE.value,
     "agent_health": EvolutionSignalType.OUTCOME_EVAL_FAILURE.value,
     "user_frustration": EvolutionSignalType.USER_REQUEST.value,
+    "user_issue_report": EvolutionSignalType.USER_REQUEST.value,
     "code_improvement": EvolutionSignalType.TOOL_GAP.value,
 }
 
@@ -34,41 +35,46 @@ _AFFECTED_CAPABILITIES_BY_TYPE = {
     "intent_pattern": ("intent_router", "chat_router", "observation_trace"),
     "agent_health": ("agent_runtime", "multica_governance", "observation_trace"),
     "user_frustration": ("chat_experience", "memory_router", "observation_trace"),
+    "user_issue_report": ("chat_experience", "intent_router", "multica_governance"),
     "code_improvement": ("zoe_codebase", "multica_governance", "verification"),
 }
 
 
-def build_mcp_evolution_proposal_contract(
+def build_legacy_evolution_proposal_contract(
     *,
     proposal_id: str,
     title: str,
     description: str,
     evidence: str = "",
     proposal_type: str = "intent_pattern",
+    legacy_writer: str,
     user_id: str | None = None,
     multica_issue_id: str | None = None,
+    target_patterns: Sequence[str] = (),
 ) -> dict[str, Any]:
-    """Build a validated contract snapshot for the MCP proposal writer.
+    """Build a validated contract snapshot for a legacy proposal writer.
 
     The returned dict is JSON-serializable and intentionally does not execute,
     approve, install, or write memory. It is safe to store beside the existing
     legacy proposal row as evidence for later Multica/review gates.
     """
 
-    normalized_type = normalize_mcp_evolution_proposal_type(proposal_type)
-    source_ref = f"mcp:create_evolution_proposal:{proposal_id}"
+    normalized_type = normalize_legacy_evolution_proposal_type(proposal_type)
+    source_ref = f"{legacy_writer}:{proposal_id}"
     evidence_refs = _evidence_refs(source_ref, evidence)
+    legacy_target_patterns = tuple(str(item) for item in target_patterns if item is not None)
     signal = EvolutionSignal(
         signal_id=f"signal_{proposal_id}",
         signal_type=_SIGNAL_BY_LEGACY_TYPE[normalized_type],
         summary=description,
-        source="mcp:create_evolution_proposal",
+        source=legacy_writer,
         evidence_refs=evidence_refs,
         user_id=user_id,
         scope="system" if not user_id else "personal",
         metadata={
             "legacy_proposal_type": normalized_type,
             "evidence_excerpt": evidence[:500],
+            "legacy_target_patterns": list(legacy_target_patterns),
         },
     )
     candidate = CandidateEvaluation(
@@ -90,10 +96,14 @@ def build_mcp_evolution_proposal_contract(
         evidence_refs=evidence_refs,
         license_risk="compatible",
         offline_viability="required",
-        runtime_notes="Legacy MCP proposal writer creates review-only proposals; no execution is granted by this contract.",
+        runtime_notes=f"Legacy proposal writer {legacy_writer} creates review-only proposals; no execution is granted by this contract.",
         overlaps_existing=("evolution_proposals", "multica_governance"),
         recommendation="needs_review",
-        metadata={"legacy_proposal_type": normalized_type},
+        metadata={
+            "legacy_proposal_type": normalized_type,
+            "legacy_writer": legacy_writer,
+            "legacy_target_patterns": list(legacy_target_patterns),
+        },
     )
     proposal = build_evolution_proposal(
         proposal_id=proposal_id,
@@ -116,21 +126,77 @@ def build_mcp_evolution_proposal_contract(
             "legacy_table": "evolution_proposals",
             "legacy_status": "pending",
             "legacy_proposal_type": normalized_type,
-            "created_by": "mcp:create_evolution_proposal",
+            "legacy_target_patterns": list(legacy_target_patterns),
+            "created_by": legacy_writer,
         },
     )
     return {
         "version": CONTRACT_ENVELOPE_VERSION,
         "schema": "zoe_evolution_proposal",
-        "legacy_writer": "mcp:create_evolution_proposal",
+        "legacy_writer": legacy_writer,
         "proposal": proposal.to_dict(),
     }
 
 
-def dump_mcp_evolution_proposal_contract(**kwargs: Any) -> str:
+def build_mcp_evolution_proposal_contract(
+    *,
+    proposal_id: str,
+    title: str,
+    description: str,
+    evidence: str = "",
+    proposal_type: str = "intent_pattern",
+    user_id: str | None = None,
+    multica_issue_id: str | None = None,
+    target_patterns: Sequence[str] = (),
+) -> dict[str, Any]:
+    """Build a validated contract snapshot for the MCP proposal writer."""
+
+    return build_legacy_evolution_proposal_contract(
+        proposal_id=proposal_id,
+        title=title,
+        description=description,
+        evidence=evidence,
+        proposal_type=proposal_type,
+        legacy_writer="mcp:create_evolution_proposal",
+        user_id=user_id,
+        multica_issue_id=multica_issue_id,
+        target_patterns=target_patterns,
+    )
+
+
+def dump_legacy_evolution_proposal_contract(**kwargs: Any) -> str:
     """Return a stable JSON string for the legacy `target_patterns` column."""
 
-    return json.dumps(build_mcp_evolution_proposal_contract(**kwargs), sort_keys=True, separators=(",", ":"))
+    return json.dumps(build_legacy_evolution_proposal_contract(**kwargs), sort_keys=True, separators=(",", ":"))
+
+
+def dump_mcp_evolution_proposal_contract(
+    *,
+    proposal_id: str,
+    title: str,
+    description: str,
+    evidence: str = "",
+    proposal_type: str = "intent_pattern",
+    user_id: str | None = None,
+    multica_issue_id: str | None = None,
+    target_patterns: Sequence[str] = (),
+) -> str:
+    """Return a stable JSON string for the legacy `target_patterns` column."""
+
+    return json.dumps(
+        build_mcp_evolution_proposal_contract(
+            proposal_id=proposal_id,
+            title=title,
+            description=description,
+            evidence=evidence,
+            proposal_type=proposal_type,
+            user_id=user_id,
+            multica_issue_id=multica_issue_id,
+            target_patterns=target_patterns,
+        ),
+        sort_keys=True,
+        separators=(",", ":"),
+    )
 
 
 def load_proposal_contract_snapshot(raw: str | bytes | Mapping[str, Any] | None) -> dict[str, Any] | None:
@@ -156,6 +222,12 @@ def load_proposal_contract_snapshot(raw: str | bytes | Mapping[str, Any] | None)
 def normalize_mcp_evolution_proposal_type(proposal_type: str | None) -> str:
     """Normalize legacy MCP proposal types before DB and contract storage."""
 
+    return normalize_legacy_evolution_proposal_type(proposal_type)
+
+
+def normalize_legacy_evolution_proposal_type(proposal_type: str | None) -> str:
+    """Normalize legacy proposal types before DB and contract storage."""
+
     normalized = (proposal_type or "intent_pattern").strip().lower()
     if normalized not in _SIGNAL_BY_LEGACY_TYPE:
         return "intent_pattern"
@@ -171,8 +243,11 @@ def _evidence_refs(source_ref: str, evidence: str) -> tuple[str, ...]:
 
 __all__ = [
     "CONTRACT_ENVELOPE_VERSION",
+    "build_legacy_evolution_proposal_contract",
     "build_mcp_evolution_proposal_contract",
+    "dump_legacy_evolution_proposal_contract",
     "dump_mcp_evolution_proposal_contract",
     "load_proposal_contract_snapshot",
+    "normalize_legacy_evolution_proposal_type",
     "normalize_mcp_evolution_proposal_type",
 ]


### PR DESCRIPTION
## Summary

- wire the remaining live `evolution_notice` proposal writers to validated Zoe proposal contract snapshots
- preserve MEASURE behavior by carrying legacy target patterns in contract metadata and teaching `_load_target_patterns` to read both legacy arrays and contract envelopes
- extend proposal adapter support for `user_issue_report` and generic legacy writers
- update harness docs/status ledger to reflect live proposal writers are contract-backed

## Why

The MCP proposal writer was contract-backed, but nightly NOTICE, user-frustration, and explicit user issue writers still created legacy-only rows. This makes proposal formation consistent before Multica/execution gates start requiring the contract.

## Validation

- `PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_evolution_notice_measure.py services/zoe-data/tests/test_zoe_evolution_proposal_adapter.py services/zoe-data/tests/test_zoe_evolution_proposal.py services/zoe-data/tests/test_panel_mcp_tools.py`
- `python3 -m py_compile services/zoe-data/evolution_notice.py services/zoe-data/zoe_evolution_proposal_adapter.py services/zoe-data/mcp_server.py`
- `python3 tools/audit/validate_structure.py`
- `python3 tools/audit/validate_critical_files.py`
- `python3 tools/audit/validate_offline_memory.py`
- `git diff --check`
