### PR TITLE
Recover pushed Kanban PR handoffs

### DIFF
--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -1023,6 +1023,8 @@ class KanbanAdapter:
         for command in shell_commands:
             if "git push -u origin HEAD" not in command:
                 continue
+            if "gh pr create" in command:
+                return True
             if re.search(r"\[exit\s+[1-9]\d*\]", command, re.IGNORECASE):
                 continue
             return True

--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -1018,8 +1018,11 @@ class KanbanAdapter:
             match = _SHELL_TOOL_LINE_RE.search(line)
             if match:
                 shell_commands.append(match.group("command"))
-        if any("gh pr create" in command for command in shell_commands) or "PR_URL=" in log:
+        if "PR_URL=" in log:
             return False
+        for command in shell_commands:
+            if "gh pr create" in command and not re.search(r"\[exit\s+[1-9]\d*\]", command, re.IGNORECASE):
+                return False
         for command in shell_commands:
             if "git push -u origin HEAD" not in command:
                 continue
@@ -1027,6 +1030,43 @@ class KanbanAdapter:
                 return False
             return True
         return False
+
+    async def _complete_recovered_pr_handoff(
+        self,
+        task_id: str,
+        row: dict[str, Any],
+        pr_url: str,
+        *,
+        branch: str | None = None,
+    ) -> str:
+        summary = (
+            f"PR_URL={pr_url}\n"
+            "BLOCKER=\n"
+            "TESTS=recovered after pushed branch; downstream verify/review must validate\n"
+            "SUMMARY=Recovered PR handoff after worker interruption following git push"
+        )
+        metadata = {
+            "pr_url": pr_url,
+            "recovery": "pushed_branch_without_pr_handoff",
+        }
+        if branch:
+            metadata["branch"] = branch
+        await self._run(
+            [
+                "complete",
+                "--result",
+                summary,
+                "--summary",
+                summary,
+                "--metadata",
+                json.dumps(metadata, sort_keys=True),
+                task_id,
+            ]
+        )
+        row["status"] = "done"
+        row["result"] = summary
+        row["block_reason"] = None
+        return pr_url
 
     async def _maybe_recover_pushed_pr(
         self,
@@ -1051,7 +1091,7 @@ class KanbanAdapter:
         ):
             match = _GITHUB_PR_URL_RE.search(haystack)
             if match:
-                return match.group(0)
+                return await self._complete_recovered_pr_handoff(task_id, row, match.group(0))
 
         try:
             from worktree_bootstrap import worktree_path
@@ -1115,36 +1155,7 @@ class KanbanAdapter:
             if not match:
                 return None
             pr_url = match.group(0)
-            summary = (
-                f"PR_URL={pr_url}\n"
-                "BLOCKER=\n"
-                "TESTS=recovered after pushed branch; downstream verify/review must validate\n"
-                "SUMMARY=Recovered PR handoff after worker interruption following git push"
-            )
-            metadata = json.dumps(
-                {
-                    "pr_url": pr_url,
-                    "recovery": "pushed_branch_without_pr_handoff",
-                    "branch": branch,
-                },
-                sort_keys=True,
-            )
-            await self._run(
-                [
-                    "complete",
-                    "--result",
-                    summary,
-                    "--summary",
-                    summary,
-                    "--metadata",
-                    metadata,
-                    task_id,
-                ]
-            )
-            row["status"] = "done"
-            row["result"] = summary
-            row["block_reason"] = None
-            return pr_url
+            return await self._complete_recovered_pr_handoff(task_id, row, pr_url, branch=branch)
         except Exception as exc:  # noqa: BLE001 - recovery must not break normal poll.
             logger.warning("kanban_adapter: pushed PR recovery failed for %s: %s", task_id, exc)
             return None

--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -77,6 +77,7 @@ _JOKE_INTENT_GAP_TITLE_RE = re.compile(
     re.IGNORECASE,
 )
 _GITHUB_PR_URL_RE = re.compile(r"https://github\.com/[^/\s]+/[^/\s]+/pull/\d+")
+_SHELL_TOOL_LINE_RE = re.compile(r"(?:^|\s)(?:💻\s+)?\$\s+(?P<command>.+)$")
 
 
 def _row_ref_key(row: dict) -> str:
