### PR TITLE
Fix Multica native daemon setup

### DIFF
--- a/docker-compose.modules.yml
+++ b/docker-compose.modules.yml
@@ -57,6 +57,8 @@ services:
       JWT_SECRET: "${MULTICA_JWT_SECRET}"
       MULTICA_DEV_VERIFICATION_CODE: "${MULTICA_DEV_CODE}"
       FRONTEND_ORIGIN: "http://zoe.local:3000"
+      # Multica backend v0.3.1 reads CORS_ALLOWED_ORIGINS; live preflight was
+      # verified for zoe.local, zoe.local:3000, localhost:3000, and 127.0.0.1:3000.
       CORS_ALLOWED_ORIGINS: "http://zoe.local,http://zoe.local:3000,http://localhost:3000,http://127.0.0.1:3000"
       MULTICA_APP_URL: "http://zoe.local:3000"
       ALLOW_SIGNUP: "true"

--- a/docker-compose.modules.yml
+++ b/docker-compose.modules.yml
@@ -56,8 +56,9 @@ services:
       APP_ENV: development
       JWT_SECRET: "${MULTICA_JWT_SECRET}"
       MULTICA_DEV_VERIFICATION_CODE: "${MULTICA_DEV_CODE}"
-      FRONTEND_ORIGIN: "http://localhost:3000"
-      MULTICA_APP_URL: "http://localhost:3000"
+      FRONTEND_ORIGIN: "http://zoe.local:3000"
+      CORS_ALLOWED_ORIGINS: "http://zoe.local,http://zoe.local:3000,http://localhost:3000,http://127.0.0.1:3000"
+      MULTICA_APP_URL: "http://zoe.local:3000"
       ALLOW_SIGNUP: "true"
       # Email verification (ZOE-48): set RESEND_API_KEY or SMTP_HOST/SMTP_PORT/SMTP_USER/SMTP_PASS
       # RESEND_API_KEY: "${RESEND_API_KEY:-}"

--- a/docker-compose.modules.yml
+++ b/docker-compose.modules.yml
@@ -57,9 +57,11 @@ services:
       JWT_SECRET: "${MULTICA_JWT_SECRET}"
       MULTICA_DEV_VERIFICATION_CODE: "${MULTICA_DEV_CODE}"
       FRONTEND_ORIGIN: "http://zoe.local:3000"
-      # Multica backend v0.3.1 reads CORS_ALLOWED_ORIGINS; live preflight was
-      # verified for zoe.local, zoe.local:3000, localhost:3000, and 127.0.0.1:3000.
+      # Multica backend v0.3.1 reads CORS_ALLOWED_ORIGINS for HTTP CORS and
+      # ALLOWED_ORIGINS for realtime WebSocket origin checks. Keep localhost
+      # dev origins explicit alongside Zoe's LAN origin.
       CORS_ALLOWED_ORIGINS: "http://zoe.local,http://zoe.local:3000,http://localhost:3000,http://127.0.0.1:3000"
+      ALLOWED_ORIGINS: "http://zoe.local,http://zoe.local:3000,http://localhost:3000,http://127.0.0.1:3000"
       MULTICA_APP_URL: "http://zoe.local:3000"
       ALLOW_SIGNUP: "true"
       # Email verification (ZOE-48): set RESEND_API_KEY or SMTP_HOST/SMTP_PORT/SMTP_USER/SMTP_PASS

--- a/scripts/maintenance/multica_runtime_heartbeat.py
+++ b/scripts/maintenance/multica_runtime_heartbeat.py
@@ -1,30 +1,17 @@
 #!/usr/bin/env python3
-"""multica_runtime_heartbeat.py — Reflect real local liveness into Multica's runtime registry.
+"""multica_runtime_heartbeat.py — Reflect Zoe API liveness into Multica.
 
 Why this exists
 ---------------
-Multica's runtime registry (``agent_runtime`` rows) is normally fed by a Multica
-*daemon* that registers and then heartbeats over the daemon-authenticated API.
-Multica's sweeper flips an ``online`` row to ``offline`` once its ``last_seen_at``
-goes stale (``staleThresholdSeconds`` = 150s server-side).
+Multica's runtime registry (``agent_runtime`` rows) is normally fed by a native
+Multica daemon. Zoe now runs that daemon for tool-backed runtimes such as
+Hermes, OpenClaw, and Cursor, so this reflector must not mark those daemon-owned
+rows.
 
