### PR TITLE
Execute profile edit outcome retain path

### DIFF
--- a/scripts/maintenance/capability_profile_edit_outcome_workflow.py
+++ b/scripts/maintenance/capability_profile_edit_outcome_workflow.py
@@ -23,9 +23,6 @@ DATA = ROOT / "services" / "zoe-data"
 if str(DATA) not in sys.path:
     sys.path.insert(0, str(DATA))
 
-from hindsight_memory import HindsightConfig, HindsightMemoryClient  # noqa: E402
-from hindsight_retain_candidates import HindsightRetainAdmissionError, build_admitted_hindsight_retain_plan  # noqa: E402
-from hindsight_retain_executor import execute_admitted_hindsight_retain_plan  # noqa: E402
 from zoe_capability_profile_edit_outcome import CapabilityProfileEditOutcomePlan, build_capability_profile_edit_outcome_plan  # noqa: E402
 from zoe_capability_profile_pr_edit_gate import CapabilityProfilePREditPlan  # noqa: E402
 from zoe_memory_router import MemoryBackend  # noqa: E402
@@ -146,8 +143,8 @@ def build_profile_edit_outcome_plan_from_args(args: argparse.Namespace) -> Capab
 async def execute_profile_edit_outcome_plan_in_hindsight(
     plan: CapabilityProfileEditOutcomePlan,
     *,
-    client: HindsightMemoryClient | None = None,
-    config: HindsightConfig | None = None,
+    client: Any | None = None,
+    config: Any | None = None,
 ) -> dict[str, Any]:
     if not plan.allowed_to_admit_memory or plan.admission_request is None or plan.admission_decision is None:
         return {
@@ -156,6 +153,9 @@ async def execute_profile_edit_outcome_plan_in_hindsight(
             "reason": "profile_edit_outcome_not_admitted",
             "execution": None,
         }
+    from hindsight_retain_candidates import HindsightRetainAdmissionError, build_admitted_hindsight_retain_plan
+    from hindsight_retain_executor import execute_admitted_hindsight_retain_plan
+
     resolved_config = config or (client.config if client else None)
     try:
         retain_plan = build_admitted_hindsight_retain_plan(

--- a/scripts/maintenance/capability_profile_edit_outcome_workflow.py
+++ b/scripts/maintenance/capability_profile_edit_outcome_workflow.py
@@ -217,7 +217,20 @@ def main(argv: list[str] | None = None) -> int:
                 "execution": None,
             }
         else:
-            execution = asyncio.run(execute_profile_edit_outcome_plan_in_hindsight(plan))
+            try:
+                execution = asyncio.run(execute_profile_edit_outcome_plan_in_hindsight(plan))
+            except Exception as exc:
+                execution = {
+                    "attempted": False,
+                    "retained": False,
+                    "reason": "hindsight_execution_error",
+                    "error": str(exc),
+                    "execution": None,
+                }
+                payload["hindsight_execution"] = execution
+                print(json.dumps(payload, indent=2, sort_keys=True))
+                print(f"hindsight execution failed: {exc}", file=sys.stderr)
+                return 2
         payload["hindsight_execution"] = execution
     print(json.dumps(payload, indent=2, sort_keys=True))
     if plan.blockers:

--- a/scripts/maintenance/capability_profile_edit_outcome_workflow.py
+++ b/scripts/maintenance/capability_profile_edit_outcome_workflow.py
@@ -10,6 +10,7 @@ write MemoryService, Hindsight, Graphiti, Multica, profile files, or GitHub.
 from __future__ import annotations
 
 import argparse
+import asyncio
 import json
 import sys
 from pathlib import Path
@@ -20,7 +21,10 @@ DATA = ROOT / "services" / "zoe-data"
 if str(DATA) not in sys.path:
     sys.path.insert(0, str(DATA))
 
-from zoe_capability_profile_edit_outcome import build_capability_profile_edit_outcome_plan  # noqa: E402
+from hindsight_memory import HindsightConfig, HindsightMemoryClient  # noqa: E402
+from hindsight_retain_candidates import HindsightRetainAdmissionError, build_admitted_hindsight_retain_plan  # noqa: E402
+from hindsight_retain_executor import execute_admitted_hindsight_retain_plan  # noqa: E402
+from zoe_capability_profile_edit_outcome import CapabilityProfileEditOutcomePlan, build_capability_profile_edit_outcome_plan  # noqa: E402
 from zoe_capability_profile_pr_edit_gate import CapabilityProfilePREditPlan  # noqa: E402
 from zoe_memory_router import MemoryBackend  # noqa: E402
 from zoe_observation_trace import ObservationTrace  # noqa: E402
@@ -121,9 +125,61 @@ def _verification_traces(paths: list[str]) -> tuple[ObservationTrace, ...]:
     return tuple(traces)
 
 
+def build_profile_edit_outcome_plan_from_args(args: argparse.Namespace) -> CapabilityProfileEditOutcomePlan:
+    target_backends = _non_empty(args.target_backend) or (MemoryBackend.HINDSIGHT.value, MemoryBackend.GRAPHITI.value)
+    return build_capability_profile_edit_outcome_plan(
+        _pr_edit_plan(args.pr_edit_plan_json_file),
+        verification_traces=_verification_traces(args.verification_trace_file),
+        user_id=args.user_id,
+        scope=args.scope,
+        target_backends=target_backends,
+        approval_refs=_non_empty(args.approval_ref),
+        admission_id=args.admission_id,
+        event_id=args.event_id,
+        promotion_manifest=_load_text_file(args.promotion_manifest_file, label="promotion manifest"),
+        metadata=_metadata(args.metadata_json),
+    )
+
+
+async def execute_profile_edit_outcome_plan_in_hindsight(
+    plan: CapabilityProfileEditOutcomePlan,
+    *,
+    client: HindsightMemoryClient | None = None,
+    config: HindsightConfig | None = None,
+) -> dict[str, Any]:
+    if not plan.allowed_to_admit_memory or plan.admission_request is None or plan.admission_decision is None:
+        return {
+            "attempted": False,
+            "retained": False,
+            "reason": "profile_edit_outcome_not_admitted",
+            "execution": None,
+        }
+    resolved_config = config or (client.config if client else None)
+    try:
+        retain_plan = build_admitted_hindsight_retain_plan(
+            plan.admission_request,
+            plan.admission_decision,
+            config=resolved_config,
+        )
+    except HindsightRetainAdmissionError as exc:
+        return {
+            "attempted": False,
+            "retained": False,
+            "reason": str(exc),
+            "execution": None,
+        }
+    execution = await execute_admitted_hindsight_retain_plan(retain_plan, client=client, config=resolved_config)
+    return {
+        "attempted": execution.attempted,
+        "retained": execution.retained,
+        "reason": execution.reason,
+        "execution": execution.to_dict(),
+    }
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        description="Build a memory/trust outcome plan from a verified capability-profile PR edit.",
+        description="Build or execute a memory/trust outcome plan from a verified capability-profile PR edit.",
     )
     parser.add_argument("--pr-edit-plan-json-file", required=True)
     parser.add_argument("--verification-trace-file", action="append", default=[], help="JSON object or list of ObservationTrace objects. May be repeated.")
