### PR TITLE
Polish Skybridge calendar cards

### DIFF
--- a/services/zoe-data/tests/test_skybridge_static.py
+++ b/services/zoe-data/tests/test_skybridge_static.py
@@ -191,6 +191,7 @@ def test_skybridge_renderer_supports_real_data_cards():
     assert "renderWeather(props)" in renderer
     assert "sky-premium-card" in renderer
     assert "formatCalendarDate" in renderer
+    assert "calendarEventSortKey" in renderer
     assert "calendarCategoryClass" in renderer
     assert "sky-calendar-scene" in renderer
     assert "sky-calendar-event-main" in renderer
@@ -216,6 +217,21 @@ def test_skybridge_renderer_supports_real_data_cards():
     assert "skybridge-premium-cards-4" in html
     assert "backdrop-filter: none !important" in html
     assert "No events " in renderer
+
+
+def test_skybridge_calendar_renderer_handles_datetime_dates_and_ordering():
+    renderer = read(UI / "js" / "skybridge-renderer.js")
+    calendar_date_helper = renderer[
+        renderer.index("function formatCalendarDate"):
+        renderer.index("function calendarEventSortKey")
+    ]
+
+    assert "const datePart = raw.slice(0, 10);" in calendar_date_helper
+    assert r"/^\d{4}-\d{2}-\d{2}$/.test(datePart)" in calendar_date_helper
+    assert "new Date(datePart + 'T12:00:00')" in calendar_date_helper
+    assert "new Date(raw + 'T12:00:00')" not in calendar_date_helper
+    assert "events.slice().sort((a, b) => calendarEventSortKey(a) - calendarEventSortKey(b)).slice(0, 8)" in renderer
+    assert "return known.indexOf(token) >= 0 ? token : 'general';" in renderer
 
 
 def test_skybridge_is_registered_in_touch_menu():

--- a/services/zoe-data/tests/test_skybridge_static.py
+++ b/services/zoe-data/tests/test_skybridge_static.py
@@ -231,6 +231,8 @@ def test_skybridge_calendar_renderer_handles_datetime_dates_and_ordering():
     assert "new Date(datePart + 'T12:00:00')" in calendar_date_helper
     assert "new Date(raw + 'T12:00:00')" not in calendar_date_helper
     assert "events.slice().sort((a, b) => calendarEventSortKey(a) - calendarEventSortKey(b)).slice(0, 8)" in renderer
+    assert "props.date || props.start_date || (visibleEvents[0] && visibleEvents[0].start_date)" in renderer
+    assert "props.date || props.start_date || (events[0] && events[0].start_date)" not in renderer
     assert "return known.indexOf(token) >= 0 ? token : 'general';" in renderer
 
 

--- a/services/zoe-data/tests/test_skybridge_static.py
+++ b/services/zoe-data/tests/test_skybridge_static.py
@@ -233,6 +233,8 @@ def test_skybridge_calendar_renderer_handles_datetime_dates_and_ordering():
     assert "events.slice().sort((a, b) => calendarEventSortKey(a) - calendarEventSortKey(b)).slice(0, 8)" in renderer
     assert "props.date || props.start_date || (visibleEvents[0] && visibleEvents[0].start_date)" in renderer
     assert "props.date || props.start_date || (events[0] && events[0].start_date)" not in renderer
+    assert "const detail = [item.location].filter(Boolean).join(' · ');" in renderer
+    assert "const detail = [item.location, calendarAccentLabel(item.category)]" not in renderer
     assert "return known.indexOf(token) >= 0 ? token : 'general';" in renderer
 
 

--- a/services/zoe-data/tests/test_skybridge_static.py
+++ b/services/zoe-data/tests/test_skybridge_static.py
@@ -190,6 +190,11 @@ def test_skybridge_renderer_supports_real_data_cards():
     assert "renderCalendar(props)" in renderer
     assert "renderWeather(props)" in renderer
     assert "sky-premium-card" in renderer
+    assert "formatCalendarDate" in renderer
+    assert "calendarCategoryClass" in renderer
+    assert "sky-calendar-scene" in renderer
+    assert "sky-calendar-event-main" in renderer
+    assert "sky-calendar-category" in renderer
     assert "formatForecastLabel" in renderer
     assert "forecastTempBand(item)" in renderer
     assert "sky-weather-tile-temp" in renderer
@@ -206,8 +211,9 @@ def test_skybridge_renderer_supports_real_data_cards():
     assert "weather-sunny" in html
     assert "skybridge-runtime-overrides" in html
     assert "skybridge-premium-card-system" in html
+    assert "skybridge-calendar-widget-overrides" in html
     assert "skybridge-forecast-widget-overrides" in html
-    assert "skybridge-premium-cards-3" in html
+    assert "skybridge-premium-cards-4" in html
     assert "backdrop-filter: none !important" in html
     assert "No events " in renderer
 

--- a/services/zoe-data/tests/test_skybridge_static.py
+++ b/services/zoe-data/tests/test_skybridge_static.py
@@ -198,7 +198,12 @@ def test_skybridge_renderer_supports_real_data_cards():
     assert "sky-calendar-category" in renderer
     assert "formatForecastLabel" in renderer
     assert "forecastTempBand(item)" in renderer
-    assert "sky-weather-tile-temp" in renderer
+    assert "formatHourLabel" in renderer
+    assert "sky-weather-hour-strip" in renderer
+    assert "sky-weather-hour-tile" in renderer
+    assert "sky-weather-day-list" in renderer
+    assert "sky-weather-day-row" in renderer
+    assert "sky-weather-day-main" in renderer
     assert "sky-weather-temp-band" in renderer
     assert "Current location" in renderer
     assert "Geraldton" not in renderer
@@ -207,16 +212,44 @@ def test_skybridge_renderer_supports_real_data_cards():
     assert "props.source === 'weather_current'" in renderer
     assert "props.source === 'weather_forecast'" in renderer
     assert "sky-event-row" in html
-    assert "sky-weather-forecast-tile" in html
+    assert "sky-weather-hour-tile" in html
+    assert "sky-weather-day-row" in html
     assert "sky-weather-scene" in html
     assert "weather-sunny" in html
     assert "skybridge-runtime-overrides" in html
     assert "skybridge-premium-card-system" in html
     assert "skybridge-calendar-widget-overrides" in html
     assert "skybridge-forecast-widget-overrides" in html
-    assert "skybridge-premium-cards-4" in html
+    assert "skybridge-weather-widget-v2" in html
+    assert "skybridge-premium-cards-5" in html
     assert "backdrop-filter: none !important" in html
     assert "No events " in renderer