-Zoe does NOT run a Multica daemon — the Zoe<->Multica pipeline talks to the
-*issues* REST API (executor_registry -> kanban_adapter), not the daemon/runtime
-protocol. The three Zoe runtime rows (openclaw-gateway, hermes-agent, Zoe Home
-Server) were seeded directly into the Multica DB by
-``scripts/setup/populate_multica.py`` with ``daemon_id = NULL``, so nothing ever
-heartbeats them and they permanently read "offline".
-
-This script closes that gap *honestly*: it probes the actual local processes and
-writes the truthful status (``online`` iff the process is really up) plus a fresh
-``last_seen_at`` directly into the Multica DB — the same channel
-``populate_multica.py`` already uses for these exact rows (POST /api/runtimes is
-405; PATCH only edits timezone/visibility). It is intended to run on a short
-systemd timer (< 150s cadence) so live runtimes stay online and dead ones flip
-offline within one tick.
-
-This is a cosmetic registry reflector. The Hermes Kanban execution pipeline does
-NOT depend on these rows; it exists so the Multica board shows reality.
+This script only reflects the seeded Zoe Home Server runtime row, which is a Zoe
+API surface rather than a native Multica daemon runtime. It updates only
+``daemon_id IS NULL`` rows so it cannot make a stale or legacy Hermes/OpenClaw
+row look dispatchable.
 
 Usage
 -----
@@ -102,12 +89,10 @@ def _zoe_alive() -> bool:
         return False
 
 
-# provider -> (human label, liveness probe). Keyed by the agent_runtime.provider
-# column so we update exactly the seeded Zoe rows and nothing else.
+# provider -> (human label, liveness probe). Only seeded non-daemon rows belong
+# here. Native Multica daemon rows heartbeat themselves.
 _RUNTIMES: tuple[tuple[str, str, Callable[[], bool]], ...] = (
     ("zoe", "Zoe Home Server", _zoe_alive),
-    ("hermes", "hermes-agent", lambda: _proc_alive("hermes gateway run")),
-    ("openclaw_gateway", "openclaw-gateway", lambda: _proc_alive("openclaw/dist/index.js gateway")),
 )
 
 
@@ -119,7 +104,7 @@ def _update_runtime(provider: str, online: bool) -> tuple[bool, str]:
         "SET status = :'st', "
         "    last_seen_at = CASE WHEN :'st' = 'online' THEN now() ELSE last_seen_at END, "
         "    updated_at = now() "
-        "WHERE workspace_id = :'ws'::uuid AND provider = :'provider';"
+        "WHERE workspace_id = :'ws'::uuid AND provider = :'provider' AND daemon_id IS NULL;"
     )
     # SQL is piped on stdin (not -c) so psql performs :'var' interpolation,
     # which quotes/escapes each value safely server-side.

--- a/scripts/setup/jetson/zoe-multica-daemon.service
+++ b/scripts/setup/jetson/zoe-multica-daemon.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Zoe Multica native agent daemon
+After=default.target
+
+[Service]
+Type=simple
+WorkingDirectory=/home/zoe/assistant
+EnvironmentFile=/home/zoe/assistant/services/zoe-data/.env
+Environment=PATH=/home/zoe/.local/bin:/home/zoe/.nvm/versions/node/v22.22.0/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+Environment=MULTICA_SERVER_URL=http://localhost:8080
+Environment=MULTICA_DAEMON_MAX_CONCURRENT_TASKS=1
+Environment=MULTICA_DAEMON_AUTO_UPDATE=false
+Environment=MULTICA_AGENT_RUNTIME_NAME=Zoe Host Multica Daemon
+Environment=MULTICA_DAEMON_DEVICE_NAME=Zoe Host
+ExecStart=/home/zoe/.local/bin/multica daemon start --foreground --max-concurrent-tasks 1 --runtime-name Zoe Host Multica Daemon --device-name Zoe Host --no-auto-update
+Restart=on-failure
+RestartSec=10
+
+[Install]
+WantedBy=default.target

--- a/scripts/setup/jetson/zoe-multica-daemon.service
+++ b/scripts/setup/jetson/zoe-multica-daemon.service
@@ -5,7 +5,6 @@ After=default.target
 [Service]
 Type=simple
 WorkingDirectory=/home/zoe/assistant
