### PR TITLE
[codex] Report Hindsight bakeoff latency gate

### DIFF
--- a/scripts/maintenance/hindsight_bakeoff.py
+++ b/scripts/maintenance/hindsight_bakeoff.py
@@ -19,7 +19,13 @@ ROOT = Path(__file__).resolve().parents[2]
 DATA = ROOT / "services" / "zoe-data"
 sys.path.insert(0, str(DATA))
 
-from hindsight_bakeoff import EVAL_QUERIES, SYNTHETIC_EVENTS, score_recall_response, summarize_bakeoff_scores  # noqa: E402
+from hindsight_bakeoff import (  # noqa: E402
+    EVAL_QUERIES,
+    SYNTHETIC_EVENTS,
+    score_recall_response,
+    summarize_bakeoff_scores,
+    summarize_recall_latency,
+)
 from hindsight_memory import HindsightConfig, HindsightMemoryClient  # noqa: E402
 
 
@@ -29,6 +35,7 @@ async def main() -> int:
     parser.add_argument("--no-wait-retain", action="store_true", help="do not wait for async retain operations before recall")
     parser.add_argument("--retain-timeout-seconds", type=float, default=180.0, help="max seconds to wait for each async retain operation")
     parser.add_argument("--retain-poll-seconds", type=float, default=1.0, help="seconds between async retain status polls")
+    parser.add_argument("--recall-latency-budget-ms", type=float, default=600.0, help="p95 recall latency budget for hot-path eligibility")
     parser.add_argument("--json", action="store_true", help="emit JSON")
     args = parser.parse_args()
 
@@ -62,16 +69,20 @@ async def main() -> int:
         score["latency_ms"] = latency_ms
         score["bank_id"] = response.get("bank_id")
         score["enabled"] = response.get("enabled", client.config.enabled)
+        score["latency_budget_ms"] = args.recall_latency_budget_ms
+        score["within_latency_budget"] = bool(score["enabled"]) and latency_ms <= args.recall_latency_budget_ms
         score["reason"] = response.get("reason")
         scores.append(score)
     output["scores"] = scores
     output["summary"] = summarize_bakeoff_scores(scores)
+    output["latency"] = summarize_recall_latency(scores, budget_ms=args.recall_latency_budget_ms)
 
     if args.json:
         print(json.dumps(output, indent=2, sort_keys=True))
     else:
         print(json.dumps(output["status"], indent=2, sort_keys=True))
         print(json.dumps(output["summary"], indent=2, sort_keys=True))
+        print(json.dumps(output["latency"], indent=2, sort_keys=True))
         for item in scores:
             print(f"{item['name']}: score={item['score']:.2f} latency_ms={item['latency_ms']:.2f} missing={item['missing']}")
     return 0

--- a/services/zoe-data/hindsight_bakeoff.py
+++ b/services/zoe-data/hindsight_bakeoff.py
@@ -153,6 +153,37 @@ def summarize_bakeoff_scores(scores: Sequence[Mapping[str, Any]]) -> dict[str, A
     }
 
 
+def summarize_recall_latency(
+    scores: Sequence[Mapping[str, Any]],
+    *,
+    budget_ms: float = 600.0,
+) -> dict[str, Any]:
+    """Build the machine-readable recall latency acceptance block."""
+
+    if budget_ms <= 0:
+        raise ValueError("budget_ms must be positive")
+    latencies = [
+        float(item.get("latency_ms") or 0.0)
+        for item in scores
+        if bool(item.get("enabled")) and "latency_ms" in item
+    ]
+    enabled_case_count = len(latencies)
+    p50_latency_ms = median(latencies) if latencies else 0.0
+    p95_latency_ms = percentile(latencies, 0.95)
+    measured = bool(latencies) and enabled_case_count > 0
+    p95_within_budget = measured and p95_latency_ms <= budget_ms
+    return {
+        "measured": measured,
+        "case_count": len(scores),
+        "enabled_case_count": enabled_case_count,
+        "budget_ms": budget_ms,
+        "p50_latency_ms": p50_latency_ms,
+        "p95_latency_ms": p95_latency_ms,
+        "p95_within_budget": p95_within_budget,
+        "hot_path_status": "eligible" if p95_within_budget else ("async_or_cached_only" if measured else "not_measured"),
+    }
+
+
 def recall_response_text(response: Mapping[str, Any]) -> str:
     results = response.get("results") or []
     texts = []
@@ -181,5 +212,6 @@ __all__ = [
     "score_recall_response",
     "score_recall_text",
     "summarize_bakeoff_scores",
+    "summarize_recall_latency",
     "synthetic_retain_payloads",
 ]

--- a/services/zoe-data/tests/test_hindsight_bakeoff.py
+++ b/services/zoe-data/tests/test_hindsight_bakeoff.py
@@ -8,6 +8,7 @@ from hindsight_bakeoff import (
     percentile,
     score_recall_response,
     summarize_bakeoff_scores,
+    summarize_recall_latency,
     synthetic_retain_payloads,
 )
 
