### PR TITLE
Enforce memory read safety filters

### DIFF
--- a/services/zoe-data/memory_service.py
+++ b/services/zoe-data/memory_service.py
@@ -38,7 +38,7 @@ import re
 import time
 import uuid
 from dataclasses import dataclass, field
-from typing import Any, Iterable, Optional
+from typing import Any, Iterable, Mapping, Optional
 
 try:
     from memory_metrics import (
@@ -74,6 +74,24 @@ def _metadata_value(value: Any) -> str | int | float | bool:
     if isinstance(value, (str, int, float, bool)):
         return value
     return json.dumps(value, sort_keys=True, separators=(",", ":"))
+
+
+_BLOCKED_READ_STATUSES = {"archived", "rejected", "superseded", "pending", "disputed"}
+
+
+def _memory_visible_to_user(metadata: Mapping[str, Any], user_id: str) -> bool:
+    """Return True only for the caller's personal rows or shared family rows."""
+
+    visibility = str(metadata.get("visibility") or "").strip().lower()
+    if visibility == "family":
+        return True
+    owner = str(metadata.get("user_id") or metadata.get("wing") or "").strip()
+    return bool(owner and owner == user_id)
+
+
+def _memory_status_visible(metadata: Mapping[str, Any]) -> bool:
+    status = str(metadata.get("status", "approved") or "approved").strip().lower()
+    return status not in _BLOCKED_READ_STATUSES
 
 
 def _scope_visibility(scope: Any | None) -> str:
@@ -718,7 +736,7 @@ class MemoryService:
     def _metadata_read(self, user_id: str, limit: int) -> list[MemoryRef]:
         col = self._collection()
         result = col.get(
-            where={"$or": [{"user_id": user_id}, {"wing": user_id}]},
+            where={"$or": [{"user_id": user_id}, {"wing": user_id}, {"visibility": "family"}]},
             include=["documents", "metadatas"],
         )
         docs = result.get("documents") or []
@@ -733,8 +751,9 @@ class MemoryService:
             expires = meta.get("expires_at")
             if expires and expires <= now_iso:
                 continue
-            st = meta.get("status", "approved")
-            if st in {"archived", "rejected", "superseded", "pending"}:
+            if not _memory_visible_to_user(meta, user_id):
+                continue
+            if not _memory_status_visible(meta):
                 continue
             filtered.append(MemoryRef(id=rid, text=doc or "", metadata=dict(meta)))
 
@@ -769,7 +788,7 @@ class MemoryService:
         result = col.query(
             query_texts=[query],
             n_results=max(limit * 3, limit),
-            where={"$or": [{"user_id": user_id}, {"wing": user_id}]},
+            where={"$or": [{"user_id": user_id}, {"wing": user_id}, {"visibility": "family"}]},
             include=["documents", "metadatas", "distances"],
         )
         ids = (result.get("ids") or [[]])[0]
@@ -784,8 +803,9 @@ class MemoryService:
             expires = md.get("expires_at")
             if expires and expires <= now_iso:
                 continue
-            st = md.get("status", "approved")
-            if st in {"archived", "rejected", "superseded", "pending"}:
+            if not _memory_visible_to_user(md, user_id):
+                continue
+            if not _memory_status_visible(md):
                 continue
             hits.append(
                 MemoryRef(

--- a/services/zoe-data/memory_service.py
+++ b/services/zoe-data/memory_service.py
@@ -85,8 +85,10 @@ def _memory_visible_to_user(metadata: Mapping[str, Any], user_id: str) -> bool:
     visibility = str(metadata.get("visibility") or "").strip().lower()
     if visibility == "family":
         return True
-    owner = str(metadata.get("user_id") or metadata.get("wing") or "").strip()
-    return bool(owner and owner == user_id)
+    caller = str(user_id or "").strip().lower()
+    uid = str(metadata.get("user_id") or "").strip().lower()
+    wing = str(metadata.get("wing") or "").strip().lower()
+    return bool(caller and ((uid and uid == caller) or (wing and wing == caller)))
 
 
 def _memory_status_visible(metadata: Mapping[str, Any]) -> bool:

--- a/services/zoe-data/tests/test_hindsight_memory.py
+++ b/services/zoe-data/tests/test_hindsight_memory.py
@@ -414,6 +414,28 @@ async def test_recall_posts_trace_enabled_request():
     assert result["results"][0]["text"] == "voice queue guard fixed weather"
 
 
+@pytest.mark.asyncio
+async def test_recall_uses_user_and_scope_isolated_bank_ids():
+    seen_paths = []
+
+    async def handler(request):
+        seen_paths.append(request.url.path)
+        return httpx.Response(200, json={"results": []})
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as http_client:
+        client = HindsightMemoryClient(HindsightConfig(enabled=True, bank_prefix="zoe-test"), client=http_client)
+        await client.recall(user_id="Jason", scope="personal", query="What failed?")
+        await client.recall(user_id="Alex", scope="personal", query="What failed?")
+        await client.recall(user_id="Jason", scope="shared", query="What failed?")
+
+    assert seen_paths == [
+        "/v1/default/banks/zoe-test-personal-jason/memories/recall",
+        "/v1/default/banks/zoe-test-personal-alex/memories/recall",
+        "/v1/default/banks/zoe-test-shared-jason/memories/recall",
+    ]
+
+
 def test_event_to_hindsight_item_serializes_structured_context_as_json():
     item = event_to_hindsight_item(_event())
 

--- a/services/zoe-data/tests/test_memory_service_metadata.py
+++ b/services/zoe-data/tests/test_memory_service_metadata.py
@@ -3,6 +3,22 @@ import pytest
 from memory_service import MemoryService, MemoryServiceError
 
 
+class _FakeCollection:
+    def __init__(self, *, get_result=None, query_result=None):
+        self.get_result = get_result or {}
+        self.query_result = query_result or {}
+        self.seen_get_where = None
+        self.seen_query_where = None
+
+    def get(self, **kwargs):
+        self.seen_get_where = kwargs.get("where")
+        return self.get_result
+
+    def query(self, **kwargs):
+        self.seen_query_where = kwargs.get("where")
+        return self.query_result
+
+
 def test_build_metadata_preserves_candidate_source_excerpt_and_structured_metadata():
     metadata = MemoryService._build_metadata(
         user_id="jason",
@@ -183,3 +199,62 @@ def test_build_metadata_defaults_keep_review_edit_call_compatible():
 
     assert metadata["source"] == "review_ui"
     assert "source_excerpt" not in metadata
+
+
+def test_metadata_prompt_read_blocks_cross_user_disputed_and_superseded_rows():
+    collection = _FakeCollection(
+        get_result={
+            "ids": ["own", "shared", "other", "disputed", "old"],
+            "documents": [
+                "Jason active fact",
+                "Shared family fact",
+                "Other private fact",
+                "Disputed fact",
+                "Old superseded fact",
+            ],
+            "metadatas": [
+                {"user_id": "jason", "visibility": "personal", "status": "approved", "added_at": "2026-01-01T00:00:00Z"},
+                {"user_id": "alex", "visibility": "family", "status": "approved", "added_at": "2026-01-02T00:00:00Z"},
+                {"user_id": "alex", "visibility": "personal", "status": "approved", "added_at": "2026-01-03T00:00:00Z"},
+                {"user_id": "jason", "visibility": "personal", "status": "disputed", "added_at": "2026-01-04T00:00:00Z"},
+                {"user_id": "jason", "visibility": "personal", "status": "superseded", "superseded_by_id": "new", "added_at": "2026-01-05T00:00:00Z"},
+            ],
+        }
+    )
+    service = MemoryService(data_dir="/tmp/zoe-test-memory-safety")
+    service._collection = lambda: collection
+
+    rows = service._metadata_read("jason", limit=10)
+
+    assert [row.id for row in rows] == ["shared", "own"]
+    assert {"visibility": "family"} in collection.seen_get_where["$or"]
+
+
+def test_semantic_search_blocks_cross_user_disputed_and_superseded_rows():
+    collection = _FakeCollection(
+        query_result={
+            "ids": [["own", "shared", "other", "disputed", "old"]],
+            "documents": [[
+                "Jason active fact",
+                "Shared family fact",
+                "Other private fact",
+                "Disputed fact",
+                "Old superseded fact",
+            ]],
+            "metadatas": [[
+                {"user_id": "jason", "visibility": "personal", "status": "approved", "confidence": 0.9, "added_at": "2026-01-01T00:00:00Z"},
+                {"user_id": "alex", "visibility": "family", "status": "approved", "confidence": 0.9, "added_at": "2026-01-02T00:00:00Z"},
+                {"user_id": "alex", "visibility": "personal", "status": "approved", "confidence": 0.9, "added_at": "2026-01-03T00:00:00Z"},
+                {"user_id": "jason", "visibility": "personal", "status": "disputed", "confidence": 0.9, "added_at": "2026-01-04T00:00:00Z"},
+                {"user_id": "jason", "visibility": "personal", "status": "superseded", "superseded_by_id": "new", "confidence": 0.9, "added_at": "2026-01-05T00:00:00Z"},
+            ]],
+            "distances": [[0.1, 0.2, 0.3, 0.4, 0.5]],
+        }
+    )
+    service = MemoryService(data_dir="/tmp/zoe-test-memory-safety")
+    service._collection = lambda: collection
+
+    rows = service._semantic_search("fact", "jason", limit=10)
+
+    assert [row.id for row in rows] == ["own", "shared"]
+    assert {"visibility": "family"} in collection.seen_query_where["$or"]

--- a/services/zoe-data/tests/test_memory_service_metadata.py
+++ b/services/zoe-data/tests/test_memory_service_metadata.py
@@ -1,6 +1,6 @@
 import pytest
 
-from memory_service import MemoryService, MemoryServiceError
+from memory_service import MemoryService, MemoryServiceError, _memory_visible_to_user
 
 
 class _FakeCollection:
@@ -201,12 +201,22 @@ def test_build_metadata_defaults_keep_review_edit_call_compatible():
     assert "source_excerpt" not in metadata
 
 
+def test_memory_visible_to_user_matches_user_id_or_wing_or_shared_visibility():
+    assert _memory_visible_to_user({"user_id": "Jason", "visibility": "personal"}, "jason") is True
+    assert _memory_visible_to_user({"wing": "jason", "visibility": "personal"}, "jason") is True
+    assert _memory_visible_to_user({"user_id": "alex", "wing": "jason", "visibility": "personal"}, "jason") is True
+    assert _memory_visible_to_user({"user_id": "alex", "visibility": "personal"}, "jason") is False
+    assert _memory_visible_to_user({"user_id": "alex", "visibility": "family"}, "jason") is True
+
+
 def test_metadata_prompt_read_blocks_cross_user_disputed_and_superseded_rows():
     collection = _FakeCollection(
         get_result={
-            "ids": ["own", "shared", "other", "disputed", "old"],
+            "ids": ["own", "wing_only", "mixed", "shared", "other", "disputed", "old"],
             "documents": [
                 "Jason active fact",
+                "Jason wing-only fact",
+                "Jason mixed wing fact",
                 "Shared family fact",
                 "Other private fact",
                 "Disputed fact",
@@ -214,10 +224,12 @@ def test_metadata_prompt_read_blocks_cross_user_disputed_and_superseded_rows():
             ],
             "metadatas": [
                 {"user_id": "jason", "visibility": "personal", "status": "approved", "added_at": "2026-01-01T00:00:00Z"},
-                {"user_id": "alex", "visibility": "family", "status": "approved", "added_at": "2026-01-02T00:00:00Z"},
-                {"user_id": "alex", "visibility": "personal", "status": "approved", "added_at": "2026-01-03T00:00:00Z"},
-                {"user_id": "jason", "visibility": "personal", "status": "disputed", "added_at": "2026-01-04T00:00:00Z"},
-                {"user_id": "jason", "visibility": "personal", "status": "superseded", "superseded_by_id": "new", "added_at": "2026-01-05T00:00:00Z"},
+                {"wing": "jason", "visibility": "personal", "status": "approved", "added_at": "2026-01-02T00:00:00Z"},
+                {"user_id": "alex", "wing": "jason", "visibility": "personal", "status": "approved", "added_at": "2026-01-03T00:00:00Z"},
+                {"user_id": "alex", "visibility": "family", "status": "approved", "added_at": "2026-01-04T00:00:00Z"},
+                {"user_id": "alex", "visibility": "personal", "status": "approved", "added_at": "2026-01-05T00:00:00Z"},
+                {"user_id": "jason", "visibility": "personal", "status": "disputed", "added_at": "2026-01-06T00:00:00Z"},
+                {"user_id": "jason", "visibility": "personal", "status": "superseded", "superseded_by_id": "new", "added_at": "2026-01-07T00:00:00Z"},
             ],
         }
     )
@@ -226,16 +238,18 @@ def test_metadata_prompt_read_blocks_cross_user_disputed_and_superseded_rows():
 
     rows = service._metadata_read("jason", limit=10)
 
-    assert [row.id for row in rows] == ["shared", "own"]
+    assert [row.id for row in rows] == ["shared", "mixed", "wing_only", "own"]
     assert {"visibility": "family"} in collection.seen_get_where["$or"]
 
 
 def test_semantic_search_blocks_cross_user_disputed_and_superseded_rows():
     collection = _FakeCollection(
         query_result={
-            "ids": [["own", "shared", "other", "disputed", "old"]],
+            "ids": [["own", "wing_only", "mixed", "shared", "other", "disputed", "old"]],
             "documents": [[
                 "Jason active fact",
+                "Jason wing-only fact",
+                "Jason mixed wing fact",
                 "Shared family fact",
                 "Other private fact",
                 "Disputed fact",
@@ -243,12 +257,14 @@ def test_semantic_search_blocks_cross_user_disputed_and_superseded_rows():
             ]],
             "metadatas": [[
                 {"user_id": "jason", "visibility": "personal", "status": "approved", "confidence": 0.9, "added_at": "2026-01-01T00:00:00Z"},
-                {"user_id": "alex", "visibility": "family", "status": "approved", "confidence": 0.9, "added_at": "2026-01-02T00:00:00Z"},
-                {"user_id": "alex", "visibility": "personal", "status": "approved", "confidence": 0.9, "added_at": "2026-01-03T00:00:00Z"},
-                {"user_id": "jason", "visibility": "personal", "status": "disputed", "confidence": 0.9, "added_at": "2026-01-04T00:00:00Z"},
-                {"user_id": "jason", "visibility": "personal", "status": "superseded", "superseded_by_id": "new", "confidence": 0.9, "added_at": "2026-01-05T00:00:00Z"},
+                {"wing": "jason", "visibility": "personal", "status": "approved", "confidence": 0.9, "added_at": "2026-01-02T00:00:00Z"},
+                {"user_id": "alex", "wing": "jason", "visibility": "personal", "status": "approved", "confidence": 0.9, "added_at": "2026-01-03T00:00:00Z"},
+                {"user_id": "alex", "visibility": "family", "status": "approved", "confidence": 0.9, "added_at": "2026-01-04T00:00:00Z"},
+                {"user_id": "alex", "visibility": "personal", "status": "approved", "confidence": 0.9, "added_at": "2026-01-05T00:00:00Z"},
+                {"user_id": "jason", "visibility": "personal", "status": "disputed", "confidence": 0.9, "added_at": "2026-01-06T00:00:00Z"},
+                {"user_id": "jason", "visibility": "personal", "status": "superseded", "superseded_by_id": "new", "confidence": 0.9, "added_at": "2026-01-07T00:00:00Z"},
             ]],
-            "distances": [[0.1, 0.2, 0.3, 0.4, 0.5]],
+            "distances": [[0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7]],
         }
     )
     service = MemoryService(data_dir="/tmp/zoe-test-memory-safety")
@@ -256,5 +272,5 @@ def test_semantic_search_blocks_cross_user_disputed_and_superseded_rows():
 
     rows = service._semantic_search("fact", "jason", limit=10)
 
-    assert [row.id for row in rows] == ["own", "shared"]
+    assert [row.id for row in rows] == ["own", "wing_only", "mixed", "shared"]
     assert {"visibility": "family"} in collection.seen_query_where["$or"]

--- a/services/zoe-data/tests/test_memory_service_metadata.py
+++ b/services/zoe-data/tests/test_memory_service_metadata.py
@@ -212,12 +212,13 @@ def test_memory_visible_to_user_matches_user_id_or_wing_or_shared_visibility():
 def test_metadata_prompt_read_blocks_cross_user_disputed_and_superseded_rows():
     collection = _FakeCollection(
         get_result={
-            "ids": ["own", "wing_only", "mixed", "shared", "other", "disputed", "old"],
+            "ids": ["own", "wing_only", "mixed", "shared", "family_disputed", "other", "disputed", "old"],
             "documents": [
                 "Jason active fact",
                 "Jason wing-only fact",
                 "Jason mixed wing fact",
                 "Shared family fact",
+                "Disputed shared family fact",
                 "Other private fact",
                 "Disputed fact",
                 "Old superseded fact",
@@ -227,9 +228,10 @@ def test_metadata_prompt_read_blocks_cross_user_disputed_and_superseded_rows():
                 {"wing": "jason", "visibility": "personal", "status": "approved", "added_at": "2026-01-02T00:00:00Z"},
                 {"user_id": "alex", "wing": "jason", "visibility": "personal", "status": "approved", "added_at": "2026-01-03T00:00:00Z"},
                 {"user_id": "alex", "visibility": "family", "status": "approved", "added_at": "2026-01-04T00:00:00Z"},
-                {"user_id": "alex", "visibility": "personal", "status": "approved", "added_at": "2026-01-05T00:00:00Z"},
-                {"user_id": "jason", "visibility": "personal", "status": "disputed", "added_at": "2026-01-06T00:00:00Z"},
-                {"user_id": "jason", "visibility": "personal", "status": "superseded", "superseded_by_id": "new", "added_at": "2026-01-07T00:00:00Z"},
+                {"user_id": "alex", "visibility": "family", "status": "disputed", "added_at": "2026-01-05T00:00:00Z"},
+                {"user_id": "alex", "visibility": "personal", "status": "approved", "added_at": "2026-01-06T00:00:00Z"},
+                {"user_id": "jason", "visibility": "personal", "status": "disputed", "added_at": "2026-01-07T00:00:00Z"},
+                {"user_id": "jason", "visibility": "personal", "status": "superseded", "superseded_by_id": "new", "added_at": "2026-01-08T00:00:00Z"},
             ],
         }
     )
@@ -238,19 +240,20 @@ def test_metadata_prompt_read_blocks_cross_user_disputed_and_superseded_rows():
 
     rows = service._metadata_read("jason", limit=10)
 
-    assert [row.id for row in rows] == ["shared", "mixed", "wing_only", "own"]
+    assert {row.id for row in rows} == {"own", "wing_only", "mixed", "shared"}
     assert {"visibility": "family"} in collection.seen_get_where["$or"]
 
 
 def test_semantic_search_blocks_cross_user_disputed_and_superseded_rows():
     collection = _FakeCollection(
         query_result={
-            "ids": [["own", "wing_only", "mixed", "shared", "other", "disputed", "old"]],
+            "ids": [["own", "wing_only", "mixed", "shared", "family_superseded", "other", "disputed", "old"]],
             "documents": [[
                 "Jason active fact",
                 "Jason wing-only fact",
                 "Jason mixed wing fact",
                 "Shared family fact",
+                "Superseded shared family fact",
                 "Other private fact",
                 "Disputed fact",
                 "Old superseded fact",
@@ -260,11 +263,12 @@ def test_semantic_search_blocks_cross_user_disputed_and_superseded_rows():
                 {"wing": "jason", "visibility": "personal", "status": "approved", "confidence": 0.9, "added_at": "2026-01-02T00:00:00Z"},
                 {"user_id": "alex", "wing": "jason", "visibility": "personal", "status": "approved", "confidence": 0.9, "added_at": "2026-01-03T00:00:00Z"},
                 {"user_id": "alex", "visibility": "family", "status": "approved", "confidence": 0.9, "added_at": "2026-01-04T00:00:00Z"},
-                {"user_id": "alex", "visibility": "personal", "status": "approved", "confidence": 0.9, "added_at": "2026-01-05T00:00:00Z"},
-                {"user_id": "jason", "visibility": "personal", "status": "disputed", "confidence": 0.9, "added_at": "2026-01-06T00:00:00Z"},
-                {"user_id": "jason", "visibility": "personal", "status": "superseded", "superseded_by_id": "new", "confidence": 0.9, "added_at": "2026-01-07T00:00:00Z"},
+                {"user_id": "alex", "visibility": "family", "status": "superseded", "superseded_by_id": "new", "confidence": 0.9, "added_at": "2026-01-05T00:00:00Z"},
+                {"user_id": "alex", "visibility": "personal", "status": "approved", "confidence": 0.9, "added_at": "2026-01-06T00:00:00Z"},
+                {"user_id": "jason", "visibility": "personal", "status": "disputed", "confidence": 0.9, "added_at": "2026-01-07T00:00:00Z"},
+                {"user_id": "jason", "visibility": "personal", "status": "superseded", "superseded_by_id": "new", "confidence": 0.9, "added_at": "2026-01-08T00:00:00Z"},
             ]],
-            "distances": [[0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7]],
+            "distances": [[0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8]],
         }
     )
     service = MemoryService(data_dir="/tmp/zoe-test-memory-safety")
@@ -272,5 +276,5 @@ def test_semantic_search_blocks_cross_user_disputed_and_superseded_rows():
 
     rows = service._semantic_search("fact", "jason", limit=10)
 
-    assert [row.id for row in rows] == ["own", "wing_only", "mixed", "shared"]
+    assert {row.id for row in rows} == {"own", "wing_only", "mixed", "shared"}
     assert {"visibility": "family"} in collection.seen_query_where["$or"]


### PR DESCRIPTION
## Summary
- include shared visibility rows in MemoryService prompt/search backend queries
- add application-level read guards so cross-user personal rows, disputed rows, pending rows, and superseded rows are not injected even if a backend returns them
- add Hindsight recall bank isolation coverage for user and scope

## Verification
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_memory_service_metadata.py services/zoe-data/tests/test_hindsight_memory.py services/zoe-data/tests/test_hindsight_retain_candidates.py services/zoe-data/tests/test_zoe_memory_contract.py
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_memory_service_metadata.py services/zoe-data/tests/test_hindsight_memory.py services/zoe-data/tests/test_hindsight_retain_candidates.py services/zoe-data/tests/test_hindsight_retain_executor.py services/zoe-data/tests/test_zoe_memory_contract.py services/zoe-data/tests/test_zoe_memory_admission.py services/zoe-data/tests/test_zoe_multica_memory_admission.py services/zoe-data/tests/test_zoe_evolution_outcome_admission.py services/zoe-data/tests/test_zoe_evolution_outcome_retain.py services/zoe-data/tests/test_zoe_memory_router.py services/zoe-data/tests/test_zoe_memory_router_runtime.py services/zoe-data/tests/test_mempalace_integration.py
- python3 tools/audit/validate_structure.py
- python3 tools/audit/validate_critical_files.py
- python3 tools/audit/validate_offline_memory.py
- git diff --check