### PR TITLE
fix(multica-poll): bound chain polls + recover zombie in_progress chains

### DIFF
--- a/services/zoe-data/main.py
+++ b/services/zoe-data/main.py
@@ -85,6 +85,83 @@ for _handler in logging.getLogger().handlers:
     _handler.addFilter(RequestIdFilter())
 
 
+async def _poll_chain_guarded(ref: str, *, issue: dict | None, timeout: float) -> dict:
+    """Poll a chain without letting one dead ref wedge the whole poll loop.
+
+    ``poll_ref`` has no internal timeout, so a died executor reference can hang
+    indefinitely and freeze the entire Multica poll loop (observed: a single
+    stale ``in_progress`` chain stalled all admission/dispatch for days). Bound
+    the call and, on timeout/error, return a safe not-found sentinel so callers
+    treat the chain as inactive and simply skip it this cycle.
+    """
+    from executor_registry import poll_ref  # type: ignore[import]
+
+    try:
+        return await asyncio.wait_for(poll_ref(ref, issue=issue), timeout=timeout)
+    except asyncio.TimeoutError:
+        logger.warning("multica_poll: poll_ref timed out for %s after %ss", ref, timeout)
+        return {"found": False, "status": "poll_timeout", "timed_out": True}
+    except Exception as exc:  # pragma: no cover - defensive; logged for operators
+        logger.debug("multica_poll: poll_ref error for %s: %s", ref, exc)
+        return {"found": False, "status": "poll_error", "error": str(exc)}
+
+
+async def _recover_stale_in_progress_issues(
+    client,
+    in_progress_issues: list[dict],
+    *,
+    hermes_id: str,
+    poll_chain,
+    now,
+    max_age_hours: float,
+) -> list[dict]:
+    """Reset dead ``in_progress`` chains to ``blocked`` so a zombie can't hold the lane.
+
+    The single-ticket lane is guarded by the presence of an ``in_progress``
+    issue. If a chain dies mid-run, its ticket sits ``in_progress`` forever and
+    the guard correctly — but unhelpfully — refuses to admit anything else. This
+    mirrors the existing stale ``Autopilot:`` todo cleanup: detect Hermes-owned
+    ``in_progress`` chains that are no longer active and untouched for
+    ``max_age_hours``, reset them to ``blocked`` (operator-visible), and return
+    the issues that are still legitimately in progress.
+    """
+    from multica_poll_dispatch import is_stale_in_progress  # type: ignore[import]
+
+    live: list[dict] = []
+    for issue in in_progress_issues or []:
+        if str(issue.get("assignee_id") or "") != hermes_id:
+            live.append(issue)
+            continue
+        if (issue.get("title") or "").lower().startswith("autopilot:"):
+            live.append(issue)
+            continue
+        chain = await poll_chain(issue)
+        if not is_stale_in_progress(issue, chain, now=now, max_age_hours=max_age_hours):
+            live.append(issue)
+            continue
+        try:
+            await client.record_progress(
+                str(issue.get("id")),
+                status="blocked",
+                blocker=(
+                    "stale in_progress reset: chain inactive and no metadata update "
+                    f"for >= {max_age_hours}h; freed the single ticket lane"
+                ),
+            )
+            logger.info(
+                "multica_poll: recovered stale in_progress %s -> blocked",
+                issue.get("identifier") or issue.get("id"),
+            )
+        except Exception as exc:  # pragma: no cover - defensive; keep issue if reset fails
+            logger.debug(
+                "multica_poll: stale in_progress recovery failed for %s: %s",
+                issue.get("id"),
+                exc,
+            )
+            live.append(issue)
+    return live
+
+
 async def _record_running_multica_chain_progress(
     client,
     issue_id: str,
@@ -605,13 +682,52 @@ async def lifespan(app: FastAPI):
                 try:
                     from multica_webhook_emitter import emit_issue_assigned, is_configured as _wh_ok
                     from multica_client import get_engineering_multica_agent_id  # type: ignore[import]
-                    from executor_registry import poll_ref  # type: ignore[import]
                     from multica_poll_dispatch import chain_is_running, chain_needs_dispatch  # type: ignore[import]
                     from multica_dispatch_control import dispatch_is_paused, pause_reason
 
                     _dispatch_paused = dispatch_is_paused()
                     if _wh_ok() and not _dispatch_paused:
                         _hermes = str(get_engineering_multica_agent_id())
+
+                        # Bound every chain poll and reclaim zombie in_progress
+                        # chains, so one dead executor ref can neither wedge the
+                        # loop nor jam the single lane indefinitely.
+                        try:
+                            _poll_timeout = float(
+                                os.environ.get("ZOE_MULTICA_POLL_REF_TIMEOUT_S", "20") or "20"
+                            )
+                        except ValueError:
+                            _poll_timeout = 20.0
+                        try:
+                            _stale_ip_hours = float(
+                                os.environ.get("ZOE_MULTICA_STALE_IN_PROGRESS_HOURS", "6") or "6"
+                            )
+                        except ValueError:
+                            _stale_ip_hours = 6.0
+                        _chain_cache: dict[str, dict] = {}
+
+                        async def _poll_chain(_issue: dict) -> dict:
+                            _tid = str(_issue.get("id") or "")
+                            if _tid not in _chain_cache:
+                                _chain_cache[_tid] = await _poll_chain_guarded(
+                                    f"multica:{_tid}", issue=_issue, timeout=_poll_timeout
+                                )
+                            return _chain_cache[_tid]
+
+                        # Recover dead in_progress chains before the idle check so a
+                        # freed lane can admit new work this same cycle.
+                        if _stale_ip_hours > 0 and in_progress_issues:
+                            import datetime as _dt
+
+                            in_progress_issues = await _recover_stale_in_progress_issues(
+                                client,
+                                in_progress_issues,
+                                hermes_id=_hermes,
+                                poll_chain=_poll_chain,
+                                now=_dt.datetime.now(_dt.timezone.utc),
+                                max_age_hours=_stale_ip_hours,
+                            )
+
                         # Throttle first-dispatch: cap new chains per cycle so a
                         # wave of assigned todos can't spawn N concurrent chains
                         # (mirrors the compatibility sync limit / kanban.max_in_progress).
@@ -648,13 +764,6 @@ async def lifespan(app: FastAPI):
                                         "multica_poll: admitted %s from backlog into the single ticket lane",
                                         _admitted.get("identifier") or _admitted.get("id"),
                                     )
