### PR TITLE
Fix Skybridge orb fallback input

### DIFF
--- a/services/zoe-data/tests/test_skybridge_static.py
+++ b/services/zoe-data/tests/test_skybridge_static.py
@@ -16,6 +16,7 @@ def read(path: Path) -> str:
 
 def test_skybridge_page_loads_required_modules_in_order():
     html = read(UI / "skybridge.html")
+    auth = read(ROOT / "zoe-ui" / "dist" / "js" / "auth.js")
     expected = [
         "/js/auth.js",
         "/touch/js/skybridge-capabilities.js",
@@ -30,6 +31,7 @@ def test_skybridge_page_loads_required_modules_in_order():
     assert "/js/touch-ui-executor.js" in html
     assert "id=\"skyCards\"" in html
     assert "id=\"skyCommandForm\"" in html
+    assert "/api/skybridge/resolve" in auth
     assert "window.confirm = function() { return true; }" not in html
 
 
@@ -50,6 +52,10 @@ def test_skybridge_uses_login_orb_to_voice_pill_layout():
     assert "body.sky-empty .sky-command:focus-within" in html
     assert "body.sky-empty .sky-command:hover" in html
     assert "body:not(.sky-empty) .sky-command:hover" in html
+    assert "body.sky-voice-fallback .sky-command" in html
+    assert "body.sky-command-open .sky-command" in html
+    assert "Type below and Zoe will render the cards" in read(UI / "js" / "skybridge.js")
+    assert "canUseMicrophone()" in read(UI / "js" / "skybridge.js")
     assert "id=\"skyOrbButton\"" in html
     assert "id=\"skyVoiceHint\"" in html
     assert "Touch the orb to speak" in html
@@ -203,3 +209,14 @@ def test_skybridge_is_registered_in_touch_menu():
     assert "/touch/skybridge.html" in menu
     assert "'skybridge.html'" in menu
     assert "'dashboard', 'skybridge', 'calendar'" not in menu
+
+
+
+def test_service_worker_does_not_cache_skybridge_runtime():
+    sw = read(ROOT / "zoe-ui" / "dist" / "sw.js")
+
+    assert "Skybridge is a live voice/data surface" in sw
+    assert "4.63.11" in sw
+    assert "url.pathname === '/touch/skybridge.html'" in sw
+    assert "url.pathname.startsWith('/touch/js/skybridge')" in sw
+    assert "new workbox.strategies.NetworkOnly()" in sw

--- a/services/zoe-ui/dist/js/auth.js
+++ b/services/zoe-ui/dist/js/auth.js
@@ -425,7 +425,8 @@
                     if (u) pathname = new URL(u, window.location.origin).pathname;
                 } catch (_e) {}
                 const skipClear = /\/api\/auth\/(login|register|password|refresh|guest)/i.test(pathname);
