### PR TITLE
Add Skybridge list and people cards

### DIFF
--- a/services/zoe-data/card_service.py
+++ b/services/zoe-data/card_service.py
@@ -117,15 +117,59 @@ def list_items(slots: dict[str, Any] | None = None) -> list[str]:
 def build_shopping_list_content(slots: dict[str, Any] | None = None) -> dict[str, Any]:
     """Build canonical content for a shopping/list view card."""
     slots = slots or {}
-    list_name = _text(slots.get("list_name") or slots.get("list_type"), "Shopping")
-    items = list_items(slots)
+    list_name = _text(slots.get("list_name") or slots.get("name") or slots.get("list_type"), "Shopping")
+    raw_items = slots.get("items") or []
+    items = raw_items if isinstance(raw_items, list) else list_items(slots)
+    open_count = sum(1 for item in items if not (isinstance(item, dict) and item.get("completed")))
+    completed_count = max(0, len(items) - open_count)
     return {
         "title": f"{list_name} List",
+        "summary": _text(slots.get("summary"), "Showing list"),
+        "list_id": _text(slots.get("list_id") or slots.get("id"), "list"),
         "list_name": list_name,
+        "list_type": _text(slots.get("list_type"), "shopping"),
+        "lists": slots.get("lists") or [],
         "items": items,
         "item_count": len(items),
+        "open_count": open_count,
+        "completed_count": completed_count,
         "view": "list",
         "source": "list_show",
+    }
+
+
+def build_people_directory_content(slots: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Build canonical content for people directory/search cards."""
+    slots = slots or {}
+    people = slots.get("people") or []
+    if not isinstance(people, list):
+        people = [people]
+    query = _text(slots.get("query"))
+    title = _text(slots.get("title"), "People")
+    return {
+        "title": title,
+        "summary": _text(slots.get("summary"), "Showing people"),
+        "source": "people_directory",
+        "view": "directory",
+        "query": query,
+        "context": _text(slots.get("context")),
+        "circle": _text(slots.get("circle")),
+        "people": people,
+        "count": int(slots.get("count") if slots.get("count") is not None else len(people)),
+    }
+
+
+def build_person_profile_content(slots: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Build canonical content for a single person profile card."""
+    slots = slots or {}
+    person = slots.get("person") or {}
+    name = _text(person.get("name") or slots.get("name"), "Person")
+    return {
+        "title": name,
+        "summary": _text(slots.get("summary"), "Showing person"),
+        "source": "person_profile",
+        "view": "profile",
+        "person": person,
     }
 
 
@@ -283,6 +327,20 @@ class CardService:
             producer="zoe-shopping",
         )
 
