### PR TITLE
Collect notice proposal traces

### DIFF
--- a/services/zoe-data/evolution_notice.py
+++ b/services/zoe-data/evolution_notice.py
@@ -88,6 +88,69 @@ async def _proposal_exists(title: str, prop_type: str, db) -> bool:
     return len(rows) > 0
 
 
+def _attach_notice_trace_to_row(
+    row: dict,
+    *,
+    proposal_id: str,
+    proposal_type: str,
+    title: str,
+    signal,
+) -> dict:
+    """Attach a non-persistent observation trace summary to proposal evidence."""
+
+    try:
+        from zoe_observation_trace import ObservationOutcome, ObservationTrace, ObservationTraceType
+        from zoe_observation_trace_collector import ObservationTraceCollectorPolicy, collect_observation_traces
+
+        evidence = json.loads(row["evidence"])
+        candidate_ids = tuple(str(item) for item in evidence.get("candidate_ids", ()))
+        trace = ObservationTrace(
+            trace_id=f"trace_notice_{proposal_id}",
+            trace_type=ObservationTraceType.PROPOSAL.value,
+            surface="multica",
+            scope=signal.scope,
+            user_id=signal.user_id,
+            outcome=ObservationOutcome.SUCCESS.value,
+            summary=f"Runtime notice proposal prepared for review: {title}",
+            evidence_refs=tuple(signal.evidence_refs),
+            subject_id=proposal_id,
+            related_ids=candidate_ids,
+            metadata={
+                "proposal_type": proposal_type,
+                "signal_id": signal.signal_id,
+                "signal_source": signal.source,
+            },
+        )
+        collection = collect_observation_traces(
+            (trace,),
+            policy=ObservationTraceCollectorPolicy(
+                max_batch_size=5,
+                allowed_surfaces=("multica",),
+                allowed_trace_types=(ObservationTraceType.PROPOSAL.value,),
+            ),
+        )
+        collection_snapshot = collection.to_dict()
+        if not collection.ok:
+            logger.warning(
+                "evolution_notice: trace collection rejected for proposal_id=%s proposal_type=%s rejected=%s",
+                proposal_id,
+                proposal_type,
+                collection_snapshot["rejected"],
+            )
+        evidence["observation_trace_collection"] = collection_snapshot
+        updated = dict(row)
+        updated["evidence"] = json.dumps(evidence, sort_keys=True)
+        return updated
+    except Exception as exc:
+        logger.warning(
+            "evolution_notice: trace collection failed for proposal_id=%s proposal_type=%s: %s",
+            proposal_id,
+            proposal_type,
+            exc,
+        )
+        return row
+
+
 async def run_evolution_notice() -> dict:
     """Run the NOTICE phase — returns summary dict."""
     from db_pool import get_db_ctx
@@ -169,7 +232,13 @@ async def run_evolution_notice() -> dict:
                 legacy_target_patterns=target_members,
                 metadata={"legacy_writer": "evolution_notice:intent_miss_cluster"},
             )
