### PR TITLE
Refuse intent helper mutations in live checkout

### DIFF
--- a/scripts/maintenance/zoe_apply_intent_gap_contract.py
+++ b/scripts/maintenance/zoe_apply_intent_gap_contract.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 from pathlib import Path
 
 
@@ -45,7 +46,22 @@ def _repo_root(raw: str | None) -> Path:
     return Path(raw or ".").resolve()
 
 
-def apply_joke_contract(root: Path) -> dict[str, object]:
+def _live_repo_root() -> Path:
+    return Path(os.environ.get("ZOE_LIVE_REPO_ROOT", "/home/zoe/assistant")).resolve()
+
+
+def _guard_not_live_root(root: Path, *, allow_live_root: bool = False) -> None:
+    live_root = _live_repo_root()
+    if allow_live_root or root.resolve() != live_root:
+        return
+    raise SystemExit(
+        f"Refusing to mutate live checkout at {live_root}; run from the task worktree "
+        "or pass --allow-live-root for an intentional operator repair"
+    )
+
+
+def apply_joke_contract(root: Path, *, allow_live_root: bool = False) -> dict[str, object]:
+    _guard_not_live_root(root, allow_live_root=allow_live_root)
     router_path = root / "services/zoe-data/intent_router.py"
     test_path = root / "services/zoe-data/tests/test_intent_open_domain.py"
     if not router_path.exists():
@@ -83,7 +99,8 @@ def apply_joke_contract(root: Path) -> dict[str, object]:
     return {"contract": "joke-open-domain", "changed": changed, "idempotent": not changed}
 
 
-def apply_say_exactly_contract(root: Path) -> dict[str, object]:
+def apply_say_exactly_contract(root: Path, *, allow_live_root: bool = False) -> dict[str, object]:
+    _guard_not_live_root(root, allow_live_root=allow_live_root)
     router_path = root / "services/zoe-data/intent_router.py"
     test_path = root / "services/zoe-data/tests/test_intent_open_domain.py"
     if not router_path.exists():
@@ -126,13 +143,18 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("contract", choices=["joke", "say_exactly"], help="Intent-gap contract to apply")
     parser.add_argument("--repo-root", default=None, help="Repo root; defaults to current directory")
+    parser.add_argument(
+        "--allow-live-root",
+        action="store_true",
+        help="Allow intentional operator mutation of the live /home/zoe/assistant checkout",
+    )
     args = parser.parse_args()
 
     root = _repo_root(args.repo_root)
     if args.contract == "joke":
-        result = apply_joke_contract(root)
+        result = apply_joke_contract(root, allow_live_root=args.allow_live_root)
     elif args.contract == "say_exactly":
-        result = apply_say_exactly_contract(root)
+        result = apply_say_exactly_contract(root, allow_live_root=args.allow_live_root)
     else:  # pragma: no cover - argparse choices keep this unreachable.
         raise SystemExit(f"Unsupported contract: {args.contract}")
     print(json.dumps(result, sort_keys=True))

--- a/services/zoe-data/tests/test_intent_gap_contract_helper.py
+++ b/services/zoe-data/tests/test_intent_gap_contract_helper.py
@@ -166,3 +166,157 @@ def test_apply_say_exactly_contract_fails_cleanly_when_router_missing(tmp_path):
         assert "intent_router.py not found" in str(exc)
     else:
         raise AssertionError("expected SystemExit for missing intent_router.py")
