### PR TITLE
Add cheap per-finding PR fixer for the Greptile loop

### DIFF
--- a/scripts/maintenance/zoe_cheap_pr_agent.py
+++ b/scripts/maintenance/zoe_cheap_pr_agent.py
@@ -275,6 +275,11 @@ def run(packet: dict, repo: Path) -> int:
         return _blocked(f"git commit failed: {commit.stderr.strip()[:200]}")
     push = _git(["push", "origin", f"HEAD:{branch}"], repo)
     if push.returncode != 0:
+        # Roll the local commit back so the branch is not left ahead of origin.
+        # The guard captured HEAD before invoking us and diffs against it; an
+        # unpushed commit would corrupt that base on the next invocation.
+        _git(["reset", "--mixed", "HEAD~1"], repo)
+        _revert()
         return _blocked(f"git push failed: {push.stderr.strip()[:200]}")
 
     print(redact(f"APPLIED: {rel} — {summary} (+{added}/-{removed}), pushed to {branch}"))

--- a/scripts/maintenance/zoe_cheap_pr_agent.py
+++ b/scripts/maintenance/zoe_cheap_pr_agent.py
@@ -54,6 +54,11 @@ def _blocked(reason: str) -> int:
 
 
 def _git(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    # Enforce the safety contract at runtime, not just by call-site convention:
+    # we never force-push, amend, or bypass hooks.
+    for arg in args:
+        if arg in _FORBIDDEN_GIT:
+            raise AssertionError(f"forbidden git flag: {arg!r}")
     return subprocess.run(["git", *args], cwd=cwd, text=True, capture_output=True)
 
 
@@ -216,7 +221,10 @@ def run(packet: dict, repo: Path) -> int:
     target.write_text(updated, encoding="utf-8")
 
     def _revert() -> None:
-        _git(["checkout", "--", rel], repo)
+        # Restore BOTH index and working tree from HEAD. `checkout -- <file>`
+        # restores only from the index, so after a `git add` it is a no-op and
+        # would leave the staged change behind.
+        _git(["checkout", "HEAD", "--", rel], repo)
 
     # Syntax gate for Python.
     if rel.endswith(".py"):
@@ -261,6 +269,9 @@ def run(packet: dict, repo: Path) -> int:
         return _blocked(f"git add failed: {add.stderr.strip()[:200]}")
     commit = _git(["commit", "-m", f"fix(review): {summary}"], repo)
     if commit.returncode != 0:
+        # The file is staged (git add succeeded) but uncommitted; restore it so
+        # we never leave a partial edit behind per the module contract.
+        _revert()
         return _blocked(f"git commit failed: {commit.stderr.strip()[:200]}")
     push = _git(["push", "origin", f"HEAD:{branch}"], repo)
     if push.returncode != 0:

--- a/scripts/maintenance/zoe_cheap_pr_agent.py
+++ b/scripts/maintenance/zoe_cheap_pr_agent.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""Cheap per-finding PR fixer for the Multica->Hermes Greptile loop.
+
+Reads a GuardPacket JSON document on stdin (see
+``services/zoe-data/greploop_guard.py``), asks a cheap LLM (DeepSeek via
+OpenRouter by default) for the smallest possible edit that addresses ONE
+Greptile finding in a single allowed file, applies it, runs the packet's
+validation commands, then commits and pushes the fix to the PR branch.
+
+Contract with greploop_guard._run_cheap_agent:
+- We run with ``cwd`` set to the repo/worktree the guard operates in, on the
+  PR branch. The guard captures HEAD before invoking us and diffs afterwards.
+- Success means: focused fix committed + pushed, exit code 0, no "BLOCKED"
+  token in our output. The guard then re-triggers Greptile.
+- Anything we cannot safely do prints ``BLOCKED: <reason>`` and exits 0 so the
+  guard classifies it as BLOCKED (never a crash, never a partial edit left
+  behind). We never merge, force-push, amend, delete branches, or bypass hooks.
+
+All output is secret-redacted before printing.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# --- secret redaction (mirrors greploop_guard.redact) ------------------------
+
+_SECRET_RE = re.compile(
+    r"(?i)(api[_-]?key|token|secret|password|authorization|bearer)\s*[:=]\s*['\"]?[^'\"\s]+"
+)
+_BEARER_RE = re.compile(r"(?i)(authorization\s*:\s*bearer)\s+[^'\"\s]+")
+
+_FORBIDDEN_GIT = ("--force", "--force-with-lease", "-f", "--amend", "--no-verify")
+_DEFAULT_MODEL = os.environ.get("ZOE_CHEAP_PR_AGENT_MODEL", "deepseek/deepseek-chat-v3.1")
+_OPENROUTER_URL = os.environ.get(
+    "ZOE_CHEAP_PR_AGENT_API_URL", "https://openrouter.ai/api/v1/chat/completions"
+)
+_HERMES_ENV = Path.home() / ".hermes" / ".env"
+
+
+def redact(text: str) -> str:
+    text = _BEARER_RE.sub(lambda m: f"{m.group(1)} <redacted>", text)
+    return _SECRET_RE.sub(lambda m: f"{m.group(1)}=<redacted>", text)
+
+
+def _blocked(reason: str) -> int:
+    print(f"BLOCKED: {redact(str(reason))}")
+    return 0
+
+
+def _git(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(["git", *args], cwd=cwd, text=True, capture_output=True)
+
+
+def _load_openrouter_key() -> str | None:
+    key = os.environ.get("OPENROUTER_API_KEY")
+    if key:
+        return key
+    # Fall back to the operator-local Hermes env file (never logged).
+    try:
+        for line in _HERMES_ENV.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if line.startswith("OPENROUTER_API_KEY="):
+                return line.split("=", 1)[1].strip().strip("'\"") or None
+    except OSError:
+        return None
+    return None
+
+
+def _number_lines(text: str) -> str:
+    return "\n".join(f"{i + 1:>4}\t{ln}" for i, ln in enumerate(text.splitlines()))
+
+
+def build_messages(*, file_path: str, file_text: str, issue_text: str, standard: str) -> list[dict]:
+    """Build the chat messages for the fixer. Pure function for testability."""
+    system = (
+        "You are a precise code-review fixer. You address EXACTLY ONE review finding "
+        "with the SMALLEST possible change to a single file. You do not refactor, "
+        "reformat, rename, or touch anything the finding does not require.\n\n"
+        "Respond with ONE JSON object and nothing else. Either:\n"
+        '  {"edits": [{"old_string": "<exact text in file>", '
+        '"new_string": "<replacement>"}], "summary": "<one line>"}\n'
+        "where every old_string appears VERBATIM and EXACTLY ONCE in the current "
+        "file (include enough surrounding context to be unique), or, if you cannot "
+        "fix it safely within one file:\n"
+        '  {"blocked": "<short reason>"}\n\n'
+        "Keep the total changed lines small. Match the existing code style. Never "
+        "add secrets, debug prints, or unrelated edits."
+    )
+    user = (
+        f"Repository review standard (obey it):\n{standard}\n\n"
+        f"File under review: {file_path}\n\n"
+        f"Greptile finding to address:\n{issue_text}\n\n"
+        f"Current file contents (with line numbers for reference only; do not "
+        f"include line numbers in old_string/new_string):\n{_number_lines(file_text)}"
+    )
+    return [{"role": "system", "content": system}, {"role": "user", "content": user}]
+
+
+def call_llm(messages: list[dict], *, api_key: str, model: str = _DEFAULT_MODEL) -> str:
+    import httpx
+
+    payload = {
+        "model": model,
+        "messages": messages,
+        "temperature": 0,
+        "max_tokens": 2000,
+        "response_format": {"type": "json_object"},
+    }
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+        "X-Title": "zoe-cheap-pr-agent",
+    }
+    with httpx.Client(timeout=120) as client:
+        resp = client.post(_OPENROUTER_URL, json=payload, headers=headers)
+        resp.raise_for_status()
+        data = resp.json()
+    return data["choices"][0]["message"]["content"]
+
+
+def parse_response(content: str) -> dict:
+    """Extract the first JSON object from the model response."""
+    content = content.strip()
+    try:
+        return json.loads(content)
+    except json.JSONDecodeError:
+        pass
+    start = content.find("{")
+    end = content.rfind("}")
+    if start != -1 and end != -1 and end > start:
+        return json.loads(content[start : end + 1])
+    raise ValueError("model did not return JSON")
+
+
+def apply_edits(file_text: str, edits: list[dict]) -> str:
+    """Apply exact-match edits. Each old_string must occur exactly once."""
+    if not edits:
+        raise ValueError("no edits returned")
+    result = file_text
+    for edit in edits:
+        old = edit.get("old_string")
+        new = edit.get("new_string")
+        if old is None or new is None:
+            raise ValueError("edit missing old_string/new_string")
+        count = result.count(old)
+        if count == 0:
+            raise ValueError("old_string not found in file")
+        if count > 1:
+            raise ValueError("old_string is not unique in file")
+        result = result.replace(old, new, 1)
+    if result == file_text:
+        raise ValueError("edits produced no change")
+    return result
+
+
+def _read_standard(repo: Path) -> str:
+    try:
+        text = (repo / ".greptile" / "rules.md").read_text(encoding="utf-8")
+    except OSError:
+        return "Smallest reviewable change; match existing patterns; no secrets; no junk files."
+    # Pass the hygiene + checklist tail, which is what most findings concern.
+    marker = "## Python And Test Hygiene"
+    idx = text.find(marker)
+    return text[idx:] if idx != -1 else text[-2000:]
+
+
+def run(packet: dict, repo: Path) -> int:
+    task_type = packet.get("task_type")
+    if task_type != "FIX_GREPTILE_FINDING":
+        return _blocked(f"unsupported task_type {task_type!r}")
+
+    allowed = packet.get("allowed_files") or []
+    if len(allowed) != 1:
+        return _blocked(f"expected exactly one allowed file, got {len(allowed)}")
+    rel = str(allowed[0]).strip()
+    target = (repo / rel).resolve()
+    if not str(target).startswith(str(repo.resolve())) or not target.is_file():
+        return _blocked(f"allowed file is missing or outside repo: {rel}")
+
+    issue_text = str(packet.get("issue_text") or "").strip()
+    if not issue_text:
+        return _blocked("finding has no issue_text")
+    max_lines = int(packet.get("max_changed_lines") or 120)
+
+    api_key = _load_openrouter_key()
+    if not api_key:
+        return _blocked("OPENROUTER_API_KEY not configured")
+
+    original = target.read_text(encoding="utf-8")
+    messages = build_messages(
+        file_path=rel,
+        file_text=original,
+        issue_text=issue_text,
+        standard=_read_standard(repo),
+    )
+    try:
+        content = call_llm(messages, api_key=api_key)
+        parsed = parse_response(content)
+    except Exception as exc:  # network / parse / API failure
+        return _blocked(f"llm call failed: {exc}")
+
+    if parsed.get("blocked"):
+        return _blocked(f"model declined: {parsed.get('blocked')}")
+
+    try:
+        updated = apply_edits(original, parsed.get("edits") or [])
+    except Exception as exc:
+        return _blocked(f"edit application failed: {exc}")
+
+    target.write_text(updated, encoding="utf-8")
+
+    def _revert() -> None:
+        _git(["checkout", "--", rel], repo)
+
+    # Syntax gate for Python.
+    if rel.endswith(".py"):
+        chk = subprocess.run(
+            [sys.executable, "-m", "py_compile", rel], cwd=repo, text=True, capture_output=True
+        )
+        if chk.returncode != 0:
+            _revert()
+            return _blocked(f"py_compile failed: {chk.stderr.strip()[:400]}")
+
+    # Validation commands from the packet.
+    for command in packet.get("commands_to_run") or []:
+        proc = subprocess.run(command, cwd=repo, shell=True, text=True, capture_output=True)
+        if proc.returncode != 0:
+            _revert()
+            tail = (proc.stderr or proc.stdout or "").strip()[-400:]
+            return _blocked(f"validation command failed ({command}): {tail}")
+
+    # Self-check the diff shape before committing (guard re-checks too).
+    changed = [
+        p for p in _git(["diff", "--name-only"], repo).stdout.splitlines() if p.strip()
+    ]
+    if changed != [rel]:
+        _revert()
+        return _blocked(f"diff touched unexpected files: {changed}")
+    numstat = _git(["diff", "--numstat"], repo).stdout.split()
+    added = int(numstat[0]) if numstat and numstat[0].isdigit() else 0
+    removed = int(numstat[1]) if len(numstat) > 1 and numstat[1].isdigit() else 0
+    if added + removed > max_lines:
+        _revert()
+        return _blocked(f"change too large: {added + removed} > {max_lines} lines")
+
+    branch = _git(["rev-parse", "--abbrev-ref", "HEAD"], repo).stdout.strip()
+    if not branch or branch in {"main", "master", "HEAD"}:
+        _revert()
+        return _blocked(f"refusing to commit on branch {branch!r}")
+
+    summary = str(parsed.get("summary") or "address Greptile review finding").splitlines()[0][:72]
+    add = _git(["add", "--", rel], repo)
+    if add.returncode != 0:
+        _revert()
+        return _blocked(f"git add failed: {add.stderr.strip()[:200]}")
+    commit = _git(["commit", "-m", f"fix(review): {summary}"], repo)
+    if commit.returncode != 0:
+        return _blocked(f"git commit failed: {commit.stderr.strip()[:200]}")
+    push = _git(["push", "origin", f"HEAD:{branch}"], repo)
+    if push.returncode != 0:
+        return _blocked(f"git push failed: {push.stderr.strip()[:200]}")
+
+    print(redact(f"APPLIED: {rel} — {summary} (+{added}/-{removed}), pushed to {branch}"))
+    return 0
+
+
+def main() -> int:
+    raw = sys.stdin.read()
+    try:
+        packet = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        return _blocked(f"invalid packet JSON: {exc}")
+    repo = Path(os.environ.get("ZOE_ASSISTANT_ROOT") or os.getcwd()).resolve()
+    try:
+        return run(packet, repo)
+    except Exception as exc:  # never crash; BLOCKED is the safe terminal
+        return _blocked(f"unexpected error: {exc}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/zoe-data/tests/test_zoe_cheap_pr_agent.py
+++ b/services/zoe-data/tests/test_zoe_cheap_pr_agent.py
@@ -1,0 +1,145 @@
+import importlib.util
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+import runtime_env  # noqa: F401  (ensures repo sys.path is set up like siblings)
+
+
+def _module():
+    path = (
+        Path(__file__).resolve().parents[3]
+        / "scripts/maintenance/zoe_cheap_pr_agent.py"
+    )
+    spec = importlib.util.spec_from_file_location("zoe_cheap_pr_agent", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_redact_scrubs_secrets():
+    mod = _module()
+    out = mod.redact("OPENROUTER_API_KEY=sk-abc123 and authorization: bearer tok-xyz")
+    assert "sk-abc123" not in out
+    assert "tok-xyz" not in out
+    assert "<redacted>" in out
+
+
+def test_parse_response_handles_wrapped_json():
+    mod = _module()
+    parsed = mod.parse_response('Sure!\n{"blocked": "ambiguous"}\nThanks')
+    assert parsed == {"blocked": "ambiguous"}
+
+
+def test_apply_edits_requires_unique_match():
+    mod = _module()
+    with pytest.raises(ValueError):
+        mod.apply_edits("a = 1\na = 1\n", [{"old_string": "a = 1", "new_string": "a = 2"}])
+    with pytest.raises(ValueError):
+        mod.apply_edits("a = 1\n", [{"old_string": "missing", "new_string": "x"}])
+    out = mod.apply_edits("a = 1\nb = 2\n", [{"old_string": "b = 2", "new_string": "b = 3"}])
+    assert out == "a = 1\nb = 3\n"
+
+
+def test_run_blocks_on_multiple_allowed_files(capsys):
+    mod = _module()
+    rc = mod.run({"task_type": "FIX_GREPTILE_FINDING", "allowed_files": ["a.py", "b.py"]}, Path("/tmp"))
+    assert rc == 0
+    assert "BLOCKED" in capsys.readouterr().out
+
+
+def test_run_blocks_on_unsupported_task_type(capsys):
+    mod = _module()
+    rc = mod.run({"task_type": "FIX_CI_FAILURE", "allowed_files": ["a.py"]}, Path("/tmp"))
+    assert rc == 0
+    assert "BLOCKED" in capsys.readouterr().out
+
+
+def _init_repo_with_remote(tmp_path: Path) -> Path:
+    bare = tmp_path / "origin.git"
+    subprocess.run(["git", "init", "--bare", str(bare)], check=True, capture_output=True)
+    repo = tmp_path / "work"
+    subprocess.run(["git", "clone", str(bare), str(repo)], check=True, capture_output=True)
+    for cfg in (["user.email", "t@t"], ["user.name", "t"]):
+        subprocess.run(["git", "-C", str(repo), "config", *cfg], check=True, capture_output=True)
+    (repo / "mod.py").write_text("x = 1\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(repo), "add", "."], check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(repo), "commit", "-m", "init"], check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(repo), "push", "origin", "HEAD:main"], check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(repo), "checkout", "-b", "fix/feature"], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(repo), "push", "-u", "origin", "HEAD:fix/feature"],
+        check=True,
+        capture_output=True,
+    )
+    return repo
+
+
+def test_run_applies_commits_and_pushes(tmp_path, monkeypatch):
+    mod = _module()
+    repo = _init_repo_with_remote(tmp_path)
+
+    monkeypatch.setattr(mod, "_load_openrouter_key", lambda: "test-key")
+    monkeypatch.setattr(
+        mod,
+        "call_llm",
+        lambda *a, **k: json.dumps(
+            {"edits": [{"old_string": "x = 1", "new_string": "x = 2"}], "summary": "bump x"}
+        ),
+    )
+
+    packet = {
+        "task_type": "FIX_GREPTILE_FINDING",
+        "allowed_files": ["mod.py"],
+        "issue_text": "x should be 2",
+        "max_changed_lines": 120,
+        "commands_to_run": ["python3 -c \"import ast; ast.parse(open('mod.py').read())\""],
+    }
+    rc = mod.run(packet, repo)
+    assert rc == 0
+    assert (repo / "mod.py").read_text(encoding="utf-8") == "x = 2\n"
+    log = subprocess.run(
+        ["git", "-C", str(repo), "log", "-1", "--pretty=%s"], text=True, capture_output=True
+    ).stdout.strip()
+    assert log == "fix(review): bump x"
+    # pushed: local branch and origin ref point at the same commit
+    local = subprocess.run(
+        ["git", "-C", str(repo), "rev-parse", "HEAD"], text=True, capture_output=True
+    ).stdout.strip()
+    remote = subprocess.run(
+        ["git", "-C", str(repo), "rev-parse", "origin/fix/feature"], text=True, capture_output=True
+    ).stdout.strip()
+    assert local == remote
+
+
+def test_run_reverts_when_validation_fails(tmp_path, monkeypatch):
+    mod = _module()
+    repo = _init_repo_with_remote(tmp_path)
+
+    monkeypatch.setattr(mod, "_load_openrouter_key", lambda: "test-key")
+    monkeypatch.setattr(
+        mod,
+        "call_llm",
+        lambda *a, **k: json.dumps(
+            {"edits": [{"old_string": "x = 1", "new_string": "x = 2"}], "summary": "bump x"}
+        ),
+    )
+
+    packet = {
+        "task_type": "FIX_GREPTILE_FINDING",
+        "allowed_files": ["mod.py"],
+        "issue_text": "x should be 2",
+        "max_changed_lines": 120,
+        "commands_to_run": ["false"],
+    }
+    rc = mod.run(packet, repo)
+    assert rc == 0
+    # reverted to original — no lingering tracked change
+    assert (repo / "mod.py").read_text(encoding="utf-8") == "x = 1\n"
+    tracked_diff = subprocess.run(
+        ["git", "-C", str(repo), "diff", "--name-only"], text=True, capture_output=True
+    ).stdout.strip()
+    assert tracked_diff == ""

--- a/services/zoe-data/tests/test_zoe_cheap_pr_agent.py
+++ b/services/zoe-data/tests/test_zoe_cheap_pr_agent.py
@@ -44,6 +44,53 @@ def test_apply_edits_requires_unique_match():
     assert out == "a = 1\nb = 3\n"
 
 
+def test_git_rejects_forbidden_flags(tmp_path):
+    mod = _module()
+    for flag in ("--force", "--force-with-lease", "-f", "--amend", "--no-verify"):
+        with pytest.raises(AssertionError):
+            mod._git(["push", flag], tmp_path)
+
+
+def test_run_reverts_staged_change_when_commit_fails(tmp_path, monkeypatch):
+    mod = _module()
+    repo = _init_repo_with_remote(tmp_path)
+
+    monkeypatch.setattr(mod, "_load_openrouter_key", lambda: "test-key")
+    monkeypatch.setattr(
+        mod,
+        "call_llm",
+        lambda *a, **k: json.dumps(
+            {"edits": [{"old_string": "x = 1", "new_string": "x = 2"}], "summary": "bump x"}
+        ),
+    )
+    # Force `git commit` to fail after `git add` has already staged the file.
+    real_git = mod._git
+
+    def _fake_git(args, cwd):
+        if args[:1] == ["commit"]:
+            return subprocess.CompletedProcess(args, 1, "", "hook rejected")
+        return real_git(args, cwd)
+
+    monkeypatch.setattr(mod, "_git", _fake_git)
+
+    packet = {
+        "task_type": "FIX_GREPTILE_FINDING",
+        "allowed_files": ["mod.py"],
+        "issue_text": "x should be 2",
+        "max_changed_lines": 120,
+    }
+    rc = mod.run(packet, repo)
+    assert rc == 0
+    # No partial edit left behind: working tree and index both restored.
+    assert (repo / "mod.py").read_text(encoding="utf-8") == "x = 1\n"
+    porcelain = subprocess.run(
+        ["git", "-C", str(repo), "status", "--porcelain", "mod.py"],
+        text=True,
+        capture_output=True,
+    ).stdout.strip()
+    assert porcelain == ""
+
+
 def test_run_blocks_on_multiple_allowed_files(capsys):
     mod = _module()
     rc = mod.run({"task_type": "FIX_GREPTILE_FINDING", "allowed_files": ["a.py", "b.py"]}, Path("/tmp"))

--- a/services/zoe-data/tests/test_zoe_cheap_pr_agent.py
+++ b/services/zoe-data/tests/test_zoe_cheap_pr_agent.py
@@ -91,6 +91,50 @@ def test_run_reverts_staged_change_when_commit_fails(tmp_path, monkeypatch):
     assert porcelain == ""
 
 
+def test_run_rolls_back_local_commit_when_push_fails(tmp_path, monkeypatch):
+    mod = _module()
+    repo = _init_repo_with_remote(tmp_path)
+    head_before = subprocess.run(
+        ["git", "-C", str(repo), "rev-parse", "HEAD"], text=True, capture_output=True
+    ).stdout.strip()
+
+    monkeypatch.setattr(mod, "_load_openrouter_key", lambda: "test-key")
+    monkeypatch.setattr(
+        mod,
+        "call_llm",
+        lambda *a, **k: json.dumps(
+            {"edits": [{"old_string": "x = 1", "new_string": "x = 2"}], "summary": "bump x"}
+        ),
+    )
+    real_git = mod._git
+
+    def _fake_git(args, cwd):
+        if args[:1] == ["push"]:
+            return subprocess.CompletedProcess(args, 1, "", "remote rejected")
+        return real_git(args, cwd)
+
+    monkeypatch.setattr(mod, "_git", _fake_git)
+
+    packet = {
+        "task_type": "FIX_GREPTILE_FINDING",
+        "allowed_files": ["mod.py"],
+        "issue_text": "x should be 2",
+        "max_changed_lines": 120,
+    }
+    rc = mod.run(packet, repo)
+    assert rc == 0
+    # Local commit rolled back: HEAD unchanged and no lingering tracked change.
+    head_after = subprocess.run(
+        ["git", "-C", str(repo), "rev-parse", "HEAD"], text=True, capture_output=True
+    ).stdout.strip()
+    assert head_after == head_before
+    assert (repo / "mod.py").read_text(encoding="utf-8") == "x = 1\n"
+    porcelain = subprocess.run(
+        ["git", "-C", str(repo), "status", "--porcelain", "mod.py"], text=True, capture_output=True
+    ).stdout.strip()
+    assert porcelain == ""
+
+
 def test_run_blocks_on_multiple_allowed_files(capsys):
     mod = _module()
     rc = mod.run({"task_type": "FIX_GREPTILE_FINDING", "allowed_files": ["a.py", "b.py"]}, Path("/tmp"))


### PR DESCRIPTION
## Summary
- Adds `scripts/maintenance/zoe_cheap_pr_agent.py`, the standalone runner that `greploop_guard._run_cheap_agent` invokes via `ZOE_CHEAP_PR_AGENT_CMD`.
- Reads a GuardPacket on stdin, asks DeepSeek (OpenRouter) for the smallest exact-match edit that addresses ONE Greptile finding in ONE allowed file, applies it, py_compiles, runs the packet's validation commands, self-checks the diff shape (only the allowed file, within `max_changed_lines`), then commits `fix(review): <summary>` and pushes to the PR branch.
- Safety terminal: any unsafe situation prints `BLOCKED: <redacted>` and exits 0 — never crashes, never leaves a partial edit (reverts via `git checkout`), never merges/force-pushes/amends/bypasses hooks. All output is secret-redacted.

## Test plan
- [x] `pytest services/zoe-data/tests/test_zoe_cheap_pr_agent.py` (7 tests): redaction, wrapped-JSON parsing, unique-match edits, blocks on multi-file / unsupported task_type, and end-to-end apply→commit→push plus revert-on-validation-failure against a real bare-remote git repo.
- [x] `py_compile` clean; `git diff --check` clean.
- [x] Smoke-tested through the wired `ZOE_CHEAP_PR_AGENT_CMD` command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)