### PR TITLE
Close Skybridge action card loop

### DIFF
--- a/docs/architecture/skybridge-action-loop.md
+++ b/docs/architecture/skybridge-action-loop.md
@@ -1,0 +1,54 @@
+# Skybridge Action Loop
+
+Skybridge cards are not just display widgets. They are the visible state for a
+voice-first action loop:
+
+`utterance -> intent -> optional mutation -> authoritative read -> card refresh`
+
+The first supported write domains are calendar, lists, and people. Weather stays
+read-only.
+
+## Runtime Contract
+
+Every handled Skybridge response may include:
+
+- `intent`: the server-classified domain/action.
+- `cards`: card-contract or renderer-native cards to display.
+- `actions`: persisted mutations Zoe performed.
+- `spoken_summary`: short user-facing result.
+- `skybridge_context`: the next-turn context to send back.
+
+The client sends `skybridge_context` with the next typed command. The local voice
+WebSocket keeps the same context in session memory and emits refreshed card
+batches with `type: "cards"`.
+
+## Page And Feature Standard
+
+Any Zoe surface that wants voice-edit support should expose the same pieces:
+
+- A read resolver that returns authoritative card data.
+- A mutation resolver that writes through the existing domain API/service.
+- A refresh step that re-reads data after mutation.
+- A card renderer that can represent both normal data and clean empty states.
+- A confirmation card when the target is ambiguous or the action is risky.
+
+The screen should update from the refreshed card, not from optimistic local-only
+state. Optimistic UI can be added later, but the authoritative read remains the
+source of truth.
+
+## V1 Actions
+
+- `calendar.create_event`: e.g. "add pick up the groceries at 3pm" while the
+  calendar card is active.
+- `calendar.update_time`: e.g. "move my 3pm appointment to 4pm".
+- `lists.add_item`: e.g. "add bread to the shopping list".
+- `people.remember_fact`: e.g. "remember that Sarah likes flowers and her
+  birthday is the 1st of May".
+
+## Ambiguity Rule
+
+Skybridge must not silently edit the wrong thing. If an utterance does not name a
+single safe target, return a status/confirmation card asking for clarification.
+
+Future calendar improvements can layer on participant notification, conflict
+checking, and trust gates without changing the core loop.

--- a/services/zoe-data/main.py
+++ b/services/zoe-data/main.py
@@ -1360,12 +1360,12 @@ async def _resolve_ws_user(session_id: str) -> str:
     return "voice-guest"
 
 
-async def _resolve_voice_cards(message_text: str, user_id: str) -> dict:
+async def _resolve_voice_cards(message_text: str, user_id: str, context: dict | None = None) -> dict:
     """Resolve voice text to real Skybridge data cards when a supported domain exists."""
     try:
         from skybridge_service import resolve_skybridge_request
 
-        return await resolve_skybridge_request(message_text, user_id)
+        return await resolve_skybridge_request(message_text, user_id, context=context)
     except Exception as exc:
         logger.warning("Voice WS Skybridge resolve failed: %s", exc)
         return {"handled": False, "cards": [], "spoken_summary": ""}
@@ -1390,6 +1390,7 @@ async def websocket_voice(websocket: WebSocket, session_id: str = Query("")):
     # Mutable cancel flag — text handler sets it; streaming pipeline checks it
     # between sentence boundaries. True mid-stream cancel requires task refactor (future).
     _ws_cancelled: list[bool] = [False]
+    skybridge_context: dict = {}
 
     try:
         while True:
@@ -1452,9 +1453,17 @@ async def websocket_voice(websocket: WebSocket, session_id: str = Query("")):
             _ws_cancelled[0] = False
 
             await websocket.send_json({"type": "state", "state": "thinking"})
-            skybridge_result = await _resolve_voice_cards(message_text, user_id)
-            for card_contract in skybridge_result.get("cards") or []:
-                await websocket.send_json({"type": "card", "card": card_contract})
+            skybridge_result = await _resolve_voice_cards(message_text, user_id, context=skybridge_context)
+            if skybridge_result.get("handled"):
+                skybridge_context = skybridge_result.get("skybridge_context") or skybridge_context
+                await websocket.send_json({"type": "cards", "result": skybridge_result})
+                await websocket.send_json({"type": "skybridge_context", "context": skybridge_context})
+                spoken_summary = str(skybridge_result.get("spoken_summary") or "").strip()
+                if spoken_summary:
+                    await websocket.send_json({"type": "transcript", "role": "assistant", "text": spoken_summary})
+                await websocket.send_json({"type": "state", "state": "ambient"})
+                await websocket.send_json({"type": "done"})
+                continue
 
             # ── Streaming LLM + per-sentence TTS ────────────────────────────────
             # Track LLM output and TTS output separately so fallback only re-runs

--- a/services/zoe-data/main.py
+++ b/services/zoe-data/main.py
@@ -1464,6 +1464,7 @@ async def websocket_voice(websocket: WebSocket, session_id: str = Query("")):
                 await websocket.send_json({"type": "state", "state": "ambient"})
                 await websocket.send_json({"type": "done"})
                 continue
+            skybridge_context = {}
 
             # ── Streaming LLM + per-sentence TTS ────────────────────────────────
             # Track LLM output and TTS output separately so fallback only re-runs

--- a/services/zoe-data/routers/skybridge.py
+++ b/services/zoe-data/routers/skybridge.py
@@ -28,10 +28,12 @@ async def get_skybridge_status():
         "entrypoint": "/touch/skybridge.html",
         "version": 1,
         "card_contract": {
-            "status": "wired_for_calendar_weather_lists_people",
+            "status": "wired_for_calendar_weather_lists_people_actions_v1",
             "supported_major": 1,
             "data_domains": ["calendar", "weather", "lists", "people"],
             "voice_ws_domains": ["calendar", "weather", "lists", "people"],
+            "action_domains": ["calendar", "lists", "people"],
+            "context_refresh": True,
             "client_capability_cards": True,
         },
         "transports": {
@@ -41,7 +43,7 @@ async def get_skybridge_status():
         "capabilities": {
             "pages": 15,
             "settings": 22,
-            "dynamic_cards": "calendar_weather_lists_people_data_cards",
+            "dynamic_cards": "calendar_weather_lists_people_data_and_action_cards",
         },
     }
 
@@ -54,4 +56,7 @@ async def resolve_skybridge_command(
 ):
     """Resolve a typed Skybridge command into real data cards when supported."""
     message = str((payload or {}).get("message") or "").strip()
-    return await resolve_skybridge_request(message, user.get("user_id", "voice-guest"), db=db)
+    context = (payload or {}).get("context")
+    if not isinstance(context, dict):
+        context = None
+    return await resolve_skybridge_request(message, user.get("user_id", "voice-guest"), context=context, db=db)

--- a/services/zoe-data/skybridge_service.py
+++ b/services/zoe-data/skybridge_service.py
@@ -1061,6 +1061,14 @@ async def _resolve_people_remember_fact(intent: SkybridgeIntent, user_id: str, d
             "actions": [],
         }
     person = await _find_or_create_person(user_id, intent.person_name, db)
+    if person.get("user_id") and person.get("user_id") != user_id:
+        return {
+            "handled": True,
+            "intent": _intent_dict(intent),
+            "spoken_summary": "I can see that person, but I cannot update their profile from this account.",
+            "cards": [_status_card("I could not update that profile", "That person is visible to the family, but this account does not own the profile. Ask the owner to update it or create a new profile.")],
+            "actions": [],
+        }
     memory_bits = []
     if intent.fact_text:
         memory_bits.append(f"{intent.person_name} {intent.fact_text}")

