### PR TITLE
[codex] Document Hindsight offline rollout flags

### DIFF
--- a/services/zoe-data/MEMORY_ROLLOUT.md
+++ b/services/zoe-data/MEMORY_ROLLOUT.md
@@ -12,6 +12,54 @@ This rollout uses environment flags so the new memory stack can be enabled gradu
   - When false, OpenClaw-extracted memories go to review queue.
   - When true, high-confidence preference memories may auto-approve.
 
+## Hindsight offline flags
+
+Hindsight remains a bake-off sidecar, not a production chat hot path.
+Defaults are intentionally local/offline and non-retaining:
+
+- `HINDSIGHT_ENABLED=false`
+  - Keeps the Hindsight client disabled until a controlled bake-off or rollout
+    explicitly enables it.
+- `HINDSIGHT_BASE_URL=http://127.0.0.1:8888`
+  - Must stay on localhost or a private-network address while
+    `HINDSIGHT_OFFLINE_ONLY=true`.
+- `HINDSIGHT_OFFLINE_ONLY=true`
+  - Rejects public/cloud memory endpoints, public LLM providers, and public
+    embedding endpoints unless an OpenAI-compatible provider is pointed at a
+    local/private base URL.
+- `HINDSIGHT_AUTO_RETAIN=false`
+  - Prevents blind durable writes. Retain candidates must stay pending until
+    memory admission, evidence, approval, and verification gates allow
+    promotion.
+- `HINDSIGHT_ASYNC_RETAIN=true`
+  - Keeps approved retain execution off the chat response path.
+- `HINDSIGHT_BANK_PREFIX=zoe`
+  - Prefixes isolated per-user and per-scope Hindsight banks.
+- `HINDSIGHT_TIMEOUT_SECONDS=6.0`
+  - Caps sidecar calls during bake-off and controlled recall tests.
+
+Local model/provider settings:
+
+- `HINDSIGHT_API_LLM_PROVIDER=llamacpp|ollama|lmstudio|vllm|openai`
+  - `openai` is allowed only when `HINDSIGHT_API_LLM_BASE_URL` points to a
+    localhost/private OpenAI-compatible endpoint.
+- `HINDSIGHT_API_LLM_BASE_URL=http://127.0.0.1:<port>/v1`
+  - Required for OpenAI-compatible local runtimes.
+- `HINDSIGHT_API_EMBEDDINGS_PROVIDER=local|onnx|sentence_transformers|tei|openai|custom`
+  - Public/cloud embedding providers are rejected by the offline validator.
+- `HINDSIGHT_API_EMBEDDINGS_TEI_URL=http://127.0.0.1:<port>`
+  - Required when using a local TEI embedding service.
+- `HINDSIGHT_API_EMBEDDINGS_OPENAI_BASE_URL=http://127.0.0.1:<port>/v1`
+  - Required when using an OpenAI-compatible local/private embedding endpoint.
+- `HINDSIGHT_API_EMBEDDINGS_LOCAL_MODEL`,
+  `HINDSIGHT_API_EMBEDDINGS_ONNX_MODEL_PATH`,
+  `HINDSIGHT_API_EMBEDDINGS_ONNX_MODEL_ID`, or
+  `HINDSIGHT_API_EMBEDDINGS_OPENAI_MODEL`
+  - Identifies the local embedding model for the selected provider.
+
+Do not disable offline-only mode or enable Hindsight auto-retain in production.
+The offline-memory validator treats those settings as rollout blockers.
+
 ## Suggested rollout stages
 
 1. Enable `PEOPLE_CUSTOM_FIELDS=true` only.
@@ -22,6 +70,9 @@ This rollout uses environment flags so the new memory stack can be enabled gradu
 
 ## Rollback
 
-- Set all flags to false and restart `zoe-data`.
+- Set feature-enabling flags to false and restart `zoe-data`.
+- When backing out Hindsight bake-off traffic, set `HINDSIGHT_ENABLED=false`
+  and `HINDSIGHT_AUTO_RETAIN=false`, and keep
+  `HINDSIGHT_OFFLINE_ONLY=true`.
 - Existing `memory_items` records are preserved; only behavior changes.
 - UI continues to function with local SQL memory list/search.


### PR DESCRIPTION
## Summary

Documents the Hindsight offline rollout flags alongside the existing memory rollout flags.

- Names the disabled/offline/no-auto-retain defaults.
- Documents local/private LLM and embedding provider expectations.
- Adds rollback guidance for Hindsight bake-off traffic.

## Why

Zoe memory must remain offline-only. The code and validator already enforce that, but the rollout document did not yet describe the Hindsight flags operators need to keep that contract intact.

## Validation

- `python3 tools/audit/validate_offline_memory.py`
- `python3 tools/audit/validate_structure.py`
- `python3 tools/audit/validate_critical_files.py`
- `git diff --check`
