### PR TITLE
ZOE-5465: Resolve Multica issues by identifier

### DIFF
--- a/services/zoe-data/multica_client.py
+++ b/services/zoe-data/multica_client.py
@@ -140,6 +140,31 @@ class MULClient:
             logger.warning("Multica get_issue(%s) failed: %s", issue_id, exc)
             return {}
 
+    async def resolve_issue(self, reference: str) -> dict:
+        """Resolve a Multica issue by backend id or visible identifier.
+
+        First attempts a direct backend-id lookup; if that returns nothing, falls
+        back to a full list scan capped at 1000 issues and matched on ``id`` or
+        ``identifier``. Workspaces with more than 1000 issues may not resolve
+        identifiers that fall outside the first page.
+        """
+        if not self.is_configured():
+            return {}
+        wanted = str(reference or "").strip()
+        if not wanted:
+            return {}
+        direct = await self.get_issue(wanted)
+        if direct.get("id"):
+            return direct
+        wanted_lower = wanted.lower()
+        for issue in await self.list_issues(limit=1000):
+            if wanted_lower in {
+                str(issue.get("id") or "").lower(),
+                str(issue.get("identifier") or "").lower(),
+            }:
+                return issue
+        return {}
+
     async def list_issues(
         self,
         status: str | None = None,
@@ -282,20 +307,20 @@ class MULClient:
         """Patch only the fenced Zoe ticket block in an issue description."""
         from multica_ticket_contract import write_ticket_block
 
-        issue = await self.get_issue(issue_id)
+        issue = await self.resolve_issue(issue_id)
         if not issue.get("id"):
             return {}
         original = issue.get("description") or ""
-        return await self.update_issue(issue_id, description=write_ticket_block(original, metadata))
+        return await self.update_issue(str(issue["id"]), description=write_ticket_block(original, metadata))
 
     async def append_issue_note(self, issue_id: str, note: str) -> dict:
         """Append a visible progress note while preserving existing description."""
-        issue = await self.get_issue(issue_id)
+        issue = await self.resolve_issue(issue_id)
         if not issue.get("id"):
             return {}
         original = (issue.get("description") or "").rstrip()
         updated = f"{original}\n\nZoe note: {note.strip()}" if original else f"Zoe note: {note.strip()}"
-        return await self.update_issue(issue_id, description=updated)
+        return await self.update_issue(str(issue["id"]), description=updated)
 
     async def create_child_issue(self, parent: dict, template: dict[str, Any]) -> dict:
         """Create a child issue linked to a parent via the Zoe ticket block.
@@ -352,7 +377,7 @@ class MULClient:
         """Record operator-visible Zoe progress on a Multica issue."""
         from multica_ticket_contract import update_ticket_progress
 
-        issue = await self.get_issue(issue_id)
+        issue = await self.resolve_issue(issue_id)
         if not issue.get("id"):
             return {}
         updated_description = update_ticket_progress(
@@ -367,7 +392,7 @@ class MULClient:
             dispatch_approved=dispatch_approved,
             completion_reason=completion_reason,
         )
-        return await self.update_issue(issue_id, status=status, description=updated_description)
+        return await self.update_issue(str(issue["id"]), status=status, description=updated_description)
 
 
 # Module-level singleton

--- a/services/zoe-data/multica_operator.py
+++ b/services/zoe-data/multica_operator.py
@@ -14,15 +14,8 @@ from multica_ticket_contract import (
 
 
 async def find_issue(reference: str) -> dict[str, Any]:
-    wanted = reference.strip().lower()
     client = get_multica_client()
-    for issue in await client.list_issues() or []:
-        if wanted in {
-            str(issue.get("id") or "").lower(),
-            str(issue.get("identifier") or "").lower(),
-        }:
-            return issue
-    return {}
+    return await client.resolve_issue(reference)
 
 
 async def create_ticket(title: str, *, source: str = "operator") -> dict[str, Any]:

--- a/services/zoe-data/tests/test_multica_client_helpers.py
+++ b/services/zoe-data/tests/test_multica_client_helpers.py
@@ -11,6 +11,9 @@ class GuardedClient(MULClient):
     async def get_issue(self, issue_id):
         return {}
 
+    async def list_issues(self, *args, **kwargs):
+        return []
+
     async def update_issue(self, *args, **kwargs):
         raise AssertionError("description write must not run when get_issue fails")
 
@@ -33,6 +36,9 @@ async def test_record_progress_skips_when_get_issue_fails():
 @pytest.mark.asyncio
 async def test_record_progress_can_clear_blocker():
     class Client(MULClient):
+        def is_configured(self):
+            return True
+
         async def get_issue(self, issue_id):
             return {
                 "id": issue_id,
@@ -51,6 +57,9 @@ async def test_record_progress_can_clear_blocker():
 @pytest.mark.asyncio
 async def test_record_progress_writes_completion_reason():
     class Client(MULClient):
+        def is_configured(self):
+            return True
+
         async def get_issue(self, issue_id):
             return {
                 "id": issue_id,
@@ -151,3 +160,74 @@ async def test_create_issue_metadata_preserves_existing_ticket_fields():
     assert metadata["source"] == "override"
     assert metadata["last_evidence"] == "old evidence"
     assert metadata["updated_at"] != old_updated_at
+
+
+@pytest.mark.asyncio
+async def test_resolve_issue_returns_backend_id_match_without_listing():
+    class Client(MULClient):
+        def is_configured(self):
+            return True
+
+        async def get_issue(self, issue_id):
+            return {"id": issue_id, "identifier": "ZOE-1"}
+
+        async def list_issues(self, *args, **kwargs):
+            raise AssertionError("direct backend id match should not list issues")
+
+    assert await Client().resolve_issue("issue-1") == {"id": "issue-1", "identifier": "ZOE-1"}
+
+
+@pytest.mark.asyncio
+async def test_resolve_issue_falls_back_to_visible_identifier():
+    class Client(MULClient):
+        def is_configured(self):
+            return True
+
+        async def get_issue(self, issue_id):
+            return {}
+
+        async def list_issues(self, status=None, *, limit=None):
+            assert limit == 1000
+            return [{"id": "issue-1", "identifier": "ZOE-5465"}]
+
+    assert await Client().resolve_issue("zoe-5465") == {"id": "issue-1", "identifier": "ZOE-5465"}
+
+
+@pytest.mark.asyncio
+async def test_resolve_issue_returns_empty_when_reference_not_found():
+    class Client(MULClient):
+        def is_configured(self):
+            return True
+
+        async def get_issue(self, issue_id):
+            return {}
+
+        async def list_issues(self, status=None, *, limit=None):
+            return [{"id": "issue-1", "identifier": "ZOE-1"}]
+
+    assert await Client().resolve_issue("ZOE-9999") == {}
+
+
+@pytest.mark.asyncio
+async def test_record_progress_updates_resolved_backend_issue_id():
+    calls = []
+
+    class Client(MULClient):
+        def is_configured(self):
+            return True
+
+        async def get_issue(self, issue_id):
+            return {}
+
+        async def list_issues(self, status=None, *, limit=None):
+            return [{"id": "issue-1", "identifier": "ZOE-5465", "description": describe_ticket("Issue") }]
+
+        async def update_issue(self, issue_id, **kwargs):
+            calls.append((issue_id, kwargs))
+            return {"id": issue_id, **kwargs}
+
+    updated = await Client().record_progress("ZOE-5465", phase="done")
+
+    assert updated["id"] == "issue-1"
+    assert calls[0][0] == "issue-1"
+    assert parse_ticket_block(calls[0][1]["description"])["phase"] == "done"


### PR DESCRIPTION
## Summary
- add a reusable Multica issue resolver for backend ids and visible identifiers
- route operator/progress helpers through the resolver so identifier references work
- add focused tests for direct id, identifier fallback, not-found, and progress update behavior

## Tests
- python3 -m py_compile services/zoe-data/multica_client.py services/zoe-data/multica_operator.py
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_multica_client_helpers.py
- python3 tools/audit/validate_structure.py

Ticket: ZOE-5465