### PR TITLE
Lint tickets for live-checkout paths at dispatch

### DIFF
--- a/services/zoe-data/multica_admission.py
+++ b/services/zoe-data/multica_admission.py
@@ -6,7 +6,7 @@ import re
 from collections import defaultdict
 from typing import Any
 
-from multica_ticket_contract import parse_ticket_block
+from multica_ticket_contract import parse_ticket_block, validate_ticket_contract
 from zoe_evolution_execution_gate import evaluate_execution_gate
 
 _CARD_UPGRADE_RE = re.compile(r"(?i)^(card-upgrade)\s*:\s*phase\s*(\d+)")
@@ -57,6 +57,10 @@ def ticket_is_dispatch_approved(
     if not metadata.get("acceptance_criteria") or not metadata.get("evidence_expectations"):
         return False
     if str(metadata.get("zoe_kind") or "") == "parent":
+        return False
+    # Fail closed on live-checkout path references: dispatching them would only
+    # trip the runtime WORKTREE_PATH_VIOLATION guard after budget is burned.
+    if not validate_ticket_contract(issue.get("description") or "", metadata=metadata)["ok"]:
         return False
     source = str(metadata.get("source") or "").lower()
     if "smoke" in source or "e2e" in source:

--- a/services/zoe-data/multica_admission.py
+++ b/services/zoe-data/multica_admission.py
@@ -60,7 +60,7 @@ def ticket_is_dispatch_approved(
         return False
     # Fail closed on live-checkout path references: dispatching them would only
     # trip the runtime WORKTREE_PATH_VIOLATION guard after budget is burned.
-    if not validate_ticket_contract(issue.get("description") or "", metadata=metadata)["ok"]:
+    if not validate_ticket_contract(issue.get("description") or "")["ok"]:
         return False
     source = str(metadata.get("source") or "").lower()
     if "smoke" in source or "e2e" in source:

--- a/services/zoe-data/multica_ticket_contract.py
+++ b/services/zoe-data/multica_ticket_contract.py
@@ -3,12 +3,24 @@
 from __future__ import annotations
 
 import json
+import os
 import re
 from datetime import datetime, timezone
 from typing import Any
 
 FENCE_LANG = "zoe-ticket"
 SCHEMA_VERSION = 1
+
+# Default live checkout root. Tickets that hardcode this absolute path steer the
+# worker out of its pinned, isolated worktree and trip the runtime
+# WORKTREE_PATH_VIOLATION guard after budget is already burned, so we lint for it
+# at dispatch instead.
+DEFAULT_LIVE_ROOT = "/home/zoe/assistant"
+
+
+def _live_root(live_root: str | None = None) -> str:
+    root = (live_root or os.environ.get("ZOE_ASSISTANT_ROOT") or DEFAULT_LIVE_ROOT).rstrip("/")
+    return root or DEFAULT_LIVE_ROOT
 
 _BLOCK_RE = re.compile(
     r"(?P<prefix>^|\n)```zoe-ticket\s*\n(?P<body>.*?)\n```(?P<suffix>\n|$)",
@@ -158,3 +170,83 @@ def append_child_id(description: str | None, child_id: str) -> str:
     metadata["child_issue_ids"] = children
     metadata["updated_at"] = datetime.now(timezone.utc).isoformat()
     return write_ticket_block(description, metadata)
+
+
+def _live_path_regex(live_root: str) -> re.Pattern[str]:
+    # Match the live root and any path beneath it, stopping at whitespace or
+    # shell/markdown delimiters so we capture a single path token cleanly. The
+    # boundary lookahead prevents matching a sibling like ``<root>-backup``.
+    return re.compile(re.escape(live_root) + r"(?![\w-])(?:/[^\s'\"`)\]>,;]*)?")
+
+
+def find_live_path_references(
+    description: str | None, *, live_root: str | None = None
+) -> list[str]:
+    """Return unique live-checkout absolute paths referenced in the ticket text.
+
+    These are the WORKTREE_PATH_VIOLATION class: any instruction that points the
+    worker at the shared live checkout instead of its pinned worktree.
+    """
+    root = _live_root(live_root)
+    seen: dict[str, None] = {}
+    for match in _live_path_regex(root).finditer(description or ""):
+        # Trim a trailing slash and any sentence punctuation the regex swept up.
+        token = match.group(0).rstrip("/.,;:")
+        seen.setdefault(token, None)
+    return list(seen)
+
+
+def normalize_live_paths(description: str | None, *, live_root: str | None = None) -> str:
+    """Rewrite hardcoded live-checkout paths to worktree-relative equivalents.
+
+    ``<root>/services/x.py`` becomes ``services/x.py`` and a bare ``<root>``
+    (e.g. ``cd <root>``) becomes ``.`` so the same prose works inside any pinned
+    worktree. Human prose and the fenced metadata block are otherwise untouched.
+    """
+    root = _live_root(live_root)
+    text = description or ""
+
+    def _replace(match: re.Match[str]) -> str:
+        token = match.group(0)
+        trailing = ""
+        # Preserve a trailing slash if the original had one.
+        if token.endswith("/") and token != root + "/":
+            token, trailing = token.rstrip("/"), "/"
+        if token == root:
+            return "." + trailing
+        relative = token[len(root) + 1 :]  # drop "<root>/"
+        return (relative or ".") + trailing
+
+    return _live_path_regex(root).sub(_replace, text)
+
+
+def validate_ticket_contract(
+    description: str | None,
+    *,
+    live_root: str | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Lint a ticket for dispatch-blocking contract violations.
+
+    Currently enforces the WORKTREE_PATH_VIOLATION class: a ticket must not pin
+    the worker to the shared live checkout. Returns a structured result so the
+    admission gate can fail closed and an operator/auto-fixer can normalize.
+
+    Returns ``{"ok", "violations", "normalized_description"}`` where
+    ``normalized_description`` is provided only when a safe rewrite exists.
+    """
+    root = _live_root(live_root)
+    violations: list[str] = []
+
+    live_paths = find_live_path_references(description, live_root=root)
+    for path in live_paths:
+        violations.append(
+            "WORKTREE_PATH_VIOLATION: ticket references live checkout path "
+            f"{path}; use a worktree-relative path so the worker stays in its "
+            "pinned isolated worktree"
+        )
+
+    result: dict[str, Any] = {"ok": not violations, "violations": violations}
+    if live_paths:
+        result["normalized_description"] = normalize_live_paths(description, live_root=root)
+    return result

--- a/services/zoe-data/multica_ticket_contract.py
+++ b/services/zoe-data/multica_ticket_contract.py
@@ -175,8 +175,22 @@ def append_child_id(description: str | None, child_id: str) -> str:
 def _live_path_regex(live_root: str) -> re.Pattern[str]:
     # Match the live root and any path beneath it, stopping at whitespace or
     # shell/markdown delimiters so we capture a single path token cleanly. The
-    # boundary lookahead prevents matching a sibling like ``<root>-backup``.
-    return re.compile(re.escape(live_root) + r"(?![\w-])(?:/[^\s'\"`)\]>,;]*)?")
+    # boundary lookahead prevents matching a sibling like ``<root>-backup`` or
+    # ``<root>.bak`` whose name merely shares the root as a string prefix.
+    return re.compile(re.escape(live_root) + r"(?![\w.\-])(?:/[^\s'\"`)\]>,;]*)?")
+
+
+def _split_off_metadata_block(text: str) -> tuple[str, str, str]:
+    """Return (before, block, after) splitting out the fenced Zoe block.
+
+    The fenced metadata block is machine-managed JSON; live-path linting and
+    rewriting must operate on the human prose only, never inside the block.
+    """
+    match = _BLOCK_RE.search(text)
+    if not match:
+        return text, "", ""
+    start, end = match.span()
+    return text[:start], text[start:end], text[end:]
 
 
 def find_live_path_references(
@@ -185,14 +199,19 @@ def find_live_path_references(
     """Return unique live-checkout absolute paths referenced in the ticket text.
 
     These are the WORKTREE_PATH_VIOLATION class: any instruction that points the
-    worker at the shared live checkout instead of its pinned worktree.
+    worker at the shared live checkout instead of its pinned worktree. Only the
+    human prose is scanned; the fenced metadata block is machine-managed JSON
+    (e.g. a ``blocked_reason`` may legitimately quote an offending path) and is
+    skipped to avoid false positives.
     """
     root = _live_root(live_root)
+    before, _block, after = _split_off_metadata_block(description or "")
     seen: dict[str, None] = {}
-    for match in _live_path_regex(root).finditer(description or ""):
-        # Trim a trailing slash and any sentence punctuation the regex swept up.
-        token = match.group(0).rstrip("/.,;:")
-        seen.setdefault(token, None)
+    for prose in (before, after):
+        for match in _live_path_regex(root).finditer(prose):
+            # Trim a trailing slash and any sentence punctuation the regex swept up.
+            token = match.group(0).rstrip("/.,;:")
+            seen.setdefault(token, None)
     return list(seen)
 
 
@@ -201,10 +220,11 @@ def normalize_live_paths(description: str | None, *, live_root: str | None = Non
 
     ``<root>/services/x.py`` becomes ``services/x.py`` and a bare ``<root>``
     (e.g. ``cd <root>``) becomes ``.`` so the same prose works inside any pinned
-    worktree. Human prose and the fenced metadata block are otherwise untouched.
+    worktree. Only the human prose is rewritten; the fenced metadata block is
+    left byte-for-byte intact so stored JSON semantics are never altered.
     """
     root = _live_root(live_root)
-    text = description or ""
+    regex = _live_path_regex(root)
 
     def _replace(match: re.Match[str]) -> str:
         token = match.group(0)
@@ -217,14 +237,14 @@ def normalize_live_paths(description: str | None, *, live_root: str | None = Non
         relative = token[len(root) + 1 :]  # drop "<root>/"
         return (relative or ".") + trailing
 
-    return _live_path_regex(root).sub(_replace, text)
+    before, block, after = _split_off_metadata_block(description or "")
+    return regex.sub(_replace, before) + block + regex.sub(_replace, after)
 
 
 def validate_ticket_contract(
     description: str | None,
     *,
     live_root: str | None = None,
-    metadata: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Lint a ticket for dispatch-blocking contract violations.
 

--- a/services/zoe-data/multica_ticket_contract.py
+++ b/services/zoe-data/multica_ticket_contract.py
@@ -6,6 +6,7 @@ import json
 import os
 import re
 from datetime import datetime, timezone
+from functools import lru_cache
 from typing import Any
 
 FENCE_LANG = "zoe-ticket"
@@ -172,6 +173,7 @@ def append_child_id(description: str | None, child_id: str) -> str:
     return write_ticket_block(description, metadata)
 
 
+@lru_cache(maxsize=8)
 def _live_path_regex(live_root: str) -> re.Pattern[str]:
     # Match the live root and any path beneath it, stopping at whitespace or
     # shell/markdown delimiters so we capture a single path token cleanly. The

--- a/services/zoe-data/tests/test_multica_admission.py
+++ b/services/zoe-data/tests/test_multica_admission.py
@@ -69,6 +69,24 @@ def test_unapproved_or_unstructured_backlog_is_not_admitted():
     )[0] is None
 
 
+def test_live_path_ticket_is_not_dispatch_approved(monkeypatch):
+    monkeypatch.setenv("ZOE_ASSISTANT_ROOT", "/home/zoe/assistant")
+    clean = _issue("ZOE-1", "Clean fix", dispatch_approved=True)
+    assert ticket_is_dispatch_approved(clean, hermes_agent_id=HERMES)
+
+    # Same approved ticket, but the prose pins the worker to the live checkout.
+    polluted = dict(clean)
+    polluted["description"] = (
+        clean["description"] + "\n\nEdit /home/zoe/assistant/services/zoe-data/x.py here."
+    )
+    assert not ticket_is_dispatch_approved(polluted, hermes_agent_id=HERMES)
+    # And it must not be selected for dispatch.
+    selected, _held = select_next_approved_issue(
+        [polluted], [polluted], hermes_agent_id=HERMES
+    )
+    assert selected is None
+
+
 def test_selects_one_approved_issue_by_queue_order():
     second = _issue("ZOE-2", "Second fix", dispatch_approved=True, queue_order=2)
     first = _issue("ZOE-1", "First fix", dispatch_approved=True, queue_order=1)

--- a/services/zoe-data/tests/test_multica_ticket_contract.py
+++ b/services/zoe-data/tests/test_multica_ticket_contract.py
@@ -1,8 +1,11 @@
 from multica_ticket_contract import (
     append_child_id,
     describe_ticket,
+    find_live_path_references,
+    normalize_live_paths,
     parse_ticket_block,
     update_ticket_progress,
+    validate_ticket_contract,
     write_ticket_block,
 )
 
@@ -66,3 +69,59 @@ def test_replacing_middle_block_preserves_suffix_newline():
     updated = write_ticket_block(description, {"schema": 1, "zoe_kind": "bug"})
 
     assert "```\nTrailing prose" in updated
+
+
+LIVE = "/home/zoe/assistant"
+
+
+def test_find_live_path_references_detects_root_and_nested(monkeypatch):
+    monkeypatch.setenv("ZOE_ASSISTANT_ROOT", LIVE)
+    text = (
+        f"cd {LIVE} && edit {LIVE}/services/zoe-data/x.py, then check "
+        f"{LIVE}/scripts/run.sh."
+    )
+    refs = find_live_path_references(text)
+    assert LIVE in refs
+    assert f"{LIVE}/services/zoe-data/x.py" in refs
+    assert f"{LIVE}/scripts/run.sh" in refs
+
+
+def test_find_live_path_references_clean_ticket(monkeypatch):
+    monkeypatch.setenv("ZOE_ASSISTANT_ROOT", LIVE)
+    # Worktree-relative paths are fine and must not be flagged.
+    assert find_live_path_references("edit services/zoe-data/x.py and run tests") == []
+
+
+def test_normalize_live_paths_rewrites_to_relative(monkeypatch):
+    monkeypatch.setenv("ZOE_ASSISTANT_ROOT", LIVE)
+    text = f"cd {LIVE} && python {LIVE}/scripts/run.sh services/x.py"
+    normalized = normalize_live_paths(text)
+    assert normalized == "cd . && python scripts/run.sh services/x.py"
+    assert LIVE not in normalized
+
+
+def test_validate_ticket_contract_blocks_live_path(monkeypatch):
+    monkeypatch.setenv("ZOE_ASSISTANT_ROOT", LIVE)
+    result = validate_ticket_contract(f"Please edit {LIVE}/services/zoe-data/x.py")
+    assert result["ok"] is False
+    assert any("WORKTREE_PATH_VIOLATION" in v for v in result["violations"])
+    assert "normalized_description" in result
+    assert LIVE not in result["normalized_description"]
+
+
+def test_validate_ticket_contract_passes_clean_ticket(monkeypatch):
+    monkeypatch.setenv("ZOE_ASSISTANT_ROOT", LIVE)
+    result = validate_ticket_contract("Edit services/zoe-data/x.py; run focused tests.")
+    assert result == {"ok": True, "violations": []}
+
+
+def test_validate_ticket_contract_honors_custom_live_root():
+    result = validate_ticket_contract("touch /srv/app/main.py", live_root="/srv/app")
+    assert result["ok"] is False
+    assert result["normalized_description"] == "touch main.py"
+
+
+def test_sibling_path_with_root_prefix_is_not_flagged(monkeypatch):
+    monkeypatch.setenv("ZOE_ASSISTANT_ROOT", LIVE)
+    # A different directory that merely shares the root as a string prefix.
+    assert find_live_path_references(f"back up {LIVE}-backup/data first") == []

--- a/services/zoe-data/tests/test_multica_ticket_contract.py
+++ b/services/zoe-data/tests/test_multica_ticket_contract.py
@@ -123,5 +123,41 @@ def test_validate_ticket_contract_honors_custom_live_root():
 
 def test_sibling_path_with_root_prefix_is_not_flagged(monkeypatch):
     monkeypatch.setenv("ZOE_ASSISTANT_ROOT", LIVE)
-    # A different directory that merely shares the root as a string prefix.
+    # Directories that merely share the root as a string prefix (hyphen and dot).
     assert find_live_path_references(f"back up {LIVE}-backup/data first") == []
+    assert find_live_path_references(f"see {LIVE}.bak and {LIVE}.config") == []
+
+
+def test_metadata_block_is_not_scanned_for_live_paths(monkeypatch):
+    monkeypatch.setenv("ZOE_ASSISTANT_ROOT", LIVE)
+    # A blocked_reason that legitimately quotes the offending path must not
+    # re-trigger a violation (it lives inside the machine-managed JSON block).
+    description = describe_ticket(
+        "Edit services/zoe-data/x.py only.",
+        zoe_kind="harness_fix",
+        acceptance_criteria=["done"],
+        evidence_expectations=["tests"],
+    )
+    blocked = update_ticket_progress(
+        description,
+        blocker=f"WORKTREE_PATH_VIOLATION: worker read {LIVE}/services/zoe-data/x.py",
+    )
+    assert find_live_path_references(blocked) == []
+    assert validate_ticket_contract(blocked)["ok"] is True
+
+
+def test_normalize_leaves_metadata_block_intact(monkeypatch):
+    monkeypatch.setenv("ZOE_ASSISTANT_ROOT", LIVE)
+    description = describe_ticket(
+        f"Run {LIVE}/scripts/run.sh.",
+        zoe_kind="harness_fix",
+        acceptance_criteria=["done"],
+        evidence_expectations=["tests"],
+    )
+    normalized = normalize_live_paths(description)
+    # Prose rewritten...
+    assert "Run scripts/run.sh." in normalized
+    # ...but the fenced block is preserved verbatim and still parses.
+    block = description[description.index("```zoe-ticket") :]
+    assert block in normalized
+    assert parse_ticket_block(normalized).get("schema") == 1


### PR DESCRIPTION
## Summary
- Adds `validate_ticket_contract()` to `multica_ticket_contract.py` (with `find_live_path_references` / `normalize_live_paths` helpers) to catch the **WORKTREE_PATH_VIOLATION** class *proactively at dispatch*.
- A ticket that hardcodes the live checkout root (`/home/zoe/assistant/...`) steers the worker out of its pinned, isolated worktree — today that only trips the runtime guard (`kanban_phase_budget.worktree_path_violation_reason_from_log`) *after* phase budget is burned. This fails closed earlier.
- Wires the lint into the admission gate: `ticket_is_dispatch_approved` now rejects live-path tickets, so `select_next_approved_issue` won't dispatch them.
- `normalize_live_paths` offers a safe worktree-relative rewrite (`<root>/services/x.py` → `services/x.py`, bare `<root>` → `.`).
- Root is configurable via `ZOE_ASSISTANT_ROOT`; a boundary lookahead avoids false-flagging siblings like `<root>-backup`.

## Test plan
- [x] `pytest tests/test_multica_ticket_contract.py tests/test_multica_admission.py` (30 passed): detection of root + nested paths, clean tickets pass, normalization to relative, custom root, sibling-prefix not flagged, and the admission gate blocks + de-selects a live-path ticket.
- [x] `pytest tests/test_kanban_adapter.py` (256 passed) — no regressions in the broader admission/adapter surface.
- [x] `py_compile` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)