### PR TITLE
Route touch voice commands through Skybridge

### DIFF
--- a/services/zoe-data/routers/voice_tts.py
+++ b/services/zoe-data/routers/voice_tts.py
@@ -656,18 +656,18 @@ async def _broadcast_skybridge_ui(
             "source": "voice:skybridge",
         },
     }
+    card_payload = {
+        "type": "skybridge",
+        "data": {"summary": summary[:300]},
+        "card": cards[0] if cards else None,
+        "cards": cards,
+        "panel_id": panel_id,
+        "source": "voice:skybridge",
+    }
     card_action = {
         "id": f"voice_skybridge_card_{panel_id}_{delivery_key}",
         "action_type": "show_card",
-        "payload": {
-            "type": "skybridge",
-            "data": {"summary": summary[:300]},
-            "card": cards[0] if cards else None,
-            "cards": cards,
-            "result": skybridge_result,
-            "panel_id": panel_id,
-            "source": "voice:skybridge",
-        },
+        "payload": card_payload,
     }
     try:
         from database import get_db as _get_db
@@ -698,7 +698,7 @@ async def _broadcast_skybridge_ui(
                 user_id=_panel_user_id,
                 panel_id=panel_id,
                 action_type="show_card",
-                payload=card_action["payload"],
+                payload={**card_payload, "result": skybridge_result},
                 requested_by="voice",
                 idempotency_key=f"voice_skybridge_card_{panel_id}_{delivery_key}",
             )

--- a/services/zoe-data/routers/voice_tts.py
+++ b/services/zoe-data/routers/voice_tts.py
@@ -670,6 +670,12 @@ async def _broadcast_skybridge_ui(
         "payload": card_payload,
     }
     try:
+        from push import broadcaster
+        await broadcaster.broadcast("all", "ui_action", {"action": nav_action})
+        await broadcaster.broadcast("all", "ui_action", {"action": card_action})
+    except Exception as exc:
+        logger.debug("voice skybridge ui broadcast failed (non-fatal): %s", exc)
+    try:
         from database import get_db as _get_db
         from ui_orchestrator import enqueue_ui_action as _enqueue_ui_action
         async for _db in _get_db():
