### PR TITLE
[codex] Add Hindsight retain admission stub

### DIFF
--- a/docs/architecture/zoe-memory-admission-gates.md
+++ b/docs/architecture/zoe-memory-admission-gates.md
@@ -43,6 +43,12 @@ auto-write to MemoryService, Hindsight, Graphiti, MemPalace, or Multica.
 Additional runtime writers should be wired in later small PRs after each
 backend path is reviewed and tested.
 
+`admit_hindsight_retain_candidate(event_id)` is the current runtime-facing
+admission interface for pending Hindsight retain candidates. It is intentionally
+inert until the admission worker is wired: it returns pending review,
+`allowed_to_write_durable: false`, and no side effects. Future chat/runtime code
+should call this interface rather than calling retain sidecars directly.
+
 ## Intended Flow
 
 1. Memory extraction or Hindsight reflection creates a pending candidate.
@@ -65,7 +71,10 @@ admission is pending or blocked.
 Hindsight retain plans follow the same rule: Zoe may create pending retain
 candidates for review, but the sidecar retain payload cannot be built or
 executed unless a matching admission decision allows durable writes to the
-Hindsight backend.
+Hindsight backend. The current `admit_hindsight_retain_candidate(event_id)`
+entrypoint is a no-op pending stub; a later worker must load the pending
+candidate, build the full admission request, evaluate evidence, and produce an
+admitted retain plan before any durable Hindsight write.
 
 ## Multica Bridge Rules
 

--- a/services/zoe-data/hindsight_retain_candidates.py
+++ b/services/zoe-data/hindsight_retain_candidates.py
@@ -14,7 +14,12 @@ from typing import Any, Mapping
 
 from hindsight_memory import HindsightConfig, event_to_hindsight_item
 from zoe_evolution_proposal import EvolutionProposal
-from zoe_memory_admission import MemoryAdmissionDecision, MemoryAdmissionRequest, evaluate_memory_admission
+from zoe_memory_admission import (
+    MemoryAdmissionDecision,
+    MemoryAdmissionRequest,
+    MemoryAdmissionStatus,
+    evaluate_memory_admission,
+)
 from zoe_memory_contract import MemoryEvent, memory_event_from_mapping
 from zoe_memory_router import MemoryBackend
 from zoe_observation_trace import ObservationTrace
@@ -45,6 +50,28 @@ class HindsightAdmittedRetainPlan:
             "bank_id": self.bank_id,
             "payload": payload,
             "evidence_refs": list(self.evidence_refs),
+        }
+
+
+@dataclass(frozen=True)
+class HindsightRetainCandidateAdmissionResult:
+    event_id: str
+    admission_id: str
+    status: MemoryAdmissionStatus
+    allowed_to_write_durable: bool
+    reason: str
+    evidence_refs: tuple[str, ...] = ()
+    side_effects: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "event_id": self.event_id,
+            "admission_id": self.admission_id,
+            "status": self.status.value,
+            "allowed_to_write_durable": self.allowed_to_write_durable,
+            "reason": self.reason,
+            "evidence_refs": list(self.evidence_refs),
+            "side_effects": list(self.side_effects),
         }
 
 
