### PR TITLE
Allow bounded post-patch file review

### DIFF
--- a/services/zoe-data/kanban_phase_budget.py
+++ b/services/zoe-data/kanban_phase_budget.py
@@ -238,11 +238,18 @@ def implement_edit_safety_reason_from_log(task_id: str, phase: str, *, session: 
         return None
 
     pending_python_patch = False
+    patched_python_paths: set[str] = set()
+    post_patch_read_counts: dict[str, int] = {}
+    allowed_post_patch_reads = _post_patch_file_read_budget()
     for line in session.splitlines():
         if not _STEP_LINE_RE.match(line):
             continue
-        if _PYTHON_PATCH_RE.search(line):
+        patch_match = _PATCH_PATH_RE.search(line) if _PYTHON_PATCH_RE.search(line) else None
+        if patch_match:
             pending_python_patch = True
+            path_key = _read_path_key(patch_match.group("path"))
+            patched_python_paths.add(path_key)
+            post_patch_read_counts.pop(path_key, None)
             continue
         if not pending_python_patch:
             continue
@@ -250,7 +257,22 @@ def implement_edit_safety_reason_from_log(task_id: str, phase: str, *, session: 
             continue
         if _PYTHON_CHECK_RE.search(line):
             pending_python_patch = False
+            patched_python_paths.clear()
+            post_patch_read_counts.clear()
             continue
+        read_match = _READ_STEP_RE.search(line)
+        if read_match:
+            path = _read_path_key(read_match.group("path"))
+            matched_patch = next(
+                (patched for patched in patched_python_paths if path.endswith(patched)),
+                "",
+            )
+            if matched_patch:
+                post_patch_read_counts[matched_patch] = (
+                    post_patch_read_counts.get(matched_patch, 0) + 1
+                )
+                if post_patch_read_counts[matched_patch] <= allowed_post_patch_reads:
+                    continue
         return (
             "BLOCKER=IMPLEMENT_EDIT_SAFETY: Python patch was followed by more "
             "exploration before py_compile/focused tests"
@@ -270,6 +292,13 @@ def _pre_edit_repeat_read_budget() -> int:
         return max(1, int(os.environ.get("ZOE_KANBAN_IMPLEMENT_PRE_EDIT_REPEAT_READ_BUDGET", "6")))
     except ValueError:
         return 6
+
+
+def _post_patch_file_read_budget() -> int:
+    try:
+        return max(0, int(os.environ.get("ZOE_KANBAN_IMPLEMENT_POST_PATCH_FILE_READ_BUDGET", "2")))
+    except ValueError:
+        return 2
 
 
 def _post_focus_read_budget() -> int:

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -2176,13 +2176,31 @@ def test_phase_budget_reason_recovers_hermes_iteration_budget_log(tmp_path, monk
     )
 
 
-def test_implement_edit_safety_blocks_python_patch_without_immediate_check(tmp_path, monkeypatch):
+def test_implement_edit_safety_allows_bounded_patched_file_read_before_check(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     log_dir = tmp_path / "kanban" / "logs"
     log_dir.mkdir(parents=True)
     (log_dir / "t_impl.log").write_text(
         "Query: work kanban task t_impl\n"
         "  ┊ 🔧 patch     /work/services/zoe-data/intent_router.py  5.9s\n"
+        "  ┊ 📖 read      /work/services/zoe-data/intent_router.py  0.1s\n"
+        "  ┊ 📖 read      /work/services/zoe-data/intent_router.py  0.1s\n"
+        "  ┊ 💻 $         python3 -m py_compile services/zoe-data/intent_router.py  0.2s\n",
+        encoding="utf-8",
+    )
+
+    assert kb.implement_edit_safety_reason_from_log("t_impl", "implement") is None
+
+
+def test_implement_edit_safety_blocks_excess_patched_file_reads_before_check(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    log_dir = tmp_path / "kanban" / "logs"
+    log_dir.mkdir(parents=True)
+    (log_dir / "t_impl.log").write_text(
+        "Query: work kanban task t_impl\n"
+        "  ┊ 🔧 patch     /work/services/zoe-data/intent_router.py  5.9s\n"
+        "  ┊ 📖 read      /work/services/zoe-data/intent_router.py  0.1s\n"
+        "  ┊ 📖 read      /work/services/zoe-data/intent_router.py  0.1s\n"
         "  ┊ 📖 read      /work/services/zoe-data/intent_router.py  0.1s\n",
         encoding="utf-8",
     )
@@ -2193,6 +2211,65 @@ def test_implement_edit_safety_blocks_python_patch_without_immediate_check(tmp_p
         "BLOCKER=IMPLEMENT_EDIT_SAFETY: Python patch was followed by more "
         "exploration before py_compile/focused tests"
     )
+
+
+def test_implement_edit_safety_blocks_unrelated_file_read_before_check(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    log_dir = tmp_path / "kanban" / "logs"
+    log_dir.mkdir(parents=True)
+    (log_dir / "t_impl.log").write_text(
+        "Query: work kanban task t_impl\n"
+        "  ┊ 🔧 patch     /work/services/zoe-data/intent_router.py  5.9s\n"
+        "  ┊ 📖 read      /work/services/zoe-data/main.py  0.1s\n",
+        encoding="utf-8",
+    )
+
+    reason = kb.implement_edit_safety_reason_from_log("t_impl", "implement")
+
+    assert reason == (
+        "BLOCKER=IMPLEMENT_EDIT_SAFETY: Python patch was followed by more "
+        "exploration before py_compile/focused tests"
+    )
+
+
+def test_implement_edit_safety_repatch_resets_patched_file_read_budget(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    log_dir = tmp_path / "kanban" / "logs"
+    log_dir.mkdir(parents=True)
+    (log_dir / "t_impl.log").write_text(
+        "Query: work kanban task t_impl\n"
+        "  ┊ 🔧 patch     /work/services/zoe-data/intent_router.py  5.9s\n"
+        "  ┊ 📖 read      /work/services/zoe-data/intent_router.py  0.1s\n"
+        "  ┊ 📖 read      /work/services/zoe-data/intent_router.py  0.1s\n"
+        "  ┊ 🔧 patch     /work/services/zoe-data/intent_router.py  0.5s\n"
+        "  ┊ 📖 read      /work/services/zoe-data/intent_router.py  0.1s\n",
+        encoding="utf-8",
+    )
+
+    assert kb.implement_edit_safety_reason_from_log("t_impl", "implement") is None
+
+
+def test_implement_edit_safety_allows_live_patch_review_shape(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    log_dir = tmp_path / "kanban" / "logs"
+    log_dir.mkdir(parents=True)
+    (log_dir / "t_impl.log").write_text(
+        "Query: work kanban task t_impl\n"
+        "  ┊ 🔧 patch     /work/services/zoe-data/multica_ticket_contract.py  1.6s\n"
+        "  ┊ review diff\n"
+        "a//work/services/zoe-data/multica_ticket_contract.py → "
+        "b//work/services/zoe-data/multica_ticket_contract.py\n"
+        "@@ -31,6 +31,7 @@\n"
+        "  ┊ 🔧 patch     /work/services/zoe-data/multica_ticket_contract.py  0.5s\n"
+        "  ┊ review diff\n"
+        "a//work/services/zoe-data/multica_ticket_contract.py → "
+        "b//work/services/zoe-data/multica_ticket_contract.py\n"
+        "@@ -119,6 +119,7 @@\n"
+        "  ┊ 📖 read      /work/services/zoe-data/multica_ticket_contract.py  0.1s\n",
+        encoding="utf-8",
+    )
+
+    assert kb.implement_edit_safety_reason_from_log("t_impl", "implement") is None
 
 
 def test_implement_edit_safety_allows_immediate_python_check(tmp_path, monkeypatch):
@@ -2240,7 +2317,7 @@ def test_implement_edit_safety_blocks_explore_after_patch_review_diff(tmp_path, 
         "  ┊ review diff\n"
         "a//work/services/zoe-data/intent_router.py → b//work/services/zoe-data/intent_router.py\n"
         "@@ -410,7 +410,8 @@\n"
-        "  ┊ 📖 read      /work/services/zoe-data/intent_router.py  0.1s\n",
+        "  ┊ 🔎 grep      def execute_intent  0.1s\n",
         encoding="utf-8",
     )
 


### PR DESCRIPTION
## Summary
- allow up to two reads of files patched by the current Python patch before the mandatory py_compile/focused test check
- keep blocking unrelated reads/greps/finds before validation
- add regression coverage for the live ZOE-5464 failure shape

## Verification
- python3 -m py_compile services/zoe-data/kanban_phase_budget.py
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_kanban_adapter.py -k implement_edit_safety
- live t_bd4422b7 edit-safety log now returns no blocker under the patched rule