### PR TITLE
Ignore generated Graphify refresh error marker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -262,5 +262,6 @@ data/touch_cache/
 graphify-out/manifest.json
 graphify-out/cost.json
 graphify-out/cache/
+graphify-out/.last_refresh_error
 !.cursor/mcp.json
 .cursor/tmp/


### PR DESCRIPTION
## Summary
- ignore the generated Graphify refresh error marker written under graphify-out
- keep failed refresh diagnostics available on disk without dirtying the repo

## Validation
- python3 tools/audit/validate_structure.py
- python3 tools/audit/validate_critical_files.py
- python3 tools/audit/validate_offline_memory.py
- git diff --check
