### PR TITLE
Add capability profile PR edit workflow

### DIFF
--- a/scripts/maintenance/capability_profile_pr_edit_workflow.py
+++ b/scripts/maintenance/capability_profile_pr_edit_workflow.py
@@ -26,8 +26,11 @@ from zoe_capability_profile_pr_edit_gate import (  # noqa: E402
 )
 
 
-def _read_text(path: str) -> str:
-    return Path(path).read_text(encoding="utf-8")
+def _read_text(path: str, *, label: str) -> str:
+    try:
+        return Path(path).read_text(encoding="utf-8")
+    except OSError as exc:
+        raise SystemExit(f"could not read {label} file {path!r}: {exc}") from exc
 
 
 def _non_empty_refs(values: list[str] | None) -> tuple[str, ...]:
@@ -72,10 +75,10 @@ def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
     plan = build_capability_profile_pr_edit_plan_from_ticket(
         ticket_id=args.ticket_id,
-        ticket_description=_read_text(args.ticket_description_file),
-        current_source_text=_read_text(args.current_source_file),
-        patch_text=_read_text(args.patch_file),
-        promotion_manifest=_read_text(args.promotion_manifest_file),
+        ticket_description=_read_text(args.ticket_description_file, label="ticket description"),
+        current_source_text=_read_text(args.current_source_file, label="current source"),
+        patch_text=_read_text(args.patch_file, label="patch"),
+        promotion_manifest=_read_text(args.promotion_manifest_file, label="promotion manifest"),
         pr_refs=_non_empty_refs(args.pr_ref),
         rollback_refs=_non_empty_refs(args.rollback_ref),
         verification_refs=_non_empty_refs(args.verification_ref),

--- a/scripts/maintenance/capability_profile_pr_edit_workflow.py
+++ b/scripts/maintenance/capability_profile_pr_edit_workflow.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Prepare capability-profile PR edits from reviewed Multica tickets.
+
+This runner closes the operator workflow around the side-effect-free PR edit
+gate. It validates a created ticket, current source, patch, promotion manifest,
+and review evidence, then emits a JSON plan. It never applies patches, creates
+branches, edits files, or calls GitHub/Multica.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+DATA = ROOT / "services" / "zoe-data"
+if str(DATA) not in sys.path:
+    sys.path.insert(0, str(DATA))
+
+from zoe_capability_profile_pr_edit_gate import (  # noqa: E402
+    build_capability_profile_pr_edit_plan_from_ticket,
+    render_capability_profile_pr_edit_patch,
+)
+
+
+def _read_text(path: str) -> str:
+    return Path(path).read_text(encoding="utf-8")
+
+
+def _non_empty_refs(values: list[str] | None) -> tuple[str, ...]:
+    return tuple(value.strip() for value in values or () if value.strip())
+
+
+def _metadata(raw: str | None) -> dict[str, Any]:
+    if not raw:
+        return {}
+    try:
+        value = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"--metadata-json must be valid JSON: {exc}") from exc
+    if not isinstance(value, dict):
+        raise SystemExit("--metadata-json must decode to an object")
+    return value
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Validate a capability-profile ticket before preparing a PR edit.",
+    )
+    parser.add_argument("--ticket-id", required=True)
+    parser.add_argument("--ticket-description-file", required=True)
+    parser.add_argument("--current-source-file", required=True)
+    parser.add_argument("--patch-file", required=True)
+    parser.add_argument("--promotion-manifest-file", required=True)
+    parser.add_argument("--pr-ref", action="append", default=[])
+    parser.add_argument("--rollback-ref", action="append", default=[])
+    parser.add_argument("--verification-ref", action="append", default=[])
+    parser.add_argument("--greptile-ref", action="append", default=[])
+    parser.add_argument("--metadata-json", default="{}")
+    parser.add_argument(
+        "--render-patch",
+        action="store_true",
+        help="Print the reviewed patch text instead of the JSON plan. Fails closed when blocked.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    plan = build_capability_profile_pr_edit_plan_from_ticket(
+        ticket_id=args.ticket_id,
+        ticket_description=_read_text(args.ticket_description_file),
+        current_source_text=_read_text(args.current_source_file),
+        patch_text=_read_text(args.patch_file),
+        promotion_manifest=_read_text(args.promotion_manifest_file),
+        pr_refs=_non_empty_refs(args.pr_ref),
+        rollback_refs=_non_empty_refs(args.rollback_ref),
+        verification_refs=_non_empty_refs(args.verification_ref),
+        greptile_refs=_non_empty_refs(args.greptile_ref),
+        metadata=_metadata(args.metadata_json),
+    )
+    if args.render_patch:
+        try:
+            print(render_capability_profile_pr_edit_patch(plan), end="")
+        except ValueError as exc:
+            print(json.dumps(plan.to_dict(), indent=2, sort_keys=True), file=sys.stderr)
+            print(str(exc), file=sys.stderr)
+            return 2
+        return 0
+    print(json.dumps(plan.to_dict(), indent=2, sort_keys=True))
+    return 0 if plan.allowed_to_prepare_pr_edit else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/zoe-data/tests/test_capability_profile_pr_edit_workflow.py
+++ b/services/zoe-data/tests/test_capability_profile_pr_edit_workflow.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+from zoe_capability_profile import DEFAULT_CAPABILITY_PROFILES
+from zoe_capability_profile_multica_handoff import build_capability_profile_multica_handoff
+from zoe_capability_profile_patch_writer import build_capability_profile_patch_plan
+from zoe_capability_profile_promotion import build_capability_profile_promotion_plan
+from zoe_capability_profile_ticket_writer import create_capability_profile_handoff_ticket
+from zoe_capability_trust_review import review_capability_trust_update_plan
+from zoe_capability_trust_update import CapabilityTrustUpdateCandidate, CapabilityTrustUpdatePlan
+
+
+def _load_runner():
+    root = Path(__file__).resolve().parents[3]
+    path = root / "scripts" / "maintenance" / "capability_profile_pr_edit_workflow.py"
+    spec = importlib.util.spec_from_file_location("capability_profile_pr_edit_workflow", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+def _source_text():
+    return (Path(__file__).parent.parent / "zoe_capability_profile.py").read_text(encoding="utf-8")
+
+
+def _candidate():
+    return CapabilityTrustUpdateCandidate(
+        capability_id="hindsight_reflective_memory",
+        proposal_id="proposal_profile_pr_edit_workflow",
+        proposal_candidate_id="hindsight_reflective_memory",
+        current_trust_level="experimental",
+        proposed_trust_level="assisted",
+        reason="Verified retained outcome supports a reviewable promotion.",
+        evidence_refs=("pytest:test_capability_profile_pr_edit_workflow", "approval:multica:ZOE-427"),
+        source_event_id="event_profile_pr_edit_workflow",
+        source_admission_id="admit_profile_pr_edit_workflow",
+        retained_backend="zoe-project-jason",
+        metadata={"source": "evolution_outcome_retain"},
+    )
+
+
+def _handoff():
+    review = review_capability_trust_update_plan(
+        CapabilityTrustUpdatePlan(candidates=(_candidate(),)),
+        reviewer_id="multica:reviewer",
+        approval_refs=("approval:trust-review:ZOE-427",),
+        approved_capability_ids=("hindsight_reflective_memory",),
+        profiles=DEFAULT_CAPABILITY_PROFILES,
+    )
+    promotion = build_capability_profile_promotion_plan(
+        review,
+        pr_refs=("pr:427",),
+        rollback_refs=("rollback:revert-pr-427",),
+        verification_refs=("pytest:test_capability_profile_pr_edit_workflow",),
+    )
+    patch = build_capability_profile_patch_plan(promotion, source_text=_source_text())
+    return build_capability_profile_multica_handoff(
+        promotion,
+        patch,
+        title="Promote Hindsight reflective memory profile",
+        parent_issue_id="ZOE-427",
+    )
+
+
+class FakeMulticaClient:
+    def __init__(self):
+        self.create_calls = []
+
+    async def create_issue(self, **kwargs):
+        self.create_calls.append(kwargs)
+        return {"id": "issue-427", "identifier": "ZOE-427"}
+
+
+async def _write_fixture_files(tmp_path: Path):
+    handoff = _handoff()
+    client = FakeMulticaClient()
+    result = await create_capability_profile_handoff_ticket(
+        handoff,
+        operator_id="operator:jason",
+        approval_refs=("approval:operator:ZOE-427",),
+        evidence_refs=("pytest:test_capability_profile_pr_edit_workflow",),
+        client=client,
+    )
+    assert result.created is True
+    files = {
+        "ticket": tmp_path / "ticket.md",
+        "source": tmp_path / "source.py",
+        "patch": tmp_path / "profile.patch",
+        "manifest": tmp_path / "manifest.json",
+    }
+    files["ticket"].write_text(client.create_calls[0]["description"], encoding="utf-8")
+    files["source"].write_text(_source_text(), encoding="utf-8")
+    files["patch"].write_text(handoff.patch_text, encoding="utf-8")
+    files["manifest"].write_text(handoff.promotion_manifest, encoding="utf-8")
+    return handoff, files
+
+
+@pytest.mark.asyncio
+async def test_workflow_cli_outputs_allowed_plan(tmp_path, capsys):
+    runner = _load_runner()
+    handoff, files = await _write_fixture_files(tmp_path)
+
+    rc = runner.main(
+        [
+            "--ticket-id", "ZOE-427",
+            "--ticket-description-file", str(files["ticket"]),
+            "--current-source-file", str(files["source"]),
+            "--patch-file", str(files["patch"]),
+            "--promotion-manifest-file", str(files["manifest"]),
+            "--pr-ref", "https://github.com/jason-easyazz/zoe-ai-assistant/pull/427",
+            "--rollback-ref", "rollback:revert-pr-427",
+            "--verification-ref", "pytest:test_capability_profile_pr_edit_workflow",
+            "--greptile-ref", "greptile:pass:427",
+            "--metadata-json", '{"operator":"jason"}',
+        ]
+    )
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["allowed_to_prepare_pr_edit"] is True
+    assert payload["metadata"]["extra"] == {"operator": "jason"}
+    assert payload["patch_text"] == handoff.patch_text
+
+
+@pytest.mark.asyncio
+async def test_workflow_cli_blocks_without_greptile_ref(tmp_path, capsys):
+    runner = _load_runner()
+    _handoff, files = await _write_fixture_files(tmp_path)
+
+    rc = runner.main(
+        [
+            "--ticket-id", "ZOE-427",
+            "--ticket-description-file", str(files["ticket"]),
+            "--current-source-file", str(files["source"]),
+            "--patch-file", str(files["patch"]),
+            "--promotion-manifest-file", str(files["manifest"]),
+            "--pr-ref", "pr:427",
+            "--rollback-ref", "rollback:revert-pr-427",
+            "--verification-ref", "pytest:test_capability_profile_pr_edit_workflow",
+        ]
+    )
+
+    assert rc == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["allowed_to_prepare_pr_edit"] is False
+    assert "missing_greptile_refs" in payload["blockers"]
+    assert payload["patch_text"] == ""
+
+
+@pytest.mark.asyncio
+async def test_workflow_cli_render_patch_fails_closed_when_blocked(tmp_path, capsys):
+    runner = _load_runner()
+    _handoff, files = await _write_fixture_files(tmp_path)
+
+    rc = runner.main(
+        [
+            "--ticket-id", "ZOE-427",
+            "--ticket-description-file", str(files["ticket"]),
+            "--current-source-file", str(files["source"]),
+            "--patch-file", str(files["patch"]),
+            "--promotion-manifest-file", str(files["manifest"]),
+            "--pr-ref", "pr:427",
+            "--rollback-ref", "rollback:revert-pr-427",
+            "--verification-ref", "pytest:test_capability_profile_pr_edit_workflow",
+            "--render-patch",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert rc == 2
+    assert captured.out == ""
+    assert "missing_greptile_refs" in captured.err
+    assert "cannot render capability profile PR edit patch" in captured.err

--- a/services/zoe-data/tests/test_capability_profile_pr_edit_workflow.py
+++ b/services/zoe-data/tests/test_capability_profile_pr_edit_workflow.py
@@ -129,6 +129,32 @@ async def test_workflow_cli_outputs_allowed_plan(tmp_path, capsys):
 
 
 @pytest.mark.asyncio
+async def test_workflow_cli_render_patch_outputs_allowed_patch(tmp_path, capsys):
+    runner = _load_runner()
+    handoff, files = await _write_fixture_files(tmp_path)
+
+    rc = runner.main(
+        [
+            "--ticket-id", "ZOE-427",
+            "--ticket-description-file", str(files["ticket"]),
+            "--current-source-file", str(files["source"]),
+            "--patch-file", str(files["patch"]),
+            "--promotion-manifest-file", str(files["manifest"]),
+            "--pr-ref", "https://github.com/jason-easyazz/zoe-ai-assistant/pull/427",
+            "--rollback-ref", "rollback:revert-pr-427",
+            "--verification-ref", "pytest:test_capability_profile_pr_edit_workflow",
+            "--greptile-ref", "greptile:pass:427",
+            "--render-patch",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert captured.out == handoff.patch_text
+    assert captured.err == ""
+
+
+@pytest.mark.asyncio
 async def test_workflow_cli_blocks_without_greptile_ref(tmp_path, capsys):
     runner = _load_runner()
     _handoff, files = await _write_fixture_files(tmp_path)
@@ -177,3 +203,23 @@ async def test_workflow_cli_render_patch_fails_closed_when_blocked(tmp_path, cap
     assert captured.out == ""
     assert "missing_greptile_refs" in captured.err
     assert "cannot render capability profile PR edit patch" in captured.err
+
+
+def test_workflow_cli_bad_file_path_fails_cleanly(tmp_path, capsys):
+    runner = _load_runner()
+    missing = tmp_path / "missing.md"
+
+    with pytest.raises(SystemExit, match="could not read ticket description file"):
+        runner.main(
+            [
+                "--ticket-id", "ZOE-427",
+                "--ticket-description-file", str(missing),
+                "--current-source-file", str(missing),
+                "--patch-file", str(missing),
+                "--promotion-manifest-file", str(missing),
+            ]
+        )
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == ""


### PR DESCRIPTION
## Summary
- add a side-effect-free maintenance runner for operator-driven capability profile PR edit preparation
- validate created ticket metadata, current source, patch, promotion manifest, and PR/rollback/verification/Greptile evidence through the existing PR edit gate
- fail closed when evidence is missing and only render the reviewed patch when explicitly requested

## Tests
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_capability_profile_pr_edit_workflow.py services/zoe-data/tests/test_zoe_capability_profile_pr_edit_gate.py services/zoe-data/tests/test_zoe_capability_profile_ticket_writer.py services/zoe-data/tests/test_zoe_capability_profile_ticket_gate.py
- python3 -m py_compile scripts/maintenance/capability_profile_pr_edit_workflow.py
- python3 tools/audit/validate_structure.py
- python3 tools/audit/validate_critical_files.py
- python3 tools/audit/validate_offline_memory.py
- git diff --check