### PR TITLE
Test metrics internal token auth

### DIFF
--- a/services/zoe-data/tests/test_metrics_auth_regression.py
+++ b/services/zoe-data/tests/test_metrics_auth_regression.py
@@ -1,0 +1,40 @@
+import importlib
+import sys
+
+from fastapi.testclient import TestClient
+
+
+def _load_main_with_internal_token(monkeypatch):
+    monkeypatch.setenv("ZOE_INTERNAL_TOKEN", "metrics-test-token")
+    for module_name in ("auth", "main"):
+        sys.modules.pop(module_name, None)
+    import auth
+    import main
+
+    importlib.reload(auth)
+    return importlib.reload(main)
+
+
+def test_metrics_rejects_non_loopback_without_internal_token(monkeypatch):
+    main = _load_main_with_internal_token(monkeypatch)
+
+    resp = TestClient(main.app).get("/metrics")
+
+    assert resp.status_code == 403
+    assert "X-Internal-Token" in resp.json()["detail"]
+
+
+def test_metrics_allows_non_loopback_with_valid_internal_token(monkeypatch):
+    main = _load_main_with_internal_token(monkeypatch)
+    import memory_metrics
+
+    monkeypatch.setattr(memory_metrics, "snapshot_collection_sizes", lambda: None)
+
+    resp = TestClient(main.app).get(
+        "/metrics",
+        headers={"X-Internal-Token": "metrics-test-token"},
+    )
+
+    assert resp.status_code == 200
+    assert "text/plain" in resp.headers["content-type"]
+    assert "zoe_memory_write_count" in resp.text

--- a/services/zoe-data/tests/test_metrics_auth_regression.py
+++ b/services/zoe-data/tests/test_metrics_auth_regression.py
@@ -5,13 +5,16 @@ from fastapi.testclient import TestClient
 
 
 def _load_main_with_internal_token(monkeypatch):
-    monkeypatch.setenv("ZOE_INTERNAL_TOKEN", "metrics-test-token")
+    monkeypatch.delenv("ZOE_INTERNAL_TOKEN", raising=False)
     for module_name in ("auth", "main"):
         sys.modules.pop(module_name, None)
     import auth
+
+    auth = importlib.reload(auth)
+    monkeypatch.setattr(auth, "_ZOE_INTERNAL_TOKEN", "metrics-test-token")
+
     import main
 
-    importlib.reload(auth)
     return importlib.reload(main)
 
 
@@ -19,6 +22,18 @@ def test_metrics_rejects_non_loopback_without_internal_token(monkeypatch):
     main = _load_main_with_internal_token(monkeypatch)
 
     resp = TestClient(main.app).get("/metrics")
+
+    assert resp.status_code == 403
+    assert "X-Internal-Token" in resp.json()["detail"]
+
+
+def test_metrics_rejects_non_loopback_with_wrong_internal_token(monkeypatch):
+    main = _load_main_with_internal_token(monkeypatch)
+
+    resp = TestClient(main.app).get(
+        "/metrics",
+        headers={"X-Internal-Token": "wrong-token"},
+    )
 
     assert resp.status_code == 403
     assert "X-Internal-Token" in resp.json()["detail"]


### PR DESCRIPTION
## Summary
- add route-level regression coverage for /metrics internal token auth
- prove non-loopback callers without X-Internal-Token get 403 and valid internal token gets 200
- patch only the metrics snapshot during the 200-path test so the real route and auth dependency stay wired

## Verification
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_metrics_auth_regression.py
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_metrics_auth_regression.py services/zoe-data/tests/test_auth_unauthenticated.py services/zoe-data/tests/test_agent_spike_metrics.py
- python3 tools/audit/validate_structure.py
- python3 tools/audit/validate_critical_files.py
- python3 tools/audit/validate_offline_memory.py
- git diff --check