### PR TITLE
Honor Multica runtime and autopilot settings

### DIFF
--- a/scripts/setup/populate_multica.py
+++ b/scripts/setup/populate_multica.py
@@ -767,6 +767,7 @@ _AUTOPILOTS = [
     {
         "title": "Morning Checkin",
         "agent": "Zoe Core",
+        "status": "paused",
         "execution_mode": "run_only",
         "cron": "30 7 * * *",
         "issue_title_template": "",
@@ -774,6 +775,7 @@ _AUTOPILOTS = [
     {
         "title": "Evening Wind Down",
         "agent": "Zoe Core",
+        "status": "paused",
         "execution_mode": "run_only",
         "cron": "0 21 * * *",
         "issue_title_template": "",
@@ -795,6 +797,7 @@ _AUTOPILOTS = [
     {
         "title": "Reminder Scan",
         "agent": "Zoe Core",
+        "status": "paused",
         "execution_mode": "run_only",
         "cron": "*/5 * * * *",
         "issue_title_template": "Reminder Scan",
@@ -827,6 +830,7 @@ def step_i_create_autopilots(agent_ids: dict[str, str]):
             sql = (
                 "update autopilot set "
                 f"assignee_id={_sql_literal(agent_id)}, "
+                f"status={_sql_literal(apdef.get('status', 'active'))}, "
                 f"execution_mode={_sql_literal(apdef['execution_mode'])}, "
                 f"issue_title_template={_sql_literal(apdef.get('issue_title_template', ''))}, "
                 "updated_at=now() "
@@ -840,6 +844,7 @@ def step_i_create_autopilots(agent_ids: dict[str, str]):
         else:
             payload = {
                 "title": title,
+                "status": apdef.get("status", "active"),
                 "execution_mode": apdef["execution_mode"],
                 "issue_title_template": apdef.get("issue_title_template", ""),
                 "assignee_id": agent_id,

--- a/scripts/setup/populate_multica.py
+++ b/scripts/setup/populate_multica.py
@@ -867,7 +867,7 @@ def step_i_create_autopilots(agent_ids: dict[str, str]):
         desired_timezone = "Australia/Perth"
         has_matching_schedule = any(
             t.get("cron_expression") == desired_cron
-            and (t.get("timezone") or desired_timezone) == desired_timezone
+            and t.get("timezone") == desired_timezone
             for t in schedule_triggers
         )
         if has_matching_schedule:

--- a/scripts/setup/populate_multica.py
+++ b/scripts/setup/populate_multica.py
@@ -827,10 +827,14 @@ def step_i_create_autopilots(agent_ids: dict[str, str]):
 
         if title in existing_titles:
             ap_id = existing_titles[title]
+            status_sql = (
+                f"status={_sql_literal(apdef['status'])}, "
+                if "status" in apdef else ""
+            )
             sql = (
                 "update autopilot set "
                 f"assignee_id={_sql_literal(agent_id)}, "
-                f"status={_sql_literal(apdef.get('status', 'active'))}, "
+                f"{status_sql}"
                 f"execution_mode={_sql_literal(apdef['execution_mode'])}, "
                 f"issue_title_template={_sql_literal(apdef.get('issue_title_template', ''))}, "
                 "updated_at=now() "
@@ -841,6 +845,7 @@ def step_i_create_autopilots(agent_ids: dict[str, str]):
                 print(f"  ↻ Autopilot '{title}' exists ({ap_id}) — refreshed settings")
             else:
                 print(f"  ⚠ Autopilot '{title}' refresh failed: {msg[:100]}")
+                continue
         else:
             payload = {
                 "title": title,

--- a/scripts/setup/populate_multica.py
+++ b/scripts/setup/populate_multica.py
@@ -565,7 +565,12 @@ def step_f_create_agents(runtime_id: str) -> dict[str, str]:
     agent_ids: dict[str, str] = dict(existing_names)
     for defn in _AGENT_DEFS:
         name = defn["name"]
-        target_runtime_id = runtime_ids.get(str(defn.get("runtime_provider") or "zoe"), runtime_id)
+        runtime_provider = str(defn.get("runtime_provider") or "zoe")
+        target_runtime_id = runtime_ids.get(runtime_provider, runtime_id)
+        if runtime_provider != "zoe" and runtime_provider not in runtime_ids:
+            print(
+                f"  ⚠ Provider '{runtime_provider}' not online — using Zoe runtime for '{name}'"
+            )
         if name in existing_names:
             agent_id = existing_names[name]
             sql = (
@@ -849,20 +854,37 @@ def step_i_create_autopilots(agent_ids: dict[str, str]):
             _counts["autopilots"] += 1
             print(f"  ✓ Created autopilot '{title}' ({ap_id})")
 
-        # Ensure cron trigger exists
+        # Ensure cron trigger matches the managed schedule.
         ap_detail = _get(f"/api/autopilots/{ap_id}")
         existing_triggers = ap_detail.get("triggers", []) if ap_detail else []
-        has_schedule_trigger = any(t.get("kind") == "schedule" for t in existing_triggers)
-        if has_schedule_trigger:
-            print(f"    ↩ Trigger already set: {apdef['cron']}")
+        schedule_triggers = [t for t in existing_triggers if t.get("kind") == "schedule"]
+        desired_cron = apdef["cron"]
+        desired_timezone = "Australia/Perth"
+        has_matching_schedule = any(
+            t.get("cron_expression") == desired_cron
+            and (t.get("timezone") or desired_timezone) == desired_timezone
+            for t in schedule_triggers
+        )
+        if has_matching_schedule:
+            print(f"    ↩ Trigger already set: {desired_cron}")
             continue
-
+        if schedule_triggers:
+            delete_sql = (
+                "delete from autopilot_trigger "
+                f"where autopilot_id={_sql_literal(ap_id)} and kind='schedule';"
+            )
+            ok, msg = _db_exec(delete_sql)
+            if ok:
+                print(f"    ↻ Replacing schedule trigger with: {desired_cron}")
+            else:
+                print(f"    ⚠ Could not replace trigger for '{title}': {msg[:100]}")
+                continue
         trig = _post(
             f"/api/autopilots/{ap_id}/triggers",
             {
                 "kind": "schedule",
-                "cron_expression": apdef["cron"],
-                "timezone": "Australia/Perth",
+                "cron_expression": desired_cron,
+                "timezone": desired_timezone,
             },
         )
         if trig and "id" in trig:

--- a/scripts/setup/populate_multica.py
+++ b/scripts/setup/populate_multica.py
@@ -873,17 +873,7 @@ def step_i_create_autopilots(agent_ids: dict[str, str]):
         if has_matching_schedule:
             print(f"    ↩ Trigger already set: {desired_cron}")
             continue
-        if schedule_triggers:
-            delete_sql = (
-                "delete from autopilot_trigger "
-                f"where autopilot_id={_sql_literal(ap_id)} and kind='schedule';"
-            )
-            ok, msg = _db_exec(delete_sql)
-            if ok:
-                print(f"    ↻ Replacing schedule trigger with: {desired_cron}")
-            else:
-                print(f"    ⚠ Could not replace trigger for '{title}': {msg[:100]}")
-                continue
+        replacing_schedule = bool(schedule_triggers)
         trig = _post(
             f"/api/autopilots/{ap_id}/triggers",
             {
@@ -893,7 +883,20 @@ def step_i_create_autopilots(agent_ids: dict[str, str]):
             },
         )
         if trig and "id" in trig:
-            print(f"    ✓ Trigger set: {apdef['cron']}")
+            if replacing_schedule:
+                delete_sql = (
+                    "delete from autopilot_trigger "
+                    f"where autopilot_id={_sql_literal(ap_id)} "
+                    "and kind='schedule' "
+                    f"and id <> {_sql_literal(trig['id'])};"
+                )
+                ok, msg = _db_exec(delete_sql)
+                if ok:
+                    print(f"    ↻ Replaced schedule trigger with: {desired_cron}")
+                else:
+                    print(f"    ⚠ New trigger created but old trigger cleanup failed for '{title}': {msg[:100]}")
+            else:
+                print(f"    ✓ Trigger set: {desired_cron}")
         else:
             print(f"    ⚠ Trigger creation returned: {trig}")
 

--- a/scripts/setup/populate_multica.py
+++ b/scripts/setup/populate_multica.py
@@ -448,21 +448,23 @@ _AGENT_DEFS = [
             "skill. Always be concise, helpful, and personal. Your wake word is 'Hey Zoe'."
         ),
         "model": "Llama-3.2-3B-Instruct-Q4_K_M",
+        "runtime_provider": "zoe",
     },
     {
         "name": "OpenClaw",
         "description": (
-            "Agentic execution runtime. Handles browser automation, code execution, skill "
-            "building, and simple-English Multica quick-create tasks through the native "
-            "Multica daemon."
+            "Agentic execution runtime. Handles browser automation, code execution, and skill "
+            "building. In Multica issue capture, route simple-English ticket creation through "
+            "the Hermes runtime until OpenClaw's Codex-backed harness has non-rate-limited capacity."
         ),
         "instructions": (
-            "You are OpenClaw, Zoe's native agentic execution runtime. Use local tools to "
-            "create well-formed Multica issues from simple-English quick-create requests, "
-            "run browser/tool tasks when explicitly assigned, and report blockers clearly. "
+            "You are OpenClaw, Zoe's native agentic execution runtime. For Multica simple-English "
+            "issue capture, use the Hermes runtime path so ticket creation remains reliable and cost-controlled; "
+            "run browser/tool tasks only when explicitly assigned, and report blockers clearly. "
             "Do not decide Zoe engineering phase advancement; Zoe/Hermes harness owns that workflow."
         ),
-        "model": "main",
+        "model": "gpt-5.4",
+        "runtime_provider": "hermes",
     },
     {
         "name": "Hermes",
@@ -479,6 +481,7 @@ _AGENT_DEFS = [
         ),
         # Multica daemon selector for the Hermes CLI profile, not a public OpenAI model id.
         "model": "gpt-5.4",
+        "runtime_provider": "hermes",
     },
     {
         "name": "Agent Zero",
@@ -493,6 +496,7 @@ _AGENT_DEFS = [
             "Be thorough and cite your sources."
         ),
         "model": "Llama-3.2-3B-Instruct-Q4_K_M",
+        "runtime_provider": "zoe",
     },
     {
         "name": "Self-Improvement Agent",
@@ -508,13 +512,47 @@ _AGENT_DEFS = [
             "test it, commit it, and report back."
         ),
         "model": "Llama-3.2-3B-Instruct-Q4_K_M",
+        "runtime_provider": "zoe",
     },
 ]
+
+
+def _runtime_ids_by_provider(default_runtime_id: str) -> dict[str, str]:
+    """Return provider -> online runtime id, falling back to the Zoe host runtime."""
+    runtime_ids = {"zoe": default_runtime_id}
+    sql = (
+        "select provider, id from agent_runtime "
+        f"where workspace_id={_sql_literal(WORKSPACE_ID)} "
+        "and status='online' "
+        "and provider in ('hermes', 'openclaw', 'cursor') "
+        "order by provider, daemon_id is null, updated_at desc;"
+    )
+    cmd = [
+        "docker", "exec", _DB_CONTAINER,
+        "psql", "-U", _DB_USER, "-d", _DB_NAME,
+        "-t", "-A", "-F", "\t", "-c", sql,
+    ]
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
+    except Exception as exc:
+        print(f"  ⚠ Runtime provider lookup failed: {exc}")
+        return runtime_ids
+    if result.returncode != 0:
+        print(f"  ⚠ Runtime provider lookup failed: {(result.stderr or result.stdout)[:100]}")
+        return runtime_ids
+    for line in result.stdout.splitlines():
+        if "\t" not in line:
+            continue
+        provider, row_id = [part.strip() for part in line.split("\t", 1)]
+        if provider and row_id and provider not in runtime_ids:
+            runtime_ids[provider] = row_id
+    return runtime_ids
 
 
 def step_f_create_agents(runtime_id: str) -> dict[str, str]:
     """Returns name → agent_id mapping."""
     print("\n[F] Creating agents...")
+    runtime_ids = _runtime_ids_by_provider(runtime_id)
     existing_raw = _get("/api/agents") or []
     existing: list[dict] = existing_raw if isinstance(existing_raw, list) else existing_raw.get("agents", [])
     managed_names = [str(defn["name"]) for defn in _AGENT_DEFS]
@@ -527,6 +565,7 @@ def step_f_create_agents(runtime_id: str) -> dict[str, str]:
     agent_ids: dict[str, str] = dict(existing_names)
     for defn in _AGENT_DEFS:
         name = defn["name"]
+        target_runtime_id = runtime_ids.get(str(defn.get("runtime_provider") or "zoe"), runtime_id)
         if name in existing_names:
             agent_id = existing_names[name]
             sql = (
@@ -534,7 +573,7 @@ def step_f_create_agents(runtime_id: str) -> dict[str, str]:
                 f"description={_sql_literal(defn['description'])}, "
                 f"instructions={_sql_literal(defn['instructions'])}, "
                 f"model={_sql_literal(defn['model'])}, "
-                f"runtime_id={_sql_literal(runtime_id)}, "
+                f"runtime_id={_sql_literal(target_runtime_id)}, "
                 "runtime_mode='local', visibility='workspace', "
                 "archived_at=NULL, archived_by=NULL, updated_at=now() "
                 f"where id={_sql_literal(agent_id)};"
@@ -550,7 +589,7 @@ def step_f_create_agents(runtime_id: str) -> dict[str, str]:
             "description": defn["description"],
             "instructions": defn["instructions"],
             "model": defn["model"],
-            "runtime_id": runtime_id,
+            "runtime_id": target_runtime_id,
             "runtime_mode": "local",
             "visibility": "workspace",
         })
@@ -723,9 +762,9 @@ _AUTOPILOTS = [
     {
         "title": "Morning Checkin",
         "agent": "Zoe Core",
-        "execution_mode": "create_issue",
+        "execution_mode": "run_only",
         "cron": "30 7 * * *",
-        "issue_title_template": "Morning Brief — {date}",
+        "issue_title_template": "",
     },
     {
         "title": "Evening Wind Down",
@@ -757,8 +796,8 @@ _AUTOPILOTS = [
     },
     {
         "title": "Platform Health Check",
-        "agent": "Zoe Core",
-        "execution_mode": "run_only",
+        "agent": "Hermes",
+        "execution_mode": "create_issue",
         "cron": "0 6 * * *",
         "issue_title_template": "Platform Health — {date}",
     },
@@ -780,7 +819,20 @@ def step_i_create_autopilots(agent_ids: dict[str, str]):
 
         if title in existing_titles:
             ap_id = existing_titles[title]
-            print(f"  ↩ Autopilot '{title}' exists ({ap_id})")
+            sql = (
+                "update autopilot set "
+                f"assignee_id={_sql_literal(agent_id)}, "
+                "status=" + _sql_literal("active") + ", "
+                f"execution_mode={_sql_literal(apdef['execution_mode'])}, "
+                f"issue_title_template={_sql_literal(apdef.get('issue_title_template', ''))}, "
+                "updated_at=now() "
+                f"where id={_sql_literal(ap_id)};"
+            )
+            ok, msg = _db_update_one(sql)
+            if ok:
+                print(f"  ↻ Autopilot '{title}' exists ({ap_id}) — refreshed settings")
+            else:
+                print(f"  ⚠ Autopilot '{title}' refresh failed: {msg[:100]}")
         else:
             payload = {
                 "title": title,

--- a/scripts/setup/populate_multica.py
+++ b/scripts/setup/populate_multica.py
@@ -524,7 +524,7 @@ def _runtime_ids_by_provider(default_runtime_id: str) -> dict[str, str]:
         "select provider, id from agent_runtime "
         f"where workspace_id={_sql_literal(WORKSPACE_ID)} "
         "and status='online' "
-        "and provider in ('hermes', 'openclaw', 'cursor') "
+        "and provider in ('hermes') "
         "order by provider, daemon_id is null, updated_at desc;"
     )
     cmd = [

--- a/scripts/setup/populate_multica.py
+++ b/scripts/setup/populate_multica.py
@@ -771,7 +771,7 @@ _AUTOPILOTS = [
         "agent": "Zoe Core",
         "execution_mode": "run_only",
         "cron": "0 21 * * *",
-        "issue_title_template": "Evening Check-In — {date}",
+        "issue_title_template": "",
     },
     {
         "title": "Evolution Nightly Notice",
@@ -822,7 +822,6 @@ def step_i_create_autopilots(agent_ids: dict[str, str]):
             sql = (
                 "update autopilot set "
                 f"assignee_id={_sql_literal(agent_id)}, "
-                "status=" + _sql_literal("active") + ", "
                 f"execution_mode={_sql_literal(apdef['execution_mode'])}, "
                 f"issue_title_template={_sql_literal(apdef.get('issue_title_template', ''))}, "
                 "updated_at=now() "

--- a/scripts/setup/populate_multica.py
+++ b/scripts/setup/populate_multica.py
@@ -464,6 +464,7 @@ _AGENT_DEFS = [
             "Do not decide Zoe engineering phase advancement; Zoe/Hermes harness owns that workflow."
         ),
         "model": "gpt-5.4",
+        "fallback_model": "main",
         "runtime_provider": "hermes",
     },
     {
@@ -481,6 +482,7 @@ _AGENT_DEFS = [
         ),
         # Multica daemon selector for the Hermes CLI profile, not a public OpenAI model id.
         "model": "gpt-5.4",
+        "fallback_model": "main",
         "runtime_provider": "hermes",
     },
     {
@@ -567,9 +569,12 @@ def step_f_create_agents(runtime_id: str) -> dict[str, str]:
         name = defn["name"]
         runtime_provider = str(defn.get("runtime_provider") or "zoe")
         target_runtime_id = runtime_ids.get(runtime_provider, runtime_id)
+        target_model = defn["model"]
         if runtime_provider != "zoe" and runtime_provider not in runtime_ids:
+            target_model = str(defn.get("fallback_model") or target_model)
             print(
-                f"  ⚠ Provider '{runtime_provider}' not online — using Zoe runtime for '{name}'"
+                f"  ⚠ Provider '{runtime_provider}' not online — using Zoe runtime for '{name}' "
+                f"with fallback model '{target_model}'"
             )
         if name in existing_names:
             agent_id = existing_names[name]
@@ -577,7 +582,7 @@ def step_f_create_agents(runtime_id: str) -> dict[str, str]:
                 "update agent set "
                 f"description={_sql_literal(defn['description'])}, "
                 f"instructions={_sql_literal(defn['instructions'])}, "
-                f"model={_sql_literal(defn['model'])}, "
+                f"model={_sql_literal(target_model)}, "
                 f"runtime_id={_sql_literal(target_runtime_id)}, "
                 "runtime_mode='local', visibility='workspace', "
                 "archived_at=NULL, archived_by=NULL, updated_at=now() "
@@ -593,7 +598,7 @@ def step_f_create_agents(runtime_id: str) -> dict[str, str]:
             "name": name,
             "description": defn["description"],
             "instructions": defn["instructions"],
-            "model": defn["model"],
+            "model": target_model,
             "runtime_id": target_runtime_id,
             "runtime_mode": "local",
             "visibility": "workspace",

--- a/services/zoe-data/multica_autopilot_sync.py
+++ b/services/zoe-data/multica_autopilot_sync.py
@@ -571,7 +571,13 @@ async def sync_autopilots_from_multica(scheduler) -> int:
     for ap in autopilots:
         ap_id: str = str(ap.get("id", "")).strip()
         ap_title: str = (ap.get("title") or ap.get("name") or "").strip()
-        ap_mode: str = ap.get("execution_mode") or ap.get("mode") or "create_issue"
+        raw_mode = ap.get("execution_mode") or ap.get("mode")
+        if not raw_mode:
+            logger.debug(
+                "sync_autopilots: autopilot %s has no execution_mode/mode; defaulting to create_issue",
+                ap_id,
+            )
+        ap_mode: str = raw_mode or "create_issue"
         ap_assignee: str | None = ap.get("assignee_agent_id") or ap.get("assignee_id")
 
         if not ap_id or not ap_title:

--- a/services/zoe-data/multica_autopilot_sync.py
+++ b/services/zoe-data/multica_autopilot_sync.py
@@ -571,7 +571,7 @@ async def sync_autopilots_from_multica(scheduler) -> int:
     for ap in autopilots:
         ap_id: str = str(ap.get("id", "")).strip()
         ap_title: str = (ap.get("title") or ap.get("name") or "").strip()
-        ap_mode: str = ap.get("mode") or "create_issue"
+        ap_mode: str = ap.get("execution_mode") or ap.get("mode") or "create_issue"
         ap_assignee: str | None = ap.get("assignee_agent_id") or ap.get("assignee_id")
 
         if not ap_id or not ap_title:

--- a/services/zoe-data/tests/test_multica_autopilot_noise.py
+++ b/services/zoe-data/tests/test_multica_autopilot_noise.py
@@ -10,6 +10,76 @@ import pytest
 import multica_autopilot_sync as mas
 
 
+@pytest.mark.asyncio
+async def test_sync_autopilots_prefers_execution_mode(monkeypatch):
+    captured_jobs: list[dict] = []
+
+    class FakeCronTrigger:
+        @classmethod
+        def from_crontab(cls, expr, timezone=None):
+            return {"expr": expr, "timezone": timezone}
+
+    class FakeScheduler:
+        def remove_job(self, job_id):
+            raise LookupError(job_id)
+
+        def add_job(self, func, *, trigger, id, replace_existing, kwargs):
+            captured_jobs.append(
+                {
+                    "func": func,
+                    "trigger": trigger,
+                    "id": id,
+                    "replace_existing": replace_existing,
+                    "kwargs": kwargs,
+                }
+            )
+
+    monkeypatch.setattr(mas, "_is_configured", lambda: True)
+    monkeypatch.setattr(
+        mas,
+        "get_multica_autopilots",
+        AsyncMock(
+            return_value=[
+                {
+                    "id": "ap-run-only",
+                    "title": "Morning Checkin",
+                    "execution_mode": "run_only",
+                    "mode": "create_issue",
+                    "assignee_id": "agent-1",
+                }
+            ]
+        ),
+    )
+    monkeypatch.setattr(
+        mas,
+        "get_autopilot_triggers",
+        AsyncMock(return_value=[{"cron_expression": "30 7 * * *"}]),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "apscheduler.triggers.cron",
+        types.SimpleNamespace(CronTrigger=FakeCronTrigger),
+    )
+
+    registered = await mas.sync_autopilots_from_multica(FakeScheduler())
+
+    assert registered == 1
+    assert captured_jobs == [
+        {
+            "func": mas._fire_autopilot_job,
+            "trigger": {"expr": "30 7 * * *", "timezone": mas._TZ},
+            "id": "multica_autopilot_ap-run-only",
+            "replace_existing": True,
+            "kwargs": {
+                "autopilot_id": "ap-run-only",
+                "autopilot_title": "Morning Checkin",
+                "mode": "run_only",
+                "assignee_agent_id": "agent-1",
+            },
+        }
+    ]
+
+
 def test_should_create_tracker_issue_default_off_for_mapped_task():
     fn = lambda: None  # noqa: E731
     with patch.object(mas, "_CREATE_ISSUES", False):

--- a/services/zoe-data/tests/test_multica_autopilot_noise.py
+++ b/services/zoe-data/tests/test_multica_autopilot_noise.py
@@ -80,6 +80,47 @@ async def test_sync_autopilots_prefers_execution_mode(monkeypatch):
     ]
 
 
+@pytest.mark.asyncio
+async def test_sync_autopilots_logs_missing_mode_default(monkeypatch, caplog):
+    captured_jobs: list[dict] = []
+
+    class FakeCronTrigger:
+        @classmethod
+        def from_crontab(cls, expr, timezone=None):
+            return {"expr": expr, "timezone": timezone}
+
+    class FakeScheduler:
+        def remove_job(self, job_id):
+            raise LookupError(job_id)
+
+        def add_job(self, func, *, trigger, id, replace_existing, kwargs):
+            captured_jobs.append(kwargs)
+
+    monkeypatch.setattr(mas, "_is_configured", lambda: True)
+    monkeypatch.setattr(
+        mas,
+        "get_multica_autopilots",
+        AsyncMock(return_value=[{"id": "ap-missing-mode", "title": "Legacy"}]),
+    )
+    monkeypatch.setattr(
+        mas,
+        "get_autopilot_triggers",
+        AsyncMock(return_value=[{"cron_expression": "0 8 * * *"}]),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "apscheduler.triggers.cron",
+        types.SimpleNamespace(CronTrigger=FakeCronTrigger),
+    )
+
+    with caplog.at_level("DEBUG", logger=mas.logger.name):
+        registered = await mas.sync_autopilots_from_multica(FakeScheduler())
+
+    assert registered == 1
+    assert captured_jobs[0]["mode"] == "create_issue"
+    assert "has no execution_mode/mode" in caplog.text
+
+
 def test_should_create_tracker_issue_default_off_for_mapped_task():
     fn = lambda: None  # noqa: E731
     with patch.object(mas, "_CREATE_ISSUES", False):

--- a/services/zoe-data/tests/test_populate_multica_contract.py
+++ b/services/zoe-data/tests/test_populate_multica_contract.py
@@ -71,4 +71,6 @@ def test_runtime_fallback_and_trigger_refresh_are_observable():
     assert "delete from autopilot_trigger" in source
     assert "kind='schedule'" in source
     assert 'desired_cron = apdef["cron"]' in source
-    assert "Replacing schedule trigger with" in source
+    assert "Replaced schedule trigger with" in source
+    assert source.index("trig = _post") < source.index("delete from autopilot_trigger")
+    assert "id <> {_sql_literal(trig['id'])}" in source

--- a/services/zoe-data/tests/test_populate_multica_contract.py
+++ b/services/zoe-data/tests/test_populate_multica_contract.py
@@ -43,17 +43,20 @@ def test_managed_agents_keep_provider_specific_runtime_contract():
 def test_managed_autopilots_keep_execution_modes_and_templates():
     autopilots = {ap["title"]: ap for ap in _assigned_literal("_AUTOPILOTS")}
 
+    assert autopilots["Morning Checkin"]["status"] == "paused"
     assert autopilots["Morning Checkin"]["execution_mode"] == "run_only"
     assert autopilots["Morning Checkin"]["issue_title_template"] == ""
+    assert autopilots["Evening Wind Down"]["status"] == "paused"
     assert autopilots["Evening Wind Down"]["execution_mode"] == "run_only"
     assert autopilots["Evening Wind Down"]["issue_title_template"] == ""
+    assert autopilots["Reminder Scan"]["status"] == "paused"
     assert autopilots["Reminder Scan"]["execution_mode"] == "run_only"
     assert autopilots["Platform Health Check"]["agent"] == "Hermes"
     assert autopilots["Platform Health Check"]["execution_mode"] == "create_issue"
 
     source = _source()
     assert "update autopilot set" in source
-    assert "f\"status={_sql_literal" not in source
+    assert "status={_sql_literal(apdef.get('status', 'active'))}" in source
     assert "execution_mode={_sql_literal(apdef['execution_mode'])}" in source
     assert "issue_title_template={_sql_literal(apdef.get('issue_title_template', ''))}" in source
 

--- a/services/zoe-data/tests/test_populate_multica_contract.py
+++ b/services/zoe-data/tests/test_populate_multica_contract.py
@@ -43,20 +43,17 @@ def test_managed_agents_keep_provider_specific_runtime_contract():
 def test_managed_autopilots_keep_execution_modes_and_templates():
     autopilots = {ap["title"]: ap for ap in _assigned_literal("_AUTOPILOTS")}
 
-    assert autopilots["Morning Checkin"]["status"] == "paused"
     assert autopilots["Morning Checkin"]["execution_mode"] == "run_only"
     assert autopilots["Morning Checkin"]["issue_title_template"] == ""
-    assert autopilots["Evening Wind Down"]["status"] == "paused"
     assert autopilots["Evening Wind Down"]["execution_mode"] == "run_only"
     assert autopilots["Evening Wind Down"]["issue_title_template"] == ""
-    assert autopilots["Reminder Scan"]["status"] == "paused"
     assert autopilots["Reminder Scan"]["execution_mode"] == "run_only"
     assert autopilots["Platform Health Check"]["agent"] == "Hermes"
     assert autopilots["Platform Health Check"]["execution_mode"] == "create_issue"
 
     source = _source()
     assert "update autopilot set" in source
-    assert "status={_sql_literal(apdef.get('status', 'active'))}" in source
+    assert "f\"status={_sql_literal" not in source
     assert "execution_mode={_sql_literal(apdef['execution_mode'])}" in source
     assert "issue_title_template={_sql_literal(apdef.get('issue_title_template', ''))}" in source
 
@@ -65,10 +62,10 @@ def test_managed_autopilots_keep_execution_modes_and_templates():
 def test_runtime_fallback_and_trigger_refresh_are_observable():
     source = _source()
 
-    assert "Provider {runtime_provider} not online" in source
-    assert "and provider in (hermes)" in source
-    assert "openclaw, cursor" not in source
+    assert "Provider '{runtime_provider}' not online" in source
+    assert "and provider in ('hermes')" in source
+    assert "openclaw', 'cursor" not in source
     assert "delete from autopilot_trigger" in source
-    assert "kind=schedule" in source
-    assert "desired_cron = apdef["cron"]" in source
+    assert "kind='schedule'" in source
+    assert 'desired_cron = apdef["cron"]' in source
     assert "Replacing schedule trigger with" in source

--- a/services/zoe-data/tests/test_populate_multica_contract.py
+++ b/services/zoe-data/tests/test_populate_multica_contract.py
@@ -19,7 +19,10 @@ def _assigned_literal(name: str):
         if isinstance(node, ast.Assign):
             for target in node.targets:
                 if isinstance(target, ast.Name) and target.id == name:
-                    return ast.literal_eval(node.value)
+                    try:
+                        return ast.literal_eval(node.value)
+                    except (ValueError, SyntaxError) as exc:
+                        raise AssertionError(f"{name} must remain a literal contract") from exc
     raise AssertionError(f"{name} assignment not found")
 
 
@@ -56,9 +59,12 @@ def test_managed_autopilots_keep_execution_modes_and_templates():
 
     source = _source()
     assert "update autopilot set" in source
-    assert "status={_sql_literal(apdef.get('status', 'active'))}" in source
+    assert "status_sql = (" in source
+    assert "if \"status\" in apdef else \"\"" in source
+    assert "status={_sql_literal(apdef.get('status', 'active'))}" not in source
     assert "execution_mode={_sql_literal(apdef['execution_mode'])}" in source
     assert "issue_title_template={_sql_literal(apdef.get('issue_title_template', ''))}" in source
+    assert "continue" in source[source.index("refresh failed"):source.index("else:", source.index("refresh failed"))]
 
 
 

--- a/services/zoe-data/tests/test_populate_multica_contract.py
+++ b/services/zoe-data/tests/test_populate_multica_contract.py
@@ -45,6 +45,8 @@ def test_managed_autopilots_keep_execution_modes_and_templates():
 
     assert autopilots["Morning Checkin"]["execution_mode"] == "run_only"
     assert autopilots["Morning Checkin"]["issue_title_template"] == ""
+    assert autopilots["Evening Wind Down"]["execution_mode"] == "run_only"
+    assert autopilots["Evening Wind Down"]["issue_title_template"] == ""
     assert autopilots["Reminder Scan"]["execution_mode"] == "run_only"
     assert autopilots["Platform Health Check"]["agent"] == "Hermes"
     assert autopilots["Platform Health Check"]["execution_mode"] == "create_issue"

--- a/services/zoe-data/tests/test_populate_multica_contract.py
+++ b/services/zoe-data/tests/test_populate_multica_contract.py
@@ -29,17 +29,23 @@ def _assigned_literal(name: str):
 def test_managed_agents_keep_provider_specific_runtime_contract():
     agent_defs = _assigned_literal("_AGENT_DEFS")
     providers = {agent["name"]: agent.get("runtime_provider") for agent in agent_defs}
+    fallback_models = {agent["name"]: agent.get("fallback_model") for agent in agent_defs}
 
     assert providers["Zoe Core"] == "zoe"
     assert providers["OpenClaw"] == "hermes"
+    assert fallback_models["OpenClaw"] == "main"
     assert providers["Hermes"] == "hermes"
+    assert fallback_models["Hermes"] == "main"
     assert providers["Agent Zero"] == "zoe"
     assert providers["Self-Improvement Agent"] == "zoe"
 
     source = _source()
     assert "def _runtime_ids_by_provider" in source
     assert "target_runtime_id = runtime_ids.get" in source
+    assert 'target_model = str(defn.get("fallback_model") or target_model)' in source
+    assert "model={_sql_literal(target_model)}" in source
     assert "runtime_id={_sql_literal(target_runtime_id)}" in source
+    assert '"model": target_model' in source
     assert '"runtime_id": target_runtime_id' in source
 
 

--- a/services/zoe-data/tests/test_populate_multica_contract.py
+++ b/services/zoe-data/tests/test_populate_multica_contract.py
@@ -1,0 +1,55 @@
+"""Static contract tests for the Zoe Multica bootstrap script."""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+def _source() -> str:
+    root = Path(__file__).resolve().parents[3]
+    return (root / "scripts/setup/populate_multica.py").read_text(encoding="utf-8")
+
+
+def _module() -> ast.Module:
+    return ast.parse(_source())
+
+
+def _assigned_literal(name: str):
+    for node in _module().body:
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == name:
+                    return ast.literal_eval(node.value)
+    raise AssertionError(f"{name} assignment not found")
+
+
+def test_managed_agents_keep_provider_specific_runtime_contract():
+    agent_defs = _assigned_literal("_AGENT_DEFS")
+    providers = {agent["name"]: agent.get("runtime_provider") for agent in agent_defs}
+
+    assert providers["Zoe Core"] == "zoe"
+    assert providers["OpenClaw"] == "hermes"
+    assert providers["Hermes"] == "hermes"
+    assert providers["Agent Zero"] == "zoe"
+    assert providers["Self-Improvement Agent"] == "zoe"
+
+    source = _source()
+    assert "def _runtime_ids_by_provider" in source
+    assert "target_runtime_id = runtime_ids.get" in source
+    assert "runtime_id={_sql_literal(target_runtime_id)}" in source
+    assert '"runtime_id": target_runtime_id' in source
+
+
+def test_managed_autopilots_keep_execution_modes_and_templates():
+    autopilots = {ap["title"]: ap for ap in _assigned_literal("_AUTOPILOTS")}
+
+    assert autopilots["Morning Checkin"]["execution_mode"] == "run_only"
+    assert autopilots["Morning Checkin"]["issue_title_template"] == ""
+    assert autopilots["Reminder Scan"]["execution_mode"] == "run_only"
+    assert autopilots["Platform Health Check"]["agent"] == "Hermes"
+    assert autopilots["Platform Health Check"]["execution_mode"] == "create_issue"
+
+    source = _source()
+    assert "update autopilot set" in source
+    assert "execution_mode={_sql_literal(apdef['execution_mode'])}" in source
+    assert "issue_title_template={_sql_literal(apdef.get('issue_title_template', ''))}" in source

--- a/services/zoe-data/tests/test_populate_multica_contract.py
+++ b/services/zoe-data/tests/test_populate_multica_contract.py
@@ -71,6 +71,8 @@ def test_runtime_fallback_and_trigger_refresh_are_observable():
     assert "delete from autopilot_trigger" in source
     assert "kind='schedule'" in source
     assert 'desired_cron = apdef["cron"]' in source
+    assert 't.get("timezone") == desired_timezone' in source
+    assert '(t.get("timezone") or desired_timezone)' not in source
     assert "Replaced schedule trigger with" in source
     assert source.index("trig = _post") < source.index("delete from autopilot_trigger")
     assert "id <> {_sql_literal(trig['id'])}" in source

--- a/services/zoe-data/tests/test_populate_multica_contract.py
+++ b/services/zoe-data/tests/test_populate_multica_contract.py
@@ -43,15 +43,32 @@ def test_managed_agents_keep_provider_specific_runtime_contract():
 def test_managed_autopilots_keep_execution_modes_and_templates():
     autopilots = {ap["title"]: ap for ap in _assigned_literal("_AUTOPILOTS")}
 
+    assert autopilots["Morning Checkin"]["status"] == "paused"
     assert autopilots["Morning Checkin"]["execution_mode"] == "run_only"
     assert autopilots["Morning Checkin"]["issue_title_template"] == ""
+    assert autopilots["Evening Wind Down"]["status"] == "paused"
     assert autopilots["Evening Wind Down"]["execution_mode"] == "run_only"
     assert autopilots["Evening Wind Down"]["issue_title_template"] == ""
+    assert autopilots["Reminder Scan"]["status"] == "paused"
     assert autopilots["Reminder Scan"]["execution_mode"] == "run_only"
     assert autopilots["Platform Health Check"]["agent"] == "Hermes"
     assert autopilots["Platform Health Check"]["execution_mode"] == "create_issue"
 
     source = _source()
     assert "update autopilot set" in source
+    assert "status={_sql_literal(apdef.get('status', 'active'))}" in source
     assert "execution_mode={_sql_literal(apdef['execution_mode'])}" in source
     assert "issue_title_template={_sql_literal(apdef.get('issue_title_template', ''))}" in source
+
+
+
+def test_runtime_fallback_and_trigger_refresh_are_observable():
+    source = _source()
+
+    assert "Provider {runtime_provider} not online" in source
+    assert "and provider in (hermes)" in source
+    assert "openclaw, cursor" not in source
+    assert "delete from autopilot_trigger" in source
+    assert "kind=schedule" in source
+    assert "desired_cron = apdef["cron"]" in source
+    assert "Replacing schedule trigger with" in source


### PR DESCRIPTION
## Summary
- assign managed Multica agents to provider-specific online runtimes instead of forcing every agent onto Zoe host runtime
- preserve managed autopilot execution modes and refresh existing autopilot settings idempotently
- make autopilot schedule sync prefer Multica execution_mode over legacy mode

## Tests
- python3 tools/audit/validate_structure.py
- python3 tools/audit/validate_critical_files.py
- python3 tools/audit/validate_offline_memory.py
- git diff --check
- python3 -m py_compile scripts/setup/populate_multica.py services/zoe-data/multica_autopilot_sync.py
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_multica_autopilot_noise.py services/zoe-data/tests/test_populate_multica_contract.py