### PR TITLE
Bound harness follow-up post-focus navigation

### DIFF
--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -386,10 +386,10 @@ def _harness_implement_hint(issue: dict | None = None) -> str:
             " `kanban_block` with BLOCKER=TEST_ENVIRONMENT and the first import error instead of"
             " spending turns on environment repair."
             " If the focused test passes before any edit, do not inspect more blocker code:"
-            " edit the named harness file already in scope (usually services/zoe-data/main.py,"
+            " use at most two symbol greps and two reads per named file, then edit the"
+            " named harness file already in scope (usually services/zoe-data/main.py,"
             " services/zoe-data/tests/test_main_multica_poll.py, or"
-            " services/zoe-data/executors/kanban_adapter.py) within 2 more tool/model"
-            " steps with the smallest guard, or call `kanban_block` with"
+            " services/zoe-data/executors/kanban_adapter.py) with the smallest guard, or call `kanban_block` with"
             " BLOCKER=ALREADY_COVERED and the passing test output. Do not rework blocker"
             " creation after a passing focused test.\n"
         )

--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -386,7 +386,7 @@ def _harness_implement_hint(issue: dict | None = None) -> str:
             " `kanban_block` with BLOCKER=TEST_ENVIRONMENT and the first import error instead of"
             " spending turns on environment repair."
             " If the focused test passes before any edit, do not inspect more blocker code:"
-            " use at most two symbol greps and two reads per named file, then edit the"
+            " use at most two symbol greps total and two reads per named file, then edit the"
             " named harness file already in scope (usually services/zoe-data/main.py,"
             " services/zoe-data/tests/test_main_multica_poll.py, or"
             " services/zoe-data/executors/kanban_adapter.py) with the smallest guard, or call `kanban_block` with"

