### PR TITLE
Allow harness follow-ups to read named files

### DIFF
--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -386,8 +386,10 @@ def _harness_implement_hint(issue: dict | None = None) -> str:
             " `kanban_block` with BLOCKER=TEST_ENVIRONMENT and the first import error instead of"
             " spending turns on environment repair."
             " If the focused test passes before any edit, do not inspect more blocker code:"
-            " edit services/zoe-data/executors/kanban_adapter.py within 2 more tool/model"
-            " steps with the smallest prompt/locator guard, or call `kanban_block` with"
+            " edit the named harness file already in scope (usually services/zoe-data/main.py,"
+            " services/zoe-data/tests/test_main_multica_poll.py, or"
+            " services/zoe-data/executors/kanban_adapter.py) within 2 more tool/model"
+            " steps with the smallest guard, or call `kanban_block` with"
             " BLOCKER=ALREADY_COVERED and the passing test output. Do not rework blocker"
             " creation after a passing focused test.\n"
         )

--- a/services/zoe-data/kanban_phase_budget.py
+++ b/services/zoe-data/kanban_phase_budget.py
@@ -552,7 +552,12 @@ def implement_pre_edit_drift_reason_from_log(
     repeat_read_budget = _pre_edit_repeat_read_budget()
     explore_steps = 0
     focused_harness_test_seen = False
-    post_focus_adapter_read_allowed = True
+    post_focus_allowed_reads = {
+        "services/zoe-data/main.py",
+        "services/zoe-data/tests/test_main_multica_poll.py",
+        "services/zoe-data/executors/kanban_adapter.py",
+    }
+    post_focus_reads_seen: set[str] = set()
     read_counts: dict[str, int] = {}
     for line in step_lines:
         if _PATCH_STEP_RE.search(line) or _TERMINAL_STEP_RE.search(line):
@@ -566,18 +571,18 @@ def implement_pre_edit_drift_reason_from_log(
         read_match = _READ_STEP_RE.search(line)
         if focused_harness_test_seen:
             path = _read_path_key(read_match.group("path")) if read_match else ""
-            if (
-                post_focus_adapter_read_allowed
-                and path.endswith("services/zoe-data/executors/kanban_adapter.py")
-            ):
-                post_focus_adapter_read_allowed = False
+            matched_allowed_path = next(
+                (allowed for allowed in post_focus_allowed_reads if path.endswith(allowed)),
+                "",
+            )
+            if matched_allowed_path and matched_allowed_path not in post_focus_reads_seen:
+                post_focus_reads_seen.add(matched_allowed_path)
                 continue
-            else:
-                return (
-                    "BLOCKER=IMPLEMENT_HANDOFF_DRIFT: engineering blocker follow-up kept "
-                    "exploring after focused test instead of editing kanban_adapter.py "
-                    "or blocking ALREADY_COVERED"
-                )
+            return (
+                "BLOCKER=IMPLEMENT_HANDOFF_DRIFT: engineering blocker follow-up kept "
+                "exploring after focused test instead of editing the named harness file "
+                "or blocking ALREADY_COVERED"
+            )
         if explore_steps > explore_budget:
             return (
                 "BLOCKER=IMPLEMENT_HANDOFF_DRIFT: pre-edit exploration exceeded "

--- a/services/zoe-data/kanban_phase_budget.py
+++ b/services/zoe-data/kanban_phase_budget.py
@@ -567,7 +567,6 @@ def implement_pre_edit_drift_reason_from_log(
             continue
         if not _EXPLORE_STEP_RE.search(line):
             continue
-        explore_steps += 1
         read_match = _READ_STEP_RE.search(line)
         if focused_harness_test_seen:
             path = _read_path_key(read_match.group("path")) if read_match else ""
@@ -583,6 +582,7 @@ def implement_pre_edit_drift_reason_from_log(
                 "exploring after focused test instead of editing the named harness file "
                 "or blocking ALREADY_COVERED"
             )
+        explore_steps += 1
         if explore_steps > explore_budget:
             return (
                 "BLOCKER=IMPLEMENT_HANDOFF_DRIFT: pre-edit exploration exceeded "

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -2407,7 +2407,7 @@ def test_implement_pre_edit_drift_blocks_harness_followup_after_focused_test(tmp
     assert "engineering blocker follow-up kept exploring after focused test" in reason
 
 
-def test_implement_pre_edit_drift_allows_harness_followup_adapter_read_after_focused_test(
+def test_implement_pre_edit_drift_allows_harness_followup_named_file_read_after_focused_test(
     tmp_path, monkeypatch
 ):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
@@ -2418,7 +2418,7 @@ def test_implement_pre_edit_drift_allows_harness_followup_adapter_read_after_foc
         "  ┊ 💻 $         cd /work && PYTHONPATH=services/zoe-data python3 -m pytest -q "
         "services/zoe-data/tests/test_main_multica_poll.py::"
         "test_record_blocked_multica_chain_creates_iteration_budget_followup  3.3s\n"
-        "  ┊ 📖 read      /work/services/zoe-data/executors/kanban_adapter.py  0.1s\n",
+        "  ┊ 📖 read      /work/services/zoe-data/main.py  0.1s\n",
         encoding="utf-8",
     )
 
@@ -2459,6 +2459,32 @@ def test_implement_pre_edit_drift_does_not_charge_allowed_adapter_read_to_budget
     )
 
     assert reason is None
+
+
+def test_implement_pre_edit_drift_blocks_repeated_harness_followup_named_file_read_after_focused_test(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    log_dir = tmp_path / "kanban" / "logs"
+    log_dir.mkdir(parents=True)
+    (log_dir / "t_impl.log").write_text(
+        "Query: work kanban task t_impl\n"
+        "  ┊ 💻 $         cd /work && PYTHONPATH=services/zoe-data python3 -m pytest -q "
+        "services/zoe-data/tests/test_main_multica_poll.py::"
+        "test_record_blocked_multica_chain_creates_iteration_budget_followup  3.3s\n"
+        "  ┊ 📖 read      /work/services/zoe-data/main.py  0.1s\n"
+        "  ┊ 📖 read      /work/services/zoe-data/main.py  0.1s\n",
+        encoding="utf-8",
+    )
+
+    reason = kb.implement_pre_edit_drift_reason_from_log(
+        "t_impl",
+        "implement",
+        task_body='{"source":"engineering_blocker_followup"}',
+    )
+
+    assert reason is not None
+    assert "engineering blocker follow-up kept exploring after focused test" in reason
 
 
 def test_implement_pre_edit_drift_covers_harness_followup_focused_tests_in_other_files(
@@ -4588,7 +4614,9 @@ def test_implement_body_includes_harness_repo_map_for_blocker_followup_source():
     assert "do not create `.venv`, run `pip install`" in body
     assert "BLOCKER=TEST_ENVIRONMENT" in body
     assert "If the focused test passes before any edit, do not inspect more blocker code" in body
-    assert "edit services/zoe-data/executors/kanban_adapter.py within 2 more tool/model steps" in body
+    assert "edit the named harness file already in scope" in body
+    assert "services/zoe-data/main.py" in body
+    assert "services/zoe-data/executors/kanban_adapter.py" in body
     assert "BLOCKER=ALREADY_COVERED" in body
 
 
@@ -4636,7 +4664,9 @@ def test_implement_body_includes_harness_blocker_followup_focused_tests(
     assert expected_test in body
     assert "Use the existing repo/runtime environment only" in body
     assert "If the focused test passes before any edit, do not inspect more blocker code" in body
-    assert "edit services/zoe-data/executors/kanban_adapter.py within 2 more tool/model steps" in body
+    assert "edit the named harness file already in scope" in body
+    assert "services/zoe-data/main.py" in body
+    assert "services/zoe-data/executors/kanban_adapter.py" in body
     assert "BLOCKER=ALREADY_COVERED" in body
 
 

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -2431,7 +2431,7 @@ def test_implement_pre_edit_drift_allows_harness_followup_named_file_read_after_
     assert reason is None
 
 
-def test_implement_pre_edit_drift_does_not_charge_allowed_adapter_read_to_budget(
+def test_implement_pre_edit_drift_does_not_charge_allowed_named_file_read_to_budget(
     tmp_path, monkeypatch
 ):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
@@ -2449,6 +2449,31 @@ def test_implement_pre_edit_drift_does_not_charge_allowed_adapter_read_to_budget
         "services/zoe-data/tests/test_main_multica_poll.py::"
         "test_record_blocked_multica_chain_creates_iteration_budget_followup  3.3s\n"
         "  ┊ 📖 read      /work/services/zoe-data/executors/kanban_adapter.py  0.1s\n",
+        encoding="utf-8",
+    )
+
+    reason = kb.implement_pre_edit_drift_reason_from_log(
+        "t_impl",
+        "implement",
+        task_body='{"source":"engineering_blocker_followup"}',
+    )
+
+    assert reason is None
+
+
+def test_implement_pre_edit_drift_allows_multiple_distinct_named_file_reads_after_focused_test(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    log_dir = tmp_path / "kanban" / "logs"
+    log_dir.mkdir(parents=True)
+    (log_dir / "t_impl.log").write_text(
+        "Query: work kanban task t_impl\n"
+        "  ┊ 💻 $         cd /work && PYTHONPATH=services/zoe-data python3 -m pytest -q "
+        "services/zoe-data/tests/test_main_multica_poll.py::"
+        "test_record_blocked_multica_chain_creates_iteration_budget_followup  3.3s\n"
+        "  ┊ 📖 read      /work/services/zoe-data/main.py  0.1s\n"
+        "  ┊ 📖 read      /work/services/zoe-data/tests/test_main_multica_poll.py  0.1s\n",
         encoding="utf-8",
     )
 


### PR DESCRIPTION
## Summary
- widen the post-focused-test drift guard for engineering blocker follow-ups to one read of the named harness files in scope
- update the worker prompt from adapter-only to named harness file guidance
- add regression coverage for allowed named-file reads and repeated-read drift

## Verification
- python3 -m py_compile services/zoe-data/kanban_phase_budget.py services/zoe-data/executors/kanban_adapter.py services/zoe-data/tests/test_kanban_adapter.py
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_kanban_adapter.py -k "harness_followup or IMPLEMENT_HANDOFF_DRIFT or focused_test"
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_main_multica_poll.py -k "running_multica_chain_progress or completed_multica_chain or blocker_followup"
- python3 tools/audit/validate_structure.py
- git diff --check