### PR TITLE
feat(autoresearch): governed promotion bridge + model knob

### DIFF
--- a/services/zoe-data/autoresearch_bridge.py
+++ b/services/zoe-data/autoresearch_bridge.py
@@ -1,0 +1,417 @@
+"""Promote a finished autoresearch run into the governed engineering pipeline.
+
+An autoresearch run (see ``skills/autoresearch-engineer``) optimizes ONE approved
+asset against ONE locked score on a throwaway ``autoresearch/<tag>`` branch,
+logging each round to ``results.tsv``. When a run nets a real improvement, its
+kept asset edits should not be silently committed to production — they must go
+through the SAME review gate as any other change (Greptile + the harness).
+
+This module is the bridge. It is intentionally side-effect free at import time:
+pure functions parse the run, decide whether it earned promotion, and build the
+two governed artifacts —
+
+  1. a PR body describing the validated improvement (the diff still goes through
+     Greptile review and required checks before merge), and
+  2. an OPTIONAL Multica *audit record* — a non-dispatchable ticket that documents
+     the run. It is deliberately built without ``dispatch_approved`` and with empty
+     acceptance/evidence so ``multica_admission.ticket_is_dispatch_approved`` fails
+     closed: an audit record can never be picked up as a work order.
+
+The thin ``__main__`` CLI defaults to a dry run that prints the promotion plan as
+JSON; emitting the audit ticket is opt-in behind ``--emit-audit``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import io
+import json
+import re
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+from multica_ticket_contract import describe_ticket
+
+# Result-log status vocabulary (mirrors the autoresearch skill).
+STATUS_BASELINE = "baseline"
+STATUS_KEEP = "keep"
+STATUS_DISCARD = "discard"
+STATUS_CRASH = "crash"
+STATUS_BLOCKED = "blocked"
+
+AUDIT_ZOE_KIND = "autoresearch_audit"
+AUDIT_SOURCE_PREFIX = "autoresearch_audit"
+
+
+@dataclass
+class Program:
+    """Parsed, human-owned ``program.md`` contract for one autoresearch run."""
+
+    goal: str = ""
+    why: str = ""
+    asset_paths: list[str] = field(default_factory=list)
+    scoring_command: str = ""
+    higher_is_better: bool = True
+    target_score: float | None = None
+    stop_condition: str = ""
+    model: str | None = None
+
+
+@dataclass
+class RunSummary:
+    """Derived outcome of a run's ``results.tsv`` rounds."""
+
+    rounds: int = 0
+    baseline_score: float | None = None
+    final_score: float | None = None
+    best_score: float | None = None
+    kept: int = 0
+    discarded: int = 0
+    crashed: int = 0
+    blocked: int = 0
+    improved: bool = False
+    net_improvement: float | None = None
+    best_hypothesis: str = ""
+    keeper_commits: list[str] = field(default_factory=list)
+
+
+def _first(pattern: str, text: str) -> str:
+    match = re.search(pattern, text, re.IGNORECASE | re.MULTILINE)
+    return match.group(1).strip() if match else ""
+
+
+def _to_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(str(value).strip())
+    except (TypeError, ValueError):
+        return None
+
+
+def parse_program(text: str | None) -> Program:
+    """Parse the conventions used in ``program.md`` into a typed contract.
+
+    Recognized prose lines (case-insensitive, leading list markers tolerated):
+      Goal: ... / Why: ... / Editable asset allowlist: a.py, b.md only.
+      Locked scoring command: <cmd> / Higher|Lower (score) is better.
+      Stop condition: ... / Model: <provider/name>  (also "Run model:")
+    """
+    text = text or ""
+    program = Program()
+    program.goal = _first(r"^\s*[-*]?\s*Goal\s*:\s*(.+)$", text)
+    program.why = _first(r"^\s*[-*]?\s*Why\s*:\s*(.+)$", text)
+    program.scoring_command = _first(
+        r"^\s*[-*]?\s*(?:Locked\s+)?scoring\s+command\s*:\s*(.+)$", text
+    )
+    program.stop_condition = _first(r"^\s*[-*]?\s*Stop\s+condition\s*:\s*(.+)$", text)
+
+    # Direction: default higher-is-better unless the program says lower.
+    if re.search(r"\blower\b[^.\n]*\bis\s+better\b", text, re.IGNORECASE):
+        program.higher_is_better = False
+    elif re.search(r"\bhigher\b[^.\n]*\bis\s+better\b", text, re.IGNORECASE):
+        program.higher_is_better = True
+
+    target_raw = _first(
+        r"^\s*[-*]?\s*Target(?:\s+score)?\s*:\s*([-+]?\d+(?:\.\d+)?)", text
+    )
+    program.target_score = _to_float(target_raw) if target_raw else None
+
+    # Optional model knob — the human picks which model runs the loop.
+    program.model = (
+        _first(r"^\s*[-*]?\s*(?:Run\s+)?model\s*:\s*(.+)$", text) or None
+    )
+
+    allowlist = _first(
+        r"^\s*[-*]?\s*Editable\s+asset\s+allowlist\s*:\s*(.+)$", text
+    )
+    if allowlist:
+        program.asset_paths = _split_asset_paths(allowlist)
+    return program
+
+
+def _split_asset_paths(raw: str) -> list[str]:
+    # Strip a trailing "only." qualifier and split on commas / "and" / whitespace.
+    cleaned = re.sub(r"\bonly\b\.?\s*$", "", raw.strip(), flags=re.IGNORECASE)
+    cleaned = cleaned.rstrip(". ")
+    parts = re.split(r"\s*,\s*|\s+and\s+", cleaned)
+    paths: list[str] = []
+    for part in parts:
+        token = part.strip().strip("`").rstrip(".")
+        if token and token not in paths:
+            paths.append(token)
+    return paths
+
+
+def parse_results(text: str | None) -> list[dict[str, str]]:
+    """Parse the TSV result log into ordered row dicts."""
+    text = text or ""
+    if not text.strip():
+        return []
+    reader = csv.DictReader(io.StringIO(text), delimiter="\t")
+    rows: list[dict[str, str]] = []
+    for row in reader:
+        rows.append({(k or "").strip(): (v or "").strip() for k, v in row.items()})
+    return rows
+
+
+def _is_better(candidate: float, incumbent: float, higher_is_better: bool) -> bool:
+    return candidate > incumbent if higher_is_better else candidate < incumbent
+
+
+def summarize_run(rows: list[dict[str, str]], *, higher_is_better: bool = True) -> RunSummary:
+    """Reduce result rounds to a promotion-ready outcome summary."""
+    summary = RunSummary(rounds=len(rows))
+    if not rows:
+        return summary
+
+    for row in rows:
+        status = (row.get("status") or "").lower()
+        if status == STATUS_KEEP:
+            summary.kept += 1
+            commit = row.get("commit") or ""
+            if commit:
+                summary.keeper_commits.append(commit)
+        elif status == STATUS_DISCARD:
+            summary.discarded += 1
+        elif status == STATUS_CRASH:
+            summary.crashed += 1
+        elif status == STATUS_BLOCKED:
+            summary.blocked += 1
+
+    baseline_row = next(
+        (r for r in rows if (r.get("status") or "").lower() == STATUS_BASELINE), None
+    )
+    summary.baseline_score = _to_float((baseline_row or {}).get("score"))
+
+    # Best score = best across baseline + kept rounds, per locked direction.
+    best_score: float | None = summary.baseline_score
+    best_hypothesis = ""
+    for row in rows:
+        status = (row.get("status") or "").lower()
+        if status not in {STATUS_BASELINE, STATUS_KEEP}:
+            continue
+        score = _to_float(row.get("score"))
+        if score is None:
+            continue
+        if best_score is None or _is_better(score, best_score, higher_is_better):
+            best_score = score
+            if status == STATUS_KEEP:
+                best_hypothesis = row.get("description") or ""
+    summary.best_score = best_score
+    summary.final_score = best_score
+    summary.best_hypothesis = best_hypothesis
+
+    if (
+        summary.baseline_score is not None
+        and best_score is not None
+        and _is_better(best_score, summary.baseline_score, higher_is_better)
+    ):
+        summary.improved = True
+        summary.net_improvement = round(best_score - summary.baseline_score, 6)
+    return summary
+
+
+def decide_promotion(program: Program, summary: RunSummary) -> dict[str, Any]:
+    """Decide whether a finished run earned a governed PR.
+
+    A run is promotable only when it produced at least one kept round AND a real
+    net improvement over baseline in the locked direction. Everything else (no
+    keepers, no improvement, only crashes/blocks) stays a no-op so a flat or
+    regressed run never opens a PR.
+    """
+    if summary.rounds == 0:
+        return {"promote": False, "reason": "no recorded rounds"}
+    if summary.baseline_score is None:
+        return {"promote": False, "reason": "no baseline score recorded"}
+    if summary.kept == 0:
+        return {"promote": False, "reason": "no kept rounds — nothing improved"}
+    if not summary.improved:
+        return {
+            "promote": False,
+            "reason": "no net improvement over baseline in the locked direction",
+        }
+    if not program.asset_paths:
+        return {
+            "promote": False,
+            "reason": "program declares no asset allowlist to promote",
+        }
+    return {
+        "promote": True,
+        "reason": (
+            f"net improvement {summary.net_improvement} "
+            f"({summary.baseline_score} -> {summary.final_score}) across "
+            f"{summary.kept} kept round(s)"
+        ),
+    }
+
+
+def _direction_word(higher_is_better: bool) -> str:
+    return "higher-is-better" if higher_is_better else "lower-is-better"
+
+
+def build_pr_body(run_id: str, program: Program, summary: RunSummary) -> str:
+    """Render a governed PR description for a promotable run.
+
+    The diff this body accompanies still passes through Greptile review and all
+    required status checks before merge — promotion does not bypass the gate.
+    """
+    paths = "\n".join(f"- `{p}`" for p in program.asset_paths) or "- (none declared)"
+    lines = [
+        f"## Autoresearch promotion — run `{run_id}`",
+        "",
+        "Validated keeper(s) from an autoresearch optimization loop. This PR goes "
+        "through the standard review gate (Greptile + required checks); it is not "
+        "auto-merged outside that gate.",
+        "",
+        f"**Goal:** {program.goal or '(unstated)'}",
+        f"**Why:** {program.why or '(unstated)'}",
+        f"**Model:** {program.model or '(session default)'}",
+        f"**Scoring:** `{program.scoring_command or '(unstated)'}` "
+        f"({_direction_word(program.higher_is_better)})",
+        "",
+        "### Result",
+        f"- Baseline score: {summary.baseline_score}",
+        f"- Final score: {summary.final_score}",
+        f"- Net improvement: {summary.net_improvement}",
+        f"- Rounds: {summary.rounds} (kept {summary.kept}, discarded "
+        f"{summary.discarded}, crashed {summary.crashed}, blocked {summary.blocked})",
+        f"- Best hypothesis: {summary.best_hypothesis or '(n/a)'}",
+        "",
+        "### Asset allowlist (only files this run was permitted to change)",
+        paths,
+        "",
+        "### Review checklist",
+        "- [ ] Diff is limited to the declared asset allowlist",
+        "- [ ] Improvement is real, not a scorer/goalpost change",
+        "- [ ] Greptile review passes at the required confidence",
+    ]
+    return "\n".join(lines)
+
+
+def build_audit_ticket(
+    run_id: str,
+    program: Program,
+    summary: RunSummary,
+    *,
+    pr_url: str | None = None,
+) -> str:
+    """Build a NON-dispatchable Multica audit record for a run.
+
+    The returned description is deliberately missing ``dispatch_approved`` and has
+    empty acceptance/evidence, so ``ticket_is_dispatch_approved`` fails closed and
+    the admission gate can never pick this audit record up as a work order.
+    """
+    prose_lines = [
+        f"Autoresearch run `{run_id}` audit record (not a work order).",
+        "",
+        f"Goal: {program.goal or '(unstated)'}",
+        f"Model: {program.model or '(session default)'}",
+        f"Scoring: {program.scoring_command or '(unstated)'} "
+        f"({_direction_word(program.higher_is_better)})",
+        f"Baseline {summary.baseline_score} -> final {summary.final_score} "
+        f"(net {summary.net_improvement}).",
+        f"Rounds: {summary.rounds}; kept {summary.kept}, discarded "
+        f"{summary.discarded}, crashed {summary.crashed}, blocked {summary.blocked}.",
+        f"Best hypothesis: {summary.best_hypothesis or '(n/a)'}.",
+        f"Assets: {', '.join(program.asset_paths) or '(none)'}.",
+    ]
+    if pr_url:
+        prose_lines.append(f"Governed PR: {pr_url}")
+
+    return describe_ticket(
+        "\n".join(prose_lines),
+        zoe_kind=AUDIT_ZOE_KIND,
+        evidence_profile="code",
+        engineering_mode="interactive",
+        acceptance_criteria=[],
+        evidence_expectations=[],
+        source=f"{AUDIT_SOURCE_PREFIX}:{run_id}",
+        metadata={
+            "autoresearch_run_id": run_id,
+            "autoresearch_model": program.model,
+            "autoresearch_baseline_score": summary.baseline_score,
+            "autoresearch_final_score": summary.final_score,
+            "autoresearch_net_improvement": summary.net_improvement,
+            "autoresearch_kept_rounds": summary.kept,
+            "autoresearch_keeper_commits": summary.keeper_commits,
+            "autoresearch_pr_url": pr_url,
+        },
+    )
+
+
+def _read_run_files(run_dir: Path) -> tuple[str, str]:
+    program_text = ""
+    results_text = ""
+    program_path = run_dir / "program.md"
+    results_path = run_dir / "results.tsv"
+    if program_path.exists():
+        program_text = program_path.read_text(encoding="utf-8")
+    if results_path.exists():
+        results_text = results_path.read_text(encoding="utf-8")
+    return program_text, results_text
+
+
+def prepare_promotion(run_dir: str | Path, *, pr_url: str | None = None) -> dict[str, Any]:
+    """Read a run directory and return a complete, side-effect-free promotion plan."""
+    run_dir = Path(run_dir)
+    run_id = run_dir.name
+    program_text, results_text = _read_run_files(run_dir)
+    program = parse_program(program_text)
+    summary = summarize_run(parse_results(results_text), higher_is_better=program.higher_is_better)
+    decision = decide_promotion(program, summary)
+
+    plan: dict[str, Any] = {
+        "ok": True,
+        "run_id": run_id,
+        "model": program.model,
+        "promote": decision["promote"],
+        "reason": decision["reason"],
+        "program": asdict(program),
+        "summary": asdict(summary),
+    }
+    if decision["promote"]:
+        plan["pr_title"] = f"autoresearch({run_id}): promote validated keeper"
+        plan["pr_body"] = build_pr_body(run_id, program, summary)
+        plan["audit_description"] = build_audit_ticket(
+            run_id, program, summary, pr_url=pr_url
+        )
+    return plan
+
+
+def _main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Autoresearch promotion bridge")
+    parser.add_argument("run_dir", help="Path to data/autoresearch/<run>")
+    parser.add_argument("--pr-url", default=None, help="Governed PR URL to record")
+    parser.add_argument(
+        "--emit-audit",
+        action="store_true",
+        help="Create the Multica audit record (default: dry run, plan only)",
+    )
+    args = parser.parse_args(argv)
+
+    plan = prepare_promotion(args.run_dir, pr_url=args.pr_url)
+    print(json.dumps(plan, indent=2, default=str))
+
+    if args.emit_audit and plan.get("promote"):
+        import asyncio
+
+        from multica_client import get_multica_client
+
+        async def _emit() -> dict[str, Any]:
+            client = get_multica_client()
+            return await client.create_issue(
+                title=plan["pr_title"],
+                description=plan["audit_description"],
+                status="backlog",
+            )
+
+        result = asyncio.run(_emit())
+        print(json.dumps({"audit_ticket": result}, indent=2, default=str))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(_main())

