### PR TITLE
Clean up local Graphify timeouts

### DIFF
--- a/docs/architecture/zoe-graphify-refresh-evidence.md
+++ b/docs/architecture/zoe-graphify-refresh-evidence.md
@@ -48,6 +48,9 @@ Current evidence:
 - Local refresh wrapper short-timeout dry run rejected current main with
   `graphify_timed_out` and `graphify_exit_nonzero`, produced status JSON with a
   scrubbed workdir, and did not sync graph artifacts.
+- Timeout cleanup now runs Graphify in its own process group and terminates the
+  group on timeout; focused tests cover child-process cleanup, bytes output from
+  timeout exceptions, dry-run marker preservation, and rsync timeout reporting.
 
 ## Refresh 2026-06-09 Foundation Pass
 

--- a/docs/strategy/zoe-evolution-harness-status.md
+++ b/docs/strategy/zoe-evolution-harness-status.md
@@ -57,7 +57,8 @@ Important non-complete truth:
   the probe, requires repo mode plus clustering, and syncs `graphify-out` back to
   the repo only when the probe is accepted and required graph/report files exist.
   Rejected local runs write the generated refresh marker and leave the committed
-  graph untouched.
+  graph untouched. Probe timeouts now terminate the whole Graphify process group
+  so worker children do not survive failed local refresh attempts.
 - Tool/capability and memory read/write inventories now exist as cleanup gates; keep them updated as runtime paths change.
 - MemPalace now has a repeatable local baseline harness and first measured Zoe-host run; Hindsight now has a fixed measured runner, read-only probes, Zoe-host availability baseline, and first live offline retain/recall bake-off: 4/4 synthetic events retained and recalled at score 1.0 using local Gemma and cached BGE embeddings, but p95 recall stayed above the 600 ms hot-path target at 649.00 ms live and 643.25 ms warm.
 - Graphiti/FalkorDB/Neo4j have not yet been accepted for Zoe relational memory. Zoe-specific Graphiti fixtures, a read-only backend probe, and a read-only runtime readiness probe now define the first relationship eval set and availability preflight. A temporary FalkorDB sidecar was reachable, but Zoe's normal Python runtime lacks Graphiti backend packages and the current local Gemma endpoint failed Graphiti structured extraction in a smoke test.

--- a/scripts/maintenance/graphify_local_probe.py
+++ b/scripts/maintenance/graphify_local_probe.py
@@ -13,6 +13,7 @@ import argparse
 import json
 import os
 import re
+import signal
 import shutil
 import subprocess
 import sys
@@ -147,23 +148,44 @@ def classify_probe_result(
     }
 
 
+def _text_output(value: str | bytes | None) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return value
+
+
 def run_command(command: Sequence[str], *, cwd: Path, env: dict[str, str], timeout_sec: int) -> tuple[int, bool, str]:
+    process = subprocess.Popen(
+        list(command),
+        cwd=cwd,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        start_new_session=True,
+    )
     try:
-        completed = subprocess.run(
-            list(command),
-            cwd=cwd,
-            env=env,
-            text=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            timeout=timeout_sec,
-            check=False,
-        )
-        return completed.returncode, False, completed.stdout
+        stdout, _ = process.communicate(timeout=timeout_sec)
+        return process.returncode or 0, False, stdout or ""
     except subprocess.TimeoutExpired as exc:
-        output = exc.stdout or ""
-        if isinstance(output, bytes):
-            output = output.decode("utf-8", errors="replace")
+        try:
+            os.killpg(process.pid, signal.SIGTERM)
+        except OSError:
+            pass
+        try:
+            stdout, _ = process.communicate(timeout=5)
+        except subprocess.TimeoutExpired:
+            try:
+                os.killpg(process.pid, signal.SIGKILL)
+            except OSError:
+                pass
+            try:
+                stdout, _ = process.communicate(timeout=10)
+            except subprocess.TimeoutExpired:
+                stdout = b""
+        output = "".join(_text_output(part) for part in (exc.stdout, stdout))
         return 124, True, output
 
 

