### PR TITLE
Prevent stale duplicate phase regression

### DIFF
--- a/services/zoe-data/pipeline_store.py
+++ b/services/zoe-data/pipeline_store.py
@@ -13,6 +13,7 @@ from typing import Any, Awaitable, Callable
 
 from pipeline_evidence import (
     EvidenceItem,
+    PHASE_ORDER,
     PipelinePhase,
     PipelineState,
     TransitionRecord,
@@ -39,10 +40,29 @@ _PHASE_SKILLS: dict[str, tuple[str, ...]] = {
 
 _LOCK = threading.Lock()
 _TERMINAL = {"done", "archived", "blocked"}
+_TERMINAL_SUCCESS = {"done", "archived"}
 
 
 class PipelineStateConflict(RuntimeError):
     """Raised when a caller tries to persist a stale pipeline mutation."""
+
+
+def _phase_after(candidate: PipelinePhase, current: PipelinePhase) -> bool:
+    return PHASE_ORDER.index(candidate) > PHASE_ORDER.index(current)
+
+
+def _has_later_successful_phase(phases: dict[str, dict], phase: PipelinePhase) -> bool:
+    phase_idx = PHASE_ORDER.index(phase)
+    for candidate in PHASE_ORDER[phase_idx + 1 :]:
+        row = phases.get(candidate)
+        if row and (row.get("status") or "").lower() in _TERMINAL_SUCCESS:
+            return True
+    return False
+
+
+def _is_stale_duplicate_block(row: dict) -> bool:
+    reason = str(row.get("block_reason") or row.get("reason") or "").upper()
+    return "DUPLICATE_REDISPATCH" in reason
 
 
 def store_path() -> Path:
@@ -556,12 +576,22 @@ async def _sync_pipeline_from_chain_once(
         if (row.get("status") or "").lower() != "blocked":
             return state
 
-    for phase in ("scout", "implement", "verify", "review", "closeout", "retro"):
+    blocked_catch_up_allowed_from: PipelinePhase | None = None
+    for phase in PHASE_ORDER:
         row = phases.get(phase)
         if not row:
             continue
         row_status = (row.get("status") or "").lower()
         skills = _PHASE_SKILLS.get(phase, ())
+
+        if (
+            row_status == "blocked"
+            and _is_stale_duplicate_block(row)
+            and _has_later_successful_phase(phases, phase)
+        ):
+            if state.status == "blocked" and state.phase == phase:
+                blocked_catch_up_allowed_from = phase
+            continue
 
         if phase == state.phase and row_status not in _TERMINAL and phase == "verify":
             state = await _append_harness_validators(state, "verify")
@@ -573,6 +603,39 @@ async def _sync_pipeline_from_chain_once(
         detail: dict[str, Any] = {}
         if task_id:
             detail = await fetch_detail(task_id)
+
+        while (
+            phase != state.phase
+            and _phase_after(phase, state.phase)
+            and (state.status != "blocked" or state.phase == blocked_catch_up_allowed_from)
+            and can_complete_phase(state)
+        ):
+            previous_phase = state.phase
+            state = transition(
+                state,
+                "complete",
+                reason=f"caught up to terminal {phase} row",
+            )
+            state = state.model_copy(
+                update={
+                    "last_block_fingerprint": None,
+                    "repeated_block_count": 0,
+                    "block_classification": None,
+                    "split_packet": None,
+                }
+            )
+            state = await _run_io(
+                partial(
+                    save_state,
+                    state,
+                    event="phase_catch_up",
+                    extra={
+                        "from_phase": previous_phase,
+                        "to_phase": state.phase,
+                        "row_phase": phase,
+                    },
+                )
+            )
 
         if phase != state.phase:
             continue

--- a/services/zoe-data/tests/test_pipeline_store.py
+++ b/services/zoe-data/tests/test_pipeline_store.py
@@ -609,6 +609,137 @@ async def test_sync_pipeline_advances_with_live_run_metadata_recovery(isolated_s
 
 
 @pytest.mark.asyncio
+async def test_sync_pipeline_ignores_stale_duplicate_implement_block_after_verify_success(
+    isolated_store,
+):
+    state = await store.bootstrap_state(
+        "multica:duplicate-implement-block",
+        issue={"metadata": {"evidence_profile": "code"}},
+    )
+    state = with_evidence(
+        state,
+        EvidenceItem(
+            kind="tool",
+            summary="implementation used repo context",
+            passed=True,
+            metadata={"phase": "implement", "source": "handoff"},
+        ),
+        EvidenceItem(
+            kind="pr",
+            summary="https://github.com/jason-easyazz/zoe-ai-assistant/pull/342",
+            artifact="https://github.com/jason-easyazz/zoe-ai-assistant/pull/342",
+            passed=True,
+            metadata={"phase": "implement", "source": "handoff"},
+        ),
+    )
+    store.save_state(state, event="implement_evidence_recorded")
+
+    phases = {
+        "implement": {
+            "id": "t_duplicate",
+            "status": "blocked",
+            "block_reason": "DUPLICATE_REDISPATCH PR_URL=https://github.com/jason-easyazz/zoe-ai-assistant/pull/342",
+        },
+        "verify": {"id": "t_verify", "status": "done"},
+    }
+
+    async def fetch_detail(task_id: str):
+        if task_id == "t_verify":
+            return {
+                "latest_summary": (
+                    "TESTS=pytest passed\n"
+                    "VALIDATORS=validate_structure.py passed\n"
+                    "SUMMARY=verify passed"
+                ),
+                "comments": [],
+            }
+        return {"latest_summary": "BLOCKER=DUPLICATE_REDISPATCH", "comments": []}
+
+    synced = await store.sync_pipeline_from_chain(
+        "multica:duplicate-implement-block",
+        phases,
+        fetch_detail,
+    )
+
+    assert synced.phase == "review"
+    assert synced.status == "todo"
+    assert synced.attempts.get("implement") is None
+    assert synced.last_block_fingerprint is None
+    assert synced.repeated_block_count == 0
+    assert synced.block_classification is None
+    assert synced.history[-1].from_phase == "verify"
+    assert synced.history[-1].outcome == "complete"
+    assert store.pipeline_summary(synced)["block_reason"] is None
+    events = [
+        json.loads(line)["event"]
+        for line in isolated_store.read_text(encoding="utf-8").strip().splitlines()
+    ]
+    assert "phase_catch_up" in events
+
+
+@pytest.mark.asyncio
+async def test_sync_pipeline_keeps_legitimate_implement_block_with_later_orphan_success(
+    isolated_store,
+):
+    state = await store.bootstrap_state(
+        "multica:legitimate-block-with-orphan-verify",
+        issue={"metadata": {"evidence_profile": "code"}},
+    )
+    state = with_evidence(
+        state,
+        EvidenceItem(
+            kind="tool",
+            summary="implementation used repo context",
+            passed=True,
+            metadata={"phase": "implement", "source": "handoff"},
+        ),
+        EvidenceItem(
+            kind="pr",
+            summary="https://github.com/jason-easyazz/zoe-ai-assistant/pull/999",
+            artifact="https://github.com/jason-easyazz/zoe-ai-assistant/pull/999",
+            passed=True,
+            metadata={"phase": "implement", "source": "handoff"},
+        ),
+    )
+    store.save_state(state, event="implement_evidence_recorded")
+    phases = {
+        "implement": {
+            "id": "t_blocked",
+            "status": "blocked",
+            "block_reason": "GATE_BLOCKED: missing required evidence pr",
+        },
+        "verify": {"id": "t_orphan_verify", "status": "done"},
+    }
+
+    async def fetch_detail(task_id: str):
+        if task_id == "t_blocked":
+            return {
+                "latest_summary": (
+                    "BLOCKER=GATE_BLOCKED: missing required evidence pr\n"
+                    "SUMMARY=implementation did not produce a PR"
+                ),
+                "comments": [],
+            }
+        return {"latest_summary": "TESTS=pytest passed", "comments": []}
+
+    synced = await store.sync_pipeline_from_chain(
+        "multica:legitimate-block-with-orphan-verify",
+        phases,
+        fetch_detail,
+    )
+
+    assert synced.phase == "implement"
+    assert synced.status == "blocked"
+    assert synced.history[-1].outcome == "block"
+    assert synced.history[-1].reason == "GATE_BLOCKED: missing required evidence pr"
+    events = [
+        json.loads(line)["event"]
+        for line in isolated_store.read_text(encoding="utf-8").strip().splitlines()
+    ]
+    assert "phase_catch_up" not in events
+
+
+@pytest.mark.asyncio
 async def test_sync_pipeline_retries_a_concurrent_transition_write(
     isolated_store, monkeypatch
 ):


### PR DESCRIPTION
## Summary
- ignore stale blocked lower-phase Kanban rows when a later phase has already succeeded
- allow the pipeline journal to catch up to later terminal phase rows when required evidence is already present
- add a regression test for the live ZOE-5457 shape: duplicate implement block after verify success

## Verification
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_pipeline_store.py services/zoe-data/tests/test_kanban_adapter.py -q
- python3 -m py_compile services/zoe-data/pipeline_store.py services/zoe-data/tests/test_pipeline_store.py
- python3 tools/audit/validate_structure.py
- python3 tools/audit/validate_critical_files.py

Production dispatch remains paused until this is reviewed, merged, deployed, and the live ZOE-5457 state is reconciled safely.