### PR TITLE
Gate outcome memory through admission

### DIFF
--- a/docs/architecture/zoe-memory-admission-gates.md
+++ b/docs/architecture/zoe-memory-admission-gates.md
@@ -7,7 +7,9 @@ memory, but they cannot silently promote it into truth.
 The executable contract lives in
 `services/zoe-data/zoe_memory_admission.py`. Multica/review records can be
 converted into the same inert decision shape by
-`services/zoe-data/zoe_multica_memory_admission.py`.
+`services/zoe-data/zoe_multica_memory_admission.py`. Terminal evolution
+outcome memory candidates can be evaluated by
+`services/zoe-data/zoe_evolution_outcome_admission.py`.
 
 ## Rules
 
@@ -21,10 +23,10 @@ converted into the same inert decision shape by
 
 ## Current Scope
 
-This is a schema, decision contract, and Multica metadata bridge only. It does
-not write to MemoryService, Hindsight, Graphiti, or Multica. Runtime writer
-wiring should happen in a later small PR after this contract is reviewed and
-tested.
+This is a schema, decision contract, Multica metadata bridge, and outcome
+memory admission bridge only. It does not write to MemoryService, Hindsight,
+Graphiti, MemPalace, or Multica. Runtime writer wiring should happen in a
+later small PR after this contract is reviewed and tested.
 
 ## Intended Flow
 
@@ -37,6 +39,11 @@ tested.
 4. `evaluate_memory_admission()` returns whether Zoe may keep the candidate
    pending or write durable/trusted memory.
 5. The runtime writer uses the decision as a gate before touching any backend.
+
+Outcome memory candidates follow the same rule: Zoe may build a pending event
+from a terminal proposal outcome, but durable promotion still requires
+`memory_admission` proposal context, approval refs, and successful
+admission/verification evidence.
 
 ## Multica Bridge Rules
 

--- a/docs/architecture/zoe-observation-trace-schema.md
+++ b/docs/architecture/zoe-observation-trace-schema.md
@@ -6,7 +6,9 @@ Zoe needs proof that memory and self-evolution are helping before those systems 
 
 This is an executable trace contract, not a persistence layer. Terminal
 self-evolution proposal traces can be converted into pending memory event
-candidates by `services/zoe-data/zoe_evolution_outcome_memory.py`.
+candidates by `services/zoe-data/zoe_evolution_outcome_memory.py`, then
+evaluated through memory admission by
+`services/zoe-data/zoe_evolution_outcome_admission.py`.
 
 ## Trace Types
 
@@ -34,6 +36,8 @@ candidates by `services/zoe-data/zoe_evolution_outcome_memory.py`.
 - Verified, failed, or retired proposal outcomes can become pending
   self-evolution memory candidates only after matching verification or outcome
   evidence exists.
+- Outcome memory candidates must pass memory admission before any durable
+  backend promotion is allowed.
 
 ## Current Scope
 

--- a/docs/strategy/zoe-evolution-harness-status.md
+++ b/docs/strategy/zoe-evolution-harness-status.md
@@ -41,6 +41,9 @@ Important non-complete truth:
 - Zoe now has an inert evolution outcome memory builder that converts
   verified, failed, or retired proposal outcomes plus trace evidence into
   pending self-evolution memory candidates.
+- Zoe now has an inert evolution outcome admission bridge that evaluates those
+  pending candidates through memory admission before any durable backend writer
+  can promote them.
 - Zoe now has an inert memory admission contract that keeps retain candidates pending until evidence, successful admission/verification traces, and approval refs allow durable/trusted memory writes.
 - Zoe now has a read-only Pi runtime probe and policy contract; actual Pi execution is still blocked until Node/npm/Pi and local/offline model configuration are present and approved.
 - The deterministic memory router now has a disabled-by-default runtime status gate, optional non-persistent observation trace packets, and a governed non-persistent trace collector; it is not yet used for prompt injection or backend recall in production chat.