@@ -705,12 +711,6 @@ async def _broadcast_skybridge_ui(
             break
     except Exception as exc:
         logger.debug("voice skybridge ui enqueue failed (non-fatal): %s", exc)
-    try:
-        from push import broadcaster
-        await broadcaster.broadcast("all", "ui_action", {"action": nav_action})
-        await broadcaster.broadcast("all", "ui_action", {"action": card_action})
-    except Exception as exc:
-        logger.debug("voice skybridge ui broadcast failed (non-fatal): %s", exc)
 
 
 async def _broadcast_shopping_chat_ui(

--- a/services/zoe-data/routers/voice_tts.py
+++ b/services/zoe-data/routers/voice_tts.py
@@ -631,6 +631,88 @@ async def _broadcast_calendar_ui(
         logger.debug("voice calendar ui enqueue failed (non-fatal): %s", exc)
 
 
+async def _broadcast_skybridge_ui(
+    panel_id: str,
+    skybridge_result: dict,
+    *,
+    utterance: str = "",
+    turn_key: Optional[str] = None,
+) -> None:
+    """Display a Skybridge result on the touch panel without routing to a domain page."""
+    if not skybridge_result or not skybridge_result.get("handled"):
+        return
+    delivery_key = turn_key or str(time.monotonic_ns())
+    query = quote_plus(str(utterance or skybridge_result.get("spoken_summary") or ""))
+    url = "/touch/skybridge.html" + (f"?q={query}" if query else "")
+    cards = skybridge_result.get("cards") if isinstance(skybridge_result.get("cards"), list) else []
+    summary = str(skybridge_result.get("spoken_summary") or "Showing this in Skybridge.")
+    nav_action = {
+        "id": f"voice_skybridge_nav_{panel_id}_{delivery_key}",
+        "action_type": "panel_navigate",
+        "payload": {
+            "url": url,
+            "label": "Opening Skybridge",
+            "panel_id": panel_id,
+            "source": "voice:skybridge",
+        },
+    }
+    card_action = {
+        "id": f"voice_skybridge_card_{panel_id}_{delivery_key}",
+        "action_type": "show_card",
+        "payload": {
+            "type": "skybridge",
+            "data": {"summary": summary[:300]},
+            "card": cards[0] if cards else None,
+            "cards": cards,
+            "result": skybridge_result,
+            "panel_id": panel_id,
+            "source": "voice:skybridge",
+        },
+    }
+    try:
+        from database import get_db as _get_db
+        from ui_orchestrator import enqueue_ui_action as _enqueue_ui_action
+        async for _db in _get_db():
+            _panel_user_id = "family-admin"
+            try:
+                _cur = await _db.execute(
+                    "SELECT user_id FROM ui_panel_sessions WHERE panel_id = ? ORDER BY last_seen_at DESC LIMIT 1",
+                    (panel_id,),
+                )
+                _row = await _cur.fetchone()
+                if _row and _row["user_id"]:
+                    _panel_user_id = str(_row["user_id"])
+            except Exception:
+                pass
+            await _enqueue_ui_action(
+                _db,
+                user_id=_panel_user_id,
+                panel_id=panel_id,
+                action_type="panel_navigate",
+                payload=nav_action["payload"],
+                requested_by="voice",
+                idempotency_key=f"voice_skybridge_nav_{panel_id}_{delivery_key}",
+            )
+            await _enqueue_ui_action(
+                _db,
+                user_id=_panel_user_id,
+                panel_id=panel_id,
+                action_type="show_card",
+                payload=card_action["payload"],
+                requested_by="voice",
+                idempotency_key=f"voice_skybridge_card_{panel_id}_{delivery_key}",
+            )
+            break
+    except Exception as exc:
+        logger.debug("voice skybridge ui enqueue failed (non-fatal): %s", exc)
+    try:
+        from push import broadcaster
+        await broadcaster.broadcast("all", "ui_action", {"action": nav_action})
+        await broadcaster.broadcast("all", "ui_action", {"action": card_action})
+    except Exception as exc:
+        logger.debug("voice skybridge ui broadcast failed (non-fatal): %s", exc)
+
+
 async def _broadcast_shopping_chat_ui(
     panel_id: str,
     list_type: str,
@@ -2322,6 +2404,52 @@ async def voice_command(
         await _bc.broadcast("all", "voice:thinking", {"panel_id": panel_id})
     except Exception:
         pass
+
+    # Skybridge-first touch prototype: supported visual domains render as cards
+    # on the single Skybridge surface instead of navigating to domain pages.
+    try:
+        from skybridge_service import resolve_skybridge_request
+
+        _voice_entry = _VOICE_SESSIONS.get(panel_id, {})
+        _skybridge_context = _voice_entry.get("skybridge_context") or {}
+        _skybridge_result = await resolve_skybridge_request(
+            text,
+            effective_user,
+            context=_skybridge_context,
+            db=db,
+        )
+        if _skybridge_result and _skybridge_result.get("handled"):
+            _VOICE_SESSIONS.setdefault(panel_id, {})["skybridge_context"] = (
+                _skybridge_result.get("skybridge_context") or {}
+            )
+            _skybridge_reply = str(_skybridge_result.get("spoken_summary") or "Showing that in Skybridge.")
+            await _broadcast_skybridge_ui(
+                panel_id,
+                _skybridge_result,
+                utterance=text,
+                turn_key=_turn_key,
+            )
+            try:
+                from push import broadcaster as _bc_sky
+                await _bc_sky.broadcast("all", "voice:responding", {"panel_id": panel_id, "text": _skybridge_reply[:200]})
+                await _bc_sky.broadcast("all", "voice:done", {"panel_id": panel_id})
+            except Exception:
+                pass
+            _skybridge_audio = await synthesize({"text": _skybridge_reply}, caller=caller)
+            await _schedule_voice_chat_save(session_id, text, _skybridge_reply, effective_user)
+            asyncio.ensure_future(_run_voice_memory_passes(text, _skybridge_reply, effective_user, session_id))
+            return {
+                "ok": True,
+                "panel_id": panel_id,
+                "reply": _skybridge_reply,
+                "audio_base64": base64.b64encode(_skybridge_audio.body).decode("ascii"),
+                "content_type": _skybridge_audio.media_type,
+                "intent": f"skybridge:{(_skybridge_result.get('intent') or {}).get('domain', 'unknown')}",
+                "skybridge": True,
+            }
+        _VOICE_SESSIONS.setdefault(panel_id, {})["skybridge_context"] = {}
+    except Exception as _skybridge_exc:
+        logger.debug("voice/command skybridge fast path failed (non-fatal): %s", _skybridge_exc)
 
     # Fallback audio used when any part of the pipeline fails — panel never goes silent.
     _FALLBACK_PHRASE = "Sorry, something went wrong. Please try again."

--- a/services/zoe-data/routers/voice_tts.py
+++ b/services/zoe-data/routers/voice_tts.py
@@ -2429,13 +2429,13 @@ async def voice_command(
                 utterance=text,
                 turn_key=_turn_key,
             )
+            _skybridge_audio = await synthesize({"text": _skybridge_reply}, caller=caller)
             try:
                 from push import broadcaster as _bc_sky
                 await _bc_sky.broadcast("all", "voice:responding", {"panel_id": panel_id, "text": _skybridge_reply[:200]})
                 await _bc_sky.broadcast("all", "voice:done", {"panel_id": panel_id})
             except Exception:
                 pass
-            _skybridge_audio = await synthesize({"text": _skybridge_reply}, caller=caller)
             await _schedule_voice_chat_save(session_id, text, _skybridge_reply, effective_user)
             asyncio.ensure_future(_run_voice_memory_passes(text, _skybridge_reply, effective_user, session_id))
             return {

--- a/services/zoe-data/tests/test_skybridge_static.py
+++ b/services/zoe-data/tests/test_skybridge_static.py
@@ -311,7 +311,8 @@ def test_skybridge_is_registered_in_touch_menu():
 
     assert "{ id: 'skybridge'" in menu
     assert "/touch/skybridge.html" in menu
-    assert "{ id: 'skybridge', path: '/touch/skybridge.html'," not in menu
+    assert "{ id: 'skybridge', path: '/touch/skybridge.html',  label: 'Home'" in menu
+    assert "{ id: 'dashboard', path: '/touch/dashboard.html',  label: 'Home'" not in menu
     assert "q=show%20my%20calendar" not in menu
     assert "Skybridge Calendar" not in menu
     assert "Skybridge Interface" not in menu
@@ -322,6 +323,39 @@ def test_skybridge_is_registered_in_touch_menu():
     assert "'dashboard', 'skybridge'," not in menu
     assert "'skybridge.html'" in menu
     assert "'dashboard', 'skybridge', 'calendar'" not in menu
+
+
+def test_touch_defaults_to_skybridge_home():
+    auth = (ROOT / "zoe-ui" / "dist" / "js" / "auth.js").read_text(encoding="utf-8")
+    touch_index = read(UI / "index.html")
+    executor = (ROOT / "zoe-ui" / "dist" / "js" / "touch-ui-executor.js").read_text(encoding="utf-8")
+    menu = read(UI / "js" / "touch-menu.js")
+
+    assert "const HOME_PATH = '/touch/skybridge.html';" in executor
+    assert "let dest = '/touch/skybridge.html';" in touch_index
+    assert "window.location.href = '/touch/skybridge.html';" in touch_index
+    assert "window.location.href = '/touch/skybridge.html';" in auth
+    assert "return '/touch/skybridge.html';" in menu
+
+
+def test_touch_executor_renders_skybridge_card_contracts():
+    executor = (ROOT / "zoe-ui" / "dist" / "js" / "touch-ui-executor.js").read_text(encoding="utf-8")
+
+    assert "function renderSkybridgeCardPayload(payload)" in executor
+    assert "payload && payload.card ? [payload.card]" in executor
+    assert "window.SkybridgeRenderer.render(card)" in executor
+    assert "if (renderSkybridgeCardPayload(payload))" in executor
+
+
+def test_voice_command_has_skybridge_first_touch_path():
+    voice = read(DATA / "routers" / "voice_tts.py")
+
+    assert "async def _broadcast_skybridge_ui" in voice
+    assert "resolve_skybridge_request(" in voice
+    assert "intent\": f\"skybridge:" in voice
+    assert "\"url\": url" in voice
+    assert "\"type\": \"skybridge\"" in voice
+    assert "\"result\": skybridge_result" in voice
 
 
 

--- a/services/zoe-data/tests/test_skybridge_static.py
+++ b/services/zoe-data/tests/test_skybridge_static.py
@@ -342,8 +342,12 @@ def test_touch_executor_renders_skybridge_card_contracts():
     executor = (ROOT / "zoe-ui" / "dist" / "js" / "touch-ui-executor.js").read_text(encoding="utf-8")
 
     assert "function renderSkybridgeCardPayload(payload)" in executor
+    assert "function sanitizeSkybridgeHtml(html)" in executor
+    assert "querySelectorAll('script, iframe, object, embed, link, meta, style')" in executor
+    assert "name.startsWith('on')" in executor
+    assert "/^(javascript|data):/.test(value)" in executor
     assert "payload && payload.card ? [payload.card]" in executor
-    assert "window.SkybridgeRenderer.render(card)" in executor
+    assert "sanitizeSkybridgeHtml(window.SkybridgeRenderer.render(card))" in executor
     assert "if (renderSkybridgeCardPayload(payload))" in executor
 
 
@@ -355,7 +359,8 @@ def test_voice_command_has_skybridge_first_touch_path():
     assert "intent\": f\"skybridge:" in voice
     assert "\"url\": url" in voice
     assert "\"type\": \"skybridge\"" in voice
-    assert "\"result\": skybridge_result" in voice
+    assert "payload={**card_payload, \"result\": skybridge_result}" in voice
+    assert "\"payload\": card_payload" in voice
 
 
 

--- a/services/zoe-data/tests/test_voice_weather_queue.py
+++ b/services/zoe-data/tests/test_voice_weather_queue.py
@@ -324,7 +324,7 @@ async def test_voice_command_uses_skybridge_fast_path(monkeypatch) -> None:
     monkeypatch.setattr(voice_tts, "_schedule_voice_chat_save", save_chat)
     monkeypatch.setattr(voice_tts, "_run_voice_memory_passes", memory_passes)
     monkeypatch.setattr(voice_tts.asyncio, "ensure_future", lambda coro: coro.close() if hasattr(coro, "close") else None)
-    voice_tts._VOICE_SESSIONS.pop("panel-sky", None)
+    monkeypatch.setattr(voice_tts, "_VOICE_SESSIONS", {})
 
     response = await voice_command(
         {"text": "show weather", "panel_id": "panel-sky", "session_id": "session-sky"},

--- a/services/zoe-data/tests/test_voice_weather_queue.py
+++ b/services/zoe-data/tests/test_voice_weather_queue.py
@@ -258,7 +258,7 @@ async def test_broadcast_skybridge_ui_opens_skybridge_with_card_payload(monkeypa
 
 @pytest.mark.asyncio
 async def test_voice_command_uses_skybridge_fast_path(monkeypatch) -> None:
-    calls: dict[str, object] = {"broadcast": []}
+    calls: dict[str, object] = {"broadcast": [], "events": []}
 
     async def resolve_skybridge_request(text, user_id, *, context=None, db=None):
         calls["resolver"] = {
@@ -296,6 +296,7 @@ async def test_voice_command_uses_skybridge_fast_path(monkeypatch) -> None:
     class Broadcaster:
         async def broadcast(self, channel, event, payload):
             calls["broadcast"].append((channel, event, payload))
+            calls["events"].append(event)
 
     class Audio:
         body = b"RIFF-test"
@@ -303,6 +304,7 @@ async def test_voice_command_uses_skybridge_fast_path(monkeypatch) -> None:
 
     async def synthesize(payload, caller=None):
         calls["synthesize"] = payload
+        calls["events"].append("synthesize")
         return Audio()
 
     async def no_user(*_args, **_kwargs):
@@ -345,4 +347,5 @@ async def test_voice_command_uses_skybridge_fast_path(monkeypatch) -> None:
     assert calls["synthesize"] == {"text": "It is sunny in Perth."}
     assert ("all", "voice:responding", {"panel_id": "panel-sky", "text": "It is sunny in Perth."}) in calls["broadcast"]
     assert ("all", "voice:done", {"panel_id": "panel-sky"}) in calls["broadcast"]
+    assert calls["events"].index("synthesize") < calls["events"].index("voice:done")
     assert voice_tts._VOICE_SESSIONS["panel-sky"]["skybridge_context"] == {"domain": "weather"}

--- a/services/zoe-data/tests/test_voice_weather_queue.py
+++ b/services/zoe-data/tests/test_voice_weather_queue.py
@@ -4,10 +4,12 @@ import types
 
 import pytest
 
+import routers.voice_tts as voice_tts
 from routers.voice_tts import (
     _broadcast_skybridge_ui,
     _broadcast_weather_ui,
     _should_supersede_voice_weather_action,
+    voice_command,
 )
 
 
@@ -248,3 +250,99 @@ async def test_broadcast_skybridge_ui_opens_skybridge_with_card_payload(monkeypa
     assert enqueue_calls[1]["payload"]["card"] == card
     assert enqueue_calls[1]["payload"]["result"] == result
     assert [item[2]["action"]["action_type"] for item in broadcasts] == ["panel_navigate", "show_card"]
+    broadcast_card = broadcasts[1][2]["action"]["payload"]
+    assert broadcast_card["card"] == card
+    assert broadcast_card["cards"] == [card]
+    assert "result" not in broadcast_card
+
+
+@pytest.mark.asyncio
+async def test_voice_command_uses_skybridge_fast_path(monkeypatch) -> None:
+    calls: dict[str, object] = {"broadcast": []}
+
+    async def resolve_skybridge_request(text, user_id, *, context=None, db=None):
+        calls["resolver"] = {
+            "text": text,
+            "user_id": user_id,
+            "context": context,
+            "db": db,
+        }
+        return {
+            "handled": True,
+            "spoken_summary": "It is sunny in Perth.",
+            "intent": {"domain": "weather", "action": "current"},
+            "skybridge_context": {"domain": "weather"},
+            "cards": [
+                {
+                    "schema_version": "1.0.0",
+                    "card_type": "generic",
+                    "card_id": "22222222-2222-2222-2222-222222222222",
+                    "content": {"title": "Weather", "source": "weather_current"},
+                    "producer": "test",
+                    "producer_version": "1",
+                    "created_at": "2026-06-14T00:00:00Z",
+                }
+            ],
+        }
+
+    async def broadcast_skybridge_ui(panel_id, result, *, utterance="", turn_key=None):
+        calls["broadcast_skybridge_ui"] = {
+            "panel_id": panel_id,
+            "result": result,
+            "utterance": utterance,
+            "turn_key": turn_key,
+        }
+
+    class Broadcaster:
+        async def broadcast(self, channel, event, payload):
+            calls["broadcast"].append((channel, event, payload))
+
+    class Audio:
+        body = b"RIFF-test"
+        media_type = "audio/wav"
+
+    async def synthesize(payload, caller=None):
+        calls["synthesize"] = payload
+        return Audio()
+
+    async def no_user(*_args, **_kwargs):
+        return None
+
+    async def save_chat(*args, **_kwargs):
+        calls["save_chat"] = args
+
+    async def memory_passes(*args, **_kwargs):
+        calls["memory_passes"] = args
+
+    skybridge_module = types.SimpleNamespace(resolve_skybridge_request=resolve_skybridge_request)
+    monkeypatch.setitem(sys.modules, "skybridge_service", skybridge_module)
+    monkeypatch.setitem(sys.modules, "push", types.SimpleNamespace(broadcaster=Broadcaster()))
+    monkeypatch.setattr(voice_tts, "_broadcast_skybridge_ui", broadcast_skybridge_ui)
+    monkeypatch.setattr(voice_tts, "synthesize", synthesize)
+    monkeypatch.setattr(voice_tts, "_resolve_recent_panel_session_user", no_user)
+    monkeypatch.setattr(voice_tts, "_resolve_panel_default_user", no_user)
+    monkeypatch.setattr(voice_tts, "_schedule_voice_chat_save", save_chat)
+    monkeypatch.setattr(voice_tts, "_run_voice_memory_passes", memory_passes)
+    monkeypatch.setattr(voice_tts.asyncio, "ensure_future", lambda coro: coro.close() if hasattr(coro, "close") else None)
+    voice_tts._VOICE_SESSIONS.pop("panel-sky", None)
+
+    response = await voice_command(
+        {"text": "show weather", "panel_id": "panel-sky", "session_id": "session-sky"},
+        caller={"user_id": "guest", "panel_id": "panel-sky"},
+        db=object(),
+    )
+
+    assert response["ok"] is True
+    assert response["panel_id"] == "panel-sky"
+    assert response["reply"] == "It is sunny in Perth."
+    assert response["intent"] == "skybridge:weather"
+    assert response["skybridge"] is True
+    assert response["audio_base64"]
+    assert calls["resolver"]["text"] == "show weather"
+    assert calls["resolver"]["user_id"] == "guest"
+    assert calls["broadcast_skybridge_ui"]["panel_id"] == "panel-sky"
+    assert calls["broadcast_skybridge_ui"]["utterance"] == "show weather"
+    assert calls["synthesize"] == {"text": "It is sunny in Perth."}
+    assert ("all", "voice:responding", {"panel_id": "panel-sky", "text": "It is sunny in Perth."}) in calls["broadcast"]
+    assert ("all", "voice:done", {"panel_id": "panel-sky"}) in calls["broadcast"]
+    assert voice_tts._VOICE_SESSIONS["panel-sky"]["skybridge_context"] == {"domain": "weather"}

--- a/services/zoe-data/tests/test_voice_weather_queue.py
+++ b/services/zoe-data/tests/test_voice_weather_queue.py
@@ -5,6 +5,7 @@ import types
 import pytest
 
 from routers.voice_tts import (
+    _broadcast_skybridge_ui,
     _broadcast_weather_ui,
     _should_supersede_voice_weather_action,
 )
@@ -188,3 +189,62 @@ async def test_broadcast_weather_ui_supersedes_stale_rows_after_deduped_enqueue(
     assert db.events.index("transaction_exit") < db.events.index(
         "broadcast:voice_weather_nav_panel-1_turn-1"
     )
+
+
+@pytest.mark.asyncio
+async def test_broadcast_skybridge_ui_opens_skybridge_with_card_payload(monkeypatch) -> None:
+    db = _Db()
+    enqueue_calls = []
+    broadcasts = []
+
+    async def get_db():
+        yield db
+
+    async def enqueue_ui_action(_db, **kwargs):
+        enqueue_calls.append(kwargs)
+        return {
+            "id": kwargs["idempotency_key"],
+            "status": "queued",
+            "panel_id": kwargs["panel_id"],
+        }
+
+    class Broadcaster:
+        async def broadcast(self, channel, event, payload):
+            broadcasts.append((channel, event, payload))
+
+    monkeypatch.setitem(sys.modules, "database", types.SimpleNamespace(get_db=get_db))
+    monkeypatch.setitem(
+        sys.modules,
+        "ui_orchestrator",
+        types.SimpleNamespace(enqueue_ui_action=enqueue_ui_action),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "push",
+        types.SimpleNamespace(broadcaster=Broadcaster()),
+    )
+
+    card = {
+        "schema_version": "1.0.0",
+        "card_type": "generic",
+        "card_id": "11111111-1111-1111-1111-111111111111",
+        "content": {"title": "Weather", "source": "weather_current"},
+        "producer": "test",
+        "producer_version": "1",
+        "created_at": "2026-06-14T00:00:00Z",
+    }
+    result = {
+        "handled": True,
+        "spoken_summary": "Here is the weather.",
+        "intent": {"domain": "weather", "action": "current"},
+        "cards": [card],
+    }
+
+    await _broadcast_skybridge_ui("panel-1", result, utterance="show weather", turn_key="turn-1")
+
+    assert [call["action_type"] for call in enqueue_calls] == ["panel_navigate", "show_card"]
+    assert enqueue_calls[0]["payload"]["url"] == "/touch/skybridge.html?q=show+weather"
+    assert enqueue_calls[1]["payload"]["type"] == "skybridge"
+    assert enqueue_calls[1]["payload"]["card"] == card
+    assert enqueue_calls[1]["payload"]["result"] == result
+    assert [item[2]["action"]["action_type"] for item in broadcasts] == ["panel_navigate", "show_card"]

--- a/services/zoe-ui/dist/js/auth.js
+++ b/services/zoe-ui/dist/js/auth.js
@@ -346,7 +346,7 @@
                             showNotification('Please sign in with an allowed profile for this page.', 'error');
                         }
                     } catch (_) {}
-                    window.location.href = '/touch/dashboard.html';
+                    window.location.href = '/touch/skybridge.html';
                     return;
                 }
             }

--- a/services/zoe-ui/dist/js/touch-ui-executor.js
+++ b/services/zoe-ui/dist/js/touch-ui-executor.js
@@ -601,6 +601,28 @@ body.light-mode #zvo-header { border-bottom-color: rgba(0,0,0,0.07); }
         showBar: function (_text) { /* no-op */ },
     };
 
+    function sanitizeSkybridgeHtml(html) {
+        const template = document.createElement('template');
+        template.innerHTML = String(html || '');
+        template.content.querySelectorAll('script, iframe, object, embed, link, meta, style').forEach((node) => {
+            node.remove();
+        });
+        template.content.querySelectorAll('*').forEach((node) => {
+            Array.from(node.attributes || []).forEach((attr) => {
+                const name = String(attr.name || '').toLowerCase();
+                const value = String(attr.value || '').trim().toLowerCase();
+                if (name.startsWith('on')) {
+                    node.removeAttribute(attr.name);
+                    return;
+                }
+                if ((name === 'href' || name === 'src' || name === 'xlink:href') && /^(javascript|data):/.test(value)) {
+                    node.removeAttribute(attr.name);
+                }
+            });
+        });
+        return template.innerHTML;
+    }
+
     function renderSkybridgeCardPayload(payload) {
         const result = payload && payload.result;
         const cards = (
@@ -617,18 +639,19 @@ body.light-mode #zvo-header { border-bottom-color: rgba(0,0,0,0.07); }
             const wrap = document.createElement('div');
             wrap.className = 'sky-card-shell';
             wrap.style.animationDelay = `${Math.min(index * 90, 360)}ms`;
-            wrap.innerHTML = window.SkybridgeRenderer.render(card);
+            wrap.innerHTML = sanitizeSkybridgeHtml(window.SkybridgeRenderer.render(card));
             cardRoot.appendChild(wrap);
         });
         try {
             document.body.classList.remove('sky-empty');
             document.body.classList.add('sky-has-cards');
             const copy = document.getElementById('skyListeningCopy');
-            if (copy && result && result.spoken_summary) copy.textContent = result.spoken_summary;
+            const summary = (result && result.spoken_summary) || (payload && payload.data && payload.data.summary) || '';
+            if (copy && summary) copy.textContent = summary;
             const title = document.getElementById('skyContextTitle');
             if (title) title.textContent = 'Skybridge';
             const detail = document.getElementById('skyContextDetail');
-            if (detail && result && result.spoken_summary) detail.textContent = result.spoken_summary;
+            if (detail && summary) detail.textContent = summary;
         } catch (_) {
             // Non-fatal; the cards are already rendered.
         }

--- a/services/zoe-ui/dist/js/touch-ui-executor.js
+++ b/services/zoe-ui/dist/js/touch-ui-executor.js
@@ -53,7 +53,7 @@
     const AUTH_CHALLENGE_TTL_MS = 10 * 60 * 1000;
 
     const AUTO_HOME_TIMEOUT_S = Number(window.ZOE_AUTO_HOME_TIMEOUT_S || 20);
-    const HOME_PATH = '/touch/dashboard.html';
+    const HOME_PATH = '/touch/skybridge.html';
 
     function isHomePath(path) {
         try {
@@ -601,6 +601,40 @@ body.light-mode #zvo-header { border-bottom-color: rgba(0,0,0,0.07); }
         showBar: function (_text) { /* no-op */ },
     };
 
+    function renderSkybridgeCardPayload(payload) {
+        const result = payload && payload.result;
+        const cards = (
+            result && Array.isArray(result.cards) ? result.cards :
+            Array.isArray(payload && payload.cards) ? payload.cards :
+            payload && payload.card ? [payload.card] : []
+        ).filter(Boolean);
+        const cardRoot = document.getElementById('skyCards');
+        if (!cardRoot || !window.SkybridgeRenderer || typeof window.SkybridgeRenderer.render !== 'function' || !cards.length) {
+            return false;
+        }
+        cardRoot.innerHTML = '';
+        cards.forEach((card, index) => {
+            const wrap = document.createElement('div');
+            wrap.className = 'sky-card-shell';
+            wrap.style.animationDelay = `${Math.min(index * 90, 360)}ms`;
+            wrap.innerHTML = window.SkybridgeRenderer.render(card);
+            cardRoot.appendChild(wrap);
+        });
+        try {
+            document.body.classList.remove('sky-empty');
+            document.body.classList.add('sky-has-cards');
+            const copy = document.getElementById('skyListeningCopy');
+            if (copy && result && result.spoken_summary) copy.textContent = result.spoken_summary;
+            const title = document.getElementById('skyContextTitle');
+            if (title) title.textContent = 'Skybridge';
+            const detail = document.getElementById('skyContextDetail');
+            if (detail && result && result.spoken_summary) detail.textContent = result.spoken_summary;
+        } catch (_) {
+            // Non-fatal; the cards are already rendered.
+        }
+        return true;
+    }
+
     function setOrbMode(mode) {
         // Drive the floating orb (orb-loader.js) if present
         const orb = document.getElementById('zoeOrb') || document.querySelector('.zoe-orb');
@@ -642,7 +676,7 @@ body.light-mode #zvo-header { border-bottom-color: rgba(0,0,0,0.07); }
             'settings':   _page('settings.html'),
             'smart home': _page('smart-home.html'),
             'smarthome':  _page('smart-home.html'),
-            'home':       _page('dashboard.html'),
+            'home':       _page('skybridge.html'),
             'dashboard':  _page('dashboard.html'),
             'people':     _page('people.html'),
             'memories':   _page('memories.html'),
@@ -1224,6 +1258,9 @@ body.light-mode #zvo-header { border-bottom-color: rgba(0,0,0,0.07); }
                 // Ignore cards targeting a different panel.
                 if (payload.panel_id && payload.panel_id !== state.panelId) {
                     return { status: 'skipped', error_code: 'wrong_panel' };
+                }
+                if (renderSkybridgeCardPayload(payload)) {
+                    return { status: 'success' };
                 }
                 const cardType = payload.type || 'answer';
                 const cardData = payload.data || {};

--- a/services/zoe-ui/dist/touch/index.html
+++ b/services/zoe-ui/dist/touch/index.html
@@ -1491,7 +1491,7 @@
             };
             setTimeout(() => {
                 // Use stored destination if we were redirected here from a touch page
-                let dest = '/touch/dashboard.html';
+                let dest = '/touch/skybridge.html';
                 try {
                     const stored = sessionStorage.getItem('zoe_redirect_after_login');
                     if (stored && stored.startsWith('/touch/')) {
@@ -1644,7 +1644,7 @@
                                 localStorage.removeItem('redirect_loop_detected');
                             }, 5000); // Clear flag after 5 seconds
                             
-                            window.location.href = '/touch/dashboard.html';
+                            window.location.href = '/touch/skybridge.html';
                             return;
                         } else {
                             // Session expired

--- a/services/zoe-ui/dist/touch/js/touch-menu.js
+++ b/services/zoe-ui/dist/touch/js/touch-menu.js
@@ -14,15 +14,15 @@ const TouchMenu = (() => {
     const NAV_H = 64;
 
     const PRIMARY = [
-        { id: 'dashboard', path: '/touch/dashboard.html',  label: 'Home'     },
+        { id: 'skybridge', path: '/touch/skybridge.html',  label: 'Home'     },
         { id: 'calendar',  path: '/touch/calendar.html',   label: 'Calendar' },
         { id: 'lists',     path: '/touch/lists.html',      label: 'Lists'    },
         { id: 'chat',      path: '/touch/chat.html',       label: 'Chat'     },
     ];
 
     const ALL_PAGES = [
-        { id: 'dashboard',  path: '/touch/dashboard.html',  icon: '🏠', label: 'Home'       },
-        { id: 'skybridge',  path: '/touch/skybridge.html',  icon: '◇',  label: 'Skybridge'  },
+        { id: 'skybridge',  path: '/touch/skybridge.html',  icon: '◇',  label: 'Home'       },
+        { id: 'dashboard',  path: '/touch/dashboard.html',  icon: '🏠', label: 'Dashboard'  },
         { id: 'calendar',   path: '/touch/calendar.html',   icon: '📅', label: 'Calendar'   },
         { id: 'lists',      path: '/touch/lists.html',      icon: '☰',  label: 'Lists'      },
         { id: 'notes',      path: '/touch/notes.html',      icon: '📝', label: 'Notes'      },
@@ -532,7 +532,7 @@ html.dark-mode .ztm-ctx-item { color: rgba(255,255,255,0.88); border-bottom-colo
         try {
             const u = new URL(String(input || ''), window.location.origin);
             // External targets are never allowed from touch nav.
-            if (u.origin !== window.location.origin) return '/touch/dashboard.html';
+            if (u.origin !== window.location.origin) return '/touch/skybridge.html';
             const p = u.pathname || '/';
             const base = p.split('/').pop() || '';
             const allowed = new Set([
@@ -543,16 +543,16 @@ html.dark-mode .ztm-ctx-item { color: rgba(255,255,255,0.88); border-bottom-colo
             ]);
             // Already in touch namespace — allow only known touch pages.
             if (p.startsWith('/touch/')) {
-                return allowed.has(base) ? (p + (u.search || '') + (u.hash || '')) : '/touch/dashboard.html';
+                return allowed.has(base) ? (p + (u.search || '') + (u.hash || '')) : '/touch/skybridge.html';
             }
 
             // Map desktop routes to touch equivalents by basename.
             if (allowed.has(base)) return '/touch/' + base + (u.search || '') + (u.hash || '');
 
             // Default hard guard.
-            return '/touch/dashboard.html';
+            return '/touch/skybridge.html';
         } catch (_) {
-            return '/touch/dashboard.html';
+            return '/touch/skybridge.html';
         }
     }
 


### PR DESCRIPTION
## Summary
- make Skybridge the default touch home surface after login and home navigation
- route supported /api/voice/command requests through the Skybridge resolver before legacy domain navigation
- enqueue/broadcast Skybridge navigation plus card payloads so touch panels can render card-contract data in place

## Verification
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_skybridge_service.py services/zoe-data/tests/test_skybridge_static.py services/zoe-data/tests/test_skybridge_status.py services/zoe-data/tests/test_card_contract.py services/zoe-data/tests/test_voice_weather_queue.py
- python3 tools/audit/validate_structure.py
- python3 tools/audit/validate_critical_files.py
- git diff --check

## Deploy note
The live IP currently serves the older Skybridge asset version and does not yet include this voice bridge until this PR is merged/deployed.