--- a/services/zoe-data/autoresearch_bridge.py
+++ b/services/zoe-data/autoresearch_bridge.py
@@ -186,8 +186,12 @@ def summarize_run(rows: list[dict[str, str]], *, higher_is_better: bool = True) 
     )
     summary.baseline_score = _to_float((baseline_row or {}).get("score"))
 
-    # Best score = best across baseline + kept rounds, per locked direction.
+    # best_score  = best observed across baseline + kept rounds (informational).
+    # final_score = score of the LAST kept round. Because worse rounds are reverted,
+    # the run branch ends at the last kept commit, so final_score is the asset's
+    # actual accumulated state — and that, not best-ever, is what gets promoted.
     best_score: float | None = summary.baseline_score
+    final_score: float | None = summary.baseline_score
     best_hypothesis = ""
     for row in rows:
         status = (row.get("status") or "").lower()
@@ -200,17 +204,24 @@ def summarize_run(rows: list[dict[str, str]], *, higher_is_better: bool = True) 
             best_score = score
             if status == STATUS_KEEP:
                 best_hypothesis = row.get("description") or ""
+        if status == STATUS_KEEP:
+            final_score = score
     summary.best_score = best_score
-    summary.final_score = best_score
+    summary.final_score = final_score
     summary.best_hypothesis = best_hypothesis
 
