### PR TITLE
Harden memory router code-context terms

### DIFF
--- a/services/zoe-data/tests/test_zoe_memory_router.py
+++ b/services/zoe-data/tests/test_zoe_memory_router.py
@@ -58,3 +58,38 @@ def test_router_uses_word_boundaries_for_slow_backend_terms():
 
     for query in examples:
         assert route_memory_query(query).primary == MemoryBackend.MEMPALACE
+
+
+def test_casual_service_language_stays_on_fast_chat_path():
+    examples = [
+        "I like the breakfast service at that cafe",
+        "The breakfast service runs from 7am",
+        "The hotel service was great",
+        "My cleaning service handles the laundry",
+        "The cleaning services are expensive",
+        "What service can you recommend for laundry?",
+        "Which service is best for house cleaning?",
+        "Which services are nearby?",
+        "Remind me to compliment the service team",
+    ]
+
+    for query in examples:
+        assert route_memory_query(query).primary == MemoryBackend.MEMPALACE
+
+
+def test_code_service_context_still_routes_to_graphify():
+    examples = [
+        "Which service owns chat routing?",
+        "Which services depend on memory?",
+        "What service handles memory writes?",
+        "What services own reminders?",
+        "Show the backend service dependency map",
+        "Which Zoe service handles auth?",
+        "What data service feeds the chat router?",
+        "Show service module boundaries",
+        "Find the service router for voice",
+        "Which service owns the calendar sync?",
+    ]
+
+    for query in examples:
+        assert route_memory_query(query).primary == MemoryBackend.GRAPHIFY

--- a/services/zoe-data/zoe_memory_router.py
+++ b/services/zoe-data/zoe_memory_router.py
@@ -75,7 +75,6 @@ EXPERIENCE_TERMS = {
 
 CODE_TERMS = {
     "code",
-    "service",
     "dependency",
     "router",
     "module",
@@ -83,6 +82,19 @@ CODE_TERMS = {
     "graphify",
     "repo",
     "commit",
+}
+
+CODE_CONTEXT_PHRASES = {
+    "backend service",
+    "data service",
+    "zoe service",
+    "service owns",
+    "which service owns",
+    "which service handles",
+    "which services depend",
+    "which services own",
+    "what service handles",
+    "what services own",
 }
 
 EVOLUTION_TERMS = {
@@ -104,6 +116,12 @@ def _contains_any(text: str, terms: set[str]) -> bool:
         if re.search(pattern, text):
             return True
     return False
+
+
+def _contains_code_context(text: str) -> bool:
+    if _contains_any(text, CODE_TERMS):
+        return True
+    return _contains_any(text, CODE_CONTEXT_PHRASES)
 
 
 def route_memory_query(query: str, *, purpose: str = "chat") -> MemoryRoute:
@@ -167,7 +185,7 @@ def route_memory_query(query: str, *, purpose: str = "chat") -> MemoryRoute:
             reason="experience or outcome memory query",
         )
 
-    if _contains_any(text, CODE_TERMS):
+    if _contains_code_context(text):
         return MemoryRoute(
             primary=MemoryBackend.GRAPHIFY,
             secondary=(MemoryBackend.MEMPALACE,),


### PR DESCRIPTION
## Summary
- stop routing casual uses of the word service to Graphify
- keep explicit service ownership/dependency questions on the Graphify path
- add regression coverage for casual service language and service-code context

## Verification
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_zoe_memory_router.py
- python3 -m py_compile services/zoe-data/zoe_memory_router.py
- python3 tools/audit/validate_structure.py
- python3 tools/audit/validate_critical_files.py
- python3 tools/audit/validate_offline_memory.py
- git diff --check