-                const allowSessionClear = /\/api\/auth\/(profile|me|session|logout)/i.test(pathname);
+                const allowSessionClear = /\/api\/auth\/(profile|me|session|logout)/i.test(pathname) ||
+                    pathname === '/api/skybridge/resolve';
                 const sidBefore = getSession();
                 if (sidBefore && allowSessionClear && !skipClear && !options.__zoe401Retried) {
                     console.warn('⚠️ 401 — clearing stale session and retrying once without X-Session-ID:', url);

--- a/services/zoe-ui/dist/sw.js
+++ b/services/zoe-ui/dist/sw.js
@@ -8,7 +8,7 @@
 importScripts('https://storage.googleapis.com/workbox-cdn/releases/7.0.0/workbox-sw.js');
 
 // Zoe UI Version 4.17.3 - public modules (with or without trailing path segment)
-const SW_VERSION = '4.63.10'; // agent activity sidebar: escape/slice fixes, task detail fetch
+const SW_VERSION = '4.63.11'; // skybridge: bypass stale cached voice surface
 const CACHE_NAME = `zoe-ui-v${SW_VERSION}`;
 
 // Verify Workbox loaded
@@ -80,6 +80,12 @@ if (workbox) {
         new workbox.strategies.NetworkOnly()
     );
     
+    // Skybridge is a live voice/data surface. Never serve stale HTML or runtime JS.
+    workbox.routing.registerRoute(
+        ({ url }) => url.pathname === '/touch/skybridge.html' || url.pathname.startsWith('/touch/js/skybridge'),
+        new workbox.strategies.NetworkOnly()
+    );
+
     // 1. HTML Pages - Network First (fresh content, fallback to cache)
     workbox.routing.registerRoute(
         ({ request }) => request.destination === 'document',
@@ -570,4 +576,3 @@ self.addEventListener('activate', (event) => {
 // above, causing notifications to be shown twice. Removed intentionally.
 
 console.log(`🎯 Zoe Service Worker ${SW_VERSION} loaded successfully`);
-

--- a/services/zoe-ui/dist/touch/js/skybridge.js
+++ b/services/zoe-ui/dist/touch/js/skybridge.js
@@ -11,6 +11,7 @@
     let cardSequence = 0;
     let currentUtterance = '';
     let voiceStartedByUser = false;
+    let commandFallbackOpen = false;
 
     const colors = {
         ambient: ['#5fc6ff', '#66d19e'],
@@ -24,6 +25,7 @@
         bindEvents();
         startOrb();
         renderHome();
+        syncVoiceFallbackState();
         loadBackendStatus();
         setMode(mode);
         if (typeof TouchMenu !== 'undefined') TouchMenu.init({ page: 'skybridge' });
@@ -75,6 +77,11 @@
             submitCommand(els.input.value);
             els.input.value = '';
         });
+        els.input.addEventListener('focus', () => openCommandFallback('Type anything Zoe should show.'));
+        els.input.addEventListener('input', () => {
+            commandFallbackOpen = true;
+            document.body.classList.add('sky-command-open');
+        });
         els.mic.addEventListener('click', toggleVoiceCapture);
         els.orbButton.addEventListener('click', toggleVoiceCapture);
         els.voiceAction.addEventListener('click', toggleVoiceCapture);
@@ -125,6 +132,8 @@
     async function submitCommand(text) {
         const query = String(text || '').trim();
         if (!query) return;
+        commandFallbackOpen = false;
+        document.body.classList.remove('sky-command-open');
         currentUtterance = 'Heard: ' + query;
         els.copy.textContent = currentUtterance;
         addTranscript('user', query);
@@ -248,6 +257,7 @@
                 addCard(card, false, index * 90);
             });
         }
+        syncVoiceFallbackState();
         updateVoiceHint('Touch the orb to speak', getMicGuidance(), 'Start mic');
         requestAnimationFrame(resizeOrb);
     }
@@ -336,16 +346,41 @@
         if (document.body.classList.contains('sky-empty') || !currentUtterance) {
             els.copy.textContent = copy[state] || copy.ambient;
         }
+        syncVoiceFallbackState();
+        if (!commandFallbackOpen && state !== 'ambient') document.body.classList.remove('sky-command-open');
         setStatus(state.charAt(0).toUpperCase() + state.slice(1));
         updateVoiceControl(state);
     }
 