@@ -135,33 +191,29 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--event-id")
     parser.add_argument("--promotion-manifest-file")
     parser.add_argument("--metadata-json", default="{}")
+    parser.add_argument("--execute-hindsight", action="store_true", help="Execute the admitted Hindsight retain plan. HindsightConfig still disables writes by default.")
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
     try:
-        target_backends = _non_empty(args.target_backend) or (MemoryBackend.HINDSIGHT.value, MemoryBackend.GRAPHITI.value)
-        plan = build_capability_profile_edit_outcome_plan(
-            _pr_edit_plan(args.pr_edit_plan_json_file),
-            verification_traces=_verification_traces(args.verification_trace_file),
-            user_id=args.user_id,
-            scope=args.scope,
-            target_backends=target_backends,
-            approval_refs=_non_empty(args.approval_ref),
-            admission_id=args.admission_id,
-            event_id=args.event_id,
-            promotion_manifest=_load_text_file(args.promotion_manifest_file, label="promotion manifest"),
-            metadata=_metadata(args.metadata_json),
-        )
+        plan = build_profile_edit_outcome_plan_from_args(args)
     except SystemExit as exc:
         if isinstance(exc.code, str):
             print(exc.code, file=sys.stderr)
             return 2
         raise
-    print(json.dumps(plan.to_dict(), indent=2, sort_keys=True))
+    payload = {"outcome_plan": plan.to_dict()}
+    execution = None
+    if args.execute_hindsight:
+        execution = asyncio.run(execute_profile_edit_outcome_plan_in_hindsight(plan))
+        payload["hindsight_execution"] = execution
+    print(json.dumps(payload, indent=2, sort_keys=True))
     if plan.blockers:
         return 1