+    # Promotion keys off the committed end state (final_score), so a run that
+    # regresses below baseline by its last kept round is never sold as a win.
     if (
         summary.baseline_score is not None
-        and best_score is not None
-        and _is_better(best_score, summary.baseline_score, higher_is_better)
+        and final_score is not None
+        and _is_better(final_score, summary.baseline_score, higher_is_better)
     ):
         summary.improved = True
-        summary.net_improvement = round(best_score - summary.baseline_score, 6)
+        raw_delta = round(final_score - summary.baseline_score, 6)
+        # Normalize so an improvement is always reported as a positive magnitude,
+        # regardless of whether higher or lower is better.
+        summary.net_improvement = raw_delta if higher_is_better else -raw_delta
     return summary
 
 

--- a/services/zoe-data/autoresearch_bridge.py
+++ b/services/zoe-data/autoresearch_bridge.py
@@ -74,6 +74,7 @@ class RunSummary:
     improved: bool = False
     net_improvement: float | None = None
     best_hypothesis: str = ""
+    final_hypothesis: str = ""
     keeper_commits: list[str] = field(default_factory=list)
 
 
@@ -193,6 +194,7 @@ def summarize_run(rows: list[dict[str, str]], *, higher_is_better: bool = True) 
     best_score: float | None = summary.baseline_score
     final_score: float | None = summary.baseline_score
     best_hypothesis = ""