--- a/services/zoe-data/skybridge_service.py
+++ b/services/zoe-data/skybridge_service.py
@@ -398,16 +398,16 @@ def classify_skybridge_intent(message: str, context: dict[str, Any] | None = Non
         list_type = _list_type_from_text(text)
         return SkybridgeIntent(domain="lists", action="show", list_type=list_type)
     if any(term in text for term in (" people", " contacts", " contact", " person", " profile", " family", " friends")):
-        query, context, circle = _people_filters_from_text(text)
+        query, people_ctx, circle = _people_filters_from_text(text)
         if " family " in text and not query:
             query = "family"
         if " friends " in text and not query:
             query = "friend"
-        return SkybridgeIntent(domain="people", action="show", query=query, context=context, circle=circle)
+        return SkybridgeIntent(domain="people", action="show", query=query, context=people_ctx, circle=circle)
     if re.search(r"\b(?:find|search for|look up|show)\s+(?:my\s+)?[a-z][a-z .'-]{1,80}\b", text):
-        query, context, circle = _people_filters_from_text(text)
+        query, people_ctx, circle = _people_filters_from_text(text)
         if query:
-            return SkybridgeIntent(domain="people", action="show", query=query, context=context, circle=circle)
+            return SkybridgeIntent(domain="people", action="show", query=query, context=people_ctx, circle=circle)
     return None
 
 
@@ -469,6 +469,15 @@ async def _maybe_commit(db: Any) -> None:
     commit = getattr(db, "commit", None)
     if callable(commit):
         await commit()
+
+
+def _affected_rows(result: Any) -> int | None:
+    if result is None:
+        return None
+    if isinstance(result, int):
+        return result
+    match = re.search(r"\b(?:INSERT|UPDATE|DELETE)\s+(\d+)\b", str(result))
+    return int(match.group(1)) if match else None
 
 
 def _status_card(title: str, body: str, *, status: str = "Needs context") -> dict[str, Any]:
@@ -593,12 +602,20 @@ async def _resolve_calendar_update_time(intent: SkybridgeIntent, user_id: str, d
         }
     event = matches[0]
     event_id = event.get("id")
-    await db.execute(
+    update_result = await db.execute(
         "UPDATE events SET start_time = $1, updated_at = NOW() WHERE id = $2 AND user_id = $3 AND deleted = 0",
         intent.target_time,
         event_id,
         user_id,
     )
+    if _affected_rows(update_result) == 0:
+        return {
+            "handled": True,
+            "intent": _intent_dict(intent),
+            "spoken_summary": "I can see that event, but I cannot move it from this account.",
+            "cards": [_status_card("I could not move that event", "The event is visible to the family, but this account does not own it. Ask the owner to move it or create a new event.")],
+            "actions": [],
+        }
     await _maybe_commit(db)
     start = date.fromisoformat(str(event.get("start_date") or _context_calendar_date(context).isoformat())[:10])
     refreshed = await _resolve_calendar(SkybridgeIntent("calendar", "show", start.isoformat(), start, start), user_id, db)
@@ -1044,6 +1061,26 @@ async def _resolve_people_remember_fact(intent: SkybridgeIntent, user_id: str, d
             "actions": [],
         }
     person = await _find_or_create_person(user_id, intent.person_name, db)
+    memory_bits = []
+    if intent.fact_text:
+        memory_bits.append(f"{intent.person_name} {intent.fact_text}")
+    if intent.birthday:
+        memory_bits.append(f"{intent.person_name}'s birthday is {intent.birthday}")
+    if memory_bits:
+        memory_stored = await _store_skybridge_memory_fact(
+            ". ".join(memory_bits),
+            user_id=user_id,
+            person_id=str(person.get("id") or ""),
+            person_name=intent.person_name,
+        )
+        if not memory_stored:
+            return {
+                "handled": True,
+                "intent": _intent_dict(intent),
+                "spoken_summary": "I could not save that memory.",
+                "cards": [_status_card("Memory was not saved", "Zoe could not store that people fact through the memory service, so the profile card was left unchanged.")],
+                "actions": [],
+            }
     updates = []
     params: list[Any] = []
     note_fact = intent.fact_text
@@ -1056,22 +1093,13 @@ async def _resolve_people_remember_fact(intent: SkybridgeIntent, user_id: str, d
     if updates:
         updates.append("updated_at = NOW()")
         params.extend([person["id"], user_id])
+        # MemoryService is the write gate for the fact; this table update is the
+        # people-card projection so the visible profile reflects the saved memory.
         await db.execute(
             f"UPDATE people SET {', '.join(updates)} WHERE id = ${len(params)-1} AND user_id = ${len(params)}",
             *params,
         )
         await _maybe_commit(db)
-    memory_bits = []
-    if note_fact:
-        memory_bits.append(f"{intent.person_name} {note_fact}")
-    if intent.birthday:
-        memory_bits.append(f"{intent.person_name}'s birthday is {intent.birthday}")
-    await _store_skybridge_memory_fact(
-        ". ".join(memory_bits),
-        user_id=user_id,
-        person_id=str(person.get("id") or ""),
-        person_name=intent.person_name,
-    )
     refreshed = await _resolve_people(
         SkybridgeIntent(domain="people", action="show", query=intent.person_name),
         user_id,

--- a/services/zoe-data/skybridge_service.py
+++ b/services/zoe-data/skybridge_service.py
@@ -227,8 +227,10 @@ def _parse_time(text: str) -> str:
         return ""
     if ampm.startswith("p") and hour < 12:
         hour += 12
-    if ampm.startswith("a") and hour == 12:
+    elif ampm.startswith("a") and hour == 12:
         hour = 0
+    elif not ampm and 1 <= hour <= 11:
+        hour += 12
     return f"{hour:02d}:{minute:02d}"
 
 

--- a/services/zoe-data/skybridge_service.py
+++ b/services/zoe-data/skybridge_service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+import uuid
 from dataclasses import dataclass
 from datetime import date, timedelta
 from typing import Any
@@ -24,6 +25,13 @@ class SkybridgeIntent:
     list_type: str = ""
     context: str = ""
     circle: str = ""
+    item_text: str = ""
+    target_time: str = ""
+    title: str = ""
+    target_text: str = ""
+    person_name: str = ""
+    fact_text: str = ""
+    birthday: str = ""
 
 
 MONTHS = {
@@ -156,6 +164,160 @@ def _list_type_from_text(text: str) -> str:
     return ""
 
 
+def _context_domain(context: dict[str, Any] | None) -> str:
+    if not isinstance(context, dict):
+        return ""
+    intent = context.get("intent") if isinstance(context.get("intent"), dict) else {}
+    return str(intent.get("domain") or context.get("domain") or "").strip().lower()
+
+
+def _context_cards(context: dict[str, Any] | None) -> list[dict[str, Any]]:
+    if not isinstance(context, dict):
+        return []
+    cards = context.get("cards")
+    return cards if isinstance(cards, list) else []
+
+
+def _context_calendar_date(context: dict[str, Any] | None) -> date:
+    for card in _context_cards(context):
+        content = card.get("content") if isinstance(card, dict) else {}
+        if isinstance(content, dict) and content.get("source") == "calendar_show":
+            raw = content.get("start_date") or content.get("date")
+            if raw:
+                try:
+                    return date.fromisoformat(str(raw)[:10])
+                except ValueError:
+                    pass
+    return _today()
+
+
+def _context_events(context: dict[str, Any] | None) -> list[dict[str, Any]]:
+    events: list[dict[str, Any]] = []
+    for card in _context_cards(context):
+        content = card.get("content") if isinstance(card, dict) else {}
+        if isinstance(content, dict) and content.get("source") == "calendar_show":
+            raw_events = content.get("events") or []
+            if isinstance(raw_events, list):
+                events.extend(item for item in raw_events if isinstance(item, dict))
+    return events
+
+
+def _context_list_hint(context: dict[str, Any] | None) -> tuple[str, str]:
+    for card in _context_cards(context):
+        content = card.get("content") if isinstance(card, dict) else {}
+        if isinstance(content, dict) and content.get("source") == "list_show":
+            list_id = str(content.get("list_id") or "")
+            if list_id and list_id != "lists-overview":
+                return list_id, str(content.get("list_type") or "")
+            lists = content.get("lists")
+            if isinstance(lists, list) and len(lists) == 1 and isinstance(lists[0], dict):
+                return str(lists[0].get("id") or ""), str(lists[0].get("list_type") or content.get("list_type") or "")
+            return "", str(content.get("list_type") or "")
+    return "", ""
+
+
+def _parse_time(text: str) -> str:
+    match = re.search(r"\b(?P<hour>\d{1,2})(?::(?P<minute>\d{2}))?\s*(?P<ampm>a\.?m\.?|p\.?m\.?)?\b", text, re.IGNORECASE)
+    if not match:
+        return ""
+    hour = int(match.group("hour"))
+    minute = int(match.group("minute") or "0")
+    ampm = (match.group("ampm") or "").lower()
+    if hour > 23 or minute > 59:
+        return ""
+    if ampm.startswith("p") and hour < 12:
+        hour += 12
+    if ampm.startswith("a") and hour == 12:
+        hour = 0
+    return f"{hour:02d}:{minute:02d}"
+
+
+def _clean_action_text(value: str) -> str:
+    text = re.sub(r"\s+", " ", value or "").strip(" .")
+    return re.sub(r"^(?:my|the|a|an)\s+", "", text, flags=re.IGNORECASE).strip()
+
+
+def _list_add_from_text(message: str) -> tuple[str, str] | None:
+    match = re.search(
+        r"\badd\s+(?P<item>.+?)\s+to\s+(?:the\s+|my\s+)?(?P<list>shopping list|grocery list|groceries|list|task list|todo list|tasks|todos)\b",
+        message,
+        re.IGNORECASE,
+    )
+    if not match:
+        return None
+    item = _clean_action_text(match.group("item"))
+    list_phrase = f" {match.group('list').lower()} "
+    list_type = _list_type_from_text(list_phrase) or ("shopping" if "grocery" in list_phrase else "")
+    return item, list_type or "shopping"
+
+
+def _calendar_create_from_text(message: str, context: dict[str, Any] | None) -> tuple[str, str] | None:
+    match = re.search(r"\badd\s+(?P<title>.+?)\s+(?:at|for)\s+(?P<time>\d{1,2}(?::\d{2})?\s*(?:a\.?m\.?|p\.?m\.?)?)\b", message, re.IGNORECASE)
+    if not match:
+        return None
+    if _context_domain(context) != "calendar" and not re.search(r"\b(calendar|schedule|event|appointment|meeting)\b", message, re.IGNORECASE):
+        return None
+    title = _clean_action_text(match.group("title"))
+    target_time = _parse_time(match.group("time"))
+    return (title, target_time) if title and target_time else None
+
+
+def _calendar_update_from_text(message: str, context: dict[str, Any] | None) -> tuple[str, str] | None:
+    match = re.search(
+        r"\b(?:change|move|reschedule)\s+(?P<target>.+?)\s+to\s+(?P<time>\d{1,2}(?::\d{2})?\s*(?:a\.?m\.?|p\.?m\.?)?)\b",
+        message,
+        re.IGNORECASE,
+    )
+    if not match:
+        return None
+    if _context_domain(context) != "calendar" and not re.search(r"\b(calendar|schedule|event|appointment|meeting)\b", message, re.IGNORECASE):
+        return None
+    target = _clean_action_text(match.group("target"))
+    target_time = _parse_time(match.group("time"))
+    return (target, target_time) if target_time else None
+
+
+def _birthday_from_text(text: str) -> str:
+    match = re.search(
+        rf"\b(?:birthday\s+is|birthday\s+on|born\s+on)\s+(?:the\s+)?(?P<day>\d{{1,2}})(?:st|nd|rd|th)?(?:\s+of)?\s+(?P<month>{MONTH_PATTERN})\b",
+        text,
+        re.IGNORECASE,
+    )
+    if not match:
+        return ""
+    day = int(match.group("day"))
+    month_name = match.group("month").lower()
+    month = MONTHS.get(month_name)
+    if not month:
+        return ""
+    try:
+        target = date(2000, month, day)
+    except ValueError:
+        return ""
+    return f"{target.day} {target.strftime('%B')}"
+
+
+def _people_fact_from_text(message: str) -> tuple[str, str, str] | None:
+    match = re.search(
+        r"\bremember\s+(?:that\s+)?(?P<name>[a-z][a-z]+(?:\s+[a-z][a-z]+)?)\s+(?P<fact>(?:likes|loves|hates|prefers|birthday|born|has|is)\b.+)$",
+        message.strip(),
+        re.IGNORECASE,
+    )
+    if not match:
+        return None
+    name = match.group("name").strip().title()
+    fact = match.group("fact").strip(" .")
+    birthday = _birthday_from_text(fact)
+    fact = re.sub(
+        rf"\s*(?:and\s+)?(?:her|his|their)?\s*birthday\s+is\s+(?:the\s+)?\d{{1,2}}(?:st|nd|rd|th)?(?:\s+of)?\s+(?:{MONTH_PATTERN})\s*",
+        " ",
+        fact,
+        flags=re.IGNORECASE,
+    )
+    fact = _clean_action_text(fact)
+    return name, fact, birthday
+
+
 def _people_filters_from_text(text: str) -> tuple[str, str, str]:
     context = next((value for value in PEOPLE_CONTEXTS if f" {value} " in text), "")
     circle = next((value for value in PEOPLE_CIRCLES if f" {value} " in text), "")
@@ -188,9 +350,28 @@ def _people_filters_from_text(text: str) -> tuple[str, str, str]:
     return query, context, circle
 
 
-def classify_skybridge_intent(message: str) -> SkybridgeIntent | None:
+def classify_skybridge_intent(message: str, context: dict[str, Any] | None = None) -> SkybridgeIntent | None:
     """Classify only domains that Skybridge can resolve to real data cards."""
-    text = f" {(message or '').lower()} "
+    raw_message = message or ""
+    text = f" {raw_message.lower()} "
+    person_fact = _people_fact_from_text(raw_message)
+    if person_fact:
+        name, fact, birthday = person_fact
+        return SkybridgeIntent(domain="people", action="remember_fact", person_name=name, fact_text=fact, birthday=birthday)
+    calendar_update = _calendar_update_from_text(raw_message, context)
+    if calendar_update:
+        target, target_time = calendar_update
+        return SkybridgeIntent(domain="calendar", action="update_time", target_text=target, target_time=target_time)
+    list_add = _list_add_from_text(raw_message)
+    if list_add:
+        item, list_type = list_add
+        return SkybridgeIntent(domain="lists", action="add_item", item_text=item, list_type=list_type)
+    calendar_create = _calendar_create_from_text(raw_message, context)
+    if calendar_create:
+        title, target_time = calendar_create
+        parsed_range = _calendar_date_from_text(text, _today())
+        start = parsed_range[1] if parsed_range else _context_calendar_date(context)
+        return SkybridgeIntent(domain="calendar", action="create_event", title=title, target_time=target_time, range_label=start.isoformat(), start_date=start, end_date=start)
     if any(term in text for term in (" weather", " forecast", " temperature", " rain", " windy", " wind ")):
         action = "forecast" if any(term in text for term in ("forecast", "tomorrow", "week", "next few days")) else "current"
         return SkybridgeIntent(domain="weather", action=action)
@@ -234,35 +415,197 @@ async def resolve_skybridge_request(
     message: str,
     user_id: str,
     *,
+    context: dict[str, Any] | None = None,
     db: Any | None = None,
 ) -> dict[str, Any]:
     """Resolve a typed or spoken Skybridge request into real card contracts."""
-    intent = classify_skybridge_intent(message)
+    intent = classify_skybridge_intent(message, context)
     if intent is None:
         return {
             "handled": False,
             "intent": None,
             "spoken_summary": "",
             "cards": [],
+            "skybridge_context": context or {},
         }
 
     if db is not None:
-        return await _resolve_with_db(intent, user_id, db)
+        return _attach_skybridge_context(await _resolve_with_db(intent, user_id, db, context=context))
 
     async with get_db_ctx() as ctx_db:
-        return await _resolve_with_db(intent, user_id, ctx_db)
+        return _attach_skybridge_context(await _resolve_with_db(intent, user_id, ctx_db, context=context))
 
 
-async def _resolve_with_db(intent: SkybridgeIntent, user_id: str, db: Any) -> dict[str, Any]:
+def _attach_skybridge_context(result: dict[str, Any]) -> dict[str, Any]:
+    if result.get("handled"):
+        result["skybridge_context"] = {
+            "intent": result.get("intent") or {},
+            "cards": result.get("cards") or [],
+        }
+    return result
+
+
+async def _resolve_with_db(intent: SkybridgeIntent, user_id: str, db: Any, *, context: dict[str, Any] | None = None) -> dict[str, Any]:
     if intent.domain == "calendar":
+        if intent.action == "create_event":
+            return await _resolve_calendar_create(intent, user_id, db)
+        if intent.action == "update_time":
+            return await _resolve_calendar_update_time(intent, user_id, db, context)
         return await _resolve_calendar(intent, user_id, db)
     if intent.domain == "weather":
         return await _resolve_weather(intent, user_id, db)
     if intent.domain == "lists":
+        if intent.action == "add_item":
+            return await _resolve_list_add_item(intent, user_id, db, context)
         return await _resolve_lists(intent, user_id, db)
     if intent.domain == "people":
+        if intent.action == "remember_fact":
+            return await _resolve_people_remember_fact(intent, user_id, db)
         return await _resolve_people(intent, user_id, db)
     return {"handled": False, "intent": None, "spoken_summary": "", "cards": []}
+
+
+async def _maybe_commit(db: Any) -> None:
+    commit = getattr(db, "commit", None)
+    if callable(commit):
+        await commit()
+
+
+def _status_card(title: str, body: str, *, status: str = "Needs context") -> dict[str, Any]:
+    return {
+        "component": "status",
+        "props": {
+            "title": title,
+            "body": body,
+            "status": status,
+            "tone": "warn",
+            "wide": True,
+        },
+    }
+
+
+def _intent_dict(intent: SkybridgeIntent) -> dict[str, Any]:
+    return {
+        "domain": intent.domain,
+        "action": intent.action,
+        "list_type": intent.list_type,
+        "target_time": intent.target_time,
+    }
+
+
+async def _resolve_calendar_create(intent: SkybridgeIntent, user_id: str, db: Any) -> dict[str, Any]:
+    if user_id in {"guest", "voice-guest"}:
+        return {
+            "handled": True,
+            "intent": _intent_dict(intent),
+            "spoken_summary": "Calendar changes are not available for guest sessions.",
+            "cards": [_status_card("Sign in to change calendar", "Zoe needs to know who is speaking before creating calendar events.")],
+            "actions": [],
+        }
+    start = intent.start_date or _today()
+    event_id = str(uuid.uuid4())
+    await db.execute(
+        """
+        INSERT INTO events (
+            id, user_id, title, start_date, start_time, end_date, end_time,
+            duration, category, location, all_day, recurring, metadata,
+            visibility, deleted
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, 0)
+        """,
+        event_id,
+        user_id,
+        intent.title,
+        start.isoformat(),
+        intent.target_time,
+        start.isoformat(),
+        "",
+        None,
+        "general",
+        None,
+        0,
+        None,
+        None,
+        "family",
+    )
+    await _maybe_commit(db)
+    refreshed = await _resolve_calendar(SkybridgeIntent("calendar", "show", start.isoformat(), start, start), user_id, db)
+    refreshed["intent"] = {"domain": "calendar", "action": "create_event", "event_id": event_id}
+    refreshed["spoken_summary"] = f"Added {intent.title} at {intent.target_time}."
+    refreshed["actions"] = [{"type": "created", "domain": "calendar", "id": event_id}]
+    return refreshed
+
+
+def _score_event_for_target(event: dict[str, Any], target: str) -> int:
+    score = 0
+    target_time = _parse_time(target)
+    if target_time and str(event.get("start_time") or "")[:5] == target_time:
+        score += 4
+    target_tokens = {token for token in re.split(r"\W+", target.lower()) if token and token not in {"my", "the", "appointment", "event"}}
+    haystack = " ".join(str(event.get(key) or "") for key in ("title", "category", "location")).lower()
+    if not target_tokens:
+        return score or 1
+    return score + sum(1 for token in target_tokens if token in haystack)
+
+
+async def _resolve_calendar_update_time(intent: SkybridgeIntent, user_id: str, db: Any, context: dict[str, Any] | None) -> dict[str, Any]:
+    if user_id in {"guest", "voice-guest"}:
+        return {
+            "handled": True,
+            "intent": _intent_dict(intent),
+            "spoken_summary": "Calendar changes are not available for guest sessions.",
+            "cards": [_status_card("Sign in to change calendar", "Zoe needs to know who is speaking before moving appointments.")],
+            "actions": [],
+        }
+    candidates = _context_events(context)
+    if not candidates:
+        start = _context_calendar_date(context)
+        rows = await db.fetch(
+            """
+            SELECT *
+            FROM events
+            WHERE (visibility = 'family' OR user_id = $1)
+              AND deleted = 0
+              AND start_date = $2
+            ORDER BY start_time
+            """,
+            user_id,
+            start.isoformat(),
+        )
+        candidates = [row_to_event(row) for row in rows]
+    if not candidates:
+        return {
+            "handled": True,
+            "intent": _intent_dict(intent),
+            "spoken_summary": "I could not find a calendar event to move.",
+            "cards": [_status_card("Which appointment?", "I could not find a visible calendar event to move. Show the calendar first or name the event.")],
+            "actions": [],
+        }
+    scored = sorted(((event, _score_event_for_target(event, intent.target_text)) for event in candidates), key=lambda pair: pair[1], reverse=True)
+    top_score = scored[0][1]
+    matches = [event for event, score in scored if score == top_score and score > 0]
+    if len(matches) != 1:
+        return {
+            "handled": True,
+            "intent": _intent_dict(intent),
+            "spoken_summary": "I need to know which event to move.",
+            "cards": [_status_card("Which event should move?", "There is more than one possible calendar event. Say the event title and the new time.")],
+            "actions": [],
+        }
+    event = matches[0]
+    event_id = event.get("id")
+    await db.execute(
+        "UPDATE events SET start_time = $1, updated_at = NOW() WHERE id = $2 AND user_id = $3 AND deleted = 0",
+        intent.target_time,
+        event_id,
+        user_id,
+    )
+    await _maybe_commit(db)
+    start = date.fromisoformat(str(event.get("start_date") or _context_calendar_date(context).isoformat())[:10])
+    refreshed = await _resolve_calendar(SkybridgeIntent("calendar", "show", start.isoformat(), start, start), user_id, db)
+    refreshed["intent"] = {"domain": "calendar", "action": "update_time", "event_id": event_id}
+    refreshed["spoken_summary"] = f"Moved {event.get('title') or 'the event'} to {intent.target_time}."
+    refreshed["actions"] = [{"type": "updated", "domain": "calendar", "id": event_id}]
+    return refreshed
 
 
 async def _resolve_calendar(intent: SkybridgeIntent, user_id: str, db: Any) -> dict[str, Any]:
@@ -433,6 +776,85 @@ async def _resolve_lists(intent: SkybridgeIntent, user_id: str, db: Any) -> dict
     }
 
 
+async def _find_or_create_list(intent: SkybridgeIntent, user_id: str, db: Any, context: dict[str, Any] | None) -> tuple[str, str]:
+    hinted_id, hinted_type = _context_list_hint(context)
+    list_type = intent.list_type or hinted_type or "shopping"
+    if hinted_id:
+        return hinted_id, list_type
+    rows = await db.fetch(
+        """
+        SELECT id, name, list_type
+        FROM lists
+        WHERE list_type = $2 AND deleted = 0
+          AND (visibility = 'family' OR user_id = $1)
+        ORDER BY updated_at DESC
+        LIMIT 1
+        """,
+        user_id,
+        list_type,
+    )
+    if rows:
+        row = dict(rows[0])
+        return str(row["id"]), str(row.get("list_type") or list_type)
+    list_id = str(uuid.uuid4())
+    list_name = "Shopping" if list_type == "shopping" else list_type.title()
+    await db.execute(
+        """
+        INSERT INTO lists (id, user_id, name, list_type, description, visibility)
+        VALUES ($1, $2, $3, $4, $5, $6)
+        """,
+        list_id,
+        user_id,
+        list_name,
+        list_type,
+        "",
+        "family",
+    )
+    await _maybe_commit(db)
+    return list_id, list_type
+
+
+async def _resolve_list_add_item(intent: SkybridgeIntent, user_id: str, db: Any, context: dict[str, Any] | None) -> dict[str, Any]:
+    if user_id in {"guest", "voice-guest"}:
+        return {
+            "handled": True,
+            "intent": _intent_dict(intent),
+            "spoken_summary": "List changes are not available for guest sessions.",
+            "cards": [_status_card("Sign in to change lists", "Zoe needs to know who is speaking before editing list items.")],
+            "actions": [],
+        }
+    if not intent.item_text:
+        return {
+            "handled": True,
+            "intent": _intent_dict(intent),
+            "spoken_summary": "I did not catch the list item.",
+            "cards": [_status_card("What should I add?", "Say the item and the list, for example: add bread to the shopping list.")],
+            "actions": [],
+        }
+    list_id, list_type = await _find_or_create_list(intent, user_id, db, context)
+    item_id = str(uuid.uuid4())
+    await db.execute(
+        """
+        INSERT INTO list_items (id, list_id, text, priority, category, quantity, parent_id, assigned_to)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+        """,
+        item_id,
+        list_id,
+        intent.item_text,
+        "normal",
+        "",
+        "",
+        None,
+        None,
+    )
+    await _maybe_commit(db)
+    refreshed = await _resolve_lists(SkybridgeIntent(domain="lists", action="show", list_type=list_type), user_id, db)
+    refreshed["intent"] = {"domain": "lists", "action": "add_item", "list_type": list_type, "item_id": item_id}
+    refreshed["spoken_summary"] = f"Added {intent.item_text} to the {list_type} list."
+    refreshed["actions"] = [{"type": "created", "domain": "lists", "id": item_id, "list_id": list_id}]
+    return refreshed
+
+
 async def _resolve_people(intent: SkybridgeIntent, user_id: str, db: Any) -> dict[str, Any]:
     if user_id in {"guest", "voice-guest"}:
         card = card_service.build_people_directory_card(
@@ -515,3 +937,147 @@ async def _resolve_people(intent: SkybridgeIntent, user_id: str, db: Any) -> dic
         "spoken_summary": spoken,
         "cards": [card_service.convert_emit(card, target_major=1)],
     }
+
+
+async def _store_skybridge_memory_fact(
+    fact: str,
+    *,
+    user_id: str,
+    person_id: str | None = None,
+    person_name: str = "",
+) -> bool:
+    if not fact.strip():
+        return False
+    try:
+        from memory_service import MemoryServiceError, get_memory_service
+
+        try:
+            await get_memory_service().ingest(
+                fact,
+                user_id=user_id,
+                source="skybridge_action",
+                memory_type="person" if person_id else "fact",
+                confidence=0.86,
+                status="approved",
+                tags=["skybridge", "person"] if person_id else ["skybridge"],
+                entity_type="person" if person_id else None,
+                entity_id=person_id,
+                source_excerpt=person_name or fact[:80],
+            )
+            return True
+        except MemoryServiceError:
+            return False
+    except Exception:
+        return False
+
+
+async def _find_or_create_person(user_id: str, name: str, db: Any) -> dict[str, Any]:
+    rows = await db.fetch(
+        """
+        SELECT *
+        FROM people
+        WHERE deleted = 0
+          AND (visibility = 'family' OR user_id = $1)
+          AND lower(name) = lower($2)
+        ORDER BY is_partial ASC, updated_at DESC
+        LIMIT 1
+        """,
+        user_id,
+        name,
+    )
+    if rows:
+        return row_to_person(rows[0])
+    person_id = str(uuid.uuid4())
+    await db.execute(
+        """
+        INSERT INTO people (id, user_id, name, relationship, circle, context, visibility, is_partial)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+        """,
+        person_id,
+        user_id,
+        name,
+        None,
+        "circle",
+        "personal",
+        "family",
+        0,
+    )
+    await _maybe_commit(db)
+    return {
+        "id": person_id,
+        "user_id": user_id,
+        "name": name,
+        "relationship": None,
+        "circle": "circle",
+        "context": "personal",
+        "visibility": "family",
+        "is_partial": False,
+    }
+
+
+def _append_note(existing: str | None, addition: str) -> str:
+    existing_text = str(existing or "").strip()
+    addition_text = addition.strip().rstrip(".")
+    if not addition_text:
+        return existing_text
+    sentence = addition_text[:1].upper() + addition_text[1:] + "."
+    if sentence.lower() in existing_text.lower():
+        return existing_text
+    return f"{existing_text} {sentence}".strip()
+
+
+async def _resolve_people_remember_fact(intent: SkybridgeIntent, user_id: str, db: Any) -> dict[str, Any]:
+    if user_id in {"guest", "voice-guest"}:
+        return {
+            "handled": True,
+            "intent": _intent_dict(intent),
+            "spoken_summary": "People memory changes are not available for guest sessions.",
+            "cards": [_status_card("Sign in to remember this", "Zoe needs to know who is speaking before saving people facts.")],
+            "actions": [],
+        }
+    if not intent.person_name:
+        return {
+            "handled": True,
+            "intent": _intent_dict(intent),
+            "spoken_summary": "I did not catch who this is about.",
+            "cards": [_status_card("Who is this about?", "Say the person's name and the fact you want Zoe to remember.")],
+            "actions": [],
+        }
+    person = await _find_or_create_person(user_id, intent.person_name, db)
+    updates = []
+    params: list[Any] = []
+    note_fact = intent.fact_text
+    if note_fact:
+        updates.append("notes = $" + str(len(params) + 1))
+        params.append(_append_note(person.get("notes"), note_fact))
+    if intent.birthday:
+        updates.append("birthday = $" + str(len(params) + 1))
+        params.append(intent.birthday)
+    if updates:
+        updates.append("updated_at = NOW()")
+        params.extend([person["id"], user_id])
+        await db.execute(
+            f"UPDATE people SET {', '.join(updates)} WHERE id = ${len(params)-1} AND user_id = ${len(params)}",
+            *params,
+        )
+        await _maybe_commit(db)
+    memory_bits = []
+    if note_fact:
+        memory_bits.append(f"{intent.person_name} {note_fact}")
+    if intent.birthday:
+        memory_bits.append(f"{intent.person_name}'s birthday is {intent.birthday}")
+    await _store_skybridge_memory_fact(
+        ". ".join(memory_bits),
+        user_id=user_id,
+        person_id=str(person.get("id") or ""),
+        person_name=intent.person_name,
+    )
+    refreshed = await _resolve_people(
+        SkybridgeIntent(domain="people", action="show", query=intent.person_name),
+        user_id,
+        db,
+    )
+    refreshed["intent"] = {"domain": "people", "action": "remember_fact", "query": intent.person_name}
+    refreshed["spoken_summary"] = f"Remembered that for {intent.person_name}."
+    refreshed["actions"] = [{"type": "updated", "domain": "people", "id": person.get("id")}]
+    return refreshed

--- a/services/zoe-data/skybridge_service.py
+++ b/services/zoe-data/skybridge_service.py
@@ -554,7 +554,7 @@ async def _resolve_calendar_create(intent: SkybridgeIntent, user_id: str, db: An
         start.isoformat(),
         intent.target_time,
         start.isoformat(),
-        "",
+        None,
         None,
         "general",
         None,

--- a/services/zoe-data/skybridge_service.py
+++ b/services/zoe-data/skybridge_service.py
@@ -793,11 +793,25 @@ async def _resolve_lists(intent: SkybridgeIntent, user_id: str, db: Any) -> dict
     }
 
 
-async def _find_or_create_list(intent: SkybridgeIntent, user_id: str, db: Any, context: dict[str, Any] | None) -> tuple[str, str]:
+async def _find_or_create_list(intent: SkybridgeIntent, user_id: str, db: Any, context: dict[str, Any] | None) -> tuple[str, str] | None:
     hinted_id, hinted_type = _context_list_hint(context)
     list_type = intent.list_type or hinted_type or "shopping"
     if hinted_id:
-        return hinted_id, list_type
+        rows = await db.fetch(
+            """
+            SELECT id, name, list_type
+            FROM lists
+            WHERE id = $1 AND deleted = 0
+              AND (visibility = 'family' OR user_id = $2)
+            LIMIT 1
+            """,
+            hinted_id,
+            user_id,
+        )
+        if not rows:
+            return None
+        row = dict(rows[0])
+        return str(row["id"]), str(row.get("list_type") or list_type)
     rows = await db.fetch(
         """
         SELECT id, name, list_type
@@ -848,7 +862,16 @@ async def _resolve_list_add_item(intent: SkybridgeIntent, user_id: str, db: Any,
             "cards": [_status_card("What should I add?", "Say the item and the list, for example: add bread to the shopping list.")],
             "actions": [],
         }
-    list_id, list_type = await _find_or_create_list(intent, user_id, db, context)
+    list_target = await _find_or_create_list(intent, user_id, db, context)
+    if not list_target:
+        return {
+            "handled": True,
+            "intent": _intent_dict(intent),
+            "spoken_summary": "I could not find that list anymore.",
+            "cards": [_status_card("Which list should I use?", "The list from the visible card is no longer available. Show your lists again or name the list to update.")],
+            "actions": [],
+        }
+    list_id, list_type = list_target
     item_id = str(uuid.uuid4())
     await db.execute(
         """

--- a/services/zoe-data/skybridge_service.py
+++ b/services/zoe-data/skybridge_service.py
@@ -230,6 +230,27 @@ def _parse_time(text: str) -> str:
     elif ampm.startswith("a") and hour == 12:
         hour = 0
     elif not ampm and 1 <= hour <= 11:
+        return ""
+    return f"{hour:02d}:{minute:02d}"
+
+
+def _parse_contextual_time(text: str, target: str, context: dict[str, Any] | None) -> str:
+    parsed = _parse_time(text)
+    if parsed:
+        return parsed
+    match = re.search(r"\b(?P<hour>\d{1,2})(?::(?P<minute>\d{2}))?\s*\b", text, re.IGNORECASE)
+    if not match:
+        return ""
+    hour = int(match.group("hour"))
+    minute = int(match.group("minute") or "0")
+    if not (1 <= hour <= 11) or minute > 59:
+        return ""
+    anchor_time = _parse_time(target)
+    if not anchor_time:
+        scored = sorted(((_score_event_for_target(event, target), event) for event in _context_events(context)), reverse=True, key=lambda pair: pair[0])
+        if scored and scored[0][0] > 0 and sum(1 for score, _event in scored if score == scored[0][0]) == 1:
+            anchor_time = str(scored[0][1].get("start_time") or "")[:5]
+    if anchor_time and int(anchor_time[:2]) >= 12:
         hour += 12
     return f"{hour:02d}:{minute:02d}"
 
@@ -275,7 +296,7 @@ def _calendar_update_from_text(message: str, context: dict[str, Any] | None) -> 
     if _context_domain(context) != "calendar" and not re.search(r"\b(calendar|schedule|event|appointment|meeting)\b", message, re.IGNORECASE):
         return None
     target = _clean_action_text(match.group("target"))
-    target_time = _parse_time(match.group("time"))
+    target_time = _parse_contextual_time(match.group("time"), target, context)
     return (target, target_time) if target_time else None
 
 
@@ -307,7 +328,11 @@ def _people_fact_from_text(message: str) -> tuple[str, str, str] | None:
     )
     if not match:
         return None
-    name = match.group("name").strip().title()
+    raw_name = match.group("name").strip()
+    first_word = raw_name.split()[0].lower()
+    if first_word in {"a", "an", "the", "my", "our", "your", "his", "her", "their", "this", "that"}:
+        return None
+    name = raw_name.title()
     fact = match.group("fact").strip(" .")
     birthday = _birthday_from_text(fact)
     fact = re.sub(

--- a/services/zoe-data/tests/test_skybridge_service.py
+++ b/services/zoe-data/tests/test_skybridge_service.py
@@ -40,6 +40,8 @@ class FakeDb:
         if "FROM events" in sql:
             return self.events
         if "FROM lists" in sql:
+            if "WHERE id = $1" in sql:
+                return [row for row in self.lists if row.get("id") == args[1]]
             return self.lists
         if "FROM list_items" in sql:
             self.list_item_fetch_count += 1
@@ -478,6 +480,27 @@ async def test_list_add_item_persists_and_refreshes_list_card():
     assert result["actions"][0]["domain"] == "lists"
     assert result["cards"][0]["content"]["items"][0]["text"] == "bread"
     assert result["skybridge_context"]["cards"][0]["content"]["items"][0]["text"] == "bread"
+
+
+@pytest.mark.asyncio
+async def test_list_add_item_rejects_stale_context_list_id():
+    context = {
+        "intent": {"domain": "lists"},
+        "cards": [{"content": {"source": "list_show", "list_id": "missing-list", "list_type": "shopping"}}],
+    }
+    db = FakeDb(lists=[], items_by_list={})
+
+    result = await resolve_skybridge_request(
+        "add bread to the shopping list",
+        "family-admin",
+        context=context,
+        db=db,
+    )
+
+    assert result["handled"] is True
+    assert result["actions"] == []
+    assert "could not find" in result["spoken_summary"]
+    assert not db.items_by_list
 
 
 @pytest.mark.asyncio

--- a/services/zoe-data/tests/test_skybridge_service.py
+++ b/services/zoe-data/tests/test_skybridge_service.py
@@ -321,6 +321,32 @@ async def test_calendar_update_can_target_visible_event_by_start_time():
 
 
 @pytest.mark.asyncio
+async def test_calendar_update_defaults_bare_voice_hour_to_pm():
+    event = {
+        "id": "event-1",
+        "user_id": "family-admin",
+        "title": "School pickup",
+        "start_date": "2026-06-17",
+        "start_time": "15:00",
+        "end_time": "15:30",
+        "category": "family",
+        "visibility": "family",
+        "deleted": False,
+    }
+    context = {
+        "intent": {"domain": "calendar"},
+        "cards": [{"content": {"source": "calendar_show", "start_date": "2026-06-17", "events": [event]}}],
+    }
+    db = FakeDb(events=[event])
+
+    result = await resolve_skybridge_request("move my 3pm to 4", "family-admin", context=context, db=db)
+
+    assert result["handled"] is True
+    assert result["intent"]["action"] == "update_time"
+    assert result["cards"][0]["content"]["events"][0]["start_time"] == "16:00"
+
+
+@pytest.mark.asyncio
 async def test_calendar_update_does_not_confirm_family_event_owned_by_someone_else():
     event = {
         "id": "event-1",

--- a/services/zoe-data/tests/test_skybridge_service.py
+++ b/services/zoe-data/tests/test_skybridge_service.py
@@ -31,6 +31,8 @@ class FakeDb:
         self.people = people or []
         self.fetch_args = None
         self.list_item_fetch_count = 0
+        self.executed = []
+        self.commits = 0
 
     async def fetch(self, *args):
         self.fetch_args = args
@@ -55,8 +57,84 @@ class FakeDb:
     async def fetchrow(self, *_args):
         return self.prefs
 
-    async def execute(self, *_args):
-        raise AssertionError("Skybridge service must use asyncpg fetch/fetchrow APIs")
+    async def execute(self, *args):
+        self.executed.append(args)
+        sql = str(args[0])
+        if "INSERT INTO events" in sql:
+            self.events.append(
+                {
+                    "id": args[1],
+                    "user_id": args[2],
+                    "title": args[3],
+                    "start_date": args[4],
+                    "start_time": args[5],
+                    "end_date": args[6],
+                    "end_time": args[7],
+                    "category": args[9],
+                    "location": args[10],
+                    "visibility": args[14],
+                    "deleted": False,
+                }
+            )
+            return None
+        if "UPDATE events SET start_time" in sql:
+            for event in self.events:
+                if event.get("id") == args[2]:
+                    event["start_time"] = args[1]
+            return None
+        if "INSERT INTO lists" in sql:
+            self.lists.append(
+                {
+                    "id": args[1],
+                    "user_id": args[2],
+                    "name": args[3],
+                    "list_type": args[4],
+                    "description": args[5],
+                    "visibility": args[6],
+                }
+            )
+            return None
+        if "INSERT INTO list_items" in sql:
+            item = {
+                "id": args[1],
+                "list_id": args[2],
+                "text": args[3],
+                "priority": args[4],
+                "category": args[5],
+                "quantity": args[6],
+                "completed": False,
+            }
+            self.items_by_list.setdefault(args[2], []).append(item)
+            return None
+        if "INSERT INTO people" in sql:
+            self.people.append(
+                {
+                    "id": args[1],
+                    "user_id": args[2],
+                    "name": args[3],
+                    "relationship": args[4],
+                    "circle": args[5],
+                    "context": args[6],
+                    "visibility": args[7],
+                    "is_partial": bool(args[8]),
+                }
+            )
+            return None
+        if "UPDATE people SET" in sql:
+            person_id = args[-2]
+            for person in self.people:
+                if person.get("id") == person_id:
+                    idx = 1
+                    if "notes =" in sql:
+                        person["notes"] = args[idx]
+                        idx += 1
+                    if "birthday =" in sql:
+                        person["birthday"] = args[idx]
+            return None
+        return None
+
+    async def commit(self):
+        self.commits += 1
 
 
 class GuardedGuestDb(FakeDb):
@@ -73,6 +151,39 @@ def test_classify_calendar_and_weather_requests():
     assert classify_skybridge_intent("find Sarah").domain == "people"
     assert classify_skybridge_intent("what is there to do this week") is None
     assert classify_skybridge_intent("open settings") is None
+
+
+def test_classify_skybridge_action_requests():
+    calendar_context = {"intent": {"domain": "calendar"}, "cards": []}
+
+    add_item = classify_skybridge_intent("Can you add bread to the shopping list")
+    assert add_item.domain == "lists"
+    assert add_item.action == "add_item"
+    assert add_item.item_text == "bread"
+    assert add_item.list_type == "shopping"
+
+    create_event = classify_skybridge_intent("Can you add pick up the groceries at 3pm", calendar_context)
+    assert create_event.domain == "calendar"
+    assert create_event.action == "create_event"
+    assert create_event.title == "pick up the groceries"
+    assert create_event.target_time == "15:00"
+
+    move_event = classify_skybridge_intent("Can you change my appointment to 9am", calendar_context)
+    assert move_event.domain == "calendar"
+    assert move_event.action == "update_time"
+    assert move_event.target_time == "09:00"
+
+    remember = classify_skybridge_intent("Can you remember that Sarah likes flowers and her birthday is the 1st of may")
+    assert remember.domain == "people"
+    assert remember.action == "remember_fact"
+    assert remember.person_name == "Sarah"
+    assert remember.fact_text == "likes flowers"
+    assert remember.birthday == "1 May"
+
+    lowercase_remember = classify_skybridge_intent("remember that sarah likes flowers")
+    assert lowercase_remember.domain == "people"
+    assert lowercase_remember.action == "remember_fact"
+    assert lowercase_remember.person_name == "Sarah"
 
 
 def test_classify_calendar_date_and_range_requests(monkeypatch):
@@ -147,6 +258,81 @@ async def test_calendar_request_returns_real_event_card():
     assert card["content"]["source"] == "calendar_show"
     assert card["content"]["events"][0]["title"] == "Dentist"
     assert "Surface" not in str(card)
+
+
+@pytest.mark.asyncio
+async def test_calendar_update_time_refreshes_visible_calendar_card():
+    event = {
+        "id": "event-1",
+        "user_id": "family-admin",
+        "title": "Dentist appointment",
+        "start_date": "2026-06-17",
+        "start_time": "15:00",
+        "end_time": "15:30",
+        "category": "health",
+        "visibility": "family",
+        "deleted": False,
+    }
+    context = {
+        "intent": {"domain": "calendar"},
+        "cards": [{"content": {"source": "calendar_show", "start_date": "2026-06-17", "events": [event]}}],
+    }
+    db = FakeDb(events=[event])
+
+    result = await resolve_skybridge_request("change my appointment to 9am", "family-admin", context=context, db=db)
+
+    assert result["handled"] is True
+    assert result["intent"]["action"] == "update_time"
+    assert result["actions"][0]["type"] == "updated"
+    assert result["cards"][0]["content"]["events"][0]["start_time"] == "09:00"
+    assert result["skybridge_context"]["intent"]["action"] == "update_time"
+
+
+@pytest.mark.asyncio
+async def test_calendar_update_can_target_visible_event_by_start_time():
+    event = {
+        "id": "event-1",
+        "user_id": "family-admin",
+        "title": "School pickup",
+        "start_date": "2026-06-17",
+        "start_time": "15:00",
+        "end_time": "15:30",
+        "category": "family",
+        "visibility": "family",
+        "deleted": False,
+    }
+    context = {
+        "intent": {"domain": "calendar"},
+        "cards": [{"content": {"source": "calendar_show", "start_date": "2026-06-17", "events": [event]}}],
+    }
+    db = FakeDb(events=[event])
+
+    result = await resolve_skybridge_request("move my 3pm to 4pm", "family-admin", context=context, db=db)
+
+    assert result["handled"] is True
+    assert result["intent"]["action"] == "update_time"
+    assert result["cards"][0]["content"]["events"][0]["start_time"] == "16:00"
+
+
+@pytest.mark.asyncio
+async def test_calendar_context_add_event_refreshes_calendar_card(monkeypatch):
+    class FrozenDate(date):
+        @classmethod
+        def today(cls):
+            return cls(2026, 6, 11)
+
+    monkeypatch.setattr(skybridge_service, "date", FrozenDate)
+    context = {"intent": {"domain": "calendar"}, "cards": [{"content": {"source": "calendar_show", "start_date": "2026-06-17", "events": []}}]}
+    db = FakeDb(events=[])
+
+    result = await resolve_skybridge_request("add pick up the groceries at 3pm", "family-admin", context=context, db=db)
+
+    assert result["handled"] is True
+    assert result["intent"]["action"] == "create_event"
+    event = result["cards"][0]["content"]["events"][0]
+    assert event["title"] == "pick up the groceries"
+    assert event["start_date"] == "2026-06-17"
+    assert event["start_time"] == "15:00"
 
 
 @pytest.mark.asyncio
@@ -239,6 +425,28 @@ async def test_lists_request_returns_real_list_items():
     assert card["content"]["items"][0]["text"] == "Milk"
     assert card["content"]["open_count"] == 1
     assert "Surface" not in str(card)
+
+
+@pytest.mark.asyncio
+async def test_list_add_item_persists_and_refreshes_list_card():
+    list_row = {
+        "id": "list-1",
+        "user_id": "family-admin",
+        "name": "Groceries",
+        "list_type": "shopping",
+        "description": "Weekly shop",
+        "visibility": "family",
+    }
+    db = FakeDb(lists=[list_row], items_by_list={"list-1": []})
+    context = {"intent": {"domain": "lists"}, "cards": [{"content": {"source": "list_show", "list_id": "list-1", "list_type": "shopping"}}]}
+
+    result = await resolve_skybridge_request("add bread to the shopping list", "family-admin", context=context, db=db)
+
+    assert result["handled"] is True
+    assert result["intent"]["action"] == "add_item"
+    assert result["actions"][0]["domain"] == "lists"
+    assert result["cards"][0]["content"]["items"][0]["text"] == "bread"
+    assert result["skybridge_context"]["cards"][0]["content"]["items"][0]["text"] == "bread"
 
 
 @pytest.mark.asyncio
@@ -355,6 +563,69 @@ async def test_people_singular_contact_request_returns_directory_not_search():
     assert result["handled"] is True
     assert result["intent"]["query"] == ""
     assert result["cards"][0]["content"]["source"] == "people_directory"
+
+
+@pytest.mark.asyncio
+async def test_people_remember_fact_updates_profile_card_and_memory(monkeypatch):
+    person = {
+        "id": "person-1",
+        "user_id": "family-admin",
+        "name": "Sarah",
+        "relationship": "Friend",
+        "circle": "inner",
+        "context": "personal",
+        "notes": "",
+        "visibility": "family",
+    }
+    remembered = {}
+
+    async def fake_memory(fact, **kwargs):
+        remembered["fact"] = fact
+        remembered.update(kwargs)
+        return True
+
+    monkeypatch.setattr(skybridge_service, "_store_skybridge_memory_fact", fake_memory)
+    result = await resolve_skybridge_request(
+        "remember that Sarah likes flowers and her birthday is the 1st of may",
+        "family-admin",
+        db=FakeDb(people=[person]),
+    )
+
+    assert result["handled"] is True
+    assert result["intent"]["action"] == "remember_fact"
+    profile = result["cards"][0]["content"]["person"]
+    assert profile["name"] == "Sarah"
+    assert profile["birthday"] == "1 May"
+    assert "Likes flowers." in profile["notes"]
+    assert remembered["fact"] == "Sarah likes flowers. Sarah's birthday is 1 May"
+    assert remembered["person_id"] == "person-1"
+
+
+@pytest.mark.asyncio
+async def test_people_remember_fact_creates_visible_profile_card(monkeypatch):
+    remembered = {}
+
+    async def fake_memory(fact, **kwargs):
+        remembered["fact"] = fact
+        remembered.update(kwargs)
+        return True
+
+    db = FakeDb(people=[])
+    monkeypatch.setattr(skybridge_service, "_store_skybridge_memory_fact", fake_memory)
+
+    result = await resolve_skybridge_request(
+        "remember that sarah likes flowers and her birthday is the 1st of may",
+        "family-admin",
+        db=db,
+    )
+
+    assert result["handled"] is True
+    profile = result["cards"][0]["content"]["person"]
+    assert profile["name"] == "Sarah"
+    assert profile["birthday"] == "1 May"
+    assert "Likes flowers." in profile["notes"]
+    assert db.people[0]["is_partial"] is False
+    assert remembered["person_id"] == db.people[0]["id"]
 
 
 @pytest.mark.asyncio

--- a/services/zoe-data/tests/test_skybridge_service.py
+++ b/services/zoe-data/tests/test_skybridge_service.py
@@ -691,6 +691,41 @@ async def test_people_remember_fact_leaves_profile_unchanged_when_memory_rejects
 
 
 @pytest.mark.asyncio
+async def test_people_remember_fact_does_not_update_family_profile_owned_by_someone_else(monkeypatch):
+    person = {
+        "id": "person-1",
+        "user_id": "other-family-user",
+        "name": "Sarah",
+        "relationship": "Friend",
+        "circle": "inner",
+        "context": "personal",
+        "notes": "",
+        "visibility": "family",
+    }
+    remembered = {}
+
+    async def fake_memory(fact, **kwargs):
+        remembered["fact"] = fact
+        remembered.update(kwargs)
+        return True
+
+    db = FakeDb(people=[person])
+    monkeypatch.setattr(skybridge_service, "_store_skybridge_memory_fact", fake_memory)
+
+    result = await resolve_skybridge_request(
+        "remember that Sarah likes flowers",
+        "family-admin",
+        db=db,
+    )
+
+    assert result["handled"] is True
+    assert result["actions"] == []
+    assert "cannot update" in result["spoken_summary"]
+    assert remembered == {}
+    assert db.people[0].get("notes", "") == ""
+
+
+@pytest.mark.asyncio
 async def test_weather_current_request_returns_current_card(monkeypatch):
     async def fake_default(_db):
         return {"latitude": -28.7, "longitude": 114.6, "city": "Geraldton", "country": "AU"}

--- a/services/zoe-data/tests/test_skybridge_service.py
+++ b/services/zoe-data/tests/test_skybridge_service.py
@@ -406,6 +406,7 @@ async def test_calendar_context_add_event_refreshes_calendar_card(monkeypatch):
     assert event["title"] == "pick up the groceries"
     assert event["start_date"] == "2026-06-17"
     assert event["start_time"] == "15:00"
+    assert event["end_time"] is None
 
 
 @pytest.mark.asyncio

--- a/services/zoe-data/tests/test_skybridge_service.py
+++ b/services/zoe-data/tests/test_skybridge_service.py
@@ -76,12 +76,14 @@ class FakeDb:
                     "deleted": False,
                 }
             )
-            return None
+            return "INSERT 0 1"
         if "UPDATE events SET start_time" in sql:
+            updated = 0
             for event in self.events:
-                if event.get("id") == args[2]:
+                if event.get("id") == args[2] and event.get("user_id") == args[3]:
                     event["start_time"] = args[1]
-            return None
+                    updated += 1
+            return f"UPDATE {updated}"
         if "INSERT INTO lists" in sql:
             self.lists.append(
                 {
@@ -93,7 +95,7 @@ class FakeDb:
                     "visibility": args[6],
                 }
             )
-            return None
+            return "INSERT 0 1"
         if "INSERT INTO list_items" in sql:
             item = {
                 "id": args[1],
@@ -105,7 +107,7 @@ class FakeDb:
                 "completed": False,
             }
             self.items_by_list.setdefault(args[2], []).append(item)
-            return None
+            return "INSERT 0 1"
         if "INSERT INTO people" in sql:
             self.people.append(
                 {
@@ -119,8 +121,9 @@ class FakeDb:
                     "is_partial": bool(args[8]),
                 }
             )
-            return None
+            return "INSERT 0 1"
         if "UPDATE people SET" in sql:
+            updated = 0
             person_id = args[-2]
             for person in self.people:
                 if person.get("id") == person_id:
@@ -130,8 +133,9 @@ class FakeDb:
                         idx += 1
                     if "birthday =" in sql:
                         person["birthday"] = args[idx]
-            return None
-        return None
+                    updated += 1
+            return f"UPDATE {updated}"
+        return "UPDATE 0"
 
     async def commit(self):
         self.commits += 1
@@ -312,6 +316,33 @@ async def test_calendar_update_can_target_visible_event_by_start_time():
     assert result["handled"] is True
     assert result["intent"]["action"] == "update_time"
     assert result["cards"][0]["content"]["events"][0]["start_time"] == "16:00"
+
+
+@pytest.mark.asyncio
+async def test_calendar_update_does_not_confirm_family_event_owned_by_someone_else():
+    event = {
+        "id": "event-1",
+        "user_id": "other-family-user",
+        "title": "School pickup",
+        "start_date": "2026-06-17",
+        "start_time": "15:00",
+        "end_time": "15:30",
+        "category": "family",
+        "visibility": "family",
+        "deleted": False,
+    }
+    context = {
+        "intent": {"domain": "calendar"},
+        "cards": [{"content": {"source": "calendar_show", "start_date": "2026-06-17", "events": [event]}}],
+    }
+    db = FakeDb(events=[event])
+
+    result = await resolve_skybridge_request("move my 3pm to 4pm", "family-admin", context=context, db=db)
+
+    assert result["handled"] is True
+    assert result["actions"] == []
+    assert "cannot move" in result["spoken_summary"]
+    assert db.events[0]["start_time"] == "15:00"
 
 
 @pytest.mark.asyncio
@@ -626,6 +657,37 @@ async def test_people_remember_fact_creates_visible_profile_card(monkeypatch):
     assert "Likes flowers." in profile["notes"]
     assert db.people[0]["is_partial"] is False
     assert remembered["person_id"] == db.people[0]["id"]
+
+
+@pytest.mark.asyncio
+async def test_people_remember_fact_leaves_profile_unchanged_when_memory_rejects(monkeypatch):
+    person = {
+        "id": "person-1",
+        "user_id": "family-admin",
+        "name": "Sarah",
+        "relationship": "Friend",
+        "circle": "inner",
+        "context": "personal",
+        "notes": "",
+        "visibility": "family",
+    }
+
+    async def fake_memory(_fact, **_kwargs):
+        return False
+
+    db = FakeDb(people=[person])
+    monkeypatch.setattr(skybridge_service, "_store_skybridge_memory_fact", fake_memory)
+
+    result = await resolve_skybridge_request(
+        "remember that Sarah likes flowers",
+        "family-admin",
+        db=db,
+    )
+
+    assert result["handled"] is True
+    assert result["actions"] == []
+    assert "not saved" in result["cards"][0]["props"]["title"].lower()
+    assert db.people[0].get("notes", "") == ""
 
 
 @pytest.mark.asyncio

--- a/services/zoe-data/tests/test_skybridge_service.py
+++ b/services/zoe-data/tests/test_skybridge_service.py
@@ -191,6 +191,20 @@ def test_classify_skybridge_action_requests():
     assert lowercase_remember.action == "remember_fact"
     assert lowercase_remember.person_name == "Sarah"
 
+    assert classify_skybridge_intent("remember that my colleague has a car") is None
+    assert classify_skybridge_intent("remember that the manager likes coffee") is None
+
+
+def test_calendar_create_requires_unambiguous_bare_time():
+    calendar_context = {"intent": {"domain": "calendar"}, "cards": []}
+
+    assert classify_skybridge_intent("Can you add dentist at 9", calendar_context) is None
+
+    create_event = classify_skybridge_intent("Can you add dentist at 9am", calendar_context)
+    assert create_event.domain == "calendar"
+    assert create_event.action == "create_event"
+    assert create_event.target_time == "09:00"
+
 
 def test_classify_calendar_date_and_range_requests(monkeypatch):
     class FrozenDate(date):

--- a/services/zoe-data/tests/test_skybridge_static.py
+++ b/services/zoe-data/tests/test_skybridge_static.py
@@ -105,6 +105,8 @@ def test_skybridge_voice_normalizes_both_transports():
     assert "connectLiveKit()" in voice
     assert "handleServerEvent(msg)" in voice
     assert "this.emit({ type: 'card'" in voice
+    assert "this.emit({ type: 'cards'" in voice
+    assert "this.emit({ type: 'skybridge_context'" in voice
     assert "scheduleReconnect()" in voice
     assert "Malformed server event" in voice
     assert "Skybridge LiveKit event parse failed" in voice
@@ -163,6 +165,13 @@ def test_skybridge_uses_backend_status_contract():
     assert "getHomeCards()" in app
     assert "/api/skybridge/resolve" in app
     assert "resolveCommand(query)" in app
+    assert "skybridgeContext" in app
+    assert "JSON.stringify({ message: query, context: skybridgeContext })" in app
+    assert "renderSkybridgeResult(data)" in app
+    assert "function renderSkybridgeResult" in app
+    assert "Voice is still connecting. Type here and Zoe will still render cards." in app
+    assert "Microphone is not available here. Type a request and Zoe will still render cards." in app
+    assert "contextLabelFor(intent)" in app
     assert "isDataQuery(query)" in app
     assert "resp.status === 401 || resp.status === 503" in app
     assert "if (voice) voice.sendText(query)" in app
@@ -179,8 +188,12 @@ def test_skybridge_auth_and_voice_bus_contracts_are_wired():
     assert 'return "voice-guest"' in main
     assert 'return "family-admin"' not in main[main.index("async def _resolve_ws_user"):main.index("@app.websocket(\"/ws/voice/\")")]
     assert "async def _resolve_voice_cards" in main
-    assert "resolve_skybridge_request(message_text, user_id)" in main
-    assert '"type": "card", "card": card_contract' in main
+    assert "resolve_skybridge_request(message_text, user_id, context=context)" in main
+    assert "skybridge_context: dict = {}" in main
+    assert '"type": "cards", "result": skybridge_result' in main
+    assert '"type": "skybridge_context", "context": skybridge_context' in main
+    assert '"type": "transcript", "role": "assistant", "text": spoken_summary' in main
+    assert 'continue\n\n            # ── Streaming LLM' in main
 
 
 def test_skybridge_renderer_supports_real_data_cards():

--- a/services/zoe-data/tests/test_skybridge_static.py
+++ b/services/zoe-data/tests/test_skybridge_static.py
@@ -193,7 +193,7 @@ def test_skybridge_auth_and_voice_bus_contracts_are_wired():
     assert '"type": "cards", "result": skybridge_result' in main
     assert '"type": "skybridge_context", "context": skybridge_context' in main
     assert '"type": "transcript", "role": "assistant", "text": spoken_summary' in main
-    assert 'continue\n\n            # ── Streaming LLM' in main
+    assert 'skybridge_context = {}\n\n            # ── Streaming LLM' in main
 
 
 def test_skybridge_renderer_supports_real_data_cards():

--- a/services/zoe-data/tests/test_skybridge_status.py
+++ b/services/zoe-data/tests/test_skybridge_status.py
@@ -27,11 +27,13 @@ def test_skybridge_status_endpoint_returns_runtime_contract():
     assert data["surface"] == "skybridge"
     assert data["status"] == "ready"
     assert data["entrypoint"] == "/touch/skybridge.html"
-    assert data["card_contract"]["status"] == "wired_for_calendar_weather_lists_people"
+    assert data["card_contract"]["status"] == "wired_for_calendar_weather_lists_people_actions_v1"
     assert data["card_contract"]["supported_major"] == 1
     assert data["card_contract"]["data_domains"] == ["calendar", "weather", "lists", "people"]
     assert data["card_contract"]["voice_ws_domains"] == ["calendar", "weather", "lists", "people"]
+    assert data["card_contract"]["action_domains"] == ["calendar", "lists", "people"]
+    assert data["card_contract"]["context_refresh"] is True
     assert data["transports"]["local_ws"] is True
     assert "livekit" in data["transports"]
     assert data["capabilities"]["settings"] == 22
-    assert data["capabilities"]["dynamic_cards"] == "calendar_weather_lists_people_data_cards"
+    assert data["capabilities"]["dynamic_cards"] == "calendar_weather_lists_people_data_and_action_cards"

--- a/services/zoe-ui/dist/touch/js/skybridge-voice.js
+++ b/services/zoe-ui/dist/touch/js/skybridge-voice.js
@@ -247,6 +247,12 @@
                 this.emit({ type: 'transcript', role: msg.role || 'zoe', text: msg.text || '' });
             } else if (type === 'audio') {
                 this.playAudio(msg.audio_base64, msg.content_type || 'audio/wav');
+            } else if (type === 'cards') {
+                this.emit({ type: 'cards', result: msg.result || msg });
+            } else if (type === 'card') {
+                this.emit({ type: 'card', card: msg.card || msg.data || msg, replace: !!msg.replace });
+            } else if (type === 'skybridge_context') {
+                this.emit({ type: 'skybridge_context', context: msg.context || {} });
             } else if (type === 'agui' || type === 'ui_component') {
                 this.emit({ type: 'card', card: msg.data || msg });
             } else if (type === 'done') {

--- a/services/zoe-ui/dist/touch/js/skybridge.js
+++ b/services/zoe-ui/dist/touch/js/skybridge.js
@@ -12,6 +12,7 @@
     let currentUtterance = '';
     let voiceStartedByUser = false;
     let commandFallbackOpen = false;
+    let skybridgeContext = {};
 
     const colors = {
         ambient: ['#5fc6ff', '#66d19e'],
@@ -113,7 +114,10 @@
         });
         if (voice) voice.stop();
         voice = new window.SkybridgeVoice({ mode, onEvent: handleVoiceEvent });
-        voice.start().catch(err => showError(err.message || 'Voice failed to start'));
+        voice.start().catch(err => {
+            showError(err.message || 'Voice failed to start');
+            openCommandFallback('Voice is still connecting. Type here and Zoe will still render cards.');
+        });
         setStatus('Connecting ' + mode);
     }
 
@@ -126,8 +130,15 @@
             addTranscript(event.role, event.text);
         } else if (event.type === 'card') {
             addCard(event.card, true);
+        } else if (event.type === 'cards') {
+            renderSkybridgeResult(event.result || event);
+        } else if (event.type === 'skybridge_context') {
+            skybridgeContext = event.context || skybridgeContext || {};
         } else if (event.type === 'error') {
             showError(event.message);
+            if (/voice disconnected|transport unavailable|livekit unavailable|websocket|microphone|permission/i.test(event.message || '')) {
+                openCommandFallback('Voice needs attention. Type here and Zoe will still render cards.');
+            }
         } else if (event.type === 'done') {
             setState('ambient');
         }
@@ -153,39 +164,20 @@
             let resp = await fetch('/api/skybridge/resolve', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
-                body: JSON.stringify({ message: query })
+                body: JSON.stringify({ message: query, context: skybridgeContext })
             });
             if (resp.status === 401 || resp.status === 503) {
                 try { localStorage.removeItem('zoe_session'); } catch (_) {}
                 resp = await fetch('/api/skybridge/resolve', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
-                    body: JSON.stringify({ message: query })
+                    body: JSON.stringify({ message: query, context: skybridgeContext })
                 });
             }
             if (!resp.ok) throw new Error('Skybridge resolver unavailable');
             const data = await resp.json();
             if (!data || !data.handled) return false;
