### PR TITLE
Filter empty Multica progress fields

### DIFF
--- a/services/zoe-data/main.py
+++ b/services/zoe-data/main.py
@@ -117,10 +117,14 @@ async def _record_running_multica_chain_progress(
         pass
 
     progress_kwargs = {
-        "phase": phase,
-        "evidence": "Engineering PR opened; validation/review in progress" if pr_url else "Engineering run in progress",
-        "pr_url": pr_url,
-        "clear_blocker": True,
+        key: value
+        for key, value in {
+            "phase": phase,
+            "evidence": "Engineering PR opened; validation/review in progress" if pr_url else "Engineering run in progress",
+            "pr_url": pr_url,
+            "clear_blocker": True,
+        }.items()
+        if value is not None
     }
     if target_status:
         progress_kwargs["status"] = target_status

--- a/services/zoe-data/main.py
+++ b/services/zoe-data/main.py
@@ -137,14 +137,18 @@ async def _record_completed_multica_chain(client, issue_id: str, chain: dict) ->
     """Persist operator-visible completion metadata for a finished Multica chain."""
     pipeline = chain.get("pipeline") or {}
     phase = pipeline.get("phase") or "closeout"
-    await client.record_progress(
-        issue_id,
-        phase=phase,
-        evidence="Engineering run done after retro" if phase == "retro" else "Engineering run done",
-        pr_url=chain.get("pr_url"),
-        clear_blocker=True,
-        status="done",
-    )
+    progress_kwargs = {
+        key: value
+        for key, value in {
+            "phase": phase,
+            "evidence": "Engineering run done after retro" if phase == "retro" else "Engineering run done",
+            "pr_url": chain.get("pr_url"),
+            "clear_blocker": True,
+            "status": "done",
+        }.items()
+        if value is not None
+    }
+    await client.record_progress(issue_id, **progress_kwargs)
     follow_up = pipeline.get("retro_followup") if isinstance(pipeline, dict) else None
     if phase != "retro" or not isinstance(follow_up, dict) or not follow_up.get("title"):
         return

--- a/services/zoe-data/tests/test_main_multica_poll.py
+++ b/services/zoe-data/tests/test_main_multica_poll.py
@@ -207,7 +207,7 @@ async def test_record_completed_multica_chain_preserves_legacy_closeout_completi
 
     await _record_completed_multica_chain(client, "issue-2", {"status": "done"})
 
-    assert client.calls[0][1]["pr_url"] is None
+    assert "pr_url" not in client.calls[0][1]
     assert client.calls[0][1]["phase"] == "closeout"
     assert client.calls[0][1]["evidence"] == "Engineering run done"
     assert client.calls[0][1]["status"] == "done"

--- a/services/zoe-data/tests/test_main_multica_poll.py
+++ b/services/zoe-data/tests/test_main_multica_poll.py
@@ -112,7 +112,7 @@ async def test_record_running_multica_chain_progress_records_phase_without_statu
 
     assert changed is True
     assert client.calls[0][1]["phase"] == "implement"
-    assert client.calls[0][1]["pr_url"] is None
+    assert "pr_url" not in client.calls[0][1]
     assert "status" not in client.calls[0][1]
 
 

--- a/services/zoe-data/tests/test_main_multica_poll.py
+++ b/services/zoe-data/tests/test_main_multica_poll.py
@@ -231,6 +231,22 @@ async def test_record_completed_multica_chain_records_non_retro_pipeline_phase()
 
 
 @pytest.mark.asyncio
+async def test_record_completed_multica_chain_omits_absent_pr_url():
+    from main import _record_completed_multica_chain
+
+    client = RecordingClient()
+
+    await _record_completed_multica_chain(
+        client,
+        "issue-no-pr",
+        {"status": "done", "pipeline": {"phase": "closeout"}},
+    )
+
+    assert "pr_url" not in client.calls[0][1]
+    assert client.calls[0][1]["status"] == "done"
+
+
+@pytest.mark.asyncio
 async def test_record_completed_multica_chain_creates_retro_followup_ticket():
     from main import _record_completed_multica_chain
     from multica_ticket_contract import parse_ticket_block


### PR DESCRIPTION
## Summary
- omit None-valued Multica progress fields before record_progress
- update phase-only progress test to assert pr_url is not forwarded when absent

## Verification
- python3 -m py_compile services/zoe-data/main.py services/zoe-data/tests/test_main_multica_poll.py
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_main_multica_poll.py -k running_multica_chain_progress
- python3 tools/audit/validate_structure.py
- python3 tools/audit/validate_critical_files.py
- python3 tools/audit/validate_offline_memory.py
- git diff --check