### PR TITLE
Add scoped local Graphify probe

### DIFF
--- a/docs/architecture/zoe-graphify-refresh-evidence.md
+++ b/docs/architecture/zoe-graphify-refresh-evidence.md
@@ -13,12 +13,15 @@ Zoe now has an observe-only local Graphify probe:
 ```bash
 python3 scripts/maintenance/graphify_local_probe.py --mode smoke --timeout-sec 60 --status-json /tmp/zoe-graphify-local-smoke-status.json
 python3 scripts/maintenance/graphify_local_probe.py --mode repo --timeout-sec 1800 --status-json /tmp/zoe-graphify-local-repo-status.json
+python3 scripts/maintenance/graphify_local_probe.py --mode scope --include-path services/zoe-data --timeout-sec 600 --status-json /tmp/zoe-graphify-local-scope-status.json
 ```
 
 The probe uses Graphify's `ollama` backend against Zoe's localhost llama.cpp
 OpenAI-compatible endpoint, removes cloud API keys from the subprocess
-environment, and runs in a temporary fixture or detached git snapshot. It never
-syncs generated `graphify-out` artifacts back into the repo.
+environment, and runs in a temporary fixture, scoped path copy, or detached git
+snapshot. It never syncs generated `graphify-out` artifacts back into the repo.
+Scoped mode is observe-only evidence for subsystem-sized local model runs; the
+sync-capable refresh wrapper still requires full repo mode with clustering.
 
 `graphify_local_refresh.py` is the sync-capable local wrapper. It runs the repo
 probe with clustering and `keep_workdir`, then syncs `graphify-out` back to the

--- a/scripts/maintenance/graphify_local_probe.py
+++ b/scripts/maintenance/graphify_local_probe.py
@@ -57,6 +57,7 @@ class GraphifyLocalProbeConfig:
     timeout_sec: int = 180
     cluster: bool = False
     keep_workdir: bool = False
+    include_paths: tuple[str, ...] = ()
 
 
 def utc_now() -> str:
@@ -205,6 +206,44 @@ def prepare_smoke_workdir(parent: Path) -> Path:
     return workdir
 
 
+SCOPE_COPY_IGNORE = shutil.ignore_patterns(
+    ".git",
+    "__pycache__",
+    ".pytest_cache",
+    "node_modules",
+    "graphify-out",
+    ".venv",
+    "venv",
+)
+
+
+def validate_scope_path(value: str) -> Path:
+    path = Path(value)
+    if not value or value == "." or path.is_absolute() or any(part in ("", ".", "..") for part in path.parts):
+        raise ValueError(f"invalid scoped Graphify path: {value!r}")
+    return path
+
+
+def prepare_scope_workdir(config: GraphifyLocalProbeConfig, parent: Path) -> Path:
+    if not config.include_paths:
+        raise ValueError("scope mode requires at least one --include-path")
+    workdir = parent / "graphify-local-scope"
+    workdir.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init", "-q"], cwd=workdir, check=True)
+    for raw_path in config.include_paths:
+        rel_path = validate_scope_path(raw_path)
+        source = config.root / rel_path
+        if not source.exists():
+            raise FileNotFoundError(f"scoped Graphify path not found: {raw_path}")
+        destination = workdir / rel_path
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        if source.is_dir():
+            shutil.copytree(source, destination, dirs_exist_ok=True, ignore=SCOPE_COPY_IGNORE)
+        else:
+            shutil.copy2(source, destination)
+    return workdir
+
+
 def prepare_repo_workdir(config: GraphifyLocalProbeConfig, parent: Path) -> Path:
     workdir = parent / "graphify-local-repo"
     subprocess.run(["git", "fetch", "--quiet", "origin", "main"], cwd=config.root, check=True)
@@ -229,6 +268,8 @@ def run_probe(config: GraphifyLocalProbeConfig) -> dict[str, object]:
             workdir = prepare_smoke_workdir(temp_parent)
         elif config.mode == "repo":
             workdir = prepare_repo_workdir(config, temp_parent)
+        elif config.mode == "scope":
+            workdir = prepare_scope_workdir(config, temp_parent)
         else:
             raise ValueError(f"unsupported probe mode: {config.mode}")
 
@@ -273,6 +314,7 @@ def run_probe(config: GraphifyLocalProbeConfig) -> dict[str, object]:
             "ref": config.ref,
             "model": config.model,
             "base_url": config.base_url,
+            "include_paths": list(config.include_paths),
             "exit_code": exit_code,
             "timed_out": timed_out,
             "workdir": str(workdir) if config.keep_workdir and workdir else None,
@@ -288,6 +330,7 @@ def run_probe(config: GraphifyLocalProbeConfig) -> dict[str, object]:
             "ref": config.ref,
             "model": config.model,
             "base_url": config.base_url,
