### PR TITLE
Codify trunk-based branching policy and add worktree prune script

### DIFF
--- a/.cursor/rules/agentic-workflow.mdc
+++ b/.cursor/rules/agentic-workflow.mdc
@@ -21,4 +21,6 @@ Use the small-PR loop for reviewable work: split large changes, push a focused P
 
 `main` is protected. Do not push directly, bypass branch protection, or use administrator merges unless the operator explicitly asks for that emergency path. If GitHub blocks a green PR because repo auto-merge is disabled or another policy requires human action, report the blocker and keep the PR ready rather than forcing it.
 
+Branching is trunk-based: one short-lived branch per issue off `origin/main`, no permanent `develop`. Use `~/.worktrees/<slug>` for agent work; do not repoint the live checkout to feature branches. After merge, remove the worktree; prune stale ones with `scripts/maintenance/prune_worktrees.sh` (dry-run first).
+
 Verify from a user perspective before commit: focused tests, `validate_structure.py`, `validate_critical_files.py`, live `/health` and `/api/system/status`, and any relevant systemd timers or MCP tools.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,16 @@ The `agentic-engineering-workflow` and `grep-loop-review-workflow` names are kep
 
 OpenClaw remains installed and available as a future/manual fallback. Do not route ordinary coding, planning, review, board work, browser work, or background work to OpenClaw by default. Zoe's Multica-first engineering driver owns workflow state and phase advancement; Hermes executes the one ready phase unless the user explicitly asks to use OpenClaw.
 
+## Branching policy
+
+Trunk-based development off protected `main`. No permanent `develop` or `staging` branch.
+
+- One branch per issue or Multica task, created from fresh `origin/main`.
+- Naming: `codex/<slug>` (agent work), `feature/<slug>`, `fix/<slug>`, `verify/<slug>` (throwaway validation).
+- Use a dedicated git worktree under `~/.worktrees/<slug>` for development; do not switch the live checkout (`/home/zoe/assistant`) to feature branches for agent work.
+- Branches die at merge: remote branches auto-delete (`delete_branch_on_merge`); remove the local worktree when done.
+- Prune stale worktrees with `scripts/maintenance/prune_worktrees.sh` (dry-run first, `--execute` after operator review). Never prune dirty, locked, or unmerged worktrees.
+
 # DOX framework
 
 - DOX is highly performant AGENTS.md hierarchy installed here

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -7,7 +7,7 @@ Operational scripting for Zoe hosts: setup, maintenance, deployment, migrations,
 ## Ownership
 
 - `setup/` — host/platform provisioning, including `setup/jetson/` systemd unit templates (e.g. `zoe-graphify-refresh.service` / `.timer`).
-- `maintenance/` — recurring operational jobs: `refresh_graphify.sh` (nightly knowledge-graph refresh), `greploop_guard.py` (Greptile fix-packet loop), triage generators.
+- `maintenance/` — recurring operational jobs: `refresh_graphify.sh` (nightly knowledge-graph refresh), `prune_worktrees.sh` (stale worktree cleanup), `greploop_guard.py` (Greptile fix-packet loop), triage generators.
 - `deploy/`, `migrations/`, `testing/`, `train/`, `utilities/`, `preview/` — task-specific script groups.
 
 ## Local Contracts
@@ -16,6 +16,7 @@ Operational scripting for Zoe hosts: setup, maintenance, deployment, migrations,
 - Installed systemd user units live in `~/.config/systemd/user/`; the copies here are templates. Keep both in sync when changing a unit.
 - Scripts run by timers/CI have no login session: prefix user-service systemctl calls with `XDG_RUNTIME_DIR=/run/user/$(id -u)`.
 - `refresh_graphify.sh` extracts from a clean git worktree snapshot of `origin/main`; it must never require a clean live working tree and must never use `graphify update` (inflates the graph).
+- `prune_worktrees.sh` is dry-run by default; never pass `--execute` without operator review of the candidate list. Skips dirty, locked, live-checkout, unmerged, and recently-active worktrees.
 
 ## Work Guidance
 

