### PR TITLE
Tune harness follow-up focused-test read budget

### DIFF
--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -386,7 +386,7 @@ def _harness_implement_hint(issue: dict | None = None) -> str:
             " `kanban_block` with BLOCKER=TEST_ENVIRONMENT and the first import error instead of"
             " spending turns on environment repair."
             " If the focused test passes before any edit, do not inspect more blocker code:"
-            " use at most two symbol greps total and two reads per named file, then edit the"
+            " use at most two symbol greps total, up to four reads of the focused test file, and two reads per other named file, then edit the"
             " named harness file already in scope (usually services/zoe-data/main.py,"
             " services/zoe-data/tests/test_main_multica_poll.py, or"
             " services/zoe-data/executors/kanban_adapter.py) with the smallest guard, or call `kanban_block` with"

--- a/services/zoe-data/kanban_phase_budget.py
+++ b/services/zoe-data/kanban_phase_budget.py
@@ -64,6 +64,10 @@ _FOCUSED_HARNESS_TEST_RE = re.compile(
     r"\bpython3\s+-m\s+pytest\b.*services/zoe-data/tests/\S+\.py::\S+",
     re.IGNORECASE,
 )
+_FOCUSED_HARNESS_TEST_PATH_RE = re.compile(
+    r"(?P<path>services/zoe-data/tests/\S+\.py)::\S+",
+    re.IGNORECASE,
+)
 _CODE_AUDIT_BODY_RE = re.compile(
     r"CODE-AUDIT FAST PATH|\bcode_audit\b",
     re.IGNORECASE,
@@ -107,6 +111,7 @@ _MARK_REVIEWED_VERDICT_RE = re.compile(
 )
 _ZERO_STEP_WARNED: set[str] = set()
 _POST_FOCUS_READ_BUDGET_DEFAULT = 2
+_POST_FOCUS_FOCUSED_TEST_READ_BUDGET_DEFAULT = 4
 _POST_FOCUS_GREP_BUDGET_DEFAULT = 2
 
 
@@ -280,6 +285,26 @@ def _post_focus_read_budget() -> int:
         )
     except ValueError:
         return _POST_FOCUS_READ_BUDGET_DEFAULT
+
+
+def _post_focus_focused_test_read_budget() -> int:
+    try:
+        return max(
+            1,
+            int(
+                os.environ.get(
+                    "ZOE_KANBAN_IMPLEMENT_POST_FOCUS_FOCUSED_TEST_READ_BUDGET",
+                    str(_POST_FOCUS_FOCUSED_TEST_READ_BUDGET_DEFAULT),
+                )
+            ),
+        )
+    except ValueError:
+        return _POST_FOCUS_FOCUSED_TEST_READ_BUDGET_DEFAULT
+
+
+def _focused_harness_test_path(line: str) -> str:
+    match = _FOCUSED_HARNESS_TEST_PATH_RE.search(line)
+    return match.group("path") if match else ""
 
 
 def _post_focus_grep_budget() -> int:
@@ -585,14 +610,17 @@ def implement_pre_edit_drift_reason_from_log(
     repeat_read_budget = _pre_edit_repeat_read_budget()
     explore_steps = 0
     focused_harness_test_seen = False
+    focused_harness_test_path = ""
     post_focus_allowed_reads = {
         "services/zoe-data/main.py",
         "services/zoe-data/tests/test_main_multica_poll.py",
         "services/zoe-data/executors/kanban_adapter.py",
     }
+    post_focus_allowed_read_paths = set(post_focus_allowed_reads)
     post_focus_read_counts: dict[str, int] = {}
     post_focus_grep_steps = 0
     post_focus_read_budget = _post_focus_read_budget()
+    post_focus_focused_test_read_budget = _post_focus_focused_test_read_budget()
     post_focus_grep_budget = _post_focus_grep_budget()
     read_counts: dict[str, int] = {}
     for line in step_lines:
@@ -600,6 +628,9 @@ def implement_pre_edit_drift_reason_from_log(
             return None
         if harness_followup and _FOCUSED_HARNESS_TEST_RE.search(line):
             focused_harness_test_seen = True
+            focused_harness_test_path = _focused_harness_test_path(line)
+            if focused_harness_test_path:
+                post_focus_allowed_read_paths.add(focused_harness_test_path)
             continue
         if not _EXPLORE_STEP_RE.search(line):
             continue
@@ -607,14 +638,17 @@ def implement_pre_edit_drift_reason_from_log(
         if focused_harness_test_seen:
             path = _read_path_key(read_match.group("path")) if read_match else ""
             matched_allowed_path = next(
-                (allowed for allowed in post_focus_allowed_reads if path.endswith(allowed)),
+                (allowed for allowed in post_focus_allowed_read_paths if path.endswith(allowed)),
                 "",
             )
             if matched_allowed_path:
                 post_focus_read_counts[matched_allowed_path] = (
                     post_focus_read_counts.get(matched_allowed_path, 0) + 1
                 )
-                if post_focus_read_counts[matched_allowed_path] <= post_focus_read_budget:
+                read_budget = post_focus_read_budget
+                if focused_harness_test_path and matched_allowed_path == focused_harness_test_path:
+                    read_budget = post_focus_focused_test_read_budget
+                if post_focus_read_counts[matched_allowed_path] <= read_budget:
                     continue
             elif _GREP_STEP_RE.search(line):
                 post_focus_grep_steps += 1

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -2516,6 +2516,95 @@ def test_implement_pre_edit_drift_allows_bounded_named_file_navigation_after_foc
     assert reason is None
 
 
+
+
+def test_implement_pre_edit_drift_allows_repeated_focused_test_reads_after_focused_test(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    log_dir = tmp_path / "kanban" / "logs"
+    log_dir.mkdir(parents=True)
+    (log_dir / "t_impl.log").write_text(
+        "Query: work kanban task t_impl\n"
+        "  ┊ ⚡ kanban_sh   0.0s\n"
+        "  ┊ 💻 $ cd /home/zoe/.worktrees/t_impl && pwd && git branch --show-current  0.1s\n"
+        "  ┊ 💻 $ cd /home/zoe/.worktrees/t_impl && PYTHONPATH=services/zoe-data "
+        "python3 -m pytest -q services/zoe-data/tests/test_main_multica_poll.py::"
+        "test_record_blocked_multica_chain_creates_iteration_budget_followup  3.3s\n"
+        "  ┊ 📖 read /home/zoe/.worktrees/t_impl/services/zoe-data/tests/test_main_multica_poll.py  0.1s\n"
+        "  ┊ 🔎 grep test_record_blocked_multica_chain_creates_iteration_budget_followup  0.1s\n"
+        "  ┊ 📖 read /home/zoe/.worktrees/t_impl/services/zoe-data/tests/test_main_multica_poll.py  0.1s\n"
+        "  ┊ 📖 read /home/zoe/.worktrees/t_impl/services/zoe-data/tests/test_main_multica_poll.py  0.1s\n",
+        encoding="utf-8",
+    )
+
+    reason = kb.implement_pre_edit_drift_reason_from_log(
+        "t_impl",
+        "implement",
+        task_body='{"source":"engineering_blocker_followup"}',
+    )
+
+    assert reason is None
+
+
+
+def test_implement_pre_edit_drift_honors_focused_test_read_budget_override(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("ZOE_KANBAN_IMPLEMENT_POST_FOCUS_FOCUSED_TEST_READ_BUDGET", "1")
+    log_dir = tmp_path / "kanban" / "logs"
+    log_dir.mkdir(parents=True)
+    (log_dir / "t_impl.log").write_text(
+        "Query: work kanban task t_impl\n"
+        "  ┊ 💻 $ cd /work && PYTHONPATH=services/zoe-data python3 -m pytest -q "
+        "services/zoe-data/tests/test_kanban_adapter.py::"
+        "test_implement_body_includes_harness_blocker_followup_focused_tests  0.9s\n"
+        "  ┊ 📖 read /work/services/zoe-data/tests/test_kanban_adapter.py  0.1s\n"
+        "  ┊ 📖 read /work/services/zoe-data/tests/test_kanban_adapter.py  0.1s\n",
+        encoding="utf-8",
+    )
+
+    reason = kb.implement_pre_edit_drift_reason_from_log(
+        "t_impl",
+        "implement",
+        task_body='{"source":"engineering_blocker_followup"}',
+    )
+
+    assert reason is not None
+    assert "engineering blocker follow-up kept exploring after focused test" in reason
+
+
+def test_implement_pre_edit_drift_blocks_excess_focused_test_reads_after_focused_test(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    log_dir = tmp_path / "kanban" / "logs"
+    log_dir.mkdir(parents=True)
+    (log_dir / "t_impl.log").write_text(
+        "Query: work kanban task t_impl\n"
+        "  ┊ 💻 $ cd /work && PYTHONPATH=services/zoe-data python3 -m pytest -q "
+        "services/zoe-data/tests/test_kanban_adapter.py::"
+        "test_implement_body_includes_harness_blocker_followup_focused_tests  0.9s\n"
+        + "\n".join(
+            "  ┊ 📖 read /work/services/zoe-data/tests/test_kanban_adapter.py  0.1s"
+            for _ in range(5)
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    reason = kb.implement_pre_edit_drift_reason_from_log(
+        "t_impl",
+        "implement",
+        task_body='{"source":"engineering_blocker_followup"}',
+    )
+
+    assert reason is not None
+    assert "engineering blocker follow-up kept exploring after focused test" in reason
+
+
+
 def test_implement_pre_edit_drift_honors_post_focus_read_budget_override(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     monkeypatch.setenv("ZOE_KANBAN_IMPLEMENT_POST_FOCUS_READ_BUDGET", "1")
@@ -4699,7 +4788,7 @@ def test_implement_body_includes_harness_repo_map_for_blocker_followup_source():
     assert "do not create `.venv`, run `pip install`" in body
     assert "BLOCKER=TEST_ENVIRONMENT" in body
     assert "If the focused test passes before any edit, do not inspect more blocker code" in body
-    assert "use at most two symbol greps total and two reads per named file" in body
+    assert "use at most two symbol greps total, up to four reads of the focused test file, and two reads per other named file" in body
     assert "edit the named harness file already in scope" in body
     assert "services/zoe-data/main.py" in body
     assert "services/zoe-data/executors/kanban_adapter.py" in body
@@ -4750,7 +4839,7 @@ def test_implement_body_includes_harness_blocker_followup_focused_tests(
     assert expected_test in body
     assert "Use the existing repo/runtime environment only" in body
     assert "If the focused test passes before any edit, do not inspect more blocker code" in body
-    assert "use at most two symbol greps total and two reads per named file" in body
+    assert "use at most two symbol greps total, up to four reads of the focused test file, and two reads per other named file" in body
     assert "edit the named harness file already in scope" in body
     assert "services/zoe-data/main.py" in body
     assert "services/zoe-data/executors/kanban_adapter.py" in body


### PR DESCRIPTION
## Summary
- allow engineering blocker follow-ups up to four reads of the exact focused test file after the focused test runs
- keep the existing two-read cap for other named files and two-grep cap after focus
- update the Hermes handoff text to match the runtime guard

## Tests
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_kanban_adapter.py -k "harness_followup or focused_test or post_focus or IMPLEMENT_HANDOFF_DRIFT"
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_kanban_adapter.py services/zoe-data/tests/test_main_multica_poll.py -k "harness_followup or focused_test or post_focus or IMPLEMENT_HANDOFF_DRIFT or blocker_followup or running_multica_chain_progress or completed_multica_chain"
- python3 tools/audit/validate_structure.py
- python3 tools/audit/validate_critical_files.py
- python3 tools/audit/validate_offline_memory.py