+    final_hypothesis = ""
     for row in rows:
         status = (row.get("status") or "").lower()
         if status not in {STATUS_BASELINE, STATUS_KEEP}:
@@ -206,9 +208,13 @@ def summarize_run(rows: list[dict[str, str]], *, higher_is_better: bool = True) 
                 best_hypothesis = row.get("description") or ""
         if status == STATUS_KEEP:
             final_score = score
+            # The last kept round is the actual promoted end state, so its
+            # description is what a reviewer should read to gauge the diff.
+            final_hypothesis = row.get("description") or ""
     summary.best_score = best_score
     summary.final_score = final_score
     summary.best_hypothesis = best_hypothesis
+    summary.final_hypothesis = final_hypothesis
 
     # Promotion keys off the committed end state (final_score), so a run that
     # regresses below baseline by its last kept round is never sold as a win.
@@ -289,7 +295,10 @@ def build_pr_body(run_id: str, program: Program, summary: RunSummary) -> str:
         f"- Net improvement: {summary.net_improvement}",
         f"- Rounds: {summary.rounds} (kept {summary.kept}, discarded "
         f"{summary.discarded}, crashed {summary.crashed}, blocked {summary.blocked})",
-        f"- Best hypothesis: {summary.best_hypothesis or '(n/a)'}",
+        f"- Promoted change (last kept round): "
+        f"{summary.final_hypothesis or '(n/a)'}",
+        f"- Best-scoring round (may be an intermediate, reverted state): "
+        f"{summary.best_hypothesis or '(n/a)'}",
         "",
         "### Asset allowlist (only files this run was permitted to change)",
         paths,
