### PR TITLE
Teach Skybridge calendar date ranges

### DIFF
--- a/services/zoe-data/calendar_utils.py
+++ b/services/zoe-data/calendar_utils.py
@@ -1,0 +1,20 @@
+"""Shared calendar data normalization helpers."""
+
+from __future__ import annotations
+
+import json
+
+
+def row_to_event(row) -> dict:
+    """Convert a calendar row to an event dict, parsing persisted metadata."""
+    d = dict(row)
+    if d.get("metadata") is not None and isinstance(d["metadata"], str):
+        try:
+            d["metadata"] = json.loads(d["metadata"]) if d["metadata"] else None
+        except json.JSONDecodeError:
+            d["metadata"] = None
+    if "all_day" in d and d["all_day"] is not None:
+        d["all_day"] = bool(d["all_day"])
+    if "deleted" in d and d["deleted"] is not None:
+        d["deleted"] = bool(d["deleted"])
+    return d

--- a/services/zoe-data/routers/calendar.py
+++ b/services/zoe-data/routers/calendar.py
@@ -2,7 +2,6 @@
 FastAPI router for calendar events.
 Mounted at prefix="/api/calendar" with tag "calendar".
 """
-import json
 import uuid
 from datetime import date
 from typing import Optional
@@ -10,6 +9,7 @@ from typing import Optional
 from fastapi import APIRouter, Depends, HTTPException, Query
 
 from auth import get_current_user
+from calendar_utils import row_to_event
 from database import get_db
 from guest_policy import require_feature_access
 from models import EventCreate, EventUpdate
@@ -20,17 +20,7 @@ router = APIRouter(prefix="/api/calendar", tags=["calendar"])
 
 def _row_to_event(row) -> dict:
     """Convert asyncpg Row to dict, parsing metadata JSON."""
-    d = dict(row)
-    if d.get("metadata") is not None and isinstance(d["metadata"], str):
-        try:
-            d["metadata"] = json.loads(d["metadata"]) if d["metadata"] else None
-        except json.JSONDecodeError:
-            d["metadata"] = None
-    if "all_day" in d and d["all_day"] is not None:
-        d["all_day"] = bool(d["all_day"])
-    if "deleted" in d and d["deleted"] is not None:
-        d["deleted"] = bool(d["deleted"])
-    return d
+    return row_to_event(row)
 
 
 def _visibility_filter_sql() -> str:

--- a/services/zoe-data/skybridge_service.py
+++ b/services/zoe-data/skybridge_service.py
@@ -2,20 +2,14 @@
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from datetime import date, timedelta
 from typing import Any
 
+from calendar_utils import row_to_event
 from card_service import card_service
 from database import get_db_ctx
-from routers.calendar import _row_to_event
-from routers.weather import (
-    _get_current,
-    _get_forecast,
-    _get_system_default_location,
-    _resolve_location,
-    _row_to_prefs,
-)
 
 
 @dataclass(frozen=True)
@@ -27,19 +21,137 @@ class SkybridgeIntent:
     end_date: date | None = None
 
 
+MONTHS = {
+    "january": 1,
+    "jan": 1,
+    "february": 2,
+    "feb": 2,
+    "march": 3,
+    "mar": 3,
+    "april": 4,
+    "apr": 4,
+    "may": 5,
+    "june": 6,
+    "jun": 6,
+    "july": 7,
+    "jul": 7,
+    "august": 8,
+    "aug": 8,
+    "september": 9,
+    "sep": 9,
+    "sept": 9,
+    "october": 10,
+    "oct": 10,
+    "november": 11,
+    "nov": 11,
+    "december": 12,
+    "dec": 12,
+}
+MONTH_PATTERN = "|".join(sorted(MONTHS, key=len, reverse=True))
+
+
+def _today() -> date:
+    return date.today()
+
+
+async def _get_current(lat, lon, city, country):
+    from routers.weather import _get_current as get_current
+
+    return await get_current(lat, lon, city, country)
+
+
+async def _get_forecast(lat, lon):
+    from routers.weather import _get_forecast as get_forecast
+
+    return await get_forecast(lat, lon)
+
+
+async def _get_system_default_location(db):
+    from routers.weather import _get_system_default_location as get_system_default_location
+
+    return await get_system_default_location(db)
+
+
+def _resolve_location(prefs, *, fallback):
+    from routers.weather import _resolve_location as resolve_location
+
+    return resolve_location(prefs, fallback=fallback)
+
+
+def _row_to_prefs(row):
+    from routers.weather import _row_to_prefs as row_to_prefs
+
+    return row_to_prefs(row)
+
+
+def _calendar_date_from_text(text: str, today: date) -> tuple[str, date, date] | None:
+    if "tomorrow" in text:
+        target = today + timedelta(days=1)
+        return "tomorrow", target, target
+    if any(term in text for term in (" next week ", " following week ")):
+        days_until_monday = (7 - today.weekday()) % 7 or 7
+        start = today + timedelta(days=days_until_monday)
+        return "next week", start, start + timedelta(days=6)
+    if any(term in text for term in (" this week ", " week ", " upcoming ", " next few days ")):
+        return "this week", today, today + timedelta(days=7)
+
+    match = re.search(
+        rf"\b(?:on\s+)?(?:the\s+)?(?P<day>\d{{1,2}})(?:st|nd|rd|th)?(?:\s+of)?\s+(?P<month>{MONTH_PATTERN})(?:\s+(?P<year>\d{{4}}))?\b",
+        text,
+    )
+    if match:
+        day = int(match.group("day"))
+        month_name = match.group("month")
+        month = MONTHS.get(month_name)
+        if month is None:
+            return None
+        year = int(match.group("year") or today.year)
+        try:
+            target = date(year, month, day)
+        except ValueError:
+            return None
+        label = f"{target.day} {target.strftime('%B %Y')}"
+        return label, target, target
+
+    iso_match = re.search(r"\b(?P<year>\d{4})-(?P<month>\d{1,2})-(?P<day>\d{1,2})\b", text)
+    if iso_match:
+        try:
+            target = date(
+                int(iso_match.group("year")),
+                int(iso_match.group("month")),
+                int(iso_match.group("day")),
+            )
+        except ValueError:
+            return None
+        return target.isoformat(), target, target
+
+    return None
+
+
 def classify_skybridge_intent(message: str) -> SkybridgeIntent | None:
     """Classify only domains that Skybridge can resolve to real data cards."""
     text = f" {(message or '').lower()} "
     if any(term in text for term in (" weather", " forecast", " temperature", " rain", " windy", " wind ")):
         action = "forecast" if any(term in text for term in ("forecast", "tomorrow", "week", "next few days")) else "current"
         return SkybridgeIntent(domain="weather", action=action)
-    if any(term in text for term in (" calendar", " schedule", " events", " appointments", " agenda")):
-        today = date.today()
-        if "tomorrow" in text:
-            target = today + timedelta(days=1)
-            return SkybridgeIntent("calendar", "show", "tomorrow", target, target)
-        if any(term in text for term in ("this week", "week", "upcoming", "next few days")):
-            return SkybridgeIntent("calendar", "show", "this week", today, today + timedelta(days=7))
+    if any(
+        term in text
+        for term in (
+            " calendar",
+            " schedule",
+            " events",
+            " appointments",
+            " agenda",
+            " happening",
+            " what's on",
+            " whats on",
+        )
+    ):
+        today = _today()
+        parsed_range = _calendar_date_from_text(text, today)
+        if parsed_range is not None:
+            label, start, end = parsed_range
+            return SkybridgeIntent("calendar", "show", label, start, end)
         return SkybridgeIntent("calendar", "show", "today", today, today)
     return None
 
@@ -94,7 +206,7 @@ async def _resolve_calendar(intent: SkybridgeIntent, user_id: str, db: Any) -> d
             start.isoformat(),
             end.isoformat(),
         )
-        events = [_row_to_event(row) for row in rows]
+        events = [row_to_event(row) for row in rows]
     qualifier = intent.range_label or start.isoformat()
     event_word = "event" if len(events) == 1 else "events"
     spoken = f"You have {len(events)} {event_word} {qualifier}."

--- a/services/zoe-data/tests/test_skybridge_service.py
+++ b/services/zoe-data/tests/test_skybridge_service.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 import sys
-from datetime import date
+from datetime import date, timedelta
 
 import pytest
 
@@ -26,8 +26,10 @@ class FakeDb:
     def __init__(self, *, events=None, prefs=None):
         self.events = events or []
         self.prefs = prefs
+        self.fetch_args = None
 
-    async def fetch(self, *_args):
+    async def fetch(self, *args):
+        self.fetch_args = args
         return self.events
 
     async def fetchrow(self, *_args):
@@ -45,7 +47,56 @@ class GuardedGuestDb(FakeDb):
 def test_classify_calendar_and_weather_requests():
     assert classify_skybridge_intent("show my calendar").domain == "calendar"
     assert classify_skybridge_intent("show me the weather").domain == "weather"
+    assert classify_skybridge_intent("what is happening this week").domain == "calendar"
     assert classify_skybridge_intent("open settings") is None
+
+
+def test_classify_calendar_date_and_range_requests(monkeypatch):
+    class FrozenDate(date):
+        @classmethod
+        def today(cls):
+            return cls(2026, 6, 11)
+
+    monkeypatch.setattr(skybridge_service, "date", FrozenDate)
+
+    dated = classify_skybridge_intent("show me my calendar on the 17th of June")
+    assert dated.domain == "calendar"
+    assert dated.start_date == date(2026, 6, 17)
+    assert dated.end_date == date(2026, 6, 17)
+    assert dated.range_label == "17 June 2026"
+
+    week = classify_skybridge_intent("what is happening this week")
+    assert week.domain == "calendar"
+    assert week.start_date == date(2026, 6, 11)
+    assert week.end_date == date(2026, 6, 18)
+
+    tomorrow = classify_skybridge_intent("show me the weather for tomorrow")
+    assert tomorrow.domain == "weather"
+    assert tomorrow.action == "forecast"
+
+    next_week = classify_skybridge_intent("show my schedule next week")
+    assert next_week.domain == "calendar"
+    assert next_week.start_date == date(2026, 6, 15)
+    assert next_week.end_date == date(2026, 6, 21)
+    assert next_week.range_label == "next week"
+
+    iso = classify_skybridge_intent("show my calendar on 2026-06-17")
+    assert iso.domain == "calendar"
+    assert iso.start_date == date(2026, 6, 17)
+    assert iso.end_date == date(2026, 6, 17)
+    assert iso.range_label == "2026-06-17"
+
+    iso_after_count = classify_skybridge_intent("show my 10 events on 2026-06-17")
+    assert iso_after_count.domain == "calendar"
+    assert iso_after_count.start_date == date(2026, 6, 17)
+    assert iso_after_count.end_date == date(2026, 6, 17)
+    assert iso_after_count.range_label == "2026-06-17"
+
+    weekend = classify_skybridge_intent("what is happening this weekend")
+    assert weekend.domain == "calendar"
+    assert weekend.range_label == "today"
+    assert weekend.start_date == date(2026, 6, 11)
+    assert weekend.end_date == date(2026, 6, 11)
 
 
 @pytest.mark.asyncio
@@ -83,6 +134,43 @@ async def test_calendar_empty_state_still_returns_data_card():
     assert card["content"]["source"] == "calendar_show"
     assert card["content"]["events"] == []
     assert "0 events" in result["spoken_summary"]
+
+
+@pytest.mark.asyncio
+async def test_calendar_explicit_date_queries_requested_day(monkeypatch):
+    class FrozenDate(date):
+        @classmethod
+        def today(cls):
+            return cls(2026, 6, 11)
+
+    monkeypatch.setattr(skybridge_service, "date", FrozenDate)
+
+    db = FakeDb(events=[])
+    result = await resolve_skybridge_request("show my calendar on the 17th of June", "family-admin", db=db)
+
+    assert result["handled"] is True
+    assert result["intent"]["range"] == "17 June 2026"
+    assert db.fetch_args[2] == "2026-06-17"
+    assert db.fetch_args[3] == "2026-06-17"
+    assert result["cards"][0]["content"]["qualifier"] == "17 June 2026"
+
+
+@pytest.mark.asyncio
+async def test_calendar_happening_this_week_queries_range(monkeypatch):
+    class FrozenDate(date):
+        @classmethod
+        def today(cls):
+            return cls(2026, 6, 11)
+
+    monkeypatch.setattr(skybridge_service, "date", FrozenDate)
+
+    db = FakeDb(events=[])
+    result = await resolve_skybridge_request("what is happening this week", "family-admin", db=db)
+
+    assert result["handled"] is True
+    assert result["intent"]["range"] == "this week"
+    assert db.fetch_args[2] == "2026-06-11"
+    assert db.fetch_args[3] == (date(2026, 6, 11) + timedelta(days=7)).isoformat()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add Skybridge calendar parsing for explicit day/month dates, next week, and vague happening/whats on phrasing
- avoid router package import cycles by keeping calendar row normalization local and lazily loading weather helpers
- add focused tests for weather tomorrow, calendar June 17, and happening this week

## Tests
- PYTHONPATH=. python3 -m pytest -q tests/test_skybridge_service.py tests/test_skybridge_static.py tests/test_skybridge_status.py tests/test_card_contract.py
- python3 tools/audit/validate_structure.py
- python3 tools/audit/validate_critical_files.py
- git diff --check