-            row = intake.to_legacy_row()
+            row = _attach_notice_trace_to_row(
+                intake.to_legacy_row(),
+                proposal_id=prop_id,
+                proposal_type=prop_type,
+                title=title,
+                signal=signal,
+            )
             await db.execute(
                 """INSERT INTO evolution_proposals
                    (id, type, title, description, evidence, target_patterns, status, proposed_at)
@@ -280,7 +349,13 @@ async def run_evolution_notice() -> dict:
                 rollback_plan="Reject or defer the proposal; no runtime change has been made by proposal creation.",
                 metadata={"legacy_writer": "evolution_notice:agent_health"},
             )
-            row_payload = intake.to_legacy_row()
+            row_payload = _attach_notice_trace_to_row(
+                intake.to_legacy_row(),
+                proposal_id=prop_id,
+                proposal_type="agent_health",
+                title=title,
+                signal=signal,
+            )
             await db.execute(
                 """INSERT INTO evolution_proposals
                    (id, type, title, description, evidence, target_patterns, status, proposed_at)
@@ -394,7 +469,13 @@ async def record_frustration_signal(
             legacy_target_patterns=(normalized_message,),
             metadata={"legacy_writer": "evolution_notice:user_frustration"},
         )
-        row = intake.to_legacy_row()
+        row = _attach_notice_trace_to_row(
+            intake.to_legacy_row(),
+            proposal_id=prop_id,
+            proposal_type="user_frustration",
+            title=title,
+            signal=signal,
+        )
         await db.execute(
             """INSERT INTO evolution_proposals
                (id, type, title, description, evidence, target_patterns, status, proposed_at)
@@ -502,7 +583,13 @@ async def record_user_issue(message: str, user_id: str) -> None:
             legacy_target_patterns=(message,),
             metadata={"legacy_writer": "evolution_notice:user_issue_report"},
         )
-        row = intake.to_legacy_row()
+        row = _attach_notice_trace_to_row(
+            intake.to_legacy_row(),
+            proposal_id=prop_id,
+            proposal_type="user_issue_report",
+            title=title,
+            signal=signal,
+        )
         await db.execute(
             """INSERT INTO evolution_proposals
                (id, type, title, description, evidence, target_patterns, status, proposed_at)

--- a/services/zoe-data/tests/test_evolution_notice_measure.py
+++ b/services/zoe-data/tests/test_evolution_notice_measure.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import sys
 import types
 
@@ -128,6 +129,62 @@ def test_load_target_patterns_extracts_contract_metadata():
     assert evolution_notice._load_target_patterns(raw) == ["turn lights on", "switch lights on"]
 
 
+def test_attach_notice_trace_failure_returns_original_row(caplog):
+    row = {"evidence": "not-json"}
+    signal = types.SimpleNamespace(
+        scope="system",
+        user_id=None,
+        evidence_refs=("trace:bad-json",),
+        signal_id="signal_bad_json",
+        source="evolution_notice:test_bad_json",
+    )
+
+    with caplog.at_level(logging.WARNING):
+        updated = evolution_notice._attach_notice_trace_to_row(
+            row,
+            proposal_id="prop_bad_json",
+            proposal_type="test_bad_json",
+            title="Bad JSON proposal",
+            signal=signal,
+        )
+
+    assert updated is row
+    assert updated["evidence"] == "not-json"
+    assert "trace collection failed for proposal_id=prop_bad_json" in caplog.text
+
+
+def test_attach_notice_trace_logs_rejected_collector_result(caplog):
+    row = {
+        "evidence": json.dumps({
+            "candidate_ids": ["existing_zoe_bad_scope_triage"],
+        })
+    }
+    signal = types.SimpleNamespace(
+        scope="bad_scope",
+        user_id=None,
+        evidence_refs=("trace:bad-scope",),
+        signal_id="signal_bad_scope",
+        source="evolution_notice:test_bad_scope",
+    )
+
+    with caplog.at_level(logging.WARNING):
+        updated = evolution_notice._attach_notice_trace_to_row(
+            row,
+            proposal_id="prop_bad_scope",
+            proposal_type="test_bad_scope",
+            title="Bad scope proposal",
+            signal=signal,
+        )
+
+    evidence = json.loads(updated["evidence"])
+    collection = evidence["observation_trace_collection"]
+    assert collection["ok"] is False
+    assert collection["persisted"] is False
+    assert collection["accepted_count"] == 0
+    assert "unknown scope" in collection["rejected"][0]["reason"]
+    assert "trace collection rejected for proposal_id=prop_bad_scope" in caplog.text
+
+
 @pytest.mark.asyncio
 async def test_record_frustration_signal_stores_runtime_intake_contract_snapshot(monkeypatch):
     db = _WriterDb()
@@ -166,6 +223,17 @@ async def test_record_frustration_signal_stores_runtime_intake_contract_snapshot
     assert evidence["signal"]["metadata"]["session_id"] == "sess-1"
     assert evidence["signal"]["metadata"]["repeat_count"] == 3
     assert evidence["candidate_ids"] == ["existing_zoe_frustration_triage"]
+    trace_collection = evidence["observation_trace_collection"]
+    assert trace_collection["ok"] is True
+    assert trace_collection["persisted"] is False
+    assert trace_collection["accepted_count"] == 1
+    trace = trace_collection["traces"][0]
+    assert trace["trace_type"] == "proposal"
+    assert trace["surface"] == "multica"
+    assert trace["scope"] == "personal"
+    assert trace["user_id"] == "jason"
+    assert trace["related_ids"] == ["existing_zoe_frustration_triage"]
+    assert trace["metadata"]["signal_source"] == "evolution_notice:user_frustration"
     assert contract["schema"] == "zoe_evolution_proposal"
     assert contract["legacy_writer"] == "runtime_evolution_intake"
     proposal = contract["proposal"]
@@ -215,6 +283,17 @@ async def test_record_user_issue_stores_runtime_intake_contract_snapshot(monkeyp
     assert evidence["signal"]["scope"] == "personal"
     assert evidence["signal"]["user_id"] == "jason"
     assert evidence["candidate_ids"] == ["existing_zoe_user_issue_triage"]
+    trace_collection = evidence["observation_trace_collection"]
+    assert trace_collection["ok"] is True
+    assert trace_collection["persisted"] is False
+    assert trace_collection["accepted_count"] == 1
+    trace = trace_collection["traces"][0]
+    assert trace["trace_type"] == "proposal"
+    assert trace["surface"] == "multica"
+    assert trace["scope"] == "personal"
+    assert trace["user_id"] == "jason"
+    assert trace["related_ids"] == ["existing_zoe_user_issue_triage"]
+    assert trace["metadata"]["signal_source"] == "evolution_notice:user_issue_report"
     assert contract["schema"] == "zoe_evolution_proposal"
     assert contract["legacy_writer"] == "runtime_evolution_intake"
     proposal = contract["proposal"]
@@ -274,6 +353,13 @@ async def test_run_evolution_notice_stores_contract_snapshots(monkeypatch):
     assert intent_evidence["signal"]["scope"] == "system"
     assert intent_evidence["signal"]["metadata"]["miss_count"] == 3
     assert intent_evidence["candidate_ids"] == ["existing_zoe_intent_pattern"]
+    intent_trace_collection = intent_evidence["observation_trace_collection"]
+    assert intent_trace_collection["ok"] is True
+    assert intent_trace_collection["persisted"] is False
+    assert intent_trace_collection["traces"][0]["trace_type"] == "proposal"
+    assert intent_trace_collection["traces"][0]["scope"] == "system"
+    assert intent_trace_collection["traces"][0]["related_ids"] == ["existing_zoe_intent_pattern"]
+    assert intent_trace_collection["traces"][0]["metadata"]["signal_source"] == "evolution_notice:intent_miss_cluster"
     assert intent_contract["legacy_writer"] == "runtime_evolution_intake"
     assert intent_contract["proposal"]["metadata"]["legacy_writer"] == "evolution_notice:intent_miss_cluster"
     assert intent_contract["proposal"]["metadata"]["legacy_target_patterns"] == [
@@ -291,6 +377,13 @@ async def test_run_evolution_notice_stores_contract_snapshots(monkeypatch):
     assert health_evidence["signal"]["scope"] == "system"
     assert health_evidence["signal"]["metadata"] == {"agent_tier": "gemma4", "total": 20, "errors": 3}
     assert health_evidence["candidate_ids"] == ["existing_zoe_agent_health_triage"]
+    health_trace_collection = health_evidence["observation_trace_collection"]
+    assert health_trace_collection["ok"] is True
+    assert health_trace_collection["persisted"] is False
+    assert health_trace_collection["traces"][0]["trace_type"] == "proposal"
+    assert health_trace_collection["traces"][0]["scope"] == "system"
+    assert health_trace_collection["traces"][0]["related_ids"] == ["existing_zoe_agent_health_triage"]
+    assert health_trace_collection["traces"][0]["metadata"]["signal_source"] == "evolution_notice:agent_health"
     assert health_contract["legacy_writer"] == "runtime_evolution_intake"
     health_proposal = health_contract["proposal"]
     assert health_proposal["metadata"]["legacy_proposal_type"] == "agent_health"


### PR DESCRIPTION
## Summary
- wire evolution_notice proposal creation through the governed non-persistent observation trace collector
- attach collector summaries to runtime-intake proposal evidence for intent gaps, agent health spikes, user frustration, and explicit user issue reports
- keep trace collection side-effect-free: no durable trace store, no memory writes, no execution grants

## Validation
- `PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_evolution_notice_measure.py services/zoe-data/tests/test_zoe_observation_trace.py services/zoe-data/tests/test_zoe_observation_trace_collector.py services/zoe-data/tests/test_zoe_evolution_runtime_intake.py services/zoe-data/tests/test_zoe_evolution_proposal.py services/zoe-data/tests/test_zoe_evolution_proposal_adapter.py`
- `python3 tools/audit/validate_structure.py`
- `python3 tools/audit/validate_critical_files.py`
- `python3 tools/audit/validate_offline_memory.py`
- `git diff --check`
