### PR TITLE
Sync running PR progress to Multica

### DIFF
--- a/services/zoe-data/main.py
+++ b/services/zoe-data/main.py
@@ -831,7 +831,7 @@ async def lifespan(app: FastAPI):
                                             "title": title,
                                             "phase": (chain.get("pipeline") if isinstance(chain.get("pipeline"), dict) else {}).get("phase"),
                                             "pr_url": chain.get("pr_url"),
-                                            "status": "in_review" if chain.get("pr_url") else None,
+                                            **({"status": "in_review"} if chain.get("pr_url") else {}),
                                         },
                                     )
                                 except Exception as _push_exc:

--- a/services/zoe-data/main.py
+++ b/services/zoe-data/main.py
@@ -124,6 +124,7 @@ async def _record_running_multica_chain_progress(
     }
     if target_status:
         progress_kwargs["status"] = target_status
+
     await client.record_progress(issue_id, **progress_kwargs)
     return True
 
@@ -828,8 +829,9 @@ async def lifespan(app: FastAPI):
                                         {
                                             "multica_issue_id": str(issue_id),
                                             "title": title,
-                                            "phase": (chain.get("pipeline") if isinstance(chain.get("pipeline"), dict) else {}).get("phase"),
+                                            "phase": (chain.get("pipeline") or {}).get("phase"),
                                             "pr_url": chain.get("pr_url"),
+                                            "status": "in_review" if chain.get("pr_url") else None,
                                         },
                                     )
                                 except Exception as _push_exc:

--- a/services/zoe-data/main.py
+++ b/services/zoe-data/main.py
@@ -116,14 +116,15 @@ async def _record_running_multica_chain_progress(
     except Exception:
         pass
 
-    await client.record_progress(
-        issue_id,
-        phase=phase,
-        evidence="Engineering PR opened; validation/review in progress" if pr_url else "Engineering run in progress",
-        pr_url=pr_url,
-        clear_blocker=True,
-        status=target_status,
-    )
+    progress_kwargs = {
+        "phase": phase,
+        "evidence": "Engineering PR opened; validation/review in progress" if pr_url else "Engineering run in progress",
+        "pr_url": pr_url,
+        "clear_blocker": True,
+    }
+    if target_status:
+        progress_kwargs["status"] = target_status
+    await client.record_progress(issue_id, **progress_kwargs)
     return True
 
 
@@ -820,6 +821,19 @@ async def lifespan(app: FastAPI):
                                     title[:40],
                                     f" PR={chain.get('pr_url')}" if chain.get("pr_url") else "",
                                 )
+                                try:
+                                    await broadcaster.broadcast(
+                                        "all",
+                                        "multica_task_progress",
+                                        {
+                                            "multica_issue_id": str(issue_id),
+                                            "title": title,
+                                            "phase": (chain.get("pipeline") if isinstance(chain.get("pipeline"), dict) else {}).get("phase"),
+                                            "pr_url": chain.get("pr_url"),
+                                        },
+                                    )
+                                except Exception as _push_exc:
+                                    logger.debug("multica_poll: ws progress push failed: %s", _push_exc)
                     except Exception as _inner_exc:
                         logger.debug("multica_poll: inner error for issue %s: %s", issue_id, _inner_exc)
 

--- a/services/zoe-data/main.py
+++ b/services/zoe-data/main.py
@@ -795,6 +795,18 @@ async def lifespan(app: FastAPI):
                                 title[:40],
                                 blocker,
                             )
+                            try:
+                                await broadcaster.broadcast(
+                                    "all",
+                                    "multica_task_blocked",
+                                    {
+                                        "multica_issue_id": str(issue_id),
+                                        "title": title,
+                                        "blocker": blocker,
+                                    },
+                                )
+                            except Exception as _push_exc:
+                                logger.debug("multica_poll: ws block push failed: %s", _push_exc)
                         elif chain.get("found") and chain.get("status") == "running":
                             if await _record_running_multica_chain_progress(
                                 client,
@@ -808,18 +820,6 @@ async def lifespan(app: FastAPI):
                                     title[:40],
                                     f" PR={chain.get('pr_url')}" if chain.get("pr_url") else "",
                                 )
-                            try:
-                                await broadcaster.broadcast(
-                                    "all",
-                                    "multica_task_blocked",
-                                    {
-                                        "multica_issue_id": str(issue_id),
-                                        "title": title,
-                                        "blocker": blocker,
-                                    },
-                                )
-                            except Exception as _push_exc:
-                                logger.debug("multica_poll: ws block push failed: %s", _push_exc)
                     except Exception as _inner_exc:
                         logger.debug("multica_poll: inner error for issue %s: %s", issue_id, _inner_exc)
 