-                        _chain_cache: dict[str, dict] = {}
-
-                        async def _poll_chain(_issue: dict) -> dict:
-                            _tid = str(_issue.get("id") or "")
-                            if _tid not in _chain_cache:
-                                _chain_cache[_tid] = await poll_ref(f"multica:{_tid}", issue=_issue)
-                            return _chain_cache[_tid]
 
                         _running_chains = 0
                         for _ip_issue in in_progress_issues:

--- a/services/zoe-data/main.py
+++ b/services/zoe-data/main.py
@@ -101,8 +101,8 @@ async def _poll_chain_guarded(ref: str, *, issue: dict | None, timeout: float) -
     except asyncio.TimeoutError:
         logger.warning("multica_poll: poll_ref timed out for %s after %ss", ref, timeout)
         return {"found": False, "status": "poll_timeout", "timed_out": True}
-    except Exception as exc:  # pragma: no cover - defensive; logged for operators
-        logger.debug("multica_poll: poll_ref error for %s: %s", ref, exc)
+    except Exception as exc:
+        logger.warning("multica_poll: poll_ref error for %s: %s", ref, exc)
         return {"found": False, "status": "poll_error", "error": str(exc)}
 
 
@@ -152,8 +152,8 @@ async def _recover_stale_in_progress_issues(
                 "multica_poll: recovered stale in_progress %s -> blocked",
                 issue.get("identifier") or issue.get("id"),
             )
