### PR TITLE
[codex] Refresh Graphify after Zoe identity utilities

### DIFF
--- a/docs/architecture/zoe-graphify-refresh-evidence.md
+++ b/docs/architecture/zoe-graphify-refresh-evidence.md
@@ -167,3 +167,26 @@ Evidence:
 - focused verification for PR #356 covered `test_kanban_adapter.py`, `test_main_multica_poll.py`, and Python compilation of touched files;
 - `graphify-out/GRAPH_REPORT.md` and `graphify-out/graph.json` contain the generated graph metrics for the final refresh;
 - structure, critical-file, offline-memory, and diff whitespace validators passed.
+
+## Refresh 2026-06-10 Zoe Identity Utility Naming Pass
+
+Trigger commit: `c766e2b11ff0a0260db86bbe62c06ce5abdf7927` (PR #360)
+
+Commands:
+
+```bash
+OPENAI_API_KEY=$(grep "^OPENAI_API_KEY=" /home/zoe/assistant/.env | cut -d= -f2-) /home/zoe/.local/share/uv/tools/graphifyy/bin/graphify extract . --backend openai
+/home/zoe/.local/share/uv/tools/graphifyy/bin/graphify cluster-only . --no-viz
+python3 tools/audit/validate_structure.py
+python3 tools/audit/validate_critical_files.py
+python3 tools/audit/validate_offline_memory.py
+git diff --check
+```
+
+Evidence:
+
+- Graphify was refreshed after PR #360 renamed utility intelligence checks from concrete Samantha naming to Zoe identity and continuity naming;
+- focused verification for PR #360 covered Python compilation of the touched utility scripts, `git grep -n -i "samantha" -- scripts/utilities`, and the standard Zoe validators;
+- `docs/reports/` is ignored so generated utility reports do not become accidental committed output;
+- `graphify-out/GRAPH_REPORT.md` and `graphify-out/graph.json` contain the generated graph metrics for the final refresh;
+- structure, critical-file, offline-memory, and diff whitespace validators passed.

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -4,12 +4,12 @@
 - cluster-only mode — file stats not available
 
 ## Summary
-- 8218 nodes · 14677 edges · 526 communities (337 shown, 189 thin omitted)
-- Extraction: 86% EXTRACTED · 14% INFERRED · 0% AMBIGUOUS · INFERRED: 2067 edges (avg confidence: 0.76)
+- 8263 nodes · 14716 edges · 543 communities (352 shown, 191 thin omitted)
+- Extraction: 86% EXTRACTED · 14% INFERRED · 0% AMBIGUOUS · INFERRED: 2115 edges (avg confidence: 0.76)
 - Token cost: 0 input · 0 output
 
 ## Graph Freshness
-- Built from commit: `068c7e87`
+- Built from commit: `c766e2b1`
 - Run `git rev-parse HEAD` and compare to check if the graph is stale.
 - Run `graphify update .` after code changes (no API cost).
 
@@ -129,8 +129,8 @@
 - [[_COMMUNITY_Community 112|Community 112]]
 - [[_COMMUNITY_Community 113|Community 113]]
 - [[_COMMUNITY_Community 114|Community 114]]
+- [[_COMMUNITY_Community 115|Community 115]]
 - [[_COMMUNITY_Community 116|Community 116]]
-- [[_COMMUNITY_Community 117|Community 117]]
 - [[_COMMUNITY_Community 118|Community 118]]
 - [[_COMMUNITY_Community 119|Community 119]]
 - [[_COMMUNITY_Community 120|Community 120]]
@@ -201,12 +201,12 @@
 - [[_COMMUNITY_Community 185|Community 185]]
 - [[_COMMUNITY_Community 186|Community 186]]
 - [[_COMMUNITY_Community 187|Community 187]]
-- [[_COMMUNITY_Community 188|Community 188]]
 - [[_COMMUNITY_Community 189|Community 189]]
 - [[_COMMUNITY_Community 190|Community 190]]
 - [[_COMMUNITY_Community 191|Community 191]]
 - [[_COMMUNITY_Community 192|Community 192]]
 - [[_COMMUNITY_Community 193|Community 193]]
+- [[_COMMUNITY_Community 194|Community 194]]
 - [[_COMMUNITY_Community 195|Community 195]]
 - [[_COMMUNITY_Community 196|Community 196]]
 - [[_COMMUNITY_Community 197|Community 197]]
@@ -324,6 +324,7 @@
 - [[_COMMUNITY_Community 309|Community 309]]
 - [[_COMMUNITY_Community 310|Community 310]]
 - [[_COMMUNITY_Community 311|Community 311]]
+- [[_COMMUNITY_Community 312|Community 312]]
 - [[_COMMUNITY_Community 313|Community 313]]
 - [[_COMMUNITY_Community 314|Community 314]]
 - [[_COMMUNITY_Community 315|Community 315]]
@@ -337,11 +338,12 @@
 - [[_COMMUNITY_Community 323|Community 323]]
 - [[_COMMUNITY_Community 324|Community 324]]
 - [[_COMMUNITY_Community 325|Community 325]]
-- [[_COMMUNITY_Community 326|Community 326]]
 - [[_COMMUNITY_Community 327|Community 327]]
 - [[_COMMUNITY_Community 328|Community 328]]
 - [[_COMMUNITY_Community 329|Community 329]]
+- [[_COMMUNITY_Community 330|Community 330]]
 - [[_COMMUNITY_Community 331|Community 331]]
+- [[_COMMUNITY_Community 332|Community 332]]
 - [[_COMMUNITY_Community 333|Community 333]]
 - [[_COMMUNITY_Community 334|Community 334]]
 - [[_COMMUNITY_Community 335|Community 335]]
@@ -356,31 +358,29 @@
 - [[_COMMUNITY_Community 344|Community 344]]
 - [[_COMMUNITY_Community 345|Community 345]]
 - [[_COMMUNITY_Community 346|Community 346]]
+- [[_COMMUNITY_Community 348|Community 348]]
 - [[_COMMUNITY_Community 350|Community 350]]
+- [[_COMMUNITY_Community 351|Community 351]]
+- [[_COMMUNITY_Community 352|Community 352]]
 - [[_COMMUNITY_Community 353|Community 353]]
 - [[_COMMUNITY_Community 354|Community 354]]
 - [[_COMMUNITY_Community 355|Community 355]]
 - [[_COMMUNITY_Community 356|Community 356]]
 - [[_COMMUNITY_Community 357|Community 357]]
+- [[_COMMUNITY_Community 358|Community 358]]
 - [[_COMMUNITY_Community 359|Community 359]]
 - [[_COMMUNITY_Community 360|Community 360]]
 - [[_COMMUNITY_Community 361|Community 361]]
-- [[_COMMUNITY_Community 364|Community 364]]
-- [[_COMMUNITY_Community 365|Community 365]]
-- [[_COMMUNITY_Community 366|Community 366]]
-- [[_COMMUNITY_Community 367|Community 367]]
-- [[_COMMUNITY_Community 368|Community 368]]
+- [[_COMMUNITY_Community 362|Community 362]]
+- [[_COMMUNITY_Community 363|Community 363]]
 - [[_COMMUNITY_Community 369|Community 369]]
 - [[_COMMUNITY_Community 370|Community 370]]
 - [[_COMMUNITY_Community 371|Community 371]]
-- [[_COMMUNITY_Community 372|Community 372]]
 - [[_COMMUNITY_Community 373|Community 373]]
 - [[_COMMUNITY_Community 374|Community 374]]
 - [[_COMMUNITY_Community 375|Community 375]]
-- [[_COMMUNITY_Community 376|Community 376]]
 - [[_COMMUNITY_Community 377|Community 377]]
 - [[_COMMUNITY_Community 378|Community 378]]
-- [[_COMMUNITY_Community 379|Community 379]]
 - [[_COMMUNITY_Community 380|Community 380]]
 - [[_COMMUNITY_Community 381|Community 381]]
 - [[_COMMUNITY_Community 382|Community 382]]
@@ -400,8 +400,10 @@
 - [[_COMMUNITY_Community 396|Community 396]]
 - [[_COMMUNITY_Community 397|Community 397]]
 - [[_COMMUNITY_Community 398|Community 398]]
+- [[_COMMUNITY_Community 399|Community 399]]
 - [[_COMMUNITY_Community 400|Community 400]]
 - [[_COMMUNITY_Community 401|Community 401]]
+- [[_COMMUNITY_Community 402|Community 402]]
 - [[_COMMUNITY_Community 403|Community 403]]
 - [[_COMMUNITY_Community 404|Community 404]]
 - [[_COMMUNITY_Community 405|Community 405]]
@@ -411,9 +413,18 @@
 - [[_COMMUNITY_Community 409|Community 409]]
 - [[_COMMUNITY_Community 410|Community 410]]
 - [[_COMMUNITY_Community 411|Community 411]]
+- [[_COMMUNITY_Community 412|Community 412]]
+- [[_COMMUNITY_Community 413|Community 413]]
+- [[_COMMUNITY_Community 414|Community 414]]
+- [[_COMMUNITY_Community 415|Community 415]]
+- [[_COMMUNITY_Community 416|Community 416]]
+- [[_COMMUNITY_Community 417|Community 417]]
+- [[_COMMUNITY_Community 418|Community 418]]
+- [[_COMMUNITY_Community 419|Community 419]]
+- [[_COMMUNITY_Community 420|Community 420]]
+- [[_COMMUNITY_Community 421|Community 421]]
 - [[_COMMUNITY_Community 423|Community 423]]
 - [[_COMMUNITY_Community 424|Community 424]]
-- [[_COMMUNITY_Community 425|Community 425]]
 - [[_COMMUNITY_Community 426|Community 426]]
 - [[_COMMUNITY_Community 427|Community 427]]
 - [[_COMMUNITY_Community 428|Community 428]]
@@ -423,17 +434,6 @@
 - [[_COMMUNITY_Community 432|Community 432]]
 - [[_COMMUNITY_Community 433|Community 433]]
 - [[_COMMUNITY_Community 434|Community 434]]
-- [[_COMMUNITY_Community 435|Community 435]]
-- [[_COMMUNITY_Community 436|Community 436]]
-- [[_COMMUNITY_Community 437|Community 437]]
-- [[_COMMUNITY_Community 438|Community 438]]
-- [[_COMMUNITY_Community 439|Community 439]]
-- [[_COMMUNITY_Community 440|Community 440]]
-- [[_COMMUNITY_Community 441|Community 441]]
-- [[_COMMUNITY_Community 442|Community 442]]
-- [[_COMMUNITY_Community 443|Community 443]]
-- [[_COMMUNITY_Community 444|Community 444]]
-- [[_COMMUNITY_Community 445|Community 445]]
 - [[_COMMUNITY_Community 446|Community 446]]
 - [[_COMMUNITY_Community 447|Community 447]]
 - [[_COMMUNITY_Community 448|Community 448]]
@@ -463,6 +463,9 @@
 - [[_COMMUNITY_Community 472|Community 472]]
 - [[_COMMUNITY_Community 473|Community 473]]
 - [[_COMMUNITY_Community 474|Community 474]]
+- [[_COMMUNITY_Community 475|Community 475]]
+- [[_COMMUNITY_Community 476|Community 476]]
+- [[_COMMUNITY_Community 477|Community 477]]
 - [[_COMMUNITY_Community 478|Community 478]]
 - [[_COMMUNITY_Community 479|Community 479]]
 - [[_COMMUNITY_Community 480|Community 480]]
@@ -483,9 +486,6 @@
 - [[_COMMUNITY_Community 495|Community 495]]
 - [[_COMMUNITY_Community 496|Community 496]]
 - [[_COMMUNITY_Community 497|Community 497]]
-- [[_COMMUNITY_Community 498|Community 498]]
-- [[_COMMUNITY_Community 499|Community 499]]
-- [[_COMMUNITY_Community 500|Community 500]]
 - [[_COMMUNITY_Community 501|Community 501]]
 - [[_COMMUNITY_Community 502|Community 502]]
 - [[_COMMUNITY_Community 503|Community 503]]
@@ -511,9 +511,26 @@
 - [[_COMMUNITY_Community 523|Community 523]]
 - [[_COMMUNITY_Community 524|Community 524]]
 - [[_COMMUNITY_Community 525|Community 525]]
+- [[_COMMUNITY_Community 526|Community 526]]
+- [[_COMMUNITY_Community 527|Community 527]]
+- [[_COMMUNITY_Community 528|Community 528]]
+- [[_COMMUNITY_Community 529|Community 529]]
+- [[_COMMUNITY_Community 530|Community 530]]
+- [[_COMMUNITY_Community 531|Community 531]]
+- [[_COMMUNITY_Community 532|Community 532]]
+- [[_COMMUNITY_Community 533|Community 533]]
+- [[_COMMUNITY_Community 534|Community 534]]
+- [[_COMMUNITY_Community 535|Community 535]]
+- [[_COMMUNITY_Community 536|Community 536]]
+- [[_COMMUNITY_Community 537|Community 537]]
+- [[_COMMUNITY_Community 538|Community 538]]
+- [[_COMMUNITY_Community 539|Community 539]]
+- [[_COMMUNITY_Community 540|Community 540]]
+- [[_COMMUNITY_Community 541|Community 541]]
+- [[_COMMUNITY_Community 542|Community 542]]
 
 ## God Nodes (most connected - your core abstractions)
-1. `main()` - 373 edges
+1. `main()` - 372 edges
 2. `require_feature_access()` - 110 edges
 3. `list()` - 93 edges
 4. `_FakeAdapter` - 74 edges
@@ -527,532 +544,536 @@
 ## Surprising Connections (you probably didn't know these)
 - `test_service_health_reports_malformed_json_as_unhealthy()` --calls--> `Service Health Fixes`  [INFERRED]
   services/zoe-data/tests/test_hindsight_embedding_probe.py → docs/architecture/SERVICE_HEALTH_FIX.md
-- `get_reports()` --calls--> `_row_to_dict()`  [INFERRED]
-  modules/orbit/main.py → services/zoe-data/routers/lists.py
-- `Candidate scoring for Zoe capability adoption.  Zoe should evaluate existing Pi,` --rationale_for--> `Zoe Candidate Scoring`  [EXTRACTED]
-  services/zoe-data/zoe_candidate_scoring.py → docs/architecture/zoe-candidate-scoring.md
-- `test_guest_returns_zero()` --calls--> `process_text()`  [INFERRED]
-  tests/unit/test_person_extractor.py → services/zoe-data/person_extractor.py
-- `test_maintenance_runner_imports_real_bakeoff_module()` --calls--> `list()`  [INFERRED]
-  services/zoe-data/tests/test_hindsight_bakeoff.py → tools/zoe_module.py
+- `Chat Backend (chat.py)` --conceptually_related_to--> `RouteLLM & LiteLLM Status`  [INFERRED]
+  services/zoe-core/routers/chat.py → docs/architecture/ROUTELLM_LITELLM_STATUS.md
+- `Chat Backend (chat.py)` --conceptually_related_to--> `GPU Model Setup - gemma3n-e2b-gpu:latest`  [INFERRED]
+  services/zoe-core/routers/chat.py → docs/architecture/GPU_MODEL_SETUP.md
+- `Chat Backend (chat.py)` --conceptually_related_to--> `Action Plan Progress Report`  [INFERRED]
+  services/zoe-core/routers/chat.py → docs/architecture/ACTION_PLAN_PROGRESS.md
+- `Chat Backend (chat.py)` --conceptually_related_to--> `LLM Capabilities Awareness Audit`  [INFERRED]
+  services/zoe-core/routers/chat.py → docs/architecture/LLM_CAPABILITIES_AUDIT.md
 
-## Communities (526 total, 189 thin omitted)
+## Communities (543 total, 191 thin omitted)
 
 ### Community 0 - "Community 0"
 Cohesion: 0.02
-Nodes (93): Main optimization function, Analyze a single database and return schema information, Main analysis function, Run comprehensive audit, _active_memory_files(), _assert_hindsight_policy(), _fail(), _is_allowed_line() (+85 more)
+Nodes (78): Main optimization function, Analyze a single database and return schema information, Main analysis function, Run comprehensive audit, _active_memory_files(), _assert_hindsight_policy(), _fail(), _is_allowed_line() (+70 more)
 
 ### Community 1 - "Community 1"
-Cohesion: 0.04
-Nodes (113): rate_limit(), Create a rate limiting dependency with Redis-based sliding window          Args:, get_auth_manager(), Get the singleton auth manager instance., Get track metadata from cache., get_youtube_music(), YouTube Music Provider ======================  Integration with YouTube Music us, Get or create a YTMusic client for a user.                  Args:             us (+105 more)
-
-### Community 2 - "Community 2"
 Cohesion: 0.02
 Nodes (4): _mock_ensure_worktree(), Tests for the Hermes Kanban executor adapter (CLI mocked)., Dispatch tests must not run real git worktree subprocesses., test_audit_no_pr_phases_do_not_preload_broad_skills()
 
+### Community 2 - "Community 2"
+Cohesion: 0.04
+Nodes (97): Override to customise the prompt per-check., Resolve a browser session_id to a user_id via zoe-auth HTTP.      Calls the same, Local voice session WebSocket for voice.html.      Accepts text and binary (audi, _resolve_ws_user(), websocket_voice(), _bash(), _build_memory_context(), _build_prompt() (+89 more)
+
 ### Community 3 - "Community 3"
 Cohesion: 0.04
-Nodes (89): Start discovering AirPlay devices, Get all discovered AirPlay devices, Get current playback state from an AirPlay device, Get all discovered Chromecast devices, Get a specific device by ID, Get current playback state from a Chromecast, Seek to position in current track., Set playback volume (0-100). (+81 more)
+Nodes (84): Start discovering AirPlay devices, Get all discovered AirPlay devices, Get current playback state from an AirPlay device, Get all discovered Chromecast devices, Get a specific device by ID, Get current playback state from a Chromecast, Seek to position in current track., Set playback volume (0-100). (+76 more)
 
 ### Community 4 - "Community 4"
-Cohesion: 0.04
-Nodes (97): Override to customise the prompt per-check., Local voice session WebSocket for voice.html.      Accepts text and binary (audi, websocket_voice(), _bash(), _build_memory_context(), _build_prompt(), _build_tools(), _build_voice_tools() (+89 more)
+Cohesion: 0.05
+Nodes (87): _issue_sort_key(), Return (sequence_key, phase_number) when title encodes a phased track., True when every lower phase in the same sequence is ``done`` (or missing)., Pick up to ``count`` backlog issues respecting phased ordering.      ``all_issue, select_batch(), _event(), _plain_event(), test_admit_hindsight_retain_candidate_requires_event_id() (+79 more)
 
 ### Community 5 - "Community 5"
 Cohesion: 0.04
-Nodes (59): get_event_tracker(), Get the singleton event tracker instance., get_media_controller(), MediaController, Media Controller ================  Routes playback commands to appropriate devic, Play a track on the target device.                  Args:             track_id:, Lazy load event tracker., Play previous track (from history). (+51 more)
+Nodes (52): Get session by ID with validation, MCPMusicStateManager, get_event_tracker(), Get the singleton event tracker instance., MediaController, Media Controller ================  Routes playback commands to appropriate devic, Play a track on the target device.                  Args:             track_id:, Lazy load event tracker. (+44 more)
 
 ### Community 6 - "Community 6"
 Cohesion: 0.04
-Nodes (68): _build_hermes_payload(), _build_panel_intent_card(), chat_inject_background(), chat_stream_generator(), _chatgpt_connect_flow(), _check_frustration(), _create_pending_approval(), _detect_preview_urls() (+60 more)
+Nodes (69): _build_hermes_payload(), _build_panel_intent_card(), chat_inject_background(), chat_stream_generator(), _chatgpt_connect_flow(), _check_frustration(), _create_pending_approval(), _detect_preview_urls() (+61 more)
 
 ### Community 7 - "Community 7"
-Cohesion: 0.03
-Nodes (68): browse(), Browser automation endpoint - navigates websites and extracts data.          Use, Log startup information., startup_event(), AutomationTriggerRequest, DeviceControlRequest, ha_voice_turn(), ha_voice_wake() (+60 more)
+Cohesion: 0.04
+Nodes (77): _should_supersede_voice_weather_action(), _FakeAdapter, A Kanban list row shaped like the real CLI: body marker, NO idempotency_key., KanbanAdapter with the CLI replaced by a scripted recorder., _row(), test_dispatch_blocks_existing_pr_revision_when_precheckout_fails(), test_dispatch_blocks_on_first_worker_failure(), test_dispatch_blocks_regular_worktree_failures_with_generic_reason() (+69 more)
 
 ### Community 8 - "Community 8"
-Cohesion: 0.04
-Nodes (78): _should_supersede_voice_weather_action(), _FakeAdapter, A Kanban list row shaped like the real CLI: body marker, NO idempotency_key., KanbanAdapter with the CLI replaced by a scripted recorder., _row(), test_dispatch_archives_stale_terminal_revision_phase_row(), test_dispatch_blocks_existing_pr_revision_when_precheckout_fails(), test_dispatch_blocks_on_first_worker_failure() (+70 more)
+Cohesion: 0.07
+Nodes (67): Agent Zero Safety Guardrails ============================  Provides safety contr, Safety modes for Agent Zero., SafetyMode, Enum, OutputState, OutputType, Types of output targets., Playback state of an output. (+59 more)
 
 ### Community 9 - "Community 9"
-Cohesion: 0.06
-Nodes (72): RuntimeError, acquire_lock(), _actionable_greptile_findings(), analyze_result(), _append_progress(), assess_merge_readiness(), _ci_status_from_rollup(), _diff_changed_lines() (+64 more)
+Cohesion: 0.03
+Nodes (66): a2a_task_result(), a2a_task_stream(), _A2ATaskRequest, board_cancel(), board_review(), build_engineering_guard_packet(), delegate_to_agent(), _EngineeringGuardRunRequest (+58 more)
 
 ### Community 10 - "Community 10"
-Cohesion: 0.03
-Nodes (65): a2a_task_result(), a2a_task_stream(), _A2ATaskRequest, board_cancel(), board_review(), build_engineering_guard_packet(), delegate_to_agent(), _EngineeringGuardRunRequest (+57 more)
+Cohesion: 0.04
+Nodes (56): browse(), Browser automation endpoint - navigates websites and extracts data.          Use, Log startup information., startup_event(), AutomationTriggerRequest, DeviceControlRequest, ha_voice_turn(), ha_voice_wake() (+48 more)
 
 ### Community 11 - "Community 11"
-Cohesion: 0.06
-Nodes (41): test_enabled_status_includes_embedding_config(), test_event_to_hindsight_item_keeps_evidence_and_scope_tags(), test_event_to_hindsight_item_serializes_structured_context_as_json(), test_operation_status_gets_hindsight_operation_endpoint(), test_recall_posts_trace_enabled_request(), test_recall_uses_user_and_scope_isolated_bank_ids(), test_request_wraps_non_json_response(), test_retain_payload_posts_pre_admitted_payload_without_auto_retain() (+33 more)
-
-### Community 12 - "Community 12"
-Cohesion: 0.07
-Nodes (61): test_capability_trust_update_blocks_failed_proposal(), test_capability_trust_update_blocks_unretained_outcome(), test_execution_gate_allows_when_required_evidence_refs_exist(), test_execution_gate_fails_closed_without_approval_evidence(), test_missing_approval_required_blocks_execution(), test_missing_proposal_id_blocks_execution(), test_non_execute_proposal_cannot_execute_even_with_evidence(), test_promote_memory_admission_requires_memory_approval_and_pr() (+53 more)
-
-### Community 13 - "Community 13"
 Cohesion: 0.05
 Nodes (34): CalendarExpert, HomeAssistantExpert, ImprovedBirthdayExpert, JournalExpert, ListExpert, MemoryExpert, PlanningExpert, Comprehensive Expert System Test Suite ====================================== Te (+26 more)
 
+### Community 12 - "Community 12"
+Cohesion: 0.05
+Nodes (57): FileSystemEventHandler, get_peer_agent_card(), Return a live A2A v1.0 proxy card for a peer agent with dynamic skills[]., Admin-only: force-flush the skill discovery cache for a peer agent., reload_peer_skills(), test_capabilities_snapshot_is_stable(), test_generated_context_mentions_hermes_engineering_loop(), test_graphify_rebuild_is_opt_in_by_default() (+49 more)
+
+### Community 13 - "Community 13"
+Cohesion: 0.05
+Nodes (58): Test that pattern extraction is fast enough for nightly jobs, fresh_collection(), _install_mempalace_stubs(), Comprehensive MemPalace integration tests.  Tests: user isolation, upsert behavi, Install mempalace module stubs so zoe_agent doesn't require the real package., Reset the in-memory Chroma collection before each test.      Also resets the Mem, Writing for 'jason' must not appear when loading facts for 'family-admin'., Deleting a CRM entity should archive all scoped MemPalace facts for it. (+50 more)
+
 ### Community 14 - "Community 14"
 Cohesion: 0.05
-Nodes (63): activate_scene(), analyze_home_assistant(), control_device(), get_automations(), get_entities(), get_entity(), get_lights(), get_scenes() (+55 more)
+Nodes (59): AuthResponse, escalate_session(), get_current_user(), get_passcode_status(), get_user_profile(), guest_login(), InitialPasswordSetupRequest, login() (+51 more)
 
 ### Community 15 - "Community 15"
 Cohesion: 0.05
-Nodes (48): AffinityEngine, AffinityScore, get_affinity_engine(), Music Affinity Engine =====================  Calculates user preferences from li, Get affinity score for an artist.                  Aggregates affinity across al, Get user's top tracks by affinity score.                  Args:             user, Get aggregate listening statistics for a user.                  Returns:, Rank a list of tracks by user affinity.                  Args:             track (+40 more)
+Nodes (54): Invalidate a specific session (user can only invalidate their own sessions), clear_all_device_caches(), clear_device_cache(), get_cached_users(), get_device_config(), get_device_status(), list_touch_panel_devices(), quick_user_switch() (+46 more)
 
 ### Community 16 - "Community 16"
-Cohesion: 0.05
-Nodes (41): Generate comprehensive audit report, Test that API endpoints are accessible, IntelligentSystemTester, Test manual model adaptation, Run comprehensive test of the intelligent system, Test the intelligent model management system, Test the enhanced chat endpoint, Test the performance monitoring endpoints (+33 more)
+Cohesion: 0.06
+Nodes (34): test_enabled_status_includes_embedding_config(), test_event_to_hindsight_item_keeps_evidence_and_scope_tags(), test_event_to_hindsight_item_serializes_structured_context_as_json(), test_operation_status_gets_hindsight_operation_endpoint(), test_recall_posts_trace_enabled_request(), test_recall_uses_user_and_scope_isolated_bank_ids(), test_request_wraps_non_json_response(), test_retain_payload_posts_pre_admitted_payload_without_auto_retain() (+26 more)
 
 ### Community 17 - "Community 17"
-Cohesion: 0.09
-Nodes (58): test_dispatch_after_scout_evidence_creates_next_phase(), test_audit_profile_closeout_requires_log_not_greptile(), test_audit_profile_verify_does_not_require_test(), test_block_fingerprint_aborts_after_two_identical(), test_block_preserves_phase_and_evidence_until_restarted(), test_evidence_metadata_rejects_secret_fields(), test_explicit_scope_split_is_allowed_from_scout(), test_failed_evidence_does_not_satisfy_gate() (+50 more)
-
-### Community 18 - "Community 18"
-Cohesion: 0.07
-Nodes (46): _promotion_plan(), _source_text(), test_profile_patch_writer_blocks_missing_source_profile(), test_profile_patch_writer_blocks_stale_source_trust_level(), test_profile_patch_writer_blocks_unapplyable_promotion_plan(), test_profile_patch_writer_renders_deterministic_unified_diff(), test_profile_patch_writer_validates_record_and_plan_invariants(), _review_result() (+38 more)
-
-### Community 19 - "Community 19"
-Cohesion: 0.05
-Nodes (56): Test that pattern extraction is fast enough for nightly jobs, fresh_collection(), _install_mempalace_stubs(), Comprehensive MemPalace integration tests.  Tests: user isolation, upsert behavi, Install mempalace module stubs so zoe_agent doesn't require the real package., Reset the in-memory Chroma collection before each test.      Also resets the Mem, Writing for 'jason' must not appear when loading facts for 'family-admin'., Deleting a CRM entity should archive all scoped MemPalace facts for it. (+48 more)
-
-### Community 20 - "Community 20"
-Cohesion: 0.06
-Nodes (40): escalate_session(), Refresh current session expiration          Args:         current_session: Curre, Escalate passcode session to full session with password verification          Ar, refresh_session(), Verify passcode for user                  Args:             user_id: User identi, AuthenticationResult, EnhancedSessionManager, Enhanced session manager with multi-factor support (+32 more)
-
-### Community 21 - "Community 21"
 Cohesion: 0.05
 Nodes (56): get_plugins(), get_skills(), install_plugin_endpoint(), install_skill_endpoint(), openclaw_health(), preview_skill_endpoint(), routers/openclaw.py — REST API for OpenClaw plugin and skill management.  Endpoi, Return workspace-installed + eligible bundled skills for the skills_manager comp (+48 more)
 
-### Community 22 - "Community 22"
-Cohesion: 0.07
-Nodes (57): post_install_component(), build_updates_snapshot(), _check_and_notify_zoe_release(), _check_docker_service(), _check_hermes(), _check_openclaw(), _check_zoe_data(), _docker_inspect() (+49 more)
+### Community 18 - "Community 18"
+Cohesion: 0.09
+Nodes (51): test_capability_trust_update_blocks_failed_proposal(), test_capability_trust_update_blocks_unretained_outcome(), test_failed_outcome_remains_pending_only_and_never_trusted_durable_memory(), test_graphiti_target_is_allowed_for_relational_outcome_candidate(), test_none_items_are_ignored_in_backend_and_approval_sequences(), test_outcome_admission_requires_proposal_memory_admission_gate(), test_result_serializes_candidate_request_and_decision(), test_retired_outcome_remains_blocked_until_retirement_memory_policy_exists() (+43 more)
 
-### Community 23 - "Community 23"
-Cohesion: 0.04
-Nodes (56): AuthResponse, get_current_user(), get_passcode_status(), get_user_profile(), guest_login(), InitialPasswordSetupRequest, login(), login_passcode() (+48 more)
-
-### Community 24 - "Community 24"
+### Community 19 - "Community 19"
 Cohesion: 0.05
-Nodes (37): Check if Agent Zero is available.                  Returns:             True if, Analyze a target (file, system, configuration).                  Args:, analyze(), Analysis endpoint - analyzes files, configurations, systems.          Uses Agent, Analyze all files in root, RootCleaner, AudioAnalyzer, Audio Analyzer ==============  Extracts audio features from music tracks using E (+29 more)
+Nodes (46): test_dispatch_adjusts_running_scout_journal_when_scout_row_is_done(), test_dispatch_adjusts_stale_scout_journal_for_scope_split_child(), test_dispatch_archives_stale_terminal_revision_phase_row(), test_dispatch_does_not_adjust_running_scout_journal_with_active_row(), test_poll_v4_audit_protocol_recovery_reports_partial_for_next_phase(), test_mark_greptile_passes_only_on_five_of_five(), test_mark_reviewed_requires_zero_critical(), test_mark_tested_records_hashed_evidence() (+38 more)
 
-### Community 25 - "Community 25"
+### Community 20 - "Community 20"
+Cohesion: 0.1
+Nodes (52): test_dispatch_after_scout_evidence_creates_next_phase(), test_audit_profile_closeout_requires_log_not_greptile(), test_audit_profile_verify_does_not_require_test(), test_block_fingerprint_aborts_after_two_identical(), test_block_preserves_phase_and_evidence_until_restarted(), test_evidence_metadata_rejects_secret_fields(), test_failed_evidence_does_not_satisfy_gate(), test_implement_requires_tool_evidence_before_complete() (+44 more)
+
+### Community 21 - "Community 21"
+Cohesion: 0.07
+Nodes (54): build_updates_snapshot(), _check_and_notify_zoe_release(), _check_docker_service(), _check_hermes(), _check_openclaw(), _check_zoe_data(), _docker_inspect(), _dockerhub_digest() (+46 more)
+
+### Community 22 - "Community 22"
 Cohesion: 0.06
 Nodes (49): cleanup_documentation_files(), cleanup_duplicate_files(), cleanup_python_cache(), cleanup_ui_dist_files(), optimize_git(), Remove duplicate or redundant files, Remove redundant documentation files, Run a command and return success status (+41 more)
 
+### Community 23 - "Community 23"
+Cohesion: 0.06
+Nodes (34): Generate comprehensive audit report, Test that API endpoints are accessible, IntelligentSystemTester, Test manual model adaptation, Run comprehensive test of the intelligent system, Test the intelligent model management system, Test the enhanced chat endpoint, Test the performance monitoring endpoints (+26 more)
+
+### Community 24 - "Community 24"
+Cohesion: 0.06
+Nodes (46): Normalize a YouTube Music item to standard format., Make a request to the Home Assistant API., AppleMusicProvider, Get user's Music User Token from database., Make authenticated API request., Convert Apple Music track data to Track., Convert Apple Music album data to Album., Convert Apple Music artist data to Artist. (+38 more)
+
+### Community 25 - "Community 25"
+Cohesion: 0.09
+Nodes (51): add_activity(), add_bucket_item(), add_gift_idea(), add_important_date(), add_relationship(), _archive_person_mempalace(), create_people_field(), create_person() (+43 more)
+
 ### Community 26 - "Community 26"
 Cohesion: 0.06
-Nodes (36): demo_action_execution(), demo_complex_queries(), demo_memory_storage(), Demo: Action execution (lists, calendar, etc.), Send a chat message to Zoe, Demo: Complex queries requiring reasoning, Demo: P0-2 Confidence formatting, Verify that a fact was stored in memory (+28 more)
+Nodes (50): run_music_digest(), get_emotional_moments(), Return recent emotional memories (admin or self only)., Manually trigger the LLM memory digest for a user (or the requesting user)., trigger_memory_digest(), _deep_sleep_pass(), _emotional_memory_pass(), _extract_concept_tags() (+42 more)
 
 ### Community 27 - "Community 27"
 Cohesion: 0.06
-Nodes (44): BaseHTTPMiddleware, evaluate(), load_device_tokens(), Load all active device tokens from DB into the in-memory cache (call at startup), Manually trigger the morning brief for the calling user.     Useful for testing, trigger_morning_brief(), check(), What a trigger wants to send. (+36 more)
+Nodes (47): Get user information (without sensitive data), hash_secret(), OIDC client registration and secret verification., Exact match only — no wildcards., Insert or update a client. Safe to call on every startup., upsert_client(), validate_redirect_uri(), verify_secret() (+39 more)
 
 ### Community 28 - "Community 28"
 Cohesion: 0.06
-Nodes (39): test_dispatch_adjusts_running_scout_journal_when_scout_row_is_done(), test_dispatch_adjusts_stale_scout_journal_for_scope_split_child(), test_dispatch_does_not_adjust_running_scout_journal_with_active_row(), test_poll_v4_audit_protocol_recovery_reports_partial_for_next_phase(), test_mark_greptile_passes_only_on_five_of_five(), test_mark_reviewed_requires_zero_critical(), test_mark_tested_records_hashed_evidence(), test_record_evidence_retries_once_after_journal_conflict() (+31 more)
-
-### Community 29 - "Community 29"
-Cohesion: 0.1
-Nodes (46): Convert to dictionary for API responses., test_failed_outcome_trace_becomes_notice_signal_when_repeated(), test_failed_outcome_trace_respects_existing_signal_ids(), test_failed_outcome_trace_threshold_is_repeat_count_two(), test_memory_route_trace_allows_safe_metadata_without_evidence(), test_metadata_allows_author_attribution_key(), test_metadata_rejects_secret_keys(), test_metadata_rejects_secret_keys_inside_lists() (+38 more)
-
-### Community 30 - "Community 30"
-Cohesion: 0.06
-Nodes (48): run_music_digest(), Manually trigger the LLM memory digest for a user (or the requesting user)., trigger_memory_digest(), _deep_sleep_pass(), _emotional_memory_pass(), _extract_concept_tags(), _extract_facts_with_gemma(), _extract_open_loops() (+40 more)
-
-### Community 31 - "Community 31"
-Cohesion: 0.06
 Nodes (44): HA full-setup shorthand intent and OpenClaw message expansion., test_detect_ha_full_setup(), test_execute_ha_full_setup_returns_none(), test_openclaw_user_message_expands_with_intent(), test_openclaw_user_message_expands_without_intent(), Open-domain creative intent routing., test_joke_requests_route_to_open_domain_agent(), test_board_status_reports_lifecycle_metadata() (+36 more)
 
-### Community 32 - "Community 32"
-Cohesion: 0.08
-Nodes (46): BaseModel, contactData, Record a reaction. Mutual thumbs-up → silent connection., speed_dating_react(), ChallengeAnswerCreate, ChallengeCreate, CheckInCreate, CheckInPublic (+38 more)
-
-### Community 33 - "Community 33"
-Cohesion: 0.08
-Nodes (41): _audit_no_pr_issue(), _chain_for_issue(), _code_audit_implement_hint(), _engineering_mode(), _escalation_model_hint(), _existing_pr_url(), _goal_mode_args(), _greptile_mcp_bin() (+33 more)
-
-### Community 34 - "Community 34"
+### Community 29 - "Community 29"
 Cohesion: 0.06
 Nodes (37): analyze_login_patterns(), AuditLogger, log_authentication_attempt(), log_security_event(), RateLimiter, RateLimitRule, Security Features and Controls Rate limiting, audit logging, and advanced securi, Clear rate limit for identifier (admin function) (+29 more)
 
-### Community 35 - "Community 35"
-Cohesion: 0.07
-Nodes (21): Initialize Agent Zero client.                  Args:             base_url: Base, Initialize safety guardrails.                  Args:             mode: Safety mo, MCPMusicStateManager, Initialize the affinity engine.                  Args:             half_life_day, Initialize the AirPlay service, Initialize the audio analyzer with Essentia., Initialize the auth manager.                  Args:             encryption_key:, Initialize the Cast service (+13 more)
+### Community 30 - "Community 30"
+Cohesion: 0.1
+Nodes (37): _promotion_plan(), _source_text(), test_profile_patch_writer_blocks_missing_source_profile(), test_profile_patch_writer_blocks_stale_source_trust_level(), test_profile_patch_writer_blocks_unapplyable_promotion_plan(), test_profile_patch_writer_renders_deterministic_unified_diff(), test_profile_patch_writer_validates_record_and_plan_invariants(), _review_result() (+29 more)
 
-### Community 36 - "Community 36"
+### Community 31 - "Community 31"
 Cohesion: 0.08
 Nodes (45): Attach Hermes log evidence when a silent exit was really a budget stop., _with_recovered_log_budget(), _budget_phase(), implement_code_audit_post_patch_drift_reason_from_log(), implement_code_audit_post_validation_ship_reason_from_log(), implement_edit_safety_reason_from_log(), implement_intent_gap_pre_edit_reason_from_log(), implement_patch_ambiguity_reason_from_log() (+37 more)
 
-### Community 37 - "Community 37"
+### Community 32 - "Community 32"
+Cohesion: 0.05
+Nodes (44): create_role(), get_audit_logs(), get_sync_data(), get_system_stats(), invalidate_session_admin(), list_all_sessions(), list_roles(), list_users() (+36 more)
+
+### Community 33 - "Community 33"
+Cohesion: 0.06
+Nodes (42): _broadcast_calendar_chat_prefill_ui(), _broadcast_shopping_chat_ui(), chatgpt_auth_status(), _extract_complete_sentences(), _get_kokoro_instance(), get_livekit_token(), _has_espeak_ng(), _parse_voice_escalation_delta() (+34 more)
+
+### Community 34 - "Community 34"
 Cohesion: 0.08
-Nodes (45): add_activity(), add_bucket_item(), add_gift_idea(), add_important_date(), add_relationship(), _archive_person_mempalace(), create_person(), delete_person() (+37 more)
+Nodes (44): BaseModel, contactData, ChallengeAnswerCreate, ChallengeCreate, CheckInCreate, CheckInPublic, Connection, ConnectionCreate (+36 more)
+
+### Community 35 - "Community 35"
+Cohesion: 0.06
+Nodes (35): db_conn(), Integration tests: People CRM — PostgreSQL + MemPalace sync.  Tests the dual fan, All CRM tables must exist., 0007 migration columns must exist on people table., Create a person, run process_text → verify DB activity row AND MemPalace entry., recalc_and_save updates health_score in DB., The /api/people/fields route fix: /fields must come before /{person_id} in sourc, Open an asyncpg connection for tests. (+27 more)
+
+### Community 36 - "Community 36"
+Cohesion: 0.09
+Nodes (6): saveZoneEditor(), showToast(), MusicPlaylistsWidget, MusicQueueWidget, MusicSearchWidget, Remove a track from the queue.                  Args:             position: If s
+
+### Community 37 - "Community 37"
+Cohesion: 0.07
+Nodes (35): rate_limit(), Create a rate limiting dependency with Redis-based sliding window          Args:, get_media_controller(), Get the singleton media controller instance., youtube(), get_youtube_music(), YouTube Music Provider ======================  Integration with YouTube Music us, Get or create a YTMusic client for a user.                  Args:             us (+27 more)
 
 ### Community 38 - "Community 38"
-Cohesion: 0.07
-Nodes (38): get_memory_router_status(), Read-only status for Zoe's disabled-by-default memory router runtime., test_default_chat_route_keeps_hindsight_and_graphiti_off_hot_path(), test_failure_and_fix_queries_route_to_reflective_memory(), test_fast_chat_layers_are_boring_hot_path_only(), test_reflective_route_is_timeout_bounded_candidate_only(), test_sidecar_layers_are_async_enrichment_not_required_for_chat(), test_supersession_queries_route_to_relational_memory() (+30 more)
-
-### Community 39 - "Community 39"
 Cohesion: 0.09
 Nodes (43): Tests for Kanban handoff → pipeline evidence parsing., test_audit_no_code_test_exemption_is_verify_only(), test_audit_no_code_verify_tests_count_as_passed(), test_block_substrings_do_not_reject_successful_test_evidence(), test_blocked_validator_does_not_count_as_passed(), test_closeout_audit_only_handoff_accepts_indented_log_lines(), test_closeout_audit_only_handoff_records_log_evidence(), test_closeout_does_not_infer_audit_log_from_generic_summary_without_pr() (+35 more)
 
-### Community 40 - "Community 40"
-Cohesion: 0.07
-Nodes (41): board_approve(), create_engineering_workflow_task(), evolution_proposal_action(), get_agent_board(), list_engineering_workflow_tasks(), multica_webhook(), _multica_webhook_dispatch_allowed(), Return Multica engineering ticket state for AG-UI display.      Falls back grace (+33 more)
+### Community 39 - "Community 39"
+Cohesion: 0.06
+Nodes (26): Clear the stream URL cache., Get cache statistics., CachedSession, CachedUser, Touch Panel Local Caching System Optimized for fast authentication on touch pane, Verify passcode using cached data (offline mode)                  Args:, Cached user information for touch panels, Cache session for offline use                  Args:             session_id: Ses (+18 more)
 
-### Community 41 - "Community 41"
+### Community 40 - "Community 40"
 Cohesion: 0.07
 Nodes (27): create_user(), Create new user (admin only)          Args:         request: User creation detai, change_password(), Change current user's password          Args:         request: Current and new p, AuthManager, AuthValidationResult, Verify user password                  Args:             user_id: User identifier, Change user password                  Args:             user_id: User identifier (+19 more)
 
-### Community 42 - "Community 42"
+### Community 41 - "Community 41"
 Cohesion: 0.07
 Nodes (39): print_results(), Scan entire project and categorize all files., Check if path should be ignored., Categorize a file and determine if it's in the right location.          Returns:, scan_project(), should_ignore(), Print validation results.          Returns:         Exit code (0 if all files ex, check_root_md_limit() (+31 more)
 
-### Community 43 - "Community 43"
+### Community 42 - "Community 42"
 Cohesion: 0.07
-Nodes (39): _broadcast_calendar_chat_prefill_ui(), _broadcast_shopping_chat_ui(), chatgpt_auth_status(), _env_int(), _extract_complete_sentences(), _get_faster_whisper_model(), get_livekit_token(), _log_voice_stt_sample() (+31 more)
+Nodes (40): add_item(), create_list(), delete_item(), delete_list(), get_list(), get_list_types(), list_items(), list_lists() (+32 more)
 
-### Community 44 - "Community 44"
+### Community 43 - "Community 43"
 Cohesion: 0.06
 Nodes (39): create_pin_challenge(), get_panel_bindings(), _hash_token(), issue_token(), lookup_device_token(), panel_public_info(), panel_status(), _pin_check_locked() (+31 more)
 
+### Community 44 - "Community 44"
+Cohesion: 0.08
+Nodes (35): get_memory_router_status(), Read-only status for Zoe's disabled-by-default memory router runtime., test_default_chat_route_keeps_hindsight_and_graphiti_off_hot_path(), test_failure_and_fix_queries_route_to_reflective_memory(), test_fast_chat_layers_are_boring_hot_path_only(), test_reflective_route_is_timeout_bounded_candidate_only(), test_sidecar_layers_are_async_enrichment_not_required_for_chat(), test_supersession_queries_route_to_relational_memory() (+27 more)
+
 ### Community 45 - "Community 45"
-Cohesion: 0.09
-Nodes (30): Validate database structure, IntentValidator, Validate a single YAML file.                  Returns:             (success, int, Check that handlers are registered for all intents., Check pattern quality and coverage., Check for potential security issues., Validates intent system configuration., Run all validations.                  Returns:             True if all validatio (+22 more)
+Cohesion: 0.07
+Nodes (24): Refresh current session expiration          Args:         current_session: Curre, refresh_session(), EnhancedSessionManager, Enhanced session manager with multi-factor support, Authenticate user and create session                  Args:             request:, Refresh session expiration, Extend session expiry to a fixed number of days from now (used for remember_me)., Invalidate all sessions for user except optionally one (+16 more)
 
 ### Community 46 - "Community 46"
-Cohesion: 0.07
-Nodes (29): Create a person, run process_text → verify DB activity row AND MemPalace entry., recalc_and_save updates health_score in DB., Minimal compatibility wrapper so person_extractor works with raw asyncpg., test_health_score_recalc(), test_person_extractor_dual_fanout(), get_db(), FakeCursor, db_compat.py — asyncpg compatibility shim providing an aiosqlite-style cursor AP (+21 more)
+Cohesion: 0.08
+Nodes (32): ABC, _check_memory_headroom(), Check if enough memory is available for ML components., BaseRecommendationEngine, get_discover(), get_mood_match(), get_radio(), get_recommendation_engine() (+24 more)
 
 ### Community 47 - "Community 47"
+Cohesion: 0.1
+Nodes (37): _audit_no_pr_issue(), _chain_for_issue(), _code_audit_implement_hint(), _engineering_mode(), _escalation_model_hint(), _existing_pr_url(), _goal_mode_args(), _greptile_mcp_bin() (+29 more)
+
+### Community 48 - "Community 48"
+Cohesion: 0.08
+Nodes (37): board_approve(), create_engineering_workflow_task(), evolution_proposal_action(), list_engineering_workflow_tasks(), multica_webhook(), Create a Hermes-assigned Multica issue and dispatch it via the executor seam., Receive Multica webhook events and update evolution proposal status., Act on an evolution proposal: approve|reject|defer.      On approve: creates a M (+29 more)
+
+### Community 49 - "Community 49"
+Cohesion: 0.1
+Nodes (31): MULClient, list_projects(), close_stale_autopilot_wrappers(), _fire_autopilot_job(), get_autopilot_triggers(), get_multica_autopilots(), _headers(), _is_configured() (+23 more)
+
+### Community 50 - "Community 50"
+Cohesion: 0.08
+Nodes (38): create_event(), delete_event(), _enforce_calendar_read_access(), get_event(), list_events(), list_today_events(), FastAPI router for calendar events. Mounted at prefix="/api/calendar" with tag ", Get a single event by ID. (+30 more)
+
+### Community 51 - "Community 51"
 Cohesion: 0.07
 Nodes (38): _agent_loop(), _build_room_handlers(), _collect_audio_stream(), _cooldown_watchdog(), _get_current_user_soft(), livekit_audio(), livekit_cancel(), _make_participant_state() (+30 more)
 
-### Community 48 - "Community 48"
-Cohesion: 0.07
-Nodes (38): _proc_alive(), Set status (+ bump last_seen_at when online) for one provider's row., True if a process whose full command line matches ``pattern`` is running.      `, True if the Zoe host API reports healthy., _update_runtime(), _zoe_alive(), _classify_proposal(), _db_exec() (+30 more)
-
-### Community 49 - "Community 49"
+### Community 52 - "Community 52"
 Cohesion: 0.05
 Nodes (38): handle_agent_zero_analyze(), handle_agent_zero_compare(), handle_agent_zero_plan(), handle_agent_zero_research(), handle_music_discover(), handle_music_like(), handle_music_mood(), handle_music_now_playing() (+30 more)
 
-### Community 50 - "Community 50"
-Cohesion: 0.07
-Nodes (23): IntEnum, AiortcRoom, _ConnState, _DataPacket, _Frame, _FrameEvent, make_room(), livekit_aiortc.py — LiveKit room participant using pure-Python aiortc.  Replaces (+15 more)
-
-### Community 51 - "Community 51"
-Cohesion: 0.08
-Nodes (38): _bridge_post(), _ambient_capture_thread(), _api_post(), _barge_in_vad_thread(), _do_single_turn(), _espeak_local(), _follow_up_listen(), _get_silero_vad() (+30 more)
-
-### Community 52 - "Community 52"
-Cohesion: 0.05
-Nodes (37): create_role(), get_audit_logs(), get_sync_data(), get_system_stats(), invalidate_session_admin(), list_all_sessions(), list_roles(), PasscodeSetRequest (+29 more)
-
 ### Community 53 - "Community 53"
-Cohesion: 0.07
-Nodes (37): clear_all_device_caches(), clear_device_cache(), get_cached_users(), get_device_config(), get_device_status(), list_touch_panel_devices(), QuickSwitchRequest, Touch Panel API Endpoints Optimized endpoints for touch panel quick authenticati (+29 more)
-
-### Community 54 - "Community 54"
-Cohesion: 0.09
-Nodes (34): Get user information (without sensitive data), hash_secret(), OIDC client registration and secret verification., Exact match only — no wildcards., Insert or update a client. Safe to call on every startup., upsert_client(), validate_redirect_uri(), verify_secret() (+26 more)
-
-### Community 55 - "Community 55"
-Cohesion: 0.09
-Nodes (30): Agent Zero Safety Guardrails ============================  Provides safety contr, Safety modes for Agent Zero., SafetyMode, Enum, OutputState, OutputType, Types of output targets., Playback state of an output. (+22 more)
-
-### Community 56 - "Community 56"
 Cohesion: 0.13
 Nodes (35): _FakeIntent, Unit tests for `voice_scope.classify`.  Covers every branch of the classifier wi, test_empty_string_defaults_public(), test_empty_string_strict_mode(), test_intent_build_widget_is_user_scoped(), test_intent_calendar_show_is_public_household(), test_intent_ha_prefix_public(), test_intent_journal_create_is_user_scoped() (+27 more)
 
-### Community 57 - "Community 57"
+### Community 54 - "Community 54"
+Cohesion: 0.09
+Nodes (31): BaseHTTPMiddleware, evaluate(), ProactiveTrigger, check(), What a trigger wants to send., Abstract trigger.  Two tiers derive from this:       - Tier 1: APScheduler-backe, TriggerResult, EveningWindDownTrigger (+23 more)
+
+### Community 55 - "Community 55"
 Cohesion: 0.06
 Nodes (29): check_home_directory(), get_category(), Determine where a file should go, Check /home/pi for violations, check_chat_router_intelligence(), Validate chat router uses intelligent systems, check_database(), Send a message to the API and return the response (+21 more)
 
-### Community 58 - "Community 58"
-Cohesion: 0.13
-Nodes (34): _plain_event(), test_admit_hindsight_retain_candidate_requires_event_id(), test_admit_hindsight_retain_candidate_stub_is_pending_and_non_writing(), test_admitted_hindsight_retain_plan_defaults_to_env_config(), test_admitted_hindsight_retain_plan_payload_is_immutable(), test_admitted_hindsight_retain_plan_rejects_mismatched_decision(), test_admitted_hindsight_retain_plan_rejects_pending_decision(), test_admitted_hindsight_retain_plan_rejects_wrong_backend() (+26 more)
-
-### Community 59 - "Community 59"
-Cohesion: 0.11
-Nodes (29): MULClient, list_projects(), close_stale_autopilot_wrappers(), _fire_autopilot_job(), get_autopilot_triggers(), get_multica_autopilots(), _headers(), _is_configured() (+21 more)
-
-### Community 60 - "Community 60"
+### Community 56 - "Community 56"
 Cohesion: 0.09
-Nodes (34): add_item(), create_list(), delete_item(), delete_list(), get_list(), get_list_types(), list_items(), list_lists() (+26 more)
+Nodes (25): AirPlay Output Target =====================  Implementation of OutputTarget for, is_initialized(), output_type(), Output Target Base Class ========================  Abstract base class for all a, Chromecast Output Target ========================  Implementation of OutputTarge, Home Assistant Output Target ============================  Implementation of Out, get_output_manager(), Output Manager ==============  Central manager for all audio output targets. Han (+17 more)
 
-### Community 61 - "Community 61"
-Cohesion: 0.09
-Nodes (26): Tests for background_runner enqueue, task lifecycle, and Hermes routing., Requests beyond _MAX_REQUEST_DEPTH must raise ValueError immediately., Requests at exactly _MAX_REQUEST_DEPTH must be accepted., enqueue_background_task should INSERT a row and return the new task id., _run_task should set status='done' and store result when Hermes succeeds., _run_task should set status='error' when Hermes raises an exception., Minimal async DB context that records calls., test_enqueue_accepts_max_depth() (+18 more)
-
-### Community 62 - "Community 62"
-Cohesion: 0.11
-Nodes (20): Get a specific provider by type.                  Args:             provider_typ, _get(), Return Atomic semantic hits as normalized records., _build_metadata(), _memory_status_visible(), _memory_visible_to_user(), MemoryRef, _metadata_value() (+12 more)
-
-### Community 63 - "Community 63"
-Cohesion: 0.13
-Nodes (33): _issue_sort_key(), Return (sequence_key, phase_number) when title encodes a phased track., True when every lower phase in the same sequence is ``done`` (or missing)., Pick up to ``count`` backlog issues respecting phased ordering.      ``all_issue, select_batch(), _approved_evolution_issue(), _issue(), Tests for safe production backlog admission. (+25 more)
-
-### Community 64 - "Community 64"
-Cohesion: 0.08
-Nodes (23): Sync password change to Home Assistant                  Args:             user_i, Sync password change to Matrix                  Args:             user_id: User, create_n8n_auth_config(), N8nIntegration, N8nUser, n8n SSO Integration Replace n8n's basic auth with Zoe's central authentication, Sync Zoe user to n8n                  Args:             user_id: Zoe user ID, Handle password change for n8n user                  Args:             user_id: (+15 more)
-
-### Community 65 - "Community 65"
+### Community 57 - "Community 57"
 Cohesion: 0.1
 Nodes (30): get_capability_matrix(), get_my_capability_matrix(), reset_capability_matrix_defaults(), update_capability_matrix_role(), _validate_matrix_shape(), test_authenticated_allowed_for_mutation(), test_default_matrix_has_fixed_shape(), test_guest_blocked_for_mutation() (+22 more)
 
-### Community 66 - "Community 66"
+### Community 58 - "Community 58"
 Cohesion: 0.07
 Nodes (27): check_readme_links(), find_doc_references(), find_hardcoded_paths(), generate_report(), Check if README references are current, Generate audit report, Find all references to documentation files in code, Find hardcoded paths to documentation (+19 more)
 
-### Community 67 - "Community 67"
+### Community 59 - "Community 59"
 Cohesion: 0.06
 Nodes (21): Unit Tests for Retry Utility ============================  Tests the retry decor, Test no retry on excluded exception type., Test on_retry callback is called., Tests for the retry_async function., Tests for the RetryContext context manager., Tests for NETWORK_CONFIG preset., Test NETWORK_CONFIG retries on network errors., Tests for RetryConfig. (+13 more)
 
-### Community 68 - "Community 68"
-Cohesion: 0.07
-Nodes (26): AgentZeroClient, _compute_agent_zero_api_key(), Agent Zero Client =================  Client for communicating with Agent Zero's, Get or create context ID for a user.                  Args:             user_id:, Extract URLs from text as sources.                  Args:             text: Text, Send a message to Agent Zero and get response.                  Uses the /api_me, Execute a research task via Agent Zero.                  Args:             query, Compute the API key that Agent Zero expects, using the same algorithm     as its (+18 more)
+### Community 60 - "Community 60"
+Cohesion: 0.1
+Nodes (29): Minimal async DB context that records calls., FakeDB, test_get_event_applies_calendar_read_gate_and_policy(), test_get_event_propagates_calendar_read_denial(), test_list_today_events_allows_guest_when_policy_allows(), test_list_today_events_applies_calendar_read_gate_and_policy(), _fake_get_db(), test_save_chat_message_only_touches_existing_strong_title() (+21 more)
 
-### Community 69 - "Community 69"
+### Community 61 - "Community 61"
+Cohesion: 0.08
+Nodes (23): disable_passcode(), Disable passcode for current user          Args:         current_session: Curren, PasswordPolicy, Password security policy, PasscodeManager, PasscodePolicy, PasscodeValidationResult, Passcode Authentication System Secure handling of 4-8 digit PIN codes with advan (+15 more)
+
+### Community 62 - "Community 62"
+Cohesion: 0.1
+Nodes (32): attachCardActions(), buildActionButtons(), buildMatchCard(), hideSDTimerOverlay(), hideSpeedDatingBanner(), loadMatches(), loadPendingConnections(), metPeople (+24 more)
+
+### Community 63 - "Community 63"
 Cohesion: 0.07
 Nodes (24): AirPlayDevice, AirPlayService, AirPlay Integration Service Discovers and controls AirPlay devices for music pla, Connect to an AirPlay device, Play media on an AirPlay device                  Args:             device_id: Ta, Represents a discovered AirPlay device, Send a control command to an AirPlay device                  Args:             d, Start pairing process for a device that requires it                  Returns: (+16 more)
 
-### Community 70 - "Community 70"
-Cohesion: 0.11
-Nodes (31): _event(), test_experience_memory_requires_evidence(), test_mapping_rejects_missing_scope(), test_mapping_rejects_missing_user_id(), test_mapping_supports_supersession_with_evidence(), test_relational_memory_requires_evidence(), test_valid_event_serializes_contract_fields(), test_blocked_multica_record_blocks_even_when_approval_flag_is_present() (+23 more)
+### Community 64 - "Community 64"
+Cohesion: 0.13
+Nodes (33): get_hermes_model_profiles(), _hermes_profile_error(), post_hermes_model_profiles_apply(), post_hermes_model_profiles_rollback(), post_hermes_model_profiles_validate(), put_hermes_model_profiles_draft(), _append_audit_best_effort(), apply_profiles() (+25 more)
 
-### Community 71 - "Community 71"
+### Community 65 - "Community 65"
+Cohesion: 0.07
+Nodes (31): accept_pending_suggestion(), create_schedule(), delete_schedule(), dismiss_pending_suggestion(), list_pending_suggestions(), list_schedules(), Proactive Engine REST router.  Endpoints:   POST   /api/proactive/schedule, List unresolved save offers for the current chat session. (+23 more)
+
+### Community 66 - "Community 66"
+Cohesion: 0.07
+Nodes (26): AgentZeroClient, _compute_agent_zero_api_key(), Agent Zero Client =================  Client for communicating with Agent Zero's, Get or create context ID for a user.                  Args:             user_id:, Extract URLs from text as sources.                  Args:             text: Text, Send a message to Agent Zero and get response.                  Uses the /api_me, Execute a research task via Agent Zero.                  Args:             query, Compute the API key that Agent Zero expects, using the same algorithm     as its (+18 more)
+
+### Community 67 - "Community 67"
 Cohesion: 0.06
 Nodes (22): Check a single router file for authentication issues.     Returns list of (line_, check_file(), Check a single file for hardcoded database paths, check_api_endpoints(), check_router_expectations(), check_ui_pages(), Check database table schemas, Check what routers expect vs what database has (+14 more)
 
-### Community 72 - "Community 72"
+### Community 68 - "Community 68"
 Cohesion: 0.06
 Nodes (8): Unit tests for person relationships feature.  Tests: - _REL_RE regex pattern mat, Test the _rel_lookup helper in people.py., Tier normalisation used in both UIs and people.py validation., Test _REL_RE patterns in person_extractor.py., Test RELATIONSHIP_TYPES constant from people.py., TestNormTier, TestRelationshipRegex, TestRelLookup
 
-### Community 73 - "Community 73"
+### Community 69 - "Community 69"
 Cohesion: 0.11
-Nodes (31): attachCardActions(), buildActionButtons(), buildMatchCard(), hideSDTimerOverlay(), hideSpeedDatingBanner(), loadMatches(), loadPendingConnections(), metPeople (+23 more)
+Nodes (23): Validate database structure, IntentValidator, Validate a single YAML file.                  Returns:             (success, int, Check that handlers are registered for all intents., Check pattern quality and coverage., Check for potential security issues., Validates intent system configuration., Run all validations.                  Returns:             True if all validatio (+15 more)
 
-### Community 74 - "Community 74"
-Cohesion: 0.12
-Nodes (28): Create a multi-step plan for a task.                  Args:             task: Ta, plan(), Planning endpoint - creates multi-step plans.          Uses Agent Zero to:, test_capability_trust_review_applies_approved_existing_profile_in_memory(), test_capability_trust_review_applies_approved_profiles_when_other_candidates_are_rejected(), test_capability_trust_review_blocks_stale_current_profile_level(), test_capability_trust_review_blocks_unknown_profile_until_profile_contract_exists(), test_capability_trust_review_clears_profiles_when_any_candidate_is_invalid() (+20 more)
-
-### Community 75 - "Community 75"
-Cohesion: 0.12
-Nodes (31): PWA Phase 2 Implementation Progress, Service Health Fixes, Action Plan Completion Summary, test_embedding_probe_accepts_cached_huggingface_model(), test_embedding_probe_accepts_existing_local_model_path(), test_embedding_probe_accepts_huggingface_hub_cache_override(), test_embedding_probe_accepts_local_tei_service(), test_embedding_probe_health_url_for_openai_compatible_base() (+23 more)
-
-### Community 76 - "Community 76"
-Cohesion: 0.08
-Nodes (31): Insert a proactive_scheduled row and register an APScheduler job.     Returns th, schedule_reminder(), init_pool(), Initialize the asyncpg connection pool. Call once at startup., _active_agents_list(), _enqueue_panel_tool(), _execute_tool(), _get_weather_default_location() (+23 more)
-
-### Community 77 - "Community 77"
+### Community 70 - "Community 70"
 Cohesion: 0.1
 Nodes (30): _broadcast_intent_nav(), _build_calendar_form_props(), _build_reminder_form_props(), _intent_action_form_payload(), _intent_card_data(), _normalized_list_items(), Build a panel_show_action_form payload for intents that show an in-place overlay, Broadcast UI actions to the touch panel when an intent is detected.      For act (+22 more)
 
+### Community 71 - "Community 71"
+Cohesion: 0.12
+Nodes (28): Create a multi-step plan for a task.                  Args:             task: Ta, plan(), Planning endpoint - creates multi-step plans.          Uses Agent Zero to:, test_capability_trust_review_applies_approved_existing_profile_in_memory(), test_capability_trust_review_applies_approved_profiles_when_other_candidates_are_rejected(), test_capability_trust_review_blocks_stale_current_profile_level(), test_capability_trust_review_blocks_unknown_profile_until_profile_contract_exists(), test_capability_trust_review_clears_profiles_when_any_candidate_is_invalid() (+20 more)
+
+### Community 72 - "Community 72"
+Cohesion: 0.07
+Nodes (31): activate_scene(), analyze_home_assistant(), control_device(), get_automations(), get_entities(), get_entity(), get_lights(), get_scenes() (+23 more)
+
+### Community 73 - "Community 73"
+Cohesion: 0.09
+Nodes (32): Make HTTP request to Home Assistant API, activate_workflow(), analyze_n8n(), create_credential(), create_workflow(), deactivate_workflow(), delete_workflow(), execute_workflow() (+24 more)
+
+### Community 74 - "Community 74"
+Cohesion: 0.09
+Nodes (18): Execute comprehensive test suite, Test RouteLLM classification, Test Enhanced MemAgent, Test RAG enhancements, Test full chat API endpoint with authentication, Get JWT token from zoe-auth service for authenticated requests, SystemTester, test_conversation() (+10 more)
+
+### Community 75 - "Community 75"
+Cohesion: 0.09
+Nodes (31): _classify_proposal(), _db_exec(), _is_noise(), _parse_psql_output(), _patch(), _post(), _post_with_workspace(), Run SQL against the multica DB via docker exec. (+23 more)
+
+### Community 76 - "Community 76"
+Cohesion: 0.1
+Nodes (18): Analyze warmth on 1-10 scale, Build a comprehensive Zoe continuity system prompt, Analyze overall Zoe continuity intelligence, Analyze warmth level on 1-10 scale, Analyze intelligence level on 1-10 scale, Analyze tool usage effectiveness on 1-10 scale, Run final comprehensive Zoe continuity intelligence test, Final comprehensive Zoe continuity intelligence testing (+10 more)
+
+### Community 77 - "Community 77"
+Cohesion: 0.13
+Nodes (30): PWA Phase 2 Implementation Progress, Service Health Fixes, test_embedding_probe_accepts_cached_huggingface_model(), test_embedding_probe_accepts_existing_local_model_path(), test_embedding_probe_accepts_huggingface_hub_cache_override(), test_embedding_probe_accepts_local_tei_service(), test_embedding_probe_health_url_for_openai_compatible_base(), test_embedding_probe_rejects_cloud_embedding_provider() (+22 more)
+
 ### Community 78 - "Community 78"
-Cohesion: 0.06
-Nodes (32): get_homeassistant_areas(), get_n8n_user_info(), get_service_configurations(), get_user_matrix_rooms(), get_user_n8n_workflows(), handle_password_change_webhook(), handle_user_deactivation_webhook(), homeassistant_auth() (+24 more)
+Cohesion: 0.1
+Nodes (30): Request model for research endpoint., ResearchRequest, _build_research_package(), _capture_research_screenshot(), Capture a screenshot for research evidence using broker-backed browser control., Build research package and attach screenshot evidence when possible., build_package(), classify_query() (+22 more)
 
 ### Community 79 - "Community 79"
-Cohesion: 0.09
-Nodes (19): Analyze warmth on 1-10 scale, Build a comprehensive Samantha-level system prompt, Analyze overall Samantha-level intelligence, Analyze warmth level on 1-10 scale, Analyze intelligence level on 1-10 scale, Analyze tool usage effectiveness on 1-10 scale, Run final comprehensive Samantha-level intelligence test, Final comprehensive Samantha-level intelligence testing (+11 more)
+Cohesion: 0.08
+Nodes (18): Test lists, tasks, and projects with context, Test calendar and event management, Test people management and relationships, Test journal entries and notes, Test Home Assistant integration, Test N8N workflow automation, Test developer tools and system management, Test voice and media capabilities (+10 more)
 
 ### Community 80 - "Community 80"
 Cohesion: 0.06
 Nodes (10): Tests for pipeline JSONL store and sync., test_bootstrap_returns_concurrently_created_state(), test_pipeline_summary_needs_split_requires_blocked_status(), test_pipeline_summary_reports_missing_evidence(), test_pipeline_summary_split_packet_alone_is_not_terminal(), test_resume_pipeline_retries_after_conflict(), test_skip_blocked_implementation_requires_tool_evidence(), test_stale_mutation_raises_conflict() (+2 more)
 
 ### Community 81 - "Community 81"
-Cohesion: 0.16
-Nodes (26): _retained_outcome(), test_capability_trust_update_candidate_validates_trust_levels(), test_capability_trust_update_candidates_require_retained_verified_outcome(), test_capability_trust_update_metadata_is_read_only_and_serializable(), test_capability_trust_update_skips_trusted_noop_candidate(), _candidate(), _signal(), test_approved_status_requires_approval_gate() (+18 more)
+Cohesion: 0.08
+Nodes (22): migrate_self_entries(), Create self entries for users in the people table, _compute_compatibility(), Compute compatibility score and shared traits between two check-ins., Get all registered providers., test_graphiti_episode_payloads_include_evidence(), test_graphiti_supersession_payloads_have_temporal_order(), test_percentile_rejects_out_of_range_values() (+14 more)
 
 ### Community 82 - "Community 82"
-Cohesion: 0.14
-Nodes (26): test_create_issue_metadata_preserves_existing_ticket_fields(), test_update_ticket_progress_can_clear_dispatch_approval(), test_block_only_description_does_not_gain_leading_blank_lines(), test_progress_and_children_patch_metadata_only(), test_replacing_middle_block_preserves_suffix_newline(), test_ticket_block_preserves_human_description(), test_ticket_block_replaces_only_zoe_section(), _blocker_followup_marker() (+18 more)
+Cohesion: 0.06
+Nodes (30): get_homeassistant_areas(), get_n8n_user_info(), get_service_configurations(), get_user_matrix_rooms(), get_user_n8n_workflows(), handle_password_change_webhook(), handle_user_deactivation_webhook(), homeassistant_auth() (+22 more)
 
 ### Community 83 - "Community 83"
-Cohesion: 0.11
-Nodes (27): get_pending_notifications(), list_notifications(), mark_read(), FastAPI router for notifications. Mounted at prefix="/api/notifications" with ta, Mark a notification as read/delivered., Delete a notification., List notifications for the current user., Get unread/pending notifications count and items. (+19 more)
+Cohesion: 0.14
+Nodes (17): Get a specific provider by type.                  Args:             provider_typ, _get(), Return Atomic semantic hits as normalized records., _build_metadata(), _memory_status_visible(), _memory_visible_to_user(), MemoryRef, _metadata_value() (+9 more)
 
 ### Community 84 - "Community 84"
-Cohesion: 0.07
-Nodes (30): _broadcast_calendar_ui(), _broadcast_lets_talk_ui(), _broadcast_reminder_ui(), _broadcast_weather_ui(), _contains_decision_keyword(), _get_or_create_voice_session(), _handle_introduce_intent(), _load_voice_history() (+22 more)
+Cohesion: 0.09
+Nodes (21): _board(), _expected_phases(), KanbanCLIError, _protocol_violation_count(), True when a worker pushed HEAD then got interrupted before PR handoff., Create/record a PR after the worker pushed but lost the terminal handoff., Report aggregate state of a chain by idempotency-key prefix.          Returns {f, Pull a PR URL from the implement/closeout task summaries or comments. (+13 more)
 
 ### Community 85 - "Community 85"
-Cohesion: 0.11
-Nodes (29): Request model for research endpoint., ResearchRequest, _build_research_package(), _capture_research_screenshot(), Capture a screenshot for research evidence using broker-backed browser control., Build research package and attach screenshot evidence when possible., build_package(), classify_query() (+21 more)
+Cohesion: 0.09
+Nodes (16): HomeAssistantIntegration, Sync user deletion to Home Assistant                  Args:             username, Authenticate user for Home Assistant (called by HA auth provider), Get Home Assistant areas for user assignment, Assign user to specific Home Assistant areas                  Args:, Sync all active Zoe users to Home Assistant                  Returns:, Sync user to HA person entity, Call Home Assistant API                  Args:             method: HTTP method (+8 more)
 
 ### Community 86 - "Community 86"
 Cohesion: 0.1
-Nodes (21): Get detailed status of Agent Zero service.          Returns:         Status info, status(), _compute_compatibility(), Compute compatibility score and shared traits between two check-ins., Get all registered providers., cli(), disable(), enable() (+13 more)
+Nodes (27): MusicProvider, Abstract base class for music streaming providers.          All providers (YouTu, Like/save a track. Override if provider supports it., Add tracks to a playlist. Override if provider supports it., Save a track to user's library., Remove track from user's library., Add tracks to a playlist., Lazy load the underlying provider. (+19 more)
 
 ### Community 87 - "Community 87"
 Cohesion: 0.07
-Nodes (29): check_no_archive_folders(), check_no_databases_in_git(), check_no_duplicate_configs(), check_no_root_tests(), check_no_temp_files(), check_no_venv_in_git(), check_required_docs(), check_root_md_files() (+21 more)
+Nodes (30): _broadcast_calendar_ui(), _broadcast_lets_talk_ui(), _broadcast_reminder_ui(), _broadcast_weather_ui(), _contains_decision_keyword(), _get_or_create_voice_session(), _handle_introduce_intent(), _load_voice_history() (+22 more)
 
 ### Community 88 - "Community 88"
-Cohesion: 0.09
-Nodes (28): parse_json_fields(), get_connection_icebreaker(), Shorter icebreaker for the QR scan connect page., create_connection(), get_matches(), get_pending_connections(), get_quiz_question(), _make_quiz_question() (+20 more)
+Cohesion: 0.1
+Nodes (28): _bridge_post(), _api_post(), _do_single_turn(), _espeak_local(), _get_voice_encoder(), _identify_speaker_from_wav(), _is_junk_transcript(), _notify_wake_background() (+20 more)
 
 ### Community 89 - "Community 89"
-Cohesion: 0.12
-Nodes (5): saveZoneEditor(), showToast(), MusicPlaylistsWidget, MusicQueueWidget, Remove a track from the queue.                  Args:             position: If s
+Cohesion: 0.1
+Nodes (17): Sync password change to Home Assistant                  Args:             user_i, Sync password change to Matrix                  Args:             user_id: User, N8nIntegration, Sync Zoe user to n8n                  Args:             user_id: Zoe user ID, Handle password change for n8n user                  Args:             user_id:, Sync user permissions to n8n                  Args:             user_id: User ID, Create workflow-specific permissions in n8n                  Args:             w, Get workflows accessible to user                  Args:             user_id: Use (+9 more)
 
 ### Community 90 - "Community 90"
 Cohesion: 0.09
 Nodes (22): bc(), _make_ws(), Unit tests for PushBroadcaster.broadcast() user_id scoping.  Regression test for, Return a mock WebSocket; user_id mapping is tracked in broadcaster state., broadcast() must accept user_id as an optional keyword argument., Without user_id, broadcast reaches every connection on the channel., With user_id set, only connections for that user receive the message., Connections with no user (panels/anonymous) always receive scoped broadcasts. (+14 more)
 
 ### Community 91 - "Community 91"
-Cohesion: 0.1
-Nodes (23): FileSystemEventHandler, get_peer_agent_card(), Return a live A2A v1.0 proxy card for a peer agent with dynamic skills[]., Admin-only: force-flush the skill discovery cache for a peer agent., reload_peer_skills(), invalidate_hermes_cache(), invalidate_openclaw_cache(), _parse_hermes_category() (+15 more)
-
-### Community 92 - "Community 92"
-Cohesion: 0.16
-Nodes (28): get_hermes_model_profiles(), _append_audit_best_effort(), apply_profiles(), _apply_to_yaml(), _apply_to_yaml_text(), audit_path(), build_diff(), count_running_workers() (+20 more)
-
-### Community 93 - "Community 93"
-Cohesion: 0.11
-Nodes (17): Sync user to Matrix homeserver          Args:         request: Sync request, sync_user_to_matrix(), MatrixIntegration, Sync Zoe user to Matrix homeserver                  Args:             user_id: Z, Deactivate Matrix user                  Args:             username: Username to, Create Matrix room                  Args:             room_config: Room configur, Join user to Matrix room                  Args:             user_id: Zoe user ID, Get Matrix rooms for user                  Args:             user_id: Zoe user I (+9 more)
-
-### Community 95 - "Community 95"
-Cohesion: 0.24
-Nodes (26): _fact_event(), _success_trace(), test_approved_memory_with_successful_admission_trace_can_write_target_backend(), test_failed_non_admission_trace_does_not_block_clean_admission(), test_failed_or_blocked_trace_blocks_even_with_approval(), test_graphiti_target_requires_relationship_or_supersession(), test_invalid_candidate_errors_are_wrapped_as_memory_admission_error(), test_invalid_trace_errors_are_wrapped_as_memory_admission_error() (+18 more)
-
-### Community 96 - "Community 96"
-Cohesion: 0.14
-Nodes (26): Tests for main.py Multica poll-loop helpers., RecordingClient, test_record_blocked_multica_chain_creates_budget_followup_once(), test_record_blocked_multica_chain_creates_iteration_budget_followup(), test_record_blocked_multica_chain_creates_protocol_followup(), test_record_blocked_multica_chain_does_not_create_recursive_harness_followup(), test_record_blocked_multica_chain_falls_back_to_classification_and_default(), test_record_blocked_multica_chain_records_terminal_block_metadata() (+18 more)
-
-### Community 97 - "Community 97"
-Cohesion: 0.08
-Nodes (27): Create a notification., delete_schedule(), Cancel a scheduled nudge., acknowledge_reminder(), create_reminder(), delete_reminder(), list_pending_notifications(), list_reminders() (+19 more)
-
-### Community 98 - "Community 98"
-Cohesion: 0.12
-Nodes (21): delete_user(), Delete user (admin only)          Args:         user_id: User ID to delete, Exception, _append_audit(), _MissingUserId, Raised when strict mode rejects a tool call with no identity., _idempotency_key(), MemoryServiceError (+13 more)
-
-### Community 99 - "Community 99"
-Cohesion: 0.13
-Nodes (24): test_probe_rejects_public_backend_host(), test_probe_rejects_unknown_backend(), test_probe_reports_disabled_without_tcp_check(), test_probe_reports_healthy_falkordb_backend(), test_probe_reports_healthy_neo4j_backend(), test_probe_reports_malformed_port_as_misconfigured(), test_probe_reports_offline_backend(), test_probe_reports_out_of_range_port_as_misconfigured() (+16 more)
-
-### Community 100 - "Community 100"
-Cohesion: 0.12
-Nodes (18): build_calendar_event_editor_content(), build_calendar_timeline_content(), build_shopping_item_editor_content(), build_shopping_list_content(), build_weather_current_content(), build_weather_forecast_content(), Zoe card service foundation for Phase 3 card upgrade.  Implements build/validate, Build canonical content for a shopping/list view card. (+10 more)
-
-### Community 101 - "Community 101"
 Cohesion: 0.15
 Nodes (16): BaseHTTPRequestHandler, get_config(), Save OAuth token to database., _HealthHandler, Handle orb-tap activation from the touch UI (POST /activate)., _discover_zoe_server(), _get_local_subnet(), _get_mac() (+8 more)
 
-### Community 102 - "Community 102"
+### Community 92 - "Community 92"
+Cohesion: 0.1
+Nodes (18): Check if Agent Zero is available.                  Returns:             True if, EmbeddingService, Embedding Service =================  Generates audio and metadata embeddings for, Initialize projection layer for fused embeddings., Generate audio embedding from audio file using CLAP.                  Args:, Generate text embedding from track metadata.                  Args:, Generate fused embedding from audio and metadata embeddings.                  If, Create and cache all embeddings for a track.                  Args: (+10 more)
+
+### Community 93 - "Community 93"
+Cohesion: 0.09
+Nodes (27): get_auth_manager(), Get the singleton auth manager instance., Check if user is authenticated with Apple Music., Get developer token for MusicKit JS authentication.                  Apple Music, Complete auth with Music User Token from MusicKit JS.                  The auth_, Disconnect user from Apple Music., Convert Apple Music playlist data to Playlist., complete_auth() (+19 more)
+
+### Community 94 - "Community 94"
+Cohesion: 0.14
+Nodes (26): get_agent_board(), Return Multica engineering ticket state for AG-UI display.      Falls back grace, test_create_issue_metadata_preserves_existing_ticket_fields(), test_update_ticket_progress_can_clear_dispatch_approval(), test_block_only_description_does_not_gain_leading_blank_lines(), test_progress_and_children_patch_metadata_only(), test_replacing_middle_block_preserves_suffix_newline(), test_ticket_block_preserves_human_description() (+18 more)
+
+### Community 95 - "Community 95"
+Cohesion: 0.14
+Nodes (26): Tests for main.py Multica poll-loop helpers., RecordingClient, test_record_blocked_multica_chain_creates_budget_followup_once(), test_record_blocked_multica_chain_creates_iteration_budget_followup(), test_record_blocked_multica_chain_creates_protocol_followup(), test_record_blocked_multica_chain_does_not_create_recursive_harness_followup(), test_record_blocked_multica_chain_falls_back_to_classification_and_default(), test_record_blocked_multica_chain_records_terminal_block_metadata() (+18 more)
+
+### Community 96 - "Community 96"
+Cohesion: 0.12
+Nodes (18): build_calendar_event_editor_content(), build_calendar_timeline_content(), build_shopping_item_editor_content(), build_shopping_list_content(), build_weather_current_content(), build_weather_forecast_content(), Zoe card service foundation for Phase 3 card upgrade.  Implements build/validate, Build canonical content for a shopping/list view card. (+10 more)
+
+### Community 97 - "Community 97"
+Cohesion: 0.24
+Nodes (26): _fact_event(), _success_trace(), test_approved_memory_with_successful_admission_trace_can_write_target_backend(), test_failed_non_admission_trace_does_not_block_clean_admission(), test_failed_or_blocked_trace_blocks_even_with_approval(), test_graphiti_target_requires_relationship_or_supersession(), test_invalid_candidate_errors_are_wrapped_as_memory_admission_error(), test_invalid_trace_errors_are_wrapped_as_memory_admission_error() (+18 more)
+
+### Community 98 - "Community 98"
 Cohesion: 0.19
 Nodes (27): Test P0-3: Temperature Adjustment, Test classification performance., Color, failure(), get_docker_logs(), log(), Test 1: Baseline with all features OFF, Test 3: P0-2 Confidence Formatting (+19 more)
 
-### Community 103 - "Community 103"
+### Community 99 - "Community 99"
+Cohesion: 0.07
+Nodes (28): Browser Cache Fix - Clear Old Broken State, Cleanup Safety Rules - Mandatory for All AI Assistants, Critical Files - Do Not Delete, Disk Space Protection System, Disk Space Protection - Implementation Complete Summary, Docker Networking Rules - MANDATORY, Enhanced Enforcement System, Hermes Optimization Playbook (+20 more)
+
+### Community 100 - "Community 100"
 Cohesion: 0.13
-Nodes (22): addFeedItem(), applyStats(), autoEndSession(), clearHostSession(), confirmEndSession(), connectWS(), endSpeedDating(), fetchStats() (+14 more)
+Nodes (24): _env_float(), _config_values(), _env_bool_snapshot(), _env_float_snapshot(), _env_int_snapshot(), GraphitiSidecarProbeResult, _matching_lines(), Read-only Graphiti graph-backend readiness probe for Zoe. (+16 more)
 
-### Community 104 - "Community 104"
-Cohesion: 0.14
-Nodes (25): get_display_preferences(), Fetch the display preferences for a specific panel device.      Deliberately una, _row_to_prefs(), _fetch_openmeteo_current(), _fetch_openmeteo_forecast(), _fetch_owm_current(), _fetch_owm_forecast(), _get_current() (+17 more)
+### Community 101 - "Community 101"
+Cohesion: 0.13
+Nodes (24): test_probe_rejects_public_backend_host(), test_probe_rejects_unknown_backend(), test_probe_reports_disabled_without_tcp_check(), test_probe_reports_healthy_falkordb_backend(), test_probe_reports_healthy_neo4j_backend(), test_probe_reports_malformed_port_as_misconfigured(), test_probe_reports_offline_backend(), test_probe_reports_out_of_range_port_as_misconfigured() (+16 more)
 
-### Community 105 - "Community 105"
-Cohesion: 0.12
-Nodes (22): test_maintenance_runner_imports_real_bakeoff_module(), test_score_recall_response_reports_missing_terms(), test_summarize_bakeoff_scores_reports_score_and_latency(), test_summarize_recall_latency_ignores_disabled_latencies_in_mixed_run(), test_summarize_recall_latency_ignores_missing_enabled_latency(), test_summarize_recall_latency_marks_disabled_runs_not_measured(), test_summarize_recall_latency_reports_budget_status(), test_summarize_recall_latency_reports_hot_path_eligible() (+14 more)
-
-### Community 106 - "Community 106"
+### Community 102 - "Community 102"
 Cohesion: 0.09
 Nodes (16): get_vector_index(), Get the vector index (Jetson only).          Returns None on Pi5 or if memory is, Vector Index =============  FAISS-based vector index for fast music similarity s, Load index and ID map from disk., Save index and ID map to disk., Add a track embedding to the index.                  Args:             track_id:, Search with similarity scores.                  Args:             query: 256-dim, Check if track is in the index. (+8 more)
 
-### Community 107 - "Community 107"
+### Community 103 - "Community 103"
+Cohesion: 0.09
+Nodes (19): Analyze a target (file, system, configuration).                  Args:, analyze(), Analysis endpoint - analyzes files, configurations, systems.          Uses Agent, Analyze all files in root, RootCleaner, AudioAnalyzer, Audio Analyzer ==============  Extracts audio features from music tracks using E, Analyze a track and extract audio features.                  Args:             t (+11 more)
+
+### Community 104 - "Community 104"
 Cohesion: 0.09
 Nodes (26): _cleanup_rate_limit_storage(), get_client_info(), get_current_session(), get_session_id_from_bearer_token(), get_session_id_from_header(), _in_memory_rate_limit(), optional_session(), FastAPI Dependencies for Authentication Reusable dependencies for session valida (+18 more)
 
-### Community 108 - "Community 108"
+### Community 105 - "Community 105"
+Cohesion: 0.11
+Nodes (20): delete_user(), Delete user (admin only)          Args:         user_id: User ID to delete, _append_audit(), _idempotency_key(), MemoryServiceError, Raised for operational failures., Fast metadata-filter read for system prompt injection., Right-to-be-forgotten. Returns number of rows removed. (+12 more)
+
+### Community 106 - "Community 106"
 Cohesion: 0.07
 Nodes (16): Test that database schema is created correctly, Test embedding generation, Test embedding hash generation, Test cosine similarity calculation, Test adding memory with automatic embedding generation, Test entity context generation, Test relationship path generation, Test relationship boost calculation (+8 more)
 
+### Community 107 - "Community 107"
+Cohesion: 0.14
+Nodes (25): get_display_preferences(), Fetch the display preferences for a specific panel device.      Deliberately una, _row_to_prefs(), _fetch_openmeteo_current(), _fetch_openmeteo_forecast(), _fetch_owm_current(), _fetch_owm_forecast(), _get_current() (+17 more)
+
+### Community 108 - "Community 108"
+Cohesion: 0.14
+Nodes (21): addFeedItem(), applyStats(), autoEndSession(), clearHostSession(), confirmEndSession(), connectWS(), endSpeedDating(), fetchStats() (+13 more)
+
 ### Community 109 - "Community 109"
+Cohesion: 0.2
+Nodes (25): acquire_lock(), _append_progress(), _ci_status_from_rollup(), _finding_hash(), _gh_mergeable_state(), GuardError, GuardPacket, _json_path() (+17 more)
+
+### Community 110 - "Community 110"
 Cohesion: 0.12
 Nodes (25): create_memory_proposal(), export_user_memories(), forget_user(), get_memory_opt_out(), link_preview(), list_memories(), list_review_queue(), _normalise_status() (+17 more)
 
-### Community 110 - "Community 110"
-Cohesion: 0.09
-Nodes (23): accept_pending_suggestion(), create_schedule(), dismiss_pending_suggestion(), list_pending_suggestions(), list_schedules(), Proactive Engine REST router.  Endpoints:   POST   /api/proactive/schedule, List unresolved save offers for the current chat session., Execute a pending save offer (direct API — no intent re-parse). (+15 more)
-
 ### Community 111 - "Community 111"
-Cohesion: 0.14
-Nodes (22): _env_float(), _config_values(), _env_bool_snapshot(), _env_float_snapshot(), GraphitiSidecarProbeResult, _matching_lines(), Read-only Graphiti graph-backend readiness probe for Zoe., _scan_containers() (+14 more)
+Cohesion: 0.11
+Nodes (16): Search for k most similar tracks.                  Args:             query: 256-, Search YouTube Music.                  Search works without authentication using, Return mock results when not authenticated., Protocol, FakeMemoryService, FakeRef, test_recall_text_from_results_supports_refs_dicts_and_strings(), test_run_mempalace_baseline_scores_fake_service() (+8 more)
 
 ### Community 112 - "Community 112"
-Cohesion: 0.11
-Nodes (13): DatabaseMigrator, Migrate people from zoe.db and memory.db, Create backup of all existing databases, Migrate calendar events from zoe.db, Migrate developer tasks from developer_tasks.db, Migrate lists and list items from zoe.db, Migrate conversations from zoe.db, Create the new unified database schema (+5 more)
+Cohesion: 0.09
+Nodes (15): Test P0-1: Measure actual latency improvements, Measure latency improvement for Tier 0 intents, Ensure data-fetching intents get context (no regression), Test memory keyword detection accuracy, TestP01ContextValidationImprovements, Tier 0 intents should have 0.0 temperature, Factual queries should have low temperature, Conversational intents should have higher temperature (+7 more)
 
 ### Community 113 - "Community 113"
-Cohesion: 0.1
-Nodes (17): _board(), _expected_phases(), _protocol_violation_count(), True when a worker pushed HEAD then got interrupted before PR handoff., Create/record a PR after the worker pushed but lost the terminal handoff., Report aggregate state of a chain by idempotency-key prefix.          Returns {f, Pull a PR URL from the implement/closeout task summaries or comments., Block a task after repeated Hermes protocol violations (silent worker exit). (+9 more)
+Cohesion: 0.11
+Nodes (13): DatabaseMigrator, Migrate people from zoe.db and memory.db, Create backup of all existing databases, Migrate calendar events from zoe.db, Migrate developer tasks from developer_tasks.db, Migrate lists and list items from zoe.db, Migrate conversations from zoe.db, Create the new unified database schema (+5 more)
 
 ### Community 114 - "Community 114"
 Cohesion: 0.12
 Nodes (24): test_audit_only_from_handoff_detects_kv_field(), test_split_request_from_handoff_parses_multiline_packet(), test_split_request_from_handoff_parses_packet(), audit_only_from_handoff(), _greptile_from_closeout(), _haystacks(), _human_review_from_metadata(), _json_field_value() (+16 more)
 
+### Community 115 - "Community 115"
+Cohesion: 0.12
+Nodes (21): test_summarize_graphiti_scores_reports_latency(), test_maintenance_runner_imports_real_bakeoff_module(), test_score_recall_response_reports_missing_terms(), test_summarize_bakeoff_scores_reports_score_and_latency(), test_summarize_recall_latency_ignores_disabled_latencies_in_mixed_run(), test_summarize_recall_latency_ignores_missing_enabled_latency(), test_summarize_recall_latency_marks_disabled_runs_not_measured(), test_summarize_recall_latency_reports_budget_status() (+13 more)
+
 ### Community 116 - "Community 116"
+Cohesion: 0.13
+Nodes (24): RuntimeError, _actionable_greptile_findings(), assess_merge_readiness(), _gh_unresolved_review_thread_count(), _greptile_confidence_from_github_comments(), Inline review comments only; PR-level Greptile summaries are not merge blockers., Parse Greptile confidence from PR issue comments (summary posts)., Count open GitHub review threads.      Returns ``None`` when the GitHub API chec (+16 more)
+
+### Community 118 - "Community 118"
+Cohesion: 0.11
+Nodes (16): create_synapse_auth_provider(), MatrixIntegration, MatrixUser, Matrix (Synapse/Dendrite) SSO Integration Authentication provider for Matrix hom, Deactivate Matrix user                  Args:             username: Username to, Matrix user representation, Join user to Matrix room                  Args:             user_id: Zoe user ID, Get Matrix rooms for user                  Args:             user_id: Zoe user I (+8 more)
+
+### Community 119 - "Community 119"
 Cohesion: 0.08
 Nodes (8): Unit Tests for Household System ===============================  Tests household, Test creating a household., Tests for DeviceBindingManager., Tests for HouseholdManager., Tests for FamilyMixGenerator., TestDeviceBindingManager, TestFamilyMixGenerator, TestHouseholdManager
 
-### Community 117 - "Community 117"
-Cohesion: 0.13
-Nodes (19): add_chat_turn(), close_chat_episode(), enhance_memory_search_with_temporal(), Get context from current and recent episodes, Close current episode, Integrates temporal memory with Zoe's chat system, Get active episode for user, Store conversation turn in episode (+11 more)
-
-### Community 118 - "Community 118"
-Cohesion: 0.09
-Nodes (13): Check if file path is within allowed directories.                  Args:, Check if system command is whitelisted.                  Args:             comma, Get user-friendly message when capability is blocked.                  Args:, Safety guardrails for Agent Zero capabilities.          Controls what Agent Zero, Allow research/web search operations., Allow task planning operations., Allow code execution operations., Allow file system operations. (+5 more)
-
-### Community 119 - "Community 119"
-Cohesion: 0.13
-Nodes (23): create_event(), delete_event(), _enforce_calendar_read_access(), get_event(), list_events(), list_today_events(), FastAPI router for calendar events. Mounted at prefix="/api/calendar" with tag ", Get a single event by ID. (+15 more)
-
 ### Community 120 - "Community 120"
-Cohesion: 0.15
-Nodes (13): close_pool(), Close the connection pool. Call on shutdown., _AcpBridge, _build_env(), openclaw_acp(), openclaw_acp_stream(), ZoeAcpClient — Zoe as a first-class OpenClaw ACP channel.  Uses the Agent Client, Send a JSON-RPC request and return the result, passing through notifications. (+5 more)
+Cohesion: 0.13
+Nodes (23): test_load_target_patterns_extracts_contract_metadata(), test_measure_phase_treats_contract_target_patterns_as_no_patterns(), test_dump_and_load_contract_snapshot_round_trip(), test_legacy_contract_snapshot_preserves_target_patterns_and_writer(), test_legacy_contract_snapshot_supports_user_issue_report(), test_loader_rejects_legacy_non_contract_payloads(), test_mcp_contract_snapshot_has_source_evidence_when_freeform_evidence_is_empty(), test_mcp_contract_snapshot_is_valid_and_review_only() (+15 more)
 
 ### Community 121 - "Community 121"
-Cohesion: 0.13
-Nodes (23): get_openclaw_info(), _load_skills_and_cron(), post_openclaw_upgrade(), OpenClaw brain info: skills, cron, gateway, versions., Background: daily npm check, notify users, optional auto-upgrade., run_scheduled_openclaw_version_check(), clear_satisfied_update_notifications(), fetch_gateway_status() (+15 more)
+Cohesion: 0.1
+Nodes (19): Tests for background_runner enqueue, task lifecycle, and Hermes routing., Requests beyond _MAX_REQUEST_DEPTH must raise ValueError immediately., Requests at exactly _MAX_REQUEST_DEPTH must be accepted., enqueue_background_task should INSERT a row and return the new task id., _run_task should set status='done' and store result when Hermes succeeds., _run_task should set status='error' when Hermes raises an exception., test_enqueue_accepts_max_depth(), test_enqueue_inserts_row_and_returns_id() (+11 more)
 
 ### Community 122 - "Community 122"
 Cohesion: 0.14
-Nodes (21): test_extract_model_ids_accepts_openai_and_llama_shapes(), test_models_url_handles_v1_base(), test_runtime_probe_rejects_public_llm_base_url(), test_runtime_probe_reports_backend_offline(), test_runtime_probe_reports_disabled_without_backend_or_llm(), test_runtime_probe_reports_llm_unavailable(), test_runtime_probe_reports_missing_llm_model(), test_runtime_probe_reports_missing_python_dependencies() (+13 more)
+Nodes (22): test_extract_model_ids_accepts_openai_and_llama_shapes(), test_models_url_handles_v1_base(), test_runtime_probe_rejects_public_llm_base_url(), test_runtime_probe_reports_backend_offline(), test_runtime_probe_reports_disabled_without_backend_or_llm(), test_runtime_probe_reports_llm_unavailable(), test_runtime_probe_reports_missing_llm_model(), test_runtime_probe_reports_missing_python_dependencies() (+14 more)
 
 ### Community 123 - "Community 123"
-Cohesion: 0.11
-Nodes (14): HomeAssistantIntegration, initialize_ha_integration(), Sync user deletion to Home Assistant                  Args:             username, Authenticate user for Home Assistant (called by HA auth provider), Get Home Assistant areas for user assignment, Assign user to specific Home Assistant areas                  Args:, Sync all active Zoe users to Home Assistant                  Returns:, Sync user to HA person entity (+6 more)
+Cohesion: 0.17
+Nodes (22): _trace(), test_collect_observation_traces_accepts_valid_non_persistent_batch(), test_collect_observation_traces_can_require_single_scope_batch(), test_collect_observation_traces_discards_entire_batch_on_rejection(), test_collect_observation_traces_rejects_disallowed_surface(), test_collect_observation_traces_rejects_empty_batch(), test_collect_observation_traces_rejects_invalid_trace_shape(), test_collect_observation_traces_rejects_mixed_user_batch() (+14 more)
 
 ### Community 124 - "Community 124"
-Cohesion: 0.1
-Nodes (14): Test P0-3: Validate temperature appropriateness, Test that temperature ranges are appropriate for intent types, Test that temperature adjusts based on context availability, TestP03TemperatureImprovements, Tier 0 intents should have 0.0 temperature, Factual queries should have low temperature, Conversational intents should have higher temperature, Tool calling should have moderate temperature (+6 more)
+Cohesion: 0.15
+Nodes (23): analyze_result(), _diff_changed_lines(), _diff_files(), _run_git(), _base_ref(), ensure_worktree(), _extract_pr_number(), kanban_db_path() (+15 more)
 
 ### Community 125 - "Community 125"
+Cohesion: 0.13
+Nodes (23): get_openclaw_info(), _load_skills_and_cron(), post_openclaw_upgrade(), OpenClaw brain info: skills, cron, gateway, versions., Background: daily npm check, notify users, optional auto-upgrade., run_scheduled_openclaw_version_check(), clear_satisfied_update_notifications(), fetch_gateway_status() (+15 more)
+
+### Community 126 - "Community 126"
+Cohesion: 0.09
+Nodes (13): Check if file path is within allowed directories.                  Args:, Check if system command is whitelisted.                  Args:             comma, Get user-friendly message when capability is blocked.                  Args:, Safety guardrails for Agent Zero capabilities.          Controls what Agent Zero, Allow research/web search operations., Allow task planning operations., Allow code execution operations., Allow file system operations. (+5 more)
+
+### Community 127 - "Community 127"
+Cohesion: 0.15
+Nodes (13): close_pool(), Close the connection pool. Call on shutdown., _AcpBridge, _build_env(), openclaw_acp(), openclaw_acp_stream(), ZoeAcpClient — Zoe as a first-class OpenClaw ACP channel.  Uses the Agent Client, Send a JSON-RPC request and return the result, passing through notifications. (+5 more)
+
+### Community 128 - "Community 128"
 Cohesion: 0.11
 Nodes (21): showScreen(), buildInterestChips(), buildValueChips(), computePersonality(), existing, initQuiz(), INTERESTS, nameInput (+13 more)
 
-### Community 126 - "Community 126"
-Cohesion: 0.11
-Nodes (22): _memory_digest_loop(), Wait until 3am, then run LLM digest for all active users daily., Start the nightly memory digest loop (if not disabled)., Manually trigger full nightly dreaming cycle including evolution notice (admin o, start_memory_digest_background(), trigger_run_digest(), _load_recent_misses(), _load_target_patterns() (+14 more)
-
-### Community 127 - "Community 127"
-Cohesion: 0.13
-Nodes (21): test_load_target_patterns_extracts_contract_metadata(), test_measure_phase_treats_contract_target_patterns_as_no_patterns(), test_dump_and_load_contract_snapshot_round_trip(), test_legacy_contract_snapshot_preserves_target_patterns_and_writer(), test_legacy_contract_snapshot_supports_user_issue_report(), test_loader_rejects_legacy_non_contract_payloads(), test_mcp_contract_snapshot_has_source_evidence_when_freeform_evidence_is_empty(), test_mcp_contract_snapshot_is_valid_and_review_only() (+13 more)
-
-### Community 128 - "Community 128"
-Cohesion: 0.13
-Nodes (20): Tests for Multica poll-loop dispatch helpers., test_chain_is_active_counts_journal_ready_phase_without_terminal_block(), test_chain_is_active_counts_running_and_partial(), test_chain_is_running_excludes_partial_backfill_work(), test_chain_needs_dispatch_does_not_resume_terminal_blocked_pipeline(), test_chain_needs_dispatch_empty_or_missing_status(), test_chain_needs_dispatch_false_when_blocked_protocol_violation(), test_chain_needs_dispatch_for_operator_resumed_blocked_executor_row() (+12 more)
-
 ### Community 129 - "Community 129"
-Cohesion: 0.13
-Nodes (16): test_disabled_probe_is_acceptable_even_when_tools_are_missing(), test_disabled_runtime_does_not_surface_agent_files(), test_empty_env_does_not_fall_through_to_process_environment(), test_enabled_probe_reports_missing_node_before_pi(), test_enabled_runtime_detects_agent_files(), test_execution_can_be_configured_with_explicit_local_model_flag(), test_malformed_boolean_env_reports_misconfigured(), test_probe_uses_current_process_path_when_env_omits_path() (+8 more)
+Cohesion: 0.11
+Nodes (21): get_my_emotional_moments(), get_my_portrait(), get_portrait(), Portrait API — exposes user portrait management endpoints.  GET  /api/portrait/m, Return recent emotional memories for the current user., Raise 403 if the requesting user is neither the target nor an admin., Return the current user's synthesized portrait text., Return a specific user's portrait (admin or self only). (+13 more)
 
 ### Community 130 - "Community 130"
 Cohesion: 0.09
-Nodes (19): backup_database(), print_header(), Apply seed data to zoe.db, Backup existing database file, Initialize a database from schema file, Test Light RAG search functionality, add_task(), Initialize the database if it doesn't exist (+11 more)
+Nodes (22): check_no_archive_folders(), check_no_databases_in_git(), check_no_duplicate_configs(), check_no_root_tests(), check_no_temp_files(), check_no_venv_in_git(), check_required_docs(), check_root_md_files() (+14 more)
 
 ### Community 131 - "Community 131"
 Cohesion: 0.21
@@ -1060,239 +1081,235 @@ Nodes (12): Check if required directories and files exist, ModuleValidator, Chec
 
 ### Community 132 - "Community 132"
 Cohesion: 0.13
-Nodes (21): create_background_task(), get_pending_tasks(), Queue a long-running task for background execution.      Body: {"message": "find, Return completed background tasks not yet shown to the user., a2a_task(), A2A task intake endpoint.      Accepts a natural-language task from another agen, _background_profile(), enqueue_background_task() (+13 more)
+Nodes (20): Tests for Multica poll-loop dispatch helpers., test_chain_is_active_counts_journal_ready_phase_without_terminal_block(), test_chain_is_active_counts_running_and_partial(), test_chain_is_running_excludes_partial_backfill_work(), test_chain_needs_dispatch_does_not_resume_terminal_blocked_pipeline(), test_chain_needs_dispatch_empty_or_missing_status(), test_chain_needs_dispatch_false_when_blocked_protocol_violation(), test_chain_needs_dispatch_for_operator_resumed_blocked_executor_row() (+12 more)
 
 ### Community 133 - "Community 133"
-Cohesion: 0.2
-Nodes (20): _trace(), test_collect_observation_traces_accepts_valid_non_persistent_batch(), test_collect_observation_traces_can_require_single_scope_batch(), test_collect_observation_traces_discards_entire_batch_on_rejection(), test_collect_observation_traces_rejects_disallowed_surface(), test_collect_observation_traces_rejects_empty_batch(), test_collect_observation_traces_rejects_invalid_trace_shape(), test_collect_observation_traces_rejects_mixed_user_batch() (+12 more)
+Cohesion: 0.11
+Nodes (18): IntEnum, _AudioStream, _ConnState, _DataPacket, _Frame, _FrameEvent, make_audio_stream(), livekit_aiortc.py — LiveKit room participant using pure-Python aiortc.  Replaces (+10 more)
 
 ### Community 134 - "Community 134"
-Cohesion: 0.1
-Nodes (21): create_entry(), delete_entry(), get_entry(), get_mood_stats(), get_prompts(), get_streak_stats(), list_entries(), list_on_this_day() (+13 more)
+Cohesion: 0.09
+Nodes (19): backup_database(), print_header(), Apply seed data to zoe.db, Backup existing database file, Initialize a database from schema file, Test Light RAG search functionality, add_task(), Initialize the database if it doesn't exist (+11 more)
 
 ### Community 135 - "Community 135"
-Cohesion: 0.13
-Nodes (12): downgrade(), Initial schema — all tables ported to PostgreSQL DDL  Revision ID: 0001 Revises:, upgrade(), FTS for ambient_memory — tsvector + GIN index  Revision ID: 0002 Revises: 0001 C, Add metadata column to chat_sessions  Revision ID: 0003 Revises: 0002 Create Dat, 0004 — A2A federation tables and column additions.  Adds: - background_tasks: cl, 0005 — Touch panel SSH fields and provisioning codes table.  Adds: - panels: ssh, 0006 — People CRM expansion.  Adds: - people: circle, health_score, notification (+4 more)
-
-### Community 136 - "Community 136"
-Cohesion: 0.12
-Nodes (13): disable_passcode(), Disable passcode for current user          Args:         current_session: Curren, PasscodeManager, Disable passcode for user                  Args:             user_id: User ident, Get passcode information for user (without hash), Reset failed attempts counter (admin function), Validate passcode against policy, Check if passcode is already used by another user (+5 more)
-
-### Community 137 - "Community 137"
 Cohesion: 0.14
 Nodes (15): Print test results summary, print_summary(), Print completion summary, Generate random text for testing, Benchmark system initialization, Benchmark embedding generation performance, Benchmark migration performance, Benchmark search performance (+7 more)
 
+### Community 136 - "Community 136"
+Cohesion: 0.14
+Nodes (15): Get detailed status of Agent Zero service.          Returns:         Status info, status(), cli(), disable(), enable(), info(), ModuleManager, Get detailed information about a module. (+7 more)
+
+### Community 137 - "Community 137"
+Cohesion: 0.13
+Nodes (21): create_background_task(), get_pending_tasks(), Queue a long-running task for background execution.      Body: {"message": "find, Return completed background tasks not yet shown to the user., a2a_task(), A2A task intake endpoint.      Accepts a natural-language task from another agen, _background_profile(), enqueue_background_task() (+13 more)
+
 ### Community 138 - "Community 138"
+Cohesion: 0.13
+Nodes (12): downgrade(), Initial schema — all tables ported to PostgreSQL DDL  Revision ID: 0001 Revises:, upgrade(), FTS for ambient_memory — tsvector + GIN index  Revision ID: 0002 Revises: 0001 C, Add metadata column to chat_sessions  Revision ID: 0003 Revises: 0002 Create Dat, 0004 — A2A federation tables and column additions.  Adds: - background_tasks: cl, 0005 — Touch panel SSH fields and provisioning codes table.  Adds: - panels: ssh, 0006 — People CRM expansion.  Adds: - people: circle, health_score, notification (+4 more)
+
+### Community 139 - "Community 139"
+Cohesion: 0.1
+Nodes (21): create_entry(), delete_entry(), get_entry(), get_mood_stats(), get_prompts(), get_streak_stats(), list_entries(), list_on_this_day() (+13 more)
+
+### Community 140 - "Community 140"
+Cohesion: 0.26
+Nodes (20): _retained_outcome(), test_capability_trust_update_candidates_require_retained_verified_outcome(), test_capability_trust_update_metadata_is_read_only_and_serializable(), test_capability_trust_update_skips_trusted_noop_candidate(), _candidate(), _signal(), test_approved_status_requires_approval_gate(), test_build_proposal_collects_signal_and_candidate_evidence() (+12 more)
+
+### Community 141 - "Community 141"
 Cohesion: 0.09
 Nodes (20): Full Integration Test: People System =====================================  Test, Test address extraction, Test adding person with all fields via natural language, Test that Person Expert can extract ALL fields from natural language, Test phone number extraction with different formats, Test email extraction, Test birthday extraction, test_all_capabilities_present() (+12 more)
 
-### Community 139 - "Community 139"
-Cohesion: 0.18
-Nodes (21): Health check endpoint.          Returns service health and Agent Zero availabili, health(), _get_active_player(), _ha_service(), _ma_available(), _ma_cmd(), _ma_play_media(), _ma_player_command() (+13 more)
-
-### Community 140 - "Community 140"
-Cohesion: 0.12
-Nodes (12): MusicEvent, MusicEventTracker, Music Event Tracker ====================  Captures listening behavior events for, Record a listening event.                  Args:             user_id: User ident, Track play start event., Track play end event.                  Automatically determines if this was a sk, Track explicit skip event., Track repeat play event. (+4 more)
-
-### Community 141 - "Community 141"
-Cohesion: 0.19
-Nodes (20): apply_person_fact(), _ensure_db(), _ingest_to_mempalace(), Extract person facts via local LLM. Silently no-ops on error., _post_write_hooks(), process_text(), person_extractor.py — Extract person facts from conversation text.  Dual fan-out, Return DB UUID if a person with this name exists for user_id, else None. (+12 more)
-
 ### Community 142 - "Community 142"
-Cohesion: 0.13
-Nodes (20): _build_compact(), _build_federation_skills_md(), _collect_intent_patterns(), _collect_mcp_tools(), _collect_openclaw_skills(), _collect_ui_pages(), _env_enabled(), graphify_search() (+12 more)
+Cohesion: 0.12
+Nodes (14): AffinityEngine, AffinityScore, get_affinity_engine(), Music Affinity Engine =====================  Calculates user preferences from li, Get affinity score for an artist.                  Aggregates affinity across al, Get user's top tracks by affinity score.                  Args:             user, Get aggregate listening statistics for a user.                  Returns:, Rank a list of tracks by user affinity.                  Args:             track (+6 more)
 
 ### Community 143 - "Community 143"
 Cohesion: 0.12
-Nodes (7): _packet(), test_analyze_result_accepts_focused_diff(), test_analyze_result_checks_committed_diff_from_pre_run_sha(), test_analyze_result_rejects_files_outside_allowlist(), test_cheap_runner_blocks_before_budget_exceeded(), test_cheap_runner_command_does_not_expand_shell_metacharacters(), test_validate_packet_rejects_broad_missing_context()
+Nodes (12): MusicEvent, MusicEventTracker, Music Event Tracker ====================  Captures listening behavior events for, Record a listening event.                  Args:             user_id: User ident, Track play start event., Track play end event.                  Automatically determines if this was a sk, Track explicit skip event., Track repeat play event. (+4 more)
 
 ### Community 144 - "Community 144"
-Cohesion: 0.13
-Nodes (19): test_parse_semver_is_strict(), test_renderer_accepts_contract_by_major_version(), test_reserved_field_names_identifies_zoe_extensions(), CardContractError, CardType, _parse_created_at(), parse_semver(), Zoe card contract schema helpers.  This module defines the stable envelope that (+11 more)
+Cohesion: 0.18
+Nodes (19): test_failed_outcome_trace_becomes_notice_signal_when_repeated(), test_failed_outcome_trace_respects_existing_signal_ids(), test_failed_outcome_trace_threshold_is_repeat_count_two(), test_memory_route_trace_allows_safe_metadata_without_evidence(), test_metadata_allows_author_attribution_key(), test_metadata_rejects_secret_keys(), test_metadata_rejects_secret_keys_inside_lists(), test_personal_trace_requires_user_id() (+11 more)
 
 ### Community 145 - "Community 145"
-Cohesion: 0.23
-Nodes (20): _contract(), _load_fixture(), Tests for Zoe card contract validation., test_content_required_fields_are_per_card_type(), test_every_card_type_has_minimal_valid_content(), test_idempotency_key_is_optional_but_not_blank(), test_invalid_card_contract_fixtures_return_actionable_errors(), test_invalid_card_type_is_rejected() (+12 more)
+Cohesion: 0.19
+Nodes (20): apply_person_fact(), _ensure_db(), _ingest_to_mempalace(), Extract person facts via local LLM. Silently no-ops on error., _post_write_hooks(), process_text(), person_extractor.py — Extract person facts from conversation text.  Dual fan-out, Return DB UUID if a person with this name exists for user_id, else None. (+12 more)
 
 ### Community 146 - "Community 146"
 Cohesion: 0.14
-Nodes (13): Test direct action execution, Run comprehensive optimization tests, ZoeOptimizationTester, Test MCP server integration, OptimizationResult, Test memory system optimization, Test MCP integration optimization, Test RouteLLM intelligence optimization (+5 more)
+Nodes (20): Exception, _active_agents_list(), _enqueue_panel_tool(), _execute_tool(), _get_weather_default_location(), handle_tool(), _load_agents_registry(), _MissingUserId (+12 more)
 
 ### Community 147 - "Community 147"
-Cohesion: 0.13
-Nodes (11): Test lists, tasks, and projects with context, Test calendar and event management, Test journal entries and notes, Test N8N workflow automation, Test developer tools and system management, Test voice and media capabilities, Test advanced orchestration and intelligence features, Send chat message and return response (+3 more)
+Cohesion: 0.12
+Nodes (19): compose_message(), Message composer for the proactive engine.  Calls llama-server (same endpoint as, Given a trigger_type and a context dict, ask the LLM for a short message.     Re, _cleanup_expired_pending(), fire_notification(), _is_in_quiet_hours(), Proactive Engine — coordinates all trigger tiers.  Tier 1: APScheduler fires _fi, Internal: import push router and call send_push_to_user. Returns subscriber coun (+11 more)
 
 ### Community 148 - "Community 148"
-Cohesion: 0.15
-Nodes (18): GuardedGuestDb, Tests for Skybridge real data card resolution., test_calendar_empty_state_still_returns_data_card(), test_calendar_request_returns_real_event_card(), test_classify_calendar_and_weather_requests(), test_guest_calendar_request_does_not_fetch_family_events(), test_weather_current_request_returns_current_card(), test_weather_forecast_request_returns_forecast_card() (+10 more)
+Cohesion: 0.12
+Nodes (7): _packet(), test_analyze_result_accepts_focused_diff(), test_analyze_result_checks_committed_diff_from_pre_run_sha(), test_analyze_result_rejects_files_outside_allowlist(), test_cheap_runner_blocks_before_budget_exceeded(), test_cheap_runner_command_does_not_expand_shell_metacharacters(), test_validate_packet_rejects_broad_missing_context()
 
 ### Community 149 - "Community 149"
-Cohesion: 0.11
-Nodes (19): _has_espeak_ng(), Signal from the Pi daemon that the wake word was detected.     Used to update pa, Synthesize via Kokoro PyTorch sidecar (GPU, natural af_sky voice).      Calls th, speak(), synthesize(), _synthesize_edge_tts(), _synthesize_espeak(), _synthesize_kokoro_sidecar() (+11 more)
+Cohesion: 0.23
+Nodes (20): _contract(), _load_fixture(), Tests for Zoe card contract validation., test_content_required_fields_are_per_card_type(), test_every_card_type_has_minimal_valid_content(), test_idempotency_key_is_optional_but_not_blank(), test_invalid_card_contract_fixtures_return_actionable_errors(), test_invalid_card_type_is_rejected() (+12 more)
 
 ### Community 150 - "Community 150"
+Cohesion: 0.13
+Nodes (19): test_parse_semver_is_strict(), test_renderer_accepts_contract_by_major_version(), test_reserved_field_names_identifies_zoe_extensions(), CardContractError, CardType, _parse_created_at(), parse_semver(), Zoe card contract schema helpers.  This module defines the stable envelope that (+11 more)
+
+### Community 151 - "Community 151"
+Cohesion: 0.18
+Nodes (21): Health check endpoint.          Returns service health and Agent Zero availabili, health(), _get_active_player(), _ha_service(), _ma_available(), _ma_cmd(), _ma_play_media(), _ma_player_command() (+13 more)
+
+### Community 152 - "Community 152"
+Cohesion: 0.14
+Nodes (13): Test direct action execution, Run comprehensive optimization tests, ZoeOptimizationTester, Test MCP server integration, OptimizationResult, Test memory system optimization, Test MCP integration optimization, Test RouteLLM intelligence optimization (+5 more)
+
+### Community 153 - "Community 153"
+Cohesion: 0.13
+Nodes (20): _env_int(), _get_faster_whisper_model(), _log_voice_stt_sample(), Run whisper.cpp CLI; return transcript text (may be empty)., Lazy-load and cache a faster-whisper WhisperModel instance., Transcribe using faster-whisper Python library (fallback when whisper.cpp unavai, Transcription waterfall:     1. whisper.cpp CLI (if binary + ggml model configur, Transcribe base64 WAV/PCM audio using whisper.cpp on the Jetson (Pi voice daemon (+12 more)
+
+### Community 154 - "Community 154"
 Cohesion: 0.1
 Nodes (16): Tests for Zoe card service foundation., Test building a valid card contract., Test domain builder registry functionality., Test global card service instance., Test validating a valid card contract., Test validating an invalid card contract raises error., Test converting compatible contract for emission., Test converting incompatible contract raises error. (+8 more)
 
-### Community 151 - "Community 151"
+### Community 155 - "Community 155"
+Cohesion: 0.12
+Nodes (9): Shared zoe-auth test helpers., Small sqlite-backed stand-in for zoe-auth's connection wrapper., SQLiteCompatConnection, _init_auth_tables(), Current-contract API tests for zoe-auth., sqlite_auth_db(), test_expired_lockout_resets_failed_attempt_window(), Active zoe-auth smoke tests for default CI gate. (+1 more)
+
+### Community 156 - "Community 156"
 Cohesion: 0.14
 Nodes (15): benchmark(), HallucinationBenchmark, pytest_addoption(), Hallucination Benchmark Test Suite  This test suite measures hallucination rates, Calculate performance metrics from results, Fixture to provide benchmark instance, Run baseline hallucination measurement          This test:     1. Loads 100 test, Measure latency by intent tier          This test measures:     - Tier 0 (determ (+7 more)
 
-### Community 152 - "Community 152"
+### Community 157 - "Community 157"
 Cohesion: 0.16
 Nodes (15): DESIRE_LABELS, getMyCheckinId(), goDiscover(), INTENT_LABELS, load(), loadQuiz(), pathParts, renderCompatibility() (+7 more)
 
-### Community 153 - "Community 153"
+### Community 158 - "Community 158"
+Cohesion: 0.11
+Nodes (16): Initialize Agent Zero client.                  Args:             base_url: Base, Initialize safety guardrails.                  Args:             mode: Safety mo, Initialize the affinity engine.                  Args:             half_life_day, Initialize the AirPlay service, Initialize the audio analyzer with Essentia., Initialize the auth manager.                  Args:             encryption_key:, Initialize the Cast service, Initialize the event tracker and ensure tables exist. (+8 more)
+
+### Community 159 - "Community 159"
+Cohesion: 0.12
+Nodes (17): Load compact Zoe self-description from file; falls back to empty string., OpenClaw message context prefix (zoe-auth role → agent)., test_context_prefix_includes_user_role_and_name(), test_context_prefix_unknown_role_when_omitted(), chat_inject(), discover_openclaw_capabilities(), _load_zoe_self_compact(), openclaw_cli() (+9 more)
+
+### Community 160 - "Community 160"
 Cohesion: 0.15
 Nodes (13): Unit tests for person_extractor.py — pattern matching and process_text() logic., Integration-style tests that mock DB and MemPalace., Create a mock DB that returns person_id on SELECT., test_birthday_pattern_known_person_writes_date(), test_bucket_list_pattern_writes_bucket(), test_empty_text_returns_zero(), test_gift_pattern_known_person_writes_gift(), test_guest_returns_zero() (+5 more)
 
-### Community 154 - "Community 154"
-Cohesion: 0.11
-Nodes (16): Proactive adapters — thin wrappers that translate external service events into T, Executor adapters for Multica-dispatched work.  Multica is the agnostic source o, get_capabilities(), Music Service Module ====================  Platform-aware music system with: - Y, Get music system capabilities for this platform.          Returns:         Dict, Music Output Targets Package ============================  Unified interface for, Zoe Proactive Engine — public surface., claim_pending() (+8 more)
-
-### Community 155 - "Community 155"
-Cohesion: 0.14
-Nodes (18): _cleanup_expired_pending(), fire_notification(), _is_in_quiet_hours(), Proactive Engine — coordinates all trigger tiers.  Tier 1: APScheduler fires _fi, Internal: import push router and call send_push_to_user. Returns subscriber coun, Tier 2 loop: poll registered triggers every SLOW_LOOP_INTERVAL seconds., Periodically prune expired, unclaimed proactive_pending rows., Swallow APScheduler's double-shutdown error that occurs on rapid restarts. (+10 more)
-
-### Community 156 - "Community 156"
-Cohesion: 0.12
-Nodes (12): Search for k most similar tracks.                  Args:             query: 256-, Search YouTube Music.                  Search works without authentication using, Return mock results when not authenticated., Protocol, FakeMemoryService, FakeRef, test_recall_text_from_results_supports_refs_dicts_and_strings(), test_run_mempalace_baseline_scores_fake_service() (+4 more)
-
-### Community 157 - "Community 157"
-Cohesion: 0.15
-Nodes (17): _extract_memory_candidates(), Back-compat shim: legacy dict shape over the unified extractor.      Kept so in-, test_extracts_preference_signal(), test_no_signal_returns_empty(), _memory_capture_retry_task(), Validate memory capture plumbing at startup.      This is a non-invasive probe:, Background retry: re-run the startup probe once, 45 s after boot.      Clears fa, _run_memory_capture_startup_probe() (+9 more)
-
-### Community 158 - "Community 158"
-Cohesion: 0.15
-Nodes (13): Role-Based Access Control Manager, Assign role to user                  Args:             user_id: User to assign r, Create a custom role                  Args:             role_id: Unique role ide, Validate permission strings, return list of invalid ones, Log role change for audit, Initialize default permission definitions, RBACManager, Current-contract RBAC behavior tests. (+5 more)
-
-### Community 159 - "Community 159"
-Cohesion: 0.13
-Nodes (11): Clear the stream URL cache., Get cache statistics., Cache session for offline use                  Args:             session_id: Ses, Get timestamp of last successful sync, Check if cache sync is stale and needs refresh, Get number of cached users, Clear all cached data, Local caching system for touch panels (+3 more)
-
-### Community 160 - "Community 160"
-Cohesion: 0.19
-Nodes (11): EnhancementTaskCreator, Create user feedback system task, Create cross-agent orchestration enhancement task, Create performance optimization task, Create enhancement tasks in the developer task system, Create comprehensive testing framework task, Create temporal memory system implementation task, Create architecture documentation task (+3 more)
-
 ### Community 161 - "Community 161"
-Cohesion: 0.16
-Nodes (14): _intent_name(), ir(), _load_intent_router(), Unit tests for intent_router.py — all A2A + Multica + Evolution intents.  These, Verify that intents used in the Multica board routing list exist., _setup_stubs(), _stub_module(), _stub_psycopg2() (+6 more)
+Cohesion: 0.13
+Nodes (18): Manually trigger full nightly dreaming cycle including evolution notice (admin o, trigger_run_digest(), _load_recent_misses(), _load_target_patterns(), _proposal_exists(), evolution_notice.py — Phase 6 of the nightly dreaming cycle.  NOTICE phase of th, Write a user frustration proposal (called from chat.py inline)., Load intent miss texts from the last N days. (+10 more)
 
 ### Community 162 - "Community 162"
 Cohesion: 0.11
-Nodes (10): Test getting all user sessions, Test session expiration, Test session metadata handling, Test concurrent session handling, Test cases for SessionManager class, Test session creation, Test session retrieval, Test session activity update (+2 more)
+Nodes (16): Proactive adapters — thin wrappers that translate external service events into T, Executor adapters for Multica-dispatched work.  Multica is the agnostic source o, get_capabilities(), Music Service Module ====================  Platform-aware music system with: - Y, Get music system capabilities for this platform.          Returns:         Dict, Music Output Targets Package ============================  Unified interface for, Zoe Proactive Engine — public surface., claim_pending() (+8 more)
 
 ### Community 163 - "Community 163"
-Cohesion: 0.11
-Nodes (15): Test Home Assistant integration, test_simple_greeting(), classifier(), Intent Classification Tests ===========================  Tests for HassIL-based, Test turn off patterns., Test greeting intents., Test basic greeting patterns., Test queries that should NOT match any intent. (+7 more)
+Cohesion: 0.15
+Nodes (7): AiortcRoom, Drop-in replacement for livekit.rtc.Room using aiortc + WebSocket signalling., Decorator: @room.on("event_name"), Handle SDP re-offer from LiveKit server (subscriber PC)., Add an ICE candidate received from the server., Called when aiortc delivers an audio track — map to participant., Extract track SID → participant SID from SDP msid attributes.          LiveKit e
 
 ### Community 164 - "Community 164"
-Cohesion: 0.11
-Nodes (6): Unit tests for the Zoe Agent skills classifier and tool builder.  Tests _select_, _llm_call must accept tool_choice kwarg defaulting to 'auto'., Verify a selection of the weather cue strings would match typical messages., TestBuildPrompt, TestChatCapabilityShortcutExists, TestLlmCallSignature
+Cohesion: 0.16
+Nodes (14): _intent_name(), ir(), _load_intent_router(), Unit tests for intent_router.py — all A2A + Multica + Evolution intents.  These, Verify that intents used in the Multica board routing list exist., _setup_stubs(), _stub_module(), _stub_psycopg2() (+6 more)
 
 ### Community 165 - "Community 165"
-Cohesion: 0.14
-Nodes (16): ensure_signing_key(), generate_rsa_key(), get_active_key(), RSA signing key management for the OIDC provider., Generate a new RSA-2048 key pair and return as dict., Return the active signing key row from DB, or None., Return the active key, generating and storing one if needed., bootstrap_oidc() (+8 more)
+Cohesion: 0.11
+Nodes (10): Test getting all user sessions, Test session expiration, Test session metadata handling, Test concurrent session handling, Test cases for SessionManager class, Test session creation, Test session retrieval, Test session activity update (+2 more)
 
 ### Community 166 - "Community 166"
-Cohesion: 0.17
-Nodes (18): boot(), btnJoin, code, codeError, doCheckin(), enterWelcomeScreen(), joinCodeInput, joinNameInput (+10 more)
+Cohesion: 0.19
+Nodes (11): EnhancementTaskCreator, Create user feedback system task, Create cross-agent orchestration enhancement task, Create performance optimization task, Create enhancement tasks in the developer task system, Create comprehensive testing framework task, Create temporal memory system implementation task, Create architecture documentation task (+3 more)
 
 ### Community 167 - "Community 167"
 Cohesion: 0.12
-Nodes (16): _hermes_review_proposal(), Ask Hermes to review an evolution proposal before implementation is queued., Use Hermes for foreground voice escalation; OpenClaw is manual-only., _run_hermes_voice_escalation(), test_run_hermes_background_task_uses_worker_cli(), test_zoe_repo_root_is_portable(), hermes_api_key(), hermes_auth_headers() (+8 more)
+Nodes (19): Enhanced MemAgent (Multi-Expert Model), LightRAG (Lightweight RAG System), LiteLLM (Universal LLM API), MemAgent (Memory Agent), RAG Enhancements (Query Expansion, Reranking, Hybrid Search), RouteLLM (Intelligent Model Router), Zoe Architecture Review, Database Consolidation Plan (+11 more)
 
 ### Community 168 - "Community 168"
-Cohesion: 0.15
-Nodes (12): BrowserActionPlan, BrowserBackendCapabilities, BrowserEvidence, build_cloak_executor(), build_openclaw_gateway_executor(), create_default_browser_broker(), Browser broker for Zoe multi-surface browser orchestration.  This module is inte, Provide side-by-side backend summary and current recommendation. (+4 more)
+Cohesion: 0.17
+Nodes (18): boot(), btnJoin, code, codeError, doCheckin(), enterWelcomeScreen(), joinCodeInput, joinNameInput (+10 more)
 
 ### Community 169 - "Community 169"
-Cohesion: 0.19
-Nodes (16): _Db, Tests for panel_* MCP tool definitions and execution paths., _RecordingDb, test_create_evolution_proposal_keeps_contract_when_multica_unconfigured(), test_create_evolution_proposal_stores_contract_snapshot(), test_panel_announce_exists(), test_panel_check_auth_exists(), test_panel_clear_exists() (+8 more)
+Cohesion: 0.12
+Nodes (17): Ensure audio features table exists., Initialize music auth table., Ensure embeddings table exists., Ensure music_events table exists., Initialize music playback tables., init_db(), migrate_db(), Module-local SQLite database for Orbit. (+9 more)
 
 ### Community 170 - "Community 170"
 Cohesion: 0.12
-Nodes (10): Save detailed report to JSON, Scan a single file for database references, Recursively scan directory for database references, Print formatted audit report, DatabaseValidator, Print validation report, Find all .db files in data directory, Check if file is in a backup/archive location (+2 more)
+Nodes (12): AuthStatus, Provider authentication status., get_provider_registry(), ProviderRegistry, Music Provider Registry =======================  Singleton registry that manages, Get the appropriate provider for a track.                  Uses track ID prefix, Search across all connected providers.                  Args:             query:, Get authentication status for all providers.                  Args: (+4 more)
 
 ### Community 171 - "Community 171"
-Cohesion: 0.12
-Nodes (11): test_session(), Test session statistics, Test cases for session API endpoints, Test session creation endpoint, Test session retrieval endpoint, Test session extension endpoint, Test session invalidation endpoint, Test get user sessions endpoint (+3 more)
-
-### Community 172 - "Community 172"
 Cohesion: 0.14
 Nodes (9): Get application log sizes, Get overall disk usage, Storage monitoring and safe optimization, SAFE: Run VACUUM on databases (reversible optimization)                  Args:, SAFE: Archive old application logs                  Args:             days_to_ke, Analyze storage usage - MONITORING ONLY, NO DELETION                  Returns:, Get Docker images usage, Get database file sizes (+1 more)
 
+### Community 172 - "Community 172"
+Cohesion: 0.13
+Nodes (17): Register a Tier 2 slow-loop trigger., register_trigger(), load_device_tokens(), Load all active device tokens from DB into the in-memory cache (call at startup), hermes_api_key(), lifespan(), _memory_capture_retry_task(), _probe_runtimes() (+9 more)
+
+### Community 173 - "Community 173"
+Cohesion: 0.14
+Nodes (16): ensure_signing_key(), generate_rsa_key(), get_active_key(), RSA signing key management for the OIDC provider., Generate a new RSA-2048 key pair and return as dict., Return the active signing key row from DB, or None., Return the active key, generating and storing one if needed., bootstrap_oidc() (+8 more)
+
 ### Community 174 - "Community 174"
-Cohesion: 0.15
-Nodes (11): AirPlay Output Target =====================  Implementation of OutputTarget for, is_initialized(), output_type(), Chromecast Output Target ========================  Implementation of OutputTarge, Home Assistant Output Target ============================  Implementation of Out, get_output_manager(), Output Manager ==============  Central manager for all audio output targets. Han, Get the singleton output manager instance. (+3 more)
+Cohesion: 0.12
+Nodes (10): Save detailed report to JSON, Scan a single file for database references, Recursively scan directory for database references, Print formatted audit report, DatabaseValidator, Print validation report, Find all .db files in data directory, Check if file is in a backup/archive location (+2 more)
 
 ### Community 175 - "Community 175"
+Cohesion: 0.12
+Nodes (11): test_session(), Test session statistics, Test cases for session API endpoints, Test session creation endpoint, Test session retrieval endpoint, Test session extension endpoint, Test session invalidation endpoint, Test get user sessions endpoint (+3 more)
+
+### Community 176 - "Community 176"
+Cohesion: 0.19
+Nodes (16): _Db, Tests for panel_* MCP tool definitions and execution paths., _RecordingDb, test_create_evolution_proposal_keeps_contract_when_multica_unconfigured(), test_create_evolution_proposal_stores_contract_snapshot(), test_panel_announce_exists(), test_panel_check_auth_exists(), test_panel_clear_exists() (+8 more)
+
+### Community 177 - "Community 177"
+Cohesion: 0.15
+Nodes (12): BrowserActionPlan, BrowserBackendCapabilities, BrowserEvidence, build_cloak_executor(), build_openclaw_gateway_executor(), create_default_browser_broker(), Browser broker for Zoe multi-surface browser orchestration.  This module is inte, Provide side-by-side backend summary and current recommendation. (+4 more)
+
+### Community 178 - "Community 178"
+Cohesion: 0.17
+Nodes (14): add_chat_turn(), enhance_memory_search_with_temporal(), Get context from current and recent episodes, Integrates temporal memory with Zoe's chat system, Store conversation turn in episode, Start a new conversation episode, Enhance existing memory search with temporal context, Start chat episode for user (+6 more)
+
+### Community 180 - "Community 180"
+Cohesion: 0.17
+Nodes (16): demo_action_execution(), demo_complex_queries(), demo_memory_storage(), Demo: Action execution (lists, calendar, etc.), Send a chat message to Zoe, Demo: Complex queries requiring reasoning, Demo: P0-2 Confidence formatting, Verify that a fact was stored in memory (+8 more)
+
+### Community 181 - "Community 181"
 Cohesion: 0.21
 Nodes (4): Legacy single-dim circle values fall back gracefully., TestCalcHealthScore, calc_health_score(), Calculate a relationship health score in [0.0, 1.0].      Args:         last_con
 
-### Community 176 - "Community 176"
-Cohesion: 0.15
-Nodes (13): test_graphiti_episode_payloads_include_evidence(), test_graphiti_supersession_payloads_have_temporal_order(), test_percentile_rejects_out_of_range_values(), test_score_graphiti_answer_reports_missing_terms(), test_score_graphiti_answer_respects_empty_text_field(), test_summarize_graphiti_scores_reports_latency(), graphiti_episode_payloads(), GraphitiEvalEpisode (+5 more)
-
-### Community 177 - "Community 177"
+### Community 182 - "Community 182"
 Cohesion: 0.19
 Nodes (16): _infer_event_category(), _call_with_tool(), _extract_calendar(), _extract_journal(), _extract_list_add(), _extract_note(), _extract_people(), _extract_reminder() (+8 more)
 
-### Community 178 - "Community 178"
+### Community 183 - "Community 183"
 Cohesion: 0.21
 Nodes (15): Static contract checks for the Skybridge touch surface., read(), test_livekit_voice_router_accepts_text_commands(), test_skybridge_auth_and_voice_bus_contracts_are_wired(), test_skybridge_capability_registry_covers_core_touch_pages(), test_skybridge_exposes_voice_transport_without_dashboard_header(), test_skybridge_is_registered_in_touch_menu(), test_skybridge_page_loads_required_modules_in_order() (+7 more)
 
-### Community 179 - "Community 179"
-Cohesion: 0.19
-Nodes (14): quick_user_switch(), Quick user switching for touch panels          Args:         request: Quick swit, validateSession(), QuickAuthManager, QuickAuthResult, Quick Authentication for Touch Panels Optimized for fast user switching and offl, Quick user switching for touch panels                  Args:             current, Validate existing session (with offline support)                  Args: (+6 more)
+### Community 184 - "Community 184"
+Cohesion: 0.17
+Nodes (13): AccessContext, Role-Based Access Control Manager, Assign role to user                  Args:             user_id: User to assign r, Context for permission checks, Log role change for audit, Initialize default permission definitions, RBACManager, Current-contract RBAC behavior tests. (+5 more)
 
-### Community 180 - "Community 180"
+### Community 185 - "Community 185"
 Cohesion: 0.12
 Nodes (12): Feature Improvement Testing Test each feature individually, measure impact, vali, Ensure we don't add qualifiers to already-qualified responses, Test P0-4: Validate grounding detection, Test P1-1: Validate behavioral pattern extraction, Test that all pattern types can be extracted, Test that all features can be imported without conflicts, Test P0-2: Validate confidence expression quality, Test that confidence qualifiers are appropriate (+4 more)
 
-### Community 181 - "Community 181"
+### Community 186 - "Community 186"
 Cohesion: 0.12
 Nodes (15): create_docs_folder(), create_project_status(), move_to_archive(), Create organized docs folder structure, Move old docs to archive, Create docs/README.md index, Create consolidated PROJECT_STATUS.md, create_docs_index() (+7 more)
 
-### Community 182 - "Community 182"
-Cohesion: 0.12
-Nodes (17): MusicDiscover Intent, MusicLike Intent, MusicMood Intent, MusicNowPlaying Intent, MusicPause Intent, MusicPlay Intent, MusicPrevious Intent, MusicQueue Intent (+9 more)
+### Community 187 - "Community 187"
+Cohesion: 0.18
+Nodes (11): test_disabled_probe_is_acceptable_even_when_tools_are_missing(), test_disabled_runtime_does_not_surface_agent_files(), test_empty_env_does_not_fall_through_to_process_environment(), test_enabled_probe_reports_missing_node_before_pi(), test_enabled_runtime_detects_agent_files(), test_execution_can_be_configured_with_explicit_local_model_flag(), test_malformed_boolean_env_reports_misconfigured(), test_probe_uses_current_process_path_when_env_omits_path() (+3 more)
 
-### Community 183 - "Community 183"
-Cohesion: 0.12
-Nodes (14): ABC, MusicProvider, ProactiveTrigger, Abstract base class for music streaming providers.          All providers (YouTu, Like/save a track. Override if provider supports it., Add tracks to a playlist. Override if provider supports it., Save a track to user's library., Remove track from user's library. (+6 more)
-
-### Community 184 - "Community 184"
-Cohesion: 0.14
-Nodes (10): get_provider_registry(), ProviderRegistry, Music Provider Registry =======================  Singleton registry that manages, Get the appropriate provider for a track.                  Uses track ID prefix, Search across all connected providers.                  Args:             query:, Get authentication status for all providers.                  Args:, Central registry for music providers.          Manages provider instances and ha, Get the singleton provider registry instance. (+2 more)
-
-### Community 185 - "Community 185"
-Cohesion: 0.13
-Nodes (15): Ensure audio features table exists., Initialize music auth table., Ensure embeddings table exists., Ensure music_events table exists., Initialize music playback tables., init_db(), migrate_db(), Module-local SQLite database for Orbit. (+7 more)
-
-### Community 186 - "Community 186"
+### Community 189 - "Community 189"
 Cohesion: 0.15
 Nodes (9): MusicAuthManager, Store encrypted authentication credentials.                  Args:             u, Retrieve and decrypt authentication credentials.                  Args:, Get the refresh token for a provider., Manages encrypted authentication credentials for music providers.          Suppo, Delete authentication credentials.                  Args:             user_id: U, Check authentication status for a provider.                  Returns:, Encrypt authentication data.                  Args:             data: Dictionary (+1 more)
 
-### Community 187 - "Community 187"
-Cohesion: 0.12
-Nodes (15): event_loop(), mock_db(), mock_device(), mock_household(), mock_playlist(), mock_track(), mock_user(), Pytest Configuration ====================  Shared fixtures and configuration for (+7 more)
-
-### Community 188 - "Community 188"
-Cohesion: 0.13
-Nodes (15): close_action_form(), confirm_action_form(), open_action_form(), Called by the touch panel when a full-screen action-form overlay opens.      Reg, Called by the touch panel when the action-form overlay is dismissed (cancel/clos, Handle a Confirm submission from a full-screen action-form overlay.      The tou, _broadcast_action_form_panel(), Broadcast a panel_show_action_form event so the touch overlay opens.      panel_ (+7 more)
-
-### Community 189 - "Community 189"
-Cohesion: 0.17
-Nodes (15): get_emotional_moments(), get_my_emotional_moments(), get_my_portrait(), get_portrait(), Portrait API — exposes user portrait management endpoints.  GET  /api/portrait/m, Return recent emotional memories for the current user., Return recent emotional memories (admin or self only)., Raise 403 if the requesting user is neither the target nor an admin. (+7 more)
-
 ### Community 190 - "Community 190"
-Cohesion: 0.14
-Nodes (7): test_ingest_passes_first_class_event_metadata_to_writer(), test_memory_visible_to_user_matches_user_id_or_wing_or_shared_visibility(), test_metadata_prompt_read_blocks_cross_user_disputed_and_superseded_rows(), test_semantic_search_blocks_cross_user_disputed_and_superseded_rows(), _FakeCollection, _match_where(), Minimal Chroma collection stub backed by a plain dict.
+Cohesion: 0.18
+Nodes (8): ProjectCleaner, Find outdated/redundant documentation, Find Mac OS resource fork files, Find archive folders that can be removed, Find files that are known to be broken, Analyze entire project structure, Find all backup files, Find duplicate router files in archive folder
 
 ### Community 191 - "Community 191"
-Cohesion: 0.15
-Nodes (14): OpenClaw message context prefix (zoe-auth role → agent)., test_context_prefix_includes_user_role_and_name(), test_context_prefix_unknown_role_when_omitted(), chat_inject(), discover_openclaw_capabilities(), openclaw_cli(), openclaw_gateway_call(), OpenClaw gateway client: ACP-based communication with the OpenClaw agent.  Uses (+6 more)
+Cohesion: 0.13
+Nodes (15): close_action_form(), confirm_action_form(), open_action_form(), Called by the touch panel when a full-screen action-form overlay opens.      Reg, Called by the touch panel when the action-form overlay is dismissed (cancel/clos, Handle a Confirm submission from a full-screen action-form overlay.      The tou, _broadcast_action_form_panel(), Broadcast a panel_show_action_form event so the touch overlay opens.      panel_ (+7 more)
 
 ### Community 192 - "Community 192"
 Cohesion: 0.18
@@ -1302,13 +1319,17 @@ Nodes (9): _decode_agui_events(), _patch_agent_context(), test_force_hermes_appr
 Cohesion: 0.16
 Nodes (11): get_permission_checker(), Helper class for complex permission checking, Check if session has specific permission, Check if session has any of the listed permissions, Check if can access another user's resource, Get permission checker instance for current session, PermissionCheck, Result of permission verification (+3 more)
 
-### Community 195 - "Community 195"
-Cohesion: 0.18
-Nodes (7): Perform time synchronization, Apply the configured timezone, Start the time synchronization service, Stop the time synchronization service, Load time synchronization settings, Save settings to file, Synchronize system time with NTP server
+### Community 194 - "Community 194"
+Cohesion: 0.14
+Nodes (7): test_ingest_passes_first_class_event_metadata_to_writer(), test_memory_visible_to_user_matches_user_id_or_wing_or_shared_visibility(), test_metadata_prompt_read_blocks_cross_user_disputed_and_superseded_rows(), test_semantic_search_blocks_cross_user_disputed_and_superseded_rows(), _FakeCollection, _match_where(), Minimal Chroma collection stub backed by a plain dict.
 
-### Community 196 - "Community 196"
+### Community 195 - "Community 195"
 Cohesion: 0.16
 Nodes (12): Test a natural language prompt, Send a chat message and get response, send_chat_message(), test_prompt(), Execute a single test query and measure performance, test_query(), Comprehensive Test Suite for Zoe Performance Optimization Tests 100+ natural lan, Get or create a test session (+4 more)
+
+### Community 196 - "Community 196"
+Cohesion: 0.18
+Nodes (7): Perform time synchronization, Apply the configured timezone, Start the time synchronization service, Stop the time synchronization service, Load time synchronization settings, Save settings to file, Synchronize system time with NTP server
 
 ### Community 197 - "Community 197"
 Cohesion: 0.13
@@ -1316,474 +1337,530 @@ Nodes (8): Test permission-based access control, Test database security features
 
 ### Community 198 - "Community 198"
 Cohesion: 0.12
-Nodes (6): Comprehensive Natural Language Integration Tests Tests the entire Zoe system wit, Test memory expert with natural language, Test orchestration system status, End-to-end natural language tests for the complete Zoe system, Test calendar expert with natural language, TestNaturalLanguageSystem
+Nodes (15): event_loop(), mock_db(), mock_device(), mock_household(), mock_playlist(), mock_track(), mock_user(), Pytest Configuration ====================  Shared fixtures and configuration for (+7 more)
 
 ### Community 199 - "Community 199"
-Cohesion: 0.18
-Nodes (8): ProjectCleaner, Find outdated/redundant documentation, Find Mac OS resource fork files, Find archive folders that can be removed, Find files that are known to be broken, Analyze entire project structure, Find all backup files, Find duplicate router files in archive folder
+Cohesion: 0.12
+Nodes (6): Comprehensive Natural Language Integration Tests Tests the entire Zoe system wit, Test memory expert with natural language, Test orchestration system status, End-to-end natural language tests for the complete Zoe system, Test calendar expert with natural language, TestNaturalLanguageSystem
 
 ### Community 200 - "Community 200"
-Cohesion: 0.22
-Nodes (14): available_providers(), _get_info(), _get_players(), _get_queue_items(), _ma_headers(), _ma_url(), music_players(), music_queue() (+6 more)
+Cohesion: 0.21
+Nodes (13): _extract_memory_candidates(), Back-compat shim: legacy dict shape over the unified extractor.      Kept so in-, test_extracts_preference_signal(), test_no_signal_returns_empty(), _clean(), extract_and_ingest(), extract_candidates(), MemoryCandidate (+5 more)
 
 ### Community 201 - "Community 201"
-Cohesion: 0.2
-Nodes (14): test_content_hash_is_stable(), build_parser(), _cmd_mark_greptile(), _cmd_mark_reviewed(), _cmd_mark_tested(), _cmd_split_ticket(), _load_state(), Command helpers for marker-backed Zoe engineering evidence. (+6 more)
-
-### Community 202 - "Community 202"
 Cohesion: 0.16
 Nodes (14): Shut down APScheduler and the slow loop., stop_proactive_engine(), cancel_job(), get_scheduler(), _jobstore_url(), APScheduler wrapper (Tier 1 — precision scheduling).  Uses PostgreSQL job store, Prefer PostgreSQL jobstore; fall back to SQLite for local dev., Schedule func(**kwargs) at run_at (UTC datetime). Returns job_id. (+6 more)
 
-### Community 203 - "Community 203"
-Cohesion: 0.31
-Nodes (14): _directive_indent(), ensure_headers(), _find_named_blocks(), _find_server_blocks(), _has_active_add_header(), _has_active_header(), _insert_after_header(), _insert_location_headers() (+6 more)
-
-### Community 204 - "Community 204"
+### Community 202 - "Community 202"
 Cohesion: 0.13
 Nodes (4): Pure conversational query with no skill match → discovery fallback., A complex query can activate multiple skills., FORCE_FULL_CONTEXT=true overrides classifier and returns all skills., TestSelectSkills
+
+### Community 203 - "Community 203"
+Cohesion: 0.2
+Nodes (14): get_matches(), intent_score(), intents_compatible(), jaccard(), personality_score(), Orbit matching algorithm — weighted multi-factor scoring., Compute match score between two checkin dicts. Returns None if incompatible., Return up to n best matches for a checkin from the active pool. (+6 more)
+
+### Community 204 - "Community 204"
+Cohesion: 0.31
+Nodes (14): _directive_indent(), ensure_headers(), _find_named_blocks(), _find_server_blocks(), _has_active_add_header(), _has_active_header(), _insert_after_header(), _insert_location_headers() (+6 more)
 
 ### Community 205 - "Community 205"
 Cohesion: 0.17
 Nodes (10): Episode, Create new episode with context-aware timeout, Get or generate episode summary, Extends Light RAG with temporal capabilities, Get episode history for user, Clean up old episodes to prevent database bloat, Initialize temporal memory database schema, Test the temporal memory system (+2 more)
 
 ### Community 206 - "Community 206"
-Cohesion: 0.16
-Nodes (11): generate(), Orbit icebreaker engine — rule cascade, strongest signal wins., Generate the best icebreaker line for a match pair., get_enabled_modules(), ComposeGenerator, Write the generated compose file., Generate docker-compose.generated-modules.yml from enabled modules., Load modules configuration. (+3 more)
+Cohesion: 0.15
+Nodes (10): Create a new music zone, Current playback state for a zone, Add a device to a zone, Music zone configuration, Save zone to database, Save zone device to database, Load zones from database, Zone (+2 more)
 
 ### Community 207 - "Community 207"
 Cohesion: 0.2
-Nodes (12): _mock_repo_validators(), test_sync_pipeline_auto_validators_on_implement_done(), Tests for harness-run repo validators., test_run_repo_validators_failure(), test_run_repo_validators_success(), test_validator_evidence_item_tags_phase(), Run repo audit validators and return structured pipeline evidence., Run validate_structure + validate_critical_files; return aggregate result. (+4 more)
+Nodes (12): Refresh session recency and promote weak titles from the saved turn., save_message(), _touch_chat_session(), test_assistant_prefix_stripped(), test_code_block_not_in_title(), test_derive_strips_markdown(), test_derive_truncates_words(), test_weak_titles() (+4 more)
 
 ### Community 208 - "Community 208"
-Cohesion: 0.18
-Nodes (9): GuardedClient, test_append_issue_note_skips_when_get_issue_fails(), test_record_progress_can_clear_blocker(), test_record_progress_skips_when_get_issue_fails(), test_safe_patch_description_skips_when_get_issue_fails(), Update an issue's status and/or other fields (description, title, etc.)., Patch only the fenced Zoe ticket block in an issue description., Append a visible progress note while preserving existing description. (+1 more)
+Cohesion: 0.2
+Nodes (12): _mock_repo_validators(), test_sync_pipeline_auto_validators_on_implement_done(), Tests for harness-run repo validators., test_run_repo_validators_failure(), test_run_repo_validators_success(), test_validator_evidence_item_tags_phase(), Run repo audit validators and return structured pipeline evidence., Run validate_structure + validate_critical_files; return aggregate result. (+4 more)
 
 ### Community 209 - "Community 209"
-Cohesion: 0.18
-Nodes (13): create_note(), delete_note(), list_notes(), _owner_filter_sql(), patch_note(), FastAPI router for notes. Mounted at prefix="/api/notes" with tag "notes"., Update an existing note., Alias for update_note to support existing note editors using PATCH. (+5 more)
-
-### Community 211 - "Community 211"
-Cohesion: 0.14
-Nodes (8): Clean up expired cache entries                  Returns:             Number of e, Manages caches for multiple touch panels, Get or create cache for device, Sync all device caches with server data, Cleanup expired entries from all caches, Get statistics for all caches, Sync data from central auth server                  Args:             server_dat, TouchPanelCacheManager
-
-### Community 212 - "Community 212"
-Cohesion: 0.18
-Nodes (8): Log training run to database, CPU-optimized overnight training for Pi 5, CPU-only LoRA training using Hugging Face Transformers         Optimized for Ras, NightlyTrainer, Main training pipeline, Manages overnight training pipeline, Retrieve today's training examples, Record training run in database
-
-### Community 213 - "Community 213"
-Cohesion: 0.14
-Nodes (9): Comprehensive Test Suite for Session Management System Tests all session managem, Test cases for session middleware, Test that middleware skips excluded paths, Run all session management tests, run_session_tests(), TestSessionMiddleware, Comprehensive test suite for Light RAG Memory System Tests all functionality inc, temp_db() (+1 more)
-
-### Community 214 - "Community 214"
-Cohesion: 0.16
-Nodes (8): Build SQL time filter based on range, Get human-readable temporal context, Search memories with temporal awareness, Integrates temporal memory with existing Light RAG system, Add memory fact with automatic episode association, Search with both semantic and temporal context, Combine and deduplicate search results, TemporalLightRAGIntegration
-
-### Community 215 - "Community 215"
 Cohesion: 0.22
 Nodes (6): Organize documentation files, Organize script files, Run full organization, Determine category for a documentation file, Determine category for a test file, SmartOrganizer
 
+### Community 210 - "Community 210"
+Cohesion: 0.18
+Nodes (9): GuardedClient, test_append_issue_note_skips_when_get_issue_fails(), test_record_progress_can_clear_blocker(), test_record_progress_skips_when_get_issue_fails(), test_safe_patch_description_skips_when_get_issue_fails(), Update an issue's status and/or other fields (description, title, etc.)., Patch only the fenced Zoe ticket block in an issue description., Append a visible progress note while preserving existing description. (+1 more)
+
+### Community 211 - "Community 211"
+Cohesion: 0.2
+Nodes (12): ack_ui_action(), bind_panel(), create_ui_action(), get_action_ledger(), get_pending_ui_actions(), get_session_context(), requeue_stale_actions(), retry_ui_action() (+4 more)
+
+### Community 212 - "Community 212"
+Cohesion: 0.18
+Nodes (13): create_note(), delete_note(), list_notes(), _owner_filter_sql(), patch_note(), FastAPI router for notes. Mounted at prefix="/api/notes" with tag "notes"., Update an existing note., Alias for update_note to support existing note editors using PATCH. (+5 more)
+
+### Community 214 - "Community 214"
+Cohesion: 0.21
+Nodes (11): test_capability_profile_index_rejects_duplicate_ids(), test_capability_profile_rejects_unknown_owner_surface(), test_default_capability_profiles_validate_and_cover_core_surfaces(), test_metadata_is_read_only(), test_profiles_requiring_approval_includes_install_memory_and_graph_surfaces(), test_trusted_profile_requires_evidence(), Zoe Capability Profiles, CapabilityProfile (+3 more)
+
+### Community 215 - "Community 215"
+Cohesion: 0.14
+Nodes (13): parse_json_fields(), get_connection_icebreaker(), Orbit icebreaker engine — rule cascade, strongest signal wins., Shorter icebreaker for the QR scan connect page., get_pending_connections(), get_quiz_question(), _make_quiz_question(), _parse_checkin() (+5 more)
+
 ### Community 216 - "Community 216"
-Cohesion: 0.15
-Nodes (14): Browser Cache Fix - Clear Old Broken State, Cleanup Safety Rules - Mandatory for All AI Assistants, Critical Files - Do Not Delete, Database Path Enforcement System, Docker Networking Rules - MANDATORY, Enhanced Enforcement System, Intent System Development Rules, Issue Analysis - October 23, 2025 (+6 more)
+Cohesion: 0.18
+Nodes (8): Log training run to database, CPU-optimized overnight training for Pi 5, CPU-only LoRA training using Hugging Face Transformers         Optimized for Ras, NightlyTrainer, Main training pipeline, Manages overnight training pipeline, Retrieve today's training examples, Record training run in database
 
 ### Community 217 - "Community 217"
+Cohesion: 0.18
+Nodes (10): generate(), Generate the best icebreaker line for a match pair., get_enabled_modules(), ComposeGenerator, Write the generated compose file., Generate docker-compose.generated-modules.yml from enabled modules., Load modules configuration., Load a module's docker-compose.module.yml file. (+2 more)
+
+### Community 218 - "Community 218"
+Cohesion: 0.14
+Nodes (7): Set default model for Zoe, Deploy a specific adapter as current, Show current configuration, Manage Ollama models and LoRA adapters, List all available Ollama models, List all LoRA adapters, Pull/download a model from Ollama registry
+
+### Community 219 - "Community 219"
+Cohesion: 0.14
+Nodes (9): Comprehensive Test Suite for Session Management System Tests all session managem, Test cases for session middleware, Test that middleware skips excluded paths, Run all session management tests, run_session_tests(), TestSessionMiddleware, Comprehensive test suite for Light RAG Memory System Tests all functionality inc, temp_db() (+1 more)
+
+### Community 220 - "Community 220"
+Cohesion: 0.16
+Nodes (8): Build SQL time filter based on range, Get human-readable temporal context, Search memories with temporal awareness, Integrates temporal memory with existing Light RAG system, Add memory fact with automatic episode association, Search with both semantic and temporal context, Combine and deduplicate search results, TemporalLightRAGIntegration
+
+### Community 222 - "Community 222"
+Cohesion: 0.18
+Nodes (6): Invalidate cache for specific user, Run a conversation and display full Q&A, run_conversation_test(), Check if response meets expectations, Run a full conversation and track results, Try to resolve an ambiguous utterance relative to the last intent.         Retur
+
+### Community 223 - "Community 223"
 Cohesion: 0.15
 Nodes (7): get_intelligence_settings(), get_settings(), Stub routers for frontend endpoints that don't have full implementations yet. Re, Persist intelligence/proactive feature settings for the current user., Return general system settings (HA URL, feature flags, etc.)., Return intelligence/proactive feature settings for the current user., save_intelligence_settings()
 
-### Community 218 - "Community 218"
+### Community 224 - "Community 224"
 Cohesion: 0.15
 Nodes (5): Tests for Multica autopilot board noise controls., When _BOARD_REVIEW_AUTOPILOT_ENABLED is False (default), _run_board_review logs, When _BOARD_REVIEW_AUTOPILOT_ENABLED is True, _run_board_review proceeds past th, test_board_review_autopilot_guard_off_returns_early(), test_board_review_autopilot_guard_on_reaches_client()
 
-### Community 219 - "Community 219"
-Cohesion: 0.18
-Nodes (10): AccessContext, Context for permission checks, Enhanced Session Management for Multi-Factor Authentication Supports different s, Validate that session has permission with escalation handling                  A, Configuration for different session types, Security policies for session management, Get owner of resource for permission checks, requires_password_escalation() (+2 more)
-
-### Community 220 - "Community 220"
-Cohesion: 0.17
-Nodes (12): generate_changelog_entry(), get_commits_since_tag(), get_git_tags(), parse_conventional_commit(), Generate a changelog entry, Read existing CHANGELOG.md, Write updated CHANGELOG.md, Get all git tags sorted by date (+4 more)
-
-### Community 221 - "Community 221"
-Cohesion: 0.21
-Nodes (7): FileTagger, Load existing tags from file, Update tags based on current file usage, Check if file should be excluded from tagging, Get file access statistics, Tag files that haven't been accessed in the last week, Save tagged files to JSON file
-
-### Community 222 - "Community 222"
-Cohesion: 0.15
-Nodes (12): Verify chat router has real enhancement system integration, Check for duplicate routers in other locations, Verify chat router uses intelligent systems, not hardcoded logic, Enforce that only ONE chat router exists, Prevent backup files from cluttering the routers directory, Ensure main.py imports only one chat router, test_chat_router_has_enhancement_integration(), test_chat_uses_intelligent_systems() (+4 more)
-
-### Community 223 - "Community 223"
-Cohesion: 0.19
-Nodes (12): backup_file(), cleanup_chat_routers(), cleanup_temp_files(), optimize_main_application(), Verify that the system is properly configured, Create a backup of a file before modifying, Clean up duplicate chat router files, Optimize the main application file (+4 more)
-
-### Community 224 - "Community 224"
+### Community 225 - "Community 225"
 Cohesion: 0.24
 Nodes (5): When only memory is selected, ha_control should not be included., Selecting all skills should produce the full _TOOLS list., A typical single-skill query should load far fewer tools than the full set., OpenClaw should not execute unless explicitly enabled for manual fallback., TestBuildTools
 
-### Community 225 - "Community 225"
+### Community 226 - "Community 226"
+Cohesion: 0.24
+Nodes (11): test_execution_gate_allows_when_required_evidence_refs_exist(), test_execution_gate_fails_closed_without_approval_evidence(), test_missing_approval_required_blocks_execution(), test_missing_proposal_id_blocks_execution(), test_non_execute_proposal_cannot_execute_even_with_evidence(), test_promote_memory_admission_requires_memory_approval_and_pr(), test_unknown_approval_class_blocks_execution(), evaluate_execution_gate() (+3 more)
+
+### Community 227 - "Community 227"
+Cohesion: 0.15
+Nodes (8): check_permission(), Check if current user has specific permission          Args:         permission:, Check if user has specific permission                  Args:             user_id, Check multiple permissions at once                  Args:             user_id: U, Create a custom role                  Args:             role_id: Unique role ide, Check if any wildcard permissions grant access, Check resource-specific permissions, Validate permission strings, return list of invalid ones
+
+### Community 228 - "Community 228"
+Cohesion: 0.17
+Nodes (12): generate_changelog_entry(), get_commits_since_tag(), get_git_tags(), parse_conventional_commit(), Generate a changelog entry, Read existing CHANGELOG.md, Write updated CHANGELOG.md, Get all git tags sorted by date (+4 more)
+
+### Community 229 - "Community 229"
+Cohesion: 0.15
+Nodes (12): Verify chat router has real enhancement system integration, Check for duplicate routers in other locations, Verify chat router uses intelligent systems, not hardcoded logic, Enforce that only ONE chat router exists, Prevent backup files from cluttering the routers directory, Ensure main.py imports only one chat router, test_chat_router_has_enhancement_integration(), test_chat_uses_intelligent_systems() (+4 more)
+
+### Community 230 - "Community 230"
+Cohesion: 0.19
+Nodes (12): backup_file(), cleanup_chat_routers(), cleanup_temp_files(), optimize_main_application(), Verify that the system is properly configured, Create a backup of a file before modifying, Clean up duplicate chat router files, Optimize the main application file (+4 more)
+
+### Community 231 - "Community 231"
+Cohesion: 0.21
+Nodes (7): FileTagger, Load existing tags from file, Update tags based on current file usage, Check if file should be excluded from tagging, Get file access statistics, Tag files that haven't been accessed in the last week, Save tagged files to JSON file
+
+### Community 232 - "Community 232"
 Cohesion: 0.22
 Nodes (12): analyze_question_type(), ChatMessage, get_full_ai_response(), hybrid_chat(), integrate_enhancement_systems(), Hybrid Chat Router for Zoe - Solution 3 =======================================, Intelligently integrate enhancement systems based on content, Record interaction for satisfaction tracking and learning (+4 more)
 
-### Community 227 - "Community 227"
-Cohesion: 0.17
-Nodes (12): test_infer_outcome_blocked_verify_loops(), test_infer_outcome_closeout_budget_surfaces_block(), test_infer_outcome_done_ignores_freeform_stable_blocker_text(), test_infer_outcome_done_with_verify_budget_surfaces_block(), test_infer_outcome_done_without_blocker_completes(), test_infer_outcome_freeform_verify_budget_surfaces_block(), test_infer_outcome_pr_review_required_surfaces_block(), test_infer_outcome_review_budget_surfaces_block() (+4 more)
-
-### Community 228 - "Community 228"
-Cohesion: 0.2
-Nodes (5): Shared zoe-auth test helpers., Small sqlite-backed stand-in for zoe-auth's connection wrapper., SQLiteCompatConnection, Active zoe-auth smoke tests for default CI gate., test_health_endpoint_ok()
-
-### Community 229 - "Community 229"
-Cohesion: 0.17
-Nodes (11): db_conn(), Integration tests: People CRM — PostgreSQL + MemPalace sync.  Tests the dual fan, All CRM tables must exist., 0007 migration columns must exist on people table., The /api/people/fields route fix: /fields must come before /{person_id} in sourc, Open an asyncpg connection for tests., New people table has circle, health_score, notification_count columns., test_create_person_has_crm_columns() (+3 more)
-
-### Community 231 - "Community 231"
-Cohesion: 0.27
-Nodes (12): Enhanced MemAgent (Multi-Expert Model), LightRAG (Lightweight RAG System), LiteLLM (Universal LLM API), MemAgent (Memory Agent), RAG Enhancements (Query Expansion, Reranking, Hybrid Search), RouteLLM (Intelligent Model Router), Zoe Architecture Review, Architecture Improvements - Implementation Summary (+4 more)
-
-### Community 232 - "Community 232"
-Cohesion: 0.18
-Nodes (9): Lightweight ordering checks for AG-UI chat SSE (no live OpenClaw)., test_run_lifecycle_types(), iter_openclaw_text_chunks(), iter_text_message_chunks(), new_run_ids(), Canonical AG-UI SSE emission for zoe-data chat (ag-ui-protocol EventEncoder).  Z, Returns (run_id, assistant_message_id)., Batched TEXT_MESSAGE_CHUNK events (assistant role). (+1 more)
-
 ### Community 233 - "Community 233"
-Cohesion: 0.17
-Nodes (4): MockMCPServer, Test getting developer tasks, Test calendar event creation, Run a single conversation test
-
-### Community 234 - "Community 234"
-Cohesion: 0.17
-Nodes (11): Phase 1: Security tests for authentication hardening Tests that invalid/missing, Missing token should return 401, not default user, Invalid token should return 401, Expired token should return 401, Valid token should work, Token without user_id should return 401, test_expired_token_raises_401(), test_invalid_token_raises_401() (+3 more)
+Cohesion: 0.15
+Nodes (13): API Versioning Strategy, Chat Page Frontend (chat.html), Desktop Dashboard Fixes Complete, Database 'list_items' Table, Database 'lists' Table, Default Lists (IDs 1-4), GET /api/lists/{list_type} Endpoint, Lists Router Code Fix (+5 more)
 
 ### Community 235 - "Community 235"
 Cohesion: 0.17
-Nodes (7): Tests for error mapping utility., Test mapping 401 errors to MusicAuthError., Test mapping 429 errors to RateLimitError., Test mapping 404 errors to TrackNotFoundError., Test mapping timeout errors., Test mapping unknown errors., TestErrorMapping
+Nodes (12): test_infer_outcome_blocked_verify_loops(), test_infer_outcome_closeout_budget_surfaces_block(), test_infer_outcome_done_ignores_freeform_stable_blocker_text(), test_infer_outcome_done_with_verify_budget_surfaces_block(), test_infer_outcome_done_without_blocker_completes(), test_infer_outcome_freeform_verify_budget_surfaces_block(), test_infer_outcome_pr_review_required_surfaces_block(), test_infer_outcome_review_budget_surfaces_block() (+4 more)
 
 ### Community 236 - "Community 236"
-Cohesion: 0.17
-Nodes (7): Test personality summary generation, Tests for user profile creation and management, Test creating profile with minimal data, Test creating profile with comprehensive data, Test completeness calculation, Test extracting top values, TestUserCompatibilityProfile
-
-### Community 238 - "Community 238"
-Cohesion: 0.17
-Nodes (7): Test list-related intent classification., Test basic 'add to shopping list' pattern., Test shorthand 'add item' pattern (implies shopping list)., Test natural language variations for shopping list., Test show/display list patterns., Test remove item patterns., TestListIntents
-
-### Community 239 - "Community 239"
 Cohesion: 0.24
 Nodes (5): Check for overly large router files, Check for hardcoded command detection patterns, Check for duplicate router patterns, Check main.py for excessive imports, Check for TODO/FIXME/HACK comments
 
+### Community 237 - "Community 237"
+Cohesion: 0.27
+Nodes (12): MCP-Only Architecture for Zoe Modules, Module Intent Auto-Discovery System, Music Module Dependency Audit, Music Module Extraction Plan, Music Module Test Results, Music Routing Options, Zoe Modular Architecture - Complete, MCP Client (+4 more)
+
+### Community 238 - "Community 238"
+Cohesion: 0.17
+Nodes (4): MockMCPServer, Test getting developer tasks, Test calendar event creation, Run a single conversation test
+
+### Community 239 - "Community 239"
+Cohesion: 0.17
+Nodes (11): Phase 1: Security tests for authentication hardening Tests that invalid/missing, Missing token should return 401, not default user, Invalid token should return 401, Expired token should return 401, Valid token should work, Token without user_id should return 401, test_expired_token_raises_401(), test_invalid_token_raises_401() (+3 more)
+
 ### Community 240 - "Community 240"
+Cohesion: 0.17
+Nodes (7): Test personality summary generation, Tests for user profile creation and management, Test creating profile with minimal data, Test creating profile with comprehensive data, Test completeness calculation, Test extracting top values, TestUserCompatibilityProfile
+
+### Community 241 - "Community 241"
+Cohesion: 0.17
+Nodes (7): Tests for error mapping utility., Test mapping 401 errors to MusicAuthError., Test mapping 429 errors to RateLimitError., Test mapping 404 errors to TrackNotFoundError., Test mapping timeout errors., Test mapping unknown errors., TestErrorMapping
+
+### Community 244 - "Community 244"
+Cohesion: 0.17
+Nodes (10): test_simple_greeting(), classifier(), Intent Classification Tests ===========================  Tests for HassIL-based, Test greeting intents., Test basic greeting patterns., Test queries that should NOT match any intent., Complex queries should return None (fall back to LLM)., Initialize classifier with test intents. (+2 more)
+
+### Community 245 - "Community 245"
+Cohesion: 0.17
+Nodes (7): Test list-related intent classification., Test basic 'add to shopping list' pattern., Test shorthand 'add item' pattern (implies shopping list)., Test natural language variations for shopping list., Test show/display list patterns., Test remove item patterns., TestListIntents
+
+### Community 246 - "Community 246"
+Cohesion: 0.18
+Nodes (8): Enhanced Session Management for Multi-Factor Authentication Supports different s, Validate that session has permission with escalation handling                  A, Configuration for different session types, Security policies for session management, Get owner of resource for permission checks, requires_password_escalation(), SessionConfig, SessionSecurityPolicy
+
+### Community 247 - "Community 247"
 Cohesion: 0.22
 Nodes (7): A2AClient, get_a2a_client(), A2A v1.0 client — Zoe calling peer agents.  Provides discover/submit_task/poll_t, Call a specific skill on a peer agent and return the result text., Async A2A v1.0 client., Submit a task to a peer A2A agent.          Returns the peer's response dict (co, Poll the status of a previously submitted A2A task.
 
-### Community 241 - "Community 241"
-Cohesion: 0.25
-Nodes (9): test_assistant_prefix_stripped(), test_code_block_not_in_title(), test_derive_strips_markdown(), test_derive_truncates_words(), test_weak_titles(), derive_session_title(), Derive short, human-readable chat session titles from message content., Turn the first line / opening of a message into a sidebar-friendly title.     St (+1 more)
+### Community 248 - "Community 248"
+Cohesion: 0.24
+Nodes (7): PromptTestResult, PromptTestSuite, Real-world prompt testing for Zoe capabilities, Execute a single prompt test, Analyze if response meets success criteria, Calculate score based on success analysis, Extract actions executed from response data
 
-### Community 242 - "Community 242"
+### Community 249 - "Community 249"
 Cohesion: 0.22
 Nodes (11): _bridge_get(), get_entity_state(), list_entities(), Home Assistant direct control endpoint.  Allows the touch panel to control HA en, Accept any authenticated caller (session user or device token)., Return entity list from the HA bridge, optionally filtered by domain/area., Get current state of a single HA entity., Call a HA service directly from the touch panel.      Body:       { "entity_id": (+3 more)
 
-### Community 243 - "Community 243"
-Cohesion: 0.18
-Nodes (6): Get user's current role, Get all permissions for a role, including inherited ones, Get sorted list of all effective permissions for user, Get user permissions with caching, Get cached permissions for user, Cache permissions for user
+### Community 250 - "Community 250"
+Cohesion: 0.31
+Nodes (10): build_parser(), _cmd_mark_greptile(), _cmd_mark_reviewed(), _cmd_mark_tested(), _cmd_split_ticket(), _load_state(), Command helpers for marker-backed Zoe engineering evidence., Append a command-written evidence item to a pipeline state. (+2 more)
 
-### Community 244 - "Community 244"
-Cohesion: 0.18
-Nodes (6): Low confidence (≥0.50) should add clear qualifier, Very low confidence (<0.50) should admit limitation, Tier 0 intents should have high confidence, Test P0-2: Confidence Expression, High confidence (≥0.85) should have no qualifier, Medium confidence (≥0.70) should add soft qualifier
-
-### Community 245 - "Community 245"
-Cohesion: 0.18
-Nodes (10): check_module_structure(), Check if a file exists, Check if a module has required classes, Verify all enhancement systems, verify_enhancements(), check_file_exists(), check_for_dangerous_patterns(), Check for dangerous file patterns that indicate backups/duplicates.          Ret (+2 more)
-
-### Community 247 - "Community 247"
+### Community 251 - "Community 251"
 Cohesion: 0.24
 Nodes (10): analyze_markdown_files(), analyze_shell_scripts(), analyze_test_files(), display_plan(), execute_cleanup(), Create a cleanup plan, Display the cleanup plan, Analyze all .md files in root (+2 more)
 
-### Community 248 - "Community 248"
-Cohesion: 0.38
-Nodes (8): test_resume_tolerates_pause_file_disappearing(), test_runtime_dispatch_pause_round_trip(), dispatch_is_paused(), pause_dispatch(), pause_path(), pause_reason(), Runtime controls for the single-ticket Multica engineering lane., resume_dispatch()
-
-### Community 249 - "Community 249"
-Cohesion: 0.2
-Nodes (10): get_compat_db(), Async context manager yielding AsyncpgCompat wrapping a pooled connection., Run the morning check-in trigger for all active users., Run the evening wind-down trigger for all active users., Run the evolution weekly digest trigger for all active users., Run the reminder scan to auto-schedule upcoming reminders into APScheduler., _run_evening_winddown(), _run_evolution_weekly_digest() (+2 more)
-
-### Community 250 - "Community 250"
-Cohesion: 0.27
-Nodes (7): add_widgets(), _fetchone_layout_only(), _fetchone_layout_row(), get_layout(), Dashboard widget layout management API., Add widget(s) to a user's dashboard layout., remove_widget()
-
-### Community 251 - "Community 251"
-Cohesion: 0.2
-Nodes (7): api_health_check(), metrics(), Zoe Core Service - Enhanced Main Application with Enhancement Systems ==========, API health check endpoint (for frontend compatibility), Prometheus metrics endpoint, Health check endpoint, health_check()
-
 ### Community 252 - "Community 252"
-Cohesion: 0.2
-Nodes (9): _build_agent_team_prompt(), get_agent_info(), load_agent_registry(), zoe_agent_registry.py — Agent registry loader for zoe_agent.py.  Loads agents_re, Load agents_registry.yml. Returns empty dict on failure (agent still works)., Generate AGENT TEAM routing guidance from registry data.      Returns an empty s, Build a tool description from registry skills, falling back to static text., Return the registry entry for a named agent, or empty dict. (+1 more)
+Cohesion: 0.18
+Nodes (5): Unit tests for the Zoe Agent skills classifier and tool builder.  Tests _select_, _llm_call must accept tool_choice kwarg defaulting to 'auto'., Verify a selection of the weather cue strings would match typical messages., TestChatCapabilityShortcutExists, TestLlmCallSignature
 
 ### Community 253 - "Community 253"
-Cohesion: 0.27
-Nodes (8): Fail-closed default: no X-Session-ID → guest role.  Old behaviour (promote unaut, Unset env → guest. Fail-closed is the new default., Explicit ZOE_UNAUTHENTICATED_ROLE=guest still resolves to guest., Legacy LAN deployments can flip ZOE_UNAUTHENTICATED_ROLE=family-admin to     res, _reload_auth(), test_family_admin_opt_in_still_possible(), test_no_session_defaults_to_guest(), test_no_session_guest_when_env_set()
+Cohesion: 0.18
+Nodes (6): Get user's current role, Get all permissions for a role, including inherited ones, Get sorted list of all effective permissions for user, Get user permissions with caching, Get cached permissions for user, Cache permissions for user
 
 ### Community 254 - "Community 254"
-Cohesion: 0.2
-Nodes (7): CachedSession, CachedUser, Touch Panel Local Caching System Optimized for fast authentication on touch pane, Verify passcode using cached data (offline mode)                  Args:, Cached user information for touch panels, Get cached session information                  Args:             session_id: Se, Cached session for offline use
-
-### Community 255 - "Community 255"
-Cohesion: 0.2
-Nodes (6): P0 Feature Validation Tests Tests all P0 features against targets, Test P0-4: Grounding Checks, Verify all features can be imported, Verify feature flags are properly configured, test_all_features_importable(), test_feature_flags_status()
+Cohesion: 0.18
+Nodes (10): check_module_structure(), Check if a file exists, Check if a module has required classes, Verify all enhancement systems, verify_enhancements(), check_file_exists(), check_for_dangerous_patterns(), Check for dangerous file patterns that indicate backups/duplicates.          Ret (+2 more)
 
 ### Community 256 - "Community 256"
-Cohesion: 0.24
-Nodes (5): DatabaseConsolidator, Merge sessions from sessions.db and auth.db, Verify that consolidation was successful, Check if table exists in database, Merge users from auth.db into zoe.db
+Cohesion: 0.18
+Nodes (6): Low confidence (≥0.50) should add clear qualifier, Very low confidence (<0.50) should admit limitation, Tier 0 intents should have high confidence, Test P0-2: Confidence Expression, High confidence (≥0.85) should have no qualifier, Medium confidence (≥0.70) should add soft qualifier
 
 ### Community 257 - "Community 257"
+Cohesion: 0.29
+Nodes (7): _compact_context(), HindsightOfflineConfigError, _is_local_or_private_url(), _positive_count(), Hindsight sidecar adapter for Zoe's memory bake-off.  The adapter is disabled by, Raised when Hindsight config would violate Zoe's offline-only rule., _retain_result_succeeded()
+
+### Community 258 - "Community 258"
 Cohesion: 0.27
-Nodes (5): HTMLSyntaxValidator, Check for unterminated quotes in JavaScript, Check for basic JavaScript syntax errors, Validate a single HTML file, Validate all HTML files in the directory
+Nodes (8): _extract_approval_token(), test_approval_token_parser(), test_high_risk_requires_confirmation(), test_low_risk_read_only(), test_whatsapp_detection(), classify_request(), is_whatsapp_connect_request(), RiskDecision
 
 ### Community 259 - "Community 259"
-Cohesion: 0.2
-Nodes (6): Verify the inputs to the _first_turn_choice expression are correct.      We can', Pure weather query (no 'today' crossover) → should produce 'required'., today' triggers calendar+weather (7 tools > 6) → should produce 'auto'., Discovery fallback → real_skills is empty → should produce 'auto'., When all skills match, tool count exceeds 5 → should produce 'auto'., TestFirstTurnChoiceLogic
-
-### Community 260 - "Community 260"
 Cohesion: 0.24
 Nodes (9): auto_extract_components(), _geocode(), _parse_md_table(), zoe_ui_components.py — Automatic AG-UI component extraction from agent response, Analyse `text` and return a list of AG-UI component payloads.     Each item is a, Parse a markdown table into a list of dicts keyed by header., Convert parsed table rows into price_table component row format., Geocode an address using Nominatim (free, no API key). (+1 more)
 
+### Community 260 - "Community 260"
+Cohesion: 0.2
+Nodes (9): _build_agent_team_prompt(), get_agent_info(), load_agent_registry(), zoe_agent_registry.py — Agent registry loader for zoe_agent.py.  Loads agents_re, Load agents_registry.yml. Returns empty dict on failure (agent still works)., Generate AGENT TEAM routing guidance from registry data.      Returns an empty s, Build a tool description from registry skills, falling back to static text., Return the registry entry for a named agent, or empty dict. (+1 more)
+
 ### Community 261 - "Community 261"
+Cohesion: 0.2
+Nodes (7): api_health_check(), metrics(), Zoe Core Service - Enhanced Main Application with Enhancement Systems ==========, API health check endpoint (for frontend compatibility), Prometheus metrics endpoint, Health check endpoint, health_check()
+
+### Community 262 - "Community 262"
+Cohesion: 0.24
+Nodes (10): _ambient_capture_thread(), _barge_in_vad_thread(), _follow_up_listen(), _get_silero_vad(), Load Silero VAD model lazily — ~1MB, loads in <200ms on Pi., Return max speech probability across 512-sample windows in the chunk., Background thread: runs Silero VAD during TTS playback to detect barge-in., Background thread: always-on VAD captures room speech for ambient memory.      R (+2 more)
+
+### Community 263 - "Community 263"
+Cohesion: 0.2
+Nodes (9): _blocking_synthesize(), _load_pipeline(), _pcm_to_wav(), Load and return the Kokoro pipeline (blocking; run once in thread pool)., Convert a torch.FloatTensor of PCM samples to WAV bytes.      Uses struct.pack i, Run Kokoro inference synchronously (called inside run_in_executor).      Calls t, Async wrapper: runs blocking inference in thread pool under the lock., _run_synthesis() (+1 more)
+
+### Community 264 - "Community 264"
+Cohesion: 0.27
+Nodes (7): add_widgets(), _fetchone_layout_only(), _fetchone_layout_row(), get_layout(), Dashboard widget layout management API., Add widget(s) to a user's dashboard layout., remove_widget()
+
+### Community 265 - "Community 265"
+Cohesion: 0.2
+Nodes (9): get_pending_notifications(), list_notifications(), mark_read(), FastAPI router for notifications. Mounted at prefix="/api/notifications" with ta, Mark a notification as read/delivered., Delete a notification., List notifications for the current user., Get unread/pending notifications count and items. (+1 more)
+
+### Community 267 - "Community 267"
+Cohesion: 0.2
+Nodes (6): Verify the inputs to the _first_turn_choice expression are correct.      We can', Pure weather query (no 'today' crossover) → should produce 'required'., today' triggers calendar+weather (7 tools > 6) → should produce 'auto'., Discovery fallback → real_skills is empty → should produce 'auto'., When all skills match, tool count exceeds 5 → should produce 'auto'., TestFirstTurnChoiceLogic
+
+### Community 268 - "Community 268"
+Cohesion: 0.27
+Nodes (8): Fail-closed default: no X-Session-ID → guest role.  Old behaviour (promote unaut, Unset env → guest. Fail-closed is the new default., Explicit ZOE_UNAUTHENTICATED_ROLE=guest still resolves to guest., Legacy LAN deployments can flip ZOE_UNAUTHENTICATED_ROLE=family-admin to     res, _reload_auth(), test_family_admin_opt_in_still_possible(), test_no_session_defaults_to_guest(), test_no_session_guest_when_env_set()
+
+### Community 269 - "Community 269"
+Cohesion: 0.38
+Nodes (8): test_resume_tolerates_pause_file_disappearing(), test_runtime_dispatch_pause_round_trip(), dispatch_is_paused(), pause_dispatch(), pause_path(), pause_reason(), Runtime controls for the single-ticket Multica engineering lane., resume_dispatch()
+
+### Community 270 - "Community 270"
+Cohesion: 0.27
+Nodes (5): HTMLSyntaxValidator, Check for unterminated quotes in JavaScript, Check for basic JavaScript syntax errors, Validate a single HTML file, Validate all HTML files in the directory
+
+### Community 271 - "Community 271"
+Cohesion: 0.2
+Nodes (9): Test required directories exist, Test model manager CLI, Test if Unsloth is installed, Test that all required modules can be imported, Test training database is set up correctly, test_database(), test_directories(), test_imports() (+1 more)
+
+### Community 272 - "Community 272"
+Cohesion: 0.2
+Nodes (6): P0 Feature Validation Tests Tests all P0 features against targets, Test P0-4: Grounding Checks, Verify all features can be imported, Verify feature flags are properly configured, test_all_features_importable(), test_feature_flags_status()
+
+### Community 273 - "Community 273"
+Cohesion: 0.24
+Nodes (5): DatabaseConsolidator, Merge sessions from sessions.db and auth.db, Verify that consolidation was successful, Check if table exists in database, Merge users from auth.db into zoe.db
+
+### Community 274 - "Community 274"
 Cohesion: 0.36
 Nodes (3): TestParseBirthday, _parse_birthday(), Return (month, day, year) from a birthday string, any values may be None.
 
-### Community 262 - "Community 262"
-Cohesion: 0.25
-Nodes (8): test_capabilities_snapshot_is_stable(), test_generated_context_mentions_hermes_engineering_loop(), test_graphify_rebuild_is_opt_in_by_default(), test_graphify_rebuild_opt_in_env_is_recognized(), _build_capabilities_md(), _build_zoe_self_md(), Build a human-readable CAPABILITIES.md at the project root., Build the full ZOE_SELF.md content, capped at _MAX_ZOE_SELF_CHARS.
+### Community 275 - "Community 275"
+Cohesion: 0.22
+Nodes (8): _hermes_review_proposal(), Ask Hermes to review an evolution proposal before implementation is queued., Use Hermes for foreground voice escalation; OpenClaw is manual-only., _run_hermes_voice_escalation(), hermes_auth_headers(), hermes_bin(), Shared Hermes helpers (gateway auth, CLI paths, repo root)., Locate the hermes CLI; honour HERMES_BIN override.
 
-### Community 263 - "Community 263"
+### Community 276 - "Community 276"
+Cohesion: 0.31
+Nodes (7): build_capability_trust_update_plan(), _evidence_refs(), _proposed_trust_level(), Build reviewed capability-trust update candidates from retained outcomes.  This, Build reviewable trust-update candidates from a retained verified outcome., _trust_rank(), _trust_update_blockers()
+
+### Community 277 - "Community 277"
 Cohesion: 0.39
 Nodes (7): test_build_packet_contains_cost_policy_and_required_evidence(), test_unknown_candidate_is_rejected(), _load_module(), test_record_issue_progress_marks_pipeline_done_on_merge(), test_record_issue_progress_preserves_json_contract_on_journal_error(), test_run_guard_calls_merge_guard(), test_run_guard_calls_packet_guard()
 
-### Community 264 - "Community 264"
-Cohesion: 0.22
-Nodes (6): check_permission(), Check if current user has specific permission          Args:         permission:, Check if user has specific permission                  Args:             user_id, Check multiple permissions at once                  Args:             user_id: U, Check if any wildcard permissions grant access, Check resource-specific permissions
-
-### Community 265 - "Community 265"
-Cohesion: 0.25
-Nodes (3): Invalidate cache for specific user, Check if response meets expectations, Try to resolve an ambiguous utterance relative to the last intent.         Retur
-
-### Community 266 - "Community 266"
+### Community 278 - "Community 278"
 Cohesion: 0.22
 Nodes (6): User Profile Schema Tests ========================= Tests for the compatibility, Tests for interest categories, Test creating an interest, Test creating a life goal, TestInterestCategory, TestLifeGoal
 
-### Community 267 - "Community 267"
+### Community 279 - "Community 279"
 Cohesion: 0.22
 Nodes (3): Real Conversation Quality Tests Tests actual multi-message conversations with co, Test real conversations with context retention and usefulness, Test response quality metrics
 
-### Community 269 - "Community 269"
-Cohesion: 0.29
-Nodes (6): Proactive trigger: birthday 7-day lookahead.  Fires once daily at 8am for contac, _next_occurrence(), person_health.py — Relationship health scoring.  Health score = weighted combina, Recalculate health_score for one person and persist it to the DB.      Args:, Return the next calendar occurrence of (month, day) on or after ref (default: to, recalc_and_save()
-
-### Community 270 - "Community 270"
-Cohesion: 0.25
-Nodes (8): test_acceptance_status_in_free_text_does_not_skip_implementation(), test_acceptance_status_is_not_a_routing_signal(), test_implementation_required_from_structured_scout_handoff(), test_structured_implementation_decision_wins_over_text(), implementation_required_from_handoff(), Extract explicit KEY=value equivalents from Kanban metadata., Return an explicit scout decision about whether code changes are required., _structured_handoff_fields()
-
-### Community 271 - "Community 271"
-Cohesion: 0.39
-Nodes (7): emit_event(), emit_issue_assigned(), emit_issue_status_changed(), Emit Multica-shaped webhook events to Zoe's board webhook receiver.  Zoe impleme, POST one webhook event to the Zoe board receiver., webhook_secret(), webhook_target_url()
-
-### Community 272 - "Community 272"
-Cohesion: 0.32
-Nodes (7): _get_vapid_keys(), get_vapid_public_key(), Web Push Notifications via VAPID. Generates VAPID keys on first run, stores subs, Send a push notification to all of a user's subscriptions.      ``message`` is a, send_push_to_user(), subscribe(), unsubscribe()
-
-### Community 273 - "Community 273"
-Cohesion: 0.43
-Nodes (5): _NoticeDb, test_record_frustration_signal_stores_contract_snapshot(), test_record_user_issue_stores_contract_snapshot(), test_run_evolution_notice_stores_contract_snapshots(), _WriterDb
-
-### Community 274 - "Community 274"
-Cohesion: 0.25
-Nodes (8): _compute_resemblyzer_embedding(), _cosine_similarity(), Compute a 256-dim resemblyzer voice embedding from a WAV file.      Returns raw, Cosine similarity between two float32 byte blobs., Enroll a speaker voice profile using a WAV audio sample.      Request: { "audio_, Identify speaker by comparing to enrolled profiles.      Accepts two request for, voice_enroll(), voice_identify()
-
-### Community 275 - "Community 275"
-Cohesion: 0.25
-Nodes (8): _get_kokoro_instance(), Convert float32 [-1,1] samples to mono WAV bytes., Yield WAV chunks from Kokoro create_stream() for one sentence., Return cached Kokoro instance, loading lazily on first call., Synthesize using Kokoro ONNX (thewh1teagle/kokoro-onnx).      ~82M param ONNX mo, _stream_kokoro_sentence_wavs(), _synthesize_kokoro(), _wav_bytes_from_float32_samples()
-
-### Community 276 - "Community 276"
-Cohesion: 0.36
-Nodes (6): test_high_risk_requires_confirmation(), test_low_risk_read_only(), test_whatsapp_detection(), classify_request(), is_whatsapp_connect_request(), RiskDecision
-
-### Community 277 - "Community 277"
-Cohesion: 0.29
-Nodes (4): Background sync loop for HA integration, Manually trigger sync with server, Sync cache with server data, Check if server is reachable
-
-### Community 278 - "Community 278"
-Cohesion: 0.25
-Nodes (7): PasswordPolicy, Password security policy, PasscodePolicy, PasscodeValidationResult, Passcode Authentication System Secure handling of 4-8 digit PIN codes with advan, Result of passcode validation, Passcode security policy configuration
-
-### Community 279 - "Community 279"
-Cohesion: 0.29
-Nodes (4): _init_auth_tables(), Current-contract API tests for zoe-auth., sqlite_auth_db(), test_expired_lockout_resets_failed_attempt_window()
-
 ### Community 280 - "Community 280"
-Cohesion: 0.25
-Nodes (5): Test safeguards and error handling, Verify all features are disabled by default (safety), Test that features fail gracefully when disabled, Test that platform configs are valid, TestFeatureSafeguards
+Cohesion: 0.29
+Nodes (6): Set audio quality based on platform capabilities., detect_hardware(), get_platform_capabilities(), Platform detection for music module. Provides hardware detection independent of, Detect hardware platform.          Returns:         str: Platform identifier ('j, Get platform-specific capabilities.          Returns:         dict: Platform cap
 
 ### Community 281 - "Community 281"
 Cohesion: 0.25
-Nodes (5): Test P0-1: Measure actual latency improvements, Measure latency improvement for Tier 0 intents, Ensure data-fetching intents get context (no regression), Test memory keyword detection accuracy, TestP01ContextValidationImprovements
+Nodes (8): test_acceptance_status_in_free_text_does_not_skip_implementation(), test_acceptance_status_is_not_a_routing_signal(), test_implementation_required_from_structured_scout_handoff(), test_structured_implementation_decision_wins_over_text(), implementation_required_from_handoff(), Extract explicit KEY=value equivalents from Kanban metadata., Return an explicit scout decision about whether code changes are required., _structured_handoff_fields()
 
 ### Community 282 - "Community 282"
 Cohesion: 0.29
-Nodes (6): Apply Enhanced Lists System migration, check_migration_applied(), create_migration_table(), Check if this migration has already been applied, Create schema_migrations table if it doesn't exist, Apply Project Lists migration
+Nodes (6): Proactive trigger: birthday 7-day lookahead.  Fires once daily at 8am for contac, _next_occurrence(), person_health.py — Relationship health scoring.  Health score = weighted combina, Recalculate health_score for one person and persist it to the DB.      Args:, Return the next calendar occurrence of (month, day) on or after ref (default: to, recalc_and_save()
 
 ### Community 283 - "Community 283"
-Cohesion: 0.25
-Nodes (6): Test MusicStreamError., Test TrackNotFoundError., Test StreamExpiredError., Tests for music-specific errors., Test MusicProviderError., TestMusicErrors
+Cohesion: 0.39
+Nodes (7): emit_event(), emit_issue_assigned(), emit_issue_status_changed(), Emit Multica-shaped webhook events to Zoe's board webhook receiver.  Zoe impleme, POST one webhook event to the Zoe board receiver., webhook_secret(), webhook_target_url()
 
 ### Community 284 - "Community 284"
-Cohesion: 0.25
-Nodes (5): Tests for base ZoeError., Test basic error creation., Test error with additional details., Test error wrapping another exception., TestZoeError
+Cohesion: 0.29
+Nodes (7): Manually trigger the morning brief for the calling user.     Useful for testing, trigger_morning_brief(), _build_morning_context(), _compose_morning_message(), Morning check-in trigger — greets user with day summary at 7:30am.  Phase 3.4: e, Build a rich morning brief message from context components., Collect open loops, emotional moments, calendar events, and portrait for the bri
 
 ### Community 285 - "Community 285"
-Cohesion: 0.29
-Nodes (7): test_block_reason_from_handoff_extracts_iteration_budget_from_run_error(), test_block_reason_from_handoff_ignores_dynamic_log_tail(), test_block_reason_from_handoff_prefers_blocker_field(), test_block_reason_ignores_dynamic_log_tail_without_stable_token(), block_reason_from_handoff(), Extract a stable blocker token for fingerprinting (ignore dynamic log tails)., _stable_block_reason_from_text()
+Cohesion: 0.25
+Nodes (8): get_compat_db(), Async context manager yielding AsyncpgCompat wrapping a pooled connection., Run the evening wind-down trigger for all active users., Run the evolution weekly digest trigger for all active users., Run the reminder scan to auto-schedule upcoming reminders into APScheduler., _run_evening_winddown(), _run_evolution_weekly_digest(), _run_reminder_scan()
+
+### Community 286 - "Community 286"
+Cohesion: 0.25
+Nodes (7): build_run_at(), _parse_due_time(), Tier 2 trigger: reminder table scanner.  Reads the `reminders` table every slow-, Parse a due_time string into (hour, minute) in 24-hour format.      Handles form, Build a UTC datetime for when the reminder should fire.      The reminder times, Tier 2 trigger that scans the reminders table and auto-schedules     upcoming re, ReminderScanTrigger
 
 ### Community 287 - "Community 287"
-Cohesion: 0.29
-Nodes (6): create_synapse_auth_provider(), MatrixUser, Matrix (Synapse/Dendrite) SSO Integration Authentication provider for Matrix hom, Matrix user representation, Create Synapse authentication provider module, Initialize Matrix integration
+Cohesion: 0.25
+Nodes (8): _compute_resemblyzer_embedding(), _cosine_similarity(), Compute a 256-dim resemblyzer voice embedding from a WAV file.      Returns raw, Cosine similarity between two float32 byte blobs., Enroll a speaker voice profile using a WAV audio sample.      Request: { "audio_, Identify speaker by comparing to enrolled profiles.      Accepts two request for, voice_enroll(), voice_identify()
 
 ### Community 288 - "Community 288"
-Cohesion: 0.29
-Nodes (7): list_users(), Get all active sessions for a specific user (admin only)          Args:, List all users (admin only)          Args:         active_only: Filter to active, get_user_sessions(), Get all active sessions for current user          Args:         current_session:, List users (admin function)                  Args:             requested_by: Use, Get all active sessions for user
+Cohesion: 0.32
+Nodes (7): _get_vapid_keys(), get_vapid_public_key(), Web Push Notifications via VAPID. Generates VAPID keys on first run, stores subs, Send a push notification to all of a user's subscriptions.      ``message`` is a, send_push_to_user(), subscribe(), unsubscribe()
 
-### Community 289 - "Community 289"
-Cohesion: 0.29
-Nodes (6): analyze_query_performance(), optimize_memory_db(), optimize_zoe_db(), Analyze query plans to verify index usage, Add indexes to zoe.db for better performance, Add indexes to memory.db for better temporal memory performance
+### Community 290 - "Community 290"
+Cohesion: 0.25
+Nodes (4): Create Matrix room                  Args:             room_config: Room configur, Auto-join user to rooms based on role, Resolve room alias to room ID, Call Matrix Client-Server API
 
 ### Community 291 - "Community 291"
 Cohesion: 0.29
-Nodes (6): Tests for error class hierarchy., Test music errors inherit from ZoeError., Test casting errors inherit from ZoeError., Test household errors inherit from ZoeError., Test catching all ZoeError subclasses., TestErrorInheritance
+Nodes (6): Apply Enhanced Lists System migration, check_migration_applied(), create_migration_table(), Check if this migration has already been applied, Create schema_migrations table if it doesn't exist, Apply Project Lists migration
 
 ### Community 292 - "Community 292"
+Cohesion: 0.25
+Nodes (6): Test MusicStreamError., Test TrackNotFoundError., Test StreamExpiredError., Tests for music-specific errors., Test MusicProviderError., TestMusicErrors
+
+### Community 293 - "Community 293"
+Cohesion: 0.25
+Nodes (5): Tests for base ZoeError., Test basic error creation., Test error with additional details., Test error wrapping another exception., TestZoeError
+
+### Community 294 - "Community 294"
+Cohesion: 0.43
+Nodes (5): _NoticeDb, test_record_frustration_signal_stores_contract_snapshot(), test_record_user_issue_stores_contract_snapshot(), test_run_evolution_notice_stores_contract_snapshots(), _WriterDb
+
+### Community 296 - "Community 296"
+Cohesion: 0.25
+Nodes (5): Test safeguards and error handling, Verify all features are disabled by default (safety), Test that features fail gracefully when disabled, Test that platform configs are valid, TestFeatureSafeguards
+
+### Community 297 - "Community 297"
+Cohesion: 0.32
+Nodes (8): Cloudflare Tunnel Service, Home Assistant MCP Bridge Service, Home Assistant Service, Keeper.sh Calendar Sync Service, LiveKit Service, Zoe Auth Service, Zoe Database Service, Zoe UI Service
+
+### Community 298 - "Community 298"
+Cohesion: 0.25
+Nodes (8): Agent Zero Docker Compose Module, Agent Zero Implementation Checklist, Agent Zero Integration - COMPLETE, Agent Zero Live Integration Test Report, Agent Zero Quick Start Guide, Agent Zero Module for Zoe, Agent Zero + Zoe Integration Summary, Agent Zero Integration Test Results
+
+### Community 299 - "Community 299"
+Cohesion: 0.25
+Nodes (8): AgentZeroAnalyze Intent, AgentZeroCompare Intent, AgentZeroPlan Intent, AgentZeroResearch Intent, Agent Zero Research Skill, Agent Zero Comparison Skill, Agent Zero Planning Skill, Agent Zero Deep Research Skill
+
+### Community 301 - "Community 301"
+Cohesion: 0.29
+Nodes (7): test_block_reason_from_handoff_extracts_iteration_budget_from_run_error(), test_block_reason_from_handoff_ignores_dynamic_log_tail(), test_block_reason_from_handoff_prefers_blocker_field(), test_block_reason_ignores_dynamic_log_tail_without_stable_token(), block_reason_from_handoff(), Extract a stable blocker token for fingerprinting (ignore dynamic log tails)., _stable_block_reason_from_text()
+
+### Community 303 - "Community 303"
+Cohesion: 0.29
+Nodes (6): Sync user to Matrix homeserver          Args:         request: Sync request, Sync all users to SSO services          Args:         services: List of service, sync_all_users_to_services(), sync_user_to_matrix(), Sync Zoe user to Matrix homeserver                  Args:             user_id: Z, Create new Matrix user
+
+### Community 304 - "Community 304"
+Cohesion: 0.29
+Nodes (6): create_n8n_auth_config(), N8nUser, n8n SSO Integration Replace n8n's basic auth with Zoe's central authentication, n8n user representation, Create n8n authentication configuration, Initialize n8n integration
+
+### Community 305 - "Community 305"
+Cohesion: 0.29
+Nodes (6): analyze_query_performance(), optimize_memory_db(), optimize_zoe_db(), Analyze query plans to verify index usage, Add indexes to zoe.db for better performance, Add indexes to memory.db for better temporal memory performance
+
+### Community 306 - "Community 306"
+Cohesion: 0.29
+Nodes (6): _proc_alive(), Set status (+ bump last_seen_at when online) for one provider's row., True if a process whose full command line matches ``pattern`` is running.      `, True if the Zoe host API reports healthy., _update_runtime(), _zoe_alive()
+
+### Community 307 - "Community 307"
 Cohesion: 0.29
 Nodes (6): Tests for compatibility calculation functions, Test values alignment calculation, Test personality compatibility calculation, Test interest overlap calculation, Test that empty profiles return neutral scores, TestCompatibilityCalculations
 
-### Community 293 - "Community 293"
-Cohesion: 0.52
-Nodes (6): Zoe Modular Architecture README, MCP Client, ModuleWidgetLoader, WidgetRegistry, Zoe Module CLI, Zoe Music Module
-
-### Community 294 - "Community 294"
-Cohesion: 0.29
-Nodes (7): Data Migration SQL for Misplaced Items, Database Query in GET /api/lists/{list_type}, Default Lists Creation SQL, Frontend Lists Loading Logic, GET /api/lists/{list_type} Endpoint, lists.py Router, Response Format Update in GET /api/lists/{list_type}
-
-### Community 295 - "Community 295"
-Cohesion: 0.29
-Nodes (7): AgentZeroAnalyze Intent, AgentZeroCompare Intent, AgentZeroPlan Intent, AgentZeroResearch Intent, Agent Zero Research Skill, Agent Zero Comparison Skill, Agent Zero Planning Skill
-
-### Community 296 - "Community 296"
-Cohesion: 0.33
-Nodes (5): prometheus_metrics(), Prometheus scrape endpoint.      Exposes counters/gauges from `memory_metrics.RE, Prometheus metrics for Zoe memory + self-learning.  Exposed via `/metrics` on th, Best-effort refresh of per-user MemPalace size gauge.      Called by the `/metri, snapshot_collection_sizes()
-
-### Community 297 - "Community 297"
-Cohesion: 0.33
-Nodes (5): format_music_for_prompt(), get_music_context(), Music Context Provider ======================  Provides music context for Zoe's, Format music context for inclusion in system prompt.          Returns a concise, Get comprehensive music context for user.          Returns:         Dict with:
-
-### Community 298 - "Community 298"
-Cohesion: 0.33
-Nodes (5): get_skybridge_status(), Skybridge surface health and capability metadata., Return the runtime contract for the voice-first Skybridge interface., Resolve a typed Skybridge command into real data cards when supported., resolve_skybridge_command()
-
-### Community 299 - "Community 299"
-Cohesion: 0.33
-Nodes (6): test_patch_soul_block_is_idempotent_per_marker(), test_zoe_why_block_teaches_mission_and_stays_lean(), _build_zoe_why(), _patch_hermes_soul(), Build the ZOE_WHY block: Zoe's mission + charter, condensed for SOUL.md.      Th, Patch a <marker>_BEGIN/END block in SOUL.md. Returns True if patched.      Used
-
-### Community 300 - "Community 300"
-Cohesion: 0.33
-Nodes (6): Strip markdown and normalise text so TTS sounds natural when spoken aloud., Streaming TTS endpoint: sentence-splits text and streams WAV chunks.      Pi dae, Split text into spoken sentences for streaming TTS.      Uses a regex that avoid, _split_sentences(), _voice_preprocess(), voice_stream()
-
-### Community 301 - "Community 301"
-Cohesion: 0.33
-Nodes (6): agent_card(), _build_agent_card(), Build an A2A v1.0 compliant agent card for Zoe., A2A v1.0 agent identity card — public capability advertisement., a2a_well_known(), A2A v1.0 agent discovery — served inline to avoid redirect caching issues.
-
-### Community 302 - "Community 302"
-Cohesion: 0.6
-Nodes (5): _load_helper(), test_apply_joke_contract_appends_to_existing_open_domain_test(), test_apply_joke_contract_fails_cleanly_when_router_missing(), test_apply_joke_contract_is_idempotent_with_current_router_pattern(), test_apply_joke_contract_patches_router_and_adds_test()
-
-### Community 303 - "Community 303"
-Cohesion: 0.6
-Nodes (5): _module(), test_oidc_client_id_requires_explicit_configuration(), test_probe_rejects_client_errors(), test_probe_reports_http_status(), test_upload_check_reads_the_runtime_compose_contract()
-
-### Community 304 - "Community 304"
-Cohesion: 0.4
-Nodes (3): DatabaseReferenceUpdater, Update database references in a single file, Update all Python files in services
-
-### Community 305 - "Community 305"
-Cohesion: 0.4
-Nodes (4): add_user_id_extraction(), fix_router(), Fix a single router file, Add user_id = session.user_id after each function with AuthenticatedSession
-
-### Community 306 - "Community 306"
-Cohesion: 0.33
-Nodes (4): Tests for personality traits, Test default trait values, Test that traits stay within bounds, TestPersonalityTraits
-
-### Community 307 - "Community 307"
-Cohesion: 0.33
-Nodes (5): Test converting error to dictionary., Tests for values priority, Test default value priorities, Test conversion to dictionary, TestValuesPriority
-
 ### Community 308 - "Community 308"
-Cohesion: 0.33
-Nodes (5): Unit Tests for Custom Errors ============================  Tests custom exceptio, Tests for casting-related errors., Test DeviceNotFoundError., Test DeviceOfflineError., TestCastingErrors
+Cohesion: 0.29
+Nodes (6): Tests for error class hierarchy., Test music errors inherit from ZoeError., Test casting errors inherit from ZoeError., Test household errors inherit from ZoeError., Test catching all ZoeError subclasses., TestErrorInheritance
 
 ### Community 309 - "Community 309"
 Cohesion: 0.33
-Nodes (4): Tests for compatibility analysis, Test creating compatibility analysis, Test compatibility level descriptions, Test dimension breakdown
+Nodes (5): close_chat_episode(), Close current episode, Get active episode for user, Get active episode for user, create new one if needed, Close an episode and optionally generate summary
 
 ### Community 310 - "Community 310"
+Cohesion: 0.29
+Nodes (7): Action Plan Progress Report, AG-UI Chat Protocol for Zoe, Chat Backend (chat.py), Zoe Code Execution with MCP - Implementation Summary, GPU Model Setup - gemma3n-e2b-gpu:latest, LLM Capabilities Awareness Audit, RouteLLM & LiteLLM Status
+
+### Community 311 - "Community 311"
 Cohesion: 0.33
-Nodes (3): _ZOE_SOUL_STATIC must not contain any day/time strings (KV cache stability)., Every tool in _TOOLS must appear in either _SKILL_TOOLS or _ALWAYS_ON_TOOLS., TestStablePrompt
+Nodes (5): format_music_for_prompt(), get_music_context(), Music Context Provider ======================  Provides music context for Zoe's, Format music context for inclusion in system prompt.          Returns a concise, Get comprehensive music context for user.          Returns:         Dict with:
+
+### Community 312 - "Community 312"
+Cohesion: 0.33
+Nodes (6): agent_card(), _build_agent_card(), Build an A2A v1.0 compliant agent card for Zoe., A2A v1.0 agent identity card — public capability advertisement., a2a_well_known(), A2A v1.0 agent discovery — served inline to avoid redirect caching issues.
 
 ### Community 313 - "Community 313"
 Cohesion: 0.6
-Nodes (4): _load_harness(), Tests for the deterministic engineering harness loop helpers., test_parse_pipeline_findings_does_not_double_count_explicit_scope_split(), test_parse_pipeline_findings_does_not_double_count_fingerprint_split()
+Nodes (5): _load_helper(), test_apply_joke_contract_appends_to_existing_open_domain_test(), test_apply_joke_contract_fails_cleanly_when_router_missing(), test_apply_joke_contract_is_idempotent_with_current_router_pattern(), test_apply_joke_contract_patches_router_and_adds_test()
+
+### Community 314 - "Community 314"
+Cohesion: 0.33
+Nodes (3): _ZOE_SOUL_STATIC must not contain any day/time strings (KV cache stability)., Every tool in _TOOLS must appear in either _SKILL_TOOLS or _ALWAYS_ON_TOOLS., TestStablePrompt
 
 ### Community 315 - "Community 315"
-Cohesion: 0.4
-Nodes (5): Dashboard HTML, journal.js Widget Implementation, Widget Manifest Configuration, Quick Journal Widget, Lists HTML
+Cohesion: 0.6
+Nodes (5): _module(), test_oidc_client_id_requires_explicit_configuration(), test_probe_rejects_client_errors(), test_probe_reports_http_status(), test_upload_check_reads_the_runtime_compose_contract()
 
 ### Community 316 - "Community 316"
-Cohesion: 0.4
-Nodes (5): Dashboard Loaders, Lists Dashboard Loaders, Widget Builder API Endpoints, WidgetManager, Widget Manifest
+Cohesion: 0.33
+Nodes (5): prometheus_metrics(), Prometheus scrape endpoint.      Exposes counters/gauges from `memory_metrics.RE, Prometheus metrics for Zoe memory + self-learning.  Exposed via `/metrics` on th, Best-effort refresh of per-user MemPalace size gauge.      Called by the `/metri, snapshot_collection_sizes()
 
 ### Community 317 - "Community 317"
-Cohesion: 0.5
-Nodes (3): compose_message(), Message composer for the proactive engine.  Calls llama-server (same endpoint as, Given a trigger_type and a context dict, ask the LLM for a short message.     Re
+Cohesion: 0.33
+Nodes (4): Tests for personality traits, Test default trait values, Test that traits stay within bounds, TestPersonalityTraits
 
 ### Community 318 - "Community 318"
+Cohesion: 0.33
+Nodes (4): Tests for compatibility analysis, Test creating compatibility analysis, Test compatibility level descriptions, Test dimension breakdown
+
+### Community 319 - "Community 319"
+Cohesion: 0.33
+Nodes (5): Test converting error to dictionary., Tests for values priority, Test default value priorities, Test conversion to dictionary, TestValuesPriority
+
+### Community 320 - "Community 320"
+Cohesion: 0.33
+Nodes (5): Unit Tests for Custom Errors ============================  Tests custom exceptio, Tests for casting-related errors., Test DeviceNotFoundError., Test DeviceOfflineError., TestCastingErrors
+
+### Community 321 - "Community 321"
+Cohesion: 0.33
+Nodes (5): get_skybridge_status(), Skybridge surface health and capability metadata., Return the runtime contract for the voice-first Skybridge interface., Resolve a typed Skybridge command into real data cards when supported., resolve_skybridge_command()
+
+### Community 322 - "Community 322"
+Cohesion: 0.33
+Nodes (4): Test P0-3: Validate temperature appropriateness, Test that temperature ranges are appropriate for intent types, Test that temperature adjusts based on context availability, TestP03TemperatureImprovements
+
+### Community 323 - "Community 323"
+Cohesion: 0.4
+Nodes (3): DatabaseReferenceUpdater, Update database references in a single file, Update all Python files in services
+
+### Community 324 - "Community 324"
+Cohesion: 0.33
+Nodes (6): Dashboard Layout Protection System, Dashboard Loaders, Lists Dashboard Loaders, Widget Builder API Endpoints, WidgetManager, Widget Manifest
+
+### Community 327 - "Community 327"
+Cohesion: 0.6
+Nodes (4): _load_harness(), Tests for the deterministic engineering harness loop helpers., test_parse_pipeline_findings_does_not_double_count_explicit_scope_split(), test_parse_pipeline_findings_does_not_double_count_fingerprint_split()
+
+### Community 328 - "Community 328"
+Cohesion: 0.4
+Nodes (4): Restart llama.cpp container with new model, Test a model through Zoe's chat API with conversation history, switch_model(), test_model_via_api()
+
+### Community 330 - "Community 330"
+Cohesion: 0.6
+Nodes (5): Architecture Diagram: Memory & Hallucination Reduction, Executive Summary: Memory & Hallucination Reduction for Zoe, Quick-Start Implementation Guide: P0 Recommendations, Memory & Hallucination Reduction Analysis for Zoe, Memory & Hallucination Reduction Research - Documentation Index
+
+### Community 333 - "Community 333"
+Cohesion: 0.5
+Nodes (4): test_content_hash_is_stable(), content_hash(), Stable SHA-256 hex digest for validator/test stdout or handoff bodies., _test_from_run_metadata()
+
+### Community 334 - "Community 334"
 Cohesion: 0.5
 Nodes (4): _panel_session_trust_window_s(), Seconds that an active panel session is trusted for voice scope gating., Resolve panel user only when the panel session heartbeat is fresh enough     to, _resolve_recent_panel_session_user()
 
-### Community 321 - "Community 321"
+### Community 336 - "Community 336"
 Cohesion: 0.83
 Nodes (3): _load_main_with_internal_token(), test_metrics_allows_non_loopback_with_valid_internal_token(), test_metrics_rejects_non_loopback_without_internal_token()
 
-### Community 323 - "Community 323"
+### Community 339 - "Community 339"
 Cohesion: 0.5
 Nodes (3): PermissionResult, Role-Based Access Control (RBAC) System Advanced permission management with inhe, Permission check results
 
-### Community 327 - "Community 327"
+### Community 343 - "Community 343"
 Cohesion: 0.5
 Nodes (3): get_test_people(), Test Memories Endpoint ======================  A simple endpoint to test memorie, Get people from memories without authentication (for testing)
 
-### Community 328 - "Community 328"
+### Community 344 - "Community 344"
 Cohesion: 0.5
 Nodes (3): Final verification with real-world scenarios, final_verification(), Final verification of all enhancement systems
 
-### Community 329 - "Community 329"
+### Community 345 - "Community 345"
 Cohesion: 0.5
 Nodes (4): Code Execution Status, Code Execution Testing Results, Code Execution Testing Summary, MCP Best Practices Review
 
+### Community 346 - "Community 346"
+Cohesion: 0.67
+Nodes (3): post_install_component(), installable_components(), Synchronous — called twice by system.py for validation and error messages.
+
+### Community 361 - "Community 361"
+Cohesion: 0.67
+Nodes (3): Building Zoe Modules - Developer Guide, Zoe Module Requirements, Security & Architecture Fixes - November 17, 2025
+
 ## Knowledge Gaps
-- **2913 isolated node(s):** `Orbit matching algorithm — weighted multi-factor scoring.`, `Jaccard with intensity weighting — shared high-intensity items score higher.`, `Score personality compatibility using per-trait similarity/complementarity.`, `Compute match score between two checkin dicts. Returns None if incompatible.`, `Return up to n best matches for a checkin from the active pool.` (+2908 more)
+- **2941 isolated node(s):** `Orbit matching algorithm — weighted multi-factor scoring.`, `Jaccard with intensity weighting — shared high-intensity items score higher.`, `Score personality compatibility using per-trait similarity/complementarity.`, `Compute match score between two checkin dicts. Returns None if incompatible.`, `Return up to n best matches for a checkin from the active pool.` (+2936 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **189 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
+- **191 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `main()` connect `Community 0` to `Community 129`, `Community 130`, `Community 257`, `Community 132`, `Community 131`, `Community 9`, `Community 265`, `Community 11`, `Community 137`, `Community 271`, `Community 16`, `Community 146`, `Community 147`, `Community 20`, `Community 25`, `Community 26`, `Community 282`, `Community 27`, `Community 30`, `Community 160`, `Community 293`, `Community 40`, `Community 42`, `Community 170`, `Community 45`, `Community 48`, `Community 305`, `Community 51`, `Community 57`, `Community 59`, `Community 63`, `Community 66`, `Community 195`, `Community 196`, `Community 197`, `Community 71`, `Community 201`, `Community 75`, `Community 76`, `Community 203`, `Community 206`, `Community 79`, `Community 84`, `Community 212`, `Community 86`, `Community 220`, `Community 221`, `Community 222`, `Community 223`, `Community 99`, `Community 101`, `Community 102`, `Community 105`, `Community 233`, `Community 111`, `Community 113`, `Community 245`, `Community 120`, `Community 122`?**
-  _High betweenness centrality (0.191) - this node is a cross-community bridge._
-- **Why does `list()` connect `Community 86` to `Community 256`, `Community 0`, `Community 3`, `Community 260`, `Community 4`, `Community 6`, `Community 131`, `Community 9`, `Community 10`, `Community 11`, `Community 12`, `Community 141`, `Community 16`, `Community 18`, `Community 21`, `Community 25`, `Community 28`, `Community 29`, `Community 36`, `Community 38`, `Community 40`, `Community 45`, `Community 46`, `Community 47`, `Community 176`, `Community 305`, `Community 51`, `Community 52`, `Community 57`, `Community 58`, `Community 59`, `Community 62`, `Community 64`, `Community 65`, `Community 66`, `Community 71`, `Community 199`, `Community 74`, `Community 76`, `Community 206`, `Community 81`, `Community 82`, `Community 84`, `Community 85`, `Community 343`, `Community 88`, `Community 87`, `Community 90`, `Community 215`, `Community 95`, `Community 105`, `Community 239`, `Community 113`, `Community 243`, `Community 246`, `Community 247`?**
-  _High betweenness centrality (0.122) - this node is a cross-community bridge._
-- **Why does `_FakeAdapter` connect `Community 8` to `Community 2`, `Community 35`, `Community 207`, `Community 17`, `Community 113`, `Community 28`?**
-  _High betweenness centrality (0.060) - this node is a cross-community bridge._
+- **Why does `main()` connect `Community 0` to `Community 131`, `Community 4`, `Community 5`, `Community 134`, `Community 135`, `Community 136`, `Community 137`, `Community 270`, `Community 271`, `Community 16`, `Community 22`, `Community 23`, `Community 152`, `Community 26`, `Community 283`, `Community 291`, `Community 166`, `Community 169`, `Community 41`, `Community 174`, `Community 48`, `Community 49`, `Community 306`, `Community 180`, `Community 54`, `Community 55`, `Community 58`, `Community 187`, `Community 195`, `Community 196`, `Community 69`, `Community 197`, `Community 67`, `Community 328`, `Community 74`, `Community 75`, `Community 76`, `Community 77`, `Community 204`, `Community 79`, `Community 81`, `Community 84`, `Community 87`, `Community 216`, `Community 217`, `Community 88`, `Community 91`, `Community 218`, `Community 222`, `Community 98`, `Community 100`, `Community 101`, `Community 122`, `Community 230`, `Community 231`, `Community 229`, `Community 228`, `Community 109`, `Community 238`, `Community 111`, `Community 115`, `Community 248`, `Community 250`, `Community 254`, `Community 127`?**
+  _High betweenness centrality (0.178) - this node is a cross-community bridge._
+- **Why does `list()` connect `Community 81` to `Community 0`, `Community 2`, `Community 3`, `Community 259`, `Community 4`, `Community 6`, `Community 262`, `Community 8`, `Community 9`, `Community 136`, `Community 131`, `Community 130`, `Community 16`, `Community 17`, `Community 18`, `Community 19`, `Community 276`, `Community 146`, `Community 145`, `Community 273`, `Community 22`, `Community 23`, `Community 30`, `Community 31`, `Community 32`, `Community 44`, `Community 48`, `Community 49`, `Community 51`, `Community 55`, `Community 57`, `Community 58`, `Community 190`, `Community 67`, `Community 69`, `Community 71`, `Community 203`, `Community 78`, `Community 209`, `Community 83`, `Community 84`, `Community 87`, `Community 217`, `Community 90`, `Community 89`, `Community 218`, `Community 97`, `Community 105`, `Community 236`, `Community 115`, `Community 116`, `Community 120`, `Community 251`, `Community 253`, `Community 255`?**
+  _High betweenness centrality (0.113) - this node is a cross-community bridge._
+- **Why does `_FakeAdapter` connect `Community 7` to `Community 1`, `Community 208`, `Community 19`, `Community 20`, `Community 84`, `Community 158`?**
+  _High betweenness centrality (0.056) - this node is a cross-community bridge._
 - **Are the 21 inferred relationships involving `main()` (e.g. with `get_memory_service()` and `read_guard_state()`) actually correct?**
   _`main()` has 21 INFERRED edges - model-reasoned connections that need verification._
 - **Are the 104 inferred relationships involving `require_feature_access()` (e.g. with `create_schedule()` and `list_schedules()`) actually correct?**


### PR DESCRIPTION
## Summary
- refresh Graphify after PR #360 renamed utility intelligence checks to Zoe identity/continuity language
- append the matching refresh evidence entry
- regenerate graphify-out/GRAPH_REPORT.md and graphify-out/graph.json

## Graphify
- extract: 8263 nodes, 14716 edges, 540 communities
- cluster-only: 543 communities
- built from commit: c766e2b1
- estimated extract cost: $0.1957

## Verification
- python3 tools/audit/validate_structure.py
- python3 tools/audit/validate_critical_files.py
- python3 tools/audit/validate_offline_memory.py
- git diff --check