### PR TITLE
Add say-exactly intent-gap helper

### DIFF
--- a/scripts/maintenance/zoe_apply_intent_gap_contract.py
+++ b/scripts/maintenance/zoe_apply_intent_gap_contract.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 
 JOKE_PATTERN = r"tell me (?:a|another) joke|make me laugh|(?:do you |have you )?(?:got|have) any jokes|know any (?:good )?jokes"
+SAY_EXACTLY_PATTERN = r"say exactly[: ]+(?:.+)"
 JOKE_TEST = '''"""Open-domain creative intent routing."""
 
 import pytest
@@ -18,6 +19,20 @@ from intent_router import detect_intent
 
 @pytest.mark.parametrize("text", ["Tell me a joke.", "Tell me a joke", "Tell me another joke.", "make me laugh", "do you have any jokes?", "have you got any jokes?", "know any good jokes?"])
 def test_joke_requests_route_to_open_domain_agent(text: str):
+    intent = detect_intent(text)
+
+    assert intent is not None
+    assert intent.name == "extend_capability"
+    assert intent.slots == {"raw": text}
+'''
+
+SAY_EXACTLY_TEST = '''"""Exact repeat intent routing."""
+
+from intent_router import detect_intent
+
+
+def test_say_exactly_routes_to_open_domain_agent():
+    text = "Say exactly: Zoe chat integration ok"
     intent = detect_intent(text)
 
     assert intent is not None
@@ -68,15 +83,56 @@ def apply_joke_contract(root: Path) -> dict[str, object]:
     return {"contract": "joke-open-domain", "changed": changed, "idempotent": not changed}
 
 
+def apply_say_exactly_contract(root: Path) -> dict[str, object]:
+    router_path = root / "services/zoe-data/intent_router.py"
+    test_path = root / "services/zoe-data/tests/test_intent_open_domain.py"
+    if not router_path.exists():
+        raise SystemExit(
+            f"intent_router.py not found at {router_path}; pass --repo-root pointing at the repo root"
+        )
+    router = router_path.read_text(encoding="utf-8")
+    changed: list[str] = []
+
+    if SAY_EXACTLY_PATTERN not in router:
+        needle = f'    r"{JOKE_PATTERN})",\n'
+        replacement = f'    r"{JOKE_PATTERN}|"\n    r"{SAY_EXACTLY_PATTERN})",\n'
+        if needle not in router:
+            needle = '    r"can you explain|set up (?:a )?new automation|what is happening in)",\n'
+            replacement = (
+                '    r"can you explain|set up (?:a )?new automation|what is happening in|"\n'
+                f'    r"{SAY_EXACTLY_PATTERN})",\n'
+            )
+        if needle not in router:
+            raise SystemExit("Could not find _AGENT_CHAT_RE insertion line in intent_router.py")
+        router_path.write_text(router.replace(needle, replacement, 1), encoding="utf-8")
+        changed.append(str(router_path.relative_to(root)))
+
+    existing_test = test_path.read_text(encoding="utf-8") if test_path.exists() else ""
+    if "test_say_exactly_routes_to_open_domain_agent" not in existing_test:
+        test_path.parent.mkdir(parents=True, exist_ok=True)
+        if existing_test.strip():
+            test_path.write_text(
+                f"{existing_test.rstrip()}\n\n\n{SAY_EXACTLY_TEST}",
+                encoding="utf-8",
+            )
+        else:
+            test_path.write_text(SAY_EXACTLY_TEST, encoding="utf-8")
+        changed.append(str(test_path.relative_to(root)))
+
+    return {"contract": "say-exactly-open-domain", "changed": changed, "idempotent": not changed}
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("contract", choices=["joke"], help="Intent-gap contract to apply")
+    parser.add_argument("contract", choices=["joke", "say_exactly"], help="Intent-gap contract to apply")
     parser.add_argument("--repo-root", default=None, help="Repo root; defaults to current directory")
     args = parser.parse_args()
 
     root = _repo_root(args.repo_root)
     if args.contract == "joke":
         result = apply_joke_contract(root)
+    elif args.contract == "say_exactly":
+        result = apply_say_exactly_contract(root)
     else:  # pragma: no cover - argparse choices keep this unreachable.
         raise SystemExit(f"Unsupported contract: {args.contract}")
     print(json.dumps(result, sort_keys=True))

--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -76,6 +76,10 @@ _JOKE_INTENT_GAP_TITLE_RE = re.compile(
     r"\bintent[- ]gap\b.*['\"]?(?:tell\s+me\s+(?:another\s+)?joke|joke)['\"]?",
     re.IGNORECASE,
 )
+_SAY_EXACTLY_INTENT_GAP_TITLE_RE = re.compile(
+    r"\bintent[- ]gap\b.*\bsay\s+exactly[: ]+zoe\s+chat\s+integration\s+ok\b",
+    re.IGNORECASE,
+)
 _GITHUB_PR_URL_RE = re.compile(r"https://github\.com/[^/\s]+/[^/\s]+/pull/\d+")
 _SHELL_TOOL_LINE_RE = re.compile(r"(?:^|\s)(?:💻\s+)?\$\s+(?P<command>.+)$")
 
@@ -423,6 +427,19 @@ def _intent_gap_implement_hint(issue: dict | None = None, *, phase: str = "imple
         if phase == "implement"
         else " After the existing-PR checkout checks succeed, start the focused revision edit within 4 tool/model steps.\n"
     )
+    say_exactly_contract = ""
+    if _SAY_EXACTLY_INTENT_GAP_TITLE_RE.search(title):
+        say_exactly_contract = (
+            " Concrete edit contract for this exact-repeat gap: update `_AGENT_CHAT_RE` so"
+            " `Say exactly: Zoe chat integration ok` routes to `extend_capability` through"
+            " the existing open-domain branch. Preferred deterministic path: from the repo root,"
+            " run `python3 scripts/maintenance/zoe_apply_intent_gap_contract.py say_exactly`,"
+            " then immediately run `python3 -m py_compile services/zoe-data/intent_router.py`"
+            " and `PYTHONPATH=services/zoe-data python3 -m pytest -q"
+            " services/zoe-data/tests/test_intent_open_domain.py`. Do not add a bespoke"
+            " say/echo executor in this ticket; the acceptance goal is routing the request"
+            " to the agent path while preserving the raw phrase.\n"
+        )
     joke_contract = ""
     if _JOKE_INTENT_GAP_TITLE_RE.search(title):
         joke_contract = (
@@ -449,6 +466,7 @@ def _intent_gap_implement_hint(issue: dict | None = None, *, phase: str = "imple
         " `detect_intent`. Your first search should be one of those anchors;"
         " do not grep `_CALCULATE_`, `_execute_`, or unrelated domain sections"
         " for creative intent gaps."
+        f"{say_exactly_contract}"
         f"{joke_contract}"
         " If those files are not the right location, call `kanban_block` with"
         " BLOCKER=IMPLEMENT_BUDGET and the missing locator instead of exploring."

--- a/services/zoe-data/tests/test_intent_gap_contract_helper.py
+++ b/services/zoe-data/tests/test_intent_gap_contract_helper.py
@@ -91,3 +91,78 @@ def test_apply_joke_contract_is_idempotent_with_current_router_pattern(tmp_path)
 
     assert result["changed"] == ["services/zoe-data/tests/test_intent_open_domain.py"]
     assert "tell me (?:a|another) joke|make me laugh|(?:do you |have you )?(?:got|have) any jokes|know any (?:good )?jokes" in router_path.read_text(encoding="utf-8")
+
+
+def test_apply_say_exactly_contract_patches_router_and_adds_test(tmp_path):
+    helper = _load_helper()
+    router_path = tmp_path / "services/zoe-data/intent_router.py"
+    router_path.parent.mkdir(parents=True)
+    router_path.write_text(
+        '    r"tell me (?:a|another) joke|make me laugh|(?:do you |have you )?(?:got|have) any jokes|know any (?:good )?jokes)",\n',
+        encoding="utf-8",
+    )
+
+    result = helper.apply_say_exactly_contract(tmp_path)
+
+    router = router_path.read_text(encoding="utf-8")
+    generated_test = tmp_path / "services/zoe-data/tests/test_intent_open_domain.py"
+    assert result["idempotent"] is False
+    assert "say exactly[: ]+(?:.+)" in router
+    assert generated_test.exists()
+    assert "test_say_exactly_routes_to_open_domain_agent" in generated_test.read_text(encoding="utf-8")
+
+    second = helper.apply_say_exactly_contract(tmp_path)
+
+    assert second == {"contract": "say-exactly-open-domain", "changed": [], "idempotent": True}
+
+
+def test_apply_say_exactly_contract_can_patch_base_router_pattern(tmp_path):
+    helper = _load_helper()
+    router_path = tmp_path / "services/zoe-data/intent_router.py"
+    router_path.parent.mkdir(parents=True)
+    router_path.write_text(
+        '    r"can you explain|set up (?:a )?new automation|what is happening in)",\n',
+        encoding="utf-8",
+    )
+
+    result = helper.apply_say_exactly_contract(tmp_path)
+
+    assert result["changed"] == [
+        "services/zoe-data/intent_router.py",
+        "services/zoe-data/tests/test_intent_open_domain.py",
+    ]
+    assert "say exactly[: ]+(?:.+)" in router_path.read_text(encoding="utf-8")
+
+
+def test_apply_say_exactly_contract_appends_to_existing_open_domain_test(tmp_path):
+    helper = _load_helper()
+    router_path = tmp_path / "services/zoe-data/intent_router.py"
+    test_path = tmp_path / "services/zoe-data/tests/test_intent_open_domain.py"
+    router_path.parent.mkdir(parents=True)
+    test_path.parent.mkdir(parents=True)
+    router_path.write_text(
+        '    r"can you explain|set up (?:a )?new automation|what is happening in)",\n',
+        encoding="utf-8",
+    )
+    test_path.write_text(
+        "def test_existing_open_domain_behavior():\n"
+        "    assert True\n",
+        encoding="utf-8",
+    )
+
+    helper.apply_say_exactly_contract(tmp_path)
+
+    generated = test_path.read_text(encoding="utf-8")
+    assert "def test_existing_open_domain_behavior" in generated
+    assert "def test_say_exactly_routes_to_open_domain_agent" in generated
+
+
+def test_apply_say_exactly_contract_fails_cleanly_when_router_missing(tmp_path):
+    helper = _load_helper()
+
+    try:
+        helper.apply_say_exactly_contract(tmp_path)
+    except SystemExit as exc:
+        assert "intent_router.py not found" in str(exc)
+    else:
+        raise AssertionError("expected SystemExit for missing intent_router.py")

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -4695,6 +4695,43 @@ def test_implement_body_does_not_add_joke_contract_for_other_intent_gaps():
     assert "`Tell me a joke.`, `Tell me a joke`, and `Tell me another joke.`" not in body
 
 
+def test_implement_body_includes_say_exactly_intent_gap_contract():
+    body = ka.KanbanAdapter()._build_body(
+        "implement",
+        {
+            "id": "uuid-intent-exact",
+            "identifier": "ZOE-5458",
+            "title": "Intent gap: say exactly Zoe chat integration ok",
+            "description": "SCOUT_SUMMARY says Say exactly: Zoe chat integration ok should preserve the raw phrase.",
+        },
+        "ZOE-5458",
+    )
+
+    assert "INTENT-GAP IMPLEMENT FAST PATH" in body
+    assert "Concrete edit contract for this exact-repeat gap" in body
+    assert "Say exactly: Zoe chat integration ok" in body
+    assert "python3 scripts/maintenance/zoe_apply_intent_gap_contract.py say_exactly" in body
+    assert "to the agent path while preserving the raw phrase" in body
+    assert "Do not add a bespoke" in body
+
+
+def test_implement_body_does_not_add_say_exactly_contract_for_description_aside():
+    body = ka.KanbanAdapter()._build_body(
+        "implement",
+        {
+            "id": "uuid-intent-aside",
+            "identifier": "ZOE-5450",
+            "title": "Intent gap: profile routing regression",
+            "description": "The user did not ask Zoe to say exactly this phrase; this is unrelated prose.",
+        },
+        "ZOE-5450",
+    )
+
+    assert "INTENT-GAP IMPLEMENT FAST PATH" in body
+    assert "Concrete edit contract for this exact-repeat gap" not in body
+    assert "zoe_apply_intent_gap_contract.py say_exactly" not in body
+
+
 def test_implement_revision_body_includes_intent_gap_fast_path():
     body = ka.KanbanAdapter()._build_body(
         "implement_revision",


### PR DESCRIPTION
## Summary
- add a deterministic say_exactly contract to zoe_apply_intent_gap_contract.py
- add a ZOE-5458-specific intent-gap prompt hint so Hermes can apply the helper instead of rereading intent_router.py until budget abort
- cover the helper and prompt contract with focused tests

## Verification
- python3 -m py_compile scripts/maintenance/zoe_apply_intent_gap_contract.py services/zoe-data/executors/kanban_adapter.py services/zoe-data/intent_router.py
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_intent_gap_contract_helper.py services/zoe-data/tests/test_kanban_adapter.py::test_implement_body_includes_intent_gap_fast_path services/zoe-data/tests/test_kanban_adapter.py::test_implement_body_does_not_add_joke_contract_for_other_intent_gaps services/zoe-data/tests/test_kanban_adapter.py::test_implement_body_includes_say_exactly_intent_gap_contract services/zoe-data/tests/test_intent_open_domain.py
- python3 tools/audit/validate_structure.py
- git diff --check