--- a/services/zoe-data/tests/test_graphify_local_probe.py
+++ b/services/zoe-data/tests/test_graphify_local_probe.py
@@ -1,5 +1,8 @@
 import importlib.util
+import os
+import subprocess
 import sys
+import time
 from pathlib import Path
 
 
@@ -109,3 +112,65 @@ def test_classify_reports_missing_graph_once():
     assert result["accepted"] is False
     assert result["blockers"].count("graph_json_missing") == 1
     assert "graph_json_empty" not in result["blockers"]
+
+
+def test_run_command_timeout_kills_child_process_group(tmp_path):
+    module = _load_module()
+    token = f"zoe_graphify_probe_timeout_{os.getpid()}"
+    child_code = "import sys,time; assert sys.argv[1]; time.sleep(30)"
+    parent_code = (
+        "import subprocess,sys,time; "
+        "subprocess.Popen([sys.executable, '-c', sys.argv[1], sys.argv[2]]); "
+        "time.sleep(30)"
+    )
+    command = [sys.executable, "-c", parent_code, child_code, token]
+
+    returncode, timed_out, _output = module.run_command(command, cwd=tmp_path, env=os.environ.copy(), timeout_sec=1)
+    time.sleep(0.5)
+    lingering = subprocess.run(
+        ["pgrep", "-af", token],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    )
+    if lingering.stdout.strip():
+        subprocess.run(["pkill", "-f", token], check=False)
+
+    assert returncode == 124
+    assert timed_out is True
+    assert token not in lingering.stdout
+
+
+def test_text_output_decodes_timeout_bytes():
+    module = _load_module()
+
+    assert module._text_output(b"hello") == "hello"
+    assert module._text_output(None) == ""
+    assert module._text_output("already text") == "already text"
+
+
+def test_run_command_timeout_handles_killpg_oserror(monkeypatch, tmp_path):
+    module = _load_module()
+
+    class FakeProcess:
+        pid = 12345
+        returncode = None
+
+        def __init__(self):
+            self.calls = 0
+
+        def communicate(self, timeout=None):
+            self.calls += 1
+            raise module.subprocess.TimeoutExpired(["fake"], timeout=timeout, output=b"partial")
+
+    fake = FakeProcess()
+    monkeypatch.setattr(module.subprocess, "Popen", lambda *args, **kwargs: fake)
+    monkeypatch.setattr(module.os, "killpg", lambda *args, **kwargs: (_ for _ in ()).throw(PermissionError("denied")))
+
+    returncode, timed_out, output = module.run_command(["fake"], cwd=tmp_path, env={}, timeout_sec=1)
+
+    assert returncode == 124
+    assert timed_out is True
+    assert output == "partial"
+    assert fake.calls == 3


### PR DESCRIPTION
## Summary
- run local Graphify probe commands in their own process group
- terminate the whole process group on timeout so Graphify workers do not survive failed local refresh attempts
- normalize timeout output when subprocess exceptions return bytes
- document the timeout cleanup evidence

## Validation
- python3 -m py_compile scripts/maintenance/graphify_local_probe.py scripts/maintenance/graphify_local_refresh.py
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_graphify_local_probe.py services/zoe-data/tests/test_graphify_local_refresh.py
- python3 scripts/maintenance/graphify_local_probe.py --mode smoke --timeout-sec 60 --status-json /tmp/zoe-graphify-timeout-smoke.json
- python3 scripts/maintenance/graphify_local_refresh.py --timeout-sec 2 --dry-run --status-json /tmp/zoe-graphify-timeout-cleanup-status.json || true
- pgrep -af "graphify extract" || true
- python3 tools/audit/validate_structure.py
- python3 tools/audit/validate_critical_files.py
- python3 tools/audit/validate_offline_memory.py
- git diff --check