+
+
+def test_cli_guard_refuses_live_repo_root(tmp_path, monkeypatch):
+    helper = _load_helper()
+    monkeypatch.setenv("ZOE_LIVE_REPO_ROOT", str(tmp_path))
+
+    try:
+        helper._guard_not_live_root(tmp_path)
+    except SystemExit as exc:
+        assert "Refusing to mutate live checkout" in str(exc)
+        assert "task worktree" in str(exc)
+    else:
+        raise AssertionError("expected SystemExit for live repo root")
+
+
+def test_cli_guard_allows_explicit_live_repo_override(tmp_path, monkeypatch):
+    helper = _load_helper()
+    monkeypatch.setenv("ZOE_LIVE_REPO_ROOT", str(tmp_path))
+
+    helper._guard_not_live_root(tmp_path, allow_live_root=True)
+
+
+def test_cli_guard_resolves_relative_live_repo_root(tmp_path, monkeypatch):
+    helper = _load_helper()
+    monkeypatch.setenv("ZOE_LIVE_REPO_ROOT", str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+
+    try:
+        helper._guard_not_live_root(Path("."))
+    except SystemExit as exc:
+        assert "Refusing to mutate live checkout" in str(exc)
+    else:
+        raise AssertionError("expected SystemExit for relative live repo root")
+
+
+def test_apply_say_exactly_contract_refuses_live_repo_root(tmp_path, monkeypatch):
+    helper = _load_helper()
+    router_path = tmp_path / "services/zoe-data/intent_router.py"
+    router_path.parent.mkdir(parents=True)
+    router_path.write_text(
+        '    r"can you explain|set up (?:a )?new automation|what is happening in)",\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("ZOE_LIVE_REPO_ROOT", str(tmp_path))
+
+    try:
+        helper.apply_say_exactly_contract(tmp_path)
+    except SystemExit as exc:
+        assert "Refusing to mutate live checkout" in str(exc)
+    else:
+        raise AssertionError("expected SystemExit for direct live-root apply")
+
+
+def test_apply_say_exactly_contract_allows_explicit_live_repo_override(tmp_path, monkeypatch):
+    helper = _load_helper()
+    router_path = tmp_path / "services/zoe-data/intent_router.py"
+    router_path.parent.mkdir(parents=True)
+    router_path.write_text(
+        '    r"can you explain|set up (?:a )?new automation|what is happening in)",\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("ZOE_LIVE_REPO_ROOT", str(tmp_path))
+
+    result = helper.apply_say_exactly_contract(tmp_path, allow_live_root=True)
+
+    assert result["idempotent"] is False
+    assert "say exactly[: ]+(?:.+)" in router_path.read_text(encoding="utf-8")
+
+
+def test_apply_joke_contract_refuses_live_repo_root(tmp_path, monkeypatch):
+    helper = _load_helper()
+    router_path = tmp_path / "services/zoe-data/intent_router.py"
+    router_path.parent.mkdir(parents=True)
+    router_path.write_text(
+        '    r"can you explain|set up (?:a )?new automation|what is happening in)",\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("ZOE_LIVE_REPO_ROOT", str(tmp_path))
+
+    try:
+        helper.apply_joke_contract(tmp_path)
+    except SystemExit as exc:
+        assert "Refusing to mutate live checkout" in str(exc)
+    else:
+        raise AssertionError("expected SystemExit for direct live-root joke apply")
+
+
+def test_apply_joke_contract_allows_explicit_live_repo_override(tmp_path, monkeypatch):
+    helper = _load_helper()
+    router_path = tmp_path / "services/zoe-data/intent_router.py"
+    router_path.parent.mkdir(parents=True)
+    router_path.write_text(
+        '    r"can you explain|set up (?:a )?new automation|what is happening in)",\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("ZOE_LIVE_REPO_ROOT", str(tmp_path))
+
+    result = helper.apply_joke_contract(tmp_path, allow_live_root=True)
+
+    assert result["idempotent"] is False
+    assert "tell me (?:a|another) joke" in router_path.read_text(encoding="utf-8")
+
+
+def test_main_threads_live_root_override(tmp_path, monkeypatch, capsys):
+    helper = _load_helper()
+    router_path = tmp_path / "services/zoe-data/intent_router.py"
+    router_path.parent.mkdir(parents=True)
+    router_path.write_text(
+        '    r"can you explain|set up (?:a )?new automation|what is happening in)",\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("ZOE_LIVE_REPO_ROOT", str(tmp_path))
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "zoe_apply_intent_gap_contract.py",
+            "say_exactly",
+            "--repo-root",
+            str(tmp_path),
+            "--allow-live-root",
+        ],
+    )
+
+    assert helper.main() == 0
+
+    assert "say-exactly-open-domain" in capsys.readouterr().out
+    assert "say exactly[: ]+(?:.+)" in router_path.read_text(encoding="utf-8")
+
+
+def test_main_refuses_live_repo_root_without_override(tmp_path, monkeypatch):
+    helper = _load_helper()
+    router_path = tmp_path / "services/zoe-data/intent_router.py"
+    router_path.parent.mkdir(parents=True)
+    router_path.write_text(
+        '    r"can you explain|set up (?:a )?new automation|what is happening in)",\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("ZOE_LIVE_REPO_ROOT", str(tmp_path))
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "zoe_apply_intent_gap_contract.py",
+            "say_exactly",
+            "--repo-root",
+            str(tmp_path),
+        ],
+    )
+
+    try:
+        helper.main()
+    except SystemExit as exc:
+        assert "Refusing to mutate live checkout" in str(exc)
+    else:
+        raise AssertionError("expected SystemExit for live-root CLI without override")


### PR DESCRIPTION
## Summary
- make zoe_apply_intent_gap_contract.py refuse to mutate /home/zoe/assistant by default
- add --allow-live-root for intentional operator repair
- cover the guard and override in focused tests

## Verification
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_intent_gap_contract_helper.py
- python3 scripts/maintenance/zoe_apply_intent_gap_contract.py say_exactly exits nonzero from /home/zoe/assistant without mutating files
- python3 tools/audit/validate_structure.py
- git diff --check