### PR TITLE
ZOE-5355: Add nginx security headers

### DIFF
--- a/services/zoe-data/tests/test_nginx_security_headers_helper.py
+++ b/services/zoe-data/tests/test_nginx_security_headers_helper.py
@@ -322,6 +322,7 @@ def test_ensure_headers_is_idempotent_and_replaces_managed_blocks():
 
     assert once == twice
     assert '"DENY"' not in once
+    assert '"SAMEORIGIN"' in once
     assert once.count(helper.BEGIN_MARKER) == 1
     assert "Strict-Transport-Security" not in once
     assert helper.missing_headers(once) == []

--- a/services/zoe-data/tests/test_nginx_security_headers_helper.py
+++ b/services/zoe-data/tests/test_nginx_security_headers_helper.py
@@ -308,7 +308,7 @@ def test_ensure_headers_is_idempotent_and_replaces_managed_blocks():
     server_name _;
 
     # BEGIN ZOE MANAGED SECURITY HEADERS
-    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Frame-Options "DENY" always;
     # END ZOE MANAGED SECURITY HEADERS
 
     location / {
@@ -321,7 +321,7 @@ def test_ensure_headers_is_idempotent_and_replaces_managed_blocks():
     twice = helper.ensure_headers(once)
 
     assert once == twice
-    assert "SAMEORIGIN" not in once
+    assert '"DENY"' not in once
     assert once.count(helper.BEGIN_MARKER) == 1
     assert "Strict-Transport-Security" not in once
     assert helper.missing_headers(once) == []
@@ -387,10 +387,10 @@ def test_missing_headers_requires_server_level_headers_when_location_has_headers
     location ~* \\.(js|css)$ {
         # BEGIN ZOE MANAGED SECURITY HEADERS
         add_header Content-Security-Policy "default-src 'self'" always;
-        add_header X-Frame-Options "DENY" always;
+        add_header X-Frame-Options "SAMEORIGIN" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-        add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+        add_header Permissions-Policy "camera=(), microphone=(self), geolocation=()" always;
         # END ZOE MANAGED SECURITY HEADERS
         add_header Cache-Control "no-cache";
     }

--- a/services/zoe-ui/nginx.conf
+++ b/services/zoe-ui/nginx.conf
@@ -15,7 +15,23 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # BEGIN ZOE MANAGED SECURITY HEADERS
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' ws: wss:; frame-ancestors 'none';" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+    # END ZOE MANAGED SECURITY HEADERS
+
     location ~* \.(js|css)$ {
+        # BEGIN ZOE MANAGED SECURITY HEADERS
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' ws: wss:; frame-ancestors 'none';" always;
+        add_header X-Frame-Options "DENY" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+        # END ZOE MANAGED SECURITY HEADERS
+
         add_header Cache-Control "no-cache, must-revalidate";
         try_files $uri =404;
     }
@@ -316,7 +332,25 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # BEGIN ZOE MANAGED SECURITY HEADERS
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' ws: wss:; frame-ancestors 'none';" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    # END ZOE MANAGED SECURITY HEADERS
+
     location ~* \.(js|css)$ {
+        # BEGIN ZOE MANAGED SECURITY HEADERS
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' ws: wss:; frame-ancestors 'none';" always;
+        add_header X-Frame-Options "DENY" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+        # END ZOE MANAGED SECURITY HEADERS
+
         add_header Cache-Control "no-cache, must-revalidate";
         try_files $uri =404;
     }
@@ -605,6 +639,15 @@ server {
     ssl_certificate_key /etc/nginx/ssl/zoe.key;
     ssl_protocols TLSv1.2 TLSv1.3;
     ssl_prefer_server_ciphers off;
+
+    # BEGIN ZOE MANAGED SECURITY HEADERS
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' ws: wss:; frame-ancestors 'none';" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    # END ZOE MANAGED SECURITY HEADERS
 
     location / {
         proxy_pass http://host.docker.internal:18789;

--- a/services/zoe-ui/nginx.conf
+++ b/services/zoe-ui/nginx.conf
@@ -16,20 +16,20 @@ server {
     index index.html;
 
     # BEGIN ZOE MANAGED SECURITY HEADERS
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' ws: wss:; frame-ancestors 'none';" always;
-    add_header X-Frame-Options "DENY" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self'; frame-ancestors 'self';" always;
+    add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-    add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+    add_header Permissions-Policy "camera=(), microphone=(self), geolocation=()" always;
     # END ZOE MANAGED SECURITY HEADERS
 
     location ~* \.(js|css)$ {
         # BEGIN ZOE MANAGED SECURITY HEADERS
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' ws: wss:; frame-ancestors 'none';" always;
-        add_header X-Frame-Options "DENY" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self'; frame-ancestors 'self';" always;
+        add_header X-Frame-Options "SAMEORIGIN" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-        add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+        add_header Permissions-Policy "camera=(), microphone=(self), geolocation=()" always;
         # END ZOE MANAGED SECURITY HEADERS
 
         add_header Cache-Control "no-cache, must-revalidate";
@@ -333,21 +333,21 @@ server {
     index index.html;
 
     # BEGIN ZOE MANAGED SECURITY HEADERS
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' ws: wss:; frame-ancestors 'none';" always;
-    add_header X-Frame-Options "DENY" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self'; frame-ancestors 'self';" always;
+    add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-    add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+    add_header Permissions-Policy "camera=(), microphone=(self), geolocation=()" always;
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
     # END ZOE MANAGED SECURITY HEADERS
 
     location ~* \.(js|css)$ {
         # BEGIN ZOE MANAGED SECURITY HEADERS
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' ws: wss:; frame-ancestors 'none';" always;
-        add_header X-Frame-Options "DENY" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self'; frame-ancestors 'self';" always;
+        add_header X-Frame-Options "SAMEORIGIN" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-        add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+        add_header Permissions-Policy "camera=(), microphone=(self), geolocation=()" always;
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
         # END ZOE MANAGED SECURITY HEADERS
 
@@ -641,11 +641,11 @@ server {
     ssl_prefer_server_ciphers off;
 
     # BEGIN ZOE MANAGED SECURITY HEADERS
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' ws: wss:; frame-ancestors 'none';" always;
-    add_header X-Frame-Options "DENY" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self'; frame-ancestors 'self';" always;
+    add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-    add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+    add_header Permissions-Policy "camera=(), microphone=(self), geolocation=()" always;
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
     # END ZOE MANAGED SECURITY HEADERS
 

--- a/tools/audit/ensure_nginx_security_headers.py
+++ b/tools/audit/ensure_nginx_security_headers.py
@@ -28,12 +28,12 @@ SECURITY_HEADERS: tuple[tuple[str, str], ...] = (
         # compatibility. Keep this explicit so future security audits can tighten it.
         "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; "
         "style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; "
-        "font-src 'self'; connect-src 'self' ws: wss:; frame-ancestors 'none';",
+        "font-src 'self'; connect-src 'self'; frame-ancestors 'self';",
     ),
-    ("X-Frame-Options", "DENY"),
+    ("X-Frame-Options", "SAMEORIGIN"),
     ("X-Content-Type-Options", "nosniff"),
     ("Referrer-Policy", "strict-origin-when-cross-origin"),
-    ("Permissions-Policy", "camera=(), microphone=(), geolocation=()"),
+    ("Permissions-Policy", "camera=(), microphone=(self), geolocation=()"),
 )
 HSTS_HEADER = ("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
 TLS_LISTEN_RE = re.compile(r"^\s*listen\b[^;]*\b(?:443|ssl)\b", re.MULTILINE)


### PR DESCRIPTION
## Summary
- add managed nginx security headers using tools/audit/ensure_nginx_security_headers.py
- include CSP, X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Permissions-Policy, and TLS-scoped HSTS
- preserve nginx add_header inheritance by applying managed headers to static asset locations that define add_header

## Tests
- python3 tools/audit/ensure_nginx_security_headers.py --check
- python3 tools/audit/validate_structure.py

## Harness note
Hermes completed helper/check/validate/commit/push, then the task was interrupted during PR creation, so Codex opened this PR from the pushed worker branch.