### PR TITLE
Skip already covered harness follow-ups

### DIFF
--- a/services/zoe-data/kanban_phase_budget.py
+++ b/services/zoe-data/kanban_phase_budget.py
@@ -655,9 +655,8 @@ def implement_pre_edit_drift_reason_from_log(
                 if post_focus_grep_steps <= post_focus_grep_budget:
                     continue
             return (
-                "BLOCKER=IMPLEMENT_HANDOFF_DRIFT: engineering blocker follow-up kept "
-                "exploring after focused test beyond the named-file navigation budget "
-                "instead of editing or blocking ALREADY_COVERED"
+                "BLOCKER=ALREADY_COVERED: focused harness test passed before edit; "
+                "no code change required for this blocker follow-up"
             )
         explore_steps += 1
         if explore_steps > explore_budget:

--- a/services/zoe-data/pipeline_store.py
+++ b/services/zoe-data/pipeline_store.py
@@ -251,6 +251,11 @@ def resume_pipeline(
     raise AssertionError("unreachable")
 
 
+
+def _already_covered_block(phase: str, block_reason: str | None) -> bool:
+    return phase == "implement" and "ALREADY_COVERED" in str(block_reason or "").upper()
+
+
 def skip_blocked_implementation(
     task_ref: str,
     *,
@@ -685,6 +690,35 @@ async def _sync_pipeline_from_chain_once(
                 detail, row_block_reason=row.get("block_reason")
             ) or outcome
             split_requested, handoff_split_packet = split_request_from_handoff(detail)
+            if _already_covered_block(phase, block_reason):  # type: ignore[arg-type]
+                state = state.model_copy(update={"evidence_profile": "audit"})
+                state = with_evidence(
+                    state,
+                    EvidenceItem(
+                        kind="tool",
+                        summary="focused harness test passed before edit; implementation already covered",
+                        passed=True,
+                        metadata={"source": "already_covered", "phase": "implement"},
+                    ),
+                )
+                state = transition(state, "skip_implementation", reason=str(block_reason))
+                state = state.model_copy(
+                    update={
+                        "last_block_fingerprint": None,
+                        "repeated_block_count": 0,
+                        "block_classification": None,
+                        "split_packet": None,
+                    }
+                )
+                state = await _run_io(
+                    partial(
+                        save_state,
+                        state,
+                        event="already_covered_implementation_skipped",
+                        extra={"row_phase": phase, "reason": block_reason},
+                    )
+                )
+                continue
             fingerprint = block_fingerprint(phase, str(block_reason))  # type: ignore[arg-type]
             if state.status == "blocked" and fingerprint == state.last_block_fingerprint:
                 return state

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -2407,7 +2407,7 @@ def test_implement_pre_edit_drift_blocks_excess_harness_followup_grep_after_focu
     )
 
     assert reason is not None
-    assert "engineering blocker follow-up kept exploring after focused test" in reason
+    assert "BLOCKER=ALREADY_COVERED" in reason
 
 
 def test_implement_pre_edit_drift_allows_harness_followup_named_file_read_after_focused_test(
@@ -2515,7 +2515,7 @@ def test_implement_pre_edit_drift_honors_post_focus_grep_budget_override(tmp_pat
     )
 
     assert reason is not None
-    assert "engineering blocker follow-up kept exploring after focused test" in reason
+    assert "BLOCKER=ALREADY_COVERED" in reason
 
 
 def test_implement_pre_edit_drift_allows_bounded_named_file_navigation_after_focused_test(
@@ -2602,7 +2602,7 @@ def test_implement_pre_edit_drift_honors_focused_test_read_budget_override(
     )
 
     assert reason is not None
-    assert "engineering blocker follow-up kept exploring after focused test" in reason
+    assert "BLOCKER=ALREADY_COVERED" in reason
 
 
 def test_implement_pre_edit_drift_blocks_excess_focused_test_reads_after_focused_test(
@@ -2631,7 +2631,7 @@ def test_implement_pre_edit_drift_blocks_excess_focused_test_reads_after_focused
     )
 
     assert reason is not None
-    assert "engineering blocker follow-up kept exploring after focused test" in reason
+    assert "BLOCKER=ALREADY_COVERED" in reason
 
 
 
@@ -2657,7 +2657,7 @@ def test_implement_pre_edit_drift_honors_post_focus_read_budget_override(tmp_pat
     )
 
     assert reason is not None
-    assert "engineering blocker follow-up kept exploring after focused test" in reason
+    assert "BLOCKER=ALREADY_COVERED" in reason
 
 
 def test_implement_pre_edit_drift_blocks_excess_harness_followup_navigation_after_focused_test(
@@ -2684,7 +2684,7 @@ def test_implement_pre_edit_drift_blocks_excess_harness_followup_navigation_afte
     )
 
     assert reason is not None
-    assert "engineering blocker follow-up kept exploring after focused test" in reason
+    assert "BLOCKER=ALREADY_COVERED" in reason
 
 
 def test_implement_pre_edit_drift_blocks_excess_harness_followup_focused_test_greps_in_other_files(
@@ -2712,7 +2712,39 @@ def test_implement_pre_edit_drift_blocks_excess_harness_followup_focused_test_gr
     )
 
     assert reason is not None
-    assert "engineering blocker follow-up kept exploring after focused test" in reason
+    assert "BLOCKER=ALREADY_COVERED" in reason
+
+
+def test_implement_pre_edit_drift_maps_post_focus_budget_exhaustion_to_already_covered(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    log_dir = tmp_path / "kanban" / "logs"
+    log_dir.mkdir(parents=True)
+    (log_dir / "t_impl.log").write_text(
+        "Query: work kanban task t_impl\n"
+        "  ┊ 💻 $ cd /work && PYTHONPATH=services/zoe-data python3 -m pytest -q "
+        "services/zoe-data/tests/test_main_multica_poll.py::"
+        "test_record_blocked_multica_chain_creates_iteration_budget_followup  3.3s\n"
+        "  ┊ 📖 read /work/services/zoe-data/tests/test_main_multica_poll.py  0.1s\n"
+        "  ┊ 🔎 grep test_record_blocked_multica_chain_creates_iteration_budget_followup  0.1s\n"
+        "  ┊ 📖 read /work/services/zoe-data/tests/test_main_multica_poll.py  0.1s\n"
+        "  ┊ 🔎 grep _record_blocked_multica_chain  0.1s\n"
+        "  ┊ 📖 read /work/services/zoe-data/main.py  0.1s\n"
+        "  ┊ 🔎 grep _ensure_blocker_followup_ticket  0.1s\n"
+        "  ┊ 📖 read /work/services/zoe-data/main.py  0.1s\n"
+        "  ┊ 🔎 grep _blocker_followup_marker  0.1s\n",
+        encoding="utf-8",
+    )
+
+    reason = kb.implement_pre_edit_drift_reason_from_log(
+        "t_impl",
+        "implement",
+        task_body='{"source":"engineering_blocker_followup"}',
+    )
+
+    assert reason is not None
+    assert "BLOCKER=ALREADY_COVERED" in reason
 
 
 def test_implement_pre_edit_drift_ignores_plain_followup_prompt_without_metadata(
@@ -3102,7 +3134,7 @@ def test_phase_budget_reason_passes_harness_followup_body_to_pre_edit_guard(
     )
 
     assert reason is not None
-    assert "engineering blocker follow-up kept exploring after focused test" in reason
+    assert "BLOCKER=ALREADY_COVERED" in reason
 
 
 def test_phase_budget_blocks_repeated_ambiguous_patch_attempts(tmp_path, monkeypatch):

--- a/services/zoe-data/tests/test_pipeline_store.py
+++ b/services/zoe-data/tests/test_pipeline_store.py
@@ -463,6 +463,41 @@ async def test_sync_pipeline_advances_on_complete_handoff(isolated_store):
 
 
 @pytest.mark.asyncio
+async def test_sync_pipeline_skips_already_covered_implement_block(isolated_store):
+    await store.bootstrap_state(
+        "multica:already-covered",
+        issue={"metadata": {"evidence_profile": "code"}},
+    )
+    phases = {
+        "implement": {
+            "id": "t_impl",
+            "status": "blocked",
+            "block_reason": "ALREADY_COVERED: focused harness test passed before edit",
+        }
+    }
+
+    async def fetch_detail(_task_id: str):
+        return {
+            "latest_summary": "BLOCKER=ALREADY_COVERED: focused harness test passed before edit",
+            "comments": [],
+        }
+
+    state = await store.sync_pipeline_from_chain("multica:already-covered", phases, fetch_detail)
+
+    assert state.phase == "verify"
+    assert state.status == "todo"
+    assert state.evidence_profile == "audit"
+    assert state.last_block_fingerprint is None
+    assert state.repeated_block_count == 0
+    assert state.history[-1].outcome == "skip_implementation"
+    events = [
+        json.loads(line)["event"]
+        for line in isolated_store.read_text(encoding="utf-8").strip().splitlines()
+    ]
+    assert "already_covered_implementation_skipped" in events
+
+
+@pytest.mark.asyncio
 async def test_sync_pipeline_blocks_code_implement_without_pr(isolated_store):
     await store.bootstrap_state("multica:no-pr-code", issue={"metadata": {"evidence_profile": "code"}})
 


### PR DESCRIPTION
## Summary
- emit BLOCKER=ALREADY_COVERED when an engineering blocker follow-up proves the focused test passes but keeps navigating instead of editing
- make the pipeline driver turn ALREADY_COVERED implement blocks into a deterministic no-code skip to verify
- add regression coverage for the guard and pipeline transition

## Tests
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_kanban_adapter.py -k "harness_followup or focused_test or post_focus or IMPLEMENT_HANDOFF_DRIFT or already_covered"
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_pipeline_store.py -k "already_covered or skip_blocked_implementation"
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_kanban_adapter.py services/zoe-data/tests/test_pipeline_store.py services/zoe-data/tests/test_main_multica_poll.py -k "harness_followup or focused_test or post_focus or IMPLEMENT_HANDOFF_DRIFT or already_covered or skip_blocked_implementation or blocker_followup or running_multica_chain_progress or completed_multica_chain"
- python3 tools/audit/validate_structure.py
- python3 tools/audit/validate_critical_files.py
- python3 tools/audit/validate_offline_memory.py