### PR TITLE
[codex] Add shopping list card contracts

### DIFF
--- a/services/zoe-data/card_service.py
+++ b/services/zoe-data/card_service.py
@@ -100,6 +100,56 @@ def build_calendar_event_editor_content(slots: dict[str, Any] | None = None) -> 
     }
 
 
+def list_items(slots: dict[str, Any] | None = None) -> list[str]:
+    """Normalize list-intent item slots for compat payloads and cards."""
+    slots = slots or {}
+    raw_items = slots.get("items")
+    if isinstance(raw_items, list):
+        candidates = raw_items
+    elif raw_items:
+        candidates = [raw_items]
+    elif slots.get("item") or slots.get("text"):
+        candidates = [slots.get("item") or slots.get("text")]
+    else:
+        candidates = []
+    return [item for item in (_text(value) for value in candidates) if item]
+
+
+def build_shopping_list_content(slots: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Build canonical content for a shopping/list display card."""
+    slots = slots or {}
+    list_name = _text(slots.get("list_name"), "Shopping")
+    items = list_items(slots)
+    return {
+        "list_id": _text(slots.get("list_id"), list_name.lower().replace(" ", "-")),
+        "title": f"{list_name} List",
+        "summary": f"{len(items)} item{'s' if len(items) != 1 else ''}",
+        "source": "list_show",
+        "list_name": list_name,
+        "items": items,
+    }
+
+
+def build_shopping_item_editor_content(slots: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Build canonical content for a shopping/list item editor card."""
+    slots = slots or {}
+    list_name = _text(slots.get("list_name"), "Shopping")
+    item = _text(slots.get("item") or slots.get("text"))
+    return {
+        "form_id": "shopping_item_editor",
+        "title": f"Add to {list_name}",
+        "fields": [
+            {"name": "item", "label": "Item", "type": "text", "value": item},
+            {"name": "list_name", "label": "List", "type": "text", "value": list_name},
+        ],
+        "values": {
+            "item": item,
+            "list_name": list_name,
+        },
+        "source": "list_add",
+    }
+
+
 class CardService:
     """Service layer for Zoe card operations."""
 
@@ -220,6 +270,20 @@ class CardService:
             producer="zoe-calendar",
         )
 
+    def build_shopping_list_card(self, slots: dict[str, Any] | None = None) -> dict[str, Any]:
+        return self.build_card(
+            CardType.LIST.value,
+            build_shopping_list_content(slots),
+            producer="zoe-lists",
+        )
+
+    def build_shopping_item_editor_card(self, slots: dict[str, Any] | None = None) -> dict[str, Any]:
+        return self.build_card(
+            CardType.ACTION_FORM.value,
+            build_shopping_item_editor_content(slots),
+            producer="zoe-lists",
+        )
+
 
 
 # Global singleton instance
@@ -228,3 +292,5 @@ card_service.register_domain_builder("calendar_timeline", card_service.build_cal
 card_service.register_domain_builder("calendar_event_editor", card_service.build_calendar_event_editor_card)
 card_service.register_domain_builder("weather_current", card_service.build_weather_current_card)
 card_service.register_domain_builder("weather_forecast", card_service.build_weather_forecast_card)
+card_service.register_domain_builder("shopping_list", card_service.build_shopping_list_card)
+card_service.register_domain_builder("shopping_item_editor", card_service.build_shopping_item_editor_card)

--- a/services/zoe-data/routers/chat.py
+++ b/services/zoe-data/routers/chat.py
@@ -106,7 +106,9 @@ def _intent_card_data(intent) -> dict:
         }
         if card_service is not None:
             try:
-                payload["card"] = card_service.build_shopping_item_editor_card({**slots, "list_name": list_name})
+                payload["card"] = card_service.build_shopping_item_editor_card(
+                    {**slots, "list_name": list_name, "item": item}
+                )
             except Exception as exc:
                 logger.debug("list_add card contract build failed: %s", exc)
         return payload

--- a/services/zoe-data/routers/chat.py
+++ b/services/zoe-data/routers/chat.py
@@ -95,7 +95,8 @@ def _intent_card_data(intent) -> dict:
         except Exception:
             card_service = None
         list_name = slots.get("list_name") or "List"