--- a/services/zoe-data/kanban_phase_budget.py
+++ b/services/zoe-data/kanban_phase_budget.py
@@ -54,6 +54,7 @@ _PATCH_REVIEW_DIFF_RE = re.compile(r"^\s*(?:┊|\|)\s+review\s+diff\b", re.IGNOR
 _TERMINAL_STEP_RE = re.compile(r"^\s*(?:┊|\|)\s+\S+\s+kanban_(?:complete|block)\b", re.IGNORECASE)
 _EXPLORE_STEP_RE = re.compile(r"^\s*(?:┊|\|)\s+\S+\s+(?:read|grep|find)\b", re.IGNORECASE)
 _READ_STEP_RE = re.compile(r"^\s*(?:┊|\|)\s+\S+\s+read\s+(?P<path>\S+)", re.IGNORECASE)
+_GREP_STEP_RE = re.compile(r"^\s*(?:┊|\|)\s+\S+\s+(?:grep|find)\b", re.IGNORECASE)
 _SHELL_CD_STEP_RE = re.compile(
     r"^\s*(?:┊|\|)\s+\S+\s+\$\s+cd\s+(?P<cwd>'[^']+'|\"[^\"]+\"|\S+)\s+&&\s+(?P<command>.+)$",
     re.IGNORECASE,
@@ -557,7 +558,10 @@ def implement_pre_edit_drift_reason_from_log(
         "services/zoe-data/tests/test_main_multica_poll.py",
         "services/zoe-data/executors/kanban_adapter.py",
     }
-    post_focus_reads_seen: set[str] = set()
+    post_focus_read_counts: dict[str, int] = {}
+    post_focus_grep_steps = 0
+    post_focus_read_budget = 2
+    post_focus_grep_budget = 2
     read_counts: dict[str, int] = {}
     for line in step_lines:
         if _PATCH_STEP_RE.search(line) or _TERMINAL_STEP_RE.search(line):
@@ -574,13 +578,20 @@ def implement_pre_edit_drift_reason_from_log(
                 (allowed for allowed in post_focus_allowed_reads if path.endswith(allowed)),
                 "",
             )
-            if matched_allowed_path and matched_allowed_path not in post_focus_reads_seen:
-                post_focus_reads_seen.add(matched_allowed_path)
-                continue
+            if matched_allowed_path:
+                post_focus_read_counts[matched_allowed_path] = (
+                    post_focus_read_counts.get(matched_allowed_path, 0) + 1
+                )
+                if post_focus_read_counts[matched_allowed_path] <= post_focus_read_budget:
+                    continue
+            if _GREP_STEP_RE.search(line):
+                post_focus_grep_steps += 1
+                if post_focus_grep_steps <= post_focus_grep_budget:
+                    continue
             return (
                 "BLOCKER=IMPLEMENT_HANDOFF_DRIFT: engineering blocker follow-up kept "
-                "exploring after focused test instead of editing the named harness file "
-                "or blocking ALREADY_COVERED"
+                "exploring after focused test beyond the named-file navigation budget "
+                "instead of editing or blocking ALREADY_COVERED"
             )
         explore_steps += 1
         if explore_steps > explore_budget:

--- a/services/zoe-data/kanban_phase_budget.py
+++ b/services/zoe-data/kanban_phase_budget.py
@@ -265,6 +265,20 @@ def _pre_edit_repeat_read_budget() -> int:
         return 6
 
 
+def _post_focus_read_budget() -> int:
+    try:
+        return max(1, int(os.environ.get("ZOE_KANBAN_IMPLEMENT_POST_FOCUS_READ_BUDGET", "2")))
+    except ValueError:
+        return 2
+
+
+def _post_focus_grep_budget() -> int:
+    try:
+        return max(1, int(os.environ.get("ZOE_KANBAN_IMPLEMENT_POST_FOCUS_GREP_BUDGET", "2")))
+    except ValueError:
+        return 2
+
+
 def _read_path_key(raw_path: str) -> str:
     return re.sub(r":\d+(?:-\d+)?$", "", raw_path)
 
@@ -560,8 +574,8 @@ def implement_pre_edit_drift_reason_from_log(
     }
     post_focus_read_counts: dict[str, int] = {}
     post_focus_grep_steps = 0
-    post_focus_read_budget = 2
-    post_focus_grep_budget = 2
+    post_focus_read_budget = _post_focus_read_budget()
+    post_focus_grep_budget = _post_focus_grep_budget()
     read_counts: dict[str, int] = {}
     for line in step_lines:
         if _PATCH_STEP_RE.search(line) or _TERMINAL_STEP_RE.search(line):
@@ -584,7 +598,7 @@ def implement_pre_edit_drift_reason_from_log(
                 )
                 if post_focus_read_counts[matched_allowed_path] <= post_focus_read_budget:
                     continue
-            if _GREP_STEP_RE.search(line):
+            elif _GREP_STEP_RE.search(line):
                 post_focus_grep_steps += 1
                 if post_focus_grep_steps <= post_focus_grep_budget:
                     continue

--- a/services/zoe-data/kanban_phase_budget.py
+++ b/services/zoe-data/kanban_phase_budget.py
@@ -106,6 +106,8 @@ _MARK_REVIEWED_VERDICT_RE = re.compile(
     re.IGNORECASE,
 )
 _ZERO_STEP_WARNED: set[str] = set()
+_POST_FOCUS_READ_BUDGET_DEFAULT = 2
+_POST_FOCUS_GREP_BUDGET_DEFAULT = 2
 
 
 def _limit(phase: str, kind: str) -> int:
@@ -267,16 +269,32 @@ def _pre_edit_repeat_read_budget() -> int:
 
 def _post_focus_read_budget() -> int:
     try:
-        return max(1, int(os.environ.get("ZOE_KANBAN_IMPLEMENT_POST_FOCUS_READ_BUDGET", "2")))
+        return max(
+            1,
+            int(
+                os.environ.get(
+                    "ZOE_KANBAN_IMPLEMENT_POST_FOCUS_READ_BUDGET",
+                    str(_POST_FOCUS_READ_BUDGET_DEFAULT),
+                )
+            ),
+        )
     except ValueError:
-        return 2
+        return _POST_FOCUS_READ_BUDGET_DEFAULT
 
 
 def _post_focus_grep_budget() -> int:
     try:
-        return max(1, int(os.environ.get("ZOE_KANBAN_IMPLEMENT_POST_FOCUS_GREP_BUDGET", "2")))
+        return max(
+            1,
+            int(
+                os.environ.get(
+                    "ZOE_KANBAN_IMPLEMENT_POST_FOCUS_GREP_BUDGET",
+                    str(_POST_FOCUS_GREP_BUDGET_DEFAULT),
+                )
+            ),
+        )
     except ValueError:
-        return 2
+        return _POST_FOCUS_GREP_BUDGET_DEFAULT
 
 
 def _read_path_key(raw_path: str) -> str:

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -2381,7 +2381,7 @@ def test_implement_pre_edit_drift_blocks_exploration_without_patch(tmp_path, mon
     assert "pre-edit exploration exceeded budget" in reason
 
 
-def test_implement_pre_edit_drift_blocks_harness_followup_after_focused_test(tmp_path, monkeypatch):
+def test_implement_pre_edit_drift_blocks_excess_harness_followup_grep_after_focused_test(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     monkeypatch.setenv("ZOE_KANBAN_IMPLEMENT_PRE_EDIT_EXPLORE_BUDGET", "12")
     log_dir = tmp_path / "kanban" / "logs"
@@ -2393,7 +2393,9 @@ def test_implement_pre_edit_drift_blocks_harness_followup_after_focused_test(tmp
         "services/zoe-data/tests/test_main_multica_poll.py::"
         "test_record_blocked_multica_chain_creates_iteration_budget_followup -x  3.3s\n"
         "  ┊ 📖 read      /work/services/zoe-data/executors/kanban_adapter.py  0.1s\n"
-        "  ┊ 🔎 grep      ITERATION_BUDGET  0.1s\n",
+        "  ┊ 🔎 grep      ITERATION_BUDGET  0.1s\n"
+        "  ┊ 🔎 grep      _ensure_blocker_followup_ticket  0.1s\n"
+        "  ┊ 🔎 grep      another_symbol  0.1s\n",
         encoding="utf-8",
     )
 
@@ -2461,7 +2463,7 @@ def test_implement_pre_edit_drift_does_not_charge_allowed_named_file_read_to_bud
     assert reason is None
 
 
-def test_implement_pre_edit_drift_allows_multiple_distinct_named_file_reads_after_focused_test(
+def test_implement_pre_edit_drift_allows_bounded_named_file_navigation_after_focused_test(
     tmp_path, monkeypatch
 ):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
@@ -2472,6 +2474,9 @@ def test_implement_pre_edit_drift_allows_multiple_distinct_named_file_reads_afte
         "  ┊ 💻 $         cd /work && PYTHONPATH=services/zoe-data python3 -m pytest -q "
         "services/zoe-data/tests/test_main_multica_poll.py::"
         "test_record_blocked_multica_chain_creates_iteration_budget_followup  3.3s\n"
+        "  ┊ 🔎 grep      _record_blocked_multica_chain  0.1s\n"
+        "  ┊ 📖 read      /work/services/zoe-data/main.py  0.1s\n"
+        "  ┊ 🔎 grep      _ensure_blocker_followup_ticket  0.1s\n"
         "  ┊ 📖 read      /work/services/zoe-data/main.py  0.1s\n"
         "  ┊ 📖 read      /work/services/zoe-data/tests/test_main_multica_poll.py  0.1s\n",
         encoding="utf-8",
@@ -2486,7 +2491,7 @@ def test_implement_pre_edit_drift_allows_multiple_distinct_named_file_reads_afte
     assert reason is None
 
 
-def test_implement_pre_edit_drift_blocks_repeated_harness_followup_named_file_read_after_focused_test(
+def test_implement_pre_edit_drift_blocks_excess_harness_followup_navigation_after_focused_test(
     tmp_path, monkeypatch
 ):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
@@ -2497,6 +2502,7 @@ def test_implement_pre_edit_drift_blocks_repeated_harness_followup_named_file_re
         "  ┊ 💻 $         cd /work && PYTHONPATH=services/zoe-data python3 -m pytest -q "
         "services/zoe-data/tests/test_main_multica_poll.py::"
         "test_record_blocked_multica_chain_creates_iteration_budget_followup  3.3s\n"
+        "  ┊ 📖 read      /work/services/zoe-data/main.py  0.1s\n"
         "  ┊ 📖 read      /work/services/zoe-data/main.py  0.1s\n"
         "  ┊ 📖 read      /work/services/zoe-data/main.py  0.1s\n",
         encoding="utf-8",
@@ -2512,7 +2518,7 @@ def test_implement_pre_edit_drift_blocks_repeated_harness_followup_named_file_re
     assert "engineering blocker follow-up kept exploring after focused test" in reason
 
 
-def test_implement_pre_edit_drift_covers_harness_followup_focused_tests_in_other_files(
+def test_implement_pre_edit_drift_blocks_excess_harness_followup_focused_test_greps_in_other_files(
     tmp_path, monkeypatch
 ):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
@@ -2523,7 +2529,9 @@ def test_implement_pre_edit_drift_covers_harness_followup_focused_tests_in_other
         "  ┊ 💻 $         cd /work && PYTHONPATH=services/zoe-data python3 -m pytest -q "
         "services/zoe-data/tests/test_kanban_adapter.py::"
         "test_implement_body_includes_harness_blocker_followup_focused_tests  0.9s\n"
-        "  ┊ 🔎 grep      _ensure_blocker_followup_ticket  0.1s\n",
+        "  ┊ 🔎 grep      _ensure_blocker_followup_ticket  0.1s\n"
+        "  ┊ 🔎 grep      IMPLEMENT_HANDOFF_DRIFT  0.1s\n"
+        "  ┊ 🔎 grep      ALREADY_COVERED  0.1s\n",
         encoding="utf-8",
     )
 
@@ -2903,7 +2911,9 @@ def test_phase_budget_reason_passes_harness_followup_body_to_pre_edit_guard(
         "services/zoe-data/tests/test_main_multica_poll.py::"
         "test_record_blocked_multica_chain_creates_iteration_budget_followup  3.3s\n"
         "  ┊ 📖 read      /work/services/zoe-data/executors/kanban_adapter.py  0.1s\n"
-        "  ┊ 🔎 grep      ITERATION_BUDGET  0.1s\n",
+        "  ┊ 🔎 grep      ITERATION_BUDGET  0.1s\n"
+        "  ┊ 🔎 grep      _ensure_blocker_followup_ticket  0.1s\n"
+        "  ┊ 🔎 grep      another_symbol  0.1s\n",
         encoding="utf-8",
     )
 
@@ -4639,6 +4649,7 @@ def test_implement_body_includes_harness_repo_map_for_blocker_followup_source():
     assert "do not create `.venv`, run `pip install`" in body
     assert "BLOCKER=TEST_ENVIRONMENT" in body
     assert "If the focused test passes before any edit, do not inspect more blocker code" in body
+    assert "use at most two symbol greps and two reads per named file" in body
     assert "edit the named harness file already in scope" in body
     assert "services/zoe-data/main.py" in body
     assert "services/zoe-data/executors/kanban_adapter.py" in body
@@ -4689,6 +4700,7 @@ def test_implement_body_includes_harness_blocker_followup_focused_tests(
     assert expected_test in body
     assert "Use the existing repo/runtime environment only" in body
     assert "If the focused test passes before any edit, do not inspect more blocker code" in body
+    assert "use at most two symbol greps and two reads per named file" in body
     assert "edit the named harness file already in scope" in body
     assert "services/zoe-data/main.py" in body
     assert "services/zoe-data/executors/kanban_adapter.py" in body

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -2463,6 +2463,31 @@ def test_implement_pre_edit_drift_does_not_charge_allowed_named_file_read_to_bud
     assert reason is None
 
 
+def test_implement_pre_edit_drift_honors_post_focus_grep_budget_override(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("ZOE_KANBAN_IMPLEMENT_POST_FOCUS_GREP_BUDGET", "1")
+    log_dir = tmp_path / "kanban" / "logs"
+    log_dir.mkdir(parents=True)
+    (log_dir / "t_impl.log").write_text(
+        "Query: work kanban task t_impl\n"
+        "  ┊ 💻 $         cd /work && PYTHONPATH=services/zoe-data python3 -m pytest -q "
+        "services/zoe-data/tests/test_main_multica_poll.py::"
+        "test_record_blocked_multica_chain_creates_iteration_budget_followup  3.3s\n"
+        "  ┊ 🔎 grep      _record_blocked_multica_chain  0.1s\n"
+        "  ┊ 🔎 grep      _ensure_blocker_followup_ticket  0.1s\n",
+        encoding="utf-8",
+    )
+
+    reason = kb.implement_pre_edit_drift_reason_from_log(
+        "t_impl",
+        "implement",
+        task_body='{"source":"engineering_blocker_followup"}',
+    )
+
+    assert reason is not None
+    assert "engineering blocker follow-up kept exploring after focused test" in reason
+
+
 def test_implement_pre_edit_drift_allows_bounded_named_file_navigation_after_focused_test(
     tmp_path, monkeypatch
 ):
@@ -2489,6 +2514,31 @@ def test_implement_pre_edit_drift_allows_bounded_named_file_navigation_after_foc
     )
 
     assert reason is None
+
+
+def test_implement_pre_edit_drift_honors_post_focus_read_budget_override(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("ZOE_KANBAN_IMPLEMENT_POST_FOCUS_READ_BUDGET", "1")
+    log_dir = tmp_path / "kanban" / "logs"
+    log_dir.mkdir(parents=True)
+    (log_dir / "t_impl.log").write_text(
+        "Query: work kanban task t_impl\n"
+        "  ┊ 💻 $         cd /work && PYTHONPATH=services/zoe-data python3 -m pytest -q "
+        "services/zoe-data/tests/test_main_multica_poll.py::"
+        "test_record_blocked_multica_chain_creates_iteration_budget_followup  3.3s\n"
+        "  ┊ 📖 read      /work/services/zoe-data/main.py  0.1s\n"
+        "  ┊ 📖 read      /work/services/zoe-data/main.py  0.1s\n",
+        encoding="utf-8",
+    )
+
+    reason = kb.implement_pre_edit_drift_reason_from_log(
+        "t_impl",
+        "implement",
+        task_body='{"source":"engineering_blocker_followup"}',
+    )
+
+    assert reason is not None
+    assert "engineering blocker follow-up kept exploring after focused test" in reason
 
 
 def test_implement_pre_edit_drift_blocks_excess_harness_followup_navigation_after_focused_test(

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -4699,7 +4699,7 @@ def test_implement_body_includes_harness_repo_map_for_blocker_followup_source():
     assert "do not create `.venv`, run `pip install`" in body
     assert "BLOCKER=TEST_ENVIRONMENT" in body
     assert "If the focused test passes before any edit, do not inspect more blocker code" in body
-    assert "use at most two symbol greps and two reads per named file" in body
+    assert "use at most two symbol greps total and two reads per named file" in body
     assert "edit the named harness file already in scope" in body
     assert "services/zoe-data/main.py" in body
     assert "services/zoe-data/executors/kanban_adapter.py" in body
@@ -4750,7 +4750,7 @@ def test_implement_body_includes_harness_blocker_followup_focused_tests(
     assert expected_test in body
     assert "Use the existing repo/runtime environment only" in body
     assert "If the focused test passes before any edit, do not inspect more blocker code" in body
-    assert "use at most two symbol greps and two reads per named file" in body
+    assert "use at most two symbol greps total and two reads per named file" in body
     assert "edit the named harness file already in scope" in body
     assert "services/zoe-data/main.py" in body
     assert "services/zoe-data/executors/kanban_adapter.py" in body


### PR DESCRIPTION
## Summary
- allow a small bounded post-focused-test navigation window for engineering blocker follow-ups
- permit two symbol greps and two reads per named harness file before blocking drift
- align the worker prompt and regression tests with the observed ZOE-5463 log pattern

## Verification
- python3 -m py_compile services/zoe-data/kanban_phase_budget.py services/zoe-data/executors/kanban_adapter.py services/zoe-data/tests/test_kanban_adapter.py
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_kanban_adapter.py -k "harness_followup or IMPLEMENT_HANDOFF_DRIFT or focused_test"
- python3 tools/audit/validate_structure.py
- git diff --check