### PR TITLE
Route user issue reports through runtime intake

### DIFF
--- a/services/zoe-data/evolution_notice.py
+++ b/services/zoe-data/evolution_notice.py
@@ -317,7 +317,9 @@ async def record_user_issue(message: str, user_id: str) -> None:
     """
     from db_pool import get_db_ctx
     from multica_client import sync_evolution_proposal_to_multica
-    from zoe_evolution_proposal_adapter import dump_legacy_evolution_proposal_contract
+    from zoe_candidate_scoring import CandidateEvaluation, CandidateScore
+    from zoe_evolution_proposal import EvolutionSignal, EvolutionSignalType
+    from zoe_evolution_runtime_intake import build_runtime_evolution_proposal_intake
 
     title = f"User report: '{message[:60]}'"
     async with get_db_ctx() as db:
@@ -332,26 +334,76 @@ async def record_user_issue(message: str, user_id: str) -> None:
 
         prop_id = uuid.uuid4().hex
         description = f"User {user_id} explicitly reported a problem: {message}"
-        evidence = json.dumps({"user_id": user_id, "message": message})
-        target_patterns = dump_legacy_evolution_proposal_contract(
-            proposal_id=prop_id,
-            title=title,
-            description=description,
-            evidence=evidence,
-            proposal_type="user_issue_report",
-            legacy_writer="evolution_notice:user_issue_report",
+        evidence_ref = f"chat_user_issue:{user_id}:{prop_id}"
+        signal = EvolutionSignal(
+            signal_id=f"signal_{prop_id}",
+            signal_type=EvolutionSignalType.USER_REQUEST.value,
+            summary=description,
+            source="evolution_notice:user_issue_report",
+            evidence_refs=(evidence_ref,),
             user_id=user_id,
-            target_patterns=(message,),
+            scope="personal",
+            metadata={"message_excerpt": message[:500]},
         )
+        candidate = CandidateEvaluation(
+            candidate_id="existing_zoe_user_issue_triage",
+            name="Existing Zoe user issue triage",
+            source="existing_zoe",
+            task="review user-reported issue",
+            score=CandidateScore(
+                fit=4,
+                activity=4,
+                license=5,
+                offline=5,
+                security=4,
+                footprint=5,
+                tests=3,
+                maintainability=4,
+                overlap=5,
+            ),
+            evidence_refs=(
+                evidence_ref,
+                "services/zoe-data/evolution_notice.py:record_user_issue",
+                "services/zoe-data/intent_router.py:user_issue_report",
+            ),
+            license_risk="compatible",
+            offline_viability="required",
+            runtime_notes="Creates a review-only evolution proposal and Multica ticket; no execution or memory write is granted.",
+            overlaps_existing=("evolution_proposals", "multica_governance"),
+            recommendation="needs_review",
+            metadata={"legacy_proposal_type": "user_issue_report"},
+        )
+        intake = build_runtime_evolution_proposal_intake(
+            proposal_id=prop_id,
+            proposal_type="user_issue_report",
+            title=title,
+            problem_statement=description,
+            signal=signal,
+            candidates=(candidate,),
+            affected_capabilities=("chat_experience", "intent_router", "multica_governance"),
+            expected_benefit="Create a reviewable Zoe improvement proposal with explicit user evidence before implementation work.",
+            verification_plan=(
+                "human_or_multica_review_required_before_approval",
+                "implementation_pr_must_attach_tests_and_evidence_before_completion",
+            ),
+            rollback_plan="Reject or defer the proposal; no runtime change has been made by proposal creation.",
+            legacy_target_patterns=(message,),
+            metadata={
+                "legacy_writer": "evolution_notice:user_issue_report",
+                "user_id": user_id,
+                "message_excerpt": message[:500],
+            },
+        )
+        row = intake.to_legacy_row()
         await db.execute(
             """INSERT INTO evolution_proposals
                (id, type, title, description, evidence, target_patterns, status, proposed_at)
                VALUES ($1,'user_issue_report',$2,$3,$4,$5,'pending',$6)""",
-            prop_id,
-            title,
-            description,
-            evidence,
-            target_patterns,
+            row["id"],
+            row["title"],
+            row["description"],
+            row["evidence"],
+            row["target_patterns"],
             time.time(),
         )
         logger.info(
@@ -359,19 +411,13 @@ async def record_user_issue(message: str, user_id: str) -> None:
             user_id, message[:60],
         )
 
-        multica_id = await sync_evolution_proposal_to_multica(
-            proposal_id=prop_id,
-            title=title,
-            description=description,
-            evidence=evidence,
-            proposal_type="user_issue_report",
-            label_name="user-feedback",
-            contract_snapshot=target_patterns,
-        )
+        multica_payload = dict(intake.multica_payload or {})
+        multica_payload["label_name"] = "user-feedback"
+        multica_id = await sync_evolution_proposal_to_multica(**multica_payload)
         if multica_id:
             await db.execute(
                 "UPDATE evolution_proposals SET multica_issue_id=$1 WHERE id=$2",
-                multica_id, prop_id,
+                multica_id, row["id"],
             )
 
 

--- a/services/zoe-data/tests/test_evolution_notice_measure.py
+++ b/services/zoe-data/tests/test_evolution_notice_measure.py
@@ -161,12 +161,14 @@ async def test_record_frustration_signal_stores_contract_snapshot(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_record_user_issue_stores_contract_snapshot(monkeypatch):
+async def test_record_user_issue_stores_runtime_intake_contract_snapshot(monkeypatch):
     db = _WriterDb()
+    sync_calls = []
 
     monkeypatch.setitem(sys.modules, "db_pool", types.SimpleNamespace(get_db_ctx=lambda: db))
 
-    async def fake_sync_evolution_proposal_to_multica(**_kwargs):
+    async def fake_sync_evolution_proposal_to_multica(**kwargs):
+        sync_calls.append(kwargs)
         return None
 
     monkeypatch.setitem(
@@ -178,14 +180,30 @@ async def test_record_user_issue_stores_contract_snapshot(monkeypatch):
     await evolution_notice.record_user_issue("weather failed again", "jason")
 
     assert len(db.execute_calls) == 1
+    assert len(sync_calls) == 1
     insert_sql, insert_args = db.execute_calls[0]
     assert "target_patterns" in insert_sql
+    evidence = json.loads(insert_args[3])
     contract = json.loads(insert_args[4])
     assert insert_args[1] == "User report: 'weather failed again'"
+    assert evidence["source"] == "runtime_evolution_intake"
+    assert evidence["signal"]["source"] == "evolution_notice:user_issue_report"
+    assert evidence["signal"]["scope"] == "personal"
+    assert evidence["signal"]["user_id"] == "jason"
+    assert evidence["candidate_ids"] == ["existing_zoe_user_issue_triage"]
     assert contract["schema"] == "zoe_evolution_proposal"
-    assert contract["legacy_writer"] == "evolution_notice:user_issue_report"
-    assert contract["proposal"]["metadata"]["legacy_proposal_type"] == "user_issue_report"
-    assert contract["proposal"]["metadata"]["legacy_target_patterns"] == ["weather failed again"]
+    assert contract["legacy_writer"] == "runtime_evolution_intake"
+    proposal = contract["proposal"]
+    assert proposal["metadata"]["legacy_proposal_type"] == "user_issue_report"
+    assert proposal["metadata"]["legacy_writer"] == "evolution_notice:user_issue_report"
+    assert proposal["metadata"]["legacy_target_patterns"] == ["weather failed again"]
+    assert proposal["metadata"]["selected_candidate_id"] == "existing_zoe_user_issue_triage"
+    assert proposal["metadata"]["candidate_search"][0]["candidate_id"] == "existing_zoe_user_issue_triage"
+    assert proposal["approval_gate"]["allowed_to_execute"] is False
+    assert sync_calls[0]["proposal_id"] == insert_args[0]
+    assert sync_calls[0]["proposal_type"] == "user_issue_report"
+    assert sync_calls[0]["label_name"] == "user-feedback"
+    assert sync_calls[0]["contract_snapshot"] == insert_args[4]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- route evolution_notice.record_user_issue through the runtime evolution intake helper
- preserve the legacy evolution_proposals row shape and Multica sync behavior
- add focused assertions that runtime-intake evidence, candidate search, personal scope, and contract snapshots reach DB and Multica boundaries

## Verification
- python3 -m py_compile services/zoe-data/evolution_notice.py services/zoe-data/zoe_evolution_runtime_intake.py services/zoe-data/tests/test_evolution_notice_measure.py
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_evolution_notice_measure.py services/zoe-data/tests/test_zoe_evolution_runtime_intake.py services/zoe-data/tests/test_zoe_evolution_proposal_adapter.py
- python3 tools/audit/validate_structure.py
- python3 tools/audit/validate_critical_files.py
- python3 tools/audit/validate_offline_memory.py
- git diff --check