### PR TITLE
Fix Skybridge weather cards and voice fallback pill

### DIFF
--- a/services/zoe-data/tests/test_skybridge_static.py
+++ b/services/zoe-data/tests/test_skybridge_static.py
@@ -164,6 +164,7 @@ def test_skybridge_uses_backend_status_contract():
     assert "/api/skybridge/resolve" in app
     assert "resolveCommand(query)" in app
     assert "isDataQuery(query)" in app
+    assert "resp.status === 401 || resp.status === 503" in app
     assert "if (voice) voice.sendText(query)" in app
     assert "event.role === 'user') projectCards" not in app
     assert "projectCommand(query);\n        if (voice) voice.sendText(query);" not in app
@@ -188,6 +189,14 @@ def test_skybridge_renderer_supports_real_data_cards():
 
     assert "renderCalendar(props)" in renderer
     assert "renderWeather(props)" in renderer
+    assert "sky-premium-card" in renderer
+    assert "formatForecastLabel" in renderer
+    assert "forecastTempBand(item)" in renderer
+    assert "sky-weather-tile-temp" in renderer
+    assert "sky-weather-temp-band" in renderer
+    assert "Current location" in renderer
+    assert "Geraldton" not in renderer
+    assert "metres per second" in renderer
     assert "props.source === 'calendar_show'" in renderer
     assert "props.source === 'weather_current'" in renderer
     assert "props.source === 'weather_forecast'" in renderer
@@ -196,6 +205,9 @@ def test_skybridge_renderer_supports_real_data_cards():
     assert "sky-weather-scene" in html
     assert "weather-sunny" in html
     assert "skybridge-runtime-overrides" in html
+    assert "skybridge-premium-card-system" in html
+    assert "skybridge-forecast-widget-overrides" in html
+    assert "skybridge-premium-cards-3" in html
     assert "backdrop-filter: none !important" in html
     assert "No events " in renderer
 
@@ -231,5 +243,7 @@ def test_skybridge_has_typed_fallback_for_insecure_voice_contexts():
     assert "sky-voice-fallback.sky-empty .sky-command" in html
     assert "canUseMicrophone()" in app
     assert "openCommandFallback(" in app
+    assert "if (!commandFallbackOpen)" in app
+    assert "syncVoiceFallbackState();" in app
     assert "Microphone needs HTTPS here" in app
-    assert "resp.status === 401" not in app
+    assert "resp.status === 401 || resp.status === 503" in app

--- a/services/zoe-data/tests/test_skybridge_static.py
+++ b/services/zoe-data/tests/test_skybridge_static.py
@@ -192,7 +192,11 @@ def test_skybridge_renderer_supports_real_data_cards():
     assert "props.source === 'weather_current'" in renderer
     assert "props.source === 'weather_forecast'" in renderer
     assert "sky-event-row" in html
-    assert "sky-forecast-tile" in html
+    assert "sky-weather-forecast-tile" in html
+    assert "sky-weather-scene" in html
+    assert "weather-sunny" in html
+    assert "skybridge-runtime-overrides" in html
+    assert "backdrop-filter: none !important" in html
     assert "No events " in renderer
 
 
@@ -203,3 +207,29 @@ def test_skybridge_is_registered_in_touch_menu():
     assert "/touch/skybridge.html" in menu
     assert "'skybridge.html'" in menu
     assert "'dashboard', 'skybridge', 'calendar'" not in menu
+
+
+
+def test_service_worker_does_not_cache_skybridge_runtime():
+    sw = read(ROOT / "zoe-ui" / "dist" / "sw.js")
+
+    assert "Skybridge is a live voice/data surface" in sw
+    assert "4.63.12" in sw
+    assert "url.pathname === '/touch/skybridge.html'" in sw
+    assert "url.pathname === '/js/auth.js'" in sw
+    assert "url.pathname.startsWith('/touch/js/skybridge')" in sw
+    assert "new workbox.strategies.NetworkOnly()" in sw
+
+
+
+def test_skybridge_has_typed_fallback_for_insecure_voice_contexts():
+    html = read(UI / "skybridge.html")
+    app = read(UI / "js" / "skybridge.js")
+
+    assert "sky-command-open" in html
+    assert "skybridge-premium-pill-overrides" in html
+    assert "sky-voice-fallback.sky-empty .sky-command" in html
+    assert "canUseMicrophone()" in app
+    assert "openCommandFallback(" in app
+    assert "Microphone needs HTTPS here" in app
+    assert "resp.status === 401" not in app

--- a/services/zoe-ui/dist/js/auth.js
+++ b/services/zoe-ui/dist/js/auth.js
@@ -425,7 +425,8 @@
                     if (u) pathname = new URL(u, window.location.origin).pathname;
                 } catch (_e) {}
                 const skipClear = /\/api\/auth\/(login|register|password|refresh|guest)/i.test(pathname);
-                const allowSessionClear = /\/api\/auth\/(profile|me|session|logout)/i.test(pathname);
+                const allowSessionClear = /\/api\/auth\/(profile|me|session|logout)/i.test(pathname) ||
+                    pathname === '/api/skybridge/resolve';
                 const sidBefore = getSession();
                 if (sidBefore && allowSessionClear && !skipClear && !options.__zoe401Retried) {
                     console.warn('⚠️ 401 — clearing stale session and retrying once without X-Session-ID:', url);

--- a/services/zoe-ui/dist/sw.js
+++ b/services/zoe-ui/dist/sw.js
@@ -8,24 +8,24 @@
 importScripts('https://storage.googleapis.com/workbox-cdn/releases/7.0.0/workbox-sw.js');
 
 // Zoe UI Version 4.17.3 - public modules (with or without trailing path segment)
-const SW_VERSION = '4.63.10'; // agent activity sidebar: escape/slice fixes, task detail fetch
+const SW_VERSION = '4.63.12'; // skybridge: auth and voice surface cache bypass
 const CACHE_NAME = `zoe-ui-v${SW_VERSION}`;
 
 // Verify Workbox loaded
 if (workbox) {
     console.log(`🚀 Zoe Service Worker ${SW_VERSION} - Workbox loaded`);
-    
+
     // Configure Workbox
     workbox.setConfig({
         debug: false
     });
-    
+
     // Set cache name prefix
     workbox.core.setCacheNameDetails({
         prefix: 'zoe',
         suffix: SW_VERSION
     });
-    
+
     // Skip waiting and claim clients immediately on update
     workbox.core.skipWaiting();
     workbox.core.clientsClaim();
@@ -43,7 +43,7 @@ if (workbox) {
             return;
         }
     });
-    
+
     // ===== PRECACHING =====
     // Precache critical assets during service worker installation
     workbox.precaching.precacheAndRoute([
@@ -59,9 +59,9 @@ if (workbox) {
         { url: '/js/sw-registration.js', revision: SW_VERSION },
         { url: '/css/dark-mode-shared.css', revision: SW_VERSION }
     ]);
-    
+
     // ===== CACHING STRATEGIES =====
-    
+
     // Self-hosted module HTML (/modules/qd/, /modules/jag-board/): never cache as documents
     // (avoids storing index.html under a module URL if origin misroutes).
     workbox.routing.registerRoute(
@@ -79,7 +79,13 @@ if (workbox) {
         },
         new workbox.strategies.NetworkOnly()
     );
-    
+
+    // Skybridge is a live voice/data surface. Never serve stale HTML, auth, or runtime JS.
+    workbox.routing.registerRoute(
+        ({ url }) => url.pathname === '/touch/skybridge.html' || url.pathname === '/js/auth.js' || url.pathname.startsWith('/touch/js/skybridge'),
+        new workbox.strategies.NetworkOnly()
+    );
+
     // 1. HTML Pages - Network First (fresh content, fallback to cache)
     workbox.routing.registerRoute(
         ({ request }) => request.destination === 'document',
@@ -96,13 +102,13 @@ if (workbox) {
             ]
         })
     );
-    
+
     // 2. JavaScript - Network First for widgets and widget-system, Cache First for other JS
     workbox.routing.registerRoute(
         ({ request }) => {
             // Check if it's a widget file, widget-system.js, or widget-base.js - always network first
             return request.destination === 'script' && (
-                request.url.includes('/widgets/') || 
+                request.url.includes('/widgets/') ||
                 request.url.includes('widget-system.js') ||
                 request.url.includes('widget-base.js')
             );
@@ -121,7 +127,7 @@ if (workbox) {
             ]
         })
     );
-    
+
     // Other JavaScript - Network First (ensures auth/executor fixes deploy instantly)
     workbox.routing.registerRoute(
         ({ request }) => request.destination === 'script',
@@ -139,7 +145,7 @@ if (workbox) {
             ]
         })
     );
-    
+
     // 3. CSS - Network First for widget CSS, Cache First for others
     workbox.routing.registerRoute(
         ({ request }) => {
@@ -159,7 +165,7 @@ if (workbox) {
             ]
         })
     );