@@ -604,6 +605,8 @@ class KanbanAdapter:
         except asyncio.TimeoutError as exc:
             with contextlib.suppress(ProcessLookupError):
                 proc.kill()
+            with contextlib.suppress(Exception):
+                await proc.communicate()
             raise KanbanCLIError(f"`{' '.join(args)}` timed out after {timeout:.0f}s") from exc
         stdout = (out or b"").decode("utf-8", errors="replace").strip()
         stderr = (err or b"").decode("utf-8", errors="replace").strip()
@@ -1010,14 +1013,17 @@ class KanbanAdapter:
     def _pushed_branch_without_pr_handoff(self, task_id: str) -> bool:
         """True when a worker pushed HEAD then got interrupted before PR handoff."""
         log = latest_log_session(task_id, max_lines=120)
-        if "git push -u origin HEAD" not in log:
-            return False
-        if "gh pr create" in log or "PR_URL=" in log:
-            return False
+        shell_commands: list[str] = []
         for line in log.splitlines():
-            if "git push -u origin HEAD" not in line:
+            match = _SHELL_TOOL_LINE_RE.search(line)
+            if match:
+                shell_commands.append(match.group("command"))
+        if any("gh pr create" in command for command in shell_commands) or "PR_URL=" in log:
+            return False
+        for command in shell_commands:
+            if "git push -u origin HEAD" not in command:
                 continue
-            if re.search(r"\[exit\s+[1-9]\d*\]", line, re.IGNORECASE):
+            if re.search(r"\[exit\s+[1-9]\d*\]", command, re.IGNORECASE):
                 return False
             return True
         return False

--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -1021,9 +1021,6 @@ class KanbanAdapter:
         if "PR_URL=" in log:
             return False
         for command in shell_commands:
-            if "gh pr create" in command and not re.search(r"\[exit\s+[1-9]\d*\]", command, re.IGNORECASE):
-                return False
-        for command in shell_commands:
             if "git push -u origin HEAD" not in command:
                 continue
             if re.search(r"\[exit\s+[1-9]\d*\]", command, re.IGNORECASE):

--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -1088,7 +1088,15 @@ class KanbanAdapter:
         ):
             match = _GITHUB_PR_URL_RE.search(haystack)
             if match:
-                return await self._complete_recovered_pr_handoff(task_id, row, match.group(0))
+                try:
+                    return await self._complete_recovered_pr_handoff(task_id, row, match.group(0))
+                except Exception as exc:  # noqa: BLE001 - recovery must not break normal poll.
+                    logger.warning(
+                        "kanban_adapter: pushed PR recovery from existing URL failed for %s: %s",
+                        task_id,
+                        exc,
+                    )
+                    return None
 
         try:
             from worktree_bootstrap import worktree_path

--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -1024,7 +1024,7 @@ class KanbanAdapter:
             if "git push -u origin HEAD" not in command:
                 continue
             if re.search(r"\[exit\s+[1-9]\d*\]", command, re.IGNORECASE):
-                return False
+                continue
             return True
         return False
 
@@ -1120,6 +1120,15 @@ class KanbanAdapter:
                     )
                 ).strip()
             except KanbanCLIError:
