### PR TITLE
Block partial capability trust review results

### DIFF
--- a/services/zoe-data/tests/test_zoe_capability_trust_review.py
+++ b/services/zoe-data/tests/test_zoe_capability_trust_review.py
@@ -183,6 +183,36 @@ def test_capability_trust_review_keeps_candidate_blockers_isolated():
     assert "hindsight_reflective_memory" not in second_reason
 
 
+def test_capability_trust_review_returns_base_profiles_when_any_candidate_blocks():
+    approved = _candidate(
+        capability_id="hindsight_reflective_memory",
+        current_trust_level="experimental",
+        proposed_trust_level="assisted",
+    )
+    rejected = _candidate(
+        capability_id="openclaw_fallback",
+        current_trust_level="assisted",
+        proposed_trust_level="trusted",
+    )
+
+    result = review_capability_trust_update_plan(
+        _plan(approved, rejected),
+        reviewer_id="multica:reviewer",
+        approval_refs=("approval:multica:ZOE-322",),
+        approved_capability_ids=("hindsight_reflective_memory",),
+        rejected_capability_ids=("openclaw_fallback",),
+        profiles=DEFAULT_CAPABILITY_PROFILES,
+    )
+
+    by_id = {profile.capability_id: profile for profile in result.profiles}
+    assert result.allowed_to_apply is False
+    assert result.applied_capability_ids == ()
+    assert result.decisions[0].approved is True
+    assert result.decisions[1].approved is False
+    assert "review_rejected:openclaw_fallback" in result.blockers
+    assert by_id["hindsight_reflective_memory"].trust_level == "experimental"
+
+
 def test_capability_trust_review_rejects_invalid_promoted_profile():
     profile = CapabilityProfile(
         capability_id="scratch_memory_candidate",

--- a/services/zoe-data/zoe_capability_trust_review.py
+++ b/services/zoe-data/zoe_capability_trust_review.py
@@ -70,6 +70,8 @@ class CapabilityTrustReviewResult:
 
     @property
     def applied_capability_ids(self) -> tuple[str, ...]:
+        if self.blockers:
+            return ()
         return tuple(decision.candidate.capability_id for decision in self.decisions if decision.approved)
 
     def to_dict(self) -> dict[str, Any]:
@@ -167,11 +169,16 @@ def review_capability_trust_update_plan(
             )
         )
 
-    updated_profiles = tuple(profile_updates.get(profile.capability_id, profile) for profile in base_profiles)
+    deduped_blockers = tuple(dict.fromkeys(result_blockers))
+    updated_profiles = (
+        base_profiles
+        if deduped_blockers
+        else tuple(profile_updates.get(profile.capability_id, profile) for profile in base_profiles)
+    )
     return CapabilityTrustReviewResult(
         decisions=tuple(decisions),
         profiles=updated_profiles,
-        blockers=tuple(dict.fromkeys(result_blockers)),
+        blockers=deduped_blockers,
     )
 
 


### PR DESCRIPTION
## Summary
- prevent blocked mixed trust-review plans from returning partially promoted profiles
- make applied_capability_ids empty whenever the overall review result has blockers
- add a mixed approved/rejected candidate regression test

## Verification
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_zoe_capability_trust_review.py services/zoe-data/tests/test_zoe_capability_trust_update.py services/zoe-data/tests/test_zoe_capability_profile.py services/zoe-data/tests/test_zoe_evolution_outcome_retain.py services/zoe-data/tests/test_zoe_evolution_outcome_admission.py services/zoe-data/tests/test_hindsight_retain_executor.py services/zoe-data/tests/test_hindsight_memory.py services/zoe-data/tests/test_zoe_memory_admission.py
- PYTHONPATH=services/zoe-data python3 -m py_compile services/zoe-data/zoe_capability_trust_review.py
- python3 tools/audit/validate_structure.py
- python3 tools/audit/validate_critical_files.py
- python3 tools/audit/validate_offline_memory.py
- git diff --check