### PR TITLE
Parameterize Hindsight bakeoff user fixtures

### DIFF
--- a/scripts/maintenance/hindsight_bakeoff.py
+++ b/scripts/maintenance/hindsight_bakeoff.py
@@ -20,13 +20,20 @@ DATA = ROOT / "services" / "zoe-data"
 sys.path.insert(0, str(DATA))
 
 from hindsight_bakeoff import (  # noqa: E402
-    EVAL_QUERIES,
-    SYNTHETIC_EVENTS,
+    eval_queries_for_user,
     score_recall_response,
     summarize_bakeoff_scores,
     summarize_recall_latency,
+    synthetic_events_for_user,
 )
 from hindsight_memory import HindsightConfig, HindsightMemoryClient  # noqa: E402
+
+
+def _user_id_arg(value: str) -> str:
+    normalized = value.strip()
+    if not normalized:
+        raise argparse.ArgumentTypeError("user_id must not be blank")
+    return normalized
 
 
 async def main() -> int:
@@ -36,15 +43,26 @@ async def main() -> int:
     parser.add_argument("--retain-timeout-seconds", type=float, default=180.0, help="max seconds to wait for each async retain operation")
     parser.add_argument("--retain-poll-seconds", type=float, default=1.0, help="seconds between async retain status polls")
     parser.add_argument("--recall-latency-budget-ms", type=float, default=600.0, help="p95 recall latency budget for hot-path eligibility")
+    parser.add_argument("--user-id", type=_user_id_arg, help="override the synthetic bake-off user_id for multi-user runs")
     parser.add_argument("--json", action="store_true", help="emit JSON")
     args = parser.parse_args()
 
     client = HindsightMemoryClient(HindsightConfig.from_env())
-    output: dict[str, object] = {"status": client.enabled_status(), "retained": [], "operations": [], "scores": [], "summary": {}}
+    synthetic_events = synthetic_events_for_user(args.user_id)
+    eval_queries = eval_queries_for_user(args.user_id)
+    effective_user_id = eval_queries[0].user_id
+    output: dict[str, object] = {
+        "status": client.enabled_status(),
+        "user_id": effective_user_id,
+        "retained": [],
+        "operations": [],
+        "scores": [],
+        "summary": {},
+    }
 
     if args.retain_synthetic:
         retained = []
-        for event in SYNTHETIC_EVENTS:
+        for event in synthetic_events:
             retained.append(await client.retain_event(event, allow_auto=True))
         output["retained"] = retained
         if not args.no_wait_retain:
@@ -55,7 +73,7 @@ async def main() -> int:
             )
 
     scores = []
