### PR TITLE
Persist Multica completion reasons

### DIFF
--- a/services/zoe-data/multica_client.py
+++ b/services/zoe-data/multica_client.py
@@ -347,6 +347,7 @@ class MULClient:
         merge_sha: str | None = None,
         status: str | None = None,
         dispatch_approved: bool | None = None,
+        completion_reason: str | None = None,
     ) -> dict:
         """Record operator-visible Zoe progress on a Multica issue."""
         from multica_ticket_contract import update_ticket_progress
@@ -364,6 +365,7 @@ class MULClient:
             greptile_status=greptile_status,
             merge_sha=merge_sha,
             dispatch_approved=dispatch_approved,
+            completion_reason=completion_reason,
         )
         return await self.update_issue(issue_id, status=status, description=updated_description)
 

--- a/services/zoe-data/multica_ticket_contract.py
+++ b/services/zoe-data/multica_ticket_contract.py
@@ -31,6 +31,7 @@ DEFAULT_TICKET: dict[str, Any] = {
     "greptile_status": None,
     "phase": None,
     "last_evidence": None,
+    "completion_reason": None,
 }
 
 
@@ -118,6 +119,7 @@ def update_ticket_progress(
     merge_sha: str | None = None,
     child_issue_ids: list[str] | None = None,
     dispatch_approved: bool | None = None,
+    completion_reason: str | None = None,
 ) -> str:
     """Patch progress fields inside the Zoe block without touching prose."""
     current = parse_ticket_block(description)
@@ -140,6 +142,8 @@ def update_ticket_progress(
         metadata["child_issue_ids"] = child_issue_ids
     if dispatch_approved is not None:
         metadata["dispatch_approved"] = dispatch_approved
+    if completion_reason is not None:
+        metadata["completion_reason"] = completion_reason
     metadata["updated_at"] = datetime.now(timezone.utc).isoformat()
     return write_ticket_block(description, metadata)
 

--- a/services/zoe-data/tests/test_multica_client_helpers.py
+++ b/services/zoe-data/tests/test_multica_client_helpers.py
@@ -48,6 +48,30 @@ async def test_record_progress_can_clear_blocker():
     assert metadata["phase"] == "closeout"
 
 
+@pytest.mark.asyncio
+async def test_record_progress_writes_completion_reason():
+    class Client(MULClient):
+        async def get_issue(self, issue_id):
+            return {
+                "id": issue_id,
+                "description": describe_ticket("Done issue"),
+            }
+
+        async def update_issue(self, issue_id, **kwargs):
+            return {"id": issue_id, **kwargs}
+
+    updated = await Client().record_progress(
+        "issue-1",
+        phase="done",
+        status="done",
+        completion_reason="merged after Greptile 5/5",
+    )
+
+    metadata = parse_ticket_block(updated["description"])
+    assert metadata["phase"] == "done"
+    assert metadata["completion_reason"] == "merged after Greptile 5/5"
+
+
 def test_update_ticket_progress_can_clear_dispatch_approval():
     from multica_ticket_contract import parse_ticket_block, update_ticket_progress, write_ticket_block
 

--- a/services/zoe-data/tests/test_multica_ticket_contract.py
+++ b/services/zoe-data/tests/test_multica_ticket_contract.py
@@ -36,6 +36,23 @@ def test_progress_and_children_patch_metadata_only():
     assert meta["child_issue_ids"] == ["child-1"]
 
 
+def test_progress_records_completion_reason_without_touching_prose():
+    description = describe_ticket("Human closure notes", zoe_kind="harness_fix")
+
+    updated = update_ticket_progress(
+        description,
+        phase="done",
+        evidence="merged and deployed",
+        completion_reason="PR merged after Greptile 5/5",
+    )
+
+    assert updated.startswith("Human closure notes")
+    meta = parse_ticket_block(updated)
+    assert meta["phase"] == "done"
+    assert meta["last_evidence"] == "merged and deployed"
+    assert meta["completion_reason"] == "PR merged after Greptile 5/5"
+
+
 def test_block_only_description_does_not_gain_leading_blank_lines():
     description = describe_ticket("", zoe_kind="bug")
     updated = write_ticket_block(description, {"schema": 1, "zoe_kind": "child"})


### PR DESCRIPTION
## Summary
- add completion_reason to the structured Zoe ticket metadata contract
- allow update_ticket_progress and MULClient.record_progress to write completion_reason
- add focused contract/client tests proving human prose is preserved and record_progress writes the field

## Verification
- python3 -m py_compile services/zoe-data/multica_ticket_contract.py services/zoe-data/multica_client.py
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_multica_ticket_contract.py services/zoe-data/tests/test_multica_client_helpers.py

Fixes the live ZOE-5464 issue observed when record_progress rejected completion_reason during ticket closeout.