--- a/services/zoe-data/main.py
+++ b/services/zoe-data/main.py
@@ -84,6 +84,49 @@ for _handler in logging.getLogger().handlers:
     _handler.addFilter(RequestIdFilter())
 
 
+async def _record_running_multica_chain_progress(
+    client,
+    issue_id: str,
+    chain: dict,
+    *,
+    issue: dict | None = None,
+) -> bool:
+    """Persist operator-visible PR/phase progress for a non-terminal chain."""
+    pipeline = chain.get("pipeline") if isinstance(chain.get("pipeline"), dict) else {}
+    phase = pipeline.get("phase") or None
+    pr_url = chain.get("pr_url") or None
+    if not phase and not pr_url:
+        return False
+
+    target_status = "in_review" if pr_url else None
+    try:
+        from multica_ticket_contract import parse_ticket_block
+
+        current_issue = issue if isinstance(issue, dict) else {}
+        if not current_issue.get("description"):
+            current_issue = await client.get_issue(issue_id)
+        metadata = parse_ticket_block(current_issue.get("description") or "")
+        if (
+            metadata.get("phase") == phase
+            and metadata.get("pr_url") == pr_url
+            and not metadata.get("blocked_reason")
+            and (not target_status or current_issue.get("status") == target_status)
+        ):
+            return False
+    except Exception:
+        pass
+
+    await client.record_progress(
+        issue_id,
+        phase=phase,
+        evidence="Engineering PR opened; validation/review in progress" if pr_url else "Engineering run in progress",
+        pr_url=pr_url,
+        clear_blocker=True,
+        status=target_status,
+    )
+    return True
+
+
 async def _record_completed_multica_chain(client, issue_id: str, chain: dict) -> None:
     """Persist operator-visible completion metadata for a finished Multica chain."""
     pipeline = chain.get("pipeline") or {}
@@ -752,6 +795,19 @@ async def lifespan(app: FastAPI):
                                 title[:40],
                                 blocker,
                             )
+                        elif chain.get("found") and chain.get("status") == "running":
+                            if await _record_running_multica_chain_progress(
+                                client,
+                                str(issue_id),
+                                chain,
+                                issue=issue,
+                            ):
+                                logger.info(
+                                    "multica_poll: synced running issue %s (%s) progress%s",
+                                    issue_id,
+                                    title[:40],
+                                    f" PR={chain.get('pr_url')}" if chain.get("pr_url") else "",
+                                )
                             try:
                                 await broadcaster.broadcast(
                                     "all",

--- a/services/zoe-data/main.py
+++ b/services/zoe-data/main.py
@@ -829,7 +829,7 @@ async def lifespan(app: FastAPI):
                                         {
                                             "multica_issue_id": str(issue_id),
                                             "title": title,
-                                            "phase": (chain.get("pipeline") or {}).get("phase"),
+                                            "phase": (chain.get("pipeline") if isinstance(chain.get("pipeline"), dict) else {}).get("phase"),
                                             "pr_url": chain.get("pr_url"),
                                             "status": "in_review" if chain.get("pr_url") else None,
                                         },

--- a/services/zoe-data/tests/test_main_multica_poll.py
+++ b/services/zoe-data/tests/test_main_multica_poll.py
@@ -87,6 +87,7 @@ def test_poll_loop_keeps_blocked_broadcast_out_of_running_branch():
     assert "blocker = await _record_blocked_multica_chain" in blocked_segment
     assert '"multica_task_blocked"' in blocked_segment
     assert "_record_running_multica_chain_progress" in running_segment
+    assert '"multica_task_progress"' in running_segment
     assert '"multica_task_blocked"' not in running_segment
     assert "blocker" not in running_segment
 
@@ -114,6 +115,27 @@ async def test_record_running_multica_chain_progress_records_pr_url_and_review_s
     assert client.calls[0][1]["phase"] == "verify"
     assert client.calls[0][1]["pr_url"] == "https://github.com/jason-easyazz/zoe-ai-assistant/pull/999"
     assert client.calls[0][1]["status"] == "in_review"
+    assert client.calls[0][1]["clear_blocker"] is True
+
+
+@pytest.mark.asyncio
+async def test_record_running_multica_chain_progress_omits_status_without_pr_url():
+    from main import _record_running_multica_chain_progress
+
+    client = RecordingClient()
+    client.issues["issue-running"] = {"id": "issue-running", "status": "in_review", "description": ""}
+
+    changed = await _record_running_multica_chain_progress(
+        client,
+        "issue-running",
+        {"status": "running", "pipeline": {"phase": "implement"}},
+        issue=client.issues["issue-running"],
+    )
+
+    assert changed is True
+    assert client.calls[0][1]["phase"] == "implement"
+    assert client.calls[0][1]["pr_url"] is None
+    assert "status" not in client.calls[0][1]
     assert client.calls[0][1]["clear_blocker"] is True
 
 

--- a/services/zoe-data/tests/test_main_multica_poll.py
+++ b/services/zoe-data/tests/test_main_multica_poll.py
@@ -75,6 +75,22 @@ def test_tracked_multica_engineering_issues_includes_review_and_deduplicates():
     ]
 
 