+            "include_paths": list(config.include_paths),
             "accepted": False,
             "blockers": ["probe_error"],
             "warnings": [],
@@ -310,10 +353,11 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--base-url", default=DEFAULT_BASE_URL)
     parser.add_argument("--model", default=DEFAULT_MODEL)
     parser.add_argument("--ref", default="origin/main")
-    parser.add_argument("--mode", choices=("smoke", "repo"), default="smoke")
+    parser.add_argument("--mode", choices=("smoke", "repo", "scope"), default="smoke")
     parser.add_argument("--timeout-sec", type=int, default=180)
     parser.add_argument("--cluster", action="store_true")
     parser.add_argument("--keep-workdir", action="store_true")
+    parser.add_argument("--include-path", action="append", default=[], help="Relative path to copy for scope mode. May be repeated.")
     parser.add_argument("--status-json", type=Path)
     return parser.parse_args(argv)
 
@@ -330,6 +374,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         timeout_sec=args.timeout_sec,
         cluster=args.cluster,
         keep_workdir=args.keep_workdir,
+        include_paths=tuple(args.include_path),
     )
     status = run_probe(config)
     text = json.dumps(status, indent=2, sort_keys=True)

--- a/services/zoe-data/tests/test_graphify_local_probe.py
+++ b/services/zoe-data/tests/test_graphify_local_probe.py
@@ -174,3 +174,53 @@ def test_run_command_timeout_handles_killpg_oserror(monkeypatch, tmp_path):
     assert timed_out is True
     assert output == "partial"
     assert fake.calls == 3
+
+
+
+def test_validate_scope_path_rejects_unsafe_values():
+    module = _load_module()
+
+    assert module.validate_scope_path("services/zoe-data") == Path("services/zoe-data")
+
+    for value in ("", "/home/zoe/assistant", "../secrets", "services/../.env", "."):
+        try:
+            module.validate_scope_path(value)
+        except ValueError as exc:
+            assert "invalid scoped Graphify path" in str(exc)
+        else:
+            raise AssertionError(f"unsafe scope path accepted: {value}")
+
+
+def test_prepare_scope_workdir_copies_only_requested_paths(tmp_path):
+    module = _load_module()
+    root = tmp_path / "repo"
+    source_dir = root / "services" / "zoe-data"
+    source_dir.mkdir(parents=True)
+    (source_dir / "memory_contract.py").write_text("def retain():\\n    return True\\n", encoding="utf-8")
+    ignored = source_dir / "__pycache__"
+    ignored.mkdir()
+    (ignored / "memory_contract.pyc").write_text("cache", encoding="utf-8")
+    (root / "outside.py").write_text("outside", encoding="utf-8")
+    parent = tmp_path / "probe"
+    config = module.GraphifyLocalProbeConfig(root=root, mode="scope", include_paths=("services/zoe-data",))
+
+    workdir = module.prepare_scope_workdir(config, parent)
+
+    assert (workdir / "services" / "zoe-data" / "memory_contract.py").exists()
+    assert not (workdir / "services" / "zoe-data" / "__pycache__").exists()
+    assert not (workdir / "outside.py").exists()
+    assert (workdir / ".git").exists()
+
+
+def test_prepare_scope_workdir_requires_include_paths(tmp_path):
+    module = _load_module()
+    root = tmp_path / "repo"
+    root.mkdir()
+    config = module.GraphifyLocalProbeConfig(root=root, mode="scope")
+
+    try:
+        module.prepare_scope_workdir(config, tmp_path / "probe")
+    except ValueError as exc:
+        assert "requires at least one --include-path" in str(exc)
+    else:
+        raise AssertionError("scope mode without include paths was accepted")


### PR DESCRIPTION
## Summary
- add observe-only scope mode to the local/offline Graphify probe
- copy only explicit relative include paths into a temporary git workdir
- document the scoped probe lane as non-syncable evidence for subsystem-sized local model runs

## Validation
- python3 -m py_compile scripts/maintenance/graphify_local_probe.py scripts/maintenance/graphify_local_refresh.py
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_graphify_local_probe.py services/zoe-data/tests/test_graphify_local_refresh.py
- python3 tools/audit/validate_structure.py
- python3 tools/audit/validate_critical_files.py
- python3 tools/audit/validate_offline_memory.py
- git diff --check
- live local scoped probe accepted scripts/maintenance/graphify_local_probe.py with 16 nodes, 41 edges, no invalid JSON, no truncation, no quota events

## Notes
- Scope mode is observe-only and never syncs generated graphify-out artifacts.
- Full refresh still requires repo mode with clustering through graphify_local_refresh.py.