+
+
+def test_skybridge_weather_renderer_uses_widget_forecast_structure():
+    renderer = read(UI / "js" / "skybridge-renderer.js")
+    html = read(UI / "skybridge.html")
+    forecast_label_helper = renderer[
+        renderer.index("function formatForecastLabel"):
+        renderer.index("function formatForecastShort")
+    ]
+
+    assert "const datePart = raw.slice(0, 10);" in forecast_label_helper
+    assert r"/^\d{4}-\d{2}-\d{2}$/.test(datePart)" in forecast_label_helper
+    assert "new Date(datePart + 'T12:00:00')" in forecast_label_helper
+    assert "new Date(raw + 'T12:00:00')" not in forecast_label_helper
+    assert "const dailyRows = daily.slice(0, 5).map" in renderer
+    assert "const hourlyTiles = hourly.slice(0, 8).map" in renderer
+    assert "const fallbackTiles = !dailyRows && hourly.slice(0, 5).map" in renderer
+    assert "current && current.description" in renderer
+    assert "rain|drizzle|shower|09|10" in renderer
+    assert "cloud|overcast|03|04" in renderer
+    assert "sky-weather-forecast-head" in renderer
+    assert "sky-weather-forecast-grid" not in renderer
+    assert "sky-weather-forecast-tile" not in renderer
+    assert "grid-template-columns: repeat(8, minmax(54px, 1fr))" in html
+    assert "grid-template-columns: minmax(88px, 0.32fr) minmax(0, 1fr) auto" in html
+    assert "text-transform: capitalize" in html
 
 
 def test_skybridge_calendar_renderer_handles_datetime_dates_and_ordering():

--- a/services/zoe-data/tests/test_skybridge_static.py
+++ b/services/zoe-data/tests/test_skybridge_static.py
@@ -199,6 +199,8 @@ def test_skybridge_renderer_supports_real_data_cards():
     assert "formatForecastLabel" in renderer
     assert "forecastTempBand(item)" in renderer
     assert "formatHourLabel" in renderer
+    assert "const dayList = dailyRows;" in renderer
+    assert "fallbackTiles" not in renderer
     assert "sky-weather-hour-strip" in renderer
     assert "sky-weather-hour-tile" in renderer
     assert "sky-weather-day-list" in renderer
@@ -240,8 +242,8 @@ def test_skybridge_weather_renderer_uses_widget_forecast_structure():
     assert "new Date(raw + 'T12:00:00')" not in forecast_label_helper
     assert "const dailyRows = daily.slice(0, 5).map" in renderer
     assert "const hourlyTiles = hourly.slice(0, 8).map" in renderer
-    assert "const fallbackTiles = !dailyRows && !hourlyTiles && hourly.slice(0, 5).map" in renderer
-    assert "const dayList = dailyRows || fallbackTiles;" in renderer
+    assert "fallbackTiles" not in renderer
+    assert "const dayList = dailyRows;" in renderer
     assert "current && current.description" in renderer
     assert "rain|drizzle|shower|09|10" in renderer
     assert "cloud|overcast|03|04" in renderer

--- a/services/zoe-data/tests/test_skybridge_static.py
+++ b/services/zoe-data/tests/test_skybridge_static.py
@@ -240,10 +240,12 @@ def test_skybridge_weather_renderer_uses_widget_forecast_structure():
     assert "new Date(raw + 'T12:00:00')" not in forecast_label_helper
     assert "const dailyRows = daily.slice(0, 5).map" in renderer
     assert "const hourlyTiles = hourly.slice(0, 8).map" in renderer
-    assert "const fallbackTiles = !dailyRows && hourly.slice(0, 5).map" in renderer
+    assert "const fallbackTiles = !dailyRows && !hourlyTiles && hourly.slice(0, 5).map" in renderer
+    assert "const dayList = dailyRows || fallbackTiles;" in renderer
     assert "current && current.description" in renderer
     assert "rain|drizzle|shower|09|10" in renderer
     assert "cloud|overcast|03|04" in renderer
+    assert "replace(',', '')" in renderer
     assert "sky-weather-forecast-head" in renderer
     assert "sky-weather-forecast-grid" not in renderer
     assert "sky-weather-forecast-tile" not in renderer

