### PR TITLE
Record default Graphify shard evidence

### DIFF
--- a/docs/architecture/zoe-graphify-refresh-evidence.md
+++ b/docs/architecture/zoe-graphify-refresh-evidence.md
@@ -84,6 +84,18 @@ Current evidence:
   over 45 code files and 1 doc, producing 306 nodes and 685 edges with no invalid
   JSON, truncation, or context splits. This proves the sharded lane can capture
   bounded local Graphify evidence after the full-repo rejection.
+- Default shard matrix against `origin/main` at `911c1f6` accepted two of three
+  shards with `--allow-partial`: `data-core` accepted in 103.591 s over 289 code
+  files and 10 docs, producing 5,087 nodes and 11,145 edges; `operators`
+  accepted in 64.320 s over 176 code files and 9 docs, producing 1,640 nodes and
+  3,088 edges. Both accepted shards had zero invalid JSON chunks, truncation, or
+  context splits.
+- The same default shard matrix rejected `ui` in 85.404 s because the
+  `services/zoe-ui` shard found 0 code files, 3 docs, 0 graph nodes, and 1
+  invalid JSON chunk. This does not disprove local Gemma for Graphify; it shows
+  the UI shard definition is not yet a reliable accepted source slice. The next
+  default-shard PR should either point `ui` at indexable source assets or remove
+  it from the default matrix until a focused UI probe is accepted.
 
 ## Refresh 2026-06-09 Foundation Pass
 

--- a/docs/strategy/zoe-evolution-harness-status.md
+++ b/docs/strategy/zoe-evolution-harness-status.md
@@ -48,6 +48,12 @@ Important non-complete truth:
   11 context split warnings, three invalid JSON chunks, and one truncated chunk;
   temporary graph output existed but was not accepted or committed. The local
   backend is promising but not yet accepted for full Graphify refreshes.
+- The default shard matrix after `911c1f6` accepted `data-core` and `operators`
+  with local Gemma E4B and zero invalid JSON, truncation, or context splits, but
+  rejected `ui` because `services/zoe-ui` yielded 0 code files, 3 docs, 0 graph
+  nodes, and 1 invalid JSON chunk. Zoe should continue using local/offline
+  shard-based Graphify evidence, but the default UI shard must be corrected or
+  removed before the default matrix is treated as all-green.
 - Zoe now has a local/offline Graphify probe that runs Graphify through the
   Ollama/OpenAI-compatible localhost llama.cpp path in a temporary fixture or
   snapshot, strips cloud API keys from the probe environment, parses context,


### PR DESCRIPTION
## Summary
- records default local/offline Graphify shard matrix evidence from main at 911c1f6
- notes data-core and operators accepted with Gemma E4B while ui remains rejected
- keeps OpenRouter/cloud out of the Graphify decision path and points next work at fixing the UI shard definition

## Verification
- python3 tools/audit/validate_structure.py
- python3 tools/audit/validate_critical_files.py
- python3 tools/audit/validate_offline_memory.py
- git diff --check