### PR TITLE
Cover pending profile outcome retain guard

### DIFF
--- a/services/zoe-data/tests/test_capability_profile_edit_outcome_workflow.py
+++ b/services/zoe-data/tests/test_capability_profile_edit_outcome_workflow.py
@@ -127,6 +127,36 @@ def test_main_returns_1_for_pending_memory_approval(tmp_path, capsys):
     assert payload["trust_records"]
 
 
+def test_main_execute_hindsight_rejects_pending_memory_approval(tmp_path, capsys):
+    pr_plan = _write_json(tmp_path / "pr-plan.json", _pr_edit_plan())
+    trace = _write_json(tmp_path / "trace.json", _trace())
+
+    rc = MODULE.main([
+        "--pr-edit-plan-json-file",
+        str(pr_plan),
+        "--verification-trace-file",
+        str(trace),
+        "--user-id",
+        "zoe_system",
+        "--target-backend",
+        "hindsight",
+        "--execute-hindsight",
+    ])
+
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 1
+    assert payload["allowed_to_admit_memory"] is False
+    assert payload["blockers"] == []
+    assert payload["admission_decision"]["status"] == "pending_review"
+    assert payload["admission_decision"]["blockers"] == ["approval_required"]
+    assert payload["hindsight_execution"] == {
+        "attempted": False,
+        "retained": False,
+        "reason": "profile_edit_outcome_not_admitted",
+        "execution": None,
+    }
+
+
 def test_main_keeps_blocked_pr_edit_plan_blocked(tmp_path, capsys):
     pr_plan = _write_json(
         tmp_path / "pr-plan.json",


### PR DESCRIPTION
## Summary
- add the missing `--execute-hindsight` pending-approval guard test from PR #457 review
- prove an unapproved but otherwise unblocked outcome plan returns `profile_edit_outcome_not_admitted`
- keep the change scoped to one test file

## Verification
- `PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_capability_profile_edit_outcome_workflow.py services/zoe-data/tests/test_zoe_capability_profile_edit_outcome.py services/zoe-data/tests/test_zoe_capability_profile_pr_edit_gate.py services/zoe-data/tests/test_hindsight_retain_executor.py services/zoe-data/tests/test_zoe_memory_admission.py services/zoe-data/tests/test_zoe_evolution_outcome_retain.py` -> 49 passed
- `python3 -m py_compile scripts/maintenance/capability_profile_edit_outcome_workflow.py services/zoe-data/hindsight_retain_executor.py services/zoe-data/zoe_capability_profile_edit_outcome.py`
- `python3 tools/audit/validate_structure.py`
- `python3 tools/audit/validate_critical_files.py`
- `python3 tools/audit/validate_offline_memory.py`
- `git diff --check`
