### PR TITLE
Allow websocket connections in managed CSP

### DIFF
--- a/services/zoe-data/tests/test_nginx_security_headers_helper.py
+++ b/services/zoe-data/tests/test_nginx_security_headers_helper.py
@@ -55,6 +55,7 @@ server {
     assert updated.count("add_header Content-Security-Policy") == 3
     assert updated.count("add_header X-Frame-Options") == 3
     assert updated.count("add_header Strict-Transport-Security") == 1
+    assert updated.count("connect-src 'self' ws: wss:") == 3
     assert helper.missing_headers(updated) == []
 
 
@@ -323,9 +324,36 @@ def test_ensure_headers_is_idempotent_and_replaces_managed_blocks():
     assert once == twice
     assert '"DENY"' not in once
     assert '"SAMEORIGIN"' in once
+    assert "connect-src 'self' ws: wss:" in once
     assert once.count(helper.BEGIN_MARKER) == 1
     assert "Strict-Transport-Security" not in once
     assert helper.missing_headers(once) == []
+
+
+def test_ensure_headers_replaces_managed_csp_missing_websocket_sources():
+    config = """server {
+    listen 80;
+    server_name _;
+
+    # BEGIN ZOE MANAGED SECURITY HEADERS
+    add_header Content-Security-Policy "default-src 'self'; connect-src 'self';" always;
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Permissions-Policy "camera=(), microphone=(self), geolocation=()" always;
+    # END ZOE MANAGED SECURITY HEADERS
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}
+"""
+
+    updated = helper.ensure_headers(config)
+
+    assert "connect-src 'self' ws: wss:" in updated
+    assert "connect-src 'self';" not in updated
+    assert helper.missing_headers(updated) == []
 
 
 def test_ensure_headers_is_idempotent_from_fresh_config_with_blank_before_location():

--- a/services/zoe-ui/nginx.conf
+++ b/services/zoe-ui/nginx.conf
@@ -16,7 +16,7 @@ server {
     index index.html;
 
     # BEGIN ZOE MANAGED SECURITY HEADERS
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self'; frame-ancestors 'self';" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' ws: wss:; frame-ancestors 'self';" always;
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
@@ -25,7 +25,7 @@ server {
 
     location ~* \.(js|css)$ {
         # BEGIN ZOE MANAGED SECURITY HEADERS
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self'; frame-ancestors 'self';" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' ws: wss:; frame-ancestors 'self';" always;
         add_header X-Frame-Options "SAMEORIGIN" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
@@ -333,7 +333,7 @@ server {
     index index.html;
 
     # BEGIN ZOE MANAGED SECURITY HEADERS
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self'; frame-ancestors 'self';" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' ws: wss:; frame-ancestors 'self';" always;
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
@@ -343,7 +343,7 @@ server {
 
     location ~* \.(js|css)$ {
         # BEGIN ZOE MANAGED SECURITY HEADERS
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self'; frame-ancestors 'self';" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' ws: wss:; frame-ancestors 'self';" always;
         add_header X-Frame-Options "SAMEORIGIN" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
@@ -641,7 +641,7 @@ server {
     ssl_prefer_server_ciphers off;
 
     # BEGIN ZOE MANAGED SECURITY HEADERS
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self'; frame-ancestors 'self';" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' ws: wss:; frame-ancestors 'self';" always;
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;

--- a/tools/audit/ensure_nginx_security_headers.py
+++ b/tools/audit/ensure_nginx_security_headers.py
@@ -26,6 +26,8 @@ SECURITY_HEADERS: tuple[tuple[str, str], ...] = (
         "Content-Security-Policy",
         # The legacy Zoe SPA and proxied Multica surface still need inline/eval script
         # compatibility. Keep this explicit so future security audits can tighten it.
+        # Zoe also proxies operator-configurable local voice/LiveKit websocket
+        # endpoints whose hostnames/ports are not stable enough to enumerate here.
         "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; "
         "style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; "
         "font-src 'self'; connect-src 'self' ws: wss:; frame-ancestors 'self';",

--- a/tools/audit/ensure_nginx_security_headers.py
+++ b/tools/audit/ensure_nginx_security_headers.py
@@ -28,7 +28,7 @@ SECURITY_HEADERS: tuple[tuple[str, str], ...] = (
         # compatibility. Keep this explicit so future security audits can tighten it.
         "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; "
         "style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; "
-        "font-src 'self'; connect-src 'self'; frame-ancestors 'self';",
+        "font-src 'self'; connect-src 'self' ws: wss:; frame-ancestors 'self';",
     ),
     ("X-Frame-Options", "SAMEORIGIN"),
     ("X-Content-Type-Options", "nosniff"),


### PR DESCRIPTION
## Summary
- update the managed nginx CSP source of truth to keep ws:/wss: in connect-src for voice and LiveKit
- regenerate services/zoe-ui/nginx.conf from the helper
- add regression coverage for websocket connect-src and replacing stale managed CSP blocks

## Verification
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_nginx_security_headers_helper.py
- python3 tools/audit/ensure_nginx_security_headers.py --path services/zoe-ui/nginx.conf --check
- python3 tools/audit/validate_structure.py
- python3 tools/audit/validate_critical_files.py
- python3 tools/audit/validate_offline_memory.py
- git diff --check