-            clearCards();
-            const intent = data.intent || {};
-            const cards = Array.isArray(data.cards) ? data.cards : [];
-            setContext(
-                intent.domain === 'calendar' ? 'Calendar' : (intent.domain === 'weather' ? 'Weather' : 'Skybridge'),
-                data.spoken_summary || 'Showing live data.'
-            );
-            currentUtterance = data.spoken_summary || currentUtterance;
-            els.copy.textContent = currentUtterance;
-            cards.forEach((card, index) => addCard(card, false, index * 90));
-            if (!cards.length) {
-                addCard({
-                    component: 'status',
-                    props: {
-                        title: 'No card returned',
-                        body: data.spoken_summary || 'Zoe understood the request but did not return a display card.',
-                        status: 'Resolver'
-                    }
-                }, true);
-            }
+            renderSkybridgeResult(data);
             return true;
         } catch (err) {
             if (isDataQuery(query)) {
@@ -204,8 +196,39 @@
         }
     }
 
+    function contextLabelFor(intent) {
+        const domain = intent && intent.domain;
+        if (domain === 'calendar') return 'Calendar';
+        if (domain === 'weather') return 'Weather';
+        if (domain === 'lists') return 'Lists';
+        if (domain === 'people') return 'People';
+        return 'Skybridge';
+    }
+
+    function renderSkybridgeResult(data) {
+        if (!data) return;
+        clearCards();
+        const intent = data.intent || {};
+        const cards = Array.isArray(data.cards) ? data.cards : [];
+        skybridgeContext = data.skybridge_context || skybridgeContext || {};
+        setContext(contextLabelFor(intent), data.spoken_summary || 'Showing live data.');
+        currentUtterance = data.spoken_summary || currentUtterance;
+        els.copy.textContent = currentUtterance;
+        cards.forEach((card, index) => addCard(card, false, index * 90));
+        if (!cards.length) {
+            addCard({
+                component: 'status',
+                props: {
+                    title: 'No card returned',
+                    body: data.spoken_summary || 'Zoe understood the request but did not return a display card.',
+                    status: 'Resolver'
+                }
+            }, true);
+        }
+    }
+
     function isDataQuery(query) {
-        return /\b(calendar|schedule|events|appointments|agenda|weather|forecast|temperature|rain|windy|wind)\b/i.test(query || '');
+        return /\b(calendar|schedule|events|appointments|agenda|weather|forecast|temperature|rain|windy|wind|list|shopping|groceries|grocery|tasks|todos|people|contacts|person|profile|remember|change|move|reschedule|add)\b/i.test(query || '');
     }
 
     function projectCards(query) {
@@ -253,6 +276,7 @@
         document.body.classList.remove('sky-command-open');
         syncVoiceFallbackState();
         currentUtterance = '';
+        skybridgeContext = {};
         setContext('Listening', 'The surface will build itself when Zoe understands what you need.');
         clearCards();
         els.copy.textContent = 'Listening. Ask Zoe for anything.';
@@ -428,6 +452,7 @@
         voice.startRecording().catch(err => {
             voiceStartedByUser = false;
             showError(err.message || 'Microphone unavailable');
+            openCommandFallback('Microphone is not available here. Type a request and Zoe will still render cards.');
         });
     }
 


### PR DESCRIPTION
## Summary
- Add Skybridge action intents for calendar time changes/event creation, list item adds, and people memory facts
- Carry Skybridge context through typed resolve and voice WebSocket card batches so visible cards can refresh in place
- Prevent handled Skybridge voice actions from falling through into the generic LLM path
- Open the premium typed pill when voice/mic transport fails so the orb state is not a dead end
- Document the Skybridge action-loop standard for future Zoe surfaces

## Verification
- PYTHONPATH=. python3 -m pytest -q tests/test_skybridge_service.py tests/test_skybridge_static.py tests/test_skybridge_status.py tests/test_card_contract.py
- python3 tools/audit/validate_structure.py
- python3 tools/audit/validate_critical_files.py
- git diff --check
- Browser verified through in-app browser preview: show my calendar, move my 3pm to 4pm, add bread to the shopping list, remember Sarah likes flowers and birthday is 1 May