+                pr_url = ""
+            if pr_url and not _GITHUB_PR_URL_RE.search(pr_url):
+                logger.warning(
+                    "kanban_adapter: gh pr view returned no PR URL for recovered task %s: %s",
+                    task_id,
+                    pr_url,
+                )
+                pr_url = ""
+            if not pr_url:
                 try:
                     upstream = (
                         await self._run_worktree_command(

--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -20,6 +20,7 @@ Worker profiles + pinned skills encode Zoe's agentic-engineering loop:
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import logging
 import os
@@ -29,6 +30,7 @@ from typing import Any
 
 from hermes_http import hermes_bin, zoe_repo_root
 from kanban_phase_budget import (
+    latest_log_session,
     phase_budget_reason,
     phase_budget_reason_from_log,
     task_log_tail,
@@ -74,6 +76,7 @@ _JOKE_INTENT_GAP_TITLE_RE = re.compile(
     r"\bintent[- ]gap\b.*['\"]?(?:tell\s+me\s+(?:another\s+)?joke|joke)['\"]?",
     re.IGNORECASE,
 )
+_GITHUB_PR_URL_RE = re.compile(r"https://github\.com/[^/\s]+/[^/\s]+/pull/\d+")
 
 
 def _row_ref_key(row: dict) -> str:
@@ -583,6 +586,31 @@ class KanbanAdapter:
         except json.JSONDecodeError as exc:
             raise KanbanCLIError(f"non-JSON output from kanban {args[0]}: {exc}: {stdout[:200]}")
 
+    async def _run_worktree_command(
+        self,
+        args: list[str],
+        *,
+        cwd: Path,
+        timeout: float = 45.0,
+    ) -> str:
+        proc = await asyncio.create_subprocess_exec(
+            *args,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            cwd=str(cwd),
+        )
+        try:
+            out, err = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+        except asyncio.TimeoutError as exc:
+            with contextlib.suppress(ProcessLookupError):
+                proc.kill()
+            raise KanbanCLIError(f"`{' '.join(args)}` timed out after {timeout:.0f}s") from exc
+        stdout = (out or b"").decode("utf-8", errors="replace").strip()
+        stderr = (err or b"").decode("utf-8", errors="replace").strip()
+        if proc.returncode != 0:
+            raise KanbanCLIError(f"`{' '.join(args)}` exited {proc.returncode}: {stderr or stdout}")
+        return stdout
+
     async def _phases_for_ref(self, external_ref: str) -> dict[str, dict]:
         tasks = await self._run(["list", "--json"], expect_json=True)
         if isinstance(tasks, list):
@@ -979,6 +1007,142 @@ class KanbanAdapter:
         logger.warning("kanban_adapter: stopped %s (%s): %s", task_id, phase, reason)
         return True
 
+    def _pushed_branch_without_pr_handoff(self, task_id: str) -> bool:
+        """True when a worker pushed HEAD then got interrupted before PR handoff."""
+        log = latest_log_session(task_id, max_lines=120)
+        if "git push -u origin HEAD" not in log:
+            return False
+        if "gh pr create" in log or "PR_URL=" in log:
+            return False
+        for line in log.splitlines():
+            if "git push -u origin HEAD" not in line:
+                continue
+            if re.search(r"\[exit\s+[1-9]\d*\]", line, re.IGNORECASE):
+                return False
+            return True
+        return False
+
+    async def _maybe_recover_pushed_pr(
+        self,
+        task_id: str,
+        phase: str,
+        row: dict[str, Any],
+        *,
+        issue: dict | None = None,
+        detail: dict[str, Any] | None = None,
+    ) -> str | None:
+        """Create/record a PR after the worker pushed but lost the terminal handoff."""
+        if phase != "implement" or (row.get("status") or "").lower() != "blocked":
+            return None
+        if not self._pushed_branch_without_pr_handoff(task_id):
+            return None
+
+        detail = detail or {}
+        for haystack in (
+            json.dumps(detail.get("latest_summary") or ""),
+            json.dumps(detail.get("comments") or []),
+            str(row.get("result") or ""),
+        ):
+            match = _GITHUB_PR_URL_RE.search(haystack)
+            if match:
+                return match.group(0)
+
+        try:
+            from worktree_bootstrap import worktree_path
+
+            task = detail.get("task") if isinstance(detail.get("task"), dict) else {}
+            wt_path = Path(
+                row.get("workspace_path")
+                or task.get("workspace_path")
+                or worktree_path(task_id)
+            ).expanduser()
+            if not wt_path.exists():
+                return None
+            branch = (
+                await self._run_worktree_command(
+                    ["git", "branch", "--show-current"],
+                    cwd=wt_path,
+                    timeout=10,
+                )
+            ).strip()
+            if not branch:
+                return None
+
+            try:
+                pr_url = (
+                    await self._run_worktree_command(
+                        ["gh", "pr", "view", "--json", "url", "--jq", ".url"],
+                        cwd=wt_path,
+                        timeout=20,
+                    )
+                ).strip()
+            except KanbanCLIError:
+                try:
+                    upstream = (
+                        await self._run_worktree_command(
+                            ["git", "rev-parse", "--abbrev-ref", "HEAD@{upstream}"],
+                            cwd=wt_path,
+                            timeout=10,
+                        )
+                    ).strip()
+                    base_branch = upstream.split("/", 1)[-1].strip() or "main"
+                except KanbanCLIError:
+                    base_branch = "main"
+                identifier = (issue or {}).get("identifier") or row.get("title") or task_id
+                title = str(row.get("title") or (issue or {}).get("title") or identifier)
+                if not title.startswith(str(identifier)):
+                    title = f"{identifier}: {title}"
+                body = (
+                    "Recovered by Zoe after Hermes pushed the branch but was interrupted "
+                    "before `gh pr create`/`kanban_complete`.\n\n"
+                    f"Kanban task: `{task_id}`\n"
+                    f"Branch: `{branch}`"
+                )
+                pr_url = (
+                    await self._run_worktree_command(
+                        ["gh", "pr", "create", "--base", base_branch, "--title", title[:240], "--body", body],
+                        cwd=wt_path,
+                        timeout=45,
+                    )
+                ).strip()
+            match = _GITHUB_PR_URL_RE.search(pr_url)
+            if not match:
+                return None
+            pr_url = match.group(0)
+            summary = (
+                f"PR_URL={pr_url}\n"
+                "BLOCKER=\n"
+                "TESTS=recovered after pushed branch; downstream verify/review must validate\n"
+                "SUMMARY=Recovered PR handoff after worker interruption following git push"
+            )
+            metadata = json.dumps(
+                {
+                    "pr_url": pr_url,
+                    "recovery": "pushed_branch_without_pr_handoff",
+                    "branch": branch,
+                },
+                sort_keys=True,
+            )
+            await self._run(
+                [
+                    "complete",
+                    "--result",
+                    summary,
+                    "--summary",
+                    summary,
+                    "--metadata",
+                    metadata,
+                    task_id,
+                ]
+            )
+            row["status"] = "done"
+            row["result"] = summary
+            row["block_reason"] = None
+            return pr_url
+        except Exception as exc:  # noqa: BLE001 - recovery must not break normal poll.
+            logger.warning("kanban_adapter: pushed PR recovery failed for %s: %s", task_id, exc)
+            return None
+
     async def dispatch(self, issue: dict) -> dict:
         """Create the single current ready phase for a Multica engineering run.
 
@@ -1343,6 +1507,36 @@ class KanbanAdapter:
                 phases[phase] = row
                 continue
             if await self._maybe_auto_block_protocol_violation(task_id, phase, row, detail):
+                phases[phase] = row
+
+        for phase, row in list(phases.items()):
+            if phase != "implement" or (row.get("status") or "").lower() != "blocked":
+                continue
+            task_id = row.get("id")
+            if not task_id:
+                continue
+            detail = detail_cache.get(task_id)
+            if detail is None:
+                try:
+                    detail = await self._run(["show", task_id, "--json"], expect_json=True)
+                    detail = _with_recovered_log_budget(task_id, phase, detail)
+                except KanbanCLIError:
+                    detail = {}
+                detail_cache[task_id] = detail
+            pr_url = await self._maybe_recover_pushed_pr(
+                task_id,
+                phase,
+                row,
+                issue=issue,
+                detail=detail,
+            )
+            if pr_url:
+                detail["latest_summary"] = (
+                    f"PR_URL={pr_url}\n"
+                    "BLOCKER=\n"
+                    "TESTS=recovered after pushed branch; downstream verify/review must validate\n"
+                    "SUMMARY=Recovered PR handoff after worker interruption following git push"
+                )
                 phases[phase] = row
 
         statuses = {p: (r.get("status") or "") for p, r in phases.items()}

--- a/services/zoe-data/kanban_phase_budget.py
+++ b/services/zoe-data/kanban_phase_budget.py
@@ -136,6 +136,11 @@ def task_log_tail(task_id: str, *, max_lines: int = 80) -> str:
     return "\n".join(lines[-max_lines:])
 
 
+def latest_log_session(task_id: str, *, max_lines: int = 120) -> str:
+    """Return only the latest Hermes session from a task log."""
+    return _latest_log_session(task_id, max_lines=max_lines)
+
+
 def _latest_log_session(task_id: str, *, max_lines: int = 120) -> str:
     try:
         lines = _log_path(task_id).read_text(encoding="utf-8", errors="replace").splitlines()

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -1435,6 +1435,22 @@ def test_pushed_branch_recovery_allows_failed_pr_create_attempt(tmp_path, monkey
     assert ka.KanbanAdapter()._pushed_branch_without_pr_handoff("t_impl") is True
 
 
+def test_pushed_branch_recovery_allows_successful_pr_create_without_complete(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    log_dir = tmp_path / "kanban" / "logs"
+    log_dir.mkdir(parents=True)
+    (log_dir / "t_impl.log").write_text(
+        "Query: work kanban task t_impl\n"
+        "  ┊ 💻 $         git push -u origin HEAD  2.1s\n"
+        "  ┊ 💻 $         gh pr create --base main --title x --body y  1.1s\n"
+        "https://github.com/jason-easyazz/zoe-ai-assistant/pull/998\n"
+        "⚡ Interrupted during API call.\n",
+        encoding="utf-8",
+    )
+
+    assert ka.KanbanAdapter()._pushed_branch_without_pr_handoff("t_impl") is True
+
+
 @pytest.mark.asyncio
 async def test_poll_partial_chain_is_redispatchable():
     # closeout phase never got created (e.g. CLI error mid-chain): must report

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -1518,6 +1518,20 @@ def test_pushed_branch_recovery_scans_past_failed_push_retry(tmp_path, monkeypat
     assert ka.KanbanAdapter()._pushed_branch_without_pr_handoff("t_impl") is True
 
 
+def test_pushed_branch_recovery_allows_compound_push_then_failed_pr_create(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    log_dir = tmp_path / "kanban" / "logs"
+    log_dir.mkdir(parents=True)
+    (log_dir / "t_impl.log").write_text(
+        "Query: work kanban task t_impl\n"
+        "  ┊ 💻 $         git push -u origin HEAD && gh pr create --base main --title x --body y  3.1s [exit 1]\n"
+        "⚡ Interrupted during API call.\n",
+        encoding="utf-8",
+    )
+
+    assert ka.KanbanAdapter()._pushed_branch_without_pr_handoff("t_impl") is True
+
+
 @pytest.mark.asyncio
 async def test_poll_creates_pr_when_pr_view_returns_no_url(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -64,6 +64,8 @@ class _FakeAdapter(ka.KanbanAdapter):
             return self._show_map.get(args[1], {"comments": [], "latest_summary": ""})
         if verb == "block":
             return ""
+        if verb == "complete":
+            return ""
         return ""
 
 
@@ -1266,6 +1268,92 @@ async def test_poll_blocked_detected():
     assert out["found"] is True
     assert out["status"] == "blocked"
     assert "dirty tree" in out["blocker"]
+
+
+@pytest.mark.asyncio
+async def test_poll_recovers_pr_after_push_then_api_interruption(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    log_dir = tmp_path / "kanban" / "logs"
+    log_dir.mkdir(parents=True)
+    (log_dir / "t_implement.log").write_text(
+        "Query: work kanban task t_implement\n"
+        "  ┊ 💻 $         git add services/zoe-ui/nginx.conf && git commit -m security && git push -u origin HEAD  2.1s\n"
+        "⚡ Interrupted during API call.\n",
+        encoding="utf-8",
+    )
+    worktree = tmp_path / "worktree"
+    worktree.mkdir()
+    rows = [
+        _row(
+            "implement",
+            "blocked",
+            chain_version="v4",
+            workspace_path=str(worktree),
+            block_reason="worker interrupted after push",
+        )
+    ]
+
+    class _RecoverAdapter(_FakeAdapter):
+        def __init__(self):
+            super().__init__(
+                list_rows=rows,
+                show_map={
+                    "t_implement": {
+                        "task": {"workspace_path": str(worktree)},
+                        "latest_summary": "",
+                        "comments": [],
+                    }
+                },
+            )
+            self.worktree_commands = []
+
+        async def _run_worktree_command(self, args, *, cwd, timeout=45.0):
+            self.worktree_commands.append(args)
+            if args[:3] == ["git", "branch", "--show-current"]:
+                return "wt/t_implement"
+            if args[:3] == ["git", "rev-parse", "--abbrev-ref"]:
+                return "origin/release"
+            if args[:3] == ["gh", "pr", "view"]:
+                raise ka.KanbanCLIError("no pull request found")
+            if args[:3] == ["gh", "pr", "create"]:
+                return "https://github.com/jason-easyazz/zoe-ai-assistant/pull/999"
+            raise AssertionError(args)
+
+    a = _RecoverAdapter()
+    out = await a.poll(
+        "multica:uuid-9",
+        issue={
+            "id": "uuid-9",
+            "identifier": "ZOE-999",
+            "title": "Recover pushed branch",
+            "metadata": {"evidence_profile": "code"},
+        },
+    )
+
+    assert out["phases"]["implement"] == "done"
+    assert out["pr_url"] == "https://github.com/jason-easyazz/zoe-ai-assistant/pull/999"
+    assert out["status"] != "blocked"
+    complete = next(call for call in a.calls if call[0] == "complete")
+    assert "PR_URL=https://github.com/jason-easyazz/zoe-ai-assistant/pull/999" in "\n".join(complete)
+    create_cmd = next(cmd for cmd in a.worktree_commands if cmd[:3] == ["gh", "pr", "create"])
+    assert create_cmd[create_cmd.index("--base") + 1] == "release"
+
+
+def test_pushed_branch_recovery_scans_latest_log_session_only(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    log_dir = tmp_path / "kanban" / "logs"
+    log_dir.mkdir(parents=True)
+    (log_dir / "t_impl.log").write_text(
+        "Query: work kanban task t_impl\n"
+        "  ┊ 💻 $         git push -u origin HEAD  2.1s\n"
+        "⚡ Interrupted during API call.\n"
+        "Query: work kanban task t_impl\n"
+        "  ┊ 💻 $         python3 -m pytest services/zoe-data/tests/test_x.py  0.4s [exit 1]\n"
+        "  ┊ kanban_block BLOCKER=TEST_FAILURE\n",
+        encoding="utf-8",
+    )
+
+    assert ka.KanbanAdapter()._pushed_branch_without_pr_handoff("t_impl") is False
 
 
 @pytest.mark.asyncio

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -1451,6 +1451,78 @@ def test_pushed_branch_recovery_allows_successful_pr_create_without_complete(tmp
     assert ka.KanbanAdapter()._pushed_branch_without_pr_handoff("t_impl") is True
 
 
+def test_pushed_branch_recovery_scans_past_failed_push_retry(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    log_dir = tmp_path / "kanban" / "logs"
+    log_dir.mkdir(parents=True)
+    (log_dir / "t_impl.log").write_text(
+        "Query: work kanban task t_impl\n"
+        "  ┊ 💻 $         git push -u origin HEAD  2.1s [exit 1]\n"
+        "  ┊ 💻 $         git push -u origin HEAD  2.4s\n"
+        "⚡ Interrupted during API call.\n",
+        encoding="utf-8",
+    )
+
+    assert ka.KanbanAdapter()._pushed_branch_without_pr_handoff("t_impl") is True
+
+
+@pytest.mark.asyncio
+async def test_poll_creates_pr_when_pr_view_returns_no_url(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    log_dir = tmp_path / "kanban" / "logs"
+    log_dir.mkdir(parents=True)
+    (log_dir / "t_implement.log").write_text(
+        "Query: work kanban task t_implement\n"
+        "  ┊ 💻 $         git push -u origin HEAD  2.1s\n"
+        "⚡ Interrupted during API call.\n",
+        encoding="utf-8",
+    )
+    worktree = tmp_path / "worktree"
+    worktree.mkdir()
+    rows = [
+        _row(
+            "implement",
+            "blocked",
+            chain_version="v4",
+            workspace_path=str(worktree),
+            block_reason="worker interrupted after push",
+        )
+    ]
+
+    class _RecoverAdapter(_FakeAdapter):
+        def __init__(self):
+            super().__init__(
+                list_rows=rows,
+                show_map={
+                    "t_implement": {
+                        "task": {"workspace_path": str(worktree)},
+                        "latest_summary": "",
+                        "comments": [],
+                    }
+                },
+            )
+            self.worktree_commands = []
+
+        async def _run_worktree_command(self, args, *, cwd, timeout=45.0):
+            self.worktree_commands.append(args)
+            if args[:3] == ["git", "branch", "--show-current"]:
+                return "wt/t_implement"
+            if args[:3] == ["git", "rev-parse", "--abbrev-ref"]:
+                return "origin/main"
+            if args[:3] == ["gh", "pr", "view"]:
+                return "null"
+            if args[:3] == ["gh", "pr", "create"]:
+                return "https://github.com/jason-easyazz/zoe-ai-assistant/pull/997"
+            raise AssertionError(args)
+
+    a = _RecoverAdapter()
+    out = await a.poll("multica:uuid-9")
+
+    assert out["phases"]["implement"] == "done"
+    assert out["pr_url"] == "https://github.com/jason-easyazz/zoe-ai-assistant/pull/997"
+    assert any(cmd[:3] == ["gh", "pr", "create"] for cmd in a.worktree_commands)
+
+
 @pytest.mark.asyncio
 async def test_poll_partial_chain_is_redispatchable():
     # closeout phase never got created (e.g. CLI error mid-chain): must report

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -1356,6 +1356,21 @@ def test_pushed_branch_recovery_scans_latest_log_session_only(tmp_path, monkeypa
     assert ka.KanbanAdapter()._pushed_branch_without_pr_handoff("t_impl") is False
 
 
+def test_pushed_branch_recovery_ignores_pr_create_in_reasoning_text(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    log_dir = tmp_path / "kanban" / "logs"
+    log_dir.mkdir(parents=True)
+    (log_dir / "t_impl.log").write_text(
+        "Query: work kanban task t_impl\n"
+        "I will run `gh pr create` after this push.\n"
+        "  ┊ 💻 $         git push -u origin HEAD  2.1s\n"
+        "⚡ Interrupted during API call.\n",
+        encoding="utf-8",
+    )
+
+    assert ka.KanbanAdapter()._pushed_branch_without_pr_handoff("t_impl") is True
+
+
 @pytest.mark.asyncio
 async def test_poll_partial_chain_is_redispatchable():
     # closeout phase never got created (e.g. CLI error mid-chain): must report

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -1388,6 +1388,58 @@ async def test_poll_completes_recovered_pr_url_already_in_comments(tmp_path, mon
     assert "PR_URL=https://github.com/jason-easyazz/zoe-ai-assistant/pull/998" in "\n".join(complete)
 
 
+@pytest.mark.asyncio
+async def test_poll_does_not_crash_when_existing_url_recovery_complete_fails(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    log_dir = tmp_path / "kanban" / "logs"
+    log_dir.mkdir(parents=True)
+    (log_dir / "t_implement.log").write_text(
+        "Query: work kanban task t_implement\n"
+        "  ┊ 💻 $         git push -u origin HEAD  2.1s\n"
+        "⚡ Interrupted during API call.\n",
+        encoding="utf-8",
+    )
+    rows = [
+        _row(
+            "implement",
+            "blocked",
+            chain_version="v4",
+            block_reason="worker interrupted after push",
+        )
+    ]
+
+    class _FailCompleteAdapter(_FakeAdapter):
+        def __init__(self):
+            super().__init__(
+                list_rows=rows,
+                show_map={
+                    "t_implement": {
+                        "latest_summary": "",
+                        "comments": [
+                            {
+                                "body": "manual recovery PR: https://github.com/jason-easyazz/zoe-ai-assistant/pull/998"
+                            }
+                        ],
+                    }
+                },
+            )
+
+        async def _run(self, args, *, expect_json=False):
+            if args[0] == "complete":
+                raise ka.KanbanCLIError("transient kanban complete failure")
+            return await super()._run(args, expect_json=expect_json)
+
+        async def _run_worktree_command(self, args, *, cwd, timeout=45.0):
+            raise AssertionError(f"existing PR URL recovery should not inspect worktree: {args}")
+
+    a = _FailCompleteAdapter()
+    out = await a.poll("multica:uuid-9")
+
+    assert out["found"] is True
+    assert out["status"] == "blocked"
+    assert out["phases"]["implement"] == "blocked"
+
+
 def test_pushed_branch_recovery_scans_latest_log_session_only(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     log_dir = tmp_path / "kanban" / "logs"

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -1339,6 +1339,55 @@ async def test_poll_recovers_pr_after_push_then_api_interruption(tmp_path, monke
     assert create_cmd[create_cmd.index("--base") + 1] == "release"
 
 
+@pytest.mark.asyncio
+async def test_poll_completes_recovered_pr_url_already_in_comments(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    log_dir = tmp_path / "kanban" / "logs"
+    log_dir.mkdir(parents=True)
+    (log_dir / "t_implement.log").write_text(
+        "Query: work kanban task t_implement\n"
+        "  ┊ 💻 $         git push -u origin HEAD  2.1s\n"
+        "⚡ Interrupted during API call.\n",
+        encoding="utf-8",
+    )
+    rows = [
+        _row(
+            "implement",
+            "blocked",
+            chain_version="v4",
+            block_reason="worker interrupted after push",
+        )
+    ]
+
+    class _RecoverAdapter(_FakeAdapter):
+        def __init__(self):
+            super().__init__(
+                list_rows=rows,
+                show_map={
+                    "t_implement": {
+                        "latest_summary": "",
+                        "comments": [
+                            {
+                                "body": "manual recovery PR: https://github.com/jason-easyazz/zoe-ai-assistant/pull/998"
+                            }
+                        ],
+                    }
+                },
+            )
+
+        async def _run_worktree_command(self, args, *, cwd, timeout=45.0):
+            raise AssertionError(f"early PR URL recovery should not inspect worktree: {args}")
+
+    a = _RecoverAdapter()
+    out = await a.poll("multica:uuid-9")
+
+    assert out["phases"]["implement"] == "done"
+    assert out["pr_url"] == "https://github.com/jason-easyazz/zoe-ai-assistant/pull/998"
+    assert out["status"] != "blocked"
+    complete = next(call for call in a.calls if call[0] == "complete")
+    assert "PR_URL=https://github.com/jason-easyazz/zoe-ai-assistant/pull/998" in "\n".join(complete)
+
+
 def test_pushed_branch_recovery_scans_latest_log_session_only(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     log_dir = tmp_path / "kanban" / "logs"
@@ -1364,6 +1413,21 @@ def test_pushed_branch_recovery_ignores_pr_create_in_reasoning_text(tmp_path, mo
         "Query: work kanban task t_impl\n"
         "I will run `gh pr create` after this push.\n"
         "  ┊ 💻 $         git push -u origin HEAD  2.1s\n"
+        "⚡ Interrupted during API call.\n",
+        encoding="utf-8",
+    )
+
+    assert ka.KanbanAdapter()._pushed_branch_without_pr_handoff("t_impl") is True
+
+
+def test_pushed_branch_recovery_allows_failed_pr_create_attempt(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    log_dir = tmp_path / "kanban" / "logs"
+    log_dir.mkdir(parents=True)
+    (log_dir / "t_impl.log").write_text(
+        "Query: work kanban task t_impl\n"
+        "  ┊ 💻 $         git push -u origin HEAD  2.1s\n"
+        "  ┊ 💻 $         gh pr create --base main --title x --body y  1.1s [exit 1]\n"
         "⚡ Interrupted during API call.\n",
         encoding="utf-8",
     )


### PR DESCRIPTION
## Summary
- recover blocked implement tasks when the worker successfully pushed a branch but was interrupted before PR creation/handoff
- create or find the PR from the task worktree and complete the Kanban row with PR_URL metadata
- add regression coverage for the ZOE-5355 failure shape

## Tests
- python3 -m py_compile services/zoe-data/executors/kanban_adapter.py services/zoe-data/tests/test_kanban_adapter.py
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_kanban_adapter.py -q
- python3 tools/audit/validate_structure.py

## Production Context
This fixes the blocker observed during real-ticket ZOE-5355: Hermes pushed branch wt/t_5ef2c30c, then the session was interrupted before gh pr create / kanban_complete. Zoe had to recover manually; this patch makes that recovery deterministic in poll().