-    
+
     // Other CSS - Network First (ensures style fixes deploy instantly)
     workbox.routing.registerRoute(
         ({ request }) => request.destination === 'style',
@@ -177,7 +183,7 @@ if (workbox) {
             ]
         })
     );
-    
+
     // 4. Images - Cache First with expiration
     workbox.routing.registerRoute(
         ({ request }) => request.destination === 'image',
@@ -194,7 +200,7 @@ if (workbox) {
             ]
         })
     );
-    
+
     // 5. Auth + Chat + notifications + health + WebSocket - Network Only (never cache)
     workbox.routing.registerRoute(
         ({ url }) => {
@@ -233,7 +239,7 @@ if (workbox) {
             ]
         })
     );
-    
+
     // 7. Fonts - Cache First (rarely change)
     workbox.routing.registerRoute(
         ({ request }) => request.destination === 'font',
@@ -250,17 +256,17 @@ if (workbox) {
             ]
         })
     );
-    
+
     // ===== OFFLINE FALLBACK =====
     workbox.routing.setCatchHandler(async ({ event }) => {
         // Return cached response or offline page for navigation requests
         if (event.request.destination === 'document') {
             return caches.match('/offline.html') || Response.error();
         }
-        
+
         return Response.error();
     });
-    
+
 } else {
     console.error('❌ Workbox failed to load');
 }
