### PR TITLE
Self-load .env in Multica health report (ZOE-5669)

### DIFF
--- a/scripts/maintenance/multica_health_report.py
+++ b/scripts/maintenance/multica_health_report.py
@@ -14,6 +14,12 @@ import httpx
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "services" / "zoe-data"))
 
+import runtime_env  # noqa: E402
+
+# Self-load repo .env so the report works without manual `set -a && . ./.env`.
+# Real environment variables take precedence (runtime_env skips keys already set).
+runtime_env.bootstrap_runtime_env()
+
 
 def _uploads_configured() -> bool:
     if os.environ.get("LOCAL_UPLOAD_DIR") and os.environ.get("LOCAL_UPLOAD_BASE_URL"):

--- a/services/zoe-data/tests/test_multica_health_report.py
+++ b/services/zoe-data/tests/test_multica_health_report.py
@@ -25,9 +25,13 @@ def test_report_module_self_loads_env_on_import(monkeypatch, tmp_path):
     monkeypatch.delenv("MULTICA_BASE_URL", raising=False)
     monkeypatch.setattr(runtime_env, "_ENV_BOOTSTRAPPED", False)
 
-    _module()
-
-    assert os.environ.get("MULTICA_BASE_URL") == "http://fixture:8080"
+    # bootstrap writes os.environ directly (not via monkeypatch), so pop it in a
+    # finally to guarantee the fixture value never leaks into later tests.
+    try:
+        _module()
+        assert os.environ.get("MULTICA_BASE_URL") == "http://fixture:8080"
+    finally:
+        os.environ.pop("MULTICA_BASE_URL", None)
 
 
 def test_probe_reports_http_status(monkeypatch):

--- a/services/zoe-data/tests/test_multica_health_report.py
+++ b/services/zoe-data/tests/test_multica_health_report.py
@@ -23,7 +23,7 @@ def test_report_module_self_loads_env_on_import(monkeypatch, tmp_path):
     env_file.write_text("MULTICA_BASE_URL=http://fixture:8080\n", encoding="utf-8")
     monkeypatch.setattr(runtime_env, "_ENV_FILES", (str(env_file),))
     monkeypatch.delenv("MULTICA_BASE_URL", raising=False)
-    runtime_env._ENV_BOOTSTRAPPED = False
+    monkeypatch.setattr(runtime_env, "_ENV_BOOTSTRAPPED", False)
 
     _module()
 

--- a/services/zoe-data/tests/test_multica_health_report.py
+++ b/services/zoe-data/tests/test_multica_health_report.py
@@ -1,6 +1,9 @@
 import asyncio
 import importlib.util
+import os
 from pathlib import Path
+
+import runtime_env
 
 
 def _module():
@@ -13,6 +16,18 @@ def _module():
     assert spec and spec.loader
     spec.loader.exec_module(module)
     return module
+
+
+def test_report_module_self_loads_env_on_import(monkeypatch, tmp_path):
+    env_file = tmp_path / ".env"
+    env_file.write_text("MULTICA_BASE_URL=http://fixture:8080\n", encoding="utf-8")
+    monkeypatch.setattr(runtime_env, "_ENV_FILES", (str(env_file),))
+    monkeypatch.delenv("MULTICA_BASE_URL", raising=False)
+    runtime_env._ENV_BOOTSTRAPPED = False
+
+    _module()
+
+    assert os.environ.get("MULTICA_BASE_URL") == "http://fixture:8080"
 
 
 def test_probe_reports_http_status(monkeypatch):