--- a/services/zoe-ui/dist/touch/js/skybridge-renderer.js
+++ b/services/zoe-ui/dist/touch/js/skybridge-renderer.js
@@ -110,8 +110,16 @@
     }
 
     function calendarAccentLabel(value) {
-        const category = calendarCategoryClass(value);
-        return category.charAt(0).toUpperCase() + category.slice(1);
+        const token = String(value || 'general').toLowerCase();
+        if (token === 'work') return 'Work';
+        if (token === 'personal') return 'Personal';
+        if (token === 'bucket') return 'Bucket';
+        if (token === 'shopping') return 'Shopping';
+        if (token === 'health') return 'Health';
+        if (token === 'routine') return 'Routine';
+        if (token === 'social') return 'Social';
+        if (token === 'family') return 'Family';
+        return 'General';
     }
 
     function renderCalendar(props) {
@@ -156,7 +164,13 @@
     }
 
     function weatherClass(props, current) {
-        const text = String((current && (current.icon || current.description || current.condition)) || props.condition || '').toLowerCase();
+        const text = [
+            current && current.description,
+            current && current.condition,
+            props.description,
+            props.condition,
+            current && current.icon
+        ].filter(Boolean).join(' ').toLowerCase();
         if (/thunder|storm/.test(text)) return 'weather-stormy';
         if (/rain|drizzle|shower/.test(text)) return 'weather-rainy';
         if (/snow|sleet|ice/.test(text)) return 'weather-snowy';
@@ -167,26 +181,49 @@
     }
 
     function weatherEmoji(current) {
-        const text = String((current && (current.icon_emoji || current.icon || current.description || current.condition)) || '').toLowerCase();
         if (current && current.icon_emoji) return current.icon_emoji;
-        if (/thunder|storm/.test(text)) return '⛈️';
-        if (/rain|drizzle|shower/.test(text)) return '🌧️';
-        if (/snow|sleet|ice/.test(text)) return '❄️';
-        if (/fog|mist|haze|smoke/.test(text)) return '🌫️';
-        if (/cloud|overcast/.test(text)) return '☁️';
+        const text = [
+            current && current.description,
+            current && current.condition,
+            current && current.icon
+        ].filter(Boolean).join(' ').toLowerCase();
+        const icon = String(current && current.icon || '').toLowerCase();
+        if (/thunder|storm|11/.test(text)) return '⛈️';
+        if (/rain|drizzle|shower|09|10/.test(text)) return '🌧️';
+        if (/snow|sleet|ice|13/.test(text)) return '❄️';
+        if (/fog|mist|haze|smoke|50/.test(text)) return '🌫️';
+        if (/part|02/.test(text)) return /n$/.test(icon) ? '🌙' : '🌤️';
+        if (/cloud|overcast|03|04/.test(text)) return '☁️';
         if (/night|\dn$/.test(text)) return '🌙';
         return '☀️';
     }
 
     function formatForecastLabel(value) {
         const raw = String(value || '');
-        if (/^\d{4}-\d{2}-\d{2}/.test(raw)) {
-            const date = new Date(raw + 'T12:00:00');
+        const datePart = raw.slice(0, 10);
+        if (/^\d{4}-\d{2}-\d{2}$/.test(datePart)) {
+            const date = new Date(datePart + 'T12:00:00');
             if (!Number.isNaN(date.getTime())) {
                 return date.toLocaleDateString(undefined, { weekday: 'short', day: 'numeric', month: 'short' });
             }
         }
         return raw;
+    }
+
+    function formatForecastShort(value) {
+        const label = formatForecastLabel(value);
+        return label.replace(/^([A-Za-z]{3})\s+(\d+)\s+([A-Za-z]{3})$/, '$1 $2');
+    }
+
+    function formatHourLabel(value) {
+        const raw = String(value || '');
+        const match = raw.match(/T?(\d{1,2}):(\d{2})/);
+        if (!match) return raw || 'Now';
+        const hour = Number(match[1]);
+        if (!Number.isFinite(hour)) return raw;
+        if (hour === 0) return '12am';
+        if (hour === 12) return '12pm';
+        return (hour > 12 ? hour - 12 : hour) + (hour > 11 ? 'pm' : 'am');
     }
 
     function formatWind(value) {
@@ -224,19 +261,37 @@
         const location = props.location || {};
         const place = [location.city || current.city || props.city, location.country || current.country || props.country].filter(Boolean).join(', ') || 'Current location';
         const description = current.description || current.condition || props.description || 'Current conditions';
-        const points = daily.length ? daily.slice(0, 5) : hourly.slice(0, 5);
-        const forecastTiles = points.map(item => {
-            const label = formatForecastLabel(item.day || item.time || '');
+        const dailyRows = daily.slice(0, 5).map((item, index) => {
+            const label = formatForecastShort(item.day || item.time || '');
             const high = item.high != null ? formatTemp(item.high) : formatTemp(item.temp);
             const low = item.low != null ? formatTemp(item.low) : '';
             const band = forecastTempBand(item);
             const condition = item.description || item.condition || '';
             return [
-                '<div class="sky-weather-forecast-tile">',
-                '<div class="sky-weather-tile-top"><span>' + escapeHtml(label) + '</span><b aria-hidden="true">' + escapeHtml(weatherEmoji(item)) + '</b></div>',
-                '<div class="sky-weather-tile-temp"><strong>' + escapeHtml(high) + '</strong>' + (low ? '<small>' + escapeHtml(low) + '</small>' : '') + '</div>',
-                '<div class="sky-weather-temp-band" aria-hidden="true"><i style="left: ' + band.left + '%; width: ' + band.width + '%;"></i></div>',
-                '<em>' + escapeHtml(condition) + '</em>',
+                '<div class="sky-weather-day-row' + (index === 0 ? ' is-primary' : '') + '">',
+                '<div class="sky-weather-day-label"><span>' + escapeHtml(index === 0 ? 'Today' : label) + '</span><b aria-hidden="true">' + escapeHtml(weatherEmoji(item)) + '</b></div>',
+                '<div class="sky-weather-day-main"><strong>' + escapeHtml(condition || description) + '</strong><div class="sky-weather-temp-band" aria-hidden="true"><i style="left: ' + band.left + '%; width: ' + band.width + '%;"></i></div></div>',
+                '<div class="sky-weather-day-temp"><strong>' + escapeHtml(high) + '</strong>' + (low ? '<small>' + escapeHtml(low) + '</small>' : '') + '</div>',
+                '</div>'
+            ].join('');
+        }).join('');
+        const hourlyTiles = hourly.slice(0, 8).map((item, index) => {
+            const label = index === 0 ? 'Now' : formatHourLabel(item.time || item.day || '');
+            return [
+                '<div class="sky-weather-hour-tile">',
+                '<span>' + escapeHtml(label) + '</span>',
+                '<b aria-hidden="true">' + escapeHtml(weatherEmoji(item)) + '</b>',
+                '<strong>' + escapeHtml(formatTemp(item.temp != null ? item.temp : item.high)) + '</strong>',
+                '</div>'
+            ].join('');
+        }).join('');
+        const fallbackTiles = !dailyRows && hourly.slice(0, 5).map(item => {
+            const band = forecastTempBand(item);
+            return [
+                '<div class="sky-weather-day-row">',
+                '<div class="sky-weather-day-label"><span>' + escapeHtml(formatHourLabel(item.time || '')) + '</span><b aria-hidden="true">' + escapeHtml(weatherEmoji(item)) + '</b></div>',
+                '<div class="sky-weather-day-main"><strong>' + escapeHtml(item.description || item.condition || description) + '</strong><div class="sky-weather-temp-band" aria-hidden="true"><i style="left: ' + band.left + '%; width: ' + band.width + '%;"></i></div></div>',
+                '<div class="sky-weather-day-temp"><strong>' + escapeHtml(formatTemp(item.temp)) + '</strong></div>',
                 '</div>'
             ].join('');
         }).join('');
@@ -253,7 +308,11 @@
             '<div class="sky-weather-condition">' + escapeHtml(description) + '</div>',
             '<div class="sky-weather-meta">' + meta + '</div>',
             '</div>',
-            '<div class="sky-weather-forecast"><h4>' + escapeHtml(props.source === 'weather_forecast' ? 'Forecast' : 'Next up') + '</h4><div class="sky-weather-forecast-grid">' + forecastTiles + '</div></div>',
+            '<div class="sky-weather-forecast">',
+            '<div class="sky-weather-forecast-head"><h4>' + escapeHtml(props.source === 'weather_forecast' ? 'Forecast' : 'Next up') + '</h4><span>' + escapeHtml(daily.length ? daily.length + ' days' : hourly.length + ' hours') + '</span></div>',
+            hourlyTiles ? '<div class="sky-weather-hour-strip">' + hourlyTiles + '</div>' : '',
+            '<div class="sky-weather-day-list">' + (dailyRows || fallbackTiles || '<div class="sky-empty-data">No forecast data available yet.</div>') + '</div>',
+            '</div>',
             '</div>'
         ].join('');
         return cardFrame(Object.assign({ status: 'Weather', icon: 'W' }, props), body, { wide: true, tone: 'weather-card ' + weatherClass(props, current) });

--- a/services/zoe-ui/dist/touch/js/skybridge-renderer.js
+++ b/services/zoe-ui/dist/touch/js/skybridge-renderer.js
@@ -82,8 +82,9 @@
 
     function formatCalendarDate(value) {
         const raw = String(value || '');
-        if (/^\d{4}-\d{2}-\d{2}/.test(raw)) {
-            const date = new Date(raw + 'T12:00:00');
+        const datePart = raw.slice(0, 10);
+        if (/^\d{4}-\d{2}-\d{2}$/.test(datePart)) {
+            const date = new Date(datePart + 'T12:00:00');
             if (!Number.isNaN(date.getTime())) {
                 return {
                     weekday: date.toLocaleDateString(undefined, { weekday: 'long' }),
@@ -92,6 +93,14 @@
             }
         }
         return { weekday: 'Agenda', monthDay: raw || 'Today' };
+    }
+
+    function calendarEventSortKey(item) {
+        const datePart = String(item.start_date || item.date || '').slice(0, 10);
+        const timePart = item.all_day ? '00:00' : String(item.start_time || '00:00').slice(0, 5);
+        const sortable = datePart ? datePart + 'T' + timePart : '9999-12-31T' + timePart;
+        const timestamp = Date.parse(sortable);
+        return Number.isNaN(timestamp) ? Number.MAX_SAFE_INTEGER : timestamp;
     }
 
     function calendarCategoryClass(value) {
@@ -115,7 +124,7 @@
 
     function renderCalendar(props) {
         const events = Array.isArray(props.events) ? props.events : [];
-        const visibleEvents = events.slice(0, 8);
+        const visibleEvents = events.slice().sort((a, b) => calendarEventSortKey(a) - calendarEventSortKey(b)).slice(0, 8);
         const dateMeta = formatCalendarDate(props.date || props.start_date || (events[0] && events[0].start_date));
         const rows = visibleEvents.map((item, index) => {
             const title = item.title || item.name || 'Calendar event';

--- a/services/zoe-ui/dist/touch/js/skybridge-renderer.js
+++ b/services/zoe-ui/dist/touch/js/skybridge-renderer.js
@@ -80,17 +80,70 @@
         return start || item.start_date || 'Scheduled';
     }
 
+    function formatCalendarDate(value) {
+        const raw = String(value || '');
+        if (/^\d{4}-\d{2}-\d{2}/.test(raw)) {
+            const date = new Date(raw + 'T12:00:00');
+            if (!Number.isNaN(date.getTime())) {
+                return {
+                    weekday: date.toLocaleDateString(undefined, { weekday: 'long' }),
+                    monthDay: date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
+                };
+            }
+        }
+        return { weekday: 'Agenda', monthDay: raw || 'Today' };
+    }
+
+    function calendarCategoryClass(value) {
+        const token = safeClassTokens(String(value || 'general').toLowerCase()) || 'general';
+        const known = ['work', 'personal', 'bucket', 'shopping', 'health', 'routine', 'social', 'family', 'general'];
+        return known.indexOf(token) >= 0 ? token : 'general';
+    }
+
+    function calendarAccentLabel(value) {
+        const token = String(value || 'general').toLowerCase();
+        if (token === 'work') return 'Work';
+        if (token === 'personal') return 'Personal';
+        if (token === 'bucket') return 'Bucket';
+        if (token === 'shopping') return 'Shopping';
+        if (token === 'health') return 'Health';
+        if (token === 'routine') return 'Routine';
+        if (token === 'social') return 'Social';
+        if (token === 'family') return 'Family';
+        return 'General';
+    }
+
     function renderCalendar(props) {
         const events = Array.isArray(props.events) ? props.events : [];
-        const rows = events.slice(0, 8).map(item => {
+        const visibleEvents = events.slice(0, 8);
+        const dateMeta = formatCalendarDate(props.date || props.start_date || (events[0] && events[0].start_date));
+        const rows = visibleEvents.map((item, index) => {
             const title = item.title || item.name || 'Calendar event';
-            const detail = [item.location, item.category].filter(Boolean).join(' · ');
-            return '<div class="sky-event-row"><span>' + escapeHtml(formatEventTime(item)) + '</span><strong>' + escapeHtml(title) + '</strong>' + (detail ? '<em>' + escapeHtml(detail) + '</em>' : '') + '</div>';
+            const category = calendarCategoryClass(item.category);
+            const detail = [item.location, calendarAccentLabel(item.category)].filter(Boolean).join(' · ');
+            return [
+                '<div class="sky-event-row sky-calendar-event ' + escapeHtml(category) + '">',
+                '<div class="sky-calendar-time"><span>' + escapeHtml(formatEventTime(item)) + '</span>' + (index === 0 ? '<b>Next</b>' : '') + '</div>',
+                '<div class="sky-calendar-event-main"><strong>' + escapeHtml(title) + '</strong>' + (detail ? '<em>' + escapeHtml(detail) + '</em>' : '') + '</div>',
+                '<div class="sky-calendar-category">' + escapeHtml(calendarAccentLabel(item.category)) + '</div>',
+                '</div>'
+            ].join('');
         }).join('');
-        const empty = '<div class="sky-empty-data"><strong>No events ' + escapeHtml(props.qualifier || 'today') + '</strong><span>Your calendar is clear for this range.</span></div>';
+        const empty = [
+            '<div class="sky-empty-data sky-calendar-empty">',
+            '<div class="sky-calendar-empty-mark" aria-hidden="true"></div>',
+            '<strong>No events ' + escapeHtml(props.qualifier || 'today') + '</strong>',
+            '<span>Your calendar is clear for this range.</span>',
+            '</div>'
+        ].join('');
         const body = [
+            '<div class="sky-calendar-scene">',
+            '<div class="sky-calendar-summary">',
+            '<div class="sky-calendar-date"><span>' + escapeHtml(dateMeta.weekday) + '</span><strong>' + escapeHtml(dateMeta.monthDay) + '</strong></div>',
             '<div class="sky-widget-metric"><strong>' + escapeHtml(events.length) + '</strong><span>' + escapeHtml(events.length === 1 ? 'event' : 'events') + ' ' + escapeHtml(props.qualifier || '') + '</span></div>',
-            '<div class="sky-data-list">' + (rows || empty) + '</div>'
+            '</div>',
+            '<div class="sky-calendar-agenda"><div class="sky-calendar-rail" aria-hidden="true"></div><div class="sky-data-list">' + (rows || empty) + '</div></div>',
+            '</div>'
         ].join('');
         return cardFrame(Object.assign({ status: 'Calendar', icon: 'C' }, props), body, { wide: true, tone: 'calendar-card' });
     }

--- a/services/zoe-ui/dist/touch/js/skybridge-renderer.js
+++ b/services/zoe-ui/dist/touch/js/skybridge-renderer.js
@@ -110,16 +110,8 @@
     }
 
     function calendarAccentLabel(value) {
-        const token = String(value || 'general').toLowerCase();
-        if (token === 'work') return 'Work';
-        if (token === 'personal') return 'Personal';
-        if (token === 'bucket') return 'Bucket';
-        if (token === 'shopping') return 'Shopping';
-        if (token === 'health') return 'Health';
-        if (token === 'routine') return 'Routine';
-        if (token === 'social') return 'Social';
-        if (token === 'family') return 'Family';
-        return 'General';
+        const category = calendarCategoryClass(value);
+        return category.charAt(0).toUpperCase() + category.slice(1);
     }
 
     function renderCalendar(props) {
@@ -129,7 +121,7 @@
         const rows = visibleEvents.map((item, index) => {
             const title = item.title || item.name || 'Calendar event';
             const category = calendarCategoryClass(item.category);
-            const detail = [item.location, calendarAccentLabel(item.category)].filter(Boolean).join(' · ');
+            const detail = [item.location].filter(Boolean).join(' · ');
             return [
                 '<div class="sky-event-row sky-calendar-event ' + escapeHtml(category) + '">',
                 '<div class="sky-calendar-time"><span>' + escapeHtml(formatEventTime(item)) + '</span>' + (index === 0 ? '<b>Next</b>' : '') + '</div>',

--- a/services/zoe-ui/dist/touch/js/skybridge-renderer.js
+++ b/services/zoe-ui/dist/touch/js/skybridge-renderer.js
@@ -110,16 +110,8 @@
     }
 
     function calendarAccentLabel(value) {
-        const token = String(value || 'general').toLowerCase();
-        if (token === 'work') return 'Work';
-        if (token === 'personal') return 'Personal';
-        if (token === 'bucket') return 'Bucket';
-        if (token === 'shopping') return 'Shopping';
-        if (token === 'health') return 'Health';
-        if (token === 'routine') return 'Routine';
-        if (token === 'social') return 'Social';
-        if (token === 'family') return 'Family';
-        return 'General';
+        const category = calendarCategoryClass(value);
+        return category.charAt(0).toUpperCase() + category.slice(1);
     }
 
     function renderCalendar(props) {

--- a/services/zoe-ui/dist/touch/js/skybridge-renderer.js
+++ b/services/zoe-ui/dist/touch/js/skybridge-renderer.js
@@ -287,17 +287,7 @@
                 '</div>'
             ].join('');
         }).join('');
-        const fallbackTiles = !dailyRows && !hourlyTiles && hourly.slice(0, 5).map(item => {
-            const band = forecastTempBand(item);
-            return [
-                '<div class="sky-weather-day-row">',
-                '<div class="sky-weather-day-label"><span>' + escapeHtml(formatHourLabel(item.time || '')) + '</span><b aria-hidden="true">' + escapeHtml(weatherEmoji(item)) + '</b></div>',
-                '<div class="sky-weather-day-main"><strong>' + escapeHtml(item.description || item.condition || description) + '</strong><div class="sky-weather-temp-band" aria-hidden="true"><i style="left: ' + band.left + '%; width: ' + band.width + '%;"></i></div></div>',
-                '<div class="sky-weather-day-temp"><strong>' + escapeHtml(formatTemp(item.temp)) + '</strong></div>',
-                '</div>'
-            ].join('');
-        }).join('');
-        const dayList = dailyRows || fallbackTiles;
+        const dayList = dailyRows;
         const meta = [
             ['🌡', 'Feels ' + formatTemp(current.feels_like)],
             ['💧', current.humidity == null ? 'Humidity --' : current.humidity + '% humidity'],

--- a/services/zoe-ui/dist/touch/js/skybridge-renderer.js
+++ b/services/zoe-ui/dist/touch/js/skybridge-renderer.js
@@ -125,7 +125,7 @@
     function renderCalendar(props) {
         const events = Array.isArray(props.events) ? props.events : [];
         const visibleEvents = events.slice().sort((a, b) => calendarEventSortKey(a) - calendarEventSortKey(b)).slice(0, 8);
-        const dateMeta = formatCalendarDate(props.date || props.start_date || (events[0] && events[0].start_date));
+        const dateMeta = formatCalendarDate(props.date || props.start_date || (visibleEvents[0] && visibleEvents[0].start_date));
         const rows = visibleEvents.map((item, index) => {
             const title = item.title || item.name || 'Calendar event';
             const category = calendarCategoryClass(item.category);

--- a/services/zoe-ui/dist/touch/js/skybridge-renderer.js
+++ b/services/zoe-ui/dist/touch/js/skybridge-renderer.js
@@ -203,8 +203,18 @@
     }
 
     function formatForecastShort(value) {
-        const label = formatForecastLabel(value);
-        return label.replace(/^([A-Za-z]{3})\s+(\d+)\s+([A-Za-z]{3})$/, '$1 $2');
+        const raw = String(value || '');
+        const datePart = raw.slice(0, 10);
+        if (/^\d{4}-\d{2}-\d{2}$/.test(datePart)) {
+            const date = new Date(datePart + 'T12:00:00');
+            if (!Number.isNaN(date.getTime())) {
+                return date.toLocaleDateString(undefined, { weekday: 'short', day: 'numeric' }).replace(',', '');
+            }
+        }
+        const label = formatForecastLabel(value).replace(',', '');
+        return label
+            .replace(/^([A-Za-z]{3})\s+([A-Za-z]{3})\s+(\d+)$/, '$1 $3')
+            .replace(/^([A-Za-z]{3})\s+(\d+)\s+([A-Za-z]{3})$/, '$1 $2');
     }
 
     function formatHourLabel(value) {
@@ -277,7 +287,7 @@
                 '</div>'
             ].join('');
         }).join('');
-        const fallbackTiles = !dailyRows && hourly.slice(0, 5).map(item => {
+        const fallbackTiles = !dailyRows && !hourlyTiles && hourly.slice(0, 5).map(item => {
             const band = forecastTempBand(item);
             return [
                 '<div class="sky-weather-day-row">',
@@ -287,6 +297,7 @@
                 '</div>'
             ].join('');
         }).join('');
+        const dayList = dailyRows || fallbackTiles;
         const meta = [
             ['🌡', 'Feels ' + formatTemp(current.feels_like)],
             ['💧', current.humidity == null ? 'Humidity --' : current.humidity + '% humidity'],
@@ -303,7 +314,7 @@
             '<div class="sky-weather-forecast">',
             '<div class="sky-weather-forecast-head"><h4>' + escapeHtml(props.source === 'weather_forecast' ? 'Forecast' : 'Next up') + '</h4><span>' + escapeHtml(daily.length ? daily.length + ' days' : hourly.length + ' hours') + '</span></div>',
             hourlyTiles ? '<div class="sky-weather-hour-strip">' + hourlyTiles + '</div>' : '',
-            '<div class="sky-weather-day-list">' + (dailyRows || fallbackTiles || '<div class="sky-empty-data">No forecast data available yet.</div>') + '</div>',
+            dayList ? '<div class="sky-weather-day-list">' + dayList + '</div>' : (!hourlyTiles ? '<div class="sky-weather-day-list"><div class="sky-empty-data">No forecast data available yet.</div></div>' : ''),
             '</div>',
             '</div>'
         ].join('');

--- a/services/zoe-ui/dist/touch/skybridge.html
+++ b/services/zoe-ui/dist/touch/skybridge.html
@@ -3611,6 +3611,289 @@
             }
         }
     </style>
+    <style id="skybridge-weather-widget-v2">
+        body:not(.sky-empty) .weather-card.sky-premium-card {
+            overflow: hidden;
+        }
+
+        body:not(.sky-empty) .weather-card.sky-premium-card::after {
+            background:
+                linear-gradient(180deg, rgba(255,255,255,0.18), transparent 34%, rgba(0,0,0,0.2)),
+                radial-gradient(circle at 12% 8%, rgba(255,255,255,0.22), transparent 30%),
+                radial-gradient(circle at 86% 88%, rgba(90,224,224,0.18), transparent 36%);
+        }
+
+        body:not(.sky-empty) .sky-weather-scene {
+            grid-template-columns: minmax(0, 0.82fr) minmax(360px, 1fr) !important;
+            gap: 24px !important;
+            min-height: 430px !important;
+        }
+
+        body:not(.sky-empty) .sky-weather-main {
+            align-content: end !important;
+            padding: 10px 0 6px;
+        }
+
+        body:not(.sky-empty) .sky-weather-location {
+            max-width: min(100%, 420px);
+            background: rgba(255,255,255,0.16) !important;
+            border-color: rgba(255,255,255,0.24) !important;
+            color: rgba(255,255,255,0.9) !important;
+        }
+
+        body:not(.sky-empty) .sky-weather-meta {
+            display: grid !important;
+            grid-template-columns: repeat(3, minmax(0, 1fr));
+            gap: 10px !important;
+            max-width: 520px;
+        }
+
+        body:not(.sky-empty) .sky-weather-pill {
+            justify-content: center;
+            min-height: 54px;
+            padding: 10px 12px !important;
+            border-radius: 18px !important;
+            background:
+                linear-gradient(180deg, rgba(255,255,255,0.18), rgba(255,255,255,0.08)),
+                rgba(7,14,28,0.34) !important;
+        }
+
+        body:not(.sky-empty) .sky-weather-forecast {
+            align-self: stretch;
+            display: grid !important;
+            grid-template-rows: auto auto 1fr;
+            gap: 14px !important;
+            min-width: 0;
+            padding: 18px;
+            border: 1px solid rgba(255,255,255,0.16);
+            border-radius: 30px;
+            background:
+                radial-gradient(circle at 18% 0%, rgba(255,255,255,0.18), transparent 34%),
+                linear-gradient(180deg, rgba(8,16,34,0.36), rgba(8,16,34,0.22));
+            box-shadow:
+                inset 0 1px 0 rgba(255,255,255,0.16),
+                0 24px 60px rgba(0,0,0,0.16);
+        }
+
+        body:not(.sky-empty) .sky-weather-forecast-head {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 16px;
+        }
+
+        body:not(.sky-empty) .sky-weather-forecast-head h4 {
+            margin: 0;
+            color: rgba(255,255,255,0.86) !important;
+            font-size: 14px !important;
+            font-weight: 850;
+            letter-spacing: 0.08em !important;
+            text-transform: uppercase;
+        }
+
+        body:not(.sky-empty) .sky-weather-forecast-head span {
+            padding: 6px 10px;
+            border: 1px solid rgba(255,255,255,0.16);
+            border-radius: 999px;
+            background: rgba(255,255,255,0.12);
+            color: rgba(255,255,255,0.7);
+            font-size: 12px;
+            font-weight: 800;
+            white-space: nowrap;
+        }
+
+        body:not(.sky-empty) .sky-weather-hour-strip {
+            display: grid;
+            grid-template-columns: repeat(8, minmax(54px, 1fr));
+            gap: 8px;
+            min-width: 0;
+        }
+
+        body:not(.sky-empty) .sky-weather-hour-tile {
+            display: grid;
+            justify-items: center;
+            gap: 7px;
+            min-height: 104px;
+            padding: 10px 8px;
+            border: 1px solid rgba(255,255,255,0.16);
+            border-radius: 22px;
+            background:
+                linear-gradient(180deg, rgba(255,255,255,0.18), rgba(255,255,255,0.06)),
+                rgba(6,13,28,0.22);
+            box-shadow: inset 0 1px 0 rgba(255,255,255,0.14);
+        }
+
+        body:not(.sky-empty) .sky-weather-hour-tile span,
+        body:not(.sky-empty) .sky-weather-hour-tile strong {
+            overflow: hidden;
+            max-width: 100%;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+
+        body:not(.sky-empty) .sky-weather-hour-tile span {
+            color: rgba(255,255,255,0.62);
+            font-size: 12px;
+            font-weight: 850;
+        }
+
+        body:not(.sky-empty) .sky-weather-hour-tile b {
+            font-size: 26px;
+            line-height: 1;
+            filter: drop-shadow(0 5px 10px rgba(0,0,0,0.2));
+        }
+
+        body:not(.sky-empty) .sky-weather-hour-tile strong {
+            color: #fff;
+            font-size: 17px;
+            font-weight: 850;
+        }
+
+        body:not(.sky-empty) .sky-weather-day-list {
+            display: grid;
+            gap: 9px;
+            min-width: 0;
+            align-content: start;
+        }
+
+        body:not(.sky-empty) .sky-weather-day-row {
+            position: relative;
+            display: grid;
+            grid-template-columns: minmax(88px, 0.32fr) minmax(0, 1fr) auto;
+            align-items: center;
+            gap: 14px;
+            min-height: 68px;
+            padding: 11px 13px;
+            overflow: hidden;
+            border: 1px solid rgba(255,255,255,0.16);
+            border-radius: 22px;
+            background:
+                linear-gradient(135deg, rgba(255,255,255,0.17), rgba(255,255,255,0.055)),
+                rgba(6,13,28,0.24);
+            box-shadow: inset 0 1px 0 rgba(255,255,255,0.13);
+        }
+
+        body:not(.sky-empty) .sky-weather-day-row.is-primary {
+            background:
+                radial-gradient(circle at 0% 0%, rgba(255,255,255,0.2), transparent 34%),
+                linear-gradient(135deg, rgba(255,255,255,0.22), rgba(255,255,255,0.075)),
+                rgba(6,13,28,0.3);
+        }
+
+        body:not(.sky-empty) .sky-weather-day-label {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            min-width: 0;
+        }
+
+        body:not(.sky-empty) .sky-weather-day-label span {
+            min-width: 0;
+            overflow: hidden;
+            color: rgba(255,255,255,0.86);
+            font-size: 14px;
+            font-weight: 850;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+
+        body:not(.sky-empty) .sky-weather-day-label b {
+            flex: 0 0 auto;
+            font-size: 24px;
+            line-height: 1;
+        }
+
+        body:not(.sky-empty) .sky-weather-day-main {
+            display: grid;
+            gap: 8px;
+            min-width: 0;
+        }
+
+        body:not(.sky-empty) .sky-weather-day-main strong {
+            overflow: hidden;
+            color: rgba(255,255,255,0.82);
+            font-size: 14px;
+            font-weight: 760;
+            line-height: 1.1;
+            text-transform: capitalize;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+
+        body:not(.sky-empty) .sky-weather-day-temp {
+            display: flex;
+            align-items: baseline;
+            justify-content: flex-end;
+            gap: 7px;
+            min-width: 74px;
+            white-space: nowrap;
+        }
+
+        body:not(.sky-empty) .sky-weather-day-temp strong {
+            color: #fff;
+            font-size: 22px;
+            font-weight: 760;
+        }
+
+        body:not(.sky-empty) .sky-weather-day-temp small {
+            color: rgba(255,255,255,0.54);
+            font-size: 15px;
+            font-weight: 750;
+        }
+
+        body:not(.sky-empty) .weather-foggy .sky-weather-forecast,
+        body:not(.sky-empty) .weather-foggy .sky-weather-hour-tile,
+        body:not(.sky-empty) .weather-foggy .sky-weather-day-row,
+        body:not(.sky-empty) .weather-foggy .sky-weather-forecast-head span {
+            background: rgba(255,255,255,0.36) !important;
+            border-color: rgba(0,0,0,0.1) !important;
+            color: #1d2733 !important;
+        }
+
+        @media (hover: hover) {
+            body:not(.sky-empty) .sky-weather-hour-tile,
+            body:not(.sky-empty) .sky-weather-day-row {
+                transition: transform 220ms ease, background 220ms ease, border-color 220ms ease;
+            }
+
+            body:not(.sky-empty) .sky-weather-hour-tile:hover,
+            body:not(.sky-empty) .sky-weather-day-row:hover {
+                transform: translateY(-2px);
+                background: rgba(255,255,255,0.16);
+                border-color: rgba(255,255,255,0.26);
+            }
+        }
+
+        @media (max-width: 980px) {
+            body:not(.sky-empty) .sky-weather-scene {
+                grid-template-columns: 1fr !important;
+                min-height: 0 !important;
+            }
+
+            body:not(.sky-empty) .sky-weather-hour-strip {
+                grid-template-columns: repeat(4, minmax(0, 1fr));
+            }
+        }
+
+        @media (max-width: 560px) {
+            body:not(.sky-empty) .sky-weather-meta {
+                grid-template-columns: 1fr;
+            }
+
+            body:not(.sky-empty) .sky-weather-hour-strip {
+                grid-template-columns: repeat(2, minmax(0, 1fr));
+            }
+
+            body:not(.sky-empty) .sky-weather-day-row {
+                grid-template-columns: 1fr auto;
+            }
+
+            body:not(.sky-empty) .sky-weather-day-main {
+                grid-column: 1 / -1;
+                order: 3;
+            }
+        }
+    </style>
     <style id="skybridge-calendar-widget-overrides">
         body:not(.sky-empty) .calendar-card.sky-premium-card {
             min-height: 370px !important;
@@ -3936,9 +4219,9 @@
     <script src="/touch/js/gestures.js"></script>
     <script src="/touch/js/touch-menu.js"></script>
     <script src="/js/touch-ui-executor.js"></script>
-    <script src="/touch/js/skybridge-capabilities.js?v=skybridge-premium-cards-4"></script>
-    <script src="/touch/js/skybridge-renderer.js?v=skybridge-premium-cards-4"></script>
-    <script src="/touch/js/skybridge-voice.js?v=skybridge-premium-cards-4"></script>
-    <script src="/touch/js/skybridge.js?v=skybridge-premium-cards-4"></script>
+    <script src="/touch/js/skybridge-capabilities.js?v=skybridge-premium-cards-5"></script>
+    <script src="/touch/js/skybridge-renderer.js?v=skybridge-premium-cards-5"></script>
+    <script src="/touch/js/skybridge-voice.js?v=skybridge-premium-cards-5"></script>
+    <script src="/touch/js/skybridge.js?v=skybridge-premium-cards-5"></script>
 </body>
 </html>

--- a/services/zoe-ui/dist/touch/skybridge.html
+++ b/services/zoe-ui/dist/touch/skybridge.html
@@ -3611,6 +3611,266 @@
             }
         }
     </style>
+    <style id="skybridge-calendar-widget-overrides">
+        body:not(.sky-empty) .calendar-card.sky-premium-card {
+            min-height: 370px !important;
+            padding: 0 !important;
+            border-color: rgba(255,255,255,0.18) !important;
+            background:
+                radial-gradient(circle at 10% 0%, rgba(123,97,255,0.32), transparent 32%),
+                radial-gradient(circle at 94% 12%, rgba(90,224,224,0.18), transparent 34%),
+                linear-gradient(155deg, rgba(25,28,52,0.96), rgba(10,14,28,0.94)) !important;
+            box-shadow:
+                0 28px 90px rgba(0,0,0,0.34),
+                inset 0 1px 0 rgba(255,255,255,0.15) !important;
+        }
+
+        body:not(.sky-empty) .calendar-card .sky-widget-top,
+        body:not(.sky-empty) .calendar-card .sky-badge {
+            margin: 24px 28px 0 !important;
+        }
+
+        body:not(.sky-empty) .sky-calendar-scene {
+            display: grid;
+            grid-template-columns: minmax(220px, 0.36fr) minmax(0, 1fr);
+            gap: 22px;
+            padding: 24px 28px 28px;
+            position: relative;
+            z-index: 2;
+        }
+
+        body:not(.sky-empty) .sky-calendar-summary {
+            min-width: 0;
+            display: grid;
+            align-content: end;
+            gap: 22px;
+            padding: 18px;
+            border-radius: 28px;
+            border: 1px solid rgba(255,255,255,0.13);
+            background:
+                radial-gradient(circle at 28% 6%, rgba(255,255,255,0.2), transparent 34%),
+                linear-gradient(180deg, rgba(255,255,255,0.1), rgba(255,255,255,0.045));
+            box-shadow: inset 0 1px 0 rgba(255,255,255,0.12);
+        }
+
+        body:not(.sky-empty) .sky-calendar-date {
+            display: grid;
+            gap: 8px;
+        }
+
+        body:not(.sky-empty) .sky-calendar-date span {
+            color: rgba(255,255,255,0.55);
+            font-size: 13px;
+            font-weight: 850;
+            letter-spacing: 0.1em;
+            text-transform: uppercase;
+        }
+
+        body:not(.sky-empty) .sky-calendar-date strong {
+            color: rgba(255,255,255,0.95);
+            font-size: clamp(42px, 5vw, 76px);
+            font-weight: 360;
+            line-height: 0.92;
+            letter-spacing: 0;
+        }
+
+        body:not(.sky-empty) .calendar-card .sky-widget-metric {
+            display: grid !important;
+            gap: 8px !important;
+            margin: 0 !important;
+        }
+
+        body:not(.sky-empty) .calendar-card .sky-widget-metric strong {
+            font-size: clamp(54px, 6vw, 92px) !important;
+            font-weight: 260 !important;
+            line-height: 0.9 !important;
+        }
+
+        body:not(.sky-empty) .calendar-card .sky-widget-metric span {
+            padding: 0 !important;
+            color: rgba(255,255,255,0.58) !important;
+            font-size: 15px !important;
+            font-weight: 760 !important;
+        }
+
+        body:not(.sky-empty) .sky-calendar-agenda {
+            min-width: 0;
+            position: relative;
+            display: grid;
+            grid-template-columns: 18px minmax(0, 1fr);
+            gap: 14px;
+        }
+
+        body:not(.sky-empty) .sky-calendar-rail {
+            width: 3px;
+            justify-self: center;
+            border-radius: 999px;
+            background:
+                linear-gradient(180deg, rgba(123,97,255,0), #7B61FF 12%, #5AE0E0 52%, rgba(90,224,224,0) 100%);
+            box-shadow: 0 0 24px rgba(90,224,224,0.24);
+        }
+
+        body:not(.sky-empty) .calendar-card .sky-data-list {
+            display: grid;
+            gap: 12px !important;
+            align-content: start;
+        }
+
+        body:not(.sky-empty) .calendar-card .sky-event-row {
+            position: relative;
+            display: grid !important;
+            grid-template-columns: minmax(104px, 0.24fr) minmax(0, 1fr) auto !important;
+            gap: 14px !important;
+            align-items: center;
+            min-height: 76px;
+            padding: 14px 16px !important;
+            overflow: hidden;
+            border-radius: 22px !important;
+            background:
+                linear-gradient(180deg, rgba(255,255,255,0.12), rgba(255,255,255,0.052)),
+                rgba(255,255,255,0.04) !important;
+            border-color: rgba(255,255,255,0.13) !important;
+            box-shadow:
+                inset 0 1px 0 rgba(255,255,255,0.12),
+                0 14px 34px rgba(0,0,0,0.14) !important;
+        }
+
+        body:not(.sky-empty) .calendar-card .sky-event-row::before {
+            content: "";
+            position: absolute;
+            inset: 12px auto 12px 0;
+            width: 4px;
+            border-radius: 0 999px 999px 0;
+            background: var(--sky-cal-accent, #5AE0E0);
+            box-shadow: 0 0 18px rgba(90,224,224,0.24);
+        }
+
+        body:not(.sky-empty) .sky-calendar-time {
+            display: grid;
+            gap: 7px;
+            min-width: 0;
+        }
+
+        body:not(.sky-empty) .sky-calendar-time span {
+            color: rgba(255,255,255,0.74) !important;
+            font-size: 12px !important;
+            font-weight: 850 !important;
+            letter-spacing: 0.04em !important;
+            text-transform: uppercase;
+        }
+
+        body:not(.sky-empty) .sky-calendar-time b {
+            width: fit-content;
+            padding: 5px 8px;
+            border-radius: 999px;
+            background: rgba(90,224,224,0.14);
+            color: rgba(190,255,255,0.92);
+            font-size: 10px;
+            font-weight: 850;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+        }
+
+        body:not(.sky-empty) .sky-calendar-event-main {
+            min-width: 0;
+            display: grid;
+            gap: 6px;
+        }
+
+        body:not(.sky-empty) .sky-calendar-event-main strong {
+            color: rgba(255,255,255,0.95) !important;
+            font-size: clamp(17px, 1.65vw, 24px) !important;
+            font-weight: 670;
+            line-height: 1.1 !important;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+
+        body:not(.sky-empty) .sky-calendar-event-main em {
+            grid-column: auto !important;
+            color: rgba(255,255,255,0.54) !important;
+            font-size: 13px !important;
+            font-style: normal;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+
+        body:not(.sky-empty) .sky-calendar-category {
+            align-self: center;
+            padding: 8px 10px;
+            border-radius: 999px;
+            border: 1px solid rgba(255,255,255,0.14);
+            background: rgba(255,255,255,0.075);
+            color: rgba(255,255,255,0.82);
+            font-size: 11px;
+            font-weight: 820;
+        }
+
+        body:not(.sky-empty) .sky-calendar-event.work { --sky-cal-accent: #3B82F6; }
+        body:not(.sky-empty) .sky-calendar-event.personal { --sky-cal-accent: #A855F7; }
+        body:not(.sky-empty) .sky-calendar-event.bucket { --sky-cal-accent: #10B981; }
+        body:not(.sky-empty) .sky-calendar-event.shopping { --sky-cal-accent: #FB923C; }
+        body:not(.sky-empty) .sky-calendar-event.health { --sky-cal-accent: #EC4899; }
+        body:not(.sky-empty) .sky-calendar-event.routine { --sky-cal-accent: #9CA3AF; }
+        body:not(.sky-empty) .sky-calendar-event.social { --sky-cal-accent: #22C55E; }
+        body:not(.sky-empty) .sky-calendar-event.family { --sky-cal-accent: #9333EA; }
+        body:not(.sky-empty) .sky-calendar-event.general { --sky-cal-accent: #5AE0E0; }
+
+        body:not(.sky-empty) .sky-calendar-empty {
+            min-height: 210px;
+            display: grid !important;
+            place-items: center;
+            text-align: center;
+            gap: 8px;
+            border-radius: 28px !important;
+        }
+
+        body:not(.sky-empty) .sky-calendar-empty-mark {
+            width: 54px;
+            height: 54px;
+            border-radius: 18px;
+            background:
+                linear-gradient(90deg, rgba(255,255,255,0.2) 1px, transparent 1px),
+                linear-gradient(180deg, rgba(255,255,255,0.2) 1px, transparent 1px),
+                linear-gradient(135deg, rgba(123,97,255,0.86), rgba(90,224,224,0.72));
+            background-size: 18px 18px, 18px 18px, auto;
+            box-shadow: 0 18px 44px rgba(90,224,224,0.2);
+        }
+
+        @media (hover: hover) {
+            body:not(.sky-empty) .calendar-card .sky-event-row:hover {
+                transform: translateY(-2px);
+                border-color: rgba(255,255,255,0.22) !important;
+                background:
+                    linear-gradient(180deg, rgba(255,255,255,0.16), rgba(255,255,255,0.07)),
+                    rgba(255,255,255,0.05) !important;
+            }
+        }
+
+        @media (max-width: 780px) {
+            body:not(.sky-empty) .sky-calendar-scene {
+                grid-template-columns: 1fr;
+                gap: 16px;
+                padding: 20px;
+            }
+
+            body:not(.sky-empty) .sky-calendar-summary {
+                grid-template-columns: 1fr auto;
+                align-items: end;
+            }
+
+            body:not(.sky-empty) .calendar-card .sky-event-row {
+                grid-template-columns: 1fr !important;
+                gap: 8px !important;
+            }
+
+            body:not(.sky-empty) .sky-calendar-category {
+                justify-self: start;
+            }
+        }
+    </style>
 </head>
 <body>
     <header class="sky-topbar">
@@ -3676,9 +3936,9 @@
     <script src="/touch/js/gestures.js"></script>
     <script src="/touch/js/touch-menu.js"></script>
     <script src="/js/touch-ui-executor.js"></script>
-    <script src="/touch/js/skybridge-capabilities.js?v=skybridge-premium-cards-3"></script>
-    <script src="/touch/js/skybridge-renderer.js?v=skybridge-premium-cards-3"></script>
-    <script src="/touch/js/skybridge-voice.js?v=skybridge-premium-cards-3"></script>
-    <script src="/touch/js/skybridge.js?v=skybridge-premium-cards-3"></script>
+    <script src="/touch/js/skybridge-capabilities.js?v=skybridge-premium-cards-4"></script>
+    <script src="/touch/js/skybridge-renderer.js?v=skybridge-premium-cards-4"></script>
+    <script src="/touch/js/skybridge-voice.js?v=skybridge-premium-cards-4"></script>
+    <script src="/touch/js/skybridge.js?v=skybridge-premium-cards-4"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- upgrade Skybridge calendar contract rendering into a premium agenda widget
- add calendar date, count, category accents, next-event marker, and clean empty state structure
- bump Skybridge asset version and add static coverage for the richer renderer hooks

## Verification
- Live browser verification: `/touch/skybridge.html?q=show%20my%20calendar` rendered real calendar rows with 3 sample events
- Screenshot saved locally: `/Users/jasonbertelsen/Documents/Codex/skybridge-calendar-premium.png`
- `git diff --check`
- `cd services/zoe-data && PYTHONPATH=. python3 -m pytest -q tests/test_skybridge_static.py tests/test_skybridge_status.py tests/test_skybridge_service.py tests/test_card_contract.py`
- `python3 tools/audit/validate_structure.py`
- `python3 tools/audit/validate_critical_files.py`