@@ -73,11 +76,11 @@ Important non-complete truth:
 | Capability profiles | Complete foundation | `services/zoe-data/zoe_capability_profile.py`, `services/zoe-data/tests/test_zoe_capability_profile.py`, and `docs/architecture/zoe-capability-profiles.md` define the first executable Zoe capability self-model. | Wire profiles into candidate scoring, self-evolution proposals, and cleanup gates. |
 | Candidate scoring | Complete foundation | `services/zoe-data/zoe_candidate_scoring.py`, `services/zoe-data/tests/test_zoe_candidate_scoring.py`, and `docs/architecture/zoe-candidate-scoring.md` define candidate scoring and adoption gates. | Attach candidate scores to self-evolution proposal records before installs or replacements. |
 | Pi runtime harness | Partial | `services/zoe-data/pi_runtime_probe.py`, `scripts/maintenance/pi_runtime_probe.py`, and `docs/architecture/zoe-pi-runtime-harness.md` detect Pi readiness without installing or executing Pi. Current Zoe host lacks Node/npm/Pi. | Create an approved install/runtime proposal with local model evidence before delegated Pi execution. |
-| Observation/evaluation traces | Complete foundation | `services/zoe-data/zoe_observation_trace.py`, `services/zoe-data/zoe_observation_trace_collector.py`, `services/zoe-data/zoe_evolution_outcome_memory.py`, tests, `docs/architecture/zoe-observation-trace-schema.md`, and `docs/architecture/zoe-observation-trace-collector.md` define trace records, non-persistent collection gates, and pending outcome-memory candidates for memory route decisions, recall, retain candidate, admission, contradiction, fallback, proposal, verification, outcome eval, and hardware-budget events. | Wire runtime callers through the collector, then route outcome memory candidates through memory admission before any durable promotion. |
-| Memory admission governance | Complete foundation | `services/zoe-data/zoe_memory_admission.py`, `services/zoe-data/hindsight_retain_candidates.py`, `services/zoe-data/zoe_multica_memory_admission.py`, tests, and `docs/architecture/zoe-memory-admission-gates.md` define evidence, trace, approval, graph, Multica review metadata, and self-evolution proposal gates before durable memory writes; Hindsight retain candidates and Multica review records can now build/evaluate admission requests before promotion. | Route future Hindsight, MemPalace, Graphiti, and outcome-memory durable writers through admission before any backend write. |
+| Observation/evaluation traces | Complete foundation | `services/zoe-data/zoe_observation_trace.py`, `services/zoe-data/zoe_observation_trace_collector.py`, `services/zoe-data/zoe_evolution_outcome_memory.py`, tests, `docs/architecture/zoe-observation-trace-schema.md`, and `docs/architecture/zoe-observation-trace-collector.md` define trace records, non-persistent collection gates, and pending outcome-memory candidates for memory route decisions, recall, retain candidate, admission, contradiction, fallback, proposal, verification, outcome eval, and hardware-budget events. | Wire runtime callers through the collector, then pass outcome memory admission decisions into durable writer gates. |
+| Memory admission governance | Complete foundation | `services/zoe-data/zoe_memory_admission.py`, `services/zoe-data/hindsight_retain_candidates.py`, `services/zoe-data/zoe_multica_memory_admission.py`, `services/zoe-data/zoe_evolution_outcome_admission.py`, tests, and `docs/architecture/zoe-memory-admission-gates.md` define evidence, trace, approval, graph, Multica review metadata, outcome memory admission, and self-evolution proposal gates before durable memory writes; Hindsight retain candidates, Multica review records, and terminal evolution outcomes can now build/evaluate admission requests before promotion. | Route future Hindsight, MemPalace, Graphiti, and outcome-memory durable writers through admission decisions before any backend write. |
 | Multica evidence gates | Partial | Implement completion now requires PR evidence for code/default profiles, memory admission has a tested decision contract, Multica admission requires matching Zoe proposal contract markers before dispatching evolution-proposal tickets, execute/promote proposal tickets must pass the execution approval gate before dispatch, and Multica memory review metadata can be evaluated as an inert admission decision. | Capture verified outcomes back into memory/capability trust, then wire runtime durable writers through memory admission decisions. |
 | Self-evolution proposal records | Runtime writers wired | `services/zoe-data/zoe_evolution_proposal.py`, `services/zoe-data/zoe_evolution_proposal_adapter.py`, tests, and `docs/architecture/zoe-evolution-proposal-contract.md` define structured Notice -> Explain -> Search -> Evaluate -> Propose records. MCP proposal creation, nightly NOTICE proposals, user-frustration proposals, and explicit user issue reports now store validated contract snapshots while preserving the legacy row shape and MEASURE target patterns; Multica tickets receive compact contract markers for admission. | Require approval evidence before installs/replacements and connect verified outcomes back to memory/capability trust. |
