### PR TITLE
Route agent health notices through runtime intake

### DIFF
--- a/services/zoe-data/evolution_notice.py
+++ b/services/zoe-data/evolution_notice.py
@@ -92,7 +92,10 @@ async def run_evolution_notice() -> dict:
     """Run the NOTICE phase — returns summary dict."""
     from db_pool import get_db_ctx
     from multica_client import sync_evolution_proposal_to_multica
+    from zoe_candidate_scoring import CandidateEvaluation, CandidateScore
+    from zoe_evolution_proposal import EvolutionSignal, EvolutionSignalType
     from zoe_evolution_proposal_adapter import dump_legacy_evolution_proposal_contract
+    from zoe_evolution_runtime_intake import build_runtime_evolution_proposal_intake
 
     created = 0
     skipped = 0
@@ -193,41 +196,80 @@ async def run_evolution_notice() -> dict:
                 continue
             prop_id = uuid.uuid4().hex
             description = f"{tier} had {errors}/{total} ({int(100*errors/total)}%) slow/error calls in 24h."
-            evidence_data = json.dumps({"agent_tier": tier, "total": total, "errors": errors})
-            target_patterns = dump_legacy_evolution_proposal_contract(
-                proposal_id=prop_id,
-                title=title,
-                description=description,
-                evidence=evidence_data,
-                proposal_type="agent_health",
-                legacy_writer="evolution_notice:agent_health",
+            evidence_ref = f"llm_call_log:agent_health:{tier}:{prop_id}"
+            signal = EvolutionSignal(
+                signal_id=f"signal_{prop_id}",
+                signal_type=EvolutionSignalType.OUTCOME_EVAL_FAILURE.value,
+                summary=description,
+                source="evolution_notice:agent_health",
+                evidence_refs=(evidence_ref,),
+                scope="system",
+                metadata={"agent_tier": tier, "total": total, "errors": errors},
             )
+            candidate = CandidateEvaluation(
+                candidate_id="existing_zoe_agent_health_triage",
+                name="Existing Zoe agent health triage",
+                source="existing_zoe",
+                task="review agent health spike",
+                score=CandidateScore(
+                    fit=4,
+                    activity=4,
+                    license=5,
+                    offline=5,
+                    security=4,
+                    footprint=5,
+                    tests=3,
+                    maintainability=4,
+                    overlap=5,
+                ),
+                evidence_refs=(
+                    evidence_ref,
+                    "services/zoe-data/evolution_notice.py:run_evolution_notice",
+                    "llm_call_log:agent_tier_latency",
+                ),
+                license_risk="compatible",
+                offline_viability="required",
+                runtime_notes="Creates a review-only agent-health evolution proposal and Multica ticket; no execution is granted.",
+                overlaps_existing=("evolution_proposals", "multica_governance", "llm_call_log"),
+                recommendation="needs_review",
+                metadata={"legacy_proposal_type": "agent_health"},
+            )
+            intake = build_runtime_evolution_proposal_intake(
+                proposal_id=prop_id,
+                proposal_type="agent_health",
+                title=title,
+                problem_statement=description,
+                signal=signal,
+                candidates=(candidate,),
+                affected_capabilities=("agent_runtime", "multica_governance", "observation_trace"),
+                expected_benefit="Create a reviewable Zoe health proposal from measured LLM error evidence before implementation work.",
+                verification_plan=(
+                    "human_or_multica_review_required_before_approval",
+                    "implementation_pr_must_attach_tests_and_evidence_before_completion",
+                ),
+                rollback_plan="Reject or defer the proposal; no runtime change has been made by proposal creation.",
+                metadata={"legacy_writer": "evolution_notice:agent_health"},
+            )
+            row_payload = intake.to_legacy_row()
             await db.execute(
                 """INSERT INTO evolution_proposals
                    (id, type, title, description, evidence, target_patterns, status, proposed_at)
                    VALUES ($1,'agent_health',$2,$3,$4,$5,'pending',$6)""",
-                prop_id,
-                title,
-                description,
-                evidence_data,
-                target_patterns,
+                row_payload["id"],
+                row_payload["title"],
+                row_payload["description"],
+                row_payload["evidence"],
+                row_payload["target_patterns"],
                 time.time(),
             )
             created += 1
 
-            # Sync to Multica board
-            multica_id = await sync_evolution_proposal_to_multica(
-                proposal_id=prop_id,
-                title=title,
-                description=description,
-                evidence=evidence_data,
-                proposal_type="agent_health",
-                contract_snapshot=target_patterns,
-            )
+            multica_payload = dict(intake.multica_payload)
+            multica_id = await sync_evolution_proposal_to_multica(**multica_payload)
             if multica_id:
                 await db.execute(
                     "UPDATE evolution_proposals SET multica_issue_id=$1 WHERE id=$2",
-                    multica_id, prop_id,
+                    multica_id, row_payload["id"],
                 )
 
     return {"created": created, "skipped_dedup": skipped, "clusters": len(clusters)}
@@ -339,8 +381,6 @@ async def record_frustration_signal(
             user_id, normalized_message[:60], repeat_count,
         )
 
-        if not intake.multica_payload:
-            return
         multica_payload = dict(intake.multica_payload)
         multica_id = await sync_evolution_proposal_to_multica(**multica_payload)
         if multica_id:
@@ -449,8 +489,6 @@ async def record_user_issue(message: str, user_id: str) -> None:
             user_id, message[:60],
         )
 
