### PR TITLE
Route MCP evolution proposals through runtime intake

### DIFF
--- a/services/zoe-data/mcp_server.py
+++ b/services/zoe-data/mcp_server.py
@@ -2992,48 +2992,46 @@ async def _execute_tool(db, name: str, args: dict):
     elif name == "create_evolution_proposal":
         try:
             from multica_client import sync_evolution_proposal_to_multica  # type: ignore[import]
-            from zoe_evolution_proposal_adapter import (  # type: ignore[import]
-                dump_mcp_evolution_proposal_contract,
-                normalize_mcp_evolution_proposal_type,
-            )
+            from zoe_evolution_runtime_intake import build_mcp_runtime_evolution_proposal_intake  # type: ignore[import]
             import time as _time
             title = (args.get("title") or "").strip()
             description = (args.get("description") or "").strip()
             if not title or not description:
                 return {"error": "title and description required"}
             evidence = (args.get("evidence") or "").strip()
-            proposal_type = normalize_mcp_evolution_proposal_type(args.get("proposal_type", "intent_pattern"))
             prop_id = str(uuid.uuid4()).replace("-", "")
-            contract_snapshot = dump_mcp_evolution_proposal_contract(
+            proposal_user_id = str(_uid_raw).strip() if _uid_raw else None
+            intake = build_mcp_runtime_evolution_proposal_intake(
                 proposal_id=prop_id,
                 title=title,
                 description=description,
                 evidence=evidence,
-                proposal_type=proposal_type,
-                user_id=args.get("_user_id") or args.get("user_id"),
+                proposal_type=args.get("proposal_type", "intent_pattern"),
+                user_id=proposal_user_id,
             )
+            row_payload = intake.to_legacy_row()
             await db.execute(
                 """INSERT INTO evolution_proposals
                    (id, title, description, evidence, target_patterns, type, status, proposed_at)
                    VALUES ($1,$2,$3,$4,$5,$6,'pending',$7)""",
-                prop_id, title, description, evidence, contract_snapshot, proposal_type, _time.time(),
+                row_payload["id"],
+                row_payload["title"],
+                row_payload["description"],
+                row_payload["evidence"],
+                row_payload["target_patterns"],
+                row_payload["type"],
+                _time.time(),
             )
-            multica_id = await sync_evolution_proposal_to_multica(
-                proposal_id=prop_id,
-                title=title,
-                description=description,
-                evidence=evidence,
-                proposal_type=proposal_type,
-                contract_snapshot=contract_snapshot,
-            )
+            multica_payload = dict(intake.multica_payload)
+            multica_id = await sync_evolution_proposal_to_multica(**multica_payload)
             if multica_id:
                 await db.execute(
                     "UPDATE evolution_proposals SET multica_issue_id=$1 WHERE id=$2",
-                    multica_id, prop_id,
+                    multica_id, row_payload["id"],
                 )
             return {
                 "ok": True,
-                "proposal_id": prop_id,
+                "proposal_id": row_payload["id"],
                 "multica_issue_id": multica_id,
                 "contract_schema": "zoe_evolution_proposal",
             }

--- a/services/zoe-data/tests/test_panel_mcp_tools.py
+++ b/services/zoe-data/tests/test_panel_mcp_tools.py
@@ -80,8 +80,11 @@ class _RecordingDb:
 
 
 @pytest.mark.asyncio
-async def test_create_evolution_proposal_stores_contract_snapshot(monkeypatch):
-    async def fake_sync_evolution_proposal_to_multica(**_kwargs):
+async def test_create_evolution_proposal_stores_runtime_intake_contract_snapshot(monkeypatch):
+    sync_calls = []
+
+    async def fake_sync_evolution_proposal_to_multica(**kwargs):
+        sync_calls.append(kwargs)
         return "multica-issue-123"
 
     monkeypatch.setitem(
@@ -107,22 +110,38 @@ async def test_create_evolution_proposal_stores_contract_snapshot(monkeypatch):
     assert result["multica_issue_id"] == "multica-issue-123"
     assert result["contract_schema"] == "zoe_evolution_proposal"
     assert len(db.calls) == 2
+    assert len(sync_calls) == 1
     insert_sql, insert_args = db.calls[0]
     update_sql, update_args = db.calls[1]
     assert "target_patterns" in insert_sql
     assert "target_patterns" not in update_sql
 
+    insert_evidence = json.loads(insert_args[3])
     insert_contract = json.loads(insert_args[4])
+    assert insert_evidence["source"] == "runtime_evolution_intake"
+    assert insert_evidence["signal"]["source"] == "mcp:create_evolution_proposal"
+    assert insert_evidence["signal"]["scope"] == "personal"
+    assert insert_evidence["signal"]["user_id"] == "jason"
+    assert insert_evidence["candidate_ids"] == ["existing_zoe_intent_pattern"]
     assert insert_contract["schema"] == "zoe_evolution_proposal"
-    assert insert_contract["proposal"]["status"] == "pending_approval"
-    assert insert_contract["proposal"]["multica_issue_id"] is None
-    assert insert_contract["proposal"]["signals"][0]["signal_type"] == "repeated_failure"
-    assert insert_contract["proposal"]["approval_gate"]["allowed_to_execute"] is False
+    assert insert_contract["legacy_writer"] == "runtime_evolution_intake"
+    proposal = insert_contract["proposal"]
+    assert proposal["status"] == "pending_approval"
+    assert proposal["multica_issue_id"] is None
+    assert proposal["signals"][0]["signal_type"] == "repeated_failure"
+    assert proposal["metadata"]["legacy_writer"] == "mcp:create_evolution_proposal"
+    assert proposal["metadata"]["legacy_proposal_type"] == "intent_pattern"
+    assert proposal["metadata"]["selected_candidate_id"] == "existing_zoe_intent_pattern"
+    assert proposal["metadata"]["candidate_search"][0]["candidate_id"] == "existing_zoe_intent_pattern"
+    assert proposal["approval_gate"]["allowed_to_execute"] is False
+    assert sync_calls[0]["proposal_id"] == insert_args[0]
+    assert sync_calls[0]["proposal_type"] == "intent_pattern"
+    assert sync_calls[0]["contract_snapshot"] == insert_args[4]
     assert update_args == ("multica-issue-123", result["proposal_id"])
 
 
 @pytest.mark.asyncio
-async def test_create_evolution_proposal_keeps_contract_when_multica_unconfigured(monkeypatch):
+async def test_create_evolution_proposal_keeps_system_scope_without_explicit_user(monkeypatch):
     async def fake_sync_evolution_proposal_to_multica(**_kwargs):
         return None
 
@@ -150,9 +169,16 @@ async def test_create_evolution_proposal_keeps_contract_when_multica_unconfigure
     insert_sql, insert_args = db.calls[0]
     assert "target_patterns" in insert_sql
     contract = json.loads(insert_args[4])
+    evidence = json.loads(insert_args[3])
+    assert evidence["source"] == "runtime_evolution_intake"
+    assert evidence["signal"]["source"] == "mcp:create_evolution_proposal"
+    assert evidence["signal"]["scope"] == "system"
+    assert evidence["signal"]["user_id"] is None
     assert contract["schema"] == "zoe_evolution_proposal"
+    assert contract["legacy_writer"] == "runtime_evolution_intake"
     assert insert_args[5] == "code_improvement"
     assert contract["proposal"]["metadata"]["legacy_proposal_type"] == "code_improvement"
+    assert contract["proposal"]["metadata"]["selected_candidate_id"] == "existing_zoe_code_improvement"
     assert contract["proposal"]["multica_issue_id"] is None
     assert contract["proposal"]["signals"][0]["signal_type"] == "tool_gap"
 

--- a/services/zoe-data/zoe_evolution_proposal_adapter.py
+++ b/services/zoe-data/zoe_evolution_proposal_adapter.py
@@ -40,6 +40,58 @@ _AFFECTED_CAPABILITIES_BY_TYPE = {
 }
 
 
+def legacy_signal_type_for_proposal_type(proposal_type: str | None) -> str:
+    """Return the contract signal type for a legacy proposal type."""
+
+    return _SIGNAL_BY_LEGACY_TYPE[normalize_legacy_evolution_proposal_type(proposal_type)]
+
+
+def build_existing_zoe_proposal_candidate(
+    *,
+    proposal_type: str | None,
+    title: str,
+    evidence_refs: Sequence[str],
+    legacy_writer: str,
+    runtime_notes: str | None = None,
+    target_patterns: Sequence[str] = (),
+) -> CandidateEvaluation:
+    """Build the standard review-only existing-Zoe candidate for proposal writers."""
+
+    normalized_type = normalize_legacy_evolution_proposal_type(proposal_type)
+    legacy_target_patterns = tuple(str(item) for item in target_patterns if item is not None)
+    metadata: dict[str, Any] = {
+        "legacy_proposal_type": normalized_type,
+        "legacy_writer": legacy_writer,
+    }
+    if legacy_target_patterns:
+        metadata["legacy_target_patterns"] = list(legacy_target_patterns)
+    return CandidateEvaluation(
+        candidate_id=f"existing_zoe_{normalized_type}",
+        name="Existing Zoe proposal path",
+        source="existing_zoe",
+        task=title,
+        score=CandidateScore(
+            fit=4,
+            activity=4,
+            license=5,
+            offline=5,
+            security=4,
+            footprint=5,
+            tests=3,
+            maintainability=4,
+            overlap=5,
+        ),
+        evidence_refs=tuple(evidence_refs),
+        license_risk="compatible",
+        offline_viability="required",
+        runtime_notes=runtime_notes
+        or f"Legacy proposal writer {legacy_writer} creates review-only proposals; no execution is granted by this contract.",
+        overlaps_existing=("evolution_proposals", "multica_governance"),
+        recommendation="needs_review",
+        metadata=metadata,
+    )
+
+
 def build_legacy_evolution_proposal_contract(
     *,
     proposal_id: str,
@@ -65,7 +117,7 @@ def build_legacy_evolution_proposal_contract(
     legacy_target_patterns = tuple(str(item) for item in target_patterns if item is not None)
     signal = EvolutionSignal(
         signal_id=f"signal_{proposal_id}",
-        signal_type=_SIGNAL_BY_LEGACY_TYPE[normalized_type],
+        signal_type=legacy_signal_type_for_proposal_type(normalized_type),
         summary=description,
         source=legacy_writer,
         evidence_refs=evidence_refs,
@@ -77,33 +129,12 @@ def build_legacy_evolution_proposal_contract(
             "legacy_target_patterns": list(legacy_target_patterns),
         },
     )
-    candidate = CandidateEvaluation(
-        candidate_id=f"existing_zoe_{normalized_type}",
-        name="Existing Zoe proposal path",
-        source="existing_zoe",
-        task=title,
-        score=CandidateScore(
-            fit=4,
-            activity=4,
-            license=5,
-            offline=5,
-            security=4,
-            footprint=5,
-            tests=3,
-            maintainability=4,
-            overlap=5,
-        ),
+    candidate = build_existing_zoe_proposal_candidate(
+        proposal_type=normalized_type,
+        title=title,
         evidence_refs=evidence_refs,
-        license_risk="compatible",
-        offline_viability="required",
-        runtime_notes=f"Legacy proposal writer {legacy_writer} creates review-only proposals; no execution is granted by this contract.",
-        overlaps_existing=("evolution_proposals", "multica_governance"),
-        recommendation="needs_review",
-        metadata={
-            "legacy_proposal_type": normalized_type,
-            "legacy_writer": legacy_writer,
-            "legacy_target_patterns": list(legacy_target_patterns),
-        },
+        legacy_writer=legacy_writer,
+        target_patterns=legacy_target_patterns,
     )
     proposal = build_evolution_proposal(
         proposal_id=proposal_id,
@@ -243,10 +274,12 @@ def _evidence_refs(source_ref: str, evidence: str) -> tuple[str, ...]:
 
 __all__ = [
     "CONTRACT_ENVELOPE_VERSION",
+    "build_existing_zoe_proposal_candidate",
     "build_legacy_evolution_proposal_contract",
     "build_mcp_evolution_proposal_contract",
     "dump_legacy_evolution_proposal_contract",
     "dump_mcp_evolution_proposal_contract",
+    "legacy_signal_type_for_proposal_type",
     "load_proposal_contract_snapshot",
     "normalize_legacy_evolution_proposal_type",
     "normalize_mcp_evolution_proposal_type",

--- a/services/zoe-data/zoe_evolution_runtime_intake.py
+++ b/services/zoe-data/zoe_evolution_runtime_intake.py
@@ -21,7 +21,12 @@ from zoe_evolution_proposal import (
     TrustAutonomyClass,
     build_evolution_proposal,
 )
-from zoe_evolution_proposal_adapter import CONTRACT_ENVELOPE_VERSION
+from zoe_evolution_proposal_adapter import (
+    CONTRACT_ENVELOPE_VERSION,
+    build_existing_zoe_proposal_candidate,
+    legacy_signal_type_for_proposal_type,
+    normalize_mcp_evolution_proposal_type,
+)
 
 RUNTIME_INTAKE_SOURCE = "runtime_evolution_intake"
 _SCHEMA = "zoe_evolution_proposal"
@@ -78,6 +83,56 @@ class RuntimeEvolutionProposalIntake:
             "status": self.status,
         }
 
+
+
+def build_mcp_runtime_evolution_proposal_intake(
+    *,
+    proposal_id: str,
+    title: str,
+    description: str,
+    evidence: str = "",
+    proposal_type: str = "intent_pattern",
+    user_id: str | None = None,
+) -> RuntimeEvolutionProposalIntake:
+    """Build an inert runtime-intake row for the MCP proposal writer."""
+
+    normalized_type = normalize_mcp_evolution_proposal_type(proposal_type)
+    normalized_user_id = str(user_id).strip() if user_id else None
+    source_ref = f"mcp:create_evolution_proposal:{proposal_id}"
+    evidence_refs = _evidence_refs(source_ref, evidence)
+    signal = EvolutionSignal(
+        signal_id=f"signal_{proposal_id}",
+        signal_type=legacy_signal_type_for_proposal_type(normalized_type),
+        summary=description,
+        source="mcp:create_evolution_proposal",
+        evidence_refs=evidence_refs,
+        user_id=normalized_user_id,
+        scope="personal" if normalized_user_id else "system",
+        metadata={"evidence_excerpt": evidence[:500], "mcp_tool": "create_evolution_proposal"},
+    )
+    candidate = build_existing_zoe_proposal_candidate(
+        proposal_type=normalized_type,
+        title=title,
+        evidence_refs=evidence_refs,
+        legacy_writer="mcp:create_evolution_proposal",
+        runtime_notes="MCP creates review-only evolution proposals; no execution is granted by this contract.",
+    )
+    return build_runtime_evolution_proposal_intake(
+        proposal_id=proposal_id,
+        proposal_type=normalized_type,
+        title=title,
+        problem_statement=description,
+        signal=signal,
+        candidates=(candidate,),
+        affected_capabilities=("zoe_codebase", "multica_governance", "verification"),
+        expected_benefit="Create a reviewable Zoe improvement proposal with MCP-supplied evidence before implementation work.",
+        verification_plan=(
+            "human_or_multica_review_required_before_approval",
+            "implementation_pr_must_attach_tests_and_evidence_before_completion",
+        ),
+        rollback_plan="Reject or defer the proposal; no runtime change has been made by proposal creation.",
+        metadata={"legacy_writer": "mcp:create_evolution_proposal"},
+    )
 
 def build_runtime_evolution_proposal_intake(
     *,
@@ -170,6 +225,13 @@ def build_runtime_evolution_proposal_intake(
     )
 
 
+def _evidence_refs(source_ref: str, evidence: str) -> tuple[str, ...]:
+    refs = [source_ref]
+    if evidence.strip():
+        refs.append(f"evidence:{source_ref}")
+    return tuple(refs)
+
+
 def _approval_requirements(*, autonomy_class: str, risk: str, explicit: Sequence[str]) -> tuple[str, ...]:
     approval_required: list[str] = []
     approval_required.extend(_AUTONOMY_APPROVALS.get(autonomy_class, ()))
@@ -199,5 +261,6 @@ def _evidence_payload(
 __all__ = [
     "RUNTIME_INTAKE_SOURCE",
     "RuntimeEvolutionProposalIntake",
+    "build_mcp_runtime_evolution_proposal_intake",
     "build_runtime_evolution_proposal_intake",
 ]


### PR DESCRIPTION
## Summary
- route MCP create_evolution_proposal through the runtime evolution intake helper
- preserve the legacy evolution_proposals row shape and Multica sync behavior
- add focused assertions that runtime-intake evidence, candidate search, user scope, and contract snapshots reach DB and Multica boundaries

## Verification
- python3 -m py_compile services/zoe-data/mcp_server.py services/zoe-data/zoe_evolution_runtime_intake.py services/zoe-data/tests/test_panel_mcp_tools.py
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_panel_mcp_tools.py services/zoe-data/tests/test_zoe_evolution_runtime_intake.py services/zoe-data/tests/test_zoe_evolution_proposal_adapter.py services/zoe-data/tests/test_multica_client.py
- python3 tools/audit/validate_structure.py
- python3 tools/audit/validate_critical_files.py
- python3 tools/audit/validate_offline_memory.py
- git diff --check