### PR TITLE
Prefer Zoe identity wording in active surfaces

### DIFF
--- a/services/zoe-data/agent_sync.py
+++ b/services/zoe-data/agent_sync.py
@@ -224,7 +224,7 @@ def _build_zoe_why() -> str:
         "universality + harness rules below.\n"
         "\n"
         "## North Star\n"
-        "Zoe is modeled on Samantha from *Her*: one continuous identity, ambient presence,\n"
+        "Zoe is one continuous identity: ambient presence,\n"
         "judgment over walls, and trust that grows per user/tool. She is a being users have\n"
         "a relationship with — never an attention/engagement machine.\n"
         "\n"

--- a/services/zoe-data/routers/system.py
+++ b/services/zoe-data/routers/system.py
@@ -749,7 +749,7 @@ def _build_agent_card() -> dict:
         "url": base_url,
         "description": (
             "Personal AI companion with persistent memory, voice, home automation, "
-            "web capabilities, and a proactive open-loops engine for Samantha-tier continuity."
+            "web capabilities, and a proactive open-loops engine for Zoe-level continuity."
         ),
         "provider": {
             "name": "Zoe",

--- a/services/zoe-data/tests/test_agent_sync.py
+++ b/services/zoe-data/tests/test_agent_sync.py
@@ -32,7 +32,7 @@ def test_zoe_why_block_teaches_mission_and_stays_lean():
     why = _build_zoe_why()
 
     # North Star + the three memory scopes
-    assert "Samantha" in why
+    assert "one continuous identity" in why
     assert "personal" in why and "shared" in why and "ambient" in why
     # trust-envelope + universality + harness-first biases
     assert "proposal path" in why

--- a/services/zoe-ui/dist/js/ai-processor.js
+++ b/services/zoe-ui/dist/js/ai-processor.js
@@ -1,6 +1,6 @@
 // Unified AI Processing System for Zoe
 // Handles natural language processing across all pages
-// Your personal AI companion - like Samantha from "Her"
+// Your personal Zoe AI companion
 
 class ZoeAIProcessor {
     constructor() {
@@ -10,7 +10,7 @@ class ZoeAIProcessor {
         this.userPreferences = this.loadUserPreferences();
         this.initializeMemory();
         
-        // Samantha-level personality and intelligence
+        // Zoe-level personality and intelligence
         this.personality = {
             mood: 'cheerful',
             traits: ['helpful', 'curious', 'empathetic', 'playful', 'intelligent'],
@@ -653,7 +653,7 @@ class ZoeAIProcessor {
     }
 
     generateResponse(intent, data, context) {
-        // Samantha-level conversational responses
+        // Zoe-level conversational responses
         const responses = {
             'addToList': [
                 `Perfect! I've added "${data.text}" to your ${data.category} list. ✨`,


### PR DESCRIPTION
## Summary
- replace active runtime/UI Samantha-inspired wording with Zoe-specific identity wording
- keep archived/research inspiration untouched and leave OS voice-name matching alone
- update the agent-sync mission test to assert Zoe continuity directly

## Verification
- python3 -m py_compile services/zoe-data/agent_sync.py services/zoe-data/routers/system.py
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_agent_sync.py
- python3 tools/audit/validate_structure.py
- python3 tools/audit/validate_critical_files.py
- python3 tools/audit/validate_offline_memory.py
- git diff --check