### PR TITLE
Add profile edit outcome workflow

### DIFF
--- a/scripts/maintenance/capability_profile_edit_outcome_workflow.py
+++ b/scripts/maintenance/capability_profile_edit_outcome_workflow.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Build admitted memory/trust evidence from a verified capability-profile PR edit.
+
+This operator runner is the next step after capability_profile_pr_edit_workflow.py.
+It consumes a reviewed PR-edit plan JSON plus verification traces and emits the
+profile-edit outcome plan. It is intentionally side-effect-free: it does not
+write MemoryService, Hindsight, Graphiti, Multica, profile files, or GitHub.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Iterable
+
+ROOT = Path(__file__).resolve().parents[2]
+DATA = ROOT / "services" / "zoe-data"
+if str(DATA) not in sys.path:
+    sys.path.insert(0, str(DATA))
+
+from zoe_capability_profile_edit_outcome import build_capability_profile_edit_outcome_plan  # noqa: E402
+from zoe_capability_profile_pr_edit_gate import CapabilityProfilePREditPlan  # noqa: E402
+from zoe_memory_router import MemoryBackend  # noqa: E402
+from zoe_observation_trace import ObservationTrace  # noqa: E402
+
+
+def _load_json_file(path: str, *, label: str) -> Any:
+    try:
+        return json.loads(Path(path).read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise SystemExit(f"could not read {label} file {path!r}: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"{label} file {path!r} must be valid JSON: {exc}") from exc
+
+
+def _load_text_file(path: str | None, *, label: str) -> str | None:
+    if path is None:
+        return None
+    try:
+        return Path(path).read_text(encoding="utf-8")
+    except OSError as exc:
+        raise SystemExit(f"could not read {label} file {path!r}: {exc}") from exc
+
+
+def _metadata(raw: str | None) -> dict[str, Any]:
+    if not raw:
+        return {}
+    try:
+        value = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"--metadata-json must be valid JSON: {exc}") from exc
+    if not isinstance(value, dict):
+        raise SystemExit("--metadata-json must decode to an object")
+    return value
+
+
+def _non_empty(values: Iterable[str] | None) -> tuple[str, ...]:
+    refs: list[str] = []
+    for value in values or ():
+        item = str(value).strip()
+        if item:
+            refs.append(item)
+    return tuple(refs)
+
+
+def _pr_edit_plan(path: str) -> CapabilityProfilePREditPlan:
+    payload = _load_json_file(path, label="PR edit plan")
+    if not isinstance(payload, dict):
+        raise SystemExit("PR edit plan JSON must decode to an object")
+    blockers = _non_empty(payload.get("blockers", ()))
+    # Preserve blocked plans as blocked dataclasses: the constructor disallows
+    # patch/promoted payloads when blockers exist, so blank those fields before
+    # handing them to the outcome gate.
+    patch_text = "" if blockers else str(payload.get("patch_text") or "")
+    promoted_ids = () if blockers else _non_empty(payload.get("promoted_capability_ids", ()))
+    return CapabilityProfilePREditPlan(
+        ticket_id=str(payload.get("ticket_id") or ""),
+        target_path=str(payload.get("target_path") or ""),
+        patch_text=patch_text,
+        promoted_capability_ids=promoted_ids,
+        pr_refs=_non_empty(payload.get("pr_refs", ())),
+        rollback_refs=_non_empty(payload.get("rollback_refs", ())),
+        verification_refs=_non_empty(payload.get("verification_refs", ())),
+        greptile_refs=_non_empty(payload.get("greptile_refs", ())),
+        blockers=blockers,
+        metadata=payload.get("metadata") if isinstance(payload.get("metadata"), dict) else {},
+    )
+
+
+def _trace_payloads(paths: list[str]) -> list[dict[str, Any]]:
+    payloads: list[dict[str, Any]] = []
+    for path in paths:
+        loaded = _load_json_file(path, label="verification trace")
+        if isinstance(loaded, list):
+            for item in loaded:
+                if not isinstance(item, dict):
+                    raise SystemExit(f"verification trace file {path!r} contains a non-object trace")
+                payloads.append(item)
+        elif isinstance(loaded, dict):
+            payloads.append(loaded)
+        else:
+            raise SystemExit(f"verification trace file {path!r} must decode to an object or list of objects")
+    return payloads
+
+
+def _verification_traces(paths: list[str]) -> tuple[ObservationTrace, ...]:
+    traces: list[ObservationTrace] = []
+    for index, payload in enumerate(_trace_payloads(paths)):
+        try:
+            trace = ObservationTrace(**payload)
+            trace.validate()
+        except TypeError as exc:
+            trace_id = payload.get("trace_id") or f"index_{index}"
+            raise SystemExit(f"invalid verification trace {trace_id!r}: {exc}") from exc
+        except ValueError as exc:
+            trace_id = payload.get("trace_id") or f"index_{index}"
+            raise SystemExit(f"invalid verification trace {trace_id!r}: {exc}") from exc
+        traces.append(trace)
+    return tuple(traces)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Build a memory/trust outcome plan from a verified capability-profile PR edit.",
+    )
+    parser.add_argument("--pr-edit-plan-json-file", required=True)
+    parser.add_argument("--verification-trace-file", action="append", default=[], help="JSON object or list of ObservationTrace objects. May be repeated.")
+    parser.add_argument("--user-id", required=True)
+    parser.add_argument("--scope", default="project")
+    parser.add_argument("--target-backend", action="append", default=[])
+    parser.add_argument("--approval-ref", action="append", default=[])
+    parser.add_argument("--admission-id")
+    parser.add_argument("--event-id")
+    parser.add_argument("--promotion-manifest-file")
+    parser.add_argument("--metadata-json", default="{}")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        target_backends = _non_empty(args.target_backend) or (MemoryBackend.HINDSIGHT.value, MemoryBackend.GRAPHITI.value)
+        plan = build_capability_profile_edit_outcome_plan(
+            _pr_edit_plan(args.pr_edit_plan_json_file),
+            verification_traces=_verification_traces(args.verification_trace_file),
+            user_id=args.user_id,
+            scope=args.scope,
+            target_backends=target_backends,
+            approval_refs=_non_empty(args.approval_ref),
+            admission_id=args.admission_id,
+            event_id=args.event_id,
+            promotion_manifest=_load_text_file(args.promotion_manifest_file, label="promotion manifest"),
+            metadata=_metadata(args.metadata_json),
+        )
+    except SystemExit as exc:
+        if isinstance(exc.code, str):
+            print(exc.code, file=sys.stderr)
+            return 2
+        raise
+    print(json.dumps(plan.to_dict(), indent=2, sort_keys=True))
+    if plan.blockers:
+        return 1
+    return 0 if plan.allowed_to_admit_memory else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/zoe-data/tests/test_capability_profile_edit_outcome_workflow.py
+++ b/services/zoe-data/tests/test_capability_profile_edit_outcome_workflow.py
@@ -1,0 +1,193 @@
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = ROOT / "scripts" / "maintenance" / "capability_profile_edit_outcome_workflow.py"
+DATA = ROOT / "services" / "zoe-data"
+if str(DATA) not in sys.path:
+    sys.path.insert(0, str(DATA))
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("capability_profile_edit_outcome_workflow_test", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+MODULE = _load_module()
+
+
+def _write_json(path: Path, payload):
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def _pr_edit_plan(**overrides):
+    payload = {
+        "allowed_to_prepare_pr_edit": True,
+        "ticket_id": "ZOE-777",
+        "target_path": "services/zoe-data/zoe_capability_profile.py",
+        "patch_text": "--- a/services/zoe-data/zoe_capability_profile.py\n+++ b/services/zoe-data/zoe_capability_profile.py\n@@ -1 +1 @@\n-old\n+new\n",
+        "promoted_capability_ids": ["hindsight_reflective_memory"],
+        "pr_refs": ["https://github.com/jason-easyazz/zoe-ai-assistant/pull/777"],
+        "rollback_refs": ["rollback:revert-pr-777"],
+        "verification_refs": ["pytest:test_profile_edit_outcome_workflow"],
+        "greptile_refs": ["greptile:pass:777"],
+        "blockers": [],
+        "metadata": {"source": "capability_profile_pr_edit_gate"},
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _trace(**overrides):
+    payload = {
+        "trace_id": "trace_profile_edit_777",
+        "trace_type": "verification",
+        "surface": "multica",
+        "scope": "project",
+        "outcome": "success",
+        "summary": "Capability profile edit PR was reviewed, tested, and merged.",
+        "evidence_refs": ["pr:777:merged", "pytest:test_profile_edit_outcome_workflow"],
+        "user_id": "zoe_system",
+        "subject_id": "ZOE-777",
+        "confidence": 0.96,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _manifest(**record_overrides):
+    record = {
+        "capability_id": "hindsight_reflective_memory",
+        "from_trust_level": "experimental",
+        "to_trust_level": "assisted",
+    }
+    record.update(record_overrides)
+    return {"records": [record]}
+
+
+def test_main_builds_approved_profile_edit_outcome_plan(tmp_path, capsys):
+    pr_plan = _write_json(tmp_path / "pr-plan.json", _pr_edit_plan())
+    trace = _write_json(tmp_path / "trace.json", _trace())
+    manifest = _write_json(tmp_path / "manifest.json", _manifest())
+
+    rc = MODULE.main([
+        "--pr-edit-plan-json-file",
+        str(pr_plan),
+        "--verification-trace-file",
+        str(trace),
+        "--promotion-manifest-file",
+        str(manifest),
+        "--user-id",
+        "zoe_system",
+        "--approval-ref",
+        "approval:memory-admission:ZOE-777",
+        "--metadata-json",
+        '{"operator_surface":"capability_profile_edit_outcome_workflow"}',
+    ])
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert rc == 0
+    assert payload["allowed_to_admit_memory"] is True
+    assert payload["admission_decision"]["status"] == "approved"
+    assert payload["memory_candidate"]["event_id"] == "mem_evt_profile_edit_outcome_ZOE-777"
+    assert payload["trust_records"][0]["to_trust_level"] == "assisted"
+    assert "greptile:pass:777" in payload["trust_records"][0]["evidence_refs"]
+
+
+def test_main_returns_1_for_pending_memory_approval(tmp_path, capsys):
+    pr_plan = _write_json(tmp_path / "pr-plan.json", _pr_edit_plan())
+    trace = _write_json(tmp_path / "trace.json", _trace())
+
+    rc = MODULE.main([
+        "--pr-edit-plan-json-file",
+        str(pr_plan),
+        "--verification-trace-file",
+        str(trace),
+        "--user-id",
+        "zoe_system",
+    ])
+
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 1
+    assert payload["allowed_to_admit_memory"] is False
+    assert payload["admission_decision"]["status"] == "pending_review"
+    assert payload["admission_decision"]["blockers"] == ["approval_required"]
+    assert payload["trust_records"]
+
+
+def test_main_keeps_blocked_pr_edit_plan_blocked(tmp_path, capsys):
+    pr_plan = _write_json(
+        tmp_path / "pr-plan.json",
+        _pr_edit_plan(
+            allowed_to_prepare_pr_edit=False,
+            patch_text="",
+            promoted_capability_ids=[],
+            blockers=["missing_greptile_refs"],
+        ),
+    )
+    trace = _write_json(tmp_path / "trace.json", _trace())
+
+    rc = MODULE.main([
+        "--pr-edit-plan-json-file",
+        str(pr_plan),
+        "--verification-trace-file",
+        str(trace),
+        "--user-id",
+        "zoe_system",
+        "--approval-ref",
+        "approval:memory-admission:ZOE-777",
+    ])
+
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 1
+    assert "pr_edit_plan_not_allowed" in payload["blockers"]
+    assert "missing_greptile_refs" in payload["blockers"]
+    assert payload["memory_candidate"] is None
+
+
+def test_main_returns_2_for_invalid_verification_trace(tmp_path, capsys):
+    pr_plan = _write_json(tmp_path / "pr-plan.json", _pr_edit_plan())
+    trace = _write_json(tmp_path / "trace.json", _trace(evidence_refs=[]))
+
+    rc = MODULE.main([
+        "--pr-edit-plan-json-file",
+        str(pr_plan),
+        "--verification-trace-file",
+        str(trace),
+        "--user-id",
+        "zoe_system",
+    ])
+
+    captured = capsys.readouterr()
+    assert rc == 2
+    assert "invalid verification trace" in captured.err
+
+
+def test_main_returns_2_for_unexpected_trace_field(tmp_path, capsys):
+    pr_plan = _write_json(tmp_path / "pr-plan.json", _pr_edit_plan())
+    trace_payload = _trace()
+    trace_payload["unexpected"] = "field"
+    trace = _write_json(tmp_path / "trace.json", trace_payload)
+
+    rc = MODULE.main([
+        "--pr-edit-plan-json-file",
+        str(pr_plan),
+        "--verification-trace-file",
+        str(trace),
+        "--user-id",
+        "zoe_system",
+    ])
+
+    captured = capsys.readouterr()
+    assert rc == 2
+    assert "invalid verification trace" in captured.err
+    assert "unexpected" in captured.err


### PR DESCRIPTION
## Summary
- add a side-effect-free operator runner for verified capability-profile PR edit outcomes
- consume reviewed PR-edit plan JSON plus verification trace JSON and memory approval refs
- emit the admission-gated memory/trust outcome plan without writing MemoryService, Hindsight, Graphiti, Multica, profile files, or GitHub
- return clear CLI status codes: 0 approved, 1 pending/blocked, 2 invalid input

## Why
This closes the next operator step after capability_profile_pr_edit_workflow.py. The profile PR edit gate already validates ticket/patch/PR evidence; this runner turns the verified outcome into the existing memory-admission/trust-evidence contract so the loop has a real callable surface.

## Verification
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_capability_profile_edit_outcome_workflow.py services/zoe-data/tests/test_zoe_capability_profile_edit_outcome.py services/zoe-data/tests/test_zoe_capability_profile_pr_edit_gate.py services/zoe-data/tests/test_zoe_memory_admission.py services/zoe-data/tests/test_hindsight_retain_executor.py services/zoe-data/tests/test_zoe_evolution_outcome_retain.py
- python3 -m py_compile scripts/maintenance/capability_profile_edit_outcome_workflow.py services/zoe-data/zoe_capability_profile_edit_outcome.py
- python3 tools/audit/validate_structure.py
- python3 tools/audit/validate_critical_files.py
- python3 tools/audit/validate_offline_memory.py
- git diff --check

Result: 42 passed.