### PR TITLE
Codify trunk-based branching policy and add worktree pruning

### DIFF
--- a/.cursor/rules/agentic-workflow.mdc
+++ b/.cursor/rules/agentic-workflow.mdc
@@ -19,6 +19,8 @@ For Hermes-backed engineering work, prefer the local Hermes skills `zoe-engineer
 
 Use the small-PR loop for reviewable work: split large changes, push a focused PR, let Greptile review independently, then use Zoe's Greploop guard when an engineering task id exists. Otherwise use **Greptile MCP first** (`get_merge_request`, `list_merge_request_comments`, `trigger_code_review`) or the operator-local CLI `~/bin/greptile-mcp.py` (install path varies by host; see Cursor `/grep-loop`) before falling back to `gh` scraping. For heavier repair loops, delegate to Hermes `github-greptile-loop`. Read the PR diff before fixing comments and stop to split if the PR is too large for reliable review.
 
+Branching is trunk-based: `main` is the only permanent branch (no `develop`/`staging`). One branch per issue from fresh `origin/main`, named `codex/<slug>`, `feature/<slug>`, `fix/<slug>`, or `verify/<slug>`, developed in a worktree under `~/.worktrees/<slug>`. Remove worktrees and branches after merge, or run `scripts/maintenance/prune_worktrees.sh` (dry-run first).
+
 `main` is protected. Do not push directly, bypass branch protection, or use administrator merges unless the operator explicitly asks for that emergency path. If GitHub blocks a green PR because repo auto-merge is disabled or another policy requires human action, report the blocker and keep the PR ready rather than forcing it.
 
 Verify from a user perspective before commit: focused tests, `validate_structure.py`, `validate_critical_files.py`, live `/health` and `/api/system/status`, and any relevant systemd timers or MCP tools.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,16 @@ The `agentic-engineering-workflow` and `grep-loop-review-workflow` names are kep
 
 OpenClaw remains installed and available as a future/manual fallback. Do not route ordinary coding, planning, review, board work, browser work, or background work to OpenClaw by default. Zoe's Multica-first engineering driver owns workflow state and phase advancement; Hermes executes the one ready phase unless the user explicitly asks to use OpenClaw.
 
+## Branching policy
+
+Trunk-based development. `main` is the only permanent branch; there is no `develop`, `staging`, or other long-lived integration branch.
+
+- One branch per issue / Multica task, created from fresh `origin/main`.
+- Naming: `codex/<slug>` for agent-driven work, `feature/<slug>` for features, `fix/<slug>` for bug fixes, `verify/<slug>` for throwaway validation branches.
+- Develop in a worktree under `~/.worktrees/<slug>`; never switch the live checkout at `/home/zoe/assistant` onto a development branch for new work.
+- Branches die at merge: remote branches auto-delete (`delete_branch_on_merge`); remove the local worktree and branch promptly, or rely on `scripts/maintenance/prune_worktrees.sh`.
+- Branch protection requires green `validate`, GitGuardian, and Greptile Review checks and an up-to-date branch; when `main` moves quickly, use `gh pr update-branch` and the Greploop guard merge loop rather than any bypass.
+
 # DOX framework
 
 - DOX is highly performant AGENTS.md hierarchy installed here

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -7,7 +7,7 @@ Operational scripting for Zoe hosts: setup, maintenance, deployment, migrations,
 ## Ownership
 
 - `setup/` — host/platform provisioning, including `setup/jetson/` systemd unit templates (e.g. `zoe-graphify-refresh.service` / `.timer`).
-- `maintenance/` — recurring operational jobs: `refresh_graphify.sh` (nightly knowledge-graph refresh), `greploop_guard.py` (Greptile fix-packet loop), triage generators.
+- `maintenance/` — recurring operational jobs: `refresh_graphify.sh` (nightly knowledge-graph refresh), `greploop_guard.py` (Greptile fix-packet loop), `prune_worktrees.sh` (stale worktree cleanup, dry-run by default), triage generators.
 - `deploy/`, `migrations/`, `testing/`, `train/`, `utilities/`, `preview/` — task-specific script groups.
 
 ## Local Contracts

--- a/scripts/maintenance/prune_worktrees.sh
+++ b/scripts/maintenance/prune_worktrees.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Prune stale git worktrees under ~/.worktrees (and other registered paths).
+#
+# A worktree is a removal candidate ONLY when ALL of the following hold:
+#   - it is not the live checkout (the main working tree)
+#   - it is not locked
+#   - `git status --porcelain` is empty (no dirty or untracked tracked-path work)
+#   - its work is on main: HEAD is an ancestor of origin/main, or its branch
+#     matches a merged PR head (squash merges leave no ancestry)
+#   - it has had no filesystem activity for at least AGE_DAYS (default 7)
+#
+# Dry-run by default; pass --execute to remove. Never uses --force.
+
+ROOT="${ZOE_ASSISTANT_ROOT:-/home/zoe/assistant}"
+AGE_DAYS="${PRUNE_AGE_DAYS:-7}"
+MODE="${1:-}"
+
+log() {
+  printf '[prune-worktrees] %s\n' "$*"
+}
+
+cd "$ROOT"
+git fetch --quiet origin main || log "warning: git fetch failed; using last-known origin/main"
+git worktree prune
+
+now="$(date +%s)"
+age_limit=$((AGE_DAYS * 86400))
+candidates=()
+
+# One batched lookup: head branch names of merged PRs (squash merges leave
+# no ancestry, so the ancestor check alone misses most merged branches).
+merged_heads=""
+if command -v gh >/dev/null 2>&1; then
+  merged_heads="$(gh pr list --state merged --limit 1000 --json headRefName --jq '.[].headRefName' 2>/dev/null || true)"
+fi
+
+is_merged_pr_head() {
+  [[ -n "$1" && -n "$merged_heads" ]] && grep -Fxq "$1" <<<"$merged_heads"
+}
+
+while IFS= read -r line; do
+  case "$line" in
+    "worktree "*) wt="${line#worktree }"; locked=0 ;;
+    "locked"*) locked=1 ;;
+    "")
+      [[ -z "${wt:-}" ]] && continue
+      reason=""
+      if [[ "$wt" == "$ROOT" ]]; then
+        reason="live checkout"
+      elif [[ "$locked" == 1 ]]; then
+        reason="locked"
+      elif [[ ! -d "$wt" ]]; then
+        reason="missing (git worktree prune handles it)"
+      elif [[ -n "$(git -C "$wt" status --porcelain 2>/dev/null | head -1)" ]]; then
+        reason="dirty"
+      elif ! git -C "$wt" merge-base --is-ancestor HEAD origin/main 2>/dev/null \
+          && ! is_merged_pr_head "$(git -C "$wt" branch --show-current 2>/dev/null)"; then
+        reason="not merged into origin/main"
+      else
+        mtime="$(stat -c %Y "$wt")"
+        if (( now - mtime < age_limit )); then
+          reason="active within ${AGE_DAYS}d"
+        fi
+      fi
+      if [[ -z "$reason" ]]; then
+        candidates+=("$wt")
+      else
+        log "skip: $wt ($reason)"
+      fi
+      wt=""
+      ;;
+  esac
+done < <(git worktree list --porcelain; echo)
+
+if [[ ${#candidates[@]} -eq 0 ]]; then
+  log "no prunable worktrees"
+  exit 0
+fi
+
+log "${#candidates[@]} prunable worktree(s):"
+printf '  %s\n' "${candidates[@]}"
+
+if [[ "$MODE" != "--execute" ]]; then
+  log "dry-run complete; re-run with --execute to remove"
+  exit 0
+fi
+
+for wt in "${candidates[@]}"; do
+  branch="$(git -C "$wt" branch --show-current 2>/dev/null || true)"
+  log "removing $wt"
+  git worktree remove "$wt"
+  if [[ -n "$branch" ]]; then
+    if git branch -d "$branch" 2>/dev/null; then
+      log "deleted merged branch $branch"
+    elif is_merged_pr_head "$branch"; then
+      # squash-merged: content is on main but ancestry is not, -d refuses
+      git branch -D "$branch" && log "deleted squash-merged branch $branch"
+    else
+      log "kept branch $branch (not fully merged)"
+    fi
+  fi
+done
+git worktree prune
+log "done"

--- a/scripts/maintenance/prune_worktrees.sh
+++ b/scripts/maintenance/prune_worktrees.sh
@@ -59,8 +59,18 @@ while IFS= read -r line; do
           && ! is_merged_pr_head "$(git -C "$wt" branch --show-current 2>/dev/null)"; then
         reason="not merged into origin/main"
       else
-        mtime="$(stat -c %Y "$wt")"
-        if (( now - mtime < age_limit )); then
+        # Activity = newest of: root dir mtime, per-worktree git index mtime
+        # (updated by any git operation), and last commit time. Root mtime
+        # alone misses edits below the top level.
+        last_active="$(stat -c %Y "$wt")"
+        gitdir="$(git -C "$wt" rev-parse --absolute-git-dir 2>/dev/null || true)"
+        if [[ -n "$gitdir" && -f "$gitdir/index" ]]; then
+          idx_mtime="$(stat -c %Y "$gitdir/index")"
+          (( idx_mtime > last_active )) && last_active="$idx_mtime"
+        fi
+        commit_time="$(git -C "$wt" log -1 --format=%ct 2>/dev/null || echo 0)"
+        (( commit_time > last_active )) && last_active="$commit_time"
+        if (( now - last_active < age_limit )); then
           reason="active within ${AGE_DAYS}d"
         fi
       fi

--- a/scripts/maintenance/prune_worktrees.sh
+++ b/scripts/maintenance/prune_worktrees.sh
@@ -90,7 +90,10 @@ fi
 for wt in "${candidates[@]}"; do
   branch="$(git -C "$wt" branch --show-current 2>/dev/null || true)"
   log "removing $wt"
-  git worktree remove "$wt"
+  if ! git worktree remove "$wt"; then
+    log "failed to remove $wt (in-progress operation or new changes?); skipping"
+    continue
+  fi
   if [[ -n "$branch" ]]; then
     if git branch -d "$branch" 2>/dev/null; then
       log "deleted merged branch $branch"


### PR DESCRIPTION
## Summary
- Codifies the branching policy on the root `AGENTS.md` DOX rail and mirrors it in `.cursor/rules/agentic-workflow.mdc`: trunk-based, `main` is the only permanent branch (explicitly no `develop`/`staging`), one branch per issue from fresh `origin/main`, naming conventions (`codex/`, `feature/`, `fix/`, `verify/`), worktrees under `~/.worktrees/<slug>`, branches die at merge.
- Adds `scripts/maintenance/prune_worktrees.sh` for the ~220-worktree sprawl. Dry-run by default; `--execute` to act. A worktree is a candidate only when ALL hold: not the live checkout, not locked, clean status, work present on main (ancestor check OR merged-PR head lookup, since squash merges leave no ancestry), and no activity within `PRUNE_AGE_DAYS` (default 7).
- DOX pass: `scripts/AGENTS.md` ownership updated.

## Test plan
- [x] `bash -n` clean
- [x] Dry-run against the live repo: 224 worktrees scanned, 0 candidates today (188 active <7d, 19 unmerged, 16 dirty, 1 live checkout) -- all guards exercised, nothing eligible yet
- [x] Structure and critical-files validators pass

Made with [Cursor](https://cursor.com)