@@ -326,7 +335,8 @@ def build_audit_ticket(
         f"(net {summary.net_improvement}).",
         f"Rounds: {summary.rounds}; kept {summary.kept}, discarded "
         f"{summary.discarded}, crashed {summary.crashed}, blocked {summary.blocked}.",
-        f"Best hypothesis: {summary.best_hypothesis or '(n/a)'}.",
+        f"Promoted change (last kept round): {summary.final_hypothesis or '(n/a)'}.",
+        f"Best-scoring round (may be reverted): {summary.best_hypothesis or '(n/a)'}.",
         f"Assets: {', '.join(program.asset_paths) or '(none)'}.",
     ]
     if pr_url:

--- a/services/zoe-data/tests/test_autoresearch_bridge.py
+++ b/services/zoe-data/tests/test_autoresearch_bridge.py
@@ -82,8 +82,40 @@ def test_summarize_run_lower_is_better_direction():
     )
     summary = summarize_run(rows, higher_is_better=False)
     assert summary.best_score == 80
+    assert summary.final_score == 80
     assert summary.improved is True
-    assert summary.net_improvement == -20
+    # Improvement is reported as a positive magnitude even when lower is better.
+    assert summary.net_improvement == 20
+
+
+def test_summarize_run_final_score_reflects_last_keep_not_best():
+    # A later kept round scores worse than an earlier one: the promoted branch
+    # ends at 55, so final_score (and net_improvement) must reflect 55, not 80.
+    rows = parse_results(
+        "round\tcommit\tscore\tstatus\tdescription\n"
+        "1\tc0\t50\tbaseline\tbase\n"
+        "2\tc1\t80\tkeep\tbig win\n"
+        "3\tc2\t55\tkeep\tregressed but kept\n"
+    )
+    summary = summarize_run(rows, higher_is_better=True)
+    assert summary.best_score == 80
+    assert summary.final_score == 55
+    assert summary.improved is True
+    assert summary.net_improvement == 5
+
+
+def test_summarize_run_regressed_end_state_is_not_an_improvement():
+    # Last kept round lands below baseline — not promotable despite a kept round.
+    rows = parse_results(
+        "round\tcommit\tscore\tstatus\tdescription\n"
+        "1\tc0\t50\tbaseline\tbase\n"
+        "2\tc1\t70\tkeep\tup\n"
+        "3\tc2\t40\tkeep\tdown past baseline\n"
+    )
+    summary = summarize_run(rows, higher_is_better=True)
+    assert summary.final_score == 40
+    assert summary.improved is False
+    assert summary.net_improvement is None
 
 
 def test_decide_promotion_promotes_real_improvement():
@@ -166,6 +198,54 @@ def test_prepare_promotion_reads_run_dir(tmp_path):
     assert parse_ticket_block(plan["audit_description"])["source"] == (
         "autoresearch_audit:jun11-demo"
     )