+def test_poll_loop_keeps_blocked_broadcast_out_of_running_branch():
+    source = (Path(__file__).resolve().parents[1] / "main.py").read_text(encoding="utf-8")
+    blocked_branch = source.index('elif chain.get("found") and chain.get("status") == "blocked"')
+    running_branch = source.index('elif chain.get("found") and chain.get("status") == "running"')
+    inner_except = source.index("except Exception as _inner_exc", running_branch)
+
+    blocked_segment = source[blocked_branch:running_branch]
+    running_segment = source[running_branch:inner_except]
+
+    assert "blocker = await _record_blocked_multica_chain" in blocked_segment
+    assert '"multica_task_blocked"' in blocked_segment
+    assert "_record_running_multica_chain_progress" in running_segment
+    assert '"multica_task_blocked"' not in running_segment
+    assert "blocker" not in running_segment
+
+
 @pytest.mark.asyncio
 async def test_record_running_multica_chain_progress_records_pr_url_and_review_status():
     from main import _record_running_multica_chain_progress

--- a/services/zoe-data/tests/test_main_multica_poll.py
+++ b/services/zoe-data/tests/test_main_multica_poll.py
@@ -93,6 +93,28 @@ def test_poll_loop_keeps_blocked_broadcast_out_of_running_branch():
 
 
 @pytest.mark.asyncio
+async def test_record_running_multica_chain_progress_records_phase_without_status_none():
+    from main import _record_running_multica_chain_progress
+
+    client = RecordingClient()
+
+    changed = await _record_running_multica_chain_progress(
+        client,
+        "issue-running",
+        {
+            "status": "running",
+            "pipeline": {"phase": "implement"},
+        },
+        issue={"id": "issue-running", "status": "in_progress", "description": ""},
+    )
+
+    assert changed is True
+    assert client.calls[0][1]["phase"] == "implement"
+    assert client.calls[0][1]["pr_url"] is None
+    assert "status" not in client.calls[0][1]
+
+
+@pytest.mark.asyncio
 async def test_record_running_multica_chain_progress_records_pr_url_and_review_status():
     from main import _record_running_multica_chain_progress
 
@@ -115,27 +137,6 @@ async def test_record_running_multica_chain_progress_records_pr_url_and_review_s
     assert client.calls[0][1]["phase"] == "verify"
     assert client.calls[0][1]["pr_url"] == "https://github.com/jason-easyazz/zoe-ai-assistant/pull/999"
     assert client.calls[0][1]["status"] == "in_review"
-    assert client.calls[0][1]["clear_blocker"] is True
-
-
-@pytest.mark.asyncio
-async def test_record_running_multica_chain_progress_omits_status_without_pr_url():
-    from main import _record_running_multica_chain_progress
-
-    client = RecordingClient()
-    client.issues["issue-running"] = {"id": "issue-running", "status": "in_review", "description": ""}
-
-    changed = await _record_running_multica_chain_progress(
-        client,
-        "issue-running",
-        {"status": "running", "pipeline": {"phase": "implement"}},
-        issue=client.issues["issue-running"],
-    )
-
-    assert changed is True
-    assert client.calls[0][1]["phase"] == "implement"
-    assert client.calls[0][1]["pr_url"] is None
-    assert "status" not in client.calls[0][1]
     assert client.calls[0][1]["clear_blocker"] is True
 
 

--- a/services/zoe-data/tests/test_main_multica_poll.py
+++ b/services/zoe-data/tests/test_main_multica_poll.py
@@ -76,6 +76,59 @@ def test_tracked_multica_engineering_issues_includes_review_and_deduplicates():
 
 
 @pytest.mark.asyncio