-        except Exception as exc:  # pragma: no cover - defensive; keep issue if reset fails
-            logger.debug(
+        except Exception as exc:
+            logger.warning(
                 "multica_poll: stale in_progress recovery failed for %s: %s",
                 issue.get("id"),
                 exc,

--- a/services/zoe-data/multica_poll_dispatch.py
+++ b/services/zoe-data/multica_poll_dispatch.py
@@ -1,6 +1,8 @@
 """Helpers for the Multica poll-loop webhook dispatch bridge."""
 from __future__ import annotations
 
+import datetime as _dt
+
 
 def chain_needs_dispatch(chain: dict) -> bool:
     """Return True when a Hermes-assigned Multica issue should receive a Kanban phase.
@@ -61,3 +63,35 @@ def chain_is_running(chain: dict) -> bool:
         return True
     pipeline = chain.get("pipeline") or {}
     return pipeline.get("status") == "running"
+
+
+def _issue_age_hours(issue: dict, *, now: _dt.datetime) -> float | None:
+    """Hours since the issue's last metadata update (falls back to created_at)."""
+    raw = (issue or {}).get("updated_at") or (issue or {}).get("created_at") or ""
+    if not raw:
+        return None
+    try:
+        ts = _dt.datetime.fromisoformat(str(raw).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=_dt.timezone.utc)
+    return (now - ts).total_seconds() / 3600.0
+
+
+def is_stale_in_progress(
+    issue: dict, chain: dict, *, now: _dt.datetime, max_age_hours: float
+) -> bool:
+    """Return True when an ``in_progress`` issue is a dead chain holding the lane.
+
+    A live chain advances and records progress, bumping the issue's metadata, so
+    an ``in_progress`` ticket whose chain is no longer active (or could not be
+    polled — e.g. a timed-out/dead executor ref) and that has had no metadata
+    update for at least ``max_age_hours`` is a zombie occupying the single
+    one-ticket lane. Resumable chains (``partial`` / pipeline ``todo``) stay
+    active, so they are never reclaimed here.
+    """
+    if chain_is_active(chain):
+        return False
+    age = _issue_age_hours(issue, now=now)
+    return age is not None and age >= max_age_hours

--- a/services/zoe-data/tests/test_main_multica_poll.py
+++ b/services/zoe-data/tests/test_main_multica_poll.py
@@ -749,3 +749,106 @@ async def test_record_blocked_multica_chain_reuses_existing_protocol_followup():
     assert client.created == []
     assert client.labels == []
     assert client.notes == []
+
+
+@pytest.mark.asyncio
+async def test_poll_chain_guarded_returns_sentinel_on_timeout(monkeypatch):
+    import asyncio
+
+    import executor_registry
+    from main import _poll_chain_guarded
+
+    async def _hang(*_args, **_kwargs):
+        await asyncio.sleep(10)
+
+    monkeypatch.setattr(executor_registry, "poll_ref", _hang)
+    chain = await _poll_chain_guarded("multica:dead", issue={"id": "dead"}, timeout=0.01)
+    assert chain == {"found": False, "status": "poll_timeout", "timed_out": True}
+
+
+@pytest.mark.asyncio
+async def test_poll_chain_guarded_returns_sentinel_on_error(monkeypatch):
+    import executor_registry
+    from main import _poll_chain_guarded
+
+    async def _boom(*_args, **_kwargs):
+        raise RuntimeError("executor gone")
+
+    monkeypatch.setattr(executor_registry, "poll_ref", _boom)
+    chain = await _poll_chain_guarded("multica:x", issue={"id": "x"}, timeout=1.0)
+    assert chain["found"] is False
+    assert chain["status"] == "poll_error"
+
+
+@pytest.mark.asyncio
+async def test_poll_chain_guarded_passes_through_live_result(monkeypatch):
+    import executor_registry
+    from main import _poll_chain_guarded
+
+    async def _ok(ref, *, issue=None):
+        return {"found": True, "status": "running", "ref": ref}
+
+    monkeypatch.setattr(executor_registry, "poll_ref", _ok)
+    chain = await _poll_chain_guarded("multica:live", issue={"id": "live"}, timeout=1.0)
+    assert chain == {"found": True, "status": "running", "ref": "multica:live"}
+
+
+@pytest.mark.asyncio
+async def test_recover_stale_in_progress_resets_dead_chain_and_frees_lane():
+    import datetime as dt
+
+    from main import _recover_stale_in_progress_issues
+
+    now = dt.datetime(2026, 6, 14, 12, 0, tzinfo=dt.timezone.utc)
+    old = (now - dt.timedelta(hours=72)).isoformat()
+    client = RecordingClient()
+
+    zombie = {"id": "zombie", "identifier": "ZOE-DEAD", "assignee_id": "hermes", "updated_at": old}
+
+    async def _poll(_issue):
+        return {"found": False, "status": "poll_timeout", "timed_out": True}
+
+    live = await _recover_stale_in_progress_issues(
+        client, [zombie], hermes_id="hermes", poll_chain=_poll, now=now, max_age_hours=6
+    )
+
+    assert live == []  # lane freed
+    assert len(client.calls) == 1
+    args, kwargs = client.calls[0]
+    assert args[0] == "zombie"
+    assert kwargs["status"] == "blocked"
+    assert "stale in_progress reset" in kwargs["blocker"]
+
+
+@pytest.mark.asyncio
+async def test_recover_stale_in_progress_keeps_live_and_foreign_issues():
+    import datetime as dt
+
+    from main import _recover_stale_in_progress_issues
+
+    now = dt.datetime(2026, 6, 14, 12, 0, tzinfo=dt.timezone.utc)
+    old = (now - dt.timedelta(hours=72)).isoformat()
+    client = RecordingClient()
+
+    live_run = {"id": "live", "assignee_id": "hermes", "updated_at": old}
+    foreign = {"id": "foreign", "assignee_id": "other-agent", "updated_at": old}
+    autopilot = {"id": "ap", "assignee_id": "hermes", "title": "Autopilot: tracker", "updated_at": old}
+
+    async def _poll(issue):
+        # Only the genuine run is active; the others are skipped on
+        # ownership/title before any age-based reset is considered.
+        if issue["id"] == "live":
+            return {"found": True, "status": "running"}
+        return {"found": False, "status": "not_found"}
+
+    kept = await _recover_stale_in_progress_issues(
+        client,
+        [live_run, foreign, autopilot],
+        hermes_id="hermes",
+        poll_chain=_poll,
+        now=now,
+        max_age_hours=6,
+    )
+
+    assert kept == [live_run, foreign, autopilot]
+    assert client.calls == []  # nothing reset

--- a/services/zoe-data/tests/test_main_multica_poll.py
+++ b/services/zoe-data/tests/test_main_multica_poll.py
@@ -852,3 +852,29 @@ async def test_recover_stale_in_progress_keeps_live_and_foreign_issues():
 
     assert kept == [live_run, foreign, autopilot]
     assert client.calls == []  # nothing reset
+
+
+@pytest.mark.asyncio
+async def test_recover_stale_in_progress_keeps_issue_when_reset_fails():
+    import datetime as dt
+
+    from main import _recover_stale_in_progress_issues
+
+    now = dt.datetime(2026, 6, 14, 12, 0, tzinfo=dt.timezone.utc)
+    old = (now - dt.timedelta(hours=72)).isoformat()
+
+    class _FailingClient:
+        async def record_progress(self, *_args, **_kwargs):
+            raise RuntimeError("multica unreachable")
+
+    zombie = {"id": "zombie", "assignee_id": "hermes", "updated_at": old}
+
+    async def _poll(_issue):
+        return {"found": False, "status": "poll_timeout", "timed_out": True}
+
+    # If the reset call fails, the stale issue is conservatively kept in the lane
+    # (better than dropping it from tracking) and the failure is surfaced.
+    live = await _recover_stale_in_progress_issues(
+        _FailingClient(), [zombie], hermes_id="hermes", poll_chain=_poll, now=now, max_age_hours=6
+    )
+    assert live == [zombie]

--- a/services/zoe-data/tests/test_multica_poll_dispatch.py
+++ b/services/zoe-data/tests/test_multica_poll_dispatch.py
@@ -1,6 +1,20 @@
 """Tests for Multica poll-loop dispatch helpers."""
-from multica_poll_dispatch import chain_is_active, chain_is_running, chain_needs_dispatch
+import datetime as dt
+
+from multica_poll_dispatch import (
+    chain_is_active,
+    chain_is_running,
+    chain_needs_dispatch,
+    is_stale_in_progress,
+)
 import executors.kanban_adapter as ka
+
+
+_NOW = dt.datetime(2026, 6, 14, 12, 0, tzinfo=dt.timezone.utc)
+
+
+def _aged(hours):
+    return (_NOW - dt.timedelta(hours=hours)).isoformat()
 
 
 def test_chain_needs_dispatch_not_found():
@@ -105,3 +119,42 @@ def test_chain_is_running_excludes_partial_backfill_work():
     assert chain_is_running({"pipeline": {"status": "running"}}) is True
     assert chain_is_running({"pipeline": {"status": "todo"}}) is False
     assert chain_is_running({"status": "running", "pipeline": {"terminal_block": True}}) is False
+
+
+def test_is_stale_in_progress_reclaims_old_dead_chain():
+    # Chain no longer active (e.g. not_found) and untouched past the window.
+    issue = {"updated_at": _aged(8)}
+    assert is_stale_in_progress(
+        issue, {"found": False, "status": "not_found"}, now=_NOW, max_age_hours=6
+    ) is True
+
+
+def test_is_stale_in_progress_reclaims_timed_out_poll():
+    # A dead executor ref returns the poll-timeout sentinel; treat as inactive.
+    issue = {"updated_at": _aged(72)}
+    sentinel = {"found": False, "status": "poll_timeout", "timed_out": True}
+    assert is_stale_in_progress(issue, sentinel, now=_NOW, max_age_hours=6) is True
+
+
+def test_is_stale_in_progress_spares_active_chain_even_when_old():
+    issue = {"updated_at": _aged(48)}
+    for chain in (
+        {"found": True, "status": "running"},
+        {"found": True, "status": "partial"},
+        {"pipeline": {"status": "todo"}},
+    ):
+        assert is_stale_in_progress(issue, chain, now=_NOW, max_age_hours=6) is False
+
+
+def test_is_stale_in_progress_spares_recently_updated_chain():
+    issue = {"updated_at": _aged(1)}
+    assert is_stale_in_progress(
+        issue, {"found": False, "status": "not_found"}, now=_NOW, max_age_hours=6
+    ) is False
+
+
+def test_is_stale_in_progress_needs_a_timestamp_to_judge_age():
+    # No updated_at/created_at -> cannot prove staleness, so never reclaim.
+    assert is_stale_in_progress(
+        {}, {"found": False, "status": "not_found"}, now=_NOW, max_age_hours=6
+    ) is False


### PR DESCRIPTION
## Problem (observed live)

The autonomous Multica poll loop was silently frozen. **ZOE-5456** sat `in_progress` with **no live worker since 2026-06-11**, and the loop made zero admit/dispatch progress for ~3 days. Two root causes:

1. **`poll_ref` has no timeout.** A died executor ref hangs the poll cycle indefinitely, so one dead chain wedges the entire loop.
2. **No stale-`in_progress` recovery.** The single-ticket lane is guarded by the presence of an `in_progress` issue; a dead chain holds that slot forever and the lane never reopens.

Net effect: a single zombie chain takes down the whole autonomous pipeline, with no self-recovery.

## Fix

**1. Bounded chain polls** — `_poll_chain_guarded()` wraps `poll_ref` in `asyncio.wait_for` and returns a safe not-found sentinel (`status: poll_timeout` / `poll_error`) on timeout/error. Existing predicates (`chain_is_running` / `chain_needs_dispatch` / `chain_is_active`) already treat that sentinel as inactive, so a dead ref is skipped instead of wedging the loop. Configurable via `ZOE_MULTICA_POLL_REF_TIMEOUT_S` (default `20`).

**2. Stale-`in_progress` recovery** — `is_stale_in_progress()` (pure predicate) + `_recover_stale_in_progress_issues()` detect Hermes-owned `in_progress` chains that are no longer active **and** untouched for ≥ N hours, reset them to `blocked` (operator-visible), and free the lane *before* the same cycle's idle check — mirroring the existing stale `Autopilot:` todo cleanup. Configurable via `ZOE_MULTICA_STALE_IN_PROGRESS_HOURS` (default `6`). Resumable chains (`partial` / pipeline `todo`) and non-Hermes / `Autopilot:` issues are never reclaimed.

## Tests
10 new focused tests:
- `is_stale_in_progress` matrix (dead+old → reclaim; timed-out sentinel → reclaim; active/recent/no-timestamp → spare)
- `_poll_chain_guarded` timeout / error / live passthrough
- `_recover_stale_in_progress_issues` resets a dead chain and frees the lane; spares live/foreign/autopilot issues

`PYTHONPATH=. pytest tests/test_multica_poll_dispatch.py tests/test_main_multica_poll.py` → **48 passed**. Source-inspection ordering tests still pass.

## Note
This is the structural unblock for autonomous operation: until this lands, a single dead chain can freeze the loop. Once merged + the service restarts, the loop self-heals stale lanes and admits armed backlog work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)