@@ -163,6 +190,29 @@ def evaluate_hindsight_retain_candidate_admission(
     return evaluate_memory_admission(request)
 
 
+def admit_hindsight_retain_candidate(event_id: str) -> HindsightRetainCandidateAdmissionResult:
+    """Runtime-facing admission stub for pending Hindsight retain candidates.
+
+    Future chat/runtime code should call this interface instead of writing
+    directly to Hindsight. Until the admission worker can load a pending
+    MemoryService candidate and evaluate its evidence, this function is
+    intentionally inert: it returns pending review and records no side effects.
+    """
+
+    if not isinstance(event_id, str):
+        raise TypeError("event_id must be str")
+    event_id_value = event_id.strip()
+    if not event_id_value:
+        raise HindsightRetainAdmissionError("event_id is required")
+    return HindsightRetainCandidateAdmissionResult(
+        event_id=event_id_value,
+        admission_id=f"admit_hindsight_retain_{event_id_value}",
+        status=MemoryAdmissionStatus.PENDING_REVIEW,
+        allowed_to_write_durable=False,
+        reason="admission_worker_not_wired",
+    )
+
+
 def build_admitted_hindsight_retain_plan(
     request: MemoryAdmissionRequest,
     decision: MemoryAdmissionDecision,
@@ -241,8 +291,10 @@ async def create_hindsight_retain_candidate(
 
 __all__ = [
     "HindsightAdmittedRetainPlan",
+    "HindsightRetainCandidateAdmissionResult",
     "HINDSIGHT_RETAIN_SOURCE",
     "HindsightRetainAdmissionError",
+    "admit_hindsight_retain_candidate",
     "build_admitted_hindsight_retain_plan",
     "build_hindsight_retain_admission_request",
     "build_hindsight_retain_candidate",

--- a/services/zoe-data/tests/test_hindsight_retain_candidates.py
+++ b/services/zoe-data/tests/test_hindsight_retain_candidates.py
@@ -3,6 +3,7 @@ import pytest
 from hindsight_retain_candidates import (
     HINDSIGHT_RETAIN_SOURCE,
     HindsightRetainAdmissionError,
+    admit_hindsight_retain_candidate,
     build_admitted_hindsight_retain_plan,
     build_hindsight_retain_admission_request,
     build_hindsight_retain_candidate,
@@ -151,6 +152,37 @@ def test_hindsight_retain_candidate_admission_can_approve_hindsight_with_evidenc
     assert "chat:offline-memory" in decision.evidence_refs
     assert "multica:retain-review" in decision.evidence_refs
     assert "approval:multica:retain-review" in decision.evidence_refs
+
+
+def test_admit_hindsight_retain_candidate_stub_is_pending_and_non_writing():
+    result = admit_hindsight_retain_candidate(" mem_evt_candidate ")
+
+    assert result.event_id == "mem_evt_candidate"
+    assert result.admission_id == "admit_hindsight_retain_mem_evt_candidate"
+    assert result.status == MemoryAdmissionStatus.PENDING_REVIEW
+    assert result.allowed_to_write_durable is False
+    assert result.reason == "admission_worker_not_wired"
+    assert result.evidence_refs == ()
+    assert result.side_effects == ()
+    assert result.to_dict() == {
+        "event_id": "mem_evt_candidate",
+        "admission_id": "admit_hindsight_retain_mem_evt_candidate",
+        "status": MemoryAdmissionStatus.PENDING_REVIEW.value,
+        "allowed_to_write_durable": False,
+        "reason": "admission_worker_not_wired",
+        "evidence_refs": [],
+        "side_effects": [],
+    }
+
+
+def test_admit_hindsight_retain_candidate_requires_event_id():
+    with pytest.raises(HindsightRetainAdmissionError, match="event_id is required"):
+        admit_hindsight_retain_candidate(" ")
+
+
+def test_admit_hindsight_retain_candidate_rejects_non_string_event_id():
+    with pytest.raises(TypeError, match="event_id must be str"):
+        admit_hindsight_retain_candidate(None)  # type: ignore[arg-type]
 
 
 def test_admitted_hindsight_retain_plan_requires_approved_hindsight_decision():


### PR DESCRIPTION
## Summary

Adds a runtime-facing `admit_hindsight_retain_candidate(event_id)` stub for pending Hindsight retain candidates.

The interface is intentionally non-writing until an admission worker is wired: it returns pending review, `allowed_to_write_durable: false`, and no side effects. This gives future chat/runtime code a safe front door instead of calling Hindsight retain sidecars directly.

## Why

Recent review feedback called out that Zoe has strong contracts but can lag on last-mile wiring. This PR closes the next small admission-loop step without pretending the worker exists yet.

## Validation

- `PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_hindsight_retain_candidates.py services/zoe-data/tests/test_hindsight_retain_executor.py services/zoe-data/tests/test_zoe_memory_admission.py services/zoe-data/tests/test_zoe_multica_memory_admission.py`
- `python3 tools/audit/validate_structure.py`
- `python3 tools/audit/validate_critical_files.py`
- `python3 tools/audit/validate_offline_memory.py`
- `git diff --check`