-EnvironmentFile=/home/zoe/assistant/services/zoe-data/.env
 Environment=PATH=/home/zoe/.local/bin:/home/zoe/.nvm/versions/node/v22.22.0/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 Environment=MULTICA_SERVER_URL=http://localhost:8080
 Environment=MULTICA_DAEMON_MAX_CONCURRENT_TASKS=1

--- a/scripts/setup/jetson/zoe-multica-daemon.service
+++ b/scripts/setup/jetson/zoe-multica-daemon.service
@@ -5,7 +5,7 @@ After=default.target
 [Service]
 Type=simple
 WorkingDirectory=/home/zoe/assistant
-Environment=PATH=/home/zoe/.local/bin:/home/zoe/.nvm/versions/node/v22.22.0/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+Environment=PATH=/home/zoe/.local/bin:/home/zoe/.nvm/versions/node/current/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 Environment=MULTICA_SERVER_URL=http://localhost:8080
 Environment=MULTICA_DAEMON_MAX_CONCURRENT_TASKS=1
 Environment=MULTICA_DAEMON_AUTO_UPDATE=false

--- a/scripts/setup/jetson/zoe-multica-daemon.service
+++ b/scripts/setup/jetson/zoe-multica-daemon.service
@@ -10,9 +10,9 @@ Environment=PATH=/home/zoe/.local/bin:/home/zoe/.nvm/versions/node/v22.22.0/bin:
 Environment=MULTICA_SERVER_URL=http://localhost:8080
 Environment=MULTICA_DAEMON_MAX_CONCURRENT_TASKS=1
 Environment=MULTICA_DAEMON_AUTO_UPDATE=false
-Environment=MULTICA_AGENT_RUNTIME_NAME=Zoe Host Multica Daemon
-Environment=MULTICA_DAEMON_DEVICE_NAME=Zoe Host
-ExecStart=/home/zoe/.local/bin/multica daemon start --foreground --max-concurrent-tasks 1 --runtime-name Zoe Host Multica Daemon --device-name Zoe Host --no-auto-update
+Environment="MULTICA_AGENT_RUNTIME_NAME=Zoe Host Multica Daemon"
+Environment="MULTICA_DAEMON_DEVICE_NAME=Zoe Host"
+ExecStart=/home/zoe/.local/bin/multica daemon start --foreground --max-concurrent-tasks 1 --runtime-name "Zoe Host Multica Daemon" --device-name "Zoe Host" --no-auto-update
 Restart=on-failure
 RestartSec=10
 

--- a/scripts/setup/openclaw-multica-wrapper.sh
+++ b/scripts/setup/openclaw-multica-wrapper.sh
@@ -5,7 +5,7 @@
 # so this exact call is handled by printing the active config file. All other
 # OpenClaw invocations delegate to the real binary.
 set -euo pipefail
-REAL_OPENCLAW="${REAL_OPENCLAW:-/home/zoe/.nvm/versions/node/v22.22.0/bin/openclaw}"
+REAL_OPENCLAW="${REAL_OPENCLAW:-/home/zoe/.nvm/versions/node/current/bin/openclaw}"
 if [[ "$#" -eq 3 && "$1" == "config" && "$2" == "get" && "$3" == "--json" ]]; then
   config_path="${OPENCLAW_CONFIG_PATH:-/home/zoe/.openclaw/openclaw.json}"
   if [[ ! -f "$config_path" ]]; then

--- a/scripts/setup/openclaw-multica-wrapper.sh
+++ b/scripts/setup/openclaw-multica-wrapper.sh
@@ -7,7 +7,12 @@
 set -euo pipefail
 REAL_OPENCLAW="${REAL_OPENCLAW:-/home/zoe/.nvm/versions/node/v22.22.0/bin/openclaw}"
 if [[ "$#" -eq 3 && "$1" == "config" && "$2" == "get" && "$3" == "--json" ]]; then
-  cat "${OPENCLAW_CONFIG_PATH:-/home/zoe/.openclaw/openclaw.json}"
+  config_path="${OPENCLAW_CONFIG_PATH:-/home/zoe/.openclaw/openclaw.json}"
+  if [[ ! -f "$config_path" ]]; then
+    echo "openclaw-multica-wrapper: config file not found: $config_path" >&2
+    exit 1
+  fi
+  cat "$config_path"
   exit 0
 fi
 exec "$REAL_OPENCLAW" "$@"

