### PR TITLE
Ignore pathless Greptile summary findings

### DIFF
--- a/services/zoe-data/greploop_guard.py
+++ b/services/zoe-data/greploop_guard.py
@@ -696,13 +696,15 @@ async def run_guard_once(
         status = await get_pr_status(repo=DEFAULT_REPO, pr_number=pr_number, default_branch=DEFAULT_BASE_BRANCH)
         comments = await list_pr_comments(repo=DEFAULT_REPO, pr_number=pr_number, default_branch=DEFAULT_BASE_BRANCH)
         findings = comments.get("findings") or []
+        actionable_findings = _actionable_greptile_findings(findings)
         if status.get("reviewIsRunning"):
             wait_count = int(state.get("waiting_greptile_count") or 0) + 1
             state["waiting_greptile_count"] = wait_count
             state["greptile"] = {
                 "status": status.get("reviewCompleteness") or "review_running",
                 "confidence": status.get("confidenceScore"),
-                "unaddressed_count": len(findings),
+                "unaddressed_count": len(actionable_findings),
+                "summary_count": max(0, len(findings) - len(actionable_findings)),
             }
             if wait_count > MAX_ITERATIONS:
                 state["terminal_state"] = "BLOCKED_GREPTILE_STUCK"
@@ -713,7 +715,7 @@ async def run_guard_once(
             _write_json(pr_number, "status.json", state)
             return {"ok": True, "state": "WAITING_GREPTILE", "greptile": status}
         state["waiting_greptile_count"] = 0
-        progress_key = f"{status.get('headSha')}:{status.get('confidenceScore')}:{len(findings)}"
+        progress_key = f"{status.get('headSha')}:{status.get('confidenceScore')}:{len(actionable_findings)}:{len(findings)}"
         blocked = _update_circuit_breakers(pr_number, state, progress_key)
         if blocked:
             state["terminal_state"] = blocked
@@ -723,19 +725,20 @@ async def run_guard_once(
         state["greptile"] = {
             "status": status.get("reviewCompleteness") or "reviewed",
             "confidence": status.get("confidenceScore"),
-            "unaddressed_count": len(findings),
+            "unaddressed_count": len(actionable_findings),
+            "summary_count": max(0, len(findings) - len(actionable_findings)),
         }
         _write_json(pr_number, "status.json", state)
-        if (status.get("confidenceScore") or 0) >= int(task.get("target_confidence") or 5) and not findings:
+        if (status.get("confidenceScore") or 0) >= int(task.get("target_confidence") or 5) and not actionable_findings:
             state["terminal_state"] = "READY_TO_MERGE"
             _write_json(pr_number, "status.json", state)
             return {"ok": True, "state": "READY_TO_MERGE", "greptile": status}
-        if not findings:
+        if not actionable_findings:
             triggered = await trigger_review(repo=DEFAULT_REPO, pr_number=pr_number, default_branch=DEFAULT_BASE_BRANCH)
             state["terminal_state"] = "WAITING_GREPTILE"
             _write_json(pr_number, "status.json", {**state, "triggered_review": triggered})
             return {"ok": True, "state": "WAITING_GREPTILE", "triggered_review": triggered}
-        finding = findings[0]
+        finding = actionable_findings[0]
         if any(str(finding.get("file_path") or "").startswith(prefix) for prefix in HIGH_RISK_PREFIXES):
             state["terminal_state"] = "ESCALATE_HERMES"
             _write_json(pr_number, "status.json", state)

--- a/services/zoe-data/tests/test_greploop_guard.py
+++ b/services/zoe-data/tests/test_greploop_guard.py
@@ -320,6 +320,55 @@ async def test_run_guard_once_ignores_pathless_greptile_summary_when_confident(t
 
 
 @pytest.mark.asyncio
+async def test_run_guard_once_retriggers_low_confidence_pathless_summary(tmp_path, monkeypatch):
+    async def fake_status(**_kwargs):
+        return {
+            "confidenceScore": 4,
+            "reviewIsRunning": False,
+            "headSha": "abc",
+            "reviewCompleteness": "Summary-only review below confidence target",
+        }
+
+    async def fake_comments(**_kwargs):
+        return {
+            "findings": [
+                {
+                    "id": "summary-1",
+                    "file_path": "",
+                    "body": "Greptile summary with confidence 4/5 and no inline findings.",
+                    "addressed": False,
+                }
+            ]
+        }
+
+    triggered = {}
+
+    async def fake_trigger(**kwargs):
+        triggered.update(kwargs)
+        return {"triggered": True}
+
+    async def fail_runner(*_args, **_kwargs):
+        raise AssertionError("pathless summary comments must not become repair packets")
+
+    monkeypatch.setattr(greploop_guard, "STATE_ROOT", tmp_path)
+    monkeypatch.setattr("greptile_client.get_pr_status", fake_status)
+    monkeypatch.setattr("greptile_client.list_pr_comments", fake_comments)
+    monkeypatch.setattr("greptile_client.trigger_review", fake_trigger)
+    monkeypatch.setattr(greploop_guard, "_run_cheap_agent", fail_runner)
+
+    out = await greploop_guard.run_guard_once(66)
+
+    assert out["ok"] is True
+    assert out["state"] == "WAITING_GREPTILE"
+    assert out["triggered_review"] == {"triggered": True}
+    assert triggered["pr_number"] == 66
+    state = greploop_guard.read_guard_state(66)
+    assert state["terminal_state"] == "WAITING_GREPTILE"
+    assert state["greptile"]["unaddressed_count"] == 0
+    assert state["greptile"]["summary_count"] == 1
+
+
+@pytest.mark.asyncio
 async def test_run_guard_once_blocks_permanently_active_review(tmp_path, monkeypatch):
     async def fake_status(**_kwargs):
         return {

--- a/services/zoe-data/tests/test_greploop_guard.py
+++ b/services/zoe-data/tests/test_greploop_guard.py
@@ -276,6 +276,50 @@ async def test_run_guard_once_active_review_does_not_trip_no_progress(tmp_path, 
 
 
 @pytest.mark.asyncio
+async def test_run_guard_once_ignores_pathless_greptile_summary_when_confident(tmp_path, monkeypatch):
+    async def fake_status(**_kwargs):
+        return {
+            "confidenceScore": 5,
+            "reviewIsRunning": False,
+            "headSha": "abc",
+            "reviewCompleteness": "No Greptile review comments",
+        }
+
+    async def fake_comments(**_kwargs):
+        return {
+            "findings": [
+                {
+                    "id": "summary-1",
+                    "file_path": "",
+                    "body": "Greptile summary with confidence 5/5 and no inline findings.",
+                    "addressed": False,
+                }
+            ]
+        }
+
+    async def fail_trigger(**_kwargs):
+        raise AssertionError("confident summary-only review must not retrigger Greptile")
+
+    async def fail_runner(*_args, **_kwargs):
+        raise AssertionError("pathless summary comments must not become repair packets")
+
+    monkeypatch.setattr(greploop_guard, "STATE_ROOT", tmp_path)
+    monkeypatch.setattr("greptile_client.get_pr_status", fake_status)
+    monkeypatch.setattr("greptile_client.list_pr_comments", fake_comments)
+    monkeypatch.setattr("greptile_client.trigger_review", fail_trigger)
+    monkeypatch.setattr(greploop_guard, "_run_cheap_agent", fail_runner)
+
+    out = await greploop_guard.run_guard_once(66)
+
+    assert out["ok"] is True
+    assert out["state"] == "READY_TO_MERGE"
+    state = greploop_guard.read_guard_state(66)
+    assert state["terminal_state"] == "READY_TO_MERGE"
+    assert state["greptile"]["unaddressed_count"] == 0
+    assert state["greptile"]["summary_count"] == 1
+
+
+@pytest.mark.asyncio
 async def test_run_guard_once_blocks_permanently_active_review(tmp_path, monkeypatch):
     async def fake_status(**_kwargs):
         return {


### PR DESCRIPTION
## Summary
- treat pathless Greptile PR-summary comments as non-actionable in `run_guard_once`
- use actionable inline findings for repair packets and ready-to-merge decisions
- add a regression test for a confidence 5/5 summary-only review so Greploop no longer crashes with `BLOCKED_MISSING_CONTEXT: finding has no file path`

## Verification
- `PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_greploop_guard.py services/zoe-data/tests/test_greptile_client.py` -> 24 passed
- `python3 -m py_compile services/zoe-data/greploop_guard.py services/zoe-data/greptile_client.py scripts/maintenance/greploop_guard.py`
- `python3 tools/audit/validate_structure.py`
- `python3 tools/audit/validate_critical_files.py`
- `git diff --check`