+
+
+def test_emit_audit_cli_creates_backlog_audit_record(tmp_path, monkeypatch, capsys):
+    import multica_client
+
+    from autoresearch_bridge import _main
+
+    run_dir = tmp_path / "jun11-demo"
+    run_dir.mkdir()
+    (run_dir / "program.md").write_text(PROGRAM, encoding="utf-8")
+    (run_dir / "results.tsv").write_text(RESULTS, encoding="utf-8")
+
+    calls: dict[str, object] = {}
+
+    class _FakeClient:
+        async def create_issue(self, *, title, description, status):
+            calls.update(title=title, description=description, status=status)
+            return {"id": "audit-1", "identifier": "ZOE-9999"}
+
+    monkeypatch.setattr(multica_client, "get_multica_client", lambda: _FakeClient())
+
+    rc = _main([str(run_dir), "--emit-audit", "--pr-url", "https://github/pr/9"])
+    assert rc == 0
+    # The audit record lands in the backlog, non-dispatchable, with the run marker.
+    assert calls["status"] == "backlog"
+    assert calls["title"] == "autoresearch(jun11-demo): promote validated keeper"
+    assert "autoresearch_audit:jun11-demo" in calls["description"]
+    assert '"audit_ticket"' in capsys.readouterr().out
+
+
+def test_emit_audit_cli_is_noop_for_unpromotable_run(tmp_path, monkeypatch):
+    import multica_client
+
+    from autoresearch_bridge import _main
+
+    run_dir = tmp_path / "jun11-flat"
+    run_dir.mkdir()
+    (run_dir / "program.md").write_text(PROGRAM, encoding="utf-8")
+    (run_dir / "results.tsv").write_text(
+        "round\tcommit\tscore\tstatus\tdescription\n1\tc0\t50\tbaseline\tbase\n",
+        encoding="utf-8",
+    )
+
+    def _boom():  # pragma: no cover - must never be called
+        raise AssertionError("create_issue must not run for an unpromotable run")
+
+    monkeypatch.setattr(multica_client, "get_multica_client", _boom)
+    assert _main([str(run_dir), "--emit-audit"]) == 0
 
 
 def test_prepare_promotion_no_keeper_is_inert(tmp_path):

--- a/services/zoe-data/tests/test_autoresearch_bridge.py
+++ b/services/zoe-data/tests/test_autoresearch_bridge.py
@@ -71,6 +71,7 @@ def test_summarize_run_tracks_best_and_net_improvement():
     assert summary.improved is True
     assert summary.net_improvement == 21
     assert summary.best_hypothesis == "personalize greeting"
+    assert summary.final_hypothesis == "personalize greeting"
     assert summary.keeper_commits == ["c2", "c4"]
 
 
@@ -102,6 +103,10 @@ def test_summarize_run_final_score_reflects_last_keep_not_best():
     assert summary.final_score == 55
     assert summary.improved is True
     assert summary.net_improvement == 5
+    # best_hypothesis points at the intermediate high (c1), but the PR actually
+    # promotes the last kept commit (c2), so final_hypothesis must describe that.
+    assert summary.best_hypothesis == "big win"
+    assert summary.final_hypothesis == "regressed but kept"
 
 
 def test_summarize_run_regressed_end_state_is_not_an_improvement():
@@ -157,8 +162,28 @@ def test_pr_body_reports_scores_assets_and_model():
     assert "deepseek/deepseek-chat-v3.1" in body
     assert "Baseline score: 50" in body
     assert "Final score: 71" in body
+    assert "Promoted change (last kept round): personalize greeting" in body
     assert "`copy/onboarding_email.md`" in body
     assert "Greptile" in body
+
+
+def test_pr_body_distinguishes_promoted_from_best_scoring_round():
+    # Non-monotonic kept sequence: the best-scoring round is reverted, so the PR
+    # body must surface the promoted (last kept) change distinctly from the best.
+    program = parse_program(PROGRAM)
+    summary = summarize_run(
+        parse_results(
+            "round\tcommit\tscore\tstatus\tdescription\n"
+            "1\tc0\t50\tbaseline\tbase\n"
+            "2\tc1\t80\tkeep\tbig win\n"
+            "3\tc2\t55\tkeep\tsmall tweak\n"
+        ),
+        higher_is_better=True,
+    )
+    body = build_pr_body("jun11-demo", program, summary)
+    assert "Final score: 55" in body
+    assert "Promoted change (last kept round): small tweak" in body
+    assert "Best-scoring round" in body and "big win" in body
 
 
 def test_audit_ticket_is_never_dispatch_approved():