+async def test_record_running_multica_chain_progress_records_pr_url_and_review_status():
+    from main import _record_running_multica_chain_progress
+
+    client = RecordingClient()
+    client.issues["issue-running"] = {"id": "issue-running", "status": "in_progress", "description": ""}
+
+    changed = await _record_running_multica_chain_progress(
+        client,
+        "issue-running",
+        {
+            "status": "running",
+            "pr_url": "https://github.com/jason-easyazz/zoe-ai-assistant/pull/999",
+            "pipeline": {"phase": "verify"},
+        },
+        issue=client.issues["issue-running"],
+    )
+
+    assert changed is True
+    assert client.calls[0][0] == ("issue-running",)
+    assert client.calls[0][1]["phase"] == "verify"
+    assert client.calls[0][1]["pr_url"] == "https://github.com/jason-easyazz/zoe-ai-assistant/pull/999"
+    assert client.calls[0][1]["status"] == "in_review"
+    assert client.calls[0][1]["clear_blocker"] is True
+
+
+@pytest.mark.asyncio
+async def test_record_running_multica_chain_progress_skips_unchanged_metadata():
+    from main import _record_running_multica_chain_progress
+    from multica_ticket_contract import describe_ticket
+
+    description = describe_ticket(
+        "Already synced",
+        metadata={"phase": "verify", "pr_url": "https://github.com/jason-easyazz/zoe-ai-assistant/pull/999"},
+    )
+    client = RecordingClient()
+    issue = {"id": "issue-running", "status": "in_review", "description": description}
+
+    changed = await _record_running_multica_chain_progress(
+        client,
+        "issue-running",
+        {
+            "status": "running",
+            "pr_url": "https://github.com/jason-easyazz/zoe-ai-assistant/pull/999",
+            "pipeline": {"phase": "verify"},
+        },
+        issue=issue,
+    )
+
+    assert changed is False
+    assert client.calls == []
+
+
+@pytest.mark.asyncio
 async def test_record_completed_multica_chain_records_explicit_retro_completion_metadata():
     from main import _record_completed_multica_chain
 

--- a/services/zoe-data/tests/test_main_multica_poll.py
+++ b/services/zoe-data/tests/test_main_multica_poll.py
@@ -88,6 +88,8 @@ def test_poll_loop_keeps_blocked_broadcast_out_of_running_branch():
     assert '"multica_task_blocked"' in blocked_segment
     assert "_record_running_multica_chain_progress" in running_segment
     assert '"multica_task_progress"' in running_segment
+    assert '**({"status": "in_review"} if chain.get("pr_url") else {})' in running_segment
+    assert '"status": "in_review" if chain.get("pr_url") else None' not in running_segment
     assert '"multica_task_blocked"' not in running_segment
     assert "blocker" not in running_segment
 

--- a/services/zoe-ui/dist/js/websocket-sync.js
+++ b/services/zoe-ui/dist/js/websocket-sync.js
@@ -403,7 +403,12 @@ window.ZoeWebSockets = {
             }
         });
 
-        // ── Multica board task completion ─────────────────────────────────
+        // ── Multica board task updates ─────────────────────────────────────
+        this.push.on('multica_task_progress', (data) => {
+            const payload = unwrapPayload(data);
+            document.dispatchEvent(new CustomEvent('zoe:multica_task_progress', { detail: payload }));
+        });
+
         this.push.on('multica_task_done', (data) => {
             const payload = unwrapPayload(data);
             const title = payload.title || 'Board task';

--- a/services/zoe-ui/dist/js/websocket-sync.js
+++ b/services/zoe-ui/dist/js/websocket-sync.js
@@ -406,6 +406,10 @@ window.ZoeWebSockets = {
         // ── Multica board task updates ─────────────────────────────────────
         this.push.on('multica_task_progress', (data) => {
             const payload = unwrapPayload(data);
+            const title = payload.title || 'Board task';
+            if (payload.status === 'in_review' && payload.pr_url && typeof window._zoeShowNotification === 'function') {
+                window._zoeShowNotification(`Board task in review: ${title}`, 'info');
+            }
             document.dispatchEvent(new CustomEvent('zoe:multica_task_progress', { detail: payload }));
         });
 

--- a/services/zoe-ui/dist/js/widgets/core/multica-board.js
+++ b/services/zoe-ui/dist/js/widgets/core/multica-board.js
@@ -32,7 +32,8 @@ class MulticaBoardWidget extends WidgetModule {
         super.init(element);
         this.loadBoard();
 
-        // Refresh on multica_task_done push event
+        // Refresh on Multica push events
+        document.addEventListener('zoe:multica_task_progress', () => this.loadBoard());
         document.addEventListener('zoe:multica_task_done', () => this.loadBoard());
     }
 


### PR DESCRIPTION
## Summary
- record running-chain PR URL and phase progress back into Multica before terminal completion
- move tickets with opened PRs to in_review while validation/review continues
- avoid repeat writes when Multica metadata already matches the running chain

## Verification
- python3 -m py_compile services/zoe-data/main.py services/zoe-data/tests/test_main_multica_poll.py
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_main_multica_poll.py -k "running_multica_chain_progress or completed_multica_chain"
- python3 tools/audit/validate_structure.py
- git diff --check