--- a/scripts/setup/openclaw-multica-wrapper.sh
+++ b/scripts/setup/openclaw-multica-wrapper.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Compatibility wrapper for Multica daemon -> OpenClaw config introspection.
+# Multica CLI 0.3.19 calls `openclaw config get --json` to read the full
+# resolved config. OpenClaw 2026.5.12 requires a path argument for `config get`,
+# so this exact call is handled by printing the active config file. All other
+# OpenClaw invocations delegate to the real binary.
+set -euo pipefail
+REAL_OPENCLAW="${REAL_OPENCLAW:-/home/zoe/.nvm/versions/node/v22.22.0/bin/openclaw}"
+if [[ "$#" -eq 3 && "$1" == "config" && "$2" == "get" && "$3" == "--json" ]]; then
+  cat "${OPENCLAW_CONFIG_PATH:-/home/zoe/.openclaw/openclaw.json}"
+  exit 0
+fi
+exec "$REAL_OPENCLAW" "$@"

--- a/scripts/setup/populate_multica.py
+++ b/scripts/setup/populate_multica.py
@@ -124,6 +124,50 @@ def _db_exec(sql: str) -> tuple[bool, str]:
         return False, str(e)
 
 
+def _db_update_one(sql: str) -> tuple[bool, str]:
+    ok, msg = _db_exec(sql)
+    if not ok:
+        return False, msg
+    if "UPDATE 1" not in msg:
+        return False, (msg.strip() or "update did not report row count")
+    return True, msg
+
+
+def _db_name_id_map(table: str, names: list[str]) -> dict[str, str]:
+    if not names:
+        return {}
+    names_sql = ", ".join(_sql_literal(name) for name in names)
+    sql = (
+        "select name, id from "
+        f"{table} where workspace_id={_sql_literal(WORKSPACE_ID)} "
+        f"and name in ({names_sql}) "
+        "order by name, archived_at nulls first, updated_at desc;"
+    )
+    cmd = [
+        "docker", "exec", _DB_CONTAINER,
+        "psql", "-U", _DB_USER, "-d", _DB_NAME,
+        "-t", "-A", "-F", "\t", "-c", sql,
+    ]
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
+    except Exception as exc:
+        print(f"  ⚠ Failed to inspect existing {table} rows: {exc}")
+        return {}
+    if result.returncode != 0:
+        print(f"  ⚠ Failed to inspect existing {table} rows: {(result.stderr or result.stdout)[:100]}")
+        return {}
+    found: dict[str, str] = {}
+    for line in result.stdout.splitlines():
+        if "\t" not in line:
+            continue
+        name, row_id = line.split("\t", 1)
+        name = name.strip()
+        row_id = row_id.strip()
+        if name and row_id and name not in found:
+            found[name] = row_id
+    return found
+
+
 # ── Step A — Update workspace context ─────────────────────────────────────────
 
 def step_a_update_workspace():
@@ -468,7 +512,9 @@ def step_f_create_agents(runtime_id: str) -> dict[str, str]:
     print("\n[F] Creating agents...")
     existing_raw = _get("/api/agents") or []
     existing: list[dict] = existing_raw if isinstance(existing_raw, list) else existing_raw.get("agents", [])
-    existing_names = {a["name"]: a["id"] for a in existing}
+    managed_names = [str(defn["name"]) for defn in _AGENT_DEFS]
+    existing_names = _db_name_id_map("agent", managed_names)
+    existing_names.update({a["name"]: a["id"] for a in existing if a.get("name") in managed_names})
 
     agent_ids: dict[str, str] = dict(existing_names)
     for defn in _AGENT_DEFS:
@@ -480,10 +526,11 @@ def step_f_create_agents(runtime_id: str) -> dict[str, str]:
                 f"description={_sql_literal(defn['description'])}, "
                 f"instructions={_sql_literal(defn['instructions'])}, "
                 f"model={_sql_literal(defn['model'])}, "