--- a/services/zoe-data/tests/test_autoresearch_bridge.py
+++ b/services/zoe-data/tests/test_autoresearch_bridge.py
@@ -1,0 +1,182 @@
+"""Tests for the autoresearch -> governed-pipeline promotion bridge."""
+
+from autoresearch_bridge import (
+    build_audit_ticket,
+    build_pr_body,
+    decide_promotion,
+    parse_program,
+    parse_results,
+    prepare_promotion,
+    summarize_run,
+)
+from multica_admission import ticket_is_dispatch_approved
+from multica_ticket_contract import parse_ticket_block
+
+
+PROGRAM = """# Auto Research Run: demo
+
+Goal: improve the onboarding email open rate.
+Why: more activated users.
+
+Locked rules:
+- Editable asset allowlist: copy/onboarding_email.md and copy/subject.md only.
+- Locked scoring command: python3 score.py
+- Higher score is better.
+- Run model: deepseek/deepseek-chat-v3.1
+- Target score: 80
+
+Stop condition: after 5 rounds or score reaches 80.
+"""
+
+RESULTS = "round\tcommit\tscore\tstatus\tdescription\n" + "\n".join(
+    [
+        "1\tc0\t50\tbaseline\tcurrent copy",
+        "2\tc1\t40\tdiscard\tshorter subject",
+        "3\tc2\t62\tkeep\tadd urgency line",
+        "4\tc3\t62\tdiscard\tno-op reword",
+        "5\tc4\t71\tkeep\tpersonalize greeting",
+    ]
+)
+
+
+def test_parse_program_extracts_contract_and_model():
+    program = parse_program(PROGRAM)
+    assert program.goal == "improve the onboarding email open rate."
+    assert program.why == "more activated users."
+    assert program.scoring_command == "python3 score.py"
+    assert program.higher_is_better is True
+    assert program.model == "deepseek/deepseek-chat-v3.1"
+    assert program.target_score == 80
+    assert program.asset_paths == ["copy/onboarding_email.md", "copy/subject.md"]
+
+
+def test_parse_program_defaults_model_none_and_respects_lower_is_better():
+    program = parse_program(
+        "Goal: cut p95 latency.\nLower score is better.\n"
+        "Editable asset allowlist: config/tuning.json only."
+    )
+    assert program.model is None
+    assert program.higher_is_better is False
+    assert program.asset_paths == ["config/tuning.json"]
+
+
+def test_summarize_run_tracks_best_and_net_improvement():
+    summary = summarize_run(parse_results(RESULTS), higher_is_better=True)
+    assert summary.rounds == 5
+    assert summary.baseline_score == 50
+    assert summary.kept == 2
+    assert summary.discarded == 2
+    assert summary.best_score == 71
+    assert summary.final_score == 71
+    assert summary.improved is True
+    assert summary.net_improvement == 21
+    assert summary.best_hypothesis == "personalize greeting"
+    assert summary.keeper_commits == ["c2", "c4"]
+
+
+def test_summarize_run_lower_is_better_direction():
+    rows = parse_results(
+        "round\tcommit\tscore\tstatus\tdescription\n"
+        "1\tc0\t100\tbaseline\tbase\n"
+        "2\tc1\t80\tkeep\tfaster path\n"
+    )
+    summary = summarize_run(rows, higher_is_better=False)
+    assert summary.best_score == 80
+    assert summary.improved is True
+    assert summary.net_improvement == -20
+
+
+def test_decide_promotion_promotes_real_improvement():
+    program = parse_program(PROGRAM)
+    summary = summarize_run(parse_results(RESULTS), higher_is_better=True)
+    decision = decide_promotion(program, summary)
+    assert decision["promote"] is True
+    assert "net improvement" in decision["reason"]
+
+
+def test_decide_promotion_blocks_flat_run():
+    program = parse_program(PROGRAM)
+    flat = summarize_run(
+        parse_results(
+            "round\tcommit\tscore\tstatus\tdescription\n"
+            "1\tc0\t50\tbaseline\tbase\n"
+            "2\tc1\t49\tdiscard\tworse\n"
+        ),
+        higher_is_better=True,
+    )
+    decision = decide_promotion(program, flat)
+    assert decision["promote"] is False
+    assert "no kept rounds" in decision["reason"]
+
+
+def test_decide_promotion_blocks_when_no_asset_allowlist():
+    program = parse_program("Goal: x\nHigher is better.")  # no allowlist
+    summary = summarize_run(parse_results(RESULTS), higher_is_better=True)
+    decision = decide_promotion(program, summary)
+    assert decision["promote"] is False
+    assert "asset allowlist" in decision["reason"]
+
+
+def test_pr_body_reports_scores_assets_and_model():
+    program = parse_program(PROGRAM)
+    summary = summarize_run(parse_results(RESULTS), higher_is_better=True)
+    body = build_pr_body("jun11-demo", program, summary)
+    assert "run `jun11-demo`" in body
+    assert "deepseek/deepseek-chat-v3.1" in body
+    assert "Baseline score: 50" in body
+    assert "Final score: 71" in body
+    assert "`copy/onboarding_email.md`" in body
+    assert "Greptile" in body
+
+
+def test_audit_ticket_is_never_dispatch_approved():
+    program = parse_program(PROGRAM)
+    summary = summarize_run(parse_results(RESULTS), higher_is_better=True)
+    description = build_audit_ticket(
+        "jun11-demo", program, summary, pr_url="https://github/pr/1"
+    )
+
+    meta = parse_ticket_block(description)
+    assert meta["zoe_kind"] == "autoresearch_audit"
+    assert meta["source"] == "autoresearch_audit:jun11-demo"
+    assert meta["autoresearch_net_improvement"] == 21
+    assert meta["autoresearch_pr_url"] == "https://github/pr/1"
+
+    # The crucial safety property: an audit record is inert at the dispatch gate.
+    issue = {
+        "assignee_id": "hermes-agent",
+        "assignee_type": "agent",
+        "description": description,
+    }
+    assert ticket_is_dispatch_approved(issue, hermes_agent_id="hermes-agent") is False
+
+
+def test_prepare_promotion_reads_run_dir(tmp_path):
+    run_dir = tmp_path / "jun11-demo"
+    run_dir.mkdir()
+    (run_dir / "program.md").write_text(PROGRAM, encoding="utf-8")
+    (run_dir / "results.tsv").write_text(RESULTS, encoding="utf-8")
+
+    plan = prepare_promotion(run_dir, pr_url="https://github/pr/9")
+    assert plan["run_id"] == "jun11-demo"
+    assert plan["promote"] is True
+    assert plan["model"] == "deepseek/deepseek-chat-v3.1"
+    assert plan["pr_title"] == "autoresearch(jun11-demo): promote validated keeper"
+    assert "Final score: 71" in plan["pr_body"]
+    assert parse_ticket_block(plan["audit_description"])["source"] == (
+        "autoresearch_audit:jun11-demo"
+    )
+
+
+def test_prepare_promotion_no_keeper_is_inert(tmp_path):
+    run_dir = tmp_path / "jun11-flat"
+    run_dir.mkdir()
+    (run_dir / "program.md").write_text(PROGRAM, encoding="utf-8")
+    (run_dir / "results.tsv").write_text(
+        "round\tcommit\tscore\tstatus\tdescription\n1\tc0\t50\tbaseline\tbase\n",
+        encoding="utf-8",
+    )
+    plan = prepare_promotion(run_dir)
+    assert plan["promote"] is False
+    assert "pr_body" not in plan
+    assert "audit_description" not in plan