+    def build_people_directory_card(self, slots: dict[str, Any] | None = None) -> dict[str, Any]:
+        return self.build_card(
+            CardType.GENERIC.value,
+            build_people_directory_content(slots),
+            producer="zoe-people",
+        )
+
+    def build_person_profile_card(self, slots: dict[str, Any] | None = None) -> dict[str, Any]:
+        return self.build_card(
+            CardType.GENERIC.value,
+            build_person_profile_content(slots),
+            producer="zoe-people",
+        )
+
     def build_shopping_item_editor_card(self, slots: dict[str, Any] | None = None) -> dict[str, Any]:
         return self.build_card(
             CardType.ACTION_FORM.value,
@@ -300,3 +358,5 @@ card_service.register_domain_builder("weather_current", card_service.build_weath
 card_service.register_domain_builder("weather_forecast", card_service.build_weather_forecast_card)
 card_service.register_domain_builder("shopping_list", card_service.build_shopping_list_card)
 card_service.register_domain_builder("shopping_item_editor", card_service.build_shopping_item_editor_card)
+card_service.register_domain_builder("people_directory", card_service.build_people_directory_card)
+card_service.register_domain_builder("person_profile", card_service.build_person_profile_card)

--- a/services/zoe-data/people_utils.py
+++ b/services/zoe-data/people_utils.py
@@ -1,0 +1,45 @@
+"""Shared people data normalization helpers."""
+
+from __future__ import annotations
+
+import json
+
+
+def row_to_person(row) -> dict:
+    """Convert a people row to the canonical person dict used by UI surfaces."""
+    try:
+        pref = row["preferences"] if hasattr(row, "__getitem__") else getattr(row, "preferences", None)
+    except Exception:
+        pref = None
+    d = dict(row) if not isinstance(row, dict) else row
+    if pref is None:
+        pref = d.get("preferences")
+    if pref and isinstance(pref, str):
+        try:
+            pref = json.loads(pref)
+        except json.JSONDecodeError:
+            pref = None
+    return {
+        "id": d.get("id"),
+        "user_id": d.get("user_id"),
+        "name": d.get("name"),
+        "relationship": d.get("relationship"),
+        "circle": d.get("circle", "circle"),
+        "context": d.get("context", "personal"),
+        "email": d.get("email"),
+        "phone": d.get("phone"),
+        "birthday": d.get("birthday"),
+        "notes": d.get("notes"),
+        "preferences": pref,
+        "visibility": d.get("visibility"),
+        "health_score": d.get("health_score", 0.5),
+        "notification_count": d.get("notification_count", 0),
+        "contact_count": d.get("contact_count", 0),
+        "last_contacted_at": d.get("last_contacted_at"),
+        "is_partial": bool(d.get("is_partial", 0)),
+        "how_we_met": d.get("how_we_met"),
+        "first_met_date": d.get("first_met_date"),
+        "introduced_by_person_id": d.get("introduced_by_person_id"),
+        "created_at": d.get("created_at"),
+        "updated_at": d.get("updated_at"),
+    }

--- a/services/zoe-data/routers/people.py
+++ b/services/zoe-data/routers/people.py
@@ -26,6 +26,7 @@ from models import (
     PeopleFieldDefinitionCreate,
     PeopleFieldDefinitionUpdate,
 )
+from people_utils import row_to_person
 from push import broadcaster
 
 router = APIRouter(prefix="/api/people", tags=["people"])
@@ -70,37 +71,7 @@ _WORK_GROUPS = {"work"}
 
 def _row_to_person(row) -> dict:
     """Convert DB row to person dict with preferences as parsed JSON."""
-    pref = row["preferences"] if hasattr(row, "__getitem__") else getattr(row, "preferences", None)
-    if pref and isinstance(pref, str):
-        try:
-            pref = json.loads(pref)
-        except json.JSONDecodeError:
-            pref = None
-    d = dict(row) if not isinstance(row, dict) else row
-    return {
-        "id": d.get("id"),
-        "user_id": d.get("user_id"),
-        "name": d.get("name"),
-        "relationship": d.get("relationship"),
-        "circle": d.get("circle", "circle"),
-        "context": d.get("context", "personal"),
-        "email": d.get("email"),
-        "phone": d.get("phone"),
-        "birthday": d.get("birthday"),
-        "notes": d.get("notes"),
-        "preferences": pref,
-        "visibility": d.get("visibility"),
-        "health_score": d.get("health_score", 0.5),
-        "notification_count": d.get("notification_count", 0),
-        "contact_count": d.get("contact_count", 0),
-        "last_contacted_at": d.get("last_contacted_at"),
-        "is_partial": bool(d.get("is_partial", 0)),
-        "how_we_met": d.get("how_we_met"),
-        "first_met_date": d.get("first_met_date"),
-        "introduced_by_person_id": d.get("introduced_by_person_id"),
-        "created_at": d.get("created_at"),
-        "updated_at": d.get("updated_at"),
-    }
+    return row_to_person(row)
 
 
 async def _load_custom_fields(db, person_ids: list[str]) -> dict[str, dict]:

--- a/services/zoe-data/routers/skybridge.py
+++ b/services/zoe-data/routers/skybridge.py
@@ -28,10 +28,10 @@ async def get_skybridge_status():
         "entrypoint": "/touch/skybridge.html",
         "version": 1,
         "card_contract": {
-            "status": "wired_for_calendar_weather",
+            "status": "wired_for_calendar_weather_lists_people",
             "supported_major": 1,
-            "data_domains": ["calendar", "weather"],
-            "voice_ws_domains": ["calendar", "weather"],
+            "data_domains": ["calendar", "weather", "lists", "people"],
+            "voice_ws_domains": ["calendar", "weather", "lists", "people"],
             "client_capability_cards": True,
         },
         "transports": {
@@ -41,7 +41,7 @@ async def get_skybridge_status():
         "capabilities": {
             "pages": 15,
             "settings": 22,
-            "dynamic_cards": "calendar_weather_data_cards",
+            "dynamic_cards": "calendar_weather_lists_people_data_cards",
         },
     }
 

--- a/services/zoe-data/skybridge_service.py
+++ b/services/zoe-data/skybridge_service.py
@@ -10,6 +10,7 @@ from typing import Any
 from calendar_utils import row_to_event
 from card_service import card_service
 from database import get_db_ctx
+from people_utils import row_to_person
 
 
 @dataclass(frozen=True)
@@ -19,6 +20,10 @@ class SkybridgeIntent:
     range_label: str = ""
     start_date: date | None = None
     end_date: date | None = None
+    query: str = ""
+    list_type: str = ""
+    context: str = ""
+    circle: str = ""
 
 
 MONTHS = {
@@ -48,6 +53,22 @@ MONTHS = {
     "dec": 12,
 }
 MONTH_PATTERN = "|".join(sorted(MONTHS, key=len, reverse=True))
+LIST_TYPES = ("shopping", "personal", "work", "bucket", "tasks")
+LIST_TYPE_ALIASES = {
+    "shopping": "shopping",
+    "groceries": "shopping",
+    "grocery": "shopping",
+    "personal": "personal",
+    "work": "work",
+    "bucket": "bucket",
+    "tasks": "tasks",
+    "task": "tasks",
+    "todo": "tasks",
+    "todos": "tasks",
+    "to do": "tasks",
+}
+PEOPLE_CONTEXTS = ("personal", "work")
+PEOPLE_CIRCLES = ("inner", "circle", "public")
 
 
 def _today() -> date:
@@ -128,6 +149,45 @@ def _calendar_date_from_text(text: str, today: date) -> tuple[str, date, date] |
     return None
 
 
+def _list_type_from_text(text: str) -> str:
+    for key, value in LIST_TYPE_ALIASES.items():
+        if f" {key} " in text:
+            return value
+    return ""
+
+
+def _people_filters_from_text(text: str) -> tuple[str, str, str]:
+    context = next((value for value in PEOPLE_CONTEXTS if f" {value} " in text), "")
+    circle = next((value for value in PEOPLE_CIRCLES if f" {value} " in text), "")
+    query = ""
+    match = re.search(r"\b(?:find|show|search for|look up)\s+(?:my\s+)?(?P<name>[a-z][a-z .'-]{1,80})\b", text)
+    if match:
+        candidate = match.group("name").strip()
+        stop_words = {
+            "people",
+            "contact",
+            "contacts",
+            "person",
+            "profile",
+            "family",
+            "friends",
+            "work contacts",
+            "personal contacts",
+            "my contacts",
+            "settings",
+            "dashboard",
+            "calendar",
+            "weather",
+            "list",
+            "lists",
+            "shopping list",
+            "tasks",
+        }
+        if candidate not in stop_words and not candidate.endswith(" contacts"):
+            query = candidate
+    return query, context, circle
+
+
 def classify_skybridge_intent(message: str) -> SkybridgeIntent | None:
     """Classify only domains that Skybridge can resolve to real data cards."""
     text = f" {(message or '').lower()} "
@@ -153,6 +213,20 @@ def classify_skybridge_intent(message: str) -> SkybridgeIntent | None:
             label, start, end = parsed_range
             return SkybridgeIntent("calendar", "show", label, start, end)
         return SkybridgeIntent("calendar", "show", "today", today, today)
+    if any(term in text for term in (" list", " lists", " shopping", " groceries", " grocery", " tasks", " todos")):
+        list_type = _list_type_from_text(text)
+        return SkybridgeIntent(domain="lists", action="show", list_type=list_type)
+    if any(term in text for term in (" people", " contacts", " contact", " person", " profile", " family", " friends")):
+        query, context, circle = _people_filters_from_text(text)
+        if " family " in text and not query:
+            query = "family"
+        if " friends " in text and not query:
+            query = "friend"
+        return SkybridgeIntent(domain="people", action="show", query=query, context=context, circle=circle)
+    if re.search(r"\b(?:find|search for|look up|show)\s+(?:my\s+)?[a-z][a-z .'-]{1,80}\b", text):
+        query, context, circle = _people_filters_from_text(text)
+        if query:
+            return SkybridgeIntent(domain="people", action="show", query=query, context=context, circle=circle)
     return None
 
 
@@ -184,6 +258,10 @@ async def _resolve_with_db(intent: SkybridgeIntent, user_id: str, db: Any) -> di
         return await _resolve_calendar(intent, user_id, db)
     if intent.domain == "weather":
         return await _resolve_weather(intent, user_id, db)
+    if intent.domain == "lists":
+        return await _resolve_lists(intent, user_id, db)
+    if intent.domain == "people":
+        return await _resolve_people(intent, user_id, db)
     return {"handled": False, "intent": None, "spoken_summary": "", "cards": []}
 
 
@@ -256,6 +334,184 @@ async def _resolve_weather(intent: SkybridgeIntent, user_id: str, db: Any) -> di
     return {
         "handled": True,
         "intent": {"domain": "weather", "action": intent.action},
+        "spoken_summary": spoken,
+        "cards": [card_service.convert_emit(card, target_major=1)],
+    }
+
+
+async def _resolve_lists(intent: SkybridgeIntent, user_id: str, db: Any) -> dict[str, Any]:
+    if user_id in {"guest", "voice-guest"}:
+        card = card_service.build_shopping_list_card(
+            {
+                "list_name": "Lists",
+                "list_type": intent.list_type or "all",
+                "lists": [],
+                "items": [],
+                "summary": "No list data is available for guest sessions.",
+            }
+        )
+        return {
+            "handled": True,
+            "intent": {"domain": "lists", "action": intent.action, "list_type": intent.list_type},
+            "spoken_summary": "No list data is available for guest sessions.",
+            "cards": [card_service.convert_emit(card, target_major=1)],
+        }
+
+    list_type = intent.list_type
+    if list_type:
+        rows = await db.fetch(
+            """
+            SELECT id, user_id, name, list_type, description, visibility, created_at, updated_at
+            FROM lists
+            WHERE list_type = $2 AND deleted = 0
+              AND (visibility = 'family' OR user_id = $1)
+            ORDER BY updated_at DESC
+            LIMIT 8
+            """,
+            user_id,
+            list_type,
+        )
+    else:
+        rows = await db.fetch(
+            """
+            SELECT id, user_id, name, list_type, description, visibility, created_at, updated_at
+            FROM lists
+            WHERE deleted = 0
+              AND (visibility = 'family' OR user_id = $1)
+            ORDER BY updated_at DESC
+            LIMIT 8
+            """,
+            user_id,
+        )
+    lists = [dict(row) for row in rows]
+    list_ids = [list_row["id"] for list_row in lists]
+    items_by_list: dict[Any, list[dict[str, Any]]] = {list_id: [] for list_id in list_ids}
+    if list_ids:
+        item_rows = await db.fetch(
+            """
+            SELECT id, list_id, text, completed, priority, category, quantity, sort_order,
+                   parent_id, assigned_to, created_at, updated_at
+            FROM list_items
+            WHERE list_id = ANY($1) AND deleted = 0
+            ORDER BY list_id, completed ASC, sort_order ASC, created_at ASC
+            """,
+            list_ids,
+        )
+        for item_row in item_rows:
+            item = dict(item_row)
+            bucket = items_by_list.setdefault(item.get("list_id"), [])
+            if len(bucket) < 24:
+                bucket.append(item)
+
+    selected = lists[0] if len(lists) == 1 else None
+    for list_row in lists:
+        items = items_by_list.get(list_row["id"], [])
+        list_row["items"] = items if selected else []
+        list_row["item_count"] = len(items)
+        list_row["open_count"] = sum(1 for item in items if not item.get("completed"))
+        list_row["completed_count"] = len(items) - list_row["open_count"]
+
+    items = selected.get("items", []) if selected else []
+    list_name = selected.get("name") if selected else (list_type.title() if list_type else "Lists")
+    summary_count = len(items) if selected else sum(item.get("item_count", 0) for item in lists)
+    spoken = f"{list_name} has {summary_count} item{'s' if summary_count != 1 else ''}."
+    card = card_service.build_shopping_list_card(
+        {
+            "list_id": selected.get("id") if selected else "lists-overview",
+            "list_name": list_name,
+            "list_type": selected.get("list_type") if selected else (list_type or "all"),
+            "lists": lists,
+            "items": items,
+            "summary": spoken,
+        }
+    )
+    return {
+        "handled": True,
+        "intent": {"domain": "lists", "action": intent.action, "list_type": list_type},
+        "spoken_summary": spoken,
+        "cards": [card_service.convert_emit(card, target_major=1)],
+    }
+
+
+async def _resolve_people(intent: SkybridgeIntent, user_id: str, db: Any) -> dict[str, Any]:
+    if user_id in {"guest", "voice-guest"}:
+        card = card_service.build_people_directory_card(
+            {
+                "title": "People",
+                "people": [],
+                "count": 0,
+                "summary": "No people data is available for guest sessions.",
+            }
+        )
+        return {
+            "handled": True,
+            "intent": {"domain": "people", "action": intent.action, "query": intent.query},
+            "spoken_summary": "No people data is available for guest sessions.",
+            "cards": [card_service.convert_emit(card, target_major=1)],
+        }
+
+    filters = ["deleted = 0", "(visibility = 'family' OR user_id = $1)", "(is_partial = 0 OR is_partial IS NULL)"]
+    params: list[Any] = [user_id]
+    if intent.context:
+        params.append(intent.context)
+        filters.append(f"context = ${len(params)}")
+    if intent.circle:
+        params.append(intent.circle)
+        filters.append(f"circle = ${len(params)}")
+    if intent.query:
+        params.append(f"%{intent.query}%")
+        query_index = len(params)
+        filters.append(
+            f"(name ILIKE ${query_index} OR relationship ILIKE ${query_index} OR email ILIKE ${query_index} OR phone ILIKE ${query_index})"
+        )
+    where = " AND ".join(filters)
+    rows = await db.fetch(
+        f"""
+        SELECT *
+        FROM people
+        WHERE {where}
+        ORDER BY name
+        LIMIT 12
+        """,
+        *params,
+    )
+    people = [row_to_person(row) for row in rows]
+    exact = None
+    if intent.query:
+        normalized_query = intent.query.strip().lower()
+        exact = next((person for person in people if str(person.get("name") or "").strip().lower() == normalized_query), None)
+    if exact or (intent.query and len(people) == 1):
+        person = exact or people[0]
+        summary = f"{person.get('name')} is in your people."
+        card = card_service.build_person_profile_card({"person": person, "summary": summary})
+        return {
+            "handled": True,
+            "intent": {"domain": "people", "action": intent.action, "query": intent.query},
+            "spoken_summary": summary,
+            "cards": [card_service.convert_emit(card, target_major=1)],
+        }
+
+    title = "People"
+    if intent.context:
+        title = f"{intent.context.title()} Contacts"
+    if intent.query:
+        title = f"People matching {intent.query}"
+    count = len(people)
+    spoken = f"I found {count} contact{'s' if count != 1 else ''}."
+    card = card_service.build_people_directory_card(
+        {
+            "title": title,
+            "people": people,
+            "count": count,
+            "query": intent.query,
+            "context": intent.context,
+            "circle": intent.circle,
+            "summary": spoken,
+        }
+    )
+    return {
+        "handled": True,
+        "intent": {"domain": "people", "action": intent.action, "query": intent.query, "context": intent.context},
         "spoken_summary": spoken,
         "cards": [card_service.convert_emit(card, target_major=1)],
     }

--- a/services/zoe-data/tests/test_skybridge_service.py
+++ b/services/zoe-data/tests/test_skybridge_service.py
@@ -23,14 +23,34 @@ class Cursor:
 
 
 class FakeDb:
-    def __init__(self, *, events=None, prefs=None):
+    def __init__(self, *, events=None, prefs=None, lists=None, items_by_list=None, people=None):
         self.events = events or []
         self.prefs = prefs
+        self.lists = lists or []
+        self.items_by_list = items_by_list or {}
+        self.people = people or []
         self.fetch_args = None
+        self.list_item_fetch_count = 0
 
     async def fetch(self, *args):
         self.fetch_args = args
-        return self.events
+        sql = str(args[0])
+        if "FROM events" in sql:
+            return self.events
+        if "FROM lists" in sql:
+            return self.lists
+        if "FROM list_items" in sql:
+            self.list_item_fetch_count += 1
+            key = args[1]
+            if isinstance(key, (list, tuple, set)):
+                rows = []
+                for list_id in key:
+                    rows.extend(self.items_by_list.get(list_id, []))
+                return rows
+            return self.items_by_list.get(key, [])
+        if "FROM people" in sql:
+            return self.people
+        return []
 
     async def fetchrow(self, *_args):
         return self.prefs
@@ -48,6 +68,10 @@ def test_classify_calendar_and_weather_requests():
     assert classify_skybridge_intent("show my calendar").domain == "calendar"
     assert classify_skybridge_intent("show me the weather").domain == "weather"
     assert classify_skybridge_intent("what is happening this week").domain == "calendar"
+    assert classify_skybridge_intent("show my shopping list").domain == "lists"
+    assert classify_skybridge_intent("show my contacts").domain == "people"
+    assert classify_skybridge_intent("find Sarah").domain == "people"
+    assert classify_skybridge_intent("what is there to do this week") is None
     assert classify_skybridge_intent("open settings") is None
 
 
@@ -179,6 +203,158 @@ async def test_guest_calendar_request_does_not_fetch_family_events():
 
     assert result["handled"] is True
     assert result["cards"][0]["content"]["events"] == []
+
+
+@pytest.mark.asyncio
+async def test_lists_request_returns_real_list_items():
+    list_row = {
+        "id": "list-1",
+        "user_id": "family-admin",
+        "name": "Groceries",
+        "list_type": "shopping",
+        "description": "Weekly shop",
+        "visibility": "family",
+    }
+    item = {
+        "id": "item-1",
+        "list_id": "list-1",
+        "text": "Milk",
+        "completed": False,
+        "priority": "high",
+        "category": "dairy",
+        "quantity": "2L",
+    }
+
+    result = await resolve_skybridge_request(
+        "show my shopping list",
+        "family-admin",
+        db=FakeDb(lists=[list_row], items_by_list={"list-1": [item]}),
+    )
+
+    assert result["handled"] is True
+    assert result["intent"] == {"domain": "lists", "action": "show", "list_type": "shopping"}
+    card = result["cards"][0]
+    assert card["producer"] == "zoe-shopping"
+    assert card["content"]["source"] == "list_show"
+    assert card["content"]["items"][0]["text"] == "Milk"
+    assert card["content"]["open_count"] == 1
+    assert "Surface" not in str(card)
+
+
+@pytest.mark.asyncio
+async def test_lists_request_returns_overview_for_multiple_lists():
+    rows = [
+        {"id": "list-1", "name": "Groceries", "list_type": "shopping", "visibility": "family"},
+        {"id": "list-2", "name": "Hardware", "list_type": "shopping", "visibility": "family"},
+    ]
+
+    db = FakeDb(
+        lists=rows,
+        items_by_list={
+            "list-1": [{"id": "item-1", "list_id": "list-1", "text": "Milk", "completed": False}],
+            "list-2": [{"id": "item-2", "list_id": "list-2", "text": "Tape", "completed": True}],
+        },
+    )
+
+    result = await resolve_skybridge_request(
+        "show my shopping lists",
+        "family-admin",
+        db=db,
+    )
+
+    card = result["cards"][0]
+    assert card["content"]["source"] == "list_show"
+    assert card["content"]["items"] == []
+    assert card["content"]["lists"][0]["items"] == []
+    assert card["content"]["lists"][0]["open_count"] == 1
+    assert card["content"]["lists"][1]["completed_count"] == 1
+    assert db.list_item_fetch_count == 1
+
+
+@pytest.mark.asyncio
+async def test_guest_lists_request_does_not_fetch_private_lists():
+    result = await resolve_skybridge_request("show my shopping list", "guest", db=GuardedGuestDb())
+
+    assert result["handled"] is True
+    assert result["cards"][0]["content"]["source"] == "list_show"
+    assert result["cards"][0]["content"]["items"] == []
+
+
+@pytest.mark.asyncio
+async def test_people_request_returns_directory_card():
+    person = {
+        "id": "person-1",
+        "user_id": "family-admin",
+        "name": "Sarah Smith",
+        "relationship": "Friend",
+        "circle": "inner",
+        "context": "personal",
+        "email": "sarah@example.com",
+        "health_score": 0.82,
+        "visibility": "family",
+    }
+
+    result = await resolve_skybridge_request("show my contacts", "family-admin", db=FakeDb(people=[person]))
+
+    assert result["handled"] is True
+    assert result["intent"]["domain"] == "people"
+    card = result["cards"][0]
+    assert card["producer"] == "zoe-people"
+    assert card["content"]["source"] == "people_directory"
+    assert card["content"]["people"][0]["name"] == "Sarah Smith"
+    assert "Surface" not in str(card)
+
+
+@pytest.mark.asyncio
+async def test_people_search_returns_profile_card_for_exact_match():
+    person = {
+        "id": "person-1",
+        "user_id": "family-admin",
+        "name": "Sarah",
+        "relationship": "Friend",
+        "circle": "inner",
+        "context": "personal",
+        "notes": "Met through school.",
+        "visibility": "family",
+    }
+
+    result = await resolve_skybridge_request("find Sarah", "family-admin", db=FakeDb(people=[person]))
+
+    card = result["cards"][0]
+    assert result["intent"]["query"] == "sarah"
+    assert card["producer"] == "zoe-people"
+    assert card["content"]["source"] == "person_profile"
+    assert card["content"]["person"]["name"] == "Sarah"
+
+
+@pytest.mark.asyncio
+async def test_guest_people_request_does_not_fetch_private_people():
+    result = await resolve_skybridge_request("show my contacts", "guest", db=GuardedGuestDb())
+
+    assert result["handled"] is True
+    assert result["cards"][0]["content"]["source"] == "people_directory"
+    assert result["cards"][0]["content"]["people"] == []
+
+
+@pytest.mark.asyncio
+async def test_people_singular_contact_request_returns_directory_not_search():
+    person = {
+        "id": "person-1",
+        "user_id": "family-admin",
+        "name": "Sarah Smith",
+        "relationship": "Friend",
+        "visibility": "family",
+    }
+
+    intent = classify_skybridge_intent("show my contact")
+    assert intent.domain == "people"
+    assert intent.query == ""
+
+    result = await resolve_skybridge_request("show my contact", "family-admin", db=FakeDb(people=[person]))
+
+    assert result["handled"] is True
+    assert result["intent"]["query"] == ""
+    assert result["cards"][0]["content"]["source"] == "people_directory"
 
 
 @pytest.mark.asyncio

--- a/services/zoe-data/tests/test_skybridge_static.py
+++ b/services/zoe-data/tests/test_skybridge_static.py
@@ -186,6 +186,7 @@ def test_skybridge_auth_and_voice_bus_contracts_are_wired():
 def test_skybridge_renderer_supports_real_data_cards():
     renderer = read(UI / "js" / "skybridge-renderer.js")
     html = read(UI / "skybridge.html")
+    data_widgets_css = read(UI / "css" / "skybridge-data-widgets.css")
 
     assert "renderCalendar(props)" in renderer
     assert "renderWeather(props)" in renderer
@@ -215,9 +216,23 @@ def test_skybridge_renderer_supports_real_data_cards():
     assert "props.source === 'calendar_show'" in renderer
     assert "props.source === 'weather_current'" in renderer
     assert "props.source === 'weather_forecast'" in renderer
+    assert "props.source === 'list_show'" in renderer
+    assert "props.source === 'people_directory'" in renderer
+    assert "props.source === 'person_profile'" in renderer
+    assert "renderZoeList(props)" in renderer
+    assert "renderPeopleDirectory(props)" in renderer
+    assert "renderPersonProfile(props)" in renderer
+    assert "sky-list-scene" in renderer
+    assert "sky-people-scene" in renderer
+    assert "sky-profile-scene" in renderer
     assert "sky-event-row" in html
     assert "sky-weather-hour-tile" in html
     assert "sky-weather-day-row" in html
+    assert "/touch/css/skybridge-data-widgets.css?v=skybridge-lists-people-1" in html
+    assert "skybridge-lists-people-widgets" not in html
+    assert "sky-list-item-row" in data_widgets_css
+    assert "sky-person-row" in data_widgets_css
+    assert "sky-profile-health" in data_widgets_css
     assert "sky-weather-scene" in html
     assert "weather-sunny" in html
     assert "skybridge-runtime-overrides" in html

--- a/services/zoe-data/tests/test_skybridge_status.py
+++ b/services/zoe-data/tests/test_skybridge_status.py
@@ -27,11 +27,11 @@ def test_skybridge_status_endpoint_returns_runtime_contract():
     assert data["surface"] == "skybridge"
     assert data["status"] == "ready"
     assert data["entrypoint"] == "/touch/skybridge.html"
-    assert data["card_contract"]["status"] == "wired_for_calendar_weather"
+    assert data["card_contract"]["status"] == "wired_for_calendar_weather_lists_people"
     assert data["card_contract"]["supported_major"] == 1
-    assert data["card_contract"]["data_domains"] == ["calendar", "weather"]
-    assert data["card_contract"]["voice_ws_domains"] == ["calendar", "weather"]
+    assert data["card_contract"]["data_domains"] == ["calendar", "weather", "lists", "people"]
+    assert data["card_contract"]["voice_ws_domains"] == ["calendar", "weather", "lists", "people"]
     assert data["transports"]["local_ws"] is True
     assert "livekit" in data["transports"]
     assert data["capabilities"]["settings"] == 22
-    assert data["capabilities"]["dynamic_cards"] == "calendar_weather_data_cards"
+    assert data["capabilities"]["dynamic_cards"] == "calendar_weather_lists_people_data_cards"

--- a/services/zoe-ui/dist/touch/css/skybridge-data-widgets.css
+++ b/services/zoe-ui/dist/touch/css/skybridge-data-widgets.css
@@ -1,0 +1,363 @@
+body:not(.sky-empty) .zoe-list-card {
+    background:
+        radial-gradient(circle at 18% 8%, rgba(251,146,60,0.24), transparent 34%),
+        radial-gradient(circle at 92% 20%, rgba(34,197,94,0.18), transparent 32%),
+        linear-gradient(145deg, rgba(18,22,30,0.96), rgba(8,10,16,0.98)) !important;
+    border-color: rgba(255,255,255,0.15) !important;
+}
+
+body:not(.sky-empty) .zoe-list-card.work {
+    background:
+        radial-gradient(circle at 16% 8%, rgba(59,130,246,0.24), transparent 34%),
+        radial-gradient(circle at 92% 20%, rgba(90,224,224,0.14), transparent 32%),
+        linear-gradient(145deg, rgba(17,24,39,0.96), rgba(7,11,19,0.98)) !important;
+}
+
+body:not(.sky-empty) .zoe-list-card.personal {
+    background:
+        radial-gradient(circle at 16% 8%, rgba(168,85,247,0.24), transparent 34%),
+        radial-gradient(circle at 92% 20%, rgba(236,72,153,0.16), transparent 32%),
+        linear-gradient(145deg, rgba(24,18,34,0.96), rgba(10,8,16,0.98)) !important;
+}
+
+body:not(.sky-empty) .sky-list-scene,
+body:not(.sky-empty) .sky-people-scene,
+body:not(.sky-empty) .sky-profile-scene {
+    display: grid;
+    gap: 18px;
+    min-height: 100%;
+}
+
+body:not(.sky-empty) .sky-list-hero,
+body:not(.sky-empty) .sky-people-hero,
+body:not(.sky-empty) .sky-profile-hero {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 18px;
+}
+
+body:not(.sky-empty) .sky-profile-hero {
+    grid-template-columns: auto minmax(0, 1fr) auto;
+}
+
+body:not(.sky-empty) .sky-list-hero span,
+body:not(.sky-empty) .sky-people-hero span,
+body:not(.sky-empty) .sky-profile-title span {
+    display: block;
+    color: rgba(255,255,255,0.58);
+    font-size: 0.76rem;
+    font-weight: 800;
+    letter-spacing: 0;
+    text-transform: uppercase;
+}
+
+body:not(.sky-empty) .sky-list-hero h3,
+body:not(.sky-empty) .sky-people-hero h3,
+body:not(.sky-empty) .sky-profile-title h3 {
+    margin: 4px 0 0;
+    color: white;
+    font-size: clamp(1.7rem, 3vw, 3.2rem);
+    line-height: 0.98;
+    letter-spacing: 0;
+}
+
+body:not(.sky-empty) .sky-list-rings,
+body:not(.sky-empty) .sky-people-count {
+    width: 96px;
+    height: 96px;
+    border-radius: 32px;
+    display: grid;
+    place-items: center;
+    background: linear-gradient(180deg, rgba(255,255,255,0.18), rgba(255,255,255,0.07));
+    border: 1px solid rgba(255,255,255,0.18);
+    box-shadow: inset 0 1px 0 rgba(255,255,255,0.18), 0 18px 45px rgba(0,0,0,0.24);
+}
+
+body:not(.sky-empty) .sky-list-rings strong,
+body:not(.sky-empty) .sky-people-count strong {
+    color: white;
+    font-size: 2.05rem;
+    line-height: 1;
+}
+
+body:not(.sky-empty) .sky-list-rings span,
+body:not(.sky-empty) .sky-people-count span {
+    color: rgba(255,255,255,0.58);
+    font-size: 0.76rem;
+    font-weight: 800;
+}
+
+body:not(.sky-empty) .sky-list-stats {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 10px;
+}
+
+body:not(.sky-empty) .sky-list-stats div,
+body:not(.sky-empty) .sky-profile-grid div {
+    border-radius: 18px;
+    padding: 12px 14px;
+    background: rgba(255,255,255,0.08);
+    border: 1px solid rgba(255,255,255,0.12);
+}
+
+body:not(.sky-empty) .sky-list-stats strong,
+body:not(.sky-empty) .sky-profile-grid strong {
+    display: block;
+    color: white;
+    font-size: 1rem;
+    overflow-wrap: anywhere;
+}
+
+body:not(.sky-empty) .sky-list-stats span,
+body:not(.sky-empty) .sky-profile-grid span {
+    display: block;
+    color: rgba(255,255,255,0.55);
+    font-size: 0.74rem;
+    font-weight: 800;
+    text-transform: uppercase;
+}
+
+body:not(.sky-empty) .sky-list-items,
+body:not(.sky-empty) .sky-people-list {
+    display: grid;
+    gap: 10px;
+}
+
+body:not(.sky-empty) .sky-list-item-row,
+body:not(.sky-empty) .sky-list-overview-row,
+body:not(.sky-empty) .sky-person-row {
+    display: grid;
+    align-items: center;
+    gap: 12px;
+    border-radius: 20px;
+    padding: 12px;
+    background: rgba(255,255,255,0.085);
+    border: 1px solid rgba(255,255,255,0.12);
+    min-width: 0;
+}
+
+body:not(.sky-empty) .sky-list-item-row {
+    grid-template-columns: auto minmax(0, 1fr) auto;
+}
+
+body:not(.sky-empty) .sky-person-row {
+    grid-template-columns: auto minmax(0, 1fr) minmax(72px, 0.22fr);
+}
+
+body:not(.sky-empty) .sky-list-overview-row {
+    grid-template-columns: minmax(0, 1fr) auto;
+    border-left: 4px solid rgba(251,146,60,0.9);
+}
+
+body:not(.sky-empty) .sky-list-overview-row.work { border-left-color: rgba(59,130,246,0.9); }
+body:not(.sky-empty) .sky-list-overview-row.personal { border-left-color: rgba(168,85,247,0.9); }
+body:not(.sky-empty) .sky-list-overview-row.tasks { border-left-color: rgba(90,224,224,0.9); }
+
+body:not(.sky-empty) .sky-list-check {
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    display: grid;
+    place-items: center;
+    color: white;
+    font-size: 0.82rem;
+    font-weight: 900;
+    border: 2px solid rgba(255,255,255,0.45);
+    background: rgba(255,255,255,0.06);
+}
+
+body:not(.sky-empty) .sky-list-item-row.is-done .sky-list-check {
+    background: linear-gradient(135deg, #34D399, #5AE0E0);
+    border-color: transparent;
+}
+
+body:not(.sky-empty) .sky-list-item-row.is-done .sky-list-item-main strong {
+    color: rgba(255,255,255,0.58);
+    text-decoration: line-through;
+}
+
+body:not(.sky-empty) .sky-list-item-main,
+body:not(.sky-empty) .sky-person-main {
+    min-width: 0;
+}
+
+body:not(.sky-empty) .sky-list-item-main strong,
+body:not(.sky-empty) .sky-list-overview-row strong,
+body:not(.sky-empty) .sky-person-main strong {
+    display: block;
+    color: white;
+    font-size: 1rem;
+    overflow-wrap: anywhere;
+}
+
+body:not(.sky-empty) .sky-list-item-main em,
+body:not(.sky-empty) .sky-list-overview-row em,
+body:not(.sky-empty) .sky-person-main em {
+    display: block;
+    color: rgba(255,255,255,0.55);
+    font-style: normal;
+    font-size: 0.82rem;
+    margin-top: 3px;
+    overflow-wrap: anywhere;
+}
+
+body:not(.sky-empty) .sky-list-item-meta b,
+body:not(.sky-empty) .sky-list-item-meta span,
+body:not(.sky-empty) .sky-list-overview-row > span,
+body:not(.sky-empty) .sky-people-filter-row span {
+    display: inline-flex;
+    align-items: center;
+    border-radius: 999px;
+    padding: 6px 9px;
+    color: rgba(255,255,255,0.78);
+    background: rgba(255,255,255,0.1);
+    font-size: 0.74rem;
+    font-weight: 800;
+}
+
+body:not(.sky-empty) .people-card,
+body:not(.sky-empty) .person-profile-card {
+    background:
+        radial-gradient(circle at 18% 10%, rgba(90,224,224,0.22), transparent 34%),
+        radial-gradient(circle at 90% 18%, rgba(168,85,247,0.18), transparent 32%),
+        linear-gradient(145deg, rgba(13,20,25,0.96), rgba(8,9,15,0.98)) !important;
+}
+
+body:not(.sky-empty) .sky-people-filter-row {
+    min-height: 30px;
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+}
+
+body:not(.sky-empty) .sky-person-avatar,
+body:not(.sky-empty) .sky-profile-avatar {
+    display: grid;
+    place-items: center;
+    color: white;
+    font-weight: 900;
+    background:
+        linear-gradient(145deg, rgba(90,224,224,0.9), rgba(168,85,247,0.76)),
+        rgba(255,255,255,0.08);
+    box-shadow: inset 0 1px 0 rgba(255,255,255,0.28), 0 14px 35px rgba(90,224,224,0.14);
+}
+
+body:not(.sky-empty) .sky-person-avatar {
+    width: 46px;
+    height: 46px;
+    border-radius: 16px;
+    font-size: 0.95rem;
+}
+
+body:not(.sky-empty) .sky-profile-avatar {
+    width: 92px;
+    height: 92px;
+    border-radius: 32px;
+    font-size: 1.8rem;
+}
+
+body:not(.sky-empty) .sky-person-health {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 8px;
+}
+
+body:not(.sky-empty) .sky-person-health::before {
+    content: "";
+    grid-column: 1;
+    grid-row: 1;
+    height: 7px;
+    border-radius: 999px;
+    background: rgba(255,255,255,0.12);
+}
+
+body:not(.sky-empty) .sky-person-health i {
+    grid-column: 1;
+    grid-row: 1;
+    height: 7px;
+    border-radius: 999px;
+    background: linear-gradient(90deg, #5AE0E0, #A78BFA);
+}
+
+body:not(.sky-empty) .sky-person-health span {
+    color: rgba(255,255,255,0.62);
+    font-size: 0.74rem;
+    font-weight: 800;
+}
+
+body:not(.sky-empty) .sky-profile-health {
+    position: relative;
+    width: 78px;
+    height: 108px;
+    border-radius: 28px;
+    display: grid;
+    place-items: center;
+    overflow: hidden;
+    background: rgba(255,255,255,0.08);
+    border: 1px solid rgba(255,255,255,0.12);
+}
+
+body:not(.sky-empty) .sky-profile-health i {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: linear-gradient(180deg, rgba(90,224,224,0.78), rgba(167,139,250,0.78));
+    z-index: 0;
+}
+
+body:not(.sky-empty) .sky-profile-health strong,
+body:not(.sky-empty) .sky-profile-health span {
+    position: relative;
+    z-index: 1;
+    color: white;
+}
+
+body:not(.sky-empty) .sky-profile-health strong {
+    font-size: 1.5rem;
+    line-height: 1;
+}
+
+body:not(.sky-empty) .sky-profile-health span {
+    font-size: 0.68rem;
+    font-weight: 800;
+}
+
+body:not(.sky-empty) .sky-profile-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 10px;
+}
+
+body:not(.sky-empty) .sky-profile-notes {
+    margin: 0;
+    border-radius: 22px;
+    padding: 16px 18px;
+    color: rgba(255,255,255,0.82);
+    background: rgba(255,255,255,0.08);
+    border: 1px solid rgba(255,255,255,0.12);
+    line-height: 1.45;
+}
+
+@media (max-width: 780px) {
+    body:not(.sky-empty) .sky-list-hero,
+    body:not(.sky-empty) .sky-people-hero,
+    body:not(.sky-empty) .sky-profile-hero {
+        grid-template-columns: 1fr;
+    }
+
+    body:not(.sky-empty) .sky-person-row {
+        grid-template-columns: auto minmax(0, 1fr);
+    }
+
+    body:not(.sky-empty) .sky-person-health {
+        grid-column: 1 / -1;
+    }
+
+    body:not(.sky-empty) .sky-profile-grid {
+        grid-template-columns: 1fr;
+    }
+}

--- a/services/zoe-ui/dist/touch/js/skybridge-renderer.js
+++ b/services/zoe-ui/dist/touch/js/skybridge-renderer.js
@@ -69,6 +69,9 @@
     function renderStatus(props) {
         if (props.source === 'calendar_show') return renderCalendar(props);
         if (props.source === 'weather_current' || props.source === 'weather_forecast') return renderWeather(props);
+        if (props.source === 'list_show') return renderZoeList(props);
+        if (props.source === 'people_directory') return renderPeopleDirectory(props);
+        if (props.source === 'person_profile') return renderPersonProfile(props);
         const body = [
             props.metric ? '<div class="sky-widget-metric"><strong>' + escapeHtml(props.metric) + '</strong><span>' + escapeHtml(props.metric_label || '') + '</span></div>' : '',
             '<div class="sky-card-body">' + escapeHtml(props.body || props.message || '') + '</div>'
@@ -307,6 +310,135 @@
             '</div>'
         ].join('');
         return cardFrame(Object.assign({ status: 'Weather', icon: 'W' }, props), body, { wide: true, tone: 'weather-card ' + weatherClass(props, current) });
+    }
+
+    function normalizeListItems(items) {
+        return Array.isArray(items) ? items : [];
+    }
+
+    function listAccentClass(value) {
+        const token = safeClassTokens(String(value || 'list').toLowerCase()) || 'list';
+        const known = ['shopping', 'work', 'personal', 'bucket', 'tasks', 'all'];
+        return known.indexOf(token) >= 0 ? token : 'list';
+    }
+
+    function renderListItemRow(item, index) {
+        const isObject = typeof item === 'object' && item;
+        const title = isObject ? (item.text || item.title || item.label || 'List item') : String(item || 'List item');
+        const completed = !!(isObject && item.completed);
+        const detail = isObject ? [item.quantity, item.category, item.assigned_to].filter(Boolean).join(' · ') : '';
+        const priority = isObject && item.priority ? '<b>' + escapeHtml(item.priority) + '</b>' : '';
+        return [
+            '<div class="sky-list-item-row' + (completed ? ' is-done' : '') + '">',
+            '<div class="sky-list-check" aria-hidden="true">' + (completed ? '✓' : '') + '</div>',
+            '<div class="sky-list-item-main"><strong>' + escapeHtml(title) + '</strong>' + (detail ? '<em>' + escapeHtml(detail) + '</em>' : '') + '</div>',
+            '<div class="sky-list-item-meta">' + (priority || '<span>' + escapeHtml(String(index + 1).padStart(2, '0')) + '</span>') + '</div>',
+            '</div>'
+        ].join('');
+    }
+
+    function renderZoeList(props) {
+        const items = normalizeListItems(props.items);
+        const lists = Array.isArray(props.lists) ? props.lists : [];
+        const listType = props.list_type || (lists[0] && lists[0].list_type) || 'all';
+        const accent = listAccentClass(listType);
+        const visibleItems = items.slice(0, 12);
+        const rows = visibleItems.map(renderListItemRow).join('');
+        const overviewRows = !items.length && lists.length ? lists.slice(0, 6).map(list => {
+            const openCount = list.open_count == null ? (list.item_count || 0) : list.open_count;
+            return [
+                '<div class="sky-list-overview-row ' + escapeHtml(listAccentClass(list.list_type)) + '">',
+                '<div><strong>' + escapeHtml(list.name || list.list_name || 'List') + '</strong><em>' + escapeHtml(list.description || list.list_type || '') + '</em></div>',
+                '<span>' + escapeHtml(openCount) + ' open</span>',
+                '</div>'
+            ].join('');
+        }).join('') : '';
+        const empty = [
+            '<div class="sky-empty-data sky-list-empty">',
+            '<strong>No items in ' + escapeHtml(props.list_name || 'this list') + '</strong>',
+            '<span>Zoe did not find active items for this request.</span>',
+            '</div>'
+        ].join('');
+        const body = [
+            '<div class="sky-list-scene ' + escapeHtml(accent) + '">',
+            '<div class="sky-list-hero">',
+            '<div><span>' + escapeHtml((props.list_type || 'list').toUpperCase()) + '</span><h3>' + escapeHtml(props.list_name || props.title || 'Lists') + '</h3></div>',
+            '<div class="sky-list-rings"><strong>' + escapeHtml(props.open_count == null ? (items.length || lists.length) : props.open_count) + '</strong><span>open</span></div>',
+            '</div>',
+            '<div class="sky-list-stats">',
+            '<div><strong>' + escapeHtml(props.item_count == null ? items.length : props.item_count) + '</strong><span>items</span></div>',
+            '<div><strong>' + escapeHtml(props.completed_count || 0) + '</strong><span>done</span></div>',
+            '<div><strong>' + escapeHtml(lists.length || 1) + '</strong><span>lists</span></div>',
+            '</div>',
+            '<div class="sky-list-items">' + (rows || overviewRows || empty) + '</div>',
+            '</div>'
+        ].join('');
+        return cardFrame(Object.assign({ status: 'Lists', icon: 'L' }, props), body, { wide: true, tone: 'zoe-list-card ' + accent, hideHeader: true, hideStatus: true });
+    }
+
+    function initialsFor(name) {
+        const parts = String(name || 'Z').trim().split(/\s+/).filter(Boolean);
+        return escapeHtml((parts[0] || 'Z').charAt(0).toUpperCase() + (parts[1] || '').charAt(0).toUpperCase());
+    }
+
+    function healthPercent(value) {
+        const number = Number(value);
+        if (!Number.isFinite(number)) return 50;
+        return Math.max(0, Math.min(100, Math.round(number <= 1 ? number * 100 : number)));
+    }
+
+    function personSubline(person) {
+        return [person.relationship, person.context, person.circle].filter(Boolean).join(' · ') || 'Contact';
+    }
+
+    function renderPeopleDirectory(props) {
+        const people = Array.isArray(props.people) ? props.people : [];
+        const rows = people.slice(0, 8).map(person => {
+            const health = healthPercent(person.health_score);
+            return [
+                '<div class="sky-person-row">',
+                '<div class="sky-person-avatar" aria-hidden="true">' + initialsFor(person.name) + '</div>',
+                '<div class="sky-person-main"><strong>' + escapeHtml(person.name || 'Person') + '</strong><em>' + escapeHtml(personSubline(person)) + '</em></div>',
+                '<div class="sky-person-health"><i style="width:' + health + '%"></i><span>' + health + '</span></div>',
+                '</div>'
+            ].join('');
+        }).join('');
+        const empty = '<div class="sky-empty-data sky-people-empty"><strong>No matching people</strong><span>Zoe did not find contacts for this request.</span></div>';
+        const body = [
+            '<div class="sky-people-scene">',
+            '<div class="sky-people-hero"><div><span>PEOPLE</span><h3>' + escapeHtml(props.title || 'People') + '</h3></div><div class="sky-people-count"><strong>' + escapeHtml(props.count == null ? people.length : props.count) + '</strong><span>found</span></div></div>',
+            '<div class="sky-people-filter-row">',
+            props.query ? '<span>Search ' + escapeHtml(props.query) + '</span>' : '',
+            props.context ? '<span>' + escapeHtml(props.context) + '</span>' : '',
+            props.circle ? '<span>' + escapeHtml(props.circle) + '</span>' : '',
+            '</div>',
+            '<div class="sky-people-list">' + (rows || empty) + '</div>',
+            '</div>'
+        ].join('');
+        return cardFrame(Object.assign({ status: 'People', icon: 'P' }, props), body, { wide: true, tone: 'people-card', hideHeader: true, hideStatus: true });
+    }
+
+    function renderPersonProfile(props) {
+        const person = props.person || {};
+        const health = healthPercent(person.health_score);
+        const contactRows = [
+            ['Phone', person.phone],
+            ['Email', person.email],
+            ['Birthday', person.birthday],
+            ['Last contact', person.last_contacted_at]
+        ].filter(pair => pair[1]).map(pair => '<div><span>' + escapeHtml(pair[0]) + '</span><strong>' + escapeHtml(pair[1]) + '</strong></div>').join('');
+        const body = [
+            '<div class="sky-profile-scene">',
+            '<div class="sky-profile-hero">',
+            '<div class="sky-profile-avatar" aria-hidden="true">' + initialsFor(person.name || props.title) + '</div>',
+            '<div class="sky-profile-title"><span>' + escapeHtml(personSubline(person)) + '</span><h3>' + escapeHtml(person.name || props.title || 'Person') + '</h3></div>',
+            '<div class="sky-profile-health"><strong>' + health + '</strong><span>connection</span><i style="height:' + health + '%"></i></div>',
+            '</div>',
+            contactRows ? '<div class="sky-profile-grid">' + contactRows + '</div>' : '',
+            person.notes ? '<p class="sky-profile-notes">' + escapeHtml(person.notes) + '</p>' : '',
+            '</div>'
+        ].join('');
+        return cardFrame(Object.assign({ status: 'Person', icon: 'P' }, props), body, { wide: true, tone: 'person-profile-card', hideHeader: true, hideStatus: true });
     }
 
 

--- a/services/zoe-ui/dist/touch/skybridge.html
+++ b/services/zoe-ui/dist/touch/skybridge.html
@@ -23,6 +23,7 @@
     <meta name="theme-color" content="#0b0d12">
     <title>Zoe Skybridge</title>
     <link rel="stylesheet" href="/touch/css/touch-adapter.css">
+    <link rel="stylesheet" href="/touch/css/skybridge-data-widgets.css?v=skybridge-lists-people-1">
     <script src="/lib/livekit/livekit-client.umd.min.js" onerror="console.warn('LiveKit client not loaded')"></script>
     <style>
         :root {


### PR DESCRIPTION
## Summary
- add real Skybridge resolver support for lists and people data domains
- add list and people card builders plus shared people row normalization
- add premium Skybridge renderers/styles for list detail/overview, people directory, and person profile cards
- update Skybridge status metadata to claim only the newly wired domains

## Tests
- PYTHONPATH=. python3 -m pytest -q tests/test_skybridge_service.py tests/test_skybridge_static.py tests/test_skybridge_status.py tests/test_card_contract.py
- python3 tools/audit/validate_structure.py
- python3 tools/audit/validate_critical_files.py
- git diff --check
- renderer smoke: generated list, people directory, and person profile markup from sample card contracts