-                "runtime_mode='local', visibility='workspace', updated_at=now() "
+                "runtime_mode='local', visibility='workspace', "
+                "archived_at=NULL, archived_by=NULL, updated_at=now() "
                 f"where id={_sql_literal(agent_id)};"
             )
-            ok, msg = _db_exec(sql)
+            ok, msg = _db_update_one(sql)
             if ok:
                 print(f"  ↻ Agent '{name}' exists ({agent_id}) — refreshed managed fields")
             else:
@@ -565,9 +612,6 @@ def step_h_create_squads(agent_ids: dict[str, str]) -> dict[str, str]:
     print("\n[H] Creating squads...")
     existing_raw = _get("/api/squads") or []
     existing: list[dict] = existing_raw if isinstance(existing_raw, list) else existing_raw.get("squads", [])
-    existing_names = {s["name"]: s["id"] for s in existing}
-
-    squad_ids: dict[str, str] = dict(existing_names)
 
     squads_to_create = [
         {
@@ -599,6 +643,12 @@ def step_h_create_squads(agent_ids: dict[str, str]) -> dict[str, str]:
         },
     ]
 
+    managed_squad_names = [str(sq["name"]) for sq in squads_to_create]
+    existing_names = _db_name_id_map("squad", managed_squad_names)
+    existing_names.update({s["name"]: s["id"] for s in existing if s.get("name") in managed_squad_names})
+
+    squad_ids: dict[str, str] = dict(existing_names)
+
     for sq in squads_to_create:
         name = sq["name"]
         leader_id = agent_ids.get(sq["leader"])
@@ -612,10 +662,11 @@ def step_h_create_squads(agent_ids: dict[str, str]) -> dict[str, str]:
                 "update squad set "
                 f"description={_sql_literal(sq['description'])}, "
                 f"instructions={_sql_literal(sq['instructions'])}, "
-                f"leader_id={_sql_literal(leader_id)}, updated_at=now() "
+                f"leader_id={_sql_literal(leader_id)}, "
+                "archived_at=NULL, archived_by=NULL, updated_at=now() "
                 f"where id={_sql_literal(squad_id)};"
             )
-            ok, msg = _db_exec(sql)
+            ok, msg = _db_update_one(sql)
             if ok:
                 print(f"  ↻ Squad '{name}' exists ({squad_id}) — refreshed leader/context")
             else:

