### PR TITLE
Use accepted Graphify default shards

### DIFF
--- a/docs/architecture/zoe-graphify-refresh-evidence.md
+++ b/docs/architecture/zoe-graphify-refresh-evidence.md
@@ -29,6 +29,10 @@ RSS, model-file, invalid-JSON, truncation, and context-split evidence so Zoe can
 compare Gemma 4 E2B, E4B, and 12B before changing the sync-capable refresh lane. The shard matrix wrapper then runs the selected local model across named bounded repo slices, records blocked shards, accepted-shard latency, and max observed RSS across all shards, and keeps every shard observe-only until a later merge/sync strategy is proven. Default shards avoid `.zoe` operator state and docs-only directories; those require explicit `--shard` opt-in after separate safety/behavior evidence.
 Scoped mode is observe-only evidence for subsystem-sized local model runs; the
 sync-capable refresh wrapper still requires full repo mode with clustering.
+After the first default matrix run, the default shard set was narrowed to the
+accepted local slices only: `data-core` and `operators`. The UI tree remains an
+explicit `--shard ui=services/zoe-ui` probe until Graphify can index Zoe's HTML,
+CSS, and JavaScript assets without producing empty or malformed graph output.
 
 `graphify_local_refresh.py` is the sync-capable local wrapper. It runs the repo
 probe with clustering and `keep_workdir`, then syncs `graphify-out` back to the
@@ -96,6 +100,13 @@ Current evidence:
   the UI shard definition is not yet a reliable accepted source slice. The next
   default-shard PR should either point `ui` at indexable source assets or remove
   it from the default matrix until a focused UI probe is accepted.
+- Corrected default shard matrix after removing `ui` accepted 2/2 default shards
+  without `--allow-partial`: `data-core` accepted in 43.770 s over 289 code
+  files and 10 docs, producing 5,087 nodes and 11,145 edges; `operators`
+  accepted in 49.967 s over 176 code files and 9 docs, producing 1,638 nodes and
+  3,075 edges. The run had no blocked shards, no invalid JSON chunks, no
+  truncation, no context splits, median accepted duration 46.869 s, and max
+  observed child RSS about 86 MB.
 
 ## Refresh 2026-06-09 Foundation Pass
 

--- a/docs/strategy/zoe-evolution-harness-status.md
+++ b/docs/strategy/zoe-evolution-harness-status.md
@@ -53,7 +53,13 @@ Important non-complete truth:
   rejected `ui` because `services/zoe-ui` yielded 0 code files, 3 docs, 0 graph
   nodes, and 1 invalid JSON chunk. Zoe should continue using local/offline
   shard-based Graphify evidence, but the default UI shard must be corrected or
-  removed before the default matrix is treated as all-green.
+  removed before the default matrix is treated as all-green. The default shard
+  set now excludes `ui`; operators can still run it explicitly while the UI
+  indexing path is investigated.
+- The corrected default shard matrix accepted 2/2 local Gemma E4B shards without
+  `--allow-partial`: `data-core` in 43.770 s and `operators` in 49.967 s, with
+  no blocked shards, invalid JSON, truncation, or context splits. The default
+  shard lane is now accepted for bounded observe-only local Graphify evidence.
 - Zoe now has a local/offline Graphify probe that runs Graphify through the
   Ollama/OpenAI-compatible localhost llama.cpp path in a temporary fixture or
   snapshot, strips cloud API keys from the probe environment, parses context,

--- a/scripts/maintenance/graphify_local_shard_matrix.py
+++ b/scripts/maintenance/graphify_local_shard_matrix.py
@@ -34,7 +34,6 @@ from graphify_local_probe import (  # noqa: E402
 DEFAULT_SHARD_MODEL = "gemma-4-e4b-it-Q4_K_M.gguf"
 DEFAULT_SHARDS: tuple[tuple[str, tuple[str, ...]], ...] = (
     ("data-core", ("services/zoe-data",)),
-    ("ui", ("services/zoe-ui",)),
     ("operators", ("scripts", "tools")),
 )
 

--- a/services/zoe-data/tests/test_graphify_local_shard_matrix.py
+++ b/services/zoe-data/tests/test_graphify_local_shard_matrix.py
@@ -65,7 +65,7 @@ def test_parse_shard_validates_name_and_paths():
 
 
 
-def test_default_shards_exclude_operator_state_and_docs_only_dirs():
+def test_default_shards_include_only_accepted_local_slices():
     module = _load_module()
 
     defaults = module.default_shards()
@@ -74,7 +74,11 @@ def test_default_shards_exclude_operator_state_and_docs_only_dirs():
 
     assert ".zoe" not in flattened
     assert "harness-docs" not in names
-    assert ("scripts", "tools") in [shard.include_paths for shard in defaults]
+    assert "ui" not in names
+    assert "services/zoe-ui" not in flattened
+    assert [shard.name for shard in defaults] == ["data-core", "operators"]
+    assert [shard.include_paths for shard in defaults] == [("services/zoe-data",), ("scripts", "tools")]
+
 
 def test_summarize_shards_reports_blocked_shards_and_accepted_median():
     module = _load_module()


### PR DESCRIPTION
## Summary
- removes the rejected ui shard from the default local Graphify shard matrix
- keeps ui available as an explicit opt-in shard while the UI indexing path is investigated
- records the corrected default-matrix evidence: 2/2 accepted with local Gemma E4B, no invalid JSON, truncation, or context splits

## Verification
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_graphify_local_shard_matrix.py
- python3 -m py_compile scripts/maintenance/graphify_local_shard_matrix.py scripts/maintenance/graphify_local_probe.py scripts/maintenance/graphify_local_model_matrix.py scripts/maintenance/graphify_local_refresh.py
- python3 tools/audit/validate_structure.py
- python3 tools/audit/validate_critical_files.py
- python3 tools/audit/validate_offline_memory.py
- git diff --check
- PYTHONPATH=services/zoe-data python3 scripts/maintenance/graphify_local_shard_matrix.py --timeout-sec 600 --status-json /tmp/zoe-graphify-default-shard-fix.json

## Live local Graphify evidence
- accepted_count: 2
- all_accepted: true
- blocked_shards: []
- data-core: 43.770s, 289 code files, 10 docs, 5087 nodes, 11145 edges
- operators: 49.967s, 176 code files, 9 docs, 1638 nodes, 3075 edges
- invalid_json_chunks/context_splits/truncated_chunks: 0
- max_observed_rss_kb: 86324