--- a/services/zoe-data/tests/test_runtime_env.py
+++ b/services/zoe-data/tests/test_runtime_env.py
@@ -9,7 +9,7 @@ def test_bootstrap_runtime_env_loads_hermes_key_from_service_env(monkeypatch, tm
     monkeypatch.setattr(runtime_env, "_ENV_FILES", (str(env_file),))
     monkeypatch.delenv("HERMES_API_KEY", raising=False)
     monkeypatch.delenv("API_SERVER_KEY", raising=False)
-    runtime_env._ENV_BOOTSTRAPPED = False
+    monkeypatch.setattr(runtime_env, "_ENV_BOOTSTRAPPED", False)
 
     runtime_env.bootstrap_runtime_env()
 
@@ -37,7 +37,7 @@ def test_bootstrap_runtime_env_skips_non_bootstrap_keys(monkeypatch, tmp_path):
     monkeypatch.setattr(runtime_env, "_ENV_FILES", (str(env_file),))
     monkeypatch.delenv("HERMES_API_KEY", raising=False)
     monkeypatch.delenv("DEBUG", raising=False)
-    runtime_env._ENV_BOOTSTRAPPED = False
+    monkeypatch.setattr(runtime_env, "_ENV_BOOTSTRAPPED", False)
 
     runtime_env.bootstrap_runtime_env()
 

--- a/services/zoe-data/tests/test_runtime_env.py
+++ b/services/zoe-data/tests/test_runtime_env.py
@@ -21,7 +21,7 @@ def test_real_environment_overrides_env_file(monkeypatch, tmp_path):
     env_file.write_text("MULTICA_BASE_URL=http://fixture:8080\n", encoding="utf-8")
     monkeypatch.setattr(runtime_env, "_ENV_FILES", (str(env_file),))
     monkeypatch.setenv("MULTICA_BASE_URL", "http://real:9090")
-    runtime_env._ENV_BOOTSTRAPPED = False
+    monkeypatch.setattr(runtime_env, "_ENV_BOOTSTRAPPED", False)
 
     runtime_env.bootstrap_runtime_env()
 

--- a/services/zoe-data/tests/test_runtime_env.py
+++ b/services/zoe-data/tests/test_runtime_env.py
@@ -16,6 +16,18 @@ def test_bootstrap_runtime_env_loads_hermes_key_from_service_env(monkeypatch, tm
     assert os.environ.get("HERMES_API_KEY") == "test-bootstrap-key"
 
 
+def test_real_environment_overrides_env_file(monkeypatch, tmp_path):
+    env_file = tmp_path / ".env"
+    env_file.write_text("MULTICA_BASE_URL=http://fixture:8080\n", encoding="utf-8")
+    monkeypatch.setattr(runtime_env, "_ENV_FILES", (str(env_file),))
+    monkeypatch.setenv("MULTICA_BASE_URL", "http://real:9090")
+    runtime_env._ENV_BOOTSTRAPPED = False
+
+    runtime_env.bootstrap_runtime_env()
+
+    assert os.environ.get("MULTICA_BASE_URL") == "http://real:9090"
+
+
 def test_bootstrap_runtime_env_skips_non_bootstrap_keys(monkeypatch, tmp_path):
     env_file = tmp_path / "zoe-data.env"
     env_file.write_text(


### PR DESCRIPTION
## Summary
- `scripts/maintenance/multica_health_report.py` read `os.environ` directly, so it reported `configured=false` unless the caller manually ran `set -a && . ./.env` first — unlike other maintenance scripts which self-load `.env`.
- Now calls `runtime_env.bootstrap_runtime_env()` on import to self-load the repo-root `.env`. Real environment variables still take precedence (the loader skips keys already present in `os.environ`).
- Secrets remain redacted: the report only emits booleans/status checks, never values.

## Test plan
- [x] `python3 -m py_compile scripts/maintenance/multica_health_report.py`
- [x] `pytest tests/test_runtime_env.py tests/test_multica_health_report.py` — 8 passed (incl. new self-load + env-override-precedence tests)
- [x] Ran the report with Multica vars stripped from the environment (`env -u MULTICA_BASE_URL ...`): now reports `configured=true`, `ok=true` without manual sourcing

🤖 Generated with [Claude Code](https://claude.com/claude-code)