--- a/scripts/maintenance/prune_worktrees.sh
+++ b/scripts/maintenance/prune_worktrees.sh
@@ -65,7 +65,6 @@ while IFS= read -r line; do
       wt_path="${line#worktree }"
       wt_branch=""
       wt_locked=0
-      wt_dirty=0
       ;;
     branch\ refs/heads/*)
       wt_branch="${line#branch refs/heads/}"
@@ -136,7 +135,10 @@ for entry in "${candidates[@]}"; do
   IFS='|' read -r wt_path wt_branch wt_kind <<<"$entry"
   if [[ "$EXECUTE" == 1 ]]; then
     log "removing $wt_path ($wt_kind${wt_branch:+, branch $wt_branch})"
-    git worktree remove "$wt_path"
+    if ! git worktree remove "$wt_path"; then
+      log "warning: could not remove $wt_path; skipping"
+      continue
+    fi
     if [[ -n "$wt_branch" ]] && git show-ref --verify --quiet "refs/heads/$wt_branch"; then
       git branch -d "$wt_branch" 2>/dev/null || log "warning: could not delete local branch $wt_branch"
     fi

--- a/scripts/maintenance/prune_worktrees.sh
+++ b/scripts/maintenance/prune_worktrees.sh
@@ -123,7 +123,7 @@ while IFS= read -r line; do
     wt_branch=""
     wt_locked=0
   fi
-done < <(git worktree list --porcelain)
+done < <(git worktree list --porcelain; echo)
 
 log "candidates: ${#candidates[@]}; skipped: ${#skipped[@]} (min age ${MIN_AGE_DAYS}d)"
 

--- a/scripts/maintenance/prune_worktrees.sh
+++ b/scripts/maintenance/prune_worktrees.sh
@@ -73,7 +73,7 @@ while IFS= read -r line; do
     branch\ *)
       wt_branch=""
       ;;
-    locked)
+    locked*)
       wt_locked=1
       ;;
     *)

--- a/scripts/maintenance/prune_worktrees.sh
+++ b/scripts/maintenance/prune_worktrees.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="${ZOE_ASSISTANT_ROOT:-/home/zoe/assistant}"
+MIN_AGE_DAYS="${ZOE_WORKTREE_MIN_AGE_DAYS:-7}"
+EXECUTE=0
+
+log() {
+  printf '[prune-worktrees] %s\n' "$*"
+}
+
+usage() {
+  cat <<'EOF'
+Prune stale git worktrees whose branches are merged into origin/main.
+
+Dry-run by default. Pass --execute to remove candidates.
+
+Safety guards (all must pass):
+  - not the live checkout
+  - worktree not locked
+  - worktree has no uncommitted changes
+  - branch merged into origin/main, or detached HEAD is ancestor of origin/main
+  - no activity for MIN_AGE_DAYS (default 7) by worktree mtime
+
+Environment:
+  ZOE_ASSISTANT_ROOT       repo root (default: /home/zoe/assistant)
+  ZOE_WORKTREE_MIN_AGE_DAYS  minimum idle days (default: 7)
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --execute) EXECUTE=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) log "unknown argument: $1"; usage; exit 1 ;;
+  esac
+done
+
+cd "$ROOT"
+git fetch --quiet origin main 2>/dev/null || log "warning: git fetch origin main failed; using local origin/main ref"
+
+MAIN_REF="$(git rev-parse origin/main)"
+MIN_AGE_SECONDS=$((MIN_AGE_DAYS * 86400))
+NOW="$(date +%s)"
+LIVE_ROOT="$(git rev-parse --show-toplevel)"
+
+candidates=()
+skipped=()
+
+is_merged_ref() {
+  local ref="$1"
+  git merge-base --is-ancestor "$ref" "$MAIN_REF"
+}
+
+worktree_age_seconds() {
+  local path="$1"
+  local mtime
+  mtime="$(stat -c %Y "$path" 2>/dev/null || echo 0)"
+  echo $((NOW - mtime))
+}
+
+while IFS= read -r line; do
+  case "$line" in
+    worktree\ *)
+      wt_path="${line#worktree }"
+      wt_branch=""
+      wt_locked=0
+      wt_dirty=0
+      ;;
+    branch\ refs/heads/*)
+      wt_branch="${line#branch refs/heads/}"
+      ;;
+    branch\ *)
+      wt_branch=""
+      ;;
+    locked)
+      wt_locked=1
+      ;;
+    *)
+      ;;
+  esac
+
+  if [[ "$line" == "" && -n "${wt_path:-}" ]]; then
+    reason=""
+    if [[ "$wt_path" == "$LIVE_ROOT" ]]; then
+      reason="live checkout"
+    elif [[ "$wt_locked" == 1 ]]; then
+      reason="locked"
+    elif [[ -n "$(git -C "$wt_path" status --porcelain 2>/dev/null)" ]]; then
+      reason="dirty"
+    else
+      age="$(worktree_age_seconds "$wt_path")"
+      if [[ "$age" -lt "$MIN_AGE_SECONDS" ]]; then
+        reason="too recent (${age}s < ${MIN_AGE_SECONDS}s)"
+      elif [[ -n "$wt_branch" ]]; then
+        if git show-ref --verify --quiet "refs/heads/$wt_branch"; then
+          branch_tip="$(git rev-parse "$wt_branch")"
+          if is_merged_ref "$branch_tip"; then
+            candidates+=("$wt_path|$wt_branch|merged-branch")
+          else
+            reason="branch $wt_branch not merged into origin/main"
+          fi
+        else
+          reason="branch ref missing for $wt_branch"
+        fi
+      else
+        detached_tip="$(git -C "$wt_path" rev-parse HEAD 2>/dev/null || echo "")"
+        if [[ -z "$detached_tip" ]]; then
+          reason="cannot resolve detached HEAD"
+        elif is_merged_ref "$detached_tip"; then
+          candidates+=("$wt_path||detached-merged")
+        else
+          reason="detached HEAD not ancestor of origin/main"
+        fi
+      fi
+    fi
+
+    if [[ -n "$reason" ]]; then
+      skipped+=("$wt_path: $reason")
+    fi
+
+    wt_path=""
+    wt_branch=""
+    wt_locked=0
+  fi
+done < <(git worktree list --porcelain)
+
+log "candidates: ${#candidates[@]}; skipped: ${#skipped[@]} (min age ${MIN_AGE_DAYS}d)"
+
+if [[ "${#candidates[@]}" -eq 0 ]]; then
+  log "nothing to prune"
+  exit 0
+fi
+
+for entry in "${candidates[@]}"; do
+  IFS='|' read -r wt_path wt_branch wt_kind <<<"$entry"
+  if [[ "$EXECUTE" == 1 ]]; then
+    log "removing $wt_path ($wt_kind${wt_branch:+, branch $wt_branch})"
+    git worktree remove "$wt_path"
+    if [[ -n "$wt_branch" ]] && git show-ref --verify --quiet "refs/heads/$wt_branch"; then
+      git branch -d "$wt_branch" 2>/dev/null || log "warning: could not delete local branch $wt_branch"
+    fi
+  else
+    log "would remove $wt_path ($wt_kind${wt_branch:+, branch $wt_branch})"
+  fi
+done
+
+if [[ "$EXECUTE" == 1 ]]; then
+  git worktree prune
+  log "prune complete"
+else
+  log "dry-run only; pass --execute to remove"
+fi


### PR DESCRIPTION
## Summary
- Documents trunk-based branching (no permanent `develop`): one short-lived branch per issue off `origin/main`, worktrees under `~/.worktrees/`, live checkout stays on main.
- Adds `scripts/maintenance/prune_worktrees.sh` with dry-run default and safety guards (skips dirty, locked, live checkout, unmerged, and recently-active worktrees).
- DOX pass updates `scripts/AGENTS.md`; mirrors enforceable subset in `.cursor/rules/agentic-workflow.mdc`.

## Test plan
- [x] `bash -n` on prune script
- [x] Dry-run with `ZOE_WORKTREE_MIN_AGE_DAYS=0` lists merged candidates only; skips live checkout
- [x] `validate_structure.py` and `validate_critical_files.py` pass
- [x] Pre-commit hook passes

Made with [Cursor](https://cursor.com)