### PR TITLE
Add Multica autoresearch engineer workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ data/time_location_settings.json
 data/learning-archives/
 data/memvid/
 data/archives/
+data/autoresearch/
 
 # Database backup files
 data/*.db.backup*

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ data/learning-archives/
 data/memvid/
 data/archives/
 data/autoresearch/
+**/results.tsv
 
 # Database backup files
 data/*.db.backup*

--- a/scripts/setup/populate_multica.py
+++ b/scripts/setup/populate_multica.py
@@ -219,6 +219,7 @@ _LABELS = [
     ("feature", "#059669"),
     ("infrastructure", "#374151"),
     ("self-improvement", "#6D28D9"),
+    ("autoresearch", "#14B8A6"),
 ]
 
 
@@ -268,6 +269,8 @@ _PROJECTS = [
      "Evolution proposals, capability extension, self-improvement skill, NOTICE/PROPOSE/EXECUTE/MEASURE loop"),
     ("Infrastructure & Platform", "in_progress",
      "Auth, nginx, PostgreSQL, Docker services, OIDC provider, security"),
+    ("Autoresearch Lab", "planned",
+     "Karpathy-style fixed-budget asset optimization runs: one locked program, one editable asset, one objective score"),
     ("Agent Orchestration", "in_progress",
      "OpenClaw, Hermes, Agent Zero, A2A federation, task routing, board status"),
     ("Voice & Presence", "in_progress",
@@ -386,6 +389,7 @@ _SKILL_DEFS = [
     ("skills/shopping-list/SKILL.md", "Shopping List"),
     ("skills/smart-home/SKILL.md", "Smart Home"),
     ("skills/openclaw/zoe-capability-extender/SKILL.md", "Zoe Capability Extender"),
+    ("skills/autoresearch-engineer/SKILL.md", "Auto Research Engineer"),
     ("skills/openclaw/zoe-page-builder/SKILL.md", "Zoe Page Builder"),
     ("skills/openclaw/zoe-widget-builder/SKILL.md", "Zoe Widget Builder"),
 ]
@@ -499,6 +503,28 @@ _AGENT_DEFS = [
         ),
         "model": "Llama-3.2-3B-Instruct-Q4_K_M",
         "runtime_provider": "zoe",
+    },
+    {
+        "name": "Auto Research Engineer",
+        "description": (
+            "Karpathy-style autonomous optimizer for approved assets. It turns one business "
+            "question into one objective metric, changes only the declared asset, scores via "
+            "the locked evaluator, keeps improvements, reverts losses, and logs each round."
+        ),
+        "instructions": (
+            "You are Zoe's Auto Research Engineer. Before any run, perform the fit check: "
+            "the target must have one objective numeric score, feedback in minutes or hours, "
+            "and approved write access to exactly the asset files. Create or verify the three-file "
+            "setup: a human-owned instructions/program file, one or more agent-editable asset files, "
+            "and a locked scoring file. During a run, follow the Karpathy autoresearch loop: establish "
+            "baseline, make one hypothesis and one asset change, run the scorer, keep only better "
+            "results, revert worse or crashed changes, and append every round to an untracked results "
+            "log. Never edit the instructions/program file, scoring file, evaluators, dependencies, "
+            "or undeclared assets. Zoe/Hermes approval gates and branch/PR processes still apply."
+        ),
+        "model": "gpt-5.4",
+        "fallback_model": "main",
+        "runtime_provider": "hermes",
     },
     {
         "name": "Self-Improvement Agent",
@@ -619,9 +645,10 @@ _SKILL_ASSIGNMENTS: dict[str, list[str]] = {
     "Zoe Core": ["Calendar Events", "Personal Facts", "Shopping List", "Smart Home",
                  "Proactive Agent", "Self-Improvement"],
     "OpenClaw": ["Zoe Capability Extender", "Zoe Page Builder", "Zoe Widget Builder"],
-    "Hermes": [],
+    "Hermes": ["Auto Research Engineer"],
     "Agent Zero": ["Agent Zero Research"],
     "Self-Improvement Agent": ["Self-Improvement", "Zoe Capability Extender"],
+    "Auto Research Engineer": ["Auto Research Engineer"],
 }
 
 
@@ -697,7 +724,20 @@ def step_h_create_squads(agent_ids: dict[str, str]) -> dict[str, str]:
                 "Handle deep research, competitive analysis, and strategic planning tasks. "
                 "Agent Zero leads investigation. Zoe Core frames questions from user intent."
             ),
-            "members": ["Zoe Core"],
+            "members": ["Zoe Core", "Auto Research Engineer"],
+        },
+        {
+            "name": "Autoresearch Lab",
+            "leader": "Auto Research Engineer",
+            "description": (
+                "Bounded asset optimization squad for approved Karpathy-style autoresearch runs."
+            ),
+            "instructions": (
+                "Run only after a fit check passes and the human has approved the exact asset and "
+                "scoring file. Keep the evaluator locked, change only declared assets, record every "
+                "round, and preserve Zoe's branch, evidence, and rollback rules."
+            ),
+            "members": ["Hermes", "Self-Improvement Agent"],
         },
     ]
 

--- a/services/zoe-data/main.py
+++ b/services/zoe-data/main.py
@@ -30,6 +30,7 @@ from routers import (
     capability_matrix_router,
     music_router,
     skybridge_router,
+    autoresearch_router,
 )
 from routers.dashboard import router as dashboard_router
 from routers.stubs import router as stubs_router
@@ -1007,6 +1008,7 @@ app.include_router(panel_provision_router)
 app.include_router(capability_matrix_router)
 app.include_router(music_router)
 app.include_router(skybridge_router)
+app.include_router(autoresearch_router)
 
 from routers.portrait import router as portrait_router
 app.include_router(portrait_router)

--- a/services/zoe-data/routers/__init__.py
+++ b/services/zoe-data/routers/__init__.py
@@ -18,6 +18,7 @@ from .panel_provision import router as panel_provision_router
 from .capability_matrix import router as capability_matrix_router
 from .music import router as music_router
 from .skybridge import router as skybridge_router
+from .autoresearch import router as autoresearch_router
 
 __all__ = [
     "people_router",
@@ -40,4 +41,5 @@ __all__ = [
     "capability_matrix_router",
     "music_router",
     "skybridge_router",
+    "autoresearch_router",
 ]

--- a/services/zoe-data/routers/autoresearch.py
+++ b/services/zoe-data/routers/autoresearch.py
@@ -64,7 +64,7 @@ async def autoresearch_status() -> dict[str, Any]:
     """Return the latest local autoresearch run state for integrations."""
     root = _run_root()
     if not root.exists():
-        return {"ok": True, "surface": "autoresearch", "status": "idle", "run_count": 0, "runs": []}
+        return {"ok": True, "surface": "autoresearch", "status": "idle", "run_count": 0, "latest": None, "runs": []}
 
     try:
         run_dirs = [p for p in root.iterdir() if p.is_dir()]

--- a/services/zoe-data/routers/autoresearch.py
+++ b/services/zoe-data/routers/autoresearch.py
@@ -45,8 +45,11 @@ def _latest_result(run_dir: Path) -> dict[str, Any]:
     }
 
 
-def _run_summary(run_dir: Path) -> dict[str, Any]:
-    stat = run_dir.stat()
+def _run_summary(run_dir: Path) -> dict[str, Any] | None:
+    try:
+        stat = run_dir.stat()
+    except OSError:
+        return None
     summary: dict[str, Any] = {
         "id": run_dir.name,
         "path": str(run_dir.relative_to(_repo_root())) if run_dir.is_relative_to(_repo_root()) else str(run_dir),
@@ -68,7 +71,8 @@ async def autoresearch_status() -> dict[str, Any]:
     except OSError:
         return {"ok": False, "surface": "autoresearch", "status": "unavailable", "run_count": 0, "runs": []}
 
-    runs = sorted((_run_summary(p) for p in run_dirs), key=lambda row: row["updated_at"], reverse=True)
+    summaries = (_run_summary(p) for p in run_dirs)
+    runs = sorted((row for row in summaries if row is not None), key=lambda row: row["updated_at"], reverse=True)
     latest = runs[0] if runs else None
     return {
         "ok": True,

--- a/services/zoe-data/routers/autoresearch.py
+++ b/services/zoe-data/routers/autoresearch.py
@@ -38,10 +38,10 @@ def _latest_result(run_dir: Path) -> dict[str, Any]:
         "rounds": len(rows),
         "results_readable": True,
         "latest_round": latest.get("round") or latest.get("round_id"),
-        "latest_change": latest.get("change") or latest.get("hypothesis"),
+        "latest_change": latest.get("change") or latest.get("hypothesis") or latest.get("description"),
         "latest_before": latest.get("before") or latest.get("score_before"),
-        "latest_after": latest.get("after") or latest.get("score_after"),
-        "latest_decision": latest.get("decision") or latest.get("kept"),
+        "latest_after": latest.get("after") or latest.get("score_after") or latest.get("score"),
+        "latest_decision": latest.get("decision") or latest.get("kept") or latest.get("status"),
     }
 
 

--- a/services/zoe-data/routers/autoresearch.py
+++ b/services/zoe-data/routers/autoresearch.py
@@ -69,7 +69,7 @@ async def autoresearch_status() -> dict[str, Any]:
     try:
         run_dirs = [p for p in root.iterdir() if p.is_dir()]
     except OSError:
-        return {"ok": False, "surface": "autoresearch", "status": "unavailable", "run_count": 0, "runs": []}
+        return {"ok": False, "surface": "autoresearch", "status": "unavailable", "run_count": 0, "latest": None, "runs": []}
 
     summaries = (_run_summary(p) for p in run_dirs)
     runs = sorted((row for row in summaries if row is not None), key=lambda row: row["updated_at"], reverse=True)

--- a/services/zoe-data/routers/autoresearch.py
+++ b/services/zoe-data/routers/autoresearch.py
@@ -1,0 +1,80 @@
+"""Auto Research Engineer status surface."""
+
+from __future__ import annotations
+
+import csv
+import os
+from pathlib import Path
+from typing import Any
+
+from fastapi import APIRouter
+
+
+router = APIRouter(prefix="/api/autoresearch", tags=["autoresearch"])
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+def _run_root() -> Path:
+    configured = Path(os.environ.get("ZOE_AUTORESEARCH_RUN_ROOT", "data/autoresearch"))
+    return configured if configured.is_absolute() else _repo_root() / configured
+
+
+def _latest_result(run_dir: Path) -> dict[str, Any]:
+    results = run_dir / "results.tsv"
+    if not results.exists():
+        return {}
+    try:
+        with results.open(newline="", encoding="utf-8") as handle:
+            rows = list(csv.DictReader(handle, delimiter="\t"))
+    except (OSError, csv.Error, UnicodeError):
+        return {"results_readable": False}
+    if not rows:
+        return {"rounds": 0, "results_readable": True}
+    latest = rows[-1]
+    return {
+        "rounds": len(rows),
+        "results_readable": True,
+        "latest_round": latest.get("round") or latest.get("round_id"),
+        "latest_change": latest.get("change") or latest.get("hypothesis"),
+        "latest_before": latest.get("before") or latest.get("score_before"),
+        "latest_after": latest.get("after") or latest.get("score_after"),
+        "latest_decision": latest.get("decision") or latest.get("kept"),
+    }
+
+
+def _run_summary(run_dir: Path) -> dict[str, Any]:
+    stat = run_dir.stat()
+    summary: dict[str, Any] = {
+        "id": run_dir.name,
+        "path": str(run_dir.relative_to(_repo_root())) if run_dir.is_relative_to(_repo_root()) else str(run_dir),
+        "updated_at": stat.st_mtime,
+    }
+    summary.update(_latest_result(run_dir))
+    return summary
+
+
+@router.get("/status")
+async def autoresearch_status() -> dict[str, Any]:
+    """Return the latest local autoresearch run state for integrations."""
+    root = _run_root()
+    if not root.exists():
+        return {"ok": True, "surface": "autoresearch", "status": "idle", "run_count": 0, "runs": []}
+
+    try:
+        run_dirs = [p for p in root.iterdir() if p.is_dir()]
+    except OSError:
+        return {"ok": False, "surface": "autoresearch", "status": "unavailable", "run_count": 0, "runs": []}
+
+    runs = sorted((_run_summary(p) for p in run_dirs), key=lambda row: row["updated_at"], reverse=True)
+    latest = runs[0] if runs else None
+    return {
+        "ok": True,
+        "surface": "autoresearch",
+        "status": "running_or_recorded" if latest else "idle",
+        "run_count": len(runs),
+        "latest": latest,
+        "runs": runs[:10],
+    }

--- a/services/zoe-data/tests/test_autoresearch_status.py
+++ b/services/zoe-data/tests/test_autoresearch_status.py
@@ -28,6 +28,7 @@ def test_autoresearch_status_reports_idle_when_no_runs(tmp_path, monkeypatch):
     assert data["surface"] == "autoresearch"
     assert data["status"] == "idle"
     assert data["run_count"] == 0
+    assert data["latest"] is None
     assert data["runs"] == []
 
 
@@ -35,9 +36,9 @@ def test_autoresearch_status_reports_latest_results(tmp_path, monkeypatch):
     run_dir = tmp_path / "night-run"
     run_dir.mkdir()
     (run_dir / "results.tsv").write_text(
-        "round\tchange\tbefore\tafter\tdecision\n"
-        "1\tbaseline\t10\t10\tkept\n"
-        "2\ttighten copy\t10\t12\tkept\n",
+        "round\tcommit\tscore\tstatus\tdescription\n"
+        "1\tabc123\t10\tbaseline\tbaseline prompt\n"
+        "2\tdef456\t12\tkeep\ttighten copy\n",
         encoding="utf-8",
     )
     monkeypatch.setenv("ZOE_AUTORESEARCH_RUN_ROOT", str(tmp_path))
@@ -53,8 +54,9 @@ def test_autoresearch_status_reports_latest_results(tmp_path, monkeypatch):
     assert data["latest"]["id"] == "night-run"
     assert data["latest"]["rounds"] == 2
     assert data["latest"]["latest_round"] == "2"
+    assert data["latest"]["latest_change"] == "tighten copy"
     assert data["latest"]["latest_after"] == "12"
-    assert data["runs"][0]["latest_decision"] == "kept"
+    assert data["runs"][0]["latest_decision"] == "keep"
 
 
 def test_autoresearch_status_skips_run_removed_mid_request(tmp_path, monkeypatch):

--- a/services/zoe-data/tests/test_autoresearch_status.py
+++ b/services/zoe-data/tests/test_autoresearch_status.py
@@ -1,0 +1,57 @@
+"""Backend contract tests for the Auto Research status surface."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from routers.autoresearch import router  # noqa: E402
+
+
+def test_autoresearch_status_reports_idle_when_no_runs(tmp_path, monkeypatch):
+    monkeypatch.setenv("ZOE_AUTORESEARCH_RUN_ROOT", str(tmp_path / "missing"))
+    app = FastAPI()
+    app.include_router(router)
+
+    resp = TestClient(app).get("/api/autoresearch/status")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["ok"] is True
+    assert data["surface"] == "autoresearch"
+    assert data["status"] == "idle"
+    assert data["run_count"] == 0
+    assert data["runs"] == []
+
+
+def test_autoresearch_status_reports_latest_results(tmp_path, monkeypatch):
+    run_dir = tmp_path / "night-run"
+    run_dir.mkdir()
+    (run_dir / "results.tsv").write_text(
+        "round\tchange\tbefore\tafter\tdecision\n"
+        "1\tbaseline\t10\t10\tkept\n"
+        "2\ttighten copy\t10\t12\tkept\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("ZOE_AUTORESEARCH_RUN_ROOT", str(tmp_path))
+    app = FastAPI()
+    app.include_router(router)
+
+    resp = TestClient(app).get("/api/autoresearch/status")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "running_or_recorded"
+    assert data["run_count"] == 1
+    assert data["latest"]["id"] == "night-run"
+    assert data["latest"]["rounds"] == 2
+    assert data["latest"]["latest_round"] == "2"
+    assert data["latest"]["latest_after"] == "12"
+    assert data["runs"][0]["latest_decision"] == "kept"

--- a/services/zoe-data/tests/test_autoresearch_status.py
+++ b/services/zoe-data/tests/test_autoresearch_status.py
@@ -55,3 +55,29 @@ def test_autoresearch_status_reports_latest_results(tmp_path, monkeypatch):
     assert data["latest"]["latest_round"] == "2"
     assert data["latest"]["latest_after"] == "12"
     assert data["runs"][0]["latest_decision"] == "kept"
+
+
+def test_autoresearch_status_skips_run_removed_mid_request(tmp_path, monkeypatch):
+    from routers import autoresearch
+
+    run_dir = tmp_path / "vanishing-run"
+    run_dir.mkdir()
+    monkeypatch.setenv("ZOE_AUTORESEARCH_RUN_ROOT", str(tmp_path))
+
+    original_summary = autoresearch._run_summary
+
+    def _vanish(path):
+        path.rmdir()
+        return original_summary(path)
+
+    monkeypatch.setattr(autoresearch, "_run_summary", _vanish)
+    app = FastAPI()
+    app.include_router(autoresearch.router)
+
+    resp = TestClient(app).get("/api/autoresearch/status")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["ok"] is True
+    assert data["status"] == "idle"
+    assert data["run_count"] == 0

--- a/services/zoe-data/tests/test_autoresearch_status.py
+++ b/services/zoe-data/tests/test_autoresearch_status.py
@@ -59,6 +59,29 @@ def test_autoresearch_status_reports_latest_results(tmp_path, monkeypatch):
     assert data["runs"][0]["latest_decision"] == "keep"
 
 
+def test_autoresearch_status_reports_unavailable_with_stable_schema(tmp_path, monkeypatch):
+    from routers import autoresearch
+
+    monkeypatch.setenv("ZOE_AUTORESEARCH_RUN_ROOT", str(tmp_path))
+
+    def _raise_oserror():
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(autoresearch.Path, "iterdir", lambda self: _raise_oserror())
+    app = FastAPI()
+    app.include_router(autoresearch.router)
+
+    resp = TestClient(app).get("/api/autoresearch/status")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["ok"] is False
+    assert data["status"] == "unavailable"
+    assert data["run_count"] == 0
+    assert data["latest"] is None
+    assert data["runs"] == []
+
+
 def test_autoresearch_status_skips_run_removed_mid_request(tmp_path, monkeypatch):
     from routers import autoresearch
 

--- a/services/zoe-data/tests/test_populate_multica_contract.py
+++ b/services/zoe-data/tests/test_populate_multica_contract.py
@@ -32,6 +32,23 @@ def _assigned_literal(name: str):
     raise AssertionError(f"{name} assignment not found")
 
 
+
+def _function_literal_assignment(function_name: str, assignment_name: str):
+    for node in _module().body:
+        if not isinstance(node, ast.FunctionDef) or node.name != function_name:
+            continue
+        for child in ast.walk(node):
+            if not isinstance(child, ast.Assign):
+                continue
+            if any(isinstance(target, ast.Name) and target.id == assignment_name for target in child.targets):
+                try:
+                    return ast.literal_eval(child.value)
+                except (ValueError, SyntaxError) as exc:
+                    raise AssertionError(
+                        f"{function_name}.{assignment_name} must remain a literal contract"
+                    ) from exc
+    raise AssertionError(f"{assignment_name} assignment not found in {function_name}")
+
 def test_managed_agents_keep_provider_specific_runtime_contract():
     agent_defs = _assigned_literal("_AGENT_DEFS")
     providers = {agent["name"]: agent.get("runtime_provider") for agent in agent_defs}
@@ -79,13 +96,14 @@ def test_autoresearch_skill_agent_and_scope_are_managed():
     assert assignments["Auto Research Engineer"] == ["Auto Research Engineer"]
     assert "Auto Research Engineer" in assignments["Hermes"]
 
-    source = _source()
-    squad_block = source[source.index("squads_to_create = ["):source.index("managed_squad_names =")]
-    assert '"name": "Autoresearch Lab"' in squad_block
-    assert '"leader": "Auto Research Engineer"' in squad_block
-    assert '"members": ["Hermes", "Self-Improvement Agent"]' in squad_block
-    assert '"name": "Research & Planning Squad"' in squad_block
-    assert '"members": ["Zoe Core", "Auto Research Engineer"]' in squad_block
+    squads = {
+        squad["name"]: squad
+        for squad in _function_literal_assignment("step_h_create_squads", "squads_to_create")
+    }
+    assert squads["Autoresearch Lab"]["leader"] == "Auto Research Engineer"
+    assert squads["Autoresearch Lab"]["members"] == ["Hermes", "Self-Improvement Agent"]
+    assert "locked" in squads["Autoresearch Lab"]["instructions"]
+    assert squads["Research & Planning Squad"]["members"] == ["Zoe Core", "Auto Research Engineer"]
 
 
 def test_managed_autopilots_keep_execution_modes_and_templates():

--- a/services/zoe-data/tests/test_populate_multica_contract.py
+++ b/services/zoe-data/tests/test_populate_multica_contract.py
@@ -79,6 +79,14 @@ def test_autoresearch_skill_agent_and_scope_are_managed():
     assert assignments["Auto Research Engineer"] == ["Auto Research Engineer"]
     assert "Auto Research Engineer" in assignments["Hermes"]
 
+    source = _source()
+    squad_block = source[source.index("squads_to_create = ["):source.index("managed_squad_names =")]
+    assert '"name": "Autoresearch Lab"' in squad_block
+    assert '"leader": "Auto Research Engineer"' in squad_block
+    assert '"members": ["Hermes", "Self-Improvement Agent"]' in squad_block
+    assert '"name": "Research & Planning Squad"' in squad_block
+    assert '"members": ["Zoe Core", "Auto Research Engineer"]' in squad_block
+
 
 def test_managed_autopilots_keep_execution_modes_and_templates():
     autopilots = {ap["title"]: ap for ap in _assigned_literal("_AUTOPILOTS")}

--- a/services/zoe-data/tests/test_populate_multica_contract.py
+++ b/services/zoe-data/tests/test_populate_multica_contract.py
@@ -16,13 +16,19 @@ def _module() -> ast.Module:
 
 def _assigned_literal(name: str):
     for node in _module().body:
+        value = None
         if isinstance(node, ast.Assign):
             for target in node.targets:
                 if isinstance(target, ast.Name) and target.id == name:
-                    try:
-                        return ast.literal_eval(node.value)
-                    except (ValueError, SyntaxError) as exc:
-                        raise AssertionError(f"{name} must remain a literal contract") from exc
+                    value = node.value
+                    break
+        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name) and node.target.id == name:
+            value = node.value
+        if value is not None:
+            try:
+                return ast.literal_eval(value)
+            except (ValueError, SyntaxError) as exc:
+                raise AssertionError(f"{name} must remain a literal contract") from exc
     raise AssertionError(f"{name} assignment not found")
 
 
@@ -37,6 +43,7 @@ def test_managed_agents_keep_provider_specific_runtime_contract():
     assert providers["Hermes"] == "hermes"
     assert fallback_models["Hermes"] == "main"
     assert providers["Agent Zero"] == "zoe"
+    assert providers["Auto Research Engineer"] == "hermes"
     assert providers["Self-Improvement Agent"] == "zoe"
 
     source = _source()
@@ -47,6 +54,30 @@ def test_managed_agents_keep_provider_specific_runtime_contract():
     assert "runtime_id={_sql_literal(target_runtime_id)}" in source
     assert '"model": target_model' in source
     assert '"runtime_id": target_runtime_id' in source
+
+
+def test_autoresearch_skill_agent_and_scope_are_managed():
+    skill_defs = _assigned_literal("_SKILL_DEFS")
+    skill_names = {name for _, name in skill_defs}
+    skill_paths = {name: path for path, name in skill_defs}
+    agents = {agent["name"]: agent for agent in _assigned_literal("_AGENT_DEFS")}
+    assignments = _assigned_literal("_SKILL_ASSIGNMENTS")
+    projects = {title: description for title, _, description in _assigned_literal("_PROJECTS")}
+    labels = {name for name, _ in _assigned_literal("_LABELS")}
+
+    assert "autoresearch" in labels
+    assert "Autoresearch Lab" in projects
+    assert "fixed-budget asset optimization" in projects["Autoresearch Lab"]
+    assert "Auto Research Engineer" in skill_names
+    assert skill_paths["Auto Research Engineer"] == "skills/autoresearch-engineer/SKILL.md"
+
+    agent = agents["Auto Research Engineer"]
+    assert agent["runtime_provider"] == "hermes"
+    assert agent["fallback_model"] == "main"
+    assert "locked scoring file" in agent["instructions"]
+    assert "Never edit the instructions/program file" in agent["instructions"]
+    assert assignments["Auto Research Engineer"] == ["Auto Research Engineer"]
+    assert "Auto Research Engineer" in assignments["Hermes"]
 
 
 def test_managed_autopilots_keep_execution_modes_and_templates():

--- a/skills/autoresearch-engineer/SKILL.md
+++ b/skills/autoresearch-engineer/SKILL.md
@@ -21,7 +21,8 @@ triggers:
   - "A/B test"
   - "fit check"
   - "Karpathy"
-allowed_endpoints: []
+allowed_endpoints:
+  - /api/autoresearch/status
 ---
 # Auto Research Engineer
 

--- a/skills/autoresearch-engineer/SKILL.md
+++ b/skills/autoresearch-engineer/SKILL.md
@@ -83,8 +83,8 @@ Use a fresh branch for every run or fix. Branch names should begin with `autores
 
 Keep a result log outside committed source unless the human explicitly asks for a tracked report. Preferred names:
 
-- `results.tsv` for experiment rounds, untracked by Git.
-- `run.log` for the most recent scorer output, untracked by Git.
+- `results.tsv` for experiment rounds, untracked by Git by default via `**/results.tsv`.
+- `run.log` for the most recent scorer output, untracked by Git via `*.log`.
 
 `results.tsv` columns:
 

--- a/skills/autoresearch-engineer/SKILL.md
+++ b/skills/autoresearch-engineer/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: autoresearch-engineer
+description: "Run Karpathy-style fixed-budget optimization loops for one approved asset and one objective score. Use when the user asks to optimize, auto-research, run overnight experiments, improve a prompt/tool/copy/config, or turn 'is it good?' into a number."
+version: 1.0.0
+author: zoe-team
+api_only: false
+priority: 4
+tags:
+  - autoresearch
+  - optimization
+  - experiment-loop
+  - multica
+  - hermes
+triggers:
+  - "auto research"
+  - "autoresearch"
+  - "optimize this"
+  - "run experiments"
+  - "overnight"
+  - "score and improve"
+  - "A/B test"
+  - "fit check"
+  - "Karpathy"
+allowed_endpoints: []
+---
+# Auto Research Engineer
+
+Use this skill to run a Karpathy `autoresearch` style loop inside Zoe/Multica: one human-owned program, one editable asset, one locked objective score, and a repeatable keep-or-revert experiment loop.
+
+Reference behavior: `karpathy/autoresearch` keeps the repository small, treats `program.md` as the human-edited lightweight skill, lets the agent edit only the single asset file, runs a fixed roughly five-minute experiment, logs the metric, keeps improvements, and resets failed or worse experiments.
+
+## Greeting
+
+When starting setup, say briefly in your own words:
+
+"Hi, I'm now your Auto Research Engineer. We pick one thing in your business, turn 'is it good?' into a single honest number, then I change it, score it, keep what wins, and revert what loses."
+
+Then ask what asset is being optimized first.
+
+## Fit Check
+
+Do not begin an experiment loop until all must-haves pass.
+
+Must-haves:
+
+1. Objective score: one real numeric metric, not taste or vibes.
+2. Fast feedback: scoring returns in minutes or hours, not weeks.
+3. Editable asset: Zoe has approved write access to the declared asset files.
+
+Nice-to-haves:
+
+1. High feedback volume: enough traffic, samples, tests, or sends to compare.
+2. Cheap failure: failed variants are inexpensive and easy to revert.
+3. Consistent measuring stick: repeatable scoring without list fatigue, audience leakage, evaluator drift, or hidden goal changes.
+
+If any must-have fails, stop and suggest a better-shaped target. Do not pretend a subjective request is an autoresearch candidate.
+
+## Required Three-File Setup
+
+Create or verify these files before the first run. Names may vary by project, but the roles must be explicit.
+
+1. Human-owned instructions/program file:
+   - Usually `program.md`, `instructions.md`, or a Multica issue description.
+   - Edited only by the human/operator.
+   - Defines the goal, why it matters, the asset allowlist, scoring command, target score, run cadence, and stop conditions.
+
+2. Agent-editable asset file or files:
+   - The only files the Auto Research Engineer may change.
+   - Examples: prompt text, tool description, landing page HTML, ad copy, email copy, config, model hyperparameters, or script content.
+   - The asset allowlist must be concrete paths or named external resources.
+
+3. Locked scoring file or command:
+   - Read and execute only.
+   - Defines the single metric and whether lower or higher is better.
+   - May be `score.py`, `scoring.md`, a test command, analytics query, or API call, but the definition of better must not change during a run.
+
+Never edit the instructions/program file, scoring file, evaluation harness, dependencies, unrelated source files, secrets, or production runtime state unless the human starts a separate approved Zoe engineering ticket.
+
+## Branch And Logging Rules
+
+Use a fresh branch for every run or fix. Branch names should begin with `autoresearch/` or `codex/autoresearch-` and include a short run tag.
+
+Keep a result log outside committed source unless the human explicitly asks for a tracked report. Preferred names:
+
+- `results.tsv` for experiment rounds, untracked by Git.
+- `run.log` for the most recent scorer output, untracked by Git.
+
+`results.tsv` columns:
+
+```tsv
+round	commit	score	status	description
+```
+
+Use status values: `baseline`, `keep`, `discard`, `crash`, or `blocked`.
+
+## Setup Interview
+
+Ask only what cannot be discovered from the repo or Multica issue:
+
+1. What asset should be optimized?
+2. What single metric should decide better?
+3. Is higher or lower better?
+4. What scoring command/API/query produces the number?
+5. What is the target score or stopping condition?
+6. What is the maximum run time or round count for this Zoe-managed run?
+
+For Zoe/Multica production code, also confirm the approved asset paths and use the normal Zoe branch, evidence, validation, PR, and approval process.
+
+## Experiment Loop
+
+After setup and approval, loop until the target is reached, the bounded run limit is reached, or the human stops the run.
+
+1. Inspect git state and confirm the branch is the fresh run branch.
+2. Run the scorer on the current asset to establish or refresh the baseline.
+3. Form one hypothesis.
+4. Make one focused change to allowed asset files only.
+5. Commit the change.
+6. Run the locked scorer and capture output to `run.log` without flooding chat.
+7. Extract the single score.
+8. Compare using the locked direction: lower-is-better or higher-is-better.
+9. If better, keep the commit and make it the new baseline.
+10. If worse, equal without simplification, invalid, or crashed, log the result and reset back to the previous baseline commit.
+11. Append the round to `results.tsv`.
+
+Treat a crash as the hypothesis failing unless the crash is an obvious local typo or import mistake. Fix trivial execution bugs only within the allowed asset files.
+
+## Keep/Discard Policy
+
+Keep a change when:
+
+- The score improves against the current baseline.
+- The score ties but the asset is meaningfully simpler and the instructions allow simplification wins.
+
+Discard a change when:
+
+- The score worsens.
+- The scorer fails or does not produce the metric.
+- The change touches files outside the asset allowlist.
+- The change improves the score by moving goalposts, weakening evaluation, changing audiences, changing dependencies, or hiding errors.
+
+## Zoe And Multica Guardrails
+
+For Zoe repositories, this skill does not bypass engineering governance:
+
+- Read `.zoe/AI_ASSISTANT_CHECKLIST.md` and any host-specific Zoe rules documented by the operator.
+- Use the canonical Zoe repo and a fresh branch.
+- Respect `.zoe/AI_ASSISTANT_CHECKLIST.md` and `.zoe/manifest.json`.
+- Do not create root Markdown files unless explicitly approved.
+- Do not edit production scoring, tests, or runtime services as part of an autoresearch run unless they are the declared asset and separately approved.
+- Do not run unbounded overnight loops without an explicit operator-approved max time, max rounds, and stop mechanism.
+
+## Morning Report
+
+When the run stops, summarize:
+
+- Starting baseline and final score.
+- Total improvement.
+- Number of rounds kept, discarded, crashed, and blocked.
+- Best winning hypothesis.
+- Any risks, overfitting concerns, or next candidate ideas.


### PR DESCRIPTION
## Summary
- add the Auto Research Engineer skill using Karpathy/autoresearch-style program/asset/scoring boundaries
- seed the Multica autoresearch label, project, skill, agent, squad, and assignments
- cover the Multica bootstrap contract for the new workflow

## Validation
- python3 -m py_compile scripts/setup/populate_multica.py
- cd services/zoe-data && python3 -m pytest tests/test_populate_multica_contract.py -q
- python3 tools/audit/validate_structure.py
- python3 tools/audit/validate_critical_files.py