-| Self-evolution loop | Partial | Multica, pipeline evidence, Greploop, Greptile, Hermes, worktree bootstrap, candidate scoring, proposal contract, contract-aware Multica admission, live execution approval gating for execute/promote proposal tickets, and inert outcome-memory candidate construction exist. | Route verified/failed/retired outcome candidates through memory admission, then update capability trust only after approved durable promotion. |
+| Self-evolution loop | Partial | Multica, pipeline evidence, Greploop, Greptile, Hermes, worktree bootstrap, candidate scoring, proposal contract, contract-aware Multica admission, live execution approval gating for execute/promote proposal tickets, inert outcome-memory candidate construction, and outcome admission decisions exist. | Update capability trust only after approved durable promotion and verified runtime writer evidence. |
 | Main engine cleanup | Deferred | `zoe_agent.py` remains large and active. | Start only after inventories and chat/memory/tool dispatch tests are strong enough to prevent regressions. |
 
 ## Missing Work By Capability
@@ -202,11 +205,13 @@ Keep each pull request small enough for Greptile and Zoe verification.
    - `zoe_memory_router_runtime.py` and `/api/system/memory-router/status` expose disabled-by-default route decisions without prompt injection or writes.
    - Next: wire prompt-time recall in fallback-safe mode with latency timeout and compact cited memory packets.
 8. Memory admission governance.
-   - Status: complete foundation with Multica review bridge.
+   - Status: complete foundation with Multica review and outcome memory bridges.
    - `zoe_memory_admission.py` now gates durable memory writes on approval refs, successful admission/verification traces, graph edge requirements, user/scope matching, and proposal context for self-evolution memories.
    - Hindsight retain candidates can now build and evaluate admission requests before any durable promotion.
    - Multica memory review metadata can now be converted into the same inert decision: missing approval stays pending, explicit approval creates approval evidence, and blocked reviews fail closed.
-   - Next: route future Hindsight, MemPalace, and Graphiti durable writers through the decision before backend writes.
+   - Terminal proposal outcomes can now be converted into pending memory
+     candidates and evaluated through admission before any durable promotion.
+   - Next: route future Hindsight, MemPalace, Graphiti, and outcome-memory durable writers through admission decisions before backend writes.
 9. Self-evolution proposal records.
     - Status: foundation complete and live proposal writers now emit validated contract snapshots into `target_patterns`; Multica admission requires matching contract markers before dispatching evolution-proposal tickets.
     - Next: require approval evidence before installs/replacements and connect verified outcomes back to memory/capability trust.
@@ -228,6 +233,8 @@ Keep each pull request small enough for Greptile and Zoe verification.
     - Convert recurring failures into Notice records.
     - Convert terminal proposal outcomes into pending self-evolution memory
       candidates, not durable trusted facts.
+    - Evaluate terminal outcome candidates through memory admission before any
+      backend writer can promote them.
 14. Main engine cleanup.
     - Split only protected, well-understood areas in `zoe_agent.py`.
     - Remove duplicate or retired memory paths only after inventory and tests.

--- a/services/zoe-data/tests/test_zoe_evolution_outcome_admission.py
+++ b/services/zoe-data/tests/test_zoe_evolution_outcome_admission.py
@@ -1,6 +1,7 @@
 import pytest
 
 from zoe_candidate_scoring import CandidateEvaluation, CandidateScore