-        if not intake.multica_payload:
-            return
         multica_payload = dict(intake.multica_payload)
         multica_payload["label_name"] = "user-feedback"
         multica_id = await sync_evolution_proposal_to_multica(**multica_payload)

--- a/services/zoe-data/tests/test_evolution_notice_measure.py
+++ b/services/zoe-data/tests/test_evolution_notice_measure.py
@@ -243,7 +243,10 @@ async def test_run_evolution_notice_stores_contract_snapshots(monkeypatch):
     )
     monkeypatch.setitem(sys.modules, "db_pool", types.SimpleNamespace(get_db_ctx=lambda: db))
 
-    async def fake_sync_evolution_proposal_to_multica(**_kwargs):
+    sync_calls = []
+
+    async def fake_sync_evolution_proposal_to_multica(**kwargs):
+        sync_calls.append(kwargs)
         return None
 
     monkeypatch.setitem(
@@ -262,12 +265,27 @@ async def test_run_evolution_notice_stores_contract_snapshots(monkeypatch):
     assert "target_patterns" in health_sql
 
     intent_contract = json.loads(intent_args[5])
+    health_evidence = json.loads(health_args[3])
     health_contract = json.loads(health_args[4])
+    assert len(sync_calls) == 2
     assert intent_contract["legacy_writer"] == "evolution_notice:intent_miss_cluster"
     assert intent_contract["proposal"]["metadata"]["legacy_target_patterns"] == [
         "turn on kitchen lights",
         "turn on kitchen lights",
         "turn on kitchen lights",
     ]
-    assert health_contract["legacy_writer"] == "evolution_notice:agent_health"
-    assert health_contract["proposal"]["metadata"]["legacy_proposal_type"] == "agent_health"
+    assert health_evidence["source"] == "runtime_evolution_intake"
+    assert health_evidence["signal"]["source"] == "evolution_notice:agent_health"
+    assert health_evidence["signal"]["scope"] == "system"
+    assert health_evidence["signal"]["metadata"] == {"agent_tier": "gemma4", "total": 20, "errors": 3}
+    assert health_evidence["candidate_ids"] == ["existing_zoe_agent_health_triage"]
+    assert health_contract["legacy_writer"] == "runtime_evolution_intake"
+    health_proposal = health_contract["proposal"]
+    assert health_proposal["metadata"]["legacy_proposal_type"] == "agent_health"
+    assert health_proposal["metadata"]["legacy_writer"] == "evolution_notice:agent_health"
+    assert health_proposal["metadata"]["selected_candidate_id"] == "existing_zoe_agent_health_triage"
+    assert health_proposal["metadata"]["candidate_search"][0]["candidate_id"] == "existing_zoe_agent_health_triage"
+    assert health_proposal["approval_gate"]["allowed_to_execute"] is False
+    assert sync_calls[1]["proposal_id"] == health_args[0]
+    assert sync_calls[1]["proposal_type"] == "agent_health"
+    assert sync_calls[1]["contract_snapshot"] == health_args[4]


### PR DESCRIPTION
## Summary
- route the nightly agent_health NOTICE writer through the runtime evolution intake helper
- preserve the legacy evolution_proposals row shape and Multica sync behavior
- add focused assertions that runtime-intake evidence, candidate search, system scope, agent health metrics, and contract snapshots reach DB and Multica boundaries

## Verification
- python3 -m py_compile services/zoe-data/evolution_notice.py services/zoe-data/zoe_evolution_runtime_intake.py services/zoe-data/tests/test_evolution_notice_measure.py
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_evolution_notice_measure.py services/zoe-data/tests/test_zoe_evolution_runtime_intake.py services/zoe-data/tests/test_zoe_evolution_proposal_adapter.py
- python3 tools/audit/validate_structure.py
- python3 tools/audit/validate_critical_files.py
- python3 tools/audit/validate_offline_memory.py
- git diff --check