+    if args.execute_hindsight:
+        return 0 if execution and execution.get("retained") is True else 1
     return 0 if plan.allowed_to_admit_memory else 1
 
 

--- a/scripts/maintenance/capability_profile_edit_outcome_workflow.py
+++ b/scripts/maintenance/capability_profile_edit_outcome_workflow.py
@@ -3,8 +3,10 @@
 
 This operator runner is the next step after capability_profile_pr_edit_workflow.py.
 It consumes a reviewed PR-edit plan JSON plus verification traces and emits the
-profile-edit outcome plan. It is intentionally side-effect-free: it does not
-write MemoryService, Hindsight, Graphiti, Multica, profile files, or GitHub.
+profile-edit outcome plan. By default it is side-effect-free: it does not write
+MemoryService, Hindsight, Graphiti, Multica, profile files, or GitHub. Pass
+--execute-hindsight to execute the admitted Hindsight retain plan; that mode can
+perform a network write to the Hindsight sidecar when enabled.
 """
 
 from __future__ import annotations
@@ -204,10 +206,18 @@ def main(argv: list[str] | None = None) -> int:
             print(exc.code, file=sys.stderr)
             return 2
         raise
-    payload = {"outcome_plan": plan.to_dict()}
+    payload = plan.to_dict()
     execution = None
     if args.execute_hindsight:
-        execution = asyncio.run(execute_profile_edit_outcome_plan_in_hindsight(plan))
+        if plan.blockers:
+            execution = {
+                "attempted": False,
+                "retained": False,
+                "reason": "profile_edit_outcome_blocked",
+                "execution": None,
+            }
+        else:
+            execution = asyncio.run(execute_profile_edit_outcome_plan_in_hindsight(plan))
         payload["hindsight_execution"] = execution
     print(json.dumps(payload, indent=2, sort_keys=True))
     if plan.blockers:

--- a/scripts/maintenance/capability_profile_edit_outcome_workflow.py
+++ b/scripts/maintenance/capability_profile_edit_outcome_workflow.py
@@ -193,7 +193,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--event-id")
     parser.add_argument("--promotion-manifest-file")
     parser.add_argument("--metadata-json", default="{}")
-    parser.add_argument("--execute-hindsight", action="store_true", help="Execute the admitted Hindsight retain plan. HindsightConfig still disables writes by default.")
+    parser.add_argument("--execute-hindsight", action="store_true", help="Execute the admitted Hindsight retain plan. HindsightConfig still disables writes by default; inspect hindsight_execution.reason when rc=1.")
     return parser
 
 

--- a/services/zoe-data/tests/test_capability_profile_edit_outcome_workflow.py
+++ b/services/zoe-data/tests/test_capability_profile_edit_outcome_workflow.py
@@ -303,11 +303,20 @@ def test_main_execute_hindsight_returns_0_for_successful_retain(tmp_path, capsys
     assert payload["hindsight_execution"]["reason"] == "retained"
 
 
-def test_main_execute_hindsight_respects_disabled_default(tmp_path, capsys, monkeypatch):
-    monkeypatch.setenv("HINDSIGHT_ENABLED", "false")
+def test_main_execute_hindsight_surfaces_disabled_execution(tmp_path, capsys, monkeypatch):
     pr_plan = _write_json(tmp_path / "pr-plan.json", _pr_edit_plan())
     trace = _write_json(tmp_path / "trace.json", _trace())
 
+    async def fake_execute(plan):
+        assert plan.allowed_to_admit_memory is True
+        return {
+            "attempted": False,
+            "retained": False,
+            "reason": "disabled",
+            "execution": None,
+        }
+
+    monkeypatch.setattr(MODULE, "execute_profile_edit_outcome_plan_in_hindsight", fake_execute)
     rc = MODULE.main([
         "--pr-edit-plan-json-file",
         str(pr_plan),

--- a/services/zoe-data/tests/test_capability_profile_edit_outcome_workflow.py
+++ b/services/zoe-data/tests/test_capability_profile_edit_outcome_workflow.py
@@ -268,7 +268,8 @@ async def test_execute_profile_edit_outcome_plan_in_hindsight_posts_admitted_pay
     assert "approval:memory-admission:ZOE-777" in result["execution"]["evidence_refs"]
 
 
-def test_main_execute_hindsight_respects_disabled_default(tmp_path, capsys):
+def test_main_execute_hindsight_respects_disabled_default(tmp_path, capsys, monkeypatch):
+    monkeypatch.setenv("HINDSIGHT_ENABLED", "false")
     pr_plan = _write_json(tmp_path / "pr-plan.json", _pr_edit_plan())
     trace = _write_json(tmp_path / "trace.json", _trace())
 
@@ -292,3 +293,33 @@ def test_main_execute_hindsight_respects_disabled_default(tmp_path, capsys):
     assert payload["hindsight_execution"]["attempted"] is False
     assert payload["hindsight_execution"]["retained"] is False
     assert payload["hindsight_execution"]["reason"] == "disabled"
+
+
+def test_main_execute_hindsight_reports_config_errors_cleanly(tmp_path, capsys, monkeypatch):
+    monkeypatch.setenv("HINDSIGHT_ENABLED", "true")
+    monkeypatch.setenv("HINDSIGHT_BASE_URL", "https://example.com")
+    pr_plan = _write_json(tmp_path / "pr-plan.json", _pr_edit_plan())
+    trace = _write_json(tmp_path / "trace.json", _trace())
+
+    rc = MODULE.main([
+        "--pr-edit-plan-json-file",
+        str(pr_plan),
+        "--verification-trace-file",
+        str(trace),
+        "--user-id",
+        "zoe_system",
+        "--target-backend",
+        "hindsight",
+        "--approval-ref",
+        "approval:memory-admission:ZOE-777",
+        "--execute-hindsight",
+    ])
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert rc == 2
+    assert payload["allowed_to_admit_memory"] is True
+    assert payload["hindsight_execution"]["attempted"] is False
+    assert payload["hindsight_execution"]["retained"] is False
+    assert payload["hindsight_execution"]["reason"] == "hindsight_execution_error"
+    assert "hindsight execution failed" in captured.err

--- a/services/zoe-data/tests/test_capability_profile_edit_outcome_workflow.py
+++ b/services/zoe-data/tests/test_capability_profile_edit_outcome_workflow.py
@@ -99,12 +99,11 @@ def test_main_builds_approved_profile_edit_outcome_plan(tmp_path, capsys):
     captured = capsys.readouterr()
     payload = json.loads(captured.out)
     assert rc == 0
-    outcome = payload["outcome_plan"]
-    assert outcome["allowed_to_admit_memory"] is True
-    assert outcome["admission_decision"]["status"] == "approved"
-    assert outcome["memory_candidate"]["event_id"] == "mem_evt_profile_edit_outcome_ZOE-777"
-    assert outcome["trust_records"][0]["to_trust_level"] == "assisted"
-    assert "greptile:pass:777" in outcome["trust_records"][0]["evidence_refs"]
+    assert payload["allowed_to_admit_memory"] is True
+    assert payload["admission_decision"]["status"] == "approved"
+    assert payload["memory_candidate"]["event_id"] == "mem_evt_profile_edit_outcome_ZOE-777"
+    assert payload["trust_records"][0]["to_trust_level"] == "assisted"
+    assert "greptile:pass:777" in payload["trust_records"][0]["evidence_refs"]
 
 
 def test_main_returns_1_for_pending_memory_approval(tmp_path, capsys):
@@ -122,11 +121,10 @@ def test_main_returns_1_for_pending_memory_approval(tmp_path, capsys):
 
     payload = json.loads(capsys.readouterr().out)
     assert rc == 1
-    outcome = payload["outcome_plan"]
-    assert outcome["allowed_to_admit_memory"] is False
-    assert outcome["admission_decision"]["status"] == "pending_review"
-    assert outcome["admission_decision"]["blockers"] == ["approval_required"]
-    assert outcome["trust_records"]
+    assert payload["allowed_to_admit_memory"] is False
+    assert payload["admission_decision"]["status"] == "pending_review"
+    assert payload["admission_decision"]["blockers"] == ["approval_required"]
+    assert payload["trust_records"]
 
 
 def test_main_keeps_blocked_pr_edit_plan_blocked(tmp_path, capsys):
@@ -154,10 +152,44 @@ def test_main_keeps_blocked_pr_edit_plan_blocked(tmp_path, capsys):
 
     payload = json.loads(capsys.readouterr().out)
     assert rc == 1
-    outcome = payload["outcome_plan"]
-    assert "pr_edit_plan_not_allowed" in outcome["blockers"]
-    assert "missing_greptile_refs" in outcome["blockers"]
-    assert outcome["memory_candidate"] is None
+    assert "pr_edit_plan_not_allowed" in payload["blockers"]
+    assert "missing_greptile_refs" in payload["blockers"]
+    assert payload["memory_candidate"] is None
+
+
+def test_main_execute_hindsight_reports_blocked_plan_without_attempt(tmp_path, capsys):
+    pr_plan = _write_json(
+        tmp_path / "pr-plan.json",
+        _pr_edit_plan(
+            allowed_to_prepare_pr_edit=False,
+            patch_text="",
+            promoted_capability_ids=[],
+            blockers=["missing_greptile_refs"],
+        ),
+    )
+    trace = _write_json(tmp_path / "trace.json", _trace())
+
+    rc = MODULE.main([
+        "--pr-edit-plan-json-file",
+        str(pr_plan),
+        "--verification-trace-file",
+        str(trace),
+        "--user-id",
+        "zoe_system",
+        "--approval-ref",
+        "approval:memory-admission:ZOE-777",
+        "--execute-hindsight",
+    ])
+
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 1
+    assert "pr_edit_plan_not_allowed" in payload["blockers"]
+    assert payload["hindsight_execution"] == {
+        "attempted": False,
+        "retained": False,
+        "reason": "profile_edit_outcome_blocked",
+        "execution": None,
+    }
 
 
 def test_main_returns_2_for_invalid_verification_trace(tmp_path, capsys):
@@ -256,7 +288,7 @@ def test_main_execute_hindsight_respects_disabled_default(tmp_path, capsys):
 
     payload = json.loads(capsys.readouterr().out)
     assert rc == 1
-    assert payload["outcome_plan"]["allowed_to_admit_memory"] is True
+    assert payload["allowed_to_admit_memory"] is True
     assert payload["hindsight_execution"]["attempted"] is False
     assert payload["hindsight_execution"]["retained"] is False
     assert payload["hindsight_execution"]["reason"] == "disabled"

--- a/services/zoe-data/tests/test_capability_profile_edit_outcome_workflow.py
+++ b/services/zoe-data/tests/test_capability_profile_edit_outcome_workflow.py
@@ -268,6 +268,41 @@ async def test_execute_profile_edit_outcome_plan_in_hindsight_posts_admitted_pay
     assert "approval:memory-admission:ZOE-777" in result["execution"]["evidence_refs"]
 
 
+def test_main_execute_hindsight_returns_0_for_successful_retain(tmp_path, capsys, monkeypatch):
+    pr_plan = _write_json(tmp_path / "pr-plan.json", _pr_edit_plan())
+    trace = _write_json(tmp_path / "trace.json", _trace())
+
+    async def fake_execute(plan):
+        assert plan.allowed_to_admit_memory is True
+        return {
+            "attempted": True,
+            "retained": True,
+            "reason": "retained",
+            "execution": {"event_id": "mem_evt_profile_edit_outcome_ZOE-777"},
+        }
+
+    monkeypatch.setattr(MODULE, "execute_profile_edit_outcome_plan_in_hindsight", fake_execute)
+    rc = MODULE.main([
+        "--pr-edit-plan-json-file",
+        str(pr_plan),
+        "--verification-trace-file",
+        str(trace),
+        "--user-id",
+        "zoe_system",
+        "--target-backend",
+        "hindsight",
+        "--approval-ref",
+        "approval:memory-admission:ZOE-777",
+        "--execute-hindsight",
+    ])
+
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert payload["allowed_to_admit_memory"] is True
+    assert payload["hindsight_execution"]["retained"] is True
+    assert payload["hindsight_execution"]["reason"] == "retained"
+
+
 def test_main_execute_hindsight_respects_disabled_default(tmp_path, capsys, monkeypatch):
     monkeypatch.setenv("HINDSIGHT_ENABLED", "false")
     pr_plan = _write_json(tmp_path / "pr-plan.json", _pr_edit_plan())

--- a/services/zoe-data/tests/test_capability_profile_edit_outcome_workflow.py
+++ b/services/zoe-data/tests/test_capability_profile_edit_outcome_workflow.py
@@ -1,6 +1,9 @@
 import importlib.util
 import json
 import sys
+
+import httpx
+import pytest
 from pathlib import Path
 
 
@@ -96,11 +99,12 @@ def test_main_builds_approved_profile_edit_outcome_plan(tmp_path, capsys):
     captured = capsys.readouterr()
     payload = json.loads(captured.out)
     assert rc == 0
-    assert payload["allowed_to_admit_memory"] is True
-    assert payload["admission_decision"]["status"] == "approved"
-    assert payload["memory_candidate"]["event_id"] == "mem_evt_profile_edit_outcome_ZOE-777"
-    assert payload["trust_records"][0]["to_trust_level"] == "assisted"
-    assert "greptile:pass:777" in payload["trust_records"][0]["evidence_refs"]
+    outcome = payload["outcome_plan"]
+    assert outcome["allowed_to_admit_memory"] is True
+    assert outcome["admission_decision"]["status"] == "approved"
+    assert outcome["memory_candidate"]["event_id"] == "mem_evt_profile_edit_outcome_ZOE-777"
+    assert outcome["trust_records"][0]["to_trust_level"] == "assisted"
+    assert "greptile:pass:777" in outcome["trust_records"][0]["evidence_refs"]
 
 
 def test_main_returns_1_for_pending_memory_approval(tmp_path, capsys):
@@ -118,10 +122,11 @@ def test_main_returns_1_for_pending_memory_approval(tmp_path, capsys):
 
     payload = json.loads(capsys.readouterr().out)
     assert rc == 1
-    assert payload["allowed_to_admit_memory"] is False
-    assert payload["admission_decision"]["status"] == "pending_review"
-    assert payload["admission_decision"]["blockers"] == ["approval_required"]
-    assert payload["trust_records"]
+    outcome = payload["outcome_plan"]
+    assert outcome["allowed_to_admit_memory"] is False
+    assert outcome["admission_decision"]["status"] == "pending_review"
+    assert outcome["admission_decision"]["blockers"] == ["approval_required"]
+    assert outcome["trust_records"]
 
 
 def test_main_keeps_blocked_pr_edit_plan_blocked(tmp_path, capsys):
@@ -149,9 +154,10 @@ def test_main_keeps_blocked_pr_edit_plan_blocked(tmp_path, capsys):
 
     payload = json.loads(capsys.readouterr().out)
     assert rc == 1
-    assert "pr_edit_plan_not_allowed" in payload["blockers"]
-    assert "missing_greptile_refs" in payload["blockers"]
-    assert payload["memory_candidate"] is None
+    outcome = payload["outcome_plan"]
+    assert "pr_edit_plan_not_allowed" in outcome["blockers"]
+    assert "missing_greptile_refs" in outcome["blockers"]
+    assert outcome["memory_candidate"] is None
 
 
 def test_main_returns_2_for_invalid_verification_trace(tmp_path, capsys):
@@ -191,3 +197,66 @@ def test_main_returns_2_for_unexpected_trace_field(tmp_path, capsys):
     assert rc == 2
     assert "invalid verification trace" in captured.err
     assert "unexpected" in captured.err
+
+
+@pytest.mark.asyncio
+async def test_execute_profile_edit_outcome_plan_in_hindsight_posts_admitted_payload(tmp_path):
+    args = MODULE.build_parser().parse_args([
+        "--pr-edit-plan-json-file",
+        str(_write_json(tmp_path / "pr-plan.json", _pr_edit_plan())),
+        "--verification-trace-file",
+        str(_write_json(tmp_path / "trace.json", _trace())),
+        "--user-id",
+        "zoe_system",
+        "--target-backend",
+        "hindsight",
+        "--approval-ref",
+        "approval:memory-admission:ZOE-777",
+    ])
+    plan = MODULE.build_profile_edit_outcome_plan_from_args(args)
+    seen = {}
+
+    async def handler(request):
+        seen["path"] = request.url.path
+        seen["payload"] = json.loads(request.read().decode())
+        return httpx.Response(200, json={"success": True, "items_count": 1})
+
+    from hindsight_memory import HindsightConfig, HindsightMemoryClient
+
+    config = HindsightConfig(enabled=True, bank_prefix="zoe-test", async_retain=False)
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http_client:
+        client = HindsightMemoryClient(config, client=http_client)
+        result = await MODULE.execute_profile_edit_outcome_plan_in_hindsight(plan, client=client)
+
+    assert result["attempted"] is True
+    assert result["retained"] is True
+    assert result["reason"] == "retained"
+    assert seen["path"] == "/v1/default/banks/zoe-test-project-zoe_system/memories"
+    assert seen["payload"]["items"][0]["document_id"] == "mem_evt_profile_edit_outcome_ZOE-777"
+    assert "approval:memory-admission:ZOE-777" in result["execution"]["evidence_refs"]
+
+
+def test_main_execute_hindsight_respects_disabled_default(tmp_path, capsys):
+    pr_plan = _write_json(tmp_path / "pr-plan.json", _pr_edit_plan())
+    trace = _write_json(tmp_path / "trace.json", _trace())
+
+    rc = MODULE.main([
+        "--pr-edit-plan-json-file",
+        str(pr_plan),
+        "--verification-trace-file",
+        str(trace),
+        "--user-id",
+        "zoe_system",
+        "--target-backend",
+        "hindsight",
+        "--approval-ref",
+        "approval:memory-admission:ZOE-777",
+        "--execute-hindsight",
+    ])
+
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 1
+    assert payload["outcome_plan"]["allowed_to_admit_memory"] is True
+    assert payload["hindsight_execution"]["attempted"] is False
+    assert payload["hindsight_execution"]["retained"] is False
+    assert payload["hindsight_execution"]["reason"] == "disabled"


### PR DESCRIPTION
## Summary
- add an explicit `--execute-hindsight` mode to the profile edit outcome workflow
- reuse the admitted Hindsight retain-plan builder and executor instead of leaving the outcome as plan-only
- keep default behavior safe: no side effects unless execution is requested, and Hindsight remains disabled by default

## Verification
- `PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_capability_profile_edit_outcome_workflow.py services/zoe-data/tests/test_zoe_capability_profile_edit_outcome.py services/zoe-data/tests/test_zoe_capability_profile_pr_edit_gate.py services/zoe-data/tests/test_hindsight_retain_executor.py services/zoe-data/tests/test_zoe_memory_admission.py services/zoe-data/tests/test_zoe_evolution_outcome_retain.py` -> 45 passed
- `python3 -m py_compile scripts/maintenance/capability_profile_edit_outcome_workflow.py services/zoe-data/hindsight_retain_executor.py services/zoe-data/zoe_capability_profile_edit_outcome.py`
- `python3 tools/audit/validate_structure.py`
- `python3 tools/audit/validate_critical_files.py`
- `python3 tools/audit/validate_offline_memory.py`
- `git diff --check`

## Safety
- execution requires an admitted outcome plan
- default CLI output remains the top-level outcome plan shape
- `--execute-hindsight` returns non-zero when Hindsight is disabled by default
- tests use `httpx.MockTransport`; no live Hindsight writes are performed