@@ -269,7 +275,7 @@ if (workbox) {
 // Handle push events for notifications
 self.addEventListener('push', (event) => {
     console.log('📬 Push notification received');
-    
+
     let data = {};
     try {
         data = event.data ? event.data.json() : {};
@@ -280,7 +286,7 @@ self.addEventListener('push', (event) => {
             body: event.data ? event.data.text() : 'You have a new notification'
         };
     }
-    
+
     const title = data.title || 'Zoe';
     // Keep options minimal and iOS-safe: no undefined values, no unsupported fields
     const options = {
@@ -293,7 +299,7 @@ self.addEventListener('push', (event) => {
             timestamp: Date.now()
         },
     };
-    
+
     event.waitUntil(
         self.registration.showNotification(title, options)
     );
@@ -339,7 +345,7 @@ self.addEventListener('notificationclose', (event) => {
 // Handle background sync for queued actions
 self.addEventListener('sync', (event) => {
     console.log('🔄 Background sync triggered:', event.tag);
-    
+
     if (event.tag === 'sync-queued-actions') {
         event.waitUntil(syncQueuedActions());
     }
@@ -356,11 +362,11 @@ async function syncQueuedActions() {
 // Handle messages from clients
 self.addEventListener('message', (event) => {
     console.log('💬 Message received:', event.data);
-    
+
     if (event.data && event.data.type === 'SKIP_WAITING') {
         self.skipWaiting();
     }
-    
+
     if (event.data && event.data.type === 'CACHE_URLS') {
         event.waitUntil(
             caches.open(CACHE_NAME).then((cache) => {
@@ -368,7 +374,7 @@ self.addEventListener('message', (event) => {
             })
         );
     }
-    
+
     if (event.data && event.data.type === 'CLEAR_CACHE') {
         // Delete all zoe-* caches and take control
         event.waitUntil((async () => {
@@ -381,7 +387,7 @@ self.addEventListener('message', (event) => {
             clientList.forEach(client => client.postMessage({ type: 'CACHE_CLEARED', version: SW_VERSION }));
         })());
     }
-    
+
     if (event.data && event.data.type === 'GET_VERSION') {
         event.ports[0].postMessage({ version: SW_VERSION });
     }

--- a/services/zoe-ui/dist/touch/js/skybridge-renderer.js
+++ b/services/zoe-ui/dist/touch/js/skybridge-renderer.js
@@ -47,7 +47,7 @@
             ? '<div class="sky-actions">' + props.actions.map(buttonHtml).join('') + '</div>'
             : '';
         return [
-            '<article class="sky-card' + wide + compact + tone + '" data-card-id="' + escapeHtml(props.id || '') + '">',
+            '<article class="sky-card sky-premium-card' + wide + compact + tone + '" data-card-id="' + escapeHtml(props.id || '') + '">',
             '<div class="sky-widget-top">',
             '<div class="sky-widget-title">',
             props.kicker ? '<p>' + escapeHtml(props.kicker) + '</p>' : '',
@@ -124,11 +124,42 @@
         return '☀️';
     }
 
+    function formatForecastLabel(value) {
+        const raw = String(value || '');
+        if (/^\d{4}-\d{2}-\d{2}/.test(raw)) {
+            const date = new Date(raw + 'T12:00:00');
+            if (!Number.isNaN(date.getTime())) {
+                return date.toLocaleDateString(undefined, { weekday: 'short', day: 'numeric', month: 'short' });
+            }
+        }
+        return raw;
+    }
+
     function formatWind(value) {
+        // Zoe weather APIs expose wind_speed in metres per second; Skybridge displays km/h.
         if (value == null || value === '') return '--';
         const number = Number(value);
         if (!Number.isFinite(number)) return String(value);
         return Math.round(number * 3.6) + ' km/h';
+    }
+
+    function forecastTempBand(item) {
+        const low = Number(item.low != null ? item.low : item.temp);
+        const high = Number(item.high != null ? item.high : item.temp);
+        const min = Number.isFinite(low) ? low : high;
+        const max = Number.isFinite(high) ? high : low;
+        if (!Number.isFinite(min) || !Number.isFinite(max)) {
+            return { left: 28, width: 36 };
+        }
+        const rangeMin = -5;
+        const rangeMax = 45;
+        const clamp = value => Math.max(0, Math.min(100, ((value - rangeMin) / (rangeMax - rangeMin)) * 100));
+        const left = Math.min(clamp(min), clamp(max));
+        const right = Math.max(clamp(min), clamp(max));
+        return {
+            left: Math.round(left),
+            width: Math.max(12, Math.round(right - left))
+        };
     }
 
     function renderWeather(props) {
@@ -137,15 +168,23 @@
         const daily = Array.isArray(forecast.daily) ? forecast.daily : [];
         const hourly = Array.isArray(forecast.hourly) ? forecast.hourly : [];
         const location = props.location || {};
-        const place = [location.city || current.city || props.city || 'Geraldton', location.country || current.country || props.country || 'AU'].filter(Boolean).join(', ');
+        const place = [location.city || current.city || props.city, location.country || current.country || props.country].filter(Boolean).join(', ') || 'Current location';
         const description = current.description || current.condition || props.description || 'Current conditions';
         const points = daily.length ? daily.slice(0, 5) : hourly.slice(0, 5);
         const forecastTiles = points.map(item => {
-            const label = item.day || item.time || '';
-            const temp = item.high != null || item.low != null
-                ? formatTemp(item.high) + ' / ' + formatTemp(item.low)
-                : formatTemp(item.temp);
-            return '<div class="sky-weather-forecast-tile"><span>' + escapeHtml(label) + '</span><strong>' + escapeHtml(temp) + '</strong><em>' + escapeHtml(item.description || item.condition || '') + '</em></div>';
+            const label = formatForecastLabel(item.day || item.time || '');
+            const high = item.high != null ? formatTemp(item.high) : formatTemp(item.temp);
+            const low = item.low != null ? formatTemp(item.low) : '';
+            const band = forecastTempBand(item);
+            const condition = item.description || item.condition || '';
+            return [
+                '<div class="sky-weather-forecast-tile">',
+                '<div class="sky-weather-tile-top"><span>' + escapeHtml(label) + '</span><b aria-hidden="true">' + escapeHtml(weatherEmoji(item)) + '</b></div>',
+                '<div class="sky-weather-tile-temp"><strong>' + escapeHtml(high) + '</strong>' + (low ? '<small>' + escapeHtml(low) + '</small>' : '') + '</div>',
+                '<div class="sky-weather-temp-band" aria-hidden="true"><i style="left: ' + band.left + '%; width: ' + band.width + '%;"></i></div>',
+                '<em>' + escapeHtml(condition) + '</em>',
+                '</div>'
+            ].join('');
         }).join('');
         const meta = [
             ['🌡', 'Feels ' + formatTemp(current.feels_like)],

--- a/services/zoe-ui/dist/touch/js/skybridge-renderer.js
+++ b/services/zoe-ui/dist/touch/js/skybridge-renderer.js
@@ -101,29 +101,71 @@
         return Number.isFinite(number) ? Math.round(number) + '°' : String(value);
     }
 
+    function weatherClass(props, current) {
+        const text = String((current && (current.icon || current.description || current.condition)) || props.condition || '').toLowerCase();
+        if (/thunder|storm/.test(text)) return 'weather-stormy';
+        if (/rain|drizzle|shower/.test(text)) return 'weather-rainy';
+        if (/snow|sleet|ice/.test(text)) return 'weather-snowy';
+        if (/fog|mist|haze|smoke/.test(text)) return 'weather-foggy';
+        if (/cloud|overcast/.test(text)) return /part|02/.test(text) ? 'weather-partly-cloudy' : 'weather-cloudy';
+        if (/night|\dn$/.test(text)) return 'weather-clear-night';
+        return 'weather-sunny';
+    }
+
+    function weatherEmoji(current) {
+        const text = String((current && (current.icon_emoji || current.icon || current.description || current.condition)) || '').toLowerCase();
+        if (current && current.icon_emoji) return current.icon_emoji;
+        if (/thunder|storm/.test(text)) return '⛈️';
+        if (/rain|drizzle|shower/.test(text)) return '🌧️';
+        if (/snow|sleet|ice/.test(text)) return '❄️';
+        if (/fog|mist|haze|smoke/.test(text)) return '🌫️';
+        if (/cloud|overcast/.test(text)) return '☁️';
+        if (/night|\dn$/.test(text)) return '🌙';
+        return '☀️';
+    }
+
+    function formatWind(value) {
+        if (value == null || value === '') return '--';
+        const number = Number(value);
+        if (!Number.isFinite(number)) return String(value);
+        return Math.round(number * 3.6) + ' km/h';
+    }
+
     function renderWeather(props) {
         const current = props.current || {};
         const forecast = props.forecast || {};
         const daily = Array.isArray(forecast.daily) ? forecast.daily : [];
         const hourly = Array.isArray(forecast.hourly) ? forecast.hourly : [];
         const location = props.location || {};
-        const metric = props.source === 'weather_forecast'
-            ? '<div class="sky-widget-metric"><strong>' + escapeHtml(daily.length || hourly.length) + '</strong><span>forecast points</span></div>'
-            : '<div class="sky-widget-metric"><strong>' + escapeHtml(formatTemp(current.temp)) + '</strong><span>' + escapeHtml(current.description || 'Current conditions') + '</span></div>';
-        const facts = [
-            ['Feels like', formatTemp(current.feels_like)],
-            ['Humidity', current.humidity == null ? '--' : current.humidity + '%'],
-            ['Wind', current.wind_speed == null ? '--' : current.wind_speed + ' m/s'],
-            ['Location', [location.city || current.city, location.country || current.country].filter(Boolean).join(', ')]
-        ].map(pair => '<div class="sky-field"><span>' + escapeHtml(pair[0]) + '</span><strong>' + escapeHtml(pair[1]) + '</strong></div>').join('');
-        const tiles = daily.slice(0, 5).map(day => {
-            return '<div class="sky-forecast-tile"><span>' + escapeHtml(day.day || '') + '</span><strong>' + escapeHtml(formatTemp(day.high)) + ' / ' + escapeHtml(formatTemp(day.low)) + '</strong><em>' + escapeHtml(day.description || '') + '</em></div>';
-        }).join('') || hourly.slice(0, 5).map(hour => {
-            return '<div class="sky-forecast-tile"><span>' + escapeHtml(hour.time || '') + '</span><strong>' + escapeHtml(formatTemp(hour.temp)) + '</strong><em>' + escapeHtml(hour.description || '') + '</em></div>';
+        const place = [location.city || current.city || props.city || 'Geraldton', location.country || current.country || props.country || 'AU'].filter(Boolean).join(', ');
+        const description = current.description || current.condition || props.description || 'Current conditions';
+        const points = daily.length ? daily.slice(0, 5) : hourly.slice(0, 5);
+        const forecastTiles = points.map(item => {
+            const label = item.day || item.time || '';
+            const temp = item.high != null || item.low != null
+                ? formatTemp(item.high) + ' / ' + formatTemp(item.low)
+                : formatTemp(item.temp);
+            return '<div class="sky-weather-forecast-tile"><span>' + escapeHtml(label) + '</span><strong>' + escapeHtml(temp) + '</strong><em>' + escapeHtml(item.description || item.condition || '') + '</em></div>';
         }).join('');
-        const body = metric + '<div class="sky-widget-strip">' + facts + '</div>' + (tiles ? '<div class="sky-forecast-row">' + tiles + '</div>' : '');
-        return cardFrame(Object.assign({ status: 'Weather', icon: 'W' }, props), body, { wide: true, tone: 'weather-card' });
+        const meta = [
+            ['🌡', 'Feels ' + formatTemp(current.feels_like)],
+            ['💧', current.humidity == null ? 'Humidity --' : current.humidity + '% humidity'],
+            ['💨', formatWind(current.wind_speed)]
+        ].map(pair => '<div class="sky-weather-pill"><span>' + escapeHtml(pair[0]) + '</span>' + escapeHtml(pair[1]) + '</div>').join('');
+        const body = [
+            '<div class="sky-weather-scene">',
+            '<div class="sky-weather-main">',
+            '<div class="sky-weather-location">📍 ' + escapeHtml(place) + '</div>',
+            '<div class="sky-weather-hero"><div class="sky-weather-temp">' + escapeHtml(formatTemp(current.temp)) + '</div><div class="sky-weather-icon" aria-hidden="true">' + escapeHtml(weatherEmoji(current)) + '</div></div>',
+            '<div class="sky-weather-condition">' + escapeHtml(description) + '</div>',
+            '<div class="sky-weather-meta">' + meta + '</div>',
+            '</div>',
+            '<div class="sky-weather-forecast"><h4>' + escapeHtml(props.source === 'weather_forecast' ? 'Forecast' : 'Next up') + '</h4><div class="sky-weather-forecast-grid">' + forecastTiles + '</div></div>',
+            '</div>'
+        ].join('');
+        return cardFrame(Object.assign({ status: 'Weather', icon: 'W' }, props), body, { wide: true, tone: 'weather-card ' + weatherClass(props, current) });
     }
+
 
     function renderPage(props) {
         const fields = [

--- a/services/zoe-ui/dist/touch/js/skybridge.js
+++ b/services/zoe-ui/dist/touch/js/skybridge.js
@@ -11,6 +11,7 @@
     let cardSequence = 0;
     let currentUtterance = '';
     let voiceStartedByUser = false;
+    let commandFallbackOpen = false;
 
     const colors = {
         ambient: ['#5fc6ff', '#66d19e'],
@@ -26,6 +27,7 @@
         renderHome();
         loadBackendStatus();
         setMode(mode);
+        syncVoiceFallbackState();
         if (typeof TouchMenu !== 'undefined') TouchMenu.init({ page: 'skybridge' });
         const initialQuery = new URLSearchParams(location.search).get('q');
         if (initialQuery) {
@@ -74,6 +76,11 @@
             event.preventDefault();
             submitCommand(els.input.value);
             els.input.value = '';
+        });
+        els.input.addEventListener('focus', () => openCommandFallback('Type anything Zoe should show.'));
+        els.input.addEventListener('input', () => {
+            commandFallbackOpen = true;
+            document.body.classList.add('sky-command-open');
         });
         els.mic.addEventListener('click', toggleVoiceCapture);
         els.orbButton.addEventListener('click', toggleVoiceCapture);
@@ -144,7 +151,7 @@
                 headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
                 body: JSON.stringify({ message: query })
             });
-            if (resp.status === 401 || resp.status === 503) {
+            if (resp.status === 503) {
                 try { localStorage.removeItem('zoe_session'); } catch (_) {}
                 resp = await fetch('/api/skybridge/resolve', {
                     method: 'POST',
@@ -238,6 +245,8 @@
     function renderHome(options) {
         const showCards = options && options.showCards;
         document.body.classList.add('sky-empty');
+        commandFallbackOpen = false;
+        document.body.classList.remove('sky-command-open');
         currentUtterance = '';
         setContext('Listening', 'The surface will build itself when Zoe understands what you need.');
         clearCards();
@@ -340,6 +349,24 @@
         updateVoiceControl(state);
     }
 
+    function canUseMicrophone() {
+        return !!(window.isSecureContext || location.hostname === 'localhost' || location.hostname === '127.0.0.1') &&
+            !!(navigator.mediaDevices && navigator.mediaDevices.getUserMedia);
+    }
+
+    function syncVoiceFallbackState() {
+        document.body.classList.toggle('sky-voice-fallback', !canUseMicrophone());
+    }
+
+    function openCommandFallback(message) {
+        commandFallbackOpen = true;
+        document.body.classList.add('sky-command-open');
+        document.body.classList.add('sky-voice-fallback');
+        if (message) els.input.placeholder = message;
+        updateVoiceHint('Type to Zoe', message || 'Voice is unavailable here. The same resolver will render cards from typed requests.', 'Type');
+        requestAnimationFrame(() => els.input.focus({ preventScroll: true }));
+    }
+
     function getMicGuidance() {
         if (!window.isSecureContext && location.hostname !== 'localhost' && location.hostname !== '127.0.0.1') {
             return 'Open Skybridge over HTTPS on the touch screen so the browser can allow microphone access.';
@@ -377,11 +404,11 @@
 
     function toggleVoiceCapture() {
         if (!voice) {
-            showError('Voice transport is still connecting.');
+            openCommandFallback('Voice is still connecting. Type here or tap again in a moment.');
             return;
         }
-        if (!window.isSecureContext && location.hostname !== 'localhost' && location.hostname !== '127.0.0.1') {
-            showError('Microphone requires HTTPS. Open the touch screen using the HTTPS Zoe URL.');
+        if (!canUseMicrophone()) {
+            openCommandFallback('Microphone needs HTTPS here. Type a request and Zoe will still render cards.');
             return;
         }
         if (voice.isRecording) {

--- a/services/zoe-ui/dist/touch/js/skybridge.js
+++ b/services/zoe-ui/dist/touch/js/skybridge.js
@@ -77,7 +77,11 @@
             submitCommand(els.input.value);
             els.input.value = '';
         });
-        els.input.addEventListener('focus', () => openCommandFallback('Type anything Zoe should show.'));
+        els.input.addEventListener('focus', () => {
+            if (!commandFallbackOpen) {
+                openCommandFallback('Type anything Zoe should show.');
+            }
+        });
         els.input.addEventListener('input', () => {
             commandFallbackOpen = true;
             document.body.classList.add('sky-command-open');
@@ -151,7 +155,7 @@
                 headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
                 body: JSON.stringify({ message: query })
             });
-            if (resp.status === 503) {
+            if (resp.status === 401 || resp.status === 503) {
                 try { localStorage.removeItem('zoe_session'); } catch (_) {}
                 resp = await fetch('/api/skybridge/resolve', {
                     method: 'POST',
@@ -247,6 +251,7 @@
         document.body.classList.add('sky-empty');
         commandFallbackOpen = false;
         document.body.classList.remove('sky-command-open');
+        syncVoiceFallbackState();
         currentUtterance = '';
         setContext('Listening', 'The surface will build itself when Zoe understands what you need.');
         clearCards();
@@ -361,7 +366,7 @@
     function openCommandFallback(message) {
         commandFallbackOpen = true;
         document.body.classList.add('sky-command-open');
-        document.body.classList.add('sky-voice-fallback');
+        document.body.classList.toggle('sky-voice-fallback', !canUseMicrophone());
         if (message) els.input.placeholder = message;
         updateVoiceHint('Type to Zoe', message || 'Voice is unavailable here. The same resolver will render cards from typed requests.', 'Type');
         requestAnimationFrame(() => els.input.focus({ preventScroll: true }));

--- a/services/zoe-ui/dist/touch/skybridge.html
+++ b/services/zoe-ui/dist/touch/skybridge.html
@@ -2281,7 +2281,7 @@
 
         .sky-stage {
             position: fixed !important;
-            inset: clamp(28px, 5vh, 56px) 0 132px !important;
+            inset: clamp(28px, 5vh, 56px) 0 168px !important;
             width: min(1120px, calc(100vw - 48px)) !important;
             margin: 0 auto !important;
             transform: none !important;
@@ -2300,7 +2300,7 @@
         .sky-card-stack {
             height: 100% !important;
             max-height: none !important;
-            padding: 0 0 18px !important;
+            padding: 0 0 30px !important;
             display: grid !important;
             grid-template-columns: repeat(12, minmax(0, 1fr)) !important;
             gap: 16px !important;
@@ -2357,9 +2357,271 @@
             50% { filter: brightness(1.16); }
         }
 
+
+        /* Weather data cards borrow the animated language of the touch weather page. */
+        .sky-card.weather-card {
+            min-height: 360px !important;
+            padding: 0 !important;
+            border-color: rgba(255,255,255,0.2) !important;
+            background: linear-gradient(160deg, #1e5a87 0%, #2c82bd 48%, #3f6a8b 100%) !important;
+            box-shadow:
+                0 34px 110px rgba(0,0,0,0.42),
+                inset 0 1px 0 rgba(255,255,255,0.22) !important;
+            backdrop-filter: none !important;
+            -webkit-backdrop-filter: none !important;
+        }
+
+
+        .sky-card.weather-card > .sky-widget-top,
+        .sky-card.weather-card > .sky-badge {
+            display: none !important;
+        }
+
+        .sky-card.weather-card.weather-sunny {
+            background: linear-gradient(160deg, #ff8c00 0%, #ffb347 35%, #87ceeb 70%, #1a6ea8 100%) !important;
+        }
+
+        .sky-card.weather-card.weather-clear-night {
+            background: linear-gradient(160deg, #0a0a2e 0%, #141452 42%, #1a1a6e 100%) !important;
+        }
+
+        .sky-card.weather-card.weather-cloudy {
+            background: linear-gradient(160deg, #485563 0%, #29323c 60%, #2c3e50 100%) !important;
+        }
+
+        .sky-card.weather-card.weather-rainy {
+            background: linear-gradient(160deg, #1c3144 0%, #2c4a6e 44%, #374a5a 100%) !important;
+        }
+
+        .sky-card.weather-card.weather-stormy {
+            background: linear-gradient(160deg, #070714 0%, #1a1a2e 42%, #16213e 100%) !important;
+        }
+
+        .sky-card.weather-card.weather-foggy {
+            background: linear-gradient(160deg, #b8c6db 0%, #f5f7fa 52%, #c3cfe2 100%) !important;
+            color: #1c2430;
+        }
+
+        .sky-card.weather-card.weather-snowy {
+            background: linear-gradient(160deg, #2c3e6a 0%, #4a6fa5 42%, #8ba7d4 100%) !important;
+        }
+
+        .sky-card.weather-card::before,
+        .sky-card.weather-card::after {
+            content: "";
+            position: absolute;
+            pointer-events: none;
+        }
+
+        .sky-card.weather-card::before {
+            top: -70px;
+            right: -54px;
+            width: 190px;
+            height: 190px;
+            border-radius: 50%;
+            background: radial-gradient(circle, rgba(255,247,161,0.98) 0%, rgba(255,215,0,0.72) 36%, rgba(255,140,0,0.18) 68%, transparent 72%);
+            box-shadow: 0 0 70px 28px rgba(255,200,0,0.24);
+            animation: sky-weather-pulse 4.5s ease-in-out infinite;
+        }
+
+        .sky-card.weather-card.weather-cloudy::before,
+        .sky-card.weather-card.weather-rainy::before,
+        .sky-card.weather-card.weather-stormy::before,
+        .sky-card.weather-card.weather-foggy::before,
+        .sky-card.weather-card.weather-snowy::before {
+            background: radial-gradient(circle at 42% 42%, rgba(255,255,255,0.54), rgba(255,255,255,0.18) 48%, transparent 70%);
+            box-shadow: -56px 22px 0 rgba(255,255,255,0.14), 38px 36px 0 rgba(255,255,255,0.12);
+            animation: sky-weather-drift 7s ease-in-out infinite;
+        }
+
+        .sky-card.weather-card.weather-clear-night::before {
+            background: radial-gradient(circle at 42% 38%, #f5f0c8 0%, #f5f0c8 38%, transparent 40%);
+            box-shadow: -26px -8px 0 -2px rgba(10,10,46,0.92), 0 0 60px 18px rgba(157,133,255,0.18);
+        }
+
+        .sky-card.weather-card::after {
+            inset: 0;
+            background:
+                linear-gradient(180deg, rgba(255,255,255,0.16), transparent 28%, rgba(0,0,0,0.18)),
+                radial-gradient(circle at 8% 8%, rgba(255,255,255,0.2), transparent 28%);
+            opacity: 0.9;
+        }
+
+        .sky-weather-scene {
+            position: relative;
+            z-index: 1;
+            display: grid;
+            grid-template-columns: minmax(0, 0.95fr) minmax(300px, 0.8fr);
+            gap: 18px;
+            min-height: 360px;
+            padding: 26px;
+            color: #fff;
+            text-shadow: 0 2px 12px rgba(0,0,0,0.34);
+        }
+
+        .sky-weather-main {
+            display: grid;
+            align-content: center;
+            gap: 12px;
+            min-width: 0;
+        }
+
+        .sky-weather-location {
+            justify-self: start;
+            display: inline-flex;
+            align-items: center;
+            gap: 7px;
+            max-width: 100%;
+            padding: 8px 16px;
+            border-radius: 999px;
+            border: 1px solid rgba(255,255,255,0.28);
+            background: rgba(8,20,40,0.42);
+            color: rgba(255,255,255,0.92);
+            font-size: 14px;
+            font-weight: 800;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+
+        .sky-weather-hero {
+            display: flex;
+            align-items: flex-end;
+            gap: 18px;
+        }
+
+        .sky-weather-temp {
+            font-size: clamp(82px, 11vw, 132px);
+            font-weight: 260;
+            line-height: 0.88;
+            letter-spacing: 0 !important;
+        }
+
+        .sky-weather-icon {
+            font-size: clamp(48px, 7vw, 76px);
+            line-height: 1;
+            filter: drop-shadow(0 7px 16px rgba(0,0,0,0.36));
+            animation: sky-weather-float 4.8s ease-in-out infinite;
+        }
+
+        .sky-weather-condition {
+            font-size: clamp(22px, 2.6vw, 32px);
+            font-weight: 650;
+            text-transform: capitalize;
+        }
+
+        .sky-weather-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 9px;
+            margin-top: 8px;
+        }
+
+        .sky-weather-pill,
+        .sky-weather-forecast-tile {
+            border: 1px solid rgba(255,255,255,0.22);
+            background: rgba(8,20,40,0.38);
+            box-shadow: inset 0 1px 0 rgba(255,255,255,0.1);
+        }
+
+        .sky-weather-pill {
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            padding: 10px 14px;
+            border-radius: 14px;
+            font-size: 14px;
+            font-weight: 800;
+            white-space: nowrap;
+        }
+
+        .sky-weather-forecast {
+            align-self: stretch;
+            display: grid;
+            grid-template-rows: auto 1fr;
+            gap: 12px;
+            min-width: 0;
+        }
+
+        .sky-weather-forecast h4 {
+            margin: 0;
+            font-size: 14px;
+            color: rgba(255,255,255,0.74);
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+        }
+
+        .sky-weather-forecast-grid {
+            display: grid;
+            grid-template-columns: repeat(5, minmax(0, 1fr));
+            gap: 10px;
+            align-items: stretch;
+        }
+
+        .sky-weather-forecast-tile {
+            display: grid;
+            gap: 7px;
+            min-height: 132px;
+            padding: 14px;
+            border-radius: 18px;
+        }
+
+        .sky-weather-forecast-tile span {
+            color: rgba(255,255,255,0.72);
+            font-size: 12px;
+            font-weight: 850;
+            text-transform: uppercase;
+        }
+
+        .sky-weather-forecast-tile strong {
+            font-size: 20px;
+            color: #fff;
+        }
+
+        .sky-weather-forecast-tile em {
+            color: rgba(255,255,255,0.66);
+            font-size: 13px;
+            font-style: normal;
+            line-height: 1.28;
+        }
+
+        .weather-foggy .sky-weather-scene,
+        .weather-foggy .sky-weather-location,
+        .weather-foggy .sky-weather-pill,
+        .weather-foggy .sky-weather-forecast h4,
+        .weather-foggy .sky-weather-forecast-tile,
+        .weather-foggy .sky-weather-forecast-tile span,
+        .weather-foggy .sky-weather-forecast-tile strong,
+        .weather-foggy .sky-weather-forecast-tile em {
+            color: #1d2733;
+            text-shadow: none;
+        }
+
+        .weather-foggy .sky-weather-location,
+        .weather-foggy .sky-weather-pill,
+        .weather-foggy .sky-weather-forecast-tile {
+            background: rgba(255,255,255,0.32);
+            border-color: rgba(0,0,0,0.12);
+        }
+
+        @keyframes sky-weather-pulse {
+            0%, 100% { transform: scale(1); }
+            50% { transform: scale(1.07); }
+        }
+
+        @keyframes sky-weather-drift {
+            0%, 100% { transform: translateX(0); }
+            50% { transform: translateX(-14px); }
+        }
+
+        @keyframes sky-weather-float {
+            0%, 100% { transform: translateY(0); }
+            50% { transform: translateY(-8px); }
+        }
+
         @media (max-width: 780px) {
             .sky-stage {
-                inset: 22px 12px 116px !important;
+                inset: 18px 12px 132px !important;
                 width: auto !important;
             }
 
@@ -2587,7 +2849,7 @@
 
         .sky-stage {
             position: fixed !important;
-            inset: clamp(28px, 5vh, 56px) 0 132px !important;
+            inset: clamp(28px, 5vh, 56px) 0 168px !important;
             width: min(1120px, calc(100vw - 48px)) !important;
             margin: 0 auto !important;
             transform: none !important;
@@ -2606,7 +2868,7 @@
         .sky-card-stack {
             height: 100% !important;
             max-height: none !important;
-            padding: 0 0 18px !important;
+            padding: 0 0 30px !important;
             display: grid !important;
             grid-template-columns: repeat(12, minmax(0, 1fr)) !important;
             gap: 16px !important;
@@ -2647,13 +2909,29 @@
 
         @media (max-width: 780px) {
             .sky-stage {
-                inset: 22px 12px 116px !important;
+                inset: 22px 12px 142px !important;
                 width: auto !important;
             }
 
             .sky-card-stack {
                 grid-template-columns: 1fr !important;
                 gap: 12px !important;
+                padding-bottom: 22px !important;
+            }
+
+            .sky-weather-scene {
+                grid-template-columns: 1fr;
+                min-height: 0;
+                padding: 22px;
+                gap: 18px;
+            }
+
+            .sky-weather-forecast-grid {
+                grid-template-columns: repeat(2, minmax(0, 1fr));
+            }
+
+            .sky-weather-temp {
+                font-size: clamp(68px, 22vw, 104px);
             }
 
             .sky-card,
@@ -2696,6 +2974,258 @@
                 height: 74px !important;
                 line-height: 74px !important;
                 font-size: 15px !important;
+            }
+        }
+
+        /* Typed fallback: only appears when voice cannot start or the user focuses it. */
+        body.sky-command-open .sky-command,
+        body.sky-voice-fallback.sky-empty .sky-command {
+            display: grid !important;
+            position: fixed !important;
+            left: 50% !important;
+            bottom: max(24px, env(safe-area-inset-bottom, 18px)) !important;
+            width: min(760px, calc(100vw - 40px)) !important;
+            transform: translateX(-50%) !important;
+            grid-template-columns: minmax(0, 1fr) auto auto !important;
+            gap: 10px !important;
+            padding: 10px !important;
+            border: 1px solid rgba(255,255,255,0.14) !important;
+            border-radius: 999px !important;
+            background: rgba(9, 13, 27, 0.78) !important;
+            box-shadow: 0 24px 90px rgba(0,0,0,0.42), inset 0 1px 0 rgba(255,255,255,0.1) !important;
+            backdrop-filter: blur(28px) !important;
+            -webkit-backdrop-filter: blur(28px) !important;
+            z-index: 20 !important;
+            opacity: 1 !important;
+            pointer-events: auto !important;
+        }
+
+        body.sky-command-open:not(.sky-empty) .sky-stage {
+            inset: clamp(28px, 5vh, 56px) 0 198px !important;
+        }
+
+        body.sky-command-open .sky-orb-panel::after,
+        body.sky-command-open .sky-listening-copy {
+            opacity: 0 !important;
+            pointer-events: none !important;
+        }
+
+        .sky-command #skyHomeBtn {
+            display: none !important;
+        }
+
+        .sky-command input {
+            display: block !important;
+            min-height: 54px !important;
+            border: 0 !important;
+            border-radius: 999px !important;
+            background: rgba(255,255,255,0.08) !important;
+            color: #fff !important;
+            padding: 0 18px !important;
+        }
+
+        .sky-command button {
+            display: inline-flex !important;
+            align-items: center !important;
+            justify-content: center !important;
+            min-height: 54px !important;
+            border-radius: 999px !important;
+            white-space: nowrap !important;
+        }
+
+        @media (max-width: 780px) {
+            body.sky-command-open .sky-command,
+            body.sky-voice-fallback.sky-empty .sky-command {
+                width: calc(100vw - 24px) !important;
+                grid-template-columns: auto minmax(0, 1fr) auto !important;
+                bottom: max(18px, env(safe-area-inset-bottom, 14px)) !important;
+                border-radius: 24px !important;
+            }
+
+            body.sky-command-open:not(.sky-empty) .sky-stage {
+                inset: 18px 12px 150px !important;
+            }
+
+            .sky-command #skyMicBtn {
+                display: none !important;
+            }
+        }
+
+    </style>
+
+    <style id="skybridge-runtime-overrides">
+        /* Final runtime lock: later minimal layers must not blur rendered data cards. */
+        .sky-stage,
+        .sky-orb-panel,
+        .sky-card,
+        .sky-card.weather-card {
+            backdrop-filter: none !important;
+            -webkit-backdrop-filter: none !important;
+        }
+
+        .sky-card.weather-card {
+            min-height: 360px !important;
+            padding: 0 !important;
+            background: linear-gradient(160deg, #1e5a87 0%, #2c82bd 48%, #3f6a8b 100%) !important;
+        }
+
+        .sky-card.weather-card.weather-sunny {
+            background: linear-gradient(160deg, #ff8c00 0%, #ffb347 35%, #87ceeb 70%, #1a6ea8 100%) !important;
+        }
+
+        .sky-card.weather-card.weather-cloudy,
+        .sky-card.weather-card.weather-partly-cloudy {
+            background: linear-gradient(160deg, #1e5a87 0%, #2c82bd 50%, #3f6a8b 100%) !important;
+        }
+
+        .sky-card.weather-card.weather-rainy {
+            background: linear-gradient(160deg, #1c3144 0%, #2c4a6e 44%, #374a5a 100%) !important;
+        }
+
+        .sky-card.weather-card.weather-stormy,
+        .sky-card.weather-card.weather-clear-night {
+            background: linear-gradient(160deg, #070714 0%, #1a1a2e 42%, #16213e 100%) !important;
+        }
+
+        body:not(.sky-empty) .sky-card-stack {
+            align-content: start !important;
+            padding-bottom: 34px !important;
+        }
+
+        body:not(.sky-empty) .sky-stage {
+            inset: clamp(28px, 5vh, 56px) 0 176px !important;
+        }
+
+        body.sky-command-open:not(.sky-empty) .sky-stage {
+            inset: clamp(28px, 5vh, 56px) 0 210px !important;
+        }
+
+        @media (max-width: 780px) {
+            body:not(.sky-empty) .sky-stage {
+                inset: 18px 12px 142px !important;
+            }
+
+            body.sky-command-open:not(.sky-empty) .sky-stage {
+                inset: 18px 12px 158px !important;
+            }
+        }
+    </style>
+
+    <style id="skybridge-premium-pill-overrides">
+        /* Premium command pill: functional fallback without looking like a form bolted on. */
+        body.sky-command-open .sky-command,
+        body.sky-voice-fallback.sky-empty .sky-command {
+            display: grid !important;
+            position: fixed !important;
+            left: 50% !important;
+            bottom: max(26px, env(safe-area-inset-bottom, 20px)) !important;
+            width: min(780px, calc(100vw - 48px)) !important;
+            min-height: 82px !important;
+            transform: translateX(-50%) !important;
+            grid-template-columns: auto minmax(0, 1fr) auto !important;
+            gap: 12px !important;
+            align-items: center !important;
+            padding: 10px 12px 10px 22px !important;
+            border: 1px solid rgba(255,255,255,0.18) !important;
+            border-radius: 999px !important;
+            background:
+                radial-gradient(circle at 7% 28%, rgba(255,255,255,0.18), transparent 28%),
+                linear-gradient(145deg, rgba(255,255,255,0.18), rgba(255,255,255,0.065)),
+                rgba(9, 13, 27, 0.72) !important;
+            box-shadow:
+                0 30px 100px rgba(0,0,0,0.44),
+                0 0 70px rgba(90,224,224,0.12),
+                inset 0 1px 0 rgba(255,255,255,0.14) !important;
+            backdrop-filter: blur(30px) saturate(1.18) !important;
+            -webkit-backdrop-filter: blur(30px) saturate(1.18) !important;
+            z-index: 20 !important;
+            opacity: 1 !important;
+            pointer-events: auto !important;
+        }
+
+        body.sky-command-open .sky-command::before,
+        body.sky-voice-fallback.sky-empty .sky-command::before {
+            content: "";
+            width: 50px;
+            height: 50px;
+            border-radius: 50%;
+            background:
+                radial-gradient(circle at 34% 24%, rgba(255,255,255,0.4), transparent 24%),
+                linear-gradient(135deg, #7B61FF 0%, #5AE0E0 100%);
+            box-shadow: 0 0 34px rgba(123,97,255,0.38), 0 0 58px rgba(90,224,224,0.18);
+            animation: sky-pill-orb-pulse 2.4s ease-in-out infinite;
+        }
+
+        body.sky-command-open .sky-command input,
+        body.sky-voice-fallback.sky-empty .sky-command input {
+            min-width: 0 !important;
+            min-height: 58px !important;
+            border: 0 !important;
+            border-radius: 999px !important;
+            background: transparent !important;
+            color: rgba(255,255,255,0.94) !important;
+            padding: 0 4px !important;
+            font-size: clamp(16px, 1.25vw, 19px) !important;
+            font-weight: 520 !important;
+            outline: none !important;
+        }
+
+        body.sky-command-open .sky-command input::placeholder,
+        body.sky-voice-fallback.sky-empty .sky-command input::placeholder {
+            color: rgba(255,255,255,0.46) !important;
+        }
+
+        body.sky-command-open .sky-command .primary,
+        body.sky-voice-fallback.sky-empty .sky-command .primary {
+            display: inline-flex !important;
+            align-items: center !important;
+            justify-content: center !important;
+            min-width: 92px !important;
+            min-height: 58px !important;
+            padding: 0 22px !important;
+            border: 0 !important;
+            border-radius: 999px !important;
+            background: linear-gradient(135deg, #7B61FF, #5AE0E0) !important;
+            color: #081016 !important;
+            font-size: 15px !important;
+            font-weight: 850 !important;
+            box-shadow: 0 12px 34px rgba(90,224,224,0.22) !important;
+        }
+
+        body.sky-command-open .sky-command #skyMicBtn,
+        body.sky-command-open .sky-command #skyHomeBtn,
+        body.sky-voice-fallback.sky-empty .sky-command #skyMicBtn,
+        body.sky-voice-fallback.sky-empty .sky-command #skyHomeBtn {
+            display: none !important;
+        }
+
+        body.sky-command-open .sky-orb-panel::after,
+        body.sky-command-open .sky-listening-copy {
+            opacity: 0 !important;
+            pointer-events: none !important;
+        }
+
+        @media (max-width: 780px) {
+            body.sky-command-open .sky-command,
+            body.sky-voice-fallback.sky-empty .sky-command {
+                width: calc(100vw - 24px) !important;
+                min-height: 76px !important;
+                bottom: max(18px, env(safe-area-inset-bottom, 14px)) !important;
+                padding: 9px 10px 9px 18px !important;
+                gap: 8px !important;
+            }
+
+            body.sky-command-open .sky-command::before,
+            body.sky-voice-fallback.sky-empty .sky-command::before {
+                width: 44px;
+                height: 44px;
+            }
+
+            body.sky-command-open .sky-command .primary,
+            body.sky-voice-fallback.sky-empty .sky-command .primary {
+                min-width: 74px !important;
+                min-height: 52px !important;
+                padding: 0 16px !important;
             }
         }
     </style>
@@ -2764,9 +3294,9 @@
     <script src="/touch/js/gestures.js"></script>
     <script src="/touch/js/touch-menu.js"></script>
     <script src="/js/touch-ui-executor.js"></script>
-    <script src="/touch/js/skybridge-capabilities.js?v=skybridge-minimal-1"></script>
-    <script src="/touch/js/skybridge-renderer.js?v=skybridge-minimal-1"></script>
-    <script src="/touch/js/skybridge-voice.js?v=skybridge-minimal-1"></script>
-    <script src="/touch/js/skybridge.js?v=skybridge-minimal-1"></script>
+    <script src="/touch/js/skybridge-capabilities.js?v=skybridge-weather-pill-2"></script>
+    <script src="/touch/js/skybridge-renderer.js?v=skybridge-weather-pill-2"></script>
+    <script src="/touch/js/skybridge-voice.js?v=skybridge-weather-pill-2"></script>
+    <script src="/touch/js/skybridge.js?v=skybridge-weather-pill-2"></script>
 </body>
 </html>

--- a/services/zoe-ui/dist/touch/skybridge.html
+++ b/services/zoe-ui/dist/touch/skybridge.html
@@ -3063,30 +3063,6 @@
             -webkit-backdrop-filter: none !important;
         }
 
-        .sky-card.weather-card {
-            min-height: 360px !important;
-            padding: 0 !important;
-            background: linear-gradient(160deg, #1e5a87 0%, #2c82bd 48%, #3f6a8b 100%) !important;
-        }
-
-        .sky-card.weather-card.weather-sunny {
-            background: linear-gradient(160deg, #ff8c00 0%, #ffb347 35%, #87ceeb 70%, #1a6ea8 100%) !important;
-        }
-
-        .sky-card.weather-card.weather-cloudy,
-        .sky-card.weather-card.weather-partly-cloudy {
-            background: linear-gradient(160deg, #1e5a87 0%, #2c82bd 50%, #3f6a8b 100%) !important;
-        }
-
-        .sky-card.weather-card.weather-rainy {
-            background: linear-gradient(160deg, #1c3144 0%, #2c4a6e 44%, #374a5a 100%) !important;
-        }
-
-        .sky-card.weather-card.weather-stormy,
-        .sky-card.weather-card.weather-clear-night {
-            background: linear-gradient(160deg, #070714 0%, #1a1a2e 42%, #16213e 100%) !important;
-        }
-
         body:not(.sky-empty) .sky-card-stack {
             align-content: start !important;
             padding-bottom: 34px !important;
@@ -3229,6 +3205,412 @@
             }
         }
     </style>
+
+
+    <style id="skybridge-premium-card-system">
+        /* Premium widget system: sharp card surface, restrained lighting, clear state. */
+        body:not(.sky-empty) .sky-card.sky-premium-card {
+            position: relative !important;
+            isolation: isolate;
+            overflow: hidden !important;
+            border-radius: 30px !important;
+            border: 1px solid rgba(255,255,255,0.16) !important;
+            background:
+                radial-gradient(circle at 18% 0%, rgba(255,255,255,0.13), transparent 32%),
+                radial-gradient(circle at 92% 8%, rgba(90,224,224,0.10), transparent 34%),
+                linear-gradient(180deg, rgba(31,37,58,0.92), rgba(15,19,33,0.88)) !important;
+            box-shadow:
+                0 1px 0 rgba(255,255,255,0.12) inset,
+                0 -34px 80px rgba(0,0,0,0.16) inset,
+                0 26px 90px rgba(0,0,0,0.36) !important;
+            backdrop-filter: none !important;
+            -webkit-backdrop-filter: none !important;
+            transform: translateZ(0);
+        }
+
+        body:not(.sky-empty) .sky-card.sky-premium-card::before {
+            content: "";
+            position: absolute;
+            inset: 0;
+            z-index: -1;
+            background:
+                linear-gradient(120deg, transparent 0%, rgba(255,255,255,0.09) 38%, transparent 64%),
+                radial-gradient(circle at 50% -16%, rgba(255,255,255,0.14), transparent 34%);
+            opacity: 0.68;
+            pointer-events: none;
+        }
+
+        body:not(.sky-empty) .sky-card.sky-premium-card::after {
+            content: "";
+            position: absolute;
+            inset: auto 22px 18px 22px;
+            height: 1px;
+            z-index: 2;
+            background: linear-gradient(90deg, transparent, rgba(255,255,255,0.28), transparent);
+            opacity: 0.55;
+            pointer-events: none;
+        }
+
+        body:not(.sky-empty) .sky-widget-top {
+            position: relative;
+            z-index: 2;
+            margin-bottom: 16px !important;
+        }
+
+        body:not(.sky-empty) .sky-badge {
+            position: relative;
+            z-index: 2;
+            justify-self: start;
+            width: fit-content;
+            border-radius: 999px !important;
+            border-color: rgba(255,255,255,0.16) !important;
+            background: rgba(255,255,255,0.08) !important;
+            color: rgba(255,255,255,0.74) !important;
+            box-shadow: inset 0 1px 0 rgba(255,255,255,0.1);
+        }
+
+        body:not(.sky-empty) .sky-card-title {
+            font-weight: 650 !important;
+            letter-spacing: 0 !important;
+        }
+
+        body:not(.sky-empty) .sky-widget-glyph {
+            border-radius: 20px !important;
+            background:
+                radial-gradient(circle at 28% 18%, rgba(255,255,255,0.86), transparent 28%),
+                linear-gradient(135deg, #7B61FF, #5AE0E0) !important;
+            box-shadow:
+                0 18px 46px rgba(90,224,224,0.2),
+                inset 0 1px 0 rgba(255,255,255,0.3) !important;
+        }
+
+        body:not(.sky-empty) .sky-field,
+        body:not(.sky-empty) .sky-event-row,
+        body:not(.sky-empty) .sky-empty-data {
+            border-color: rgba(255,255,255,0.12) !important;
+            background:
+                linear-gradient(180deg, rgba(255,255,255,0.09), rgba(255,255,255,0.045)) !important;
+            box-shadow: inset 0 1px 0 rgba(255,255,255,0.09) !important;
+        }
+
+        body:not(.sky-empty) .calendar-card {
+            background:
+                radial-gradient(circle at 16% -8%, rgba(123,97,255,0.22), transparent 38%),
+                radial-gradient(circle at 96% 14%, rgba(90,224,224,0.13), transparent 34%),
+                linear-gradient(180deg, rgba(30,34,54,0.94), rgba(13,17,29,0.9)) !important;
+        }
+
+        body:not(.sky-empty) .calendar-card .sky-data-list {
+            gap: 12px !important;
+        }
+
+        body:not(.sky-empty) .calendar-card .sky-event-row {
+            position: relative;
+            grid-template-columns: minmax(88px, 0.24fr) minmax(0, 1fr) !important;
+            padding: 16px 18px 16px 20px !important;
+        }
+
+        body:not(.sky-empty) .calendar-card .sky-event-row::before {
+            content: "";
+            position: absolute;
+            left: 9px;
+            top: 18px;
+            bottom: 18px;
+            width: 3px;
+            border-radius: 999px;
+            background: linear-gradient(180deg, #7B61FF, #5AE0E0);
+            box-shadow: 0 0 18px rgba(90,224,224,0.22);
+        }
+
+        body:not(.sky-empty) .weather-card.sky-premium-card,
+        body:not(.sky-empty) .weather-card.sky-premium-card.weather-clear-night,
+        body:not(.sky-empty) .weather-card.sky-premium-card.weather-stormy {
+            min-height: 370px !important;
+            padding: 0 !important;
+            border-color: rgba(255,255,255,0.2) !important;
+            background:
+                radial-gradient(circle at 86% 6%, rgba(245,240,200,0.98) 0 7%, rgba(245,240,200,0.08) 8%, transparent 18%),
+                radial-gradient(circle at 78% 8%, rgba(123,97,255,0.22), transparent 24%),
+                linear-gradient(160deg, #11152d 0%, #171b32 48%, #0b1022 100%) !important;
+            box-shadow:
+                0 1px 0 rgba(255,255,255,0.18) inset,
+                0 40px 120px rgba(0,0,0,0.42) !important;
+            backdrop-filter: none !important;
+            -webkit-backdrop-filter: none !important;
+        }
+
+        body:not(.sky-empty) .weather-card.sky-premium-card.weather-sunny {
+            background:
+                radial-gradient(circle at 84% 6%, rgba(255,247,161,0.98) 0 8%, rgba(255,191,71,0.18) 9%, transparent 22%),
+                linear-gradient(160deg, #ff8c00 0%, #ffb347 34%, #87ceeb 72%, #1a6ea8 100%) !important;
+        }
+
+        body:not(.sky-empty) .weather-card.sky-premium-card.weather-cloudy,
+        body:not(.sky-empty) .weather-card.sky-premium-card.weather-partly-cloudy {
+            background:
+                radial-gradient(circle at 84% 10%, rgba(255,255,255,0.22), transparent 24%),
+                linear-gradient(160deg, #1e5a87 0%, #2c82bd 50%, #3f6a8b 100%) !important;
+        }
+
+        body:not(.sky-empty) .weather-card.sky-premium-card.weather-rainy {
+            background:
+                radial-gradient(circle at 90% 8%, rgba(126,180,222,0.22), transparent 24%),
+                linear-gradient(160deg, #1c3144 0%, #2c4a6e 44%, #374a5a 100%) !important;
+        }
+
+        body:not(.sky-empty) .weather-card > .sky-widget-top,
+        body:not(.sky-empty) .weather-card > .sky-badge {
+            display: none !important;
+        }
+
+        body:not(.sky-empty) .weather-card::before {
+            content: "";
+            position: absolute;
+            inset: 0;
+            z-index: 0;
+            background:
+                linear-gradient(180deg, rgba(255,255,255,0.16), transparent 28%, rgba(0,0,0,0.22)),
+                radial-gradient(circle at 8% 6%, rgba(255,255,255,0.18), transparent 30%);
+            opacity: 0.95;
+            pointer-events: none;
+        }
+
+        body:not(.sky-empty) .weather-card::after {
+            content: "";
+            position: absolute;
+            right: -36px;
+            top: -44px;
+            width: 170px;
+            height: 170px;
+            border-radius: 50%;
+            z-index: 1;
+            background: radial-gradient(circle, rgba(255,255,255,0.72), rgba(255,255,255,0.18) 48%, transparent 70%);
+            filter: blur(0.2px);
+            opacity: 0.86;
+            animation: sky-weather-float 5.5s ease-in-out infinite;
+            pointer-events: none;
+        }
+
+        body:not(.sky-empty) .sky-weather-scene {
+            position: relative;
+            z-index: 2;
+            grid-template-columns: minmax(0, 0.92fr) minmax(280px, 0.82fr) !important;
+            gap: 20px !important;
+            padding: 28px !important;
+        }
+
+        body:not(.sky-empty) .sky-weather-location,
+        body:not(.sky-empty) .sky-weather-pill,
+        body:not(.sky-empty) .sky-weather-forecast-tile {
+            background: rgba(10,18,36,0.42) !important;
+            border-color: rgba(255,255,255,0.22) !important;
+            box-shadow: inset 0 1px 0 rgba(255,255,255,0.12), 0 12px 34px rgba(0,0,0,0.12) !important;
+        }
+
+        body:not(.sky-empty) .sky-weather-temp {
+            font-size: clamp(84px, 11vw, 136px) !important;
+            font-weight: 240 !important;
+            line-height: 0.86 !important;
+        }
+
+        body:not(.sky-empty) .sky-weather-condition {
+            font-weight: 720 !important;
+            color: rgba(255,255,255,0.94) !important;
+        }
+
+        body:not(.sky-empty) .sky-weather-forecast-grid {
+            grid-template-columns: repeat(5, minmax(0, 1fr)) !important;
+            gap: 10px !important;
+        }
+
+        body:not(.sky-empty) .sky-weather-forecast-tile {
+            min-height: 138px !important;
+            align-content: space-between;
+            transition: transform 220ms ease, border-color 220ms ease, background 220ms ease;
+        }
+
+        body:not(.sky-empty) .sky-weather-forecast-tile strong {
+            font-size: 22px !important;
+            letter-spacing: 0 !important;
+        }
+
+        @media (hover: hover) {
+            body:not(.sky-empty) .sky-card.sky-premium-card:hover {
+                transform: translateY(-2px) translateZ(0);
+                border-color: rgba(255,255,255,0.22) !important;
+            }
+
+            body:not(.sky-empty) .sky-weather-forecast-tile:hover {
+                transform: translateY(-2px);
+                background: rgba(255,255,255,0.11) !important;
+                border-color: rgba(255,255,255,0.3) !important;
+            }
+        }
+
+        @media (max-width: 780px) {
+            body:not(.sky-empty) .sky-card.sky-premium-card {
+                border-radius: 28px !important;
+            }
+
+            body:not(.sky-empty) .sky-weather-scene {
+                grid-template-columns: 1fr !important;
+                padding: 24px !important;
+            }
+
+            body:not(.sky-empty) .sky-weather-forecast-grid {
+                grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+            }
+
+            body:not(.sky-empty) .sky-weather-forecast-tile {
+                min-height: 128px !important;
+            }
+        }
+    </style>
+    <style id="skybridge-forecast-widget-overrides">
+        body:not(.sky-empty) .sky-weather-forecast {
+            min-width: 0;
+        }
+
+        body:not(.sky-empty) .sky-weather-forecast-grid {
+            align-items: stretch !important;
+        }
+
+        body:not(.sky-empty) .sky-weather-forecast-tile {
+            position: relative;
+            isolation: isolate;
+            display: grid !important;
+            grid-template-rows: auto auto auto 1fr;
+            gap: 12px !important;
+            min-height: 172px !important;
+            padding: 16px !important;
+            overflow: hidden;
+            border-radius: 24px !important;
+            background:
+                radial-gradient(circle at 50% -22%, rgba(255,255,255,0.3), transparent 44%),
+                linear-gradient(180deg, rgba(255,255,255,0.17), rgba(255,255,255,0.055)),
+                rgba(12,20,40,0.58) !important;
+            box-shadow:
+                inset 0 1px 0 rgba(255,255,255,0.18),
+                0 16px 44px rgba(0,0,0,0.18) !important;
+        }
+
+        body:not(.sky-empty) .sky-weather-forecast-tile::before {
+            content: "";
+            position: absolute;
+            inset: -40% -30% auto auto;
+            width: 112px;
+            height: 112px;
+            border-radius: 50%;
+            background: radial-gradient(circle, rgba(255,255,255,0.28), rgba(255,255,255,0.08) 48%, transparent 70%);
+            z-index: -1;
+            transition: transform 320ms ease, opacity 320ms ease;
+        }
+
+        body:not(.sky-empty) .sky-weather-tile-top {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 10px;
+            min-width: 0;
+        }
+
+        body:not(.sky-empty) .sky-weather-tile-top span {
+            min-width: 0;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+            color: rgba(255,255,255,0.62) !important;
+            font-size: 11px !important;
+            font-weight: 850 !important;
+            letter-spacing: 0.1em !important;
+            text-transform: uppercase;
+        }
+
+        body:not(.sky-empty) .sky-weather-tile-top b {
+            width: 38px;
+            height: 38px;
+            display: grid;
+            place-items: center;
+            flex: 0 0 auto;
+            border-radius: 14px;
+            background: rgba(255,255,255,0.18);
+            box-shadow: inset 0 1px 0 rgba(255,255,255,0.2), 0 12px 28px rgba(0,0,0,0.14);
+            font-size: 20px;
+            line-height: 1;
+        }
+
+        body:not(.sky-empty) .sky-weather-tile-temp {
+            display: flex;
+            align-items: baseline;
+            gap: 8px;
+            min-width: 0;
+        }
+
+        body:not(.sky-empty) .sky-weather-tile-temp strong {
+            font-size: clamp(30px, 3.4vw, 46px) !important;
+            font-weight: 520 !important;
+            line-height: 0.96 !important;
+            letter-spacing: 0 !important;
+        }
+
+        body:not(.sky-empty) .sky-weather-tile-temp small {
+            color: rgba(255,255,255,0.48);
+            font-size: 18px;
+            font-weight: 650;
+        }
+
+        body:not(.sky-empty) .sky-weather-temp-band {
+            position: relative;
+            height: 8px;
+            overflow: hidden;
+            border-radius: 999px;
+            background: rgba(255,255,255,0.13);
+            box-shadow: inset 0 1px 2px rgba(0,0,0,0.18);
+        }
+
+        body:not(.sky-empty) .sky-weather-temp-band i {
+            position: absolute;
+            top: 0;
+            bottom: 0;
+            min-width: 16px;
+            border-radius: inherit;
+            background: linear-gradient(90deg, rgba(90,224,224,0.92), rgba(255,209,102,0.96), rgba(255,122,122,0.9));
+            box-shadow: 0 0 18px rgba(255,209,102,0.28);
+        }
+
+        body:not(.sky-empty) .sky-weather-forecast-tile em {
+            display: -webkit-box !important;
+            overflow: hidden;
+            -webkit-line-clamp: 2;
+            -webkit-box-orient: vertical;
+            color: rgba(255,255,255,0.64) !important;
+            font-size: 13px !important;
+            font-style: normal;
+            line-height: 1.22 !important;
+        }
+
+        .weather-rainy .sky-weather-temp-band i,
+        .weather-stormy .sky-weather-temp-band i {
+            background: linear-gradient(90deg, rgba(120,180,255,0.96), rgba(90,224,224,0.9));
+        }
+
+        .weather-clear-night .sky-weather-temp-band i {
+            background: linear-gradient(90deg, rgba(140,125,255,0.96), rgba(90,224,224,0.9));
+        }
+
+        @media (hover: hover) {
+            body:not(.sky-empty) .sky-weather-forecast-tile:hover::before {
+                opacity: 1;
+                transform: translate(-8px, 8px) scale(1.08);
+            }
+        }
+
+        @media (max-width: 780px) {
+            body:not(.sky-empty) .sky-weather-forecast-tile {
+                min-height: 156px !important;
+            }
+        }
+    </style>
 </head>
 <body>
     <header class="sky-topbar">
@@ -3294,9 +3676,9 @@
     <script src="/touch/js/gestures.js"></script>
     <script src="/touch/js/touch-menu.js"></script>
     <script src="/js/touch-ui-executor.js"></script>
-    <script src="/touch/js/skybridge-capabilities.js?v=skybridge-weather-pill-2"></script>
-    <script src="/touch/js/skybridge-renderer.js?v=skybridge-weather-pill-2"></script>
-    <script src="/touch/js/skybridge-voice.js?v=skybridge-weather-pill-2"></script>
-    <script src="/touch/js/skybridge.js?v=skybridge-weather-pill-2"></script>
+    <script src="/touch/js/skybridge-capabilities.js?v=skybridge-premium-cards-3"></script>
+    <script src="/touch/js/skybridge-renderer.js?v=skybridge-premium-cards-3"></script>
+    <script src="/touch/js/skybridge-voice.js?v=skybridge-premium-cards-3"></script>
+    <script src="/touch/js/skybridge.js?v=skybridge-premium-cards-3"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- restore Skybridge typed fallback on insecure origins without trapping users behind the orb
- render weather cards as sharp touch-weather-inspired widgets with condition colors, forecast tiles, and no card blur
- bypass stale Skybridge/auth runtime caching via service worker and script version bump

## Verification
- python3 tools/audit/validate_structure.py
- python3 tools/audit/validate_critical_files.py
- cd services/zoe-data && PYTHONPATH=. python3 -m pytest -q tests/test_skybridge_static.py tests/test_skybridge_status.py tests/test_skybridge_service.py tests/test_card_contract.py
- Browser verified http://zoe.local/touch/skybridge.html?verify=weatherpill5 with typed show weather: card rendered, card backdrop-filter none, 120px gap to command pill