-    for query in EVAL_QUERIES:
+    for query in eval_queries:
         started = time.perf_counter()
         response = await client.recall(
             user_id=query.user_id,

--- a/services/zoe-data/hindsight_bakeoff.py
+++ b/services/zoe-data/hindsight_bakeoff.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from statistics import median
 from typing import Any, Iterable, Mapping, Sequence
 
@@ -111,8 +111,31 @@ EVAL_QUERIES: tuple[HindsightEvalQuery, ...] = (
 )
 
 
-def synthetic_retain_payloads() -> list[dict[str, Any]]:
-    return [event.to_dict() for event in SYNTHETIC_EVENTS]
+def _normalize_user_id(user_id: str | None) -> str | None:
+    if user_id is None:
+        return None
+    normalized = user_id.strip()
+    if not normalized:
+        raise ValueError("user_id must not be blank")
+    return normalized
+
+
+def synthetic_events_for_user(user_id: str | None = None) -> tuple[MemoryEvent, ...]:
+    normalized = _normalize_user_id(user_id)
+    if normalized is None:
+        return SYNTHETIC_EVENTS
+    return tuple(replace(event, user_id=normalized) for event in SYNTHETIC_EVENTS)
+
+
+def eval_queries_for_user(user_id: str | None = None) -> tuple[HindsightEvalQuery, ...]:
+    normalized = _normalize_user_id(user_id)
+    if normalized is None:
+        return EVAL_QUERIES
+    return tuple(replace(query, user_id=normalized) for query in EVAL_QUERIES)
+
+
+def synthetic_retain_payloads(user_id: str | None = None) -> list[dict[str, Any]]:
+    return [event.to_dict() for event in synthetic_events_for_user(user_id)]
 
 
 def score_recall_text(text: str, expected_terms: Iterable[str]) -> dict[str, Any]:
@@ -207,11 +230,13 @@ __all__ = [
     "EVAL_QUERIES",
     "SYNTHETIC_EVENTS",
     "HindsightEvalQuery",
+    "eval_queries_for_user",
     "percentile",
     "recall_response_text",
     "score_recall_response",
     "score_recall_text",
     "summarize_bakeoff_scores",
     "summarize_recall_latency",
+    "synthetic_events_for_user",
     "synthetic_retain_payloads",
 ]

--- a/services/zoe-data/tests/test_hindsight_bakeoff.py
+++ b/services/zoe-data/tests/test_hindsight_bakeoff.py
@@ -1,3 +1,4 @@
+import argparse
 import importlib.util
 import sys
 from pathlib import Path
@@ -5,8 +6,10 @@ from pathlib import Path
 from hindsight_bakeoff import (
     EVAL_QUERIES,
     SYNTHETIC_EVENTS,
+    eval_queries_for_user,
     percentile,
     score_recall_response,
+    synthetic_events_for_user,
     summarize_bakeoff_scores,
     summarize_recall_latency,
     synthetic_retain_payloads,
@@ -20,6 +23,34 @@ def test_synthetic_events_validate_and_include_required_cases():
     assert {item["event_type"] for item in payloads} >= {"failure", "fix", "preference", "approval"}
     assert all(item["user_id"] for item in payloads)
     assert all(item["evidence_refs"] for item in payloads)
+
+
+def test_synthetic_events_can_be_parameterized_for_multi_user_runs():
+    events = synthetic_events_for_user("casey")
+    payloads = synthetic_retain_payloads("casey")
+
+    assert {event.user_id for event in events} == {"casey"}
+    assert {item["user_id"] for item in payloads} == {"casey"}
+    assert tuple(event.event_id for event in events) == tuple(event.event_id for event in SYNTHETIC_EVENTS)
+    assert {event.user_id for event in SYNTHETIC_EVENTS} == {"jason"}
+
+
+def test_eval_queries_can_be_parameterized_for_multi_user_runs():
+    queries = eval_queries_for_user("casey")
+
+    assert {query.user_id for query in queries} == {"casey"}
+    assert tuple(query.name for query in queries) == tuple(query.name for query in EVAL_QUERIES)
+    assert {query.user_id for query in EVAL_QUERIES} == {"jason"}
+
+
+def test_bakeoff_user_override_rejects_blank_user_id():
+    for helper in (synthetic_events_for_user, eval_queries_for_user, synthetic_retain_payloads):
+        try:
+            helper("  ")
+        except ValueError as exc:
+            assert "user_id must not be blank" in str(exc)
+        else:
+            raise AssertionError(f"{helper.__name__} accepted a blank user_id")
 
 
 def test_eval_queries_cover_plan_questions():
@@ -183,6 +214,14 @@ def test_maintenance_runner_imports_real_bakeoff_module():
     finally:
         sys.path[:] = original_sys_path
 
-    assert len(runner.EVAL_QUERIES) == len(EVAL_QUERIES)
+    assert len(runner.eval_queries_for_user()) == len(EVAL_QUERIES)
+    assert {event.user_id for event in runner.synthetic_events_for_user("casey")} == {"casey"}
+    assert runner._user_id_arg(" casey ") == "casey"
+    try:
+        runner._user_id_arg("  ")
+    except argparse.ArgumentTypeError as exc:
+        assert "user_id must not be blank" in str(exc)
+    else:
+        raise AssertionError("_user_id_arg accepted a blank user_id")
     assert runner.summarize_bakeoff_scores([{"score": 1, "latency_ms": 1}])["case_count"] == 1
     assert runner.summarize_recall_latency([{"latency_ms": 1, "enabled": True}], budget_ms=600)["p95_within_budget"] is True


### PR DESCRIPTION
## Summary
- add Hindsight bake-off helpers that clone synthetic events and eval queries for an override user_id
- add --user-id to the maintenance bake-off runner and report the effective user_id in JSON output
- add tests for multi-user fixture cloning, blank user rejection, and runner import compatibility

## Verification
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_hindsight_bakeoff.py
- PYTHONPATH=services/zoe-data python3 -m py_compile services/zoe-data/hindsight_bakeoff.py scripts/maintenance/hindsight_bakeoff.py
- PYTHONPATH=services/zoe-data python3 scripts/maintenance/hindsight_bakeoff.py --json --user-id casey
- python3 tools/audit/validate_structure.py
- python3 tools/audit/validate_critical_files.py
- python3 tools/audit/validate_offline_memory.py
- git diff --check