+    function isLocalhost() {
+        return location.hostname === 'localhost' || location.hostname === '127.0.0.1';
+    }
+
+    function canUseMicrophone() {
+        const nav = typeof navigator === 'undefined' ? null : navigator;
+        return (!!window.isSecureContext || isLocalhost()) && !!(nav && nav.mediaDevices && nav.mediaDevices.getUserMedia);
+    }
+
+    function syncVoiceFallbackState() {
+        document.body.classList.toggle('sky-voice-fallback', !canUseMicrophone());
+    }
+
+    function openCommandFallback(message) {
+        commandFallbackOpen = true;
+        document.body.classList.add('sky-command-open');
+        if (message) els.copy.textContent = message;
+        requestAnimationFrame(() => {
+            try { els.input.focus({ preventScroll: true }); } catch (_) { els.input.focus(); }
+        });
+    }
+
     function getMicGuidance() {
-        if (!window.isSecureContext && location.hostname !== 'localhost' && location.hostname !== '127.0.0.1') {
-            return 'Open Skybridge over HTTPS on the touch screen so the browser can allow microphone access.';
+        if (!window.isSecureContext && !isLocalhost()) {
+            return 'Voice needs HTTPS here. You can still type below and Zoe will render the cards.';
         }
-        if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
-            return 'This browser is not exposing a microphone API. Check kiosk permissions and use the HTTPS Zoe URL.';
+        const nav = typeof navigator === 'undefined' ? null : navigator;
+        if (!nav || !nav.mediaDevices || !nav.mediaDevices.getUserMedia) {
+            return 'This browser is not exposing a microphone. Type below and Zoe will render the cards.';
         }
         return 'The touch screen will ask for microphone access the first time.';
     }
@@ -376,12 +411,14 @@
     }
 
     function toggleVoiceCapture() {
-        if (!voice) {
-            showError('Voice transport is still connecting.');
+        syncVoiceFallbackState();
+        if (!canUseMicrophone()) {
+            openCommandFallback(getMicGuidance());
             return;
         }
-        if (!window.isSecureContext && location.hostname !== 'localhost' && location.hostname !== '127.0.0.1') {
-            showError('Microphone requires HTTPS. Open the touch screen using the HTTPS Zoe URL.');
+        if (!voice) {
+            openCommandFallback('Voice is still connecting. Type here or tap again in a moment.');
+            showError('Voice transport is still connecting.');
             return;
         }
         if (voice.isRecording) {
@@ -395,6 +432,7 @@
         voiceStartedByUser = true;
         voice.startRecording().catch(err => {
             voiceStartedByUser = false;
+            openCommandFallback('Microphone unavailable. Type here and Zoe will still render the cards.');
             showError(err.message || 'Microphone unavailable');
         });
     }

--- a/services/zoe-ui/dist/touch/skybridge.html
+++ b/services/zoe-ui/dist/touch/skybridge.html
@@ -2245,8 +2245,8 @@
             box-shadow:
                 0 24px 90px rgba(0,0,0,0.42),
                 inset 0 1px 0 rgba(255,255,255,0.1) !important;
-            backdrop-filter: blur(28px);
-            -webkit-backdrop-filter: blur(28px);
+            backdrop-filter: none !important;
+            -webkit-backdrop-filter: none !important;
             animation: none !important;
         }
 
@@ -2295,6 +2295,79 @@
         body.sky-empty .sky-stage {
             opacity: 0 !important;
             pointer-events: none !important;
+        }
+
+        body.sky-command-open .sky-command,
+        body.sky-voice-fallback .sky-command,
+        body:not(.sky-empty) .sky-command {
+            display: flex !important;
+            position: fixed !important;
+            left: 50% !important;
+            right: auto !important;
+            bottom: max(116px, calc(env(safe-area-inset-bottom, 0px) + 116px)) !important;
+            width: min(760px, calc(100vw - 40px)) !important;
+            min-height: 64px !important;
+            transform: translateX(-50%) !important;
+            align-items: center !important;
+            gap: 10px !important;
+            padding: 9px 10px 9px 16px !important;
+            border: 1px solid rgba(255,255,255,0.14) !important;
+            border-radius: 999px !important;
+            background:
+                linear-gradient(145deg, rgba(255,255,255,0.18), rgba(255,255,255,0.07)),
+                rgba(9, 13, 27, 0.76) !important;
+            box-shadow: 0 24px 86px rgba(0,0,0,0.34), inset 0 1px 0 rgba(255,255,255,0.1) !important;
+            backdrop-filter: blur(28px);
+            -webkit-backdrop-filter: blur(28px);
+            z-index: 32 !important;
+        }
+
+        body.sky-voice-fallback.sky-empty .sky-command {
+            bottom: max(44px, calc(env(safe-area-inset-bottom, 0px) + 34px)) !important;
+        }
+
+        .sky-command #skyHomeBtn {
+            display: none !important;
+        }
+
+        .sky-command input {
+            min-width: 0 !important;
+            flex: 1 1 auto !important;
+            height: 44px !important;
+            border: 0 !important;
+            outline: 0 !important;
+            background: transparent !important;
+            color: rgba(255,255,255,0.94) !important;
+            font-size: 17px !important;
+        }
+
+        .sky-command input::placeholder {
+            color: rgba(255,255,255,0.48) !important;
+        }
+
+        .sky-command button {
+            flex: 0 0 auto !important;
+            height: 44px !important;
+            min-width: 52px !important;
+            padding: 0 16px !important;
+            border: 1px solid rgba(255,255,255,0.13) !important;
+            border-radius: 999px !important;
+            background: rgba(255,255,255,0.1) !important;
+            color: rgba(255,255,255,0.88) !important;
+            font-weight: 700 !important;
+        }
+
+        .sky-command .primary {
+            display: inline-flex !important;
+            align-items: center !important;
+            justify-content: center !important;
+            border-color: rgba(90,224,224,0.38) !important;
+            background: linear-gradient(135deg, #7B61FF, #5AE0E0) !important;
+            color: #07111d !important;
+        }
+
+        body.sky-voice-fallback.sky-empty .sky-listening-copy {
+            color: rgba(255,255,255,0.7) !important;
         }
 
         .sky-card-stack {
@@ -2412,6 +2485,30 @@
                 height: 74px !important;
                 line-height: 74px !important;
                 font-size: 15px !important;
+            }
+
+            body.sky-command-open .sky-command,
+            body.sky-voice-fallback .sky-command,
+            body:not(.sky-empty) .sky-command {
+                width: calc(100vw - 24px) !important;
+                min-height: 60px !important;
+                bottom: max(104px, calc(env(safe-area-inset-bottom, 0px) + 104px)) !important;
+                padding: 8px 8px 8px 14px !important;
+            }
+
+            body.sky-voice-fallback.sky-empty .sky-command {
+                bottom: max(28px, calc(env(safe-area-inset-bottom, 0px) + 24px)) !important;
+            }
+
+            .sky-command input {
+                height: 42px !important;
+                font-size: 16px !important;
+            }
+
+            .sky-command button {
+                height: 42px !important;
+                min-width: 46px !important;
+                padding: 0 12px !important;
             }
         }
     </style>
@@ -2698,6 +2795,12 @@
                 font-size: 15px !important;
             }
         }