@@ -63,6 +64,85 @@ def test_summarize_bakeoff_scores_reports_score_and_latency():
     assert summary["p95_latency_ms"] == 29.0
 
 
+def test_summarize_recall_latency_reports_budget_status():
+    latency = summarize_recall_latency(
+        [
+            {"latency_ms": 20.0, "enabled": True},
+            {"latency_ms": 10.0, "enabled": True},
+            {"latency_ms": 30.0, "enabled": True},
+        ],
+        budget_ms=25.0,
+    )
+
+    assert latency == {
+        "measured": True,
+        "case_count": 3,
+        "enabled_case_count": 3,
+        "budget_ms": 25.0,
+        "p50_latency_ms": 20.0,
+        "p95_latency_ms": 29.0,
+        "p95_within_budget": False,
+        "hot_path_status": "async_or_cached_only",
+    }
+
+
+def test_summarize_recall_latency_reports_hot_path_eligible():
+    latency = summarize_recall_latency(
+        [
+            {"latency_ms": 20.0, "enabled": True},
+            {"latency_ms": 10.0, "enabled": True},
+            {"latency_ms": 30.0, "enabled": True},
+        ],
+        budget_ms=30.0,
+    )
+
+    assert latency["p95_within_budget"] is True
+    assert latency["hot_path_status"] == "eligible"
+
+
+def test_summarize_recall_latency_marks_disabled_runs_not_measured():
+    latency = summarize_recall_latency(
+        [
+            {"latency_ms": 0.01, "enabled": False},
+            {"latency_ms": 0.02, "enabled": False},
+        ],
+        budget_ms=600.0,
+    )
+
+    assert latency["measured"] is False
+    assert latency["case_count"] == 2
+    assert latency["enabled_case_count"] == 0
+    assert latency["p95_within_budget"] is False
+    assert latency["hot_path_status"] == "not_measured"
+
+
+def test_summarize_recall_latency_ignores_disabled_latencies_in_mixed_run():
+    latency = summarize_recall_latency(
+        [
+            {"latency_ms": 0.1, "enabled": False},
+            {"latency_ms": 0.2, "enabled": False},
+            {"latency_ms": 800.0, "enabled": True},
+        ],
+        budget_ms=600.0,
+    )
+
+    assert latency["measured"] is True
+    assert latency["case_count"] == 3
+    assert latency["enabled_case_count"] == 1
+    assert latency["p95_latency_ms"] == 800.0
+    assert latency["p95_within_budget"] is False
+    assert latency["hot_path_status"] == "async_or_cached_only"
+
+
+def test_summarize_recall_latency_requires_positive_budget():
+    try:
+        summarize_recall_latency([{"latency_ms": 1.0}], budget_ms=0.0)
+    except ValueError as exc:
+        assert "budget_ms must be positive" in str(exc)
+    else:
+        raise AssertionError("summarize_recall_latency accepted a non-positive budget")
+
+
 def test_percentile_rejects_out_of_range_values():
     try:
         percentile([1, 2, 3], 95)
@@ -85,3 +165,4 @@ def test_maintenance_runner_imports_real_bakeoff_module():
 
     assert len(runner.EVAL_QUERIES) == len(EVAL_QUERIES)
     assert runner.summarize_bakeoff_scores([{"score": 1, "latency_ms": 1}])["case_count"] == 1
+    assert runner.summarize_recall_latency([{"latency_ms": 1, "enabled": True}], budget_ms=600)["p95_within_budget"] is True


### PR DESCRIPTION
## Summary

Adds an explicit machine-readable recall latency gate to the Hindsight bake-off report.

- Adds `summarize_recall_latency()` with p50/p95, budget, enabled-case count, pass/fail, and hot-path status.
- Adds `--recall-latency-budget-ms` to the maintenance runner, defaulting to the 600 ms Hindsight gate.
- Annotates each recall score with its latency budget decision and emits a top-level `latency` JSON block.
- Disabled/no-sidecar runs now report `hot_path_status: not_measured` instead of accidentally looking eligible.

## Validation

- `PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_hindsight_bakeoff.py services/zoe-data/tests/test_hindsight_memory.py`
- `PYTHONPATH=services/zoe-data python3 scripts/maintenance/hindsight_bakeoff.py --json --recall-latency-budget-ms 600 | python3 -m json.tool | grep -n "\"latency\"\|\"enabled_case_count\"\|\"hot_path_status\"\|\"measured\"\|\"p95_within_budget\""`
- `python3 tools/audit/validate_structure.py`
- `python3 tools/audit/validate_critical_files.py`
- `python3 tools/audit/validate_offline_memory.py`
- `git diff --check`
