### PR TITLE
Harden intent-gap budget and blocker follow-up dedup

### DIFF
--- a/services/zoe-data/kanban_phase_budget.py
+++ b/services/zoe-data/kanban_phase_budget.py
@@ -67,6 +67,11 @@ _CODE_AUDIT_BODY_RE = re.compile(
     r"CODE-AUDIT FAST PATH|\bcode_audit\b",
     re.IGNORECASE,
 )
+_INTENT_GAP_BODY_RE = re.compile(
+    r'INTENT-GAP IMPLEMENT FAST PATH|\bintent_gap\b|"source"\s*:\s*"intent_gap',
+    re.IGNORECASE,
+)
+_BROAD_FIND_GREP_RE = re.compile(r"^find\s+\S+.*\b(?:grep|rg)\b", re.IGNORECASE)
 _POST_PATCH_VALIDATION_RE = re.compile(
     r"^(?:"
     r"(?:\w+=\S+\s+)*python3?\s+-m\s+(?:py_compile|pytest|mypy|ruff)\b|"
@@ -267,6 +272,24 @@ def _is_code_audit_body(body: str) -> bool:
     return bool(_CODE_AUDIT_BODY_RE.search(body))
 
 
+def _is_intent_gap_body(body: str) -> bool:
+    return bool(_INTENT_GAP_BODY_RE.search(body))
+
+
+def _intent_gap_pre_edit_explore_budget() -> int:
+    try:
+        return max(1, int(os.environ.get("ZOE_KANBAN_INTENT_GAP_PRE_EDIT_EXPLORE_BUDGET", "6")))
+    except ValueError:
+        return 6
+
+
+def _intent_gap_repeat_read_budget() -> int:
+    try:
+        return max(1, int(os.environ.get("ZOE_KANBAN_INTENT_GAP_REPEAT_READ_BUDGET", "2")))
+    except ValueError:
+        return 2
+
+
 def _post_patch_explore_budget() -> int:
     try:
         return max(1, int(os.environ.get("ZOE_KANBAN_CODE_AUDIT_POST_PATCH_EXPLORE_BUDGET", "2")))
@@ -418,6 +441,64 @@ def implement_patch_ambiguity_reason_from_log(
             continue
         if _PATCH_STEP_RE.search(line):
             ambiguous_patches_by_path.pop(patch_path, None)
+    return None
+
+
+def implement_intent_gap_pre_edit_reason_from_log(
+    task_id: str,
+    phase: str,
+    *,
+    session: str | None = None,
+    task_body: str = "",
+) -> str | None:
+    """Block intent-gap workers that keep locating instead of editing.
+
+    Intent-gap tickets are already narrow and name the router/test surface in the
+    task body. A live ZOE-5458 run burned its full Hermes iteration budget by
+    rereading intent_router.py and broad find/grep searching without a patch.
+    This turns the fast-path handoff into a runtime contract.
+    """
+    if phase not in {"implement", "implement_revision"}:
+        return None
+    if not _is_intent_gap_body(task_body):
+        return None
+    if session is None:
+        session = _latest_log_session(task_id, max_lines=0)
+    if not session:
+        return None
+
+    explore_budget = _intent_gap_pre_edit_explore_budget()
+    repeat_read_budget = _intent_gap_repeat_read_budget()
+    explore_steps = 0
+    read_counts: dict[str, int] = {}
+    for line in session.splitlines():
+        if not _STEP_LINE_RE.match(line):
+            continue
+        if _PATCH_STEP_RE.search(line) or _TERMINAL_STEP_RE.search(line):
+            return None
+        shell_command = _shell_command_from_step(line)
+        if shell_command and _BROAD_FIND_GREP_RE.search(shell_command):
+            return (
+                "BLOCKER=IMPLEMENT_BUDGET: intent-gap worker ran broad repo "
+                "search before editing the named router/test surface"
+            )
+        if not _EXPLORE_STEP_RE.search(line):
+            continue
+        explore_steps += 1
+        if explore_steps > explore_budget:
+            return (
+                "BLOCKER=IMPLEMENT_BUDGET: intent-gap pre-edit exploration exceeded "
+                f"budget without patch (steps={explore_steps}, limit={explore_budget})"
+            )
+        read_match = _READ_STEP_RE.search(line)
+        if read_match:
+            path = _read_path_key(read_match.group("path"))
+            read_counts[path] = read_counts.get(path, 0) + 1
+            if read_counts[path] > repeat_read_budget:
+                return (
+                    "BLOCKER=IMPLEMENT_BUDGET: intent-gap repeated pre-edit reads "
+                    f"without patch (file={path}, reads={read_counts[path]})"
+                )
     return None
 
 
@@ -702,6 +783,14 @@ def phase_budget_reason(
     )
     if code_audit_post_validation_reason:
         return code_audit_post_validation_reason
+    intent_gap_pre_edit_reason = implement_intent_gap_pre_edit_reason_from_log(
+        task_id,
+        phase,
+        session=session,
+        task_body=str(task.get("body") or ""),
+    )
+    if intent_gap_pre_edit_reason:
+        return intent_gap_pre_edit_reason
     pre_edit_drift_reason = implement_pre_edit_drift_reason_from_log(
         task_id,
         phase,

--- a/services/zoe-data/kanban_phase_budget.py
+++ b/services/zoe-data/kanban_phase_budget.py
@@ -68,7 +68,7 @@ _CODE_AUDIT_BODY_RE = re.compile(
     re.IGNORECASE,
 )
 _INTENT_GAP_BODY_RE = re.compile(
-    r'INTENT-GAP IMPLEMENT FAST PATH|\bintent_gap\b|"source"\s*:\s*"intent_gap',
+    r'INTENT-GAP IMPLEMENT FAST PATH|\bintent_gap:[\w-]+|"source"\s*:\s*"intent_gap',
     re.IGNORECASE,
 )
 _BROAD_FIND_GREP_RE = re.compile(r"^find\s+\S+.*\b(?:grep|rg)\b", re.IGNORECASE)

--- a/services/zoe-data/main.py
+++ b/services/zoe-data/main.py
@@ -204,10 +204,10 @@ async def _ensure_blocker_followup_ticket(client, issue_id: str, chain: dict, bl
         # Dedup across the whole ticket system, not just active columns. A done/no-op
         # follow-up for the same parent and blocker is still the canonical audit trail;
         # creating another ticket hides the recurring harness failure in backlog noise.
-        candidates = await client.list_issues(limit=5000) or []
-        if not candidates:
-            for status in ("backlog", "todo", "in_progress", "blocked", "in_review", "done", "canceled"):
-                candidates.extend(await client.list_issues(status=status, limit=1000) or [])
+        candidates: list[dict] = []
+        for status in ("backlog", "todo", "in_progress", "blocked", "in_review", "done", "canceled"):
+            candidates.extend(await client.list_issues(status=status, limit=1000) or [])
+        candidates.extend(await client.list_issues(limit=5000) or [])
         seen_candidates: set[str] = set()
         for candidate in candidates:
             candidate_id = str(candidate.get("id") or "")

--- a/services/zoe-data/main.py
+++ b/services/zoe-data/main.py
@@ -201,15 +201,32 @@ async def _ensure_blocker_followup_ticket(client, issue_id: str, chain: dict, bl
             )
             return {}
         parent_ident = parent.get("identifier") or issue_id
-        for status in ("backlog", "todo", "in_progress", "blocked", "in_review"):
-            for candidate in await client.list_issues(status=status, limit=1000) or []:
-                metadata = parse_ticket_block(candidate.get("description") or "")
-                if (
-                    metadata.get("source") == "engineering_blocker_followup"
-                    and str(metadata.get("parent_issue_id") or "") == str(issue_id)
-                    and metadata.get("source_blocker") == marker
-                ):
-                    return candidate
+        # Dedup across the whole ticket system, not just active columns. A done/no-op
+        # follow-up for the same parent and blocker is still the canonical audit trail;
+        # creating another ticket hides the recurring harness failure in backlog noise.
+        candidates = await client.list_issues(limit=5000) or []
+        if not candidates:
+            for status in ("backlog", "todo", "in_progress", "blocked", "in_review", "done", "canceled"):
+                candidates.extend(await client.list_issues(status=status, limit=1000) or [])
+        seen_candidates: set[str] = set()
+        for candidate in candidates:
+            candidate_id = str(candidate.get("id") or "")
+            if candidate_id and candidate_id in seen_candidates:
+                continue
+            if candidate_id:
+                seen_candidates.add(candidate_id)
+            metadata = parse_ticket_block(candidate.get("description") or "")
+            if (
+                metadata.get("source") == "engineering_blocker_followup"
+                and str(metadata.get("parent_issue_id") or "") == str(issue_id)
+                and metadata.get("source_blocker") == marker
+            ):
+                await client.append_issue_note(
+                    issue_id,
+                    f"Harness follow-up already exists for {marker}: "
+                    f"{candidate.get('identifier') or candidate_id}",
+                )
+                return candidate
 
         description = describe_ticket(
             (

--- a/services/zoe-data/main.py
+++ b/services/zoe-data/main.py
@@ -204,15 +204,12 @@ async def _ensure_blocker_followup_ticket(client, issue_id: str, chain: dict, bl
         # Dedup across the whole ticket system, not just active columns. A done/no-op
         # follow-up for the same parent and blocker is still the canonical audit trail;
         # creating another ticket hides the recurring harness failure in backlog noise.
-        candidates: list[dict] = []
-        for status in ("backlog", "todo", "in_progress", "blocked", "in_review", "done", "canceled"):
-            candidates.extend(await client.list_issues(status=status, limit=1000) or [])
-        candidates.extend(await client.list_issues(limit=5000) or [])
         seen_candidates: set[str] = set()
-        for candidate in candidates:
+
+        def matching_followup(candidate: dict) -> dict | None:
             candidate_id = str(candidate.get("id") or "")
             if candidate_id and candidate_id in seen_candidates:
-                continue
+                return None
             if candidate_id:
                 seen_candidates.add(candidate_id)
             metadata = parse_ticket_block(candidate.get("description") or "")
@@ -221,12 +218,16 @@ async def _ensure_blocker_followup_ticket(client, issue_id: str, chain: dict, bl
                 and str(metadata.get("parent_issue_id") or "") == str(issue_id)
                 and metadata.get("source_blocker") == marker
             ):
-                await client.append_issue_note(
-                    issue_id,
-                    f"Harness follow-up already exists for {marker}: "
-                    f"{candidate.get('identifier') or candidate_id}",
-                )
                 return candidate
+            return None
+
+        for status in ("backlog", "todo", "in_progress", "blocked", "in_review", "done", "canceled"):
+            for candidate in await client.list_issues(status=status, limit=1000) or []:
+                if match := matching_followup(candidate):
+                    return match
+        for candidate in await client.list_issues(limit=5000) or []:
+            if match := matching_followup(candidate):
+                return match
 
         description = describe_ticket(
             (

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -2709,6 +2709,68 @@ def test_phase_budget_blocks_intent_gap_pre_edit_churn_from_live_shape(tmp_path,
     assert "intent-gap repeated pre-edit reads" in reason
 
 
+
+def test_phase_budget_blocks_intent_gap_explore_budget_before_patch(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("ZOE_KANBAN_INTENT_GAP_PRE_EDIT_EXPLORE_BUDGET", "3")
+    log_dir = tmp_path / "kanban" / "logs"
+    log_dir.mkdir(parents=True)
+    (log_dir / "t_intent.log").write_text(
+        """Query: work kanban task t_intent
+  ┊ 📖 read      /work/services/zoe-data/intent_router.py  0.1s
+  ┊ 🔎 grep      _AGENT_CHAT_RE /work/services/zoe-data/intent_router.py  0.1s
+  ┊ 📖 read      /work/services/zoe-data/tests/test_intent_open_domain.py  0.1s
+  ┊ 🔎 grep      list_show /work/services/zoe-data/tests/test_intent_open_domain.py  0.1s
+""",
+        encoding="utf-8",
+    )
+
+    reason = kb.phase_budget_reason(
+        "t_intent",
+        "implement",
+        {
+            "task": {
+                "started_at": 100,
+                "body": "INTENT-GAP IMPLEMENT FAST PATH",
+            },
+            "runs": [{"started_at": 100}],
+        },
+        now=120,
+    )
+
+    assert reason is not None
+    assert "intent-gap pre-edit exploration exceeded" in reason
+
+
+def test_phase_budget_does_not_apply_intent_gap_budget_to_plain_mentions(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("ZOE_KANBAN_INTENT_GAP_PRE_EDIT_EXPLORE_BUDGET", "1")
+    log_dir = tmp_path / "kanban" / "logs"
+    log_dir.mkdir(parents=True)
+    (log_dir / "t_impl.log").write_text(
+        """Query: work kanban task t_impl
+  ┊ 📖 read      /work/services/zoe-data/intent_router.py  0.1s
+  ┊ 🔎 grep      intent_gap /work/services/zoe-data/intent_router.py  0.1s
+""",
+        encoding="utf-8",
+    )
+
+    reason = kb.phase_budget_reason(
+        "t_impl",
+        "implement",
+        {
+            "task": {
+                "started_at": 100,
+                "body": "General cleanup mentions intent_gap in prose but is not fast path",
+            },
+            "runs": [{"started_at": 100}],
+        },
+        now=120,
+    )
+
+    assert reason is None
+
+
 def test_phase_budget_blocks_intent_gap_broad_find_before_patch(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     log_dir = tmp_path / "kanban" / "logs"

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -2672,6 +2672,71 @@ def test_phase_budget_reason_blocks_pre_edit_handoff_drift(tmp_path, monkeypatch
     assert "IMPLEMENT_HANDOFF_DRIFT" in reason
 
 
+
+
+def test_phase_budget_blocks_intent_gap_pre_edit_churn_from_live_shape(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("ZOE_KANBAN_INTENT_GAP_REPEAT_READ_BUDGET", "2")
+    log_dir = tmp_path / "kanban" / "logs"
+    log_dir.mkdir(parents=True)
+    (log_dir / "t_intent.log").write_text(
+        """Query: work kanban task t_intent
+  | kanban_sh   0.0s
+  | $         pwd && git branch --show-current  0.2s
+  ┊ 📖 read      /work/services/zoe-data/intent_router.py  0.1s
+  ┊ 🔎 grep      _AGENT_CHAT_RE  /work/services/zoe-data/intent_router.py  0.1s
+  ┊ 📖 read      /work/services/zoe-data/intent_router.py  0.1s
+  ┊ 🔎 grep      def detect_intent /work/services/zoe-data/intent_router.py  0.1s
+  ┊ 📖 read      /work/services/zoe-data/intent_router.py  0.1s
+""",
+        encoding="utf-8",
+    )
+
+    reason = kb.phase_budget_reason(
+        "t_intent",
+        "implement",
+        {
+            "task": {
+                "started_at": 100,
+                "body": "INTENT-GAP IMPLEMENT FAST PATH",
+            },
+            "runs": [{"started_at": 100}],
+        },
+        now=120,
+    )
+
+    assert reason is not None
+    assert "intent-gap repeated pre-edit reads" in reason
+
+
+def test_phase_budget_blocks_intent_gap_broad_find_before_patch(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    log_dir = tmp_path / "kanban" / "logs"
+    log_dir.mkdir(parents=True)
+    (log_dir / "t_intent.log").write_text(
+        """Query: work kanban task t_intent
+  ┊ 📖 read      /work/services/zoe-data/intent_router.py  0.1s
+  ┊ 💻 $         find /work -name '*.py' -exec grep -l 'say exactly' {} ;  1.4s
+""",
+        encoding="utf-8",
+    )
+
+    reason = kb.phase_budget_reason(
+        "t_intent",
+        "implement",
+        {
+            "task": {
+                "started_at": 100,
+                "body": '{"source":"intent_gap:operator_single_lane_test"}',
+            },
+            "runs": [{"started_at": 100}],
+        },
+        now=120,
+    )
+
+    assert reason is not None
+    assert "intent-gap worker ran broad repo search" in reason
+
 def test_phase_budget_reason_passes_harness_followup_body_to_pre_edit_guard(
     tmp_path, monkeypatch
 ):

--- a/services/zoe-data/tests/test_main_multica_poll.py
+++ b/services/zoe-data/tests/test_main_multica_poll.py
@@ -467,11 +467,14 @@ async def test_record_blocked_multica_chain_reuses_existing_in_progress_budget_f
 
     assert client.created == []
     assert client.labels == []
-    assert client.notes == []
+    assert client.notes[-1] == (
+        "issue-budget",
+        "Harness follow-up already exists for IMPLEMENT_BUDGET: ZOE-C1",
+    )
 
 
 @pytest.mark.asyncio
-async def test_record_blocked_multica_chain_reopens_after_done_budget_followup():
+async def test_record_blocked_multica_chain_reuses_done_budget_followup():
     from main import _record_blocked_multica_chain
     from multica_ticket_contract import describe_ticket, parse_ticket_block, write_ticket_block
 
@@ -508,9 +511,12 @@ async def test_record_blocked_multica_chain_reopens_after_done_budget_followup()
         },
     )
 
-    assert len(client.created) == 1
-    metadata = parse_ticket_block(client.created[0]["description"])
-    assert metadata["source_blocker"] == "IMPLEMENT_BUDGET"
+    assert client.created == []
+    assert client.labels == []
+    assert client.notes[-1] == (
+        "issue-budget",
+        "Harness follow-up already exists for IMPLEMENT_BUDGET: ZOE-C-DONE",
+    )
 
 
 @pytest.mark.asyncio
@@ -575,4 +581,7 @@ async def test_record_blocked_multica_chain_reuses_existing_protocol_followup():
 
     assert client.created == []
     assert client.labels == []
-    assert client.notes == []
+    assert client.notes[-1] == (
+        "issue-protocol",
+        "Harness follow-up already exists for PROTOCOL_VIOLATION: ZOE-C2",
+    )

--- a/services/zoe-data/tests/test_main_multica_poll.py
+++ b/services/zoe-data/tests/test_main_multica_poll.py
@@ -12,6 +12,7 @@ class RecordingClient:
         self.created = []
         self.labels = []
         self.notes = []
+        self.default_list_statuses: set[str] | None = None
 
     async def record_progress(self, *args, **kwargs):
         self.calls.append((args, kwargs))
@@ -24,6 +25,8 @@ class RecordingClient:
         issues = list(self.issues.values()) + list(self.created)
         if status is not None:
             issues = [issue for issue in issues if issue.get("status") == status]
+        elif self.default_list_statuses is not None:
+            issues = [issue for issue in issues if issue.get("status") in self.default_list_statuses]
         return issues[:limit] if limit is not None else issues
 
     async def create_issue(self, **kwargs):
@@ -355,6 +358,7 @@ async def test_record_blocked_multica_chain_creates_budget_followup_once():
     from multica_ticket_contract import parse_ticket_block
 
     client = RecordingClient()
+    client.default_list_statuses = {"backlog", "todo", "in_progress", "blocked", "in_review"}
     client.issues["issue-budget"] = {
         "id": "issue-budget",
         "identifier": "ZOE-1",
@@ -479,6 +483,7 @@ async def test_record_blocked_multica_chain_reuses_done_budget_followup():
     from multica_ticket_contract import describe_ticket, parse_ticket_block, write_ticket_block
 
     client = RecordingClient()
+    client.default_list_statuses = {"backlog", "todo", "in_progress", "blocked", "in_review"}
     client.issues["issue-budget"] = {
         "id": "issue-budget",
         "identifier": "ZOE-1",

--- a/services/zoe-data/tests/test_main_multica_poll.py
+++ b/services/zoe-data/tests/test_main_multica_poll.py
@@ -13,6 +13,7 @@ class RecordingClient:
         self.labels = []
         self.notes = []
         self.default_list_statuses: set[str] | None = None
+        self.list_calls = []
 
     async def record_progress(self, *args, **kwargs):
         self.calls.append((args, kwargs))
@@ -22,6 +23,7 @@ class RecordingClient:
         return self.issues.get(issue_id, {})
 
     async def list_issues(self, status=None, *, limit=None):
+        self.list_calls.append({"status": status, "limit": limit})
         issues = list(self.issues.values()) + list(self.created)
         if status is not None:
             issues = [issue for issue in issues if issue.get("status") == status]
@@ -471,10 +473,49 @@ async def test_record_blocked_multica_chain_reuses_existing_in_progress_budget_f
 
     assert client.created == []
     assert client.labels == []
-    assert client.notes[-1] == (
-        "issue-budget",
-        "Harness follow-up already exists for IMPLEMENT_BUDGET: ZOE-C1",
+    assert client.notes == []
+
+
+@pytest.mark.asyncio
+async def test_record_blocked_multica_chain_returns_after_first_matching_followup_bucket():
+    from main import _record_blocked_multica_chain
+    from multica_ticket_contract import describe_ticket, parse_ticket_block, write_ticket_block
+
+    client = RecordingClient()
+    client.issues["issue-budget"] = {
+        "id": "issue-budget",
+        "identifier": "ZOE-1",
+        "description": "Parent prose",
+        "assignee_id": "hermes",
+    }
+    existing_description = describe_ticket(
+        "Existing backlog follow-up",
+        zoe_kind="harness_fix",
+        source="engineering_blocker_followup",
+        parent_issue_id="issue-budget",
     )
+    existing_metadata = parse_ticket_block(existing_description)
+    existing_metadata["source_blocker"] = "IMPLEMENT_BUDGET"
+    client.issues["existing-child"] = {
+        "id": "existing-child",
+        "identifier": "ZOE-C1",
+        "status": "backlog",
+        "description": write_ticket_block(existing_description, existing_metadata),
+    }
+
+    await _record_blocked_multica_chain(
+        client,
+        "issue-budget",
+        {
+            "pipeline": {
+                "phase": "implement",
+                "block_reason": "IMPLEMENT_BUDGET: code-enforced tool budget exceeded",
+            }
+        },
+    )
+
+    assert client.created == []
+    assert client.list_calls == [{"status": "backlog", "limit": 1000}]
 
 
 @pytest.mark.asyncio
@@ -518,10 +559,7 @@ async def test_record_blocked_multica_chain_reuses_done_budget_followup():
 
     assert client.created == []
     assert client.labels == []
-    assert client.notes[-1] == (
-        "issue-budget",
-        "Harness follow-up already exists for IMPLEMENT_BUDGET: ZOE-C-DONE",
-    )
+    assert client.notes == []
 
 
 @pytest.mark.asyncio
@@ -586,7 +624,4 @@ async def test_record_blocked_multica_chain_reuses_existing_protocol_followup():
 
     assert client.created == []
     assert client.labels == []
-    assert client.notes[-1] == (
-        "issue-protocol",
-        "Harness follow-up already exists for PROTOCOL_VIOLATION: ZOE-C2",
-    )
+    assert client.notes == []


### PR DESCRIPTION
## Summary
- add a code-enforced intent-gap pre-edit guard so Hermes blocks before burning the full implement budget on repeated reads/searches
- dedup engineering blocker follow-ups across all ticket statuses by parent_issue_id + source_blocker
- update focused coverage for intent-gap budget blocks and follow-up reuse

## Tests
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_kanban_adapter.py services/zoe-data/tests/test_main_multica_poll.py
- python3 -m py_compile services/zoe-data/kanban_phase_budget.py services/zoe-data/main.py services/zoe-data/tests/test_kanban_adapter.py services/zoe-data/tests/test_main_multica_poll.py
- python3 tools/audit/validate_structure.py
- git diff --check