--- a/skills/autoresearch-engineer/SKILL.md
+++ b/skills/autoresearch-engineer/SKILL.md
@@ -64,6 +64,7 @@ Create or verify these files before the first run. Names may vary by project, bu
    - Usually `program.md`, `instructions.md`, or a Multica issue description.
    - Edited only by the human/operator.
    - Defines the goal, why it matters, the asset allowlist, scoring command, target score, run cadence, and stop conditions.
+   - May optionally pin the model for the loop with a `Model:` (or `Run model:`) line, e.g. `Model: deepseek/deepseek-chat-v3.1`. When omitted, the run uses the invoking session's default model. The bridge parses this line, records it in the promotion PR body and audit record, and a runner may pass it through to the loop.
 
 2. Agent-editable asset file or files:
    - The only files the Auto Research Engineer may change.
@@ -149,6 +150,14 @@ For Zoe repositories, this skill does not bypass engineering governance:
 - Do not create root Markdown files unless explicitly approved.
 - Do not edit production scoring, tests, or runtime services as part of an autoresearch run unless they are the declared asset and separately approved.
 - Do not run unbounded overnight loops without an explicit operator-approved max time, max rounds, and stop mechanism.
+
+## Promotion (Governed)
+
+A finished run that nets a real improvement does not commit straight to production. Promote it through the same review gate as any other change:
+
+- Use `services/zoe-data/autoresearch_bridge.py` (`prepare_promotion(<run_dir>)`) to read the run's `program.md` + `results.tsv` and produce a promotion plan. It promotes only when there is at least one `keep` round AND a net improvement over baseline in the locked direction; flat or regressed runs stay a no-op.
+- Open the validated keeper as a normal PR from the `autoresearch/<tag>` branch using the generated PR body. The diff must still pass Greptile review and all required checks before merge — promotion never bypasses the gate.
+- Optionally emit a Multica **audit record** (`--emit-audit`) that documents the run. The audit ticket is built without `dispatch_approved` and with empty acceptance/evidence, so the admission gate fails closed and it can never be picked up as a work order.
 
 ## Morning Report
 


### PR DESCRIPTION
## Summary
- Adds `services/zoe-data/autoresearch_bridge.py` — a side-effect-free core that turns a finished autoresearch run (`program.md` + `results.tsv`) into a governed promotion plan.
- Promotes only when a run has **≥1 kept round AND a real net improvement** over baseline in the locked direction; flat/regressed runs stay a no-op.
- Builds two governed artifacts: (1) a **PR body** whose diff still passes the standard Greptile + required-check gate (promotion never bypasses review), and (2) an **optional Multica audit record** built *without* `dispatch_approved` and with empty acceptance/evidence, so `ticket_is_dispatch_approved` fails closed — an audit record can never be admitted as a work order.
- Adds an optional `Model:` / `Run model:` knob to `program.md` (parsed into the plan, PR body, and audit metadata; defaults to the session model) and documents promotion + the model knob in the autoresearch skill.
- Thin CLI defaults to a dry-run plan; `--emit-audit` opts into creating the record.

## Test plan
- [x] `pytest tests/test_autoresearch_bridge.py` — 11 tests (program/model parsing, score summarization in both directions, promotion gating, PR body, audit-ticket non-dispatch safety, run-dir reading)
- [x] Audit-record safety asserted: `ticket_is_dispatch_approved(...)` is `False` for a built audit ticket
- [x] Dogfooded CLI against `data/autoresearch/jun11-skill` (baseline-only run → correctly `promote: false`)
- [x] `pytest tests/test_multica_ticket_contract.py tests/test_multica_admission.py` still green (43 total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)