### PR TITLE
Route frustration signals through runtime intake

### DIFF
--- a/services/zoe-data/evolution_notice.py
+++ b/services/zoe-data/evolution_notice.py
@@ -242,7 +242,9 @@ async def record_frustration_signal(
     """Write a user frustration proposal (called from chat.py inline)."""
     from db_pool import get_db_ctx
     from multica_client import sync_evolution_proposal_to_multica
-    from zoe_evolution_proposal_adapter import dump_legacy_evolution_proposal_contract
+    from zoe_candidate_scoring import CandidateEvaluation, CandidateScore
+    from zoe_evolution_proposal import EvolutionSignal, EvolutionSignalType
+    from zoe_evolution_runtime_intake import build_runtime_evolution_proposal_intake
 
     title = f"User frustration: '{normalized_message[:60]}'"
     async with get_db_ctx() as db:
@@ -260,31 +262,76 @@ async def record_frustration_signal(
             f"User {user_id} sent a substantially similar message {repeat_count} times "
             f"in session {session_id} without a satisfying response."
         )
-        evidence = json.dumps({
-            "user_id": user_id,
-            "session_id": session_id,
-            "repeat_count": repeat_count,
-            "message": normalized_message,
-        })
-        target_patterns = dump_legacy_evolution_proposal_contract(
-            proposal_id=prop_id,
-            title=title,
-            description=description,
-            evidence=evidence,
-            proposal_type="user_frustration",
-            legacy_writer="evolution_notice:user_frustration",
+        evidence_ref = f"chat_user_frustration:{user_id}:{session_id}:{prop_id}"
+        signal = EvolutionSignal(
+            signal_id=f"signal_{prop_id}",
+            signal_type=EvolutionSignalType.USER_REQUEST.value,
+            summary=description,
+            source="evolution_notice:user_frustration",
+            evidence_refs=(evidence_ref,),
             user_id=user_id,
-            target_patterns=(normalized_message,),
+            scope="personal",
+            metadata={
+                "session_id": session_id,
+                "repeat_count": repeat_count,
+                "message_excerpt": normalized_message[:500],
+            },
         )
+        candidate = CandidateEvaluation(
+            candidate_id="existing_zoe_frustration_triage",
+            name="Existing Zoe frustration triage",
+            source="existing_zoe",
+            task="review repeated user frustration",
+            score=CandidateScore(
+                fit=4,
+                activity=4,
+                license=5,
+                offline=5,
+                security=4,
+                footprint=5,
+                tests=3,
+                maintainability=4,
+                overlap=5,
+            ),
+            evidence_refs=(
+                evidence_ref,
+                "services/zoe-data/evolution_notice.py:record_frustration_signal",
+                "services/zoe-data/routers/chat.py:frustration_signal",
+            ),
+            license_risk="compatible",
+            offline_viability="required",
+            runtime_notes="Creates a review-only evolution proposal and Multica ticket; no execution or memory write is granted.",
+            overlaps_existing=("evolution_proposals", "multica_governance"),
+            recommendation="needs_review",
+            metadata={"legacy_proposal_type": "user_frustration"},
+        )
+        intake = build_runtime_evolution_proposal_intake(
+            proposal_id=prop_id,
+            proposal_type="user_frustration",
+            title=title,
+            problem_statement=description,
+            signal=signal,
+            candidates=(candidate,),
+            affected_capabilities=("chat_experience", "memory_router", "observation_trace"),
+            expected_benefit="Create a reviewable Zoe improvement proposal with explicit repeated-frustration evidence before implementation work.",
+            verification_plan=(
+                "human_or_multica_review_required_before_approval",
+                "implementation_pr_must_attach_tests_and_evidence_before_completion",
+            ),
+            rollback_plan="Reject or defer the proposal; no runtime change has been made by proposal creation.",
+            legacy_target_patterns=(normalized_message,),
+            metadata={"legacy_writer": "evolution_notice:user_frustration"},
+        )
+        row = intake.to_legacy_row()
         await db.execute(
             """INSERT INTO evolution_proposals
                (id, type, title, description, evidence, target_patterns, status, proposed_at)
                VALUES ($1,'user_frustration',$2,$3,$4,$5,'pending',$6)""",
-            prop_id,
-            title,
-            description,
-            evidence,
-            target_patterns,
+            row["id"],
+            row["title"],
+            row["description"],
+            row["evidence"],
+            row["target_patterns"],
             time.time(),
         )
         logger.info(
@@ -292,19 +339,14 @@ async def record_frustration_signal(
             user_id, normalized_message[:60], repeat_count,
         )
 
-        # Sync to Multica board
-        multica_id = await sync_evolution_proposal_to_multica(
-            proposal_id=prop_id,
-            title=title,
-            description=description,
-            evidence=evidence,
-            proposal_type="user_frustration",
-            contract_snapshot=target_patterns,
-        )
+        if not intake.multica_payload:
+            return
+        multica_payload = dict(intake.multica_payload)
+        multica_id = await sync_evolution_proposal_to_multica(**multica_payload)
         if multica_id:
             await db.execute(
                 "UPDATE evolution_proposals SET multica_issue_id=$1 WHERE id=$2",
-                multica_id, prop_id,
+                multica_id, row["id"],
             )
 
 
@@ -388,11 +430,7 @@ async def record_user_issue(message: str, user_id: str) -> None:
             ),
             rollback_plan="Reject or defer the proposal; no runtime change has been made by proposal creation.",
             legacy_target_patterns=(message,),
-            metadata={
-                "legacy_writer": "evolution_notice:user_issue_report",
-                "user_id": user_id,
-                "message_excerpt": message[:500],
-            },
+            metadata={"legacy_writer": "evolution_notice:user_issue_report"},
         )
         row = intake.to_legacy_row()
         await db.execute(
@@ -411,7 +449,9 @@ async def record_user_issue(message: str, user_id: str) -> None:
             user_id, message[:60],
         )
 
-        multica_payload = dict(intake.multica_payload or {})
+        if not intake.multica_payload:
+            return
+        multica_payload = dict(intake.multica_payload)
         multica_payload["label_name"] = "user-feedback"
         multica_id = await sync_evolution_proposal_to_multica(**multica_payload)
         if multica_id:

--- a/services/zoe-data/tests/test_evolution_notice_measure.py
+++ b/services/zoe-data/tests/test_evolution_notice_measure.py
@@ -129,12 +129,14 @@ def test_load_target_patterns_extracts_contract_metadata():
 
 
 @pytest.mark.asyncio
-async def test_record_frustration_signal_stores_contract_snapshot(monkeypatch):
+async def test_record_frustration_signal_stores_runtime_intake_contract_snapshot(monkeypatch):
     db = _WriterDb()
+    sync_calls = []
 
     monkeypatch.setitem(sys.modules, "db_pool", types.SimpleNamespace(get_db_ctx=lambda: db))
 
-    async def fake_sync_evolution_proposal_to_multica(**_kwargs):
+    async def fake_sync_evolution_proposal_to_multica(**kwargs):
+        sync_calls.append(kwargs)
         return None
 
     monkeypatch.setitem(
@@ -151,13 +153,35 @@ async def test_record_frustration_signal_stores_contract_snapshot(monkeypatch):
     )
 
     assert len(db.execute_calls) == 1
+    assert len(sync_calls) == 1
     insert_sql, insert_args = db.execute_calls[0]
     assert "target_patterns" in insert_sql
+    evidence = json.loads(insert_args[3])
     contract = json.loads(insert_args[4])
+    assert insert_args[1] == "User frustration: 'why can't you remember the bins'"
+    assert evidence["source"] == "runtime_evolution_intake"
+    assert evidence["signal"]["source"] == "evolution_notice:user_frustration"
+    assert evidence["signal"]["scope"] == "personal"
+    assert evidence["signal"]["user_id"] == "jason"
+    assert evidence["signal"]["metadata"]["session_id"] == "sess-1"
+    assert evidence["signal"]["metadata"]["repeat_count"] == 3
+    assert evidence["candidate_ids"] == ["existing_zoe_frustration_triage"]
     assert contract["schema"] == "zoe_evolution_proposal"
-    assert contract["legacy_writer"] == "evolution_notice:user_frustration"
-    assert contract["proposal"]["metadata"]["legacy_target_patterns"] == ["why can't you remember the bins"]
-    assert contract["proposal"]["signals"][0]["scope"] == "personal"
+    assert contract["legacy_writer"] == "runtime_evolution_intake"
+    proposal = contract["proposal"]
+    assert proposal["metadata"]["legacy_proposal_type"] == "user_frustration"
+    assert proposal["metadata"]["legacy_writer"] == "evolution_notice:user_frustration"
+    assert proposal["metadata"]["legacy_target_patterns"] == ["why can't you remember the bins"]
+    assert "user_id" not in proposal["metadata"]
+    assert "session_id" not in proposal["metadata"]
+    assert "repeat_count" not in proposal["metadata"]
+    assert "message_excerpt" not in proposal["metadata"]
+    assert proposal["metadata"]["selected_candidate_id"] == "existing_zoe_frustration_triage"
+    assert proposal["metadata"]["candidate_search"][0]["candidate_id"] == "existing_zoe_frustration_triage"
+    assert proposal["approval_gate"]["allowed_to_execute"] is False
+    assert sync_calls[0]["proposal_id"] == insert_args[0]
+    assert sync_calls[0]["proposal_type"] == "user_frustration"
+    assert sync_calls[0]["contract_snapshot"] == insert_args[4]
 
 
 @pytest.mark.asyncio
@@ -197,6 +221,8 @@ async def test_record_user_issue_stores_runtime_intake_contract_snapshot(monkeyp
     assert proposal["metadata"]["legacy_proposal_type"] == "user_issue_report"
     assert proposal["metadata"]["legacy_writer"] == "evolution_notice:user_issue_report"
     assert proposal["metadata"]["legacy_target_patterns"] == ["weather failed again"]
+    assert "user_id" not in proposal["metadata"]
+    assert "message_excerpt" not in proposal["metadata"]
     assert proposal["metadata"]["selected_candidate_id"] == "existing_zoe_user_issue_triage"
     assert proposal["metadata"]["candidate_search"][0]["candidate_id"] == "existing_zoe_user_issue_triage"
     assert proposal["approval_gate"]["allowed_to_execute"] is False


### PR DESCRIPTION
## Summary
- route evolution_notice.record_frustration_signal through the runtime evolution intake helper
- preserve the legacy evolution_proposals row shape and Multica sync behavior
- add focused assertions that runtime-intake evidence, candidate search, personal scope, repeat/session metadata, and contract snapshots reach DB and Multica boundaries

## Verification
- python3 -m py_compile services/zoe-data/evolution_notice.py services/zoe-data/zoe_evolution_runtime_intake.py services/zoe-data/tests/test_evolution_notice_measure.py
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_evolution_notice_measure.py services/zoe-data/tests/test_zoe_evolution_runtime_intake.py services/zoe-data/tests/test_zoe_evolution_proposal_adapter.py
- python3 tools/audit/validate_structure.py
- python3 tools/audit/validate_critical_files.py
- python3 tools/audit/validate_offline_memory.py
- git diff --check