### PR TITLE
[codex] Harden Hindsight bakeoff latency summary

### DIFF
--- a/services/zoe-data/hindsight_bakeoff.py
+++ b/services/zoe-data/hindsight_bakeoff.py
@@ -163,15 +163,15 @@ def summarize_recall_latency(
     if budget_ms <= 0:
         raise ValueError("budget_ms must be positive")
     latencies = [
-        float(item.get("latency_ms") or 0.0)
+        float(item["latency_ms"])
         for item in scores
-        if bool(item.get("enabled")) and "latency_ms" in item
+        if bool(item.get("enabled")) and item.get("latency_ms") is not None
     ]
     enabled_case_count = len(latencies)
-    p50_latency_ms = median(latencies) if latencies else 0.0
-    p95_latency_ms = percentile(latencies, 0.95)
-    measured = bool(latencies) and enabled_case_count > 0
-    p95_within_budget = measured and p95_latency_ms <= budget_ms
+    measured = enabled_case_count > 0
+    p50_latency_ms = median(latencies) if measured else None
+    p95_latency_ms = percentile(latencies, 0.95) if measured else None
+    p95_within_budget = measured and p95_latency_ms is not None and p95_latency_ms <= budget_ms
     return {
         "measured": measured,
         "case_count": len(scores),

--- a/services/zoe-data/tests/test_hindsight_bakeoff.py
+++ b/services/zoe-data/tests/test_hindsight_bakeoff.py
@@ -130,6 +130,7 @@ def test_summarize_recall_latency_ignores_missing_enabled_latency():
     assert latency["measured"] is True
     assert latency["case_count"] == 2
     assert latency["enabled_case_count"] == 1
+    assert latency["p50_latency_ms"] == 800.0
     assert latency["p95_latency_ms"] == 800.0
     assert latency["p95_within_budget"] is False
     assert latency["hot_path_status"] == "async_or_cached_only"

--- a/services/zoe-data/tests/test_hindsight_bakeoff.py
+++ b/services/zoe-data/tests/test_hindsight_bakeoff.py
@@ -112,8 +112,27 @@ def test_summarize_recall_latency_marks_disabled_runs_not_measured():
     assert latency["measured"] is False
     assert latency["case_count"] == 2
     assert latency["enabled_case_count"] == 0
+    assert latency["p50_latency_ms"] is None
+    assert latency["p95_latency_ms"] is None
     assert latency["p95_within_budget"] is False
     assert latency["hot_path_status"] == "not_measured"
+
+
+def test_summarize_recall_latency_ignores_missing_enabled_latency():
+    latency = summarize_recall_latency(
+        [
+            {"latency_ms": None, "enabled": True},
+            {"latency_ms": 800.0, "enabled": True},
+        ],
+        budget_ms=600.0,
+    )
+
+    assert latency["measured"] is True
+    assert latency["case_count"] == 2
+    assert latency["enabled_case_count"] == 1
+    assert latency["p95_latency_ms"] == 800.0
+    assert latency["p95_within_budget"] is False
+    assert latency["hot_path_status"] == "async_or_cached_only"
 
 
 def test_summarize_recall_latency_ignores_disabled_latencies_in_mixed_run():


### PR DESCRIPTION
## Summary
- Treat missing enabled Hindsight latency measurements as unmeasured instead of 0ms
- Return null p50/p95 values for not-measured latency summaries
- Add regression coverage for missing enabled latency values

## Verification
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_hindsight_bakeoff.py services/zoe-data/tests/test_hindsight_memory.py
- PYTHONPATH=services/zoe-data python3 scripts/maintenance/hindsight_bakeoff.py --json --recall-latency-budget-ms 600 | python3 -m json.tool | grep -n latency|case_count|enabled_case_count|p50_latency_ms|p95_latency_ms|within_latency_budget
- python3 tools/audit/validate_structure.py
- python3 tools/audit/validate_critical_files.py
- python3 tools/audit/validate_offline_memory.py
- git diff --check