### PR TITLE
[codex] Normalize shopping card item payloads

### DIFF
--- a/services/zoe-data/card_service.py
+++ b/services/zoe-data/card_service.py
@@ -100,7 +100,9 @@ def build_calendar_event_editor_content(slots: dict[str, Any] | None = None) -> 
     }
 
 
-def _list_items(slots: dict[str, Any]) -> list[str]:
+def list_items(slots: dict[str, Any] | None = None) -> list[str]:
+    """Normalize list-intent item slots for compat payloads and cards."""
+    slots = slots or {}
     raw_items = slots.get("items")
     if isinstance(raw_items, list):
         items = raw_items
@@ -116,7 +118,7 @@ def build_shopping_list_content(slots: dict[str, Any] | None = None) -> dict[str
     """Build canonical content for a shopping/list view card."""
     slots = slots or {}
     list_name = _text(slots.get("list_name") or slots.get("list_type"), "Shopping")
-    items = _list_items(slots)
+    items = list_items(slots)
     return {
         "title": f"{list_name} List",
         "list_name": list_name,
@@ -131,7 +133,8 @@ def build_shopping_item_editor_content(slots: dict[str, Any] | None = None) -> d
     """Build canonical content for a shopping/list item editor card."""
     slots = slots or {}
     list_name = _text(slots.get("list_name") or slots.get("list_type"), "Shopping")
-    item = _text(slots.get("item") or slots.get("text"))
+    normalized_items = list_items(slots)
+    item = normalized_items[0] if normalized_items else ""
     return {
         "form_id": "shopping_item_editor",
         "title": "Add List Item",

--- a/services/zoe-data/routers/chat.py
+++ b/services/zoe-data/routers/chat.py
@@ -53,6 +53,26 @@ _ACTION_FORM_INTENTS: frozenset[str] = frozenset({
     "list_show",
 })
 
+
+def _normalized_list_items(slots: dict) -> list[str]:
+    try:
+        from card_service import list_items
+
+        return list_items(slots)
+    except ImportError as exc:
+        logging.getLogger(__name__).debug("list item normalizer import failed: %s", exc)
+        raw_items = slots.get("items")
+        if isinstance(raw_items, list):
+            candidates = raw_items
+        elif raw_items:
+            candidates = [raw_items]
+        elif slots.get("item") or slots.get("text"):
+            candidates = [slots.get("item") or slots.get("text")]
+        else:
+            candidates = []
+        return [item for item in (str(value or "").strip() for value in candidates) if item]
+
+
 def _intent_card_data(intent) -> dict:
     """Build show_card data payload from intent slots for Google Home-style card."""
     slots = intent.slots or {}
@@ -90,41 +110,41 @@ def _intent_card_data(intent) -> dict:
             logger.debug("calendar_show card contract build failed: %s", exc)
         return payload
     if name == "list_add":
+        items = _normalized_list_items(slots)
+        item = items[0] if items else ""
+        list_name = slots.get("list_name") or slots.get("list_type") or "Shopping"
         payload = {
             "type": "list",
             "data": {
-                "list_name": slots.get("list_name") or slots.get("list_type") or "Shopping",
-                "item": slots.get("item") or slots.get("text") or "",
+                "list_name": list_name,
+                "item": item,
             },
         }
         try:
             from card_service import card_service
 
-            payload["card"] = card_service.build_shopping_item_editor_card(slots)
+            payload["card"] = card_service.build_shopping_item_editor_card(
+                {**slots, "list_name": list_name, "item": item}
+            )
         except Exception as exc:
             logger.debug("list_add card contract build failed: %s", exc)
         return payload
     if name == "list_show":
-        raw_items = slots.get("items")
-        if isinstance(raw_items, list):
-            items = raw_items
-        elif raw_items:
-            items = [raw_items]
-        elif slots.get("item") or slots.get("text"):
-            items = [slots.get("item") or slots.get("text")]
-        else:
-            items = []
+        items = _normalized_list_items(slots)
+        list_name = slots.get("list_name") or slots.get("list_type") or "Shopping"
         payload = {
             "type": "list",
             "data": {
-                "list_name": slots.get("list_name") or slots.get("list_type") or "Shopping",
+                "list_name": list_name,
                 "items": items,
             },
         }
         try:
             from card_service import card_service
 
-            payload["card"] = card_service.build_shopping_list_card(slots)
+            payload["card"] = card_service.build_shopping_list_card(
+                {**slots, "list_name": list_name, "items": items}
+            )
         except Exception as exc:
             logger.debug("list_show card contract build failed: %s", exc)
         return payload
@@ -180,19 +200,15 @@ def _intent_action_form_payload(intent, panel_id: str | None = None) -> dict | N
         }
 
     if name in ("list_add", "list_show"):
-        items: list[str] = []
-        if slots.get("item"):
-            items = [str(slots["item"])]
-        elif slots.get("items"):
-            raw = slots["items"]
-            items = raw if isinstance(raw, list) else [str(raw)]
+        items = _normalized_list_items(slots)
+        item = items[0] if items else ""
         return {
             "panel_type": "shopping_list",
             "title": f"{slots.get('list_name') or slots.get('list_type') or 'Shopping'} List",
             "data": {
                 "list_name": slots.get("list_name") or slots.get("list_type") or "Shopping",
                 "items": items,
-                "item": slots.get("item") or "",
+                "item": item,
             },
             **({"panel_id": panel_id} if panel_id else {}),
         }
@@ -3346,4 +3362,3 @@ async def get_pending_tasks(user: dict = Depends(get_current_user)):
     user_name = user.get("username") or user.get("display_name") or ""
     tasks = await _get(user_id)
     return {"tasks": tasks, "user_name": user_name}
-

--- a/services/zoe-data/tests/test_card_service.py
+++ b/services/zoe-data/tests/test_card_service.py
@@ -2,7 +2,7 @@
 
 import pytest
 from unittest.mock import Mock
-from card_service import CardService, card_service
+from card_service import CardService, card_service, list_items
 from card_contract import CardContractError, CardType
 
 
@@ -137,6 +137,8 @@ def test_global_card_service_instance():
         card_service._domain_builders.clear()
         card_service.register_domain_builder("calendar_timeline", card_service.build_calendar_timeline_card)
         card_service.register_domain_builder("calendar_event_editor", card_service.build_calendar_event_editor_card)
+        card_service.register_domain_builder("weather_current", card_service.build_weather_current_card)
+        card_service.register_domain_builder("weather_forecast", card_service.build_weather_forecast_card)
         card_service.register_domain_builder("shopping_list", card_service.build_shopping_list_card)
         card_service.register_domain_builder("shopping_item_editor", card_service.build_shopping_item_editor_card)
 
@@ -174,6 +176,12 @@ def test_global_card_service_registers_calendar_builders():
     assert editor({"title": "Dentist"})["content"]["form_id"] == "calendar_event_editor"
 
 
+def test_list_items_normalizes_slots():
+    assert list_items({"items": [" milk ", 123, ""]}) == ["milk", "123"]
+    assert list_items({"item": " bread "}) == ["bread"]
+    assert list_items({"text": " eggs "}) == ["eggs"]
+
+
 def test_card_service_build_shopping_list_card():
     service = CardService()
     card = service.build_shopping_list_card({"list_name": "Groceries", "items": ["milk", "bread"]})
@@ -196,6 +204,13 @@ def test_card_service_build_shopping_item_editor_card():
     assert card["content"]["values"]["item"] == "milk"
     assert card["content"]["values"]["list_name"] == "Groceries"
     assert {field["name"] for field in card["content"]["fields"]} >= {"item", "list_name", "quantity"}
+
+
+def test_card_service_build_shopping_item_editor_uses_items_slot():
+    service = CardService()
+    card = service.build_shopping_item_editor_card({"list_name": "Groceries", "items": [" milk "]})
+
+    assert card["content"]["values"]["item"] == "milk"
 
 
 def test_global_card_service_registers_shopping_builders():

--- a/services/zoe-data/tests/test_chat_shopping_cards.py
+++ b/services/zoe-data/tests/test_chat_shopping_cards.py
@@ -1,7 +1,9 @@
 """Tests for shopping/list intent canonical card emission."""
 
+import builtins
+
 from intent_router import Intent
-from routers.chat import _intent_action_form_payload, _intent_card_data
+from routers.chat import _intent_action_form_payload, _intent_card_data, _normalized_list_items
 
 
 def test_list_show_payload_keeps_compat_shape_and_adds_contract():
@@ -33,11 +35,25 @@ def test_list_add_payload_defaults_match_contract():
     assert payload["card"]["content"]["values"]["list_name"] == "Shopping"
 
 
+def test_list_add_payload_items_slot_matches_editor_contract():
+    payload = _intent_card_data(Intent("list_add", {"list_name": "Groceries", "items": [" milk "]}))
+
+    assert payload["data"]["item"] == "milk"
+    assert payload["card"]["content"]["values"]["item"] == "milk"
+
+
 def test_list_show_payload_singular_item_matches_contract():
     payload = _intent_card_data(Intent("list_show", {"item": "milk"}))
 
     assert payload["data"]["items"] == ["milk"]
     assert payload["card"]["content"]["items"] == ["milk"]
+
+
+def test_list_show_payload_normalizes_items_for_compat_and_contract():
+    payload = _intent_card_data(Intent("list_show", {"items": [" milk ", "", "bread"]}))
+
+    assert payload["data"]["items"] == ["milk", "bread"]
+    assert payload["card"]["content"]["items"] == ["milk", "bread"]
 
 
 def test_list_show_payload_list_type_matches_contract():
@@ -52,3 +68,23 @@ def test_list_action_form_title_list_type_matches_data():
 
     assert payload["title"] == "Hardware List"
     assert payload["data"]["list_name"] == "Hardware"
+
+
+def test_list_action_form_uses_shared_item_normalization():
+    payload = _intent_action_form_payload(Intent("list_add", {"items": [" eggs "]}))
+
+    assert payload["data"]["items"] == ["eggs"]
+    assert payload["data"]["item"] == "eggs"
+
+
+def test_normalized_list_items_fallback_trims_and_filters(monkeypatch):
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "card_service":
+            raise ImportError("boom")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    assert _normalized_list_items({"items": [" milk ", "", "bread"]}) == ["milk", "bread"]


### PR DESCRIPTION
## Summary
- expose shopping list item normalization as the shared card/chat helper
- route list_add/list_show show-card and action-form payloads through the same normalization path
- add regressions for items-slot editor prefill, compat/card parity, import-fallback trimming, and global builder restoration

## Verification
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_card_service.py services/zoe-data/tests/test_chat_calendar_cards.py services/zoe-data/tests/test_chat_shopping_cards.py
- python3 tools/audit/validate_structure.py
- python3 tools/audit/validate_critical_files.py
- python3 tools/audit/validate_offline_memory.py
- git diff --check