### PR TITLE
feat(multica-health): surface native comment task guard status (ZOE-5733)

### DIFF
--- a/scripts/maintenance/multica_health_report.py
+++ b/scripts/maintenance/multica_health_report.py
@@ -40,6 +40,21 @@ def _oidc_client_id_configured() -> bool:
     return bool(os.environ.get("MULTICA_OIDC_CLIENT_ID"))
 
 
+def _native_comment_guard_status() -> str:
+    """Report the posture of the native comment task guard.
+
+    The guard suppresses no-op agent follow-up tasks for comments on done issues
+    so they do not burn agent spend; operators need to see its state in the
+    health report. Returns ``"unset"`` when the flag is absent or blank,
+    ``"enabled"`` for a truthy value, and ``"disabled"`` only when explicitly
+    turned off.
+    """
+    raw = os.environ.get("ZOE_MULTICA_NATIVE_COMMENT_GUARD")
+    if raw is None or raw.strip() == "":
+        return "unset"
+    return "enabled" if raw.strip().lower() in {"1", "true", "yes", "on"} else "disabled"
+
+
 async def _probe(url: str, *, headers: dict[str, str] | None = None) -> dict:
     try:
         async with httpx.AsyncClient(timeout=5.0, follow_redirects=True) as client:
@@ -70,6 +85,7 @@ async def run(*, ensure_shape: bool = False) -> dict:
             os.environ.get("RESEND_API_KEY") or os.environ.get("SMTP_HOST")
         ),
         "hermes_agent_id": get_engineering_multica_agent_id(),
+        "native_comment_guard": _native_comment_guard_status(),
         "checks": {},
     }
     if not client.is_configured():

--- a/services/zoe-data/tests/test_multica_health_report.py
+++ b/services/zoe-data/tests/test_multica_health_report.py
@@ -91,3 +91,51 @@ def test_oidc_client_id_requires_explicit_configuration(monkeypatch):
     assert module._oidc_client_id_configured() is False
     monkeypatch.setenv("MULTICA_OIDC_CLIENT_ID", "multica")
     assert module._oidc_client_id_configured() is True
+
+
+def test_native_comment_guard_unset_is_not_an_error(monkeypatch):
+    module = _module()
+    monkeypatch.delenv("ZOE_MULTICA_NATIVE_COMMENT_GUARD", raising=False)
+    assert module._native_comment_guard_status() == "unset"
+    # Blank string is treated the same as absent.
+    monkeypatch.setenv("ZOE_MULTICA_NATIVE_COMMENT_GUARD", "  ")
+    assert module._native_comment_guard_status() == "unset"
+
+
+def test_native_comment_guard_enabled_for_truthy_values(monkeypatch):
+    module = _module()
+    for value in ("1", "true", "TRUE", "yes", "On"):
+        monkeypatch.setenv("ZOE_MULTICA_NATIVE_COMMENT_GUARD", value)
+        assert module._native_comment_guard_status() == "enabled"
+
+
+def test_native_comment_guard_disabled_only_when_explicitly_off(monkeypatch):
+    module = _module()
+    for value in ("false", "0", "no", "off"):
+        monkeypatch.setenv("ZOE_MULTICA_NATIVE_COMMENT_GUARD", value)
+        assert module._native_comment_guard_status() == "disabled"
+
+
+def test_report_surfaces_guard_status_without_a_live_database(monkeypatch):
+    import multica_client
+
+    module = _module()
+    monkeypatch.setenv("ZOE_MULTICA_NATIVE_COMMENT_GUARD", "false")
+
+    class _Unconfigured:
+        def is_configured(self):
+            return False
+
+    # run() does `from multica_client import ...` at call time, so patch the
+    # source module rather than the script module.
+    monkeypatch.setattr(multica_client, "get_multica_client", lambda: _Unconfigured())
+    monkeypatch.setattr(
+        multica_client, "get_engineering_multica_agent_id", lambda: None
+    )
+
+    report = asyncio.run(module.run())
+    # The field is present even on the unconfigured early-return path, and an
+    # explicitly-off guard is surfaced as "disabled". ok is False here only
+    # because the client is unconfigured, not because the guard is off.
+    assert report["native_comment_guard"] == "disabled"
+    assert report["ok"] is False


### PR DESCRIPTION
## ZOE-5733 — native comment task guard visibility

The live Multica health report validates runtime contracts but doesn't expose whether the **native comment task guard** is enabled. That guard suppresses no-op agent follow-up tasks for comments on *done* issues so they don't burn agent spend — operators need to see its posture in the report.

### Change
- New helper `_native_comment_guard_status()` reads `ZOE_MULTICA_NATIVE_COMMENT_GUARD` and returns `"enabled"` / `"disabled"` / `"unset"`.
- New top-level `native_comment_guard` field in the report dict (present on both the configured and the unconfigured early-return paths).
- Informational only: it never flips overall `ok` on its own.

### Acceptance criteria
- [x] Report shows whether `ZOE_MULTICA_NATIVE_COMMENT_GUARD` is enabled
- [x] Report stays `ok` when the guard is enabled or unset; clearly shows `disabled` when set false
- [x] Focused tests cover the field without requiring a live database

### Evidence
- `python3 -m py_compile scripts/maintenance/multica_health_report.py services/zoe-data/tests/test_multica_health_report.py` → OK
- `PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_multica_health_report.py` → 9 passed
- Live smoke: `native_comment_guard` renders in the JSON report output

🤖 Generated with [Claude Code](https://claude.com/claude-code)