+
+        .sky-orb-panel,
+        .sky-stage {
+            backdrop-filter: none !important;
+            -webkit-backdrop-filter: none !important;
+        }
     </style>
 </head>
 <body>
@@ -2764,9 +2867,9 @@
     <script src="/touch/js/gestures.js"></script>
     <script src="/touch/js/touch-menu.js"></script>
     <script src="/js/touch-ui-executor.js"></script>
-    <script src="/touch/js/skybridge-capabilities.js?v=skybridge-minimal-1"></script>
-    <script src="/touch/js/skybridge-renderer.js?v=skybridge-minimal-1"></script>
-    <script src="/touch/js/skybridge-voice.js?v=skybridge-minimal-1"></script>
-    <script src="/touch/js/skybridge.js?v=skybridge-minimal-1"></script>
+    <script src="/touch/js/skybridge-capabilities.js?v=skybridge-orb-fallback-5"></script>
+    <script src="/touch/js/skybridge-renderer.js?v=skybridge-orb-fallback-5"></script>
+    <script src="/touch/js/skybridge-voice.js?v=skybridge-orb-fallback-5"></script>
+    <script src="/touch/js/skybridge.js?v=skybridge-orb-fallback-5"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- show a polished command pill when Skybridge cannot access microphone capture
- make orb tap open/focus the text fallback instead of trapping users at the orb
- allow stale sessions to retry /api/skybridge/resolve as guest so typed data cards still render

## Verification
- python3 tools/audit/validate_structure.py
- python3 tools/audit/validate_critical_files.py
- cd services/zoe-data && PYTHONPATH=. python3 -m pytest -q tests/test_skybridge_static.py tests/test_skybridge_status.py tests/test_skybridge_service.py tests/test_card_contract.py
- browser: http://zoe.local/touch/skybridge.html?verify=fallback3 shows fallback input, renders weather and calendar cards