### PR TITLE
Guard worktree tasks against live repo reads

### DIFF
--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -432,8 +432,9 @@ def _intent_gap_implement_hint(issue: dict | None = None, *, phase: str = "imple
         say_exactly_contract = (
             " Concrete edit contract for this exact-repeat gap: update `_AGENT_CHAT_RE` so"
             " `Say exactly: Zoe chat integration ok` routes to `extend_capability` through"
-            " the existing open-domain branch. Preferred deterministic path: from the repo root,"
-            " run `python3 scripts/maintenance/zoe_apply_intent_gap_contract.py say_exactly`,"
+            " the existing open-domain branch. Preferred deterministic path: after `kanban_show`,"
+            " run this from the task `workspace_path`, never from `/home/zoe/assistant`:"
+            " `python3 scripts/maintenance/zoe_apply_intent_gap_contract.py say_exactly`,"
             " then immediately run `python3 -m py_compile services/zoe-data/intent_router.py`"
             " and `PYTHONPATH=services/zoe-data python3 -m pytest -q"
             " services/zoe-data/tests/test_intent_open_domain.py`. Do not add a bespoke"

--- a/services/zoe-data/kanban_phase_budget.py
+++ b/services/zoe-data/kanban_phase_budget.py
@@ -616,6 +616,14 @@ def worktree_path_violation_reason_from_log(
         return None
 
     for line in session.splitlines():
+        read_match = _READ_STEP_RE.search(line)
+        if read_match:
+            path = _read_path_key(read_match.group("path")).rstrip("/")
+            if path.startswith("/") and path != expected and not path.startswith(expected + "/"):
+                return (
+                    "BLOCKER=WORKTREE_PATH_VIOLATION: worker read "
+                    f"{path} outside pinned task worktree {expected}"
+                )
         match = _SHELL_CD_STEP_RE.match(line)
         if not match:
             continue

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -3712,6 +3712,68 @@ def test_phase_budget_blocks_verify_worker_that_leaves_pinned_worktree(tmp_path,
     assert "`python3 tools/audit/validate_structure.py`" in reason
 
 
+def test_phase_budget_blocks_absolute_reads_outside_pinned_worktree(tmp_path, monkeypatch):
+    log_path = tmp_path / "task.log"
+    log_path.write_text(
+        "\n".join(
+            [
+                "Query: work kanban task t_impl",
+                "  ┊ 📖 read      /home/zoe/assistant/services/zoe-data/intent_router.py  0.1s",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(kb, "_log_path", lambda _task_id: log_path)
+
+    reason = kb.phase_budget_reason(
+        "t_impl",
+        "implement",
+        {
+            "task": {
+                "started_at": 100,
+                "workspace_kind": "worktree",
+                "workspace_path": "/home/zoe/.worktrees/t_impl",
+                "body": "INTENT-GAP IMPLEMENT FAST PATH",
+            }
+        },
+        now=110,
+    )
+
+    assert reason is not None
+    assert "BLOCKER=WORKTREE_PATH_VIOLATION" in reason
+    assert "/home/zoe/assistant/services/zoe-data/intent_router.py" in reason
+    assert "/home/zoe/.worktrees/t_impl" in reason
+
+
+def test_phase_budget_allows_absolute_reads_inside_pinned_worktree(tmp_path, monkeypatch):
+    log_path = tmp_path / "task.log"
+    log_path.write_text(
+        "\n".join(
+            [
+                "Query: work kanban task t_impl",
+                "  ┊ 📖 read      /home/zoe/.worktrees/t_impl/services/zoe-data/intent_router.py  0.1s",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(kb, "_log_path", lambda _task_id: log_path)
+
+    reason = kb.phase_budget_reason(
+        "t_impl",
+        "implement",
+        {
+            "task": {
+                "started_at": 100,
+                "workspace_kind": "worktree",
+                "workspace_path": "/home/zoe/.worktrees/t_impl",
+            }
+        },
+        now=110,
+    )
+
+    assert reason is None
+
+
 def test_phase_budget_allows_commands_inside_pinned_worktree(tmp_path, monkeypatch):
     log_path = tmp_path / "task.log"
     log_path.write_text(
@@ -4711,6 +4773,7 @@ def test_implement_body_includes_say_exactly_intent_gap_contract():
     assert "Concrete edit contract for this exact-repeat gap" in body
     assert "Say exactly: Zoe chat integration ok" in body
     assert "python3 scripts/maintenance/zoe_apply_intent_gap_contract.py say_exactly" in body
+    assert "run this from the task `workspace_path`, never from `/home/zoe/assistant`" in body
     assert "to the agent path while preserving the raw phrase" in body
     assert "Do not add a bespoke" in body
 


### PR DESCRIPTION
## Summary
- classify absolute reads outside a pinned worktree as WORKTREE_PATH_VIOLATION
- tighten the say_exactly helper prompt so workers run it from the task workspace_path, not /home/zoe/assistant
- add regression coverage for the live failure shape from ZOE-5458

## Verification
- python3 -m py_compile services/zoe-data/kanban_phase_budget.py services/zoe-data/executors/kanban_adapter.py
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_kanban_adapter.py::test_phase_budget_blocks_absolute_reads_outside_pinned_worktree services/zoe-data/tests/test_kanban_adapter.py::test_phase_budget_blocks_worker_that_leaves_pinned_worktree services/zoe-data/tests/test_kanban_adapter.py::test_phase_budget_allows_commands_inside_pinned_worktree services/zoe-data/tests/test_kanban_adapter.py::test_phase_budget_blocks_intent_gap_pre_edit_churn_from_live_shape services/zoe-data/tests/test_kanban_adapter.py::test_implement_body_includes_say_exactly_intent_gap_contract
- python3 tools/audit/validate_structure.py
- git diff --check