--- a/scripts/setup/populate_multica.py
+++ b/scripts/setup/populate_multica.py
@@ -397,29 +397,32 @@ _AGENT_DEFS = [
     {
         "name": "OpenClaw",
         "description": (
-            "Autonomous task execution agent. Receives approved Multica issues, implements "
-            "code changes, tests, and commits. Primary capability-building agent."
+            "Agentic execution runtime. Handles browser automation, code execution, skill "
+            "building, and simple-English Multica quick-create tasks through the native "
+            "Multica daemon."
         ),
         "instructions": (
-            "You are OpenClaw, Zoe's execution agent. You receive approved tasks from the "
-            "Multica board and implement them: writing code, adding intents, building skills, "
-            "fixing bugs, running tests, committing changes. Always read files before editing. "
-            "Work in small, testable increments."
+            "You are OpenClaw, Zoe's native agentic execution runtime. Use local tools to "
+            "create well-formed Multica issues from simple-English quick-create requests, "
+            "run browser/tool tasks when explicitly assigned, and report blockers clearly. "
+            "Do not decide Zoe engineering phase advancement; Zoe/Hermes harness owns that workflow."
         ),
-        "model": "Llama-3.2-3B-Instruct-Q4_K_M",
+        "model": "main",
     },
     {
         "name": "Hermes",
         "description": (
-            "OpenAI-compatible relay agent. Routes requests from external tools (Open WebUI, "
-            "voice clients) to OpenClaw. Entry point: port 8642."
+            "Zoe engineering and reasoning runtime. Handles Multica issue execution, architecture "
+            "review, code review, Greptile/PR loops, and deterministic harness repair through "
+            "the native Multica daemon."
         ),
         "instructions": (
-            "You are Hermes, an OpenAI-compatible API relay for the Zoe ecosystem. You accept "
-            "requests in OpenAI format and route them to the appropriate Zoe agent. You handle "
-            "voice client connections and external tool integrations."
+            "You are Hermes, Zoe's default engineering and reasoning agent. For Multica work, "
+            "follow the issue context, use available CLI/tools, keep changes scoped, provide "
+            "evidence, and surface blockers. Zoe driver owns phase advancement; do not create "
+            "unmanaged Kanban chains or bypass dispatch gates."
         ),
-        "model": "Llama-3.2-3B-Instruct-Q4_K_M",
+        "model": "gpt-5.4",
     },
     {
         "name": "Agent Zero",
@@ -549,14 +552,15 @@ def step_h_create_squads(agent_ids: dict[str, str]) -> dict[str, str]:
     squads_to_create = [
         {
             "name": "Zoe Operations Squad",
-            "leader": "OpenClaw",
+            "leader": "Hermes",
             "description": (
-                "Core operations team. Handles infrastructure, capability-building, and "
-                "self-improvement tasks. OpenClaw leads execution."
+                "Core operations team. Hermes leads engineering and harness work; OpenClaw "
+                "is available for browser/tool-heavy execution; Zoe Core provides user context."
             ),
             "instructions": (
-                "Handle all infrastructure, capability-building, and self-improvement tasks. "
-                "OpenClaw leads execution. Zoe Core provides context on user needs."
+                "Use Hermes as the default engineering lead for Multica source-of-truth tickets. "
+                "Delegate browser/tool-heavy execution to OpenClaw only when required. Keep work "
+                "cost-controlled and report blockers on the ticket."
             ),
             "members": ["Zoe Core", "Hermes", "Self-Improvement Agent"],
         },

--- a/scripts/setup/populate_multica.py
+++ b/scripts/setup/populate_multica.py
@@ -136,6 +136,10 @@ def _db_update_one(sql: str) -> tuple[bool, str]:
 def _db_name_id_map(table: str, names: list[str]) -> dict[str, str]:
     if not names:
         return {}
+    allowed_tables = {"agent", "squad"}
+    if table not in allowed_tables:
+        print(f"  ⚠ Refusing to inspect unsupported table {table!r}")
+        return {}
     names_sql = ", ".join(_sql_literal(name) for name in names)
     sql = (
         "select name, id from "

--- a/scripts/setup/populate_multica.py
+++ b/scripts/setup/populate_multica.py
@@ -128,7 +128,8 @@ def _db_update_one(sql: str) -> tuple[bool, str]:
     ok, msg = _db_exec(sql)
     if not ok:
         return False, msg
-    if "UPDATE 1" not in msg:
+    command_tags = [line.strip() for line in msg.splitlines() if line.strip().startswith("UPDATE ")]
+    if command_tags != ["UPDATE 1"]:
         return False, (msg.strip() or "update did not report row count")
     return True, msg
 
@@ -533,6 +534,7 @@ def step_f_create_agents(runtime_id: str) -> dict[str, str]:
                 f"description={_sql_literal(defn['description'])}, "
                 f"instructions={_sql_literal(defn['instructions'])}, "
                 f"model={_sql_literal(defn['model'])}, "
+                f"runtime_id={_sql_literal(runtime_id)}, "
                 "runtime_mode='local', visibility='workspace', "
                 "archived_at=NULL, archived_by=NULL, updated_at=now() "
                 f"where id={_sql_literal(agent_id)};"

--- a/scripts/setup/populate_multica.py
+++ b/scripts/setup/populate_multica.py
@@ -91,6 +91,12 @@ def _patch(path: str, payload: dict) -> dict | None:
     return None
 
 
+def _sql_literal(value: Any) -> str:
+    if value is None:
+        return "NULL"
+    return "'" + str(value).replace("'", "''") + "'"
+
+
 def _post_with_workspace(path: str, payload: dict) -> dict | None:
     """POST with workspace_id as query param (used for sub-resource endpoints)."""
     params = {"workspace_id": WORKSPACE_ID}
@@ -422,6 +428,7 @@ _AGENT_DEFS = [
             "evidence, and surface blockers. Zoe driver owns phase advancement; do not create "
             "unmanaged Kanban chains or bypass dispatch gates."
         ),
+        # Multica daemon selector for the Hermes CLI profile, not a public OpenAI model id.
         "model": "gpt-5.4",
     },
     {
@@ -467,7 +474,20 @@ def step_f_create_agents(runtime_id: str) -> dict[str, str]:
     for defn in _AGENT_DEFS:
         name = defn["name"]
         if name in existing_names:
-            print(f"  ↩ Agent '{name}' exists ({existing_names[name]}) — skipping")
+            agent_id = existing_names[name]
+            sql = (
+                "update agent set "
+                f"description={_sql_literal(defn['description'])}, "
+                f"instructions={_sql_literal(defn['instructions'])}, "
+                f"model={_sql_literal(defn['model'])}, "
+                "runtime_mode='local', visibility='workspace', updated_at=now() "
+                f"where id={_sql_literal(agent_id)};"
+            )
+            ok, msg = _db_exec(sql)
+            if ok:
+                print(f"  ↻ Agent '{name}' exists ({agent_id}) — refreshed managed fields")
+            else:
+                print(f"  ⚠ Agent '{name}' exists ({agent_id}) — refresh failed: {msg[:100]}")
             continue
         result = _post("/api/agents", {
             "name": name,
@@ -588,7 +608,18 @@ def step_h_create_squads(agent_ids: dict[str, str]) -> dict[str, str]:
 
         if name in existing_names:
             squad_id = existing_names[name]
-            print(f"  ↩ Squad '{name}' exists ({squad_id})")
+            sql = (
+                "update squad set "
+                f"description={_sql_literal(sq['description'])}, "
+                f"instructions={_sql_literal(sq['instructions'])}, "
+                f"leader_id={_sql_literal(leader_id)}, updated_at=now() "
+                f"where id={_sql_literal(squad_id)};"
+            )
+            ok, msg = _db_exec(sql)
+            if ok:
+                print(f"  ↻ Squad '{name}' exists ({squad_id}) — refreshed leader/context")
+            else:
+                print(f"  ⚠ Squad '{name}' exists ({squad_id}) — refresh failed: {msg[:100]}")
         else:
             result = _post("/api/squads", {
                 "name": name,

--- a/scripts/setup/populate_multica.py
+++ b/scripts/setup/populate_multica.py
@@ -518,7 +518,10 @@ def step_f_create_agents(runtime_id: str) -> dict[str, str]:
     existing: list[dict] = existing_raw if isinstance(existing_raw, list) else existing_raw.get("agents", [])
     managed_names = [str(defn["name"]) for defn in _AGENT_DEFS]
     existing_names = _db_name_id_map("agent", managed_names)
-    existing_names.update({a["name"]: a["id"] for a in existing if a.get("name") in managed_names})
+    for agent in existing:
+        name = agent.get("name")
+        if name in managed_names and name not in existing_names:
+            existing_names[name] = agent["id"]
 
     agent_ids: dict[str, str] = dict(existing_names)
     for defn in _AGENT_DEFS:
@@ -649,7 +652,10 @@ def step_h_create_squads(agent_ids: dict[str, str]) -> dict[str, str]:
 
     managed_squad_names = [str(sq["name"]) for sq in squads_to_create]
     existing_names = _db_name_id_map("squad", managed_squad_names)
-    existing_names.update({s["name"]: s["id"] for s in existing if s.get("name") in managed_squad_names})
+    for squad in existing:
+        name = squad.get("name")
+        if name in managed_squad_names and name not in existing_names:
+            existing_names[name] = squad["id"]
 
     squad_ids: dict[str, str] = dict(existing_names)
 


### PR DESCRIPTION
## Summary
- configure Multica backend for Zoe LAN origins so web/daemon websockets are accepted
- add the native Multica daemon user-service template and OpenClaw compatibility wrapper
- scope the Zoe runtime heartbeat to seeded non-daemon rows only
- refresh seeded Multica agent/squad context so Hermes is the default engineering lead and Hermes/OpenClaw use daemon-compatible model selectors

## Validation
- python3 -m py_compile scripts/maintenance/multica_runtime_heartbeat.py scripts/setup/populate_multica.py
- bash -n scripts/setup/openclaw-multica-wrapper.sh
- live Multica health report ok
- live native daemon registered Hermes/OpenClaw/Cursor with cli_version 0.3.19
- quick-create via Hermes completed and created issue 2a69f70b-ac49-4905-8f82-55cbab9a30ac, then marked done

## Follow-up
- OpenClaw quick-create still fails with openclaw returned no parseable output; tracked as Multica issue ZOE-5470. Hermes quick-create is the verified working path.