-        item = slots.get("item") or slots.get("text") or ""
+        items = _normalized_list_items(slots)
+        item = items[0] if items else ""
         payload = {
             "type": "list",
             "data": {

--- a/services/zoe-data/routers/chat.py
+++ b/services/zoe-data/routers/chat.py
@@ -90,13 +90,54 @@ def _intent_card_data(intent) -> dict:
             logger.debug("calendar_show card contract build failed: %s", exc)
         return payload
     if name == "list_add":
-        return {
+        try:
+            from card_service import card_service
+        except Exception:
+            card_service = None
+        list_name = slots.get("list_name") or "Shopping"
+        item = slots.get("item") or slots.get("text") or ""
+        payload = {
             "type": "list",
             "data": {
-                "list_name": slots.get("list_name") or "List",
-                "item": slots.get("item") or slots.get("text") or "",
+                "list_name": list_name,
+                "item": item,
             },
         }
+        if card_service is not None:
+            try:
+                payload["card"] = card_service.build_shopping_item_editor_card(slots)
+            except Exception as exc:
+                logger.debug("list_add card contract build failed: %s", exc)
+        return payload
+    if name == "list_show":
+        try:
+            from card_service import card_service, list_items
+
+            items = list_items(slots)
+        except Exception:
+            card_service = None
+            raw_items = slots.get("items")
+            if isinstance(raw_items, list):
+                items = raw_items
+            elif raw_items:
+                items = [raw_items]
+            elif slots.get("item") or slots.get("text"):
+                items = [slots.get("item") or slots.get("text")]
+            else:
+                items = []
+        payload = {
+            "type": "list",
+            "data": {
+                "list_name": slots.get("list_name") or "Shopping",
+                "items": items,
+            },
+        }
+        if card_service is not None:
+            try:
+                payload["card"] = card_service.build_shopping_list_card(slots)
+            except Exception as exc:
+                logger.debug("list_show card contract build failed: %s", exc)
+        return payload
     if name == "timer_create":
         return {
             "type": "timer",
@@ -3315,4 +3356,3 @@ async def get_pending_tasks(user: dict = Depends(get_current_user)):
     user_name = user.get("username") or user.get("display_name") or ""
     tasks = await _get(user_id)
     return {"tasks": tasks, "user_name": user_name}
-

--- a/services/zoe-data/routers/chat.py
+++ b/services/zoe-data/routers/chat.py
@@ -94,7 +94,7 @@ def _intent_card_data(intent) -> dict:
             from card_service import card_service
         except Exception:
             card_service = None
-        list_name = slots.get("list_name") or "Shopping"
+        list_name = slots.get("list_name") or "List"
         item = slots.get("item") or slots.get("text") or ""
         payload = {
             "type": "list",
@@ -105,26 +105,16 @@ def _intent_card_data(intent) -> dict:
         }
         if card_service is not None:
             try:
-                payload["card"] = card_service.build_shopping_item_editor_card(slots)
+                payload["card"] = card_service.build_shopping_item_editor_card({**slots, "list_name": list_name})
             except Exception as exc:
                 logger.debug("list_add card contract build failed: %s", exc)
         return payload
     if name == "list_show":
+        items = _normalized_list_items(slots)
         try:
-            from card_service import card_service, list_items
-
-            items = list_items(slots)
+            from card_service import card_service
         except Exception:
             card_service = None
-            raw_items = slots.get("items")
-            if isinstance(raw_items, list):
-                items = raw_items
-            elif raw_items:
-                items = [raw_items]
-            elif slots.get("item") or slots.get("text"):
-                items = [slots.get("item") or slots.get("text")]
-            else:
-                items = []
         payload = {
             "type": "list",
             "data": {
@@ -156,6 +146,26 @@ def _intent_card_data(intent) -> dict:
         "type": "answer",
         "data": {"text": ""},
     }
+
+
+def _normalized_list_items(slots: dict) -> list[str]:
+    """Normalize list items for chat compat, card, and action-form payloads."""
+    try:
+        from card_service import list_items
+
+        return list_items(slots)
+    except Exception:
+        raw_items = slots.get("items")
+        if isinstance(raw_items, list):
+            candidates = raw_items
+        elif raw_items:
+            candidates = [raw_items]
+        elif slots.get("item") or slots.get("text"):
+            candidates = [slots.get("item") or slots.get("text")]
+        else:
+            candidates = []
+        normalized = [str(value or "").strip() for value in candidates]
+        return [value for value in normalized if value]
 
 
 def _intent_action_form_payload(intent, panel_id: str | None = None) -> dict | None:
@@ -190,19 +200,15 @@ def _intent_action_form_payload(intent, panel_id: str | None = None) -> dict | N
         }
 
     if name in ("list_add", "list_show"):
-        items: list[str] = []
-        if slots.get("item"):
-            items = [str(slots["item"])]
-        elif slots.get("items"):
-            raw = slots["items"]
-            items = raw if isinstance(raw, list) else [str(raw)]
+        items = _normalized_list_items(slots)
+        item = items[0] if items else ""
         return {
             "panel_type": "shopping_list",
             "title": f"{slots.get('list_name', 'Shopping')} List",
             "data": {
                 "list_name": slots.get("list_name") or "Shopping",
                 "items": items,
-                "item": slots.get("item") or "",
+                "item": item,
             },
             **({"panel_id": panel_id} if panel_id else {}),
         }

--- a/services/zoe-data/tests/test_card_service.py
+++ b/services/zoe-data/tests/test_card_service.py
@@ -2,7 +2,7 @@
 
 import pytest
 from unittest.mock import Mock
-from card_service import CardService, card_service
+from card_service import CardService, card_service, list_items
 from card_contract import CardContractError, CardType
 
 
@@ -137,6 +137,10 @@ def test_global_card_service_instance():
         card_service._domain_builders.clear()
         card_service.register_domain_builder("calendar_timeline", card_service.build_calendar_timeline_card)
         card_service.register_domain_builder("calendar_event_editor", card_service.build_calendar_event_editor_card)
+        card_service.register_domain_builder("weather_current", card_service.build_weather_current_card)
+        card_service.register_domain_builder("weather_forecast", card_service.build_weather_forecast_card)
+        card_service.register_domain_builder("shopping_list", card_service.build_shopping_list_card)
+        card_service.register_domain_builder("shopping_item_editor", card_service.build_shopping_item_editor_card)
 
 
 def test_card_service_build_calendar_timeline_card():
@@ -170,3 +174,40 @@ def test_global_card_service_registers_calendar_builders():
     assert callable(editor)
     assert timeline({"qualifier": "today"})["content"]["view"] == "timeline"
     assert editor({"title": "Dentist"})["content"]["form_id"] == "calendar_event_editor"
+
+
+def test_list_items_normalizes_slots():
+    assert list_items({"items": [" milk ", 123, ""]}) == ["milk", "123"]
+    assert list_items({"item": " bread "}) == ["bread"]
+    assert list_items({"text": " eggs "}) == ["eggs"]
+
+
+def test_card_service_build_shopping_list_card():
+    service = CardService()
+    card = service.build_shopping_list_card({"list_name": "Groceries", "items": [" milk ", "eggs"]})
+
+    assert card["card_type"] == CardType.LIST.value
+    assert card["producer"] == "zoe-lists"
+    assert card["content"]["list_id"] == "groceries"
+    assert card["content"]["title"] == "Groceries List"
+    assert card["content"]["items"] == ["milk", "eggs"]
+
+
+def test_card_service_build_shopping_item_editor_card():
+    service = CardService()
+    card = service.build_shopping_item_editor_card({"list_name": "Groceries", "item": "milk"})
+
+    assert card["card_type"] == CardType.ACTION_FORM.value
+    assert card["producer"] == "zoe-lists"
+    assert card["content"]["form_id"] == "shopping_item_editor"
+    assert card["content"]["values"] == {"item": "milk", "list_name": "Groceries"}
+
+
+def test_global_card_service_registers_shopping_builders():
+    list_builder = card_service.get_domain_builder("shopping_list")
+    editor = card_service.get_domain_builder("shopping_item_editor")
+
+    assert callable(list_builder)
+    assert callable(editor)
+    assert list_builder({"list_name": "Groceries"})["content"]["list_name"] == "Groceries"
+    assert editor({"item": "milk"})["content"]["form_id"] == "shopping_item_editor"

--- a/services/zoe-data/tests/test_chat_shopping_cards.py
+++ b/services/zoe-data/tests/test_chat_shopping_cards.py
@@ -34,7 +34,7 @@ def test_list_add_payload_keeps_compat_shape_and_adds_editor_contract():
 
 
 def test_list_add_payload_preserves_compat_list_default():
-    payload = _intent_card_data(Intent("list_add", {"text": "eggs"}))
+    payload = _intent_card_data(Intent("list_add", {"text": " eggs "}))
 
     assert payload["data"] == {"list_name": "List", "item": "eggs"}
     assert payload["card"]["content"]["values"] == {"item": "eggs", "list_name": "List"}

--- a/services/zoe-data/tests/test_chat_shopping_cards.py
+++ b/services/zoe-data/tests/test_chat_shopping_cards.py
@@ -1,0 +1,40 @@
+"""Tests for shopping/list intent canonical card emission."""
+
+from intent_router import Intent
+from routers.chat import _intent_card_data
+
+
+def test_list_show_payload_keeps_compat_shape_and_adds_contract():
+    payload = _intent_card_data(
+        Intent("list_show", {"list_name": "Groceries", "items": [" milk ", "eggs"]})
+    )
+
+    assert payload["type"] == "list"
+    assert payload["data"] == {"list_name": "Groceries", "items": ["milk", "eggs"]}
+    assert payload["card"]["card_type"] == "list"
+    assert payload["card"]["content"]["list_name"] == "Groceries"
+    assert payload["card"]["content"]["items"] == ["milk", "eggs"]
+
+
+def test_list_show_payload_normalizes_single_item_slot():
+    payload = _intent_card_data(Intent("list_show", {"item": " bread "}))
+
+    assert payload["data"] == {"list_name": "Shopping", "items": ["bread"]}
+    assert payload["card"]["content"]["summary"] == "1 item"
+
+
+def test_list_add_payload_keeps_compat_shape_and_adds_editor_contract():
+    payload = _intent_card_data(Intent("list_add", {"list_name": "Groceries", "item": "milk"}))
+
+    assert payload["type"] == "list"
+    assert payload["data"] == {"list_name": "Groceries", "item": "milk"}
+    assert payload["card"]["card_type"] == "action_form"
+    assert payload["card"]["content"]["form_id"] == "shopping_item_editor"
+    assert payload["card"]["content"]["values"] == {"item": "milk", "list_name": "Groceries"}
+
+
+def test_list_add_payload_defaults_to_shopping_list():
+    payload = _intent_card_data(Intent("list_add", {"text": "eggs"}))
+
+    assert payload["data"] == {"list_name": "Shopping", "item": "eggs"}
+    assert payload["card"]["content"]["values"] == {"item": "eggs", "list_name": "Shopping"}

--- a/services/zoe-data/tests/test_chat_shopping_cards.py
+++ b/services/zoe-data/tests/test_chat_shopping_cards.py
@@ -40,6 +40,13 @@ def test_list_add_payload_preserves_compat_list_default():
     assert payload["card"]["content"]["values"] == {"item": "eggs", "list_name": "List"}
 
 
+def test_list_add_payload_forwards_items_slot_to_editor_card():
+    payload = _intent_card_data(Intent("list_add", {"items": [" milk "]}))
+
+    assert payload["data"] == {"list_name": "List", "item": "milk"}
+    assert payload["card"]["content"]["values"] == {"item": "milk", "list_name": "List"}
+
+
 def test_normalized_list_items_fallback_matches_service_shape(monkeypatch):
     real_import = __import__
 

--- a/services/zoe-data/tests/test_chat_shopping_cards.py
+++ b/services/zoe-data/tests/test_chat_shopping_cards.py
@@ -1,7 +1,7 @@
 """Tests for shopping/list intent canonical card emission."""
 
 from intent_router import Intent
-from routers.chat import _intent_card_data
+from routers.chat import _intent_action_form_payload, _intent_card_data, _normalized_list_items
 
 
 def test_list_show_payload_keeps_compat_shape_and_adds_contract():
@@ -33,8 +33,36 @@ def test_list_add_payload_keeps_compat_shape_and_adds_editor_contract():
     assert payload["card"]["content"]["values"] == {"item": "milk", "list_name": "Groceries"}
 
 
-def test_list_add_payload_defaults_to_shopping_list():
+def test_list_add_payload_preserves_compat_list_default():
     payload = _intent_card_data(Intent("list_add", {"text": "eggs"}))
 
-    assert payload["data"] == {"list_name": "Shopping", "item": "eggs"}
-    assert payload["card"]["content"]["values"] == {"item": "eggs", "list_name": "Shopping"}
+    assert payload["data"] == {"list_name": "List", "item": "eggs"}
+    assert payload["card"]["content"]["values"] == {"item": "eggs", "list_name": "List"}
+
+
+def test_normalized_list_items_fallback_matches_service_shape(monkeypatch):
+    real_import = __import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "card_service":
+            raise ImportError("forced fallback")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.__import__", fake_import)
+
+    assert _normalized_list_items({"items": [" milk ", 123, ""]}) == ["milk", "123"]
+
+
+def test_list_action_form_uses_shared_item_normalization():
+    payload = _intent_action_form_payload(Intent("list_show", {"text": " bread "}), panel_id="panel-1")
+
+    assert payload == {
+        "panel_type": "shopping_list",
+        "title": "Shopping List",
+        "data": {
+            "list_name": "Shopping",
+            "items": ["bread"],
+            "item": "bread",
+        },
+        "panel_id": "panel-1",
+    }


### PR DESCRIPTION
## Summary
- Add canonical shopping/list card builders to CardService
- Emit list_show and list_add card contracts from chat while preserving compat payloads
- Share list item normalization across compat and card paths

Supersedes stale conflicting PR #201.

## Verification
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_card_service.py services/zoe-data/tests/test_chat_calendar_cards.py services/zoe-data/tests/test_chat_shopping_cards.py
- python3 tools/audit/validate_structure.py
- python3 tools/audit/validate_critical_files.py
- python3 tools/audit/validate_offline_memory.py
- git diff --check