+from zoe_evolution_outcome_memory import EvolutionOutcomeMemoryError
 from zoe_evolution_outcome_admission import (
     DEFAULT_EVOLUTION_OUTCOME_TARGET_BACKENDS,
     build_evolution_outcome_admission_request,
@@ -166,6 +167,37 @@ def test_failed_outcome_remains_pending_only_and_never_trusted_durable_memory():
     assert result.decision.allowed_to_write_durable is False
     assert "failed_or_blocked_trace_present" in result.decision.blockers
     assert "proposal_must_be_approved_or_verified" in result.decision.blockers
+
+
+def test_retired_outcome_remains_blocked_until_retirement_memory_policy_exists():
+    retired_trace = _verification_trace(
+        trace_id="trace_retired_memory_gate",
+        outcome=ObservationOutcome.PARTIAL.value,
+        summary="Retirement evidence showed the old path was superseded.",
+        evidence_refs=("eval:retirement-review",),
+        confidence=0.7,
+    )
+
+    result = evaluate_evolution_outcome_admission(
+        _proposal(status=ProposalStatus.RETIRED.value),
+        (retired_trace,),
+        approval_refs=("approval:multica:ZOE-315",),
+    )
+
+    assert result.candidate.event_type == MemoryEventType.CAPABILITY.value
+    assert result.decision.status == MemoryAdmissionStatus.BLOCKED.value
+    assert result.decision.allowed_to_keep_pending is True
+    assert result.decision.allowed_to_write_durable is False
+    assert "proposal_must_be_approved_or_verified" in result.decision.blockers
+
+
+def test_retired_outcome_requires_matching_retirement_trace_before_admission_request():
+    with pytest.raises(EvolutionOutcomeMemoryError, match="retirement verification"):
+        build_evolution_outcome_admission_request(
+            _proposal(status=ProposalStatus.RETIRED.value),
+            (_verification_trace(outcome=ObservationOutcome.FAILED.value),),
+            approval_refs=("approval:multica:ZOE-316",),
+        )
 
 
 def test_result_serializes_candidate_request_and_decision():

--- a/services/zoe-data/tests/test_zoe_evolution_outcome_admission.py
+++ b/services/zoe-data/tests/test_zoe_evolution_outcome_admission.py
@@ -1,0 +1,197 @@
+import pytest
+
+from zoe_candidate_scoring import CandidateEvaluation, CandidateScore
+from zoe_evolution_outcome_admission import (
+    DEFAULT_EVOLUTION_OUTCOME_TARGET_BACKENDS,
+    build_evolution_outcome_admission_request,
+    evaluate_evolution_outcome_admission,
+)
+from zoe_evolution_proposal import (
+    EvolutionSignal,
+    EvolutionSignalType,
+    ProposalRisk,
+    ProposalStatus,
+    TrustAutonomyClass,
+    build_evolution_proposal,
+)
+from zoe_memory_admission import MemoryAdmissionError, MemoryAdmissionStatus
+from zoe_memory_contract import MemoryEventType
+from zoe_memory_router import MemoryBackend
+from zoe_observation_trace import ObservationOutcome, ObservationTrace, ObservationTraceType
+
+
+def _candidate():
+    return CandidateEvaluation(
+        candidate_id="existing_memory_gate",
+        name="Existing Zoe memory gate",
+        source="existing_zoe",
+        task="memory governance",
+        score=CandidateScore(
+            fit=5,
+            activity=4,
+            license=5,
+            offline=5,
+            security=5,
+            footprint=5,
+            tests=5,
+            maintainability=4,
+            overlap=5,
+        ),
+        evidence_refs=("docs:memory-gate",),
+        license_risk="compatible",
+        offline_viability="required",
+        recommendation="keep",
+    )
+
+
+def _signal(user_id="jason", scope="project"):
+    return EvolutionSignal(
+        signal_id="signal_memory_gate",
+        signal_type=EvolutionSignalType.USER_REQUEST.value,
+        summary="User asked Zoe to retain verified self-evolution outcomes.",
+        source="chat",
+        evidence_refs=("chat:self-evolution-outcomes",),
+        user_id=user_id,
+        scope=scope,
+    )
+
+
+def _proposal(status=ProposalStatus.VERIFIED.value, approval_required=("pr_evidence", "memory_admission"), **overrides):
+    values = {
+        "proposal_id": "proposal_memory_gate",
+        "title": "Retain verified evolution outcomes",
+        "problem_statement": "Zoe needs retained evidence for changes that worked or failed.",
+        "signals": (_signal(),),
+        "candidate": _candidate(),
+        "affected_capabilities": ("memory_admission", "self_evolution_loop"),
+        "autonomy_class": TrustAutonomyClass.PROMOTE.value,
+        "risk": ProposalRisk.MEDIUM.value,
+        "expected_benefit": "Zoe learns from verified outcomes without blind durable writes.",
+        "verification_plan": ("pytest:test_zoe_evolution_outcome_admission",),
+        "rollback_plan": "Do not retain the outcome candidate.",
+        "approval_required": approval_required,
+        "status": status,
+    }
+    values.update(overrides)
+    return build_evolution_proposal(**values)
+
+
+def _verification_trace(**overrides):
+    values = {
+        "trace_id": "trace_verify_memory_gate",
+        "trace_type": ObservationTraceType.VERIFICATION.value,
+        "surface": "multica",
+        "scope": "project",
+        "outcome": ObservationOutcome.SUCCESS.value,
+        "summary": "Focused tests and validators passed.",
+        "evidence_refs": ("pytest:test_zoe_evolution_outcome_admission", "pr:310"),
+        "user_id": "jason",
+        "subject_id": "proposal_memory_gate",
+        "confidence": 0.92,
+    }
+    values.update(overrides)
+    return ObservationTrace(**values)
+
+
+def test_verified_outcome_without_memory_approval_stays_pending():
+    result = evaluate_evolution_outcome_admission(_proposal(), (_verification_trace(),))
+
+    assert result.candidate.event_type == MemoryEventType.FIX.value
+    assert result.request.target_backends == DEFAULT_EVOLUTION_OUTCOME_TARGET_BACKENDS
+    assert result.request.proposal.proposal_id == "proposal_memory_gate"
+    assert result.decision.status == MemoryAdmissionStatus.PENDING_REVIEW.value
+    assert result.decision.allowed_to_keep_pending is True
+    assert result.decision.allowed_to_write_durable is False
+    assert result.decision.blockers == ("approval_required",)
+    assert result.decision.required_approvals == ("memory_admission", "self_evolution_proposal")
+
+
+def test_verified_outcome_with_memory_approval_can_write_hindsight_candidate():
+    result = evaluate_evolution_outcome_admission(
+        _proposal(),
+        (_verification_trace(),),
+        approval_refs=("approval:multica:ZOE-310",),
+    )
+
+    assert result.decision.status == MemoryAdmissionStatus.APPROVED.value
+    assert result.decision.allowed_to_write_durable is True
+    assert result.decision.allowed_backends == (MemoryBackend.HINDSIGHT.value,)
+    assert result.decision.blockers == ()
+    assert "approval:multica:ZOE-310" in result.decision.evidence_refs
+
+
+def test_outcome_admission_requires_proposal_memory_admission_gate():
+    proposal = _proposal(approval_required=("pr_evidence",))
+
+    with pytest.raises(MemoryAdmissionError, match="must require memory_admission"):
+        build_evolution_outcome_admission_request(proposal, (_verification_trace(),))
+
+
+def test_graphiti_target_is_allowed_for_relational_outcome_candidate():
+    result = evaluate_evolution_outcome_admission(
+        _proposal(),
+        (_verification_trace(),),
+        target_backends=(MemoryBackend.GRAPHITI.value,),
+        approval_refs=("approval:multica:ZOE-311",),
+    )
+
+    assert result.candidate.relationships
+    assert result.decision.status == MemoryAdmissionStatus.APPROVED.value
+    assert result.decision.allowed_backends == (MemoryBackend.GRAPHITI.value,)
+    assert result.decision.required_approvals == (
+        "memory_admission",
+        "self_evolution_proposal",
+        "relational_truth",
+    )
+
+
+def test_failed_outcome_remains_pending_only_and_never_trusted_durable_memory():
+    failed_trace = _verification_trace(
+        trace_id="trace_failed_memory_gate",
+        outcome=ObservationOutcome.FAILED.value,
+        summary="Verification failed because approval evidence was missing.",
+        evidence_refs=("pytest:failed-memory-gate",),
+        confidence=0.8,
+    )
+
+    result = evaluate_evolution_outcome_admission(
+        _proposal(status=ProposalStatus.FAILED.value),
+        (failed_trace,),
+        approval_refs=("approval:multica:ZOE-312",),
+    )
+
+    assert result.candidate.event_type == MemoryEventType.FAILURE.value
+    assert result.decision.status == MemoryAdmissionStatus.BLOCKED.value
+    assert result.decision.allowed_to_keep_pending is True
+    assert result.decision.allowed_to_write_durable is False
+    assert "failed_or_blocked_trace_present" in result.decision.blockers
+    assert "proposal_must_be_approved_or_verified" in result.decision.blockers
+
+
+def test_result_serializes_candidate_request_and_decision():
+    result = evaluate_evolution_outcome_admission(
+        _proposal(),
+        (_verification_trace(),),
+        approval_refs=("approval:multica:ZOE-313",),
+        metadata={"review": "operator-approved"},
+    )
+
+    payload = result.to_dict()
+
+    assert payload["candidate"]["event_id"] == "mem_evt_evolution_outcome_proposal_memory_gate"
+    assert payload["request"]["admission_id"] == "admit_evolution_outcome_proposal_memory_gate"
+    assert payload["request"]["metadata"]["extra"] == {"review": "operator-approved"}
+    assert payload["decision"]["status"] == MemoryAdmissionStatus.APPROVED.value
+
+
+def test_none_items_are_ignored_in_backend_and_approval_sequences():
+    result = evaluate_evolution_outcome_admission(
+        _proposal(),
+        (_verification_trace(),),
+        target_backends=(None, MemoryBackend.HINDSIGHT.value),
+        approval_refs=(None, "approval:multica:ZOE-314"),
+    )
+
+    assert result.request.target_backends == (MemoryBackend.HINDSIGHT.value,)
+    assert result.request.approval_refs == ("approval:multica:ZOE-314",)
+    assert result.decision.status == MemoryAdmissionStatus.APPROVED.value

--- a/services/zoe-data/zoe_evolution_outcome_admission.py
+++ b/services/zoe-data/zoe_evolution_outcome_admission.py
@@ -1,0 +1,131 @@
+"""Route Zoe evolution outcome memory candidates through admission gates.
+
+This module is intentionally inert. It combines the terminal-proposal outcome
+memory builder with the existing memory admission contract, returning the
+candidate, request, and decision without writing to MemoryService, Hindsight,
+Graphiti, MemPalace, or Multica.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Sequence
+
+from zoe_evolution_outcome_memory import build_evolution_outcome_memory_event
+from zoe_evolution_proposal import EvolutionProposal
+from zoe_memory_admission import MemoryAdmissionDecision, MemoryAdmissionRequest, evaluate_memory_admission
+from zoe_memory_contract import MemoryEvent
+from zoe_memory_router import MemoryBackend
+from zoe_observation_trace import ObservationTrace
+
+
+EVOLUTION_OUTCOME_ADMISSION_SOURCE = "evolution_outcome_memory"
+DEFAULT_EVOLUTION_OUTCOME_TARGET_BACKENDS = (MemoryBackend.HINDSIGHT.value,)
+
+
+@dataclass(frozen=True)
+class EvolutionOutcomeAdmissionResult:
+    candidate: MemoryEvent
+    request: MemoryAdmissionRequest
+    decision: MemoryAdmissionDecision
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "candidate": self.candidate.to_dict(),
+            "request": {
+                "admission_id": self.request.admission_id,
+                "requested_by": self.request.requested_by,
+                "target_backends": list(self.request.target_backends),
+                "approval_refs": list(self.request.approval_refs),
+                "trace_ids": [trace.trace_id for trace in self.request.observation_traces],
+                "proposal_id": self.request.proposal.proposal_id if self.request.proposal else None,
+                "metadata": dict(self.request.metadata or {}),
+            },
+            "decision": self.decision.to_dict(),
+        }
+
+
+def build_evolution_outcome_admission_request(
+    proposal: EvolutionProposal,
+    traces: Sequence[ObservationTrace],
+    *,
+    admission_id: str | None = None,
+    requested_by: str = EVOLUTION_OUTCOME_ADMISSION_SOURCE,
+    target_backends: Sequence[str] = DEFAULT_EVOLUTION_OUTCOME_TARGET_BACKENDS,
+    approval_refs: Sequence[str] = (),
+    user_id: str | None = None,
+    scope: str | None = None,
+    event_id: str | None = None,
+    metadata: Mapping[str, Any] | None = None,
+) -> MemoryAdmissionRequest:
+    """Build the admission request for an evolution outcome memory candidate."""
+
+    candidate = build_evolution_outcome_memory_event(
+        proposal,
+        traces,
+        user_id=user_id,
+        scope=scope,
+        event_id=event_id,
+    )
+    request = MemoryAdmissionRequest(
+        admission_id=admission_id or f"admit_evolution_outcome_{proposal.proposal_id}",
+        candidate=candidate,
+        requested_by=requested_by,
+        target_backends=_clean_sequence(target_backends),
+        observation_traces=tuple(traces),
+        approval_refs=_clean_sequence(approval_refs),
+        proposal=proposal,
+        metadata={
+            "source": EVOLUTION_OUTCOME_ADMISSION_SOURCE,
+            "proposal_id": proposal.proposal_id,
+            "candidate_event_id": candidate.event_id,
+            "outcome_status": proposal.status,
+            "extra": dict(metadata or {}),
+        },
+    )
+    request.validate()
+    return request
+
+
+def evaluate_evolution_outcome_admission(
+    proposal: EvolutionProposal,
+    traces: Sequence[ObservationTrace],
+    *,
+    admission_id: str | None = None,
+    requested_by: str = EVOLUTION_OUTCOME_ADMISSION_SOURCE,
+    target_backends: Sequence[str] = DEFAULT_EVOLUTION_OUTCOME_TARGET_BACKENDS,
+    approval_refs: Sequence[str] = (),
+    user_id: str | None = None,
+    scope: str | None = None,
+    event_id: str | None = None,
+    metadata: Mapping[str, Any] | None = None,
+) -> EvolutionOutcomeAdmissionResult:
+    """Evaluate outcome memory admission without promoting durable memory."""
+
+    request = build_evolution_outcome_admission_request(
+        proposal,
+        traces,
+        admission_id=admission_id,
+        requested_by=requested_by,
+        target_backends=target_backends,
+        approval_refs=approval_refs,
+        user_id=user_id,
+        scope=scope,
+        event_id=event_id,
+        metadata=metadata,
+    )
+    decision = evaluate_memory_admission(request)
+    return EvolutionOutcomeAdmissionResult(candidate=request.candidate, request=request, decision=decision)
+
+
+def _clean_sequence(values: Sequence[str]) -> tuple[str, ...]:
+    return tuple(str(item) for item in values if item is not None and str(item))
+
+
+__all__ = [
+    "DEFAULT_EVOLUTION_OUTCOME_TARGET_BACKENDS",
+    "EVOLUTION_OUTCOME_ADMISSION_SOURCE",
+    "EvolutionOutcomeAdmissionResult",
+    "build_evolution_outcome_admission_request",
+    "evaluate_evolution_outcome_admission",
+]


### PR DESCRIPTION
## Summary
- add an inert bridge that builds terminal evolution outcome memory candidates and evaluates them through Zoe memory admission
- keep verified outcomes pending until memory admission approval evidence exists, and keep failed outcomes blocked from durable trust
- document that outcome memory promotion remains gated and non-persistent

## Verification
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_zoe_evolution_outcome_admission.py services/zoe-data/tests/test_zoe_evolution_outcome_memory.py services/zoe-data/tests/test_zoe_memory_admission.py services/zoe-data/tests/test_hindsight_retain_candidates.py services/zoe-data/tests/test_zoe_multica_memory_admission.py
- PYTHONPATH=services/zoe-data python3 -m py_compile services/zoe-data/zoe_evolution_outcome_admission.py
- python3 tools/audit/validate_structure.py
- python3 tools/audit/validate_critical_files.py
- python3 tools/audit/validate_offline_memory.py
- git diff --check