### PR TITLE
Allow bound touch sessions on panel push sockets

### DIFF
--- a/services/zoe-data/main.py
+++ b/services/zoe-data/main.py
@@ -1084,6 +1084,33 @@ async def internal_broadcast(payload: dict, _: None = Depends(require_internal_t
     return {"ok": True}
 
 
+async def _session_can_subscribe_panel(panel_id: str, session_id: str | None) -> bool:
+    """Allow browser panel sockets only for sessions bound to that panel."""
+    user = await _resolve_ws_session(session_id)
+    if user is None:
+        return False
+    user_id = str(user.get("user_id") or "")
+    role = str(user.get("role") or "").lower()
+    if not user_id:
+        return False
+    if role in {"admin", "agent"}:
+        return True
+    try:
+        from database import get_db
+
+        async for db in get_db():
+            cursor = await db.execute(
+                "SELECT user_id FROM ui_panel_sessions WHERE panel_id = ? ORDER BY last_seen_at DESC LIMIT 1",
+                (panel_id,),
+            )
+            row = await cursor.fetchone()
+            return bool(row and str(row["user_id"]) == user_id)
+    except Exception as exc:
+        logger.debug("push websocket panel session validation failed: %s", exc)
+        return False
+    return False
+
+
 @app.websocket("/ws/push")
 async def websocket_push(
     websocket: WebSocket,
@@ -1106,12 +1133,13 @@ async def websocket_push(
         if token_header:
             from routers.panel_auth import lookup_device_token
             device_info = lookup_device_token(token_header)
-        # If token missing or invalid, close immediately.
-        # lookup_device_token already returns None for revoked tokens; no need to re-check.
-        if not device_info:
+        session_id = websocket.query_params.get("session_id") or websocket.headers.get("X-Session-ID")
+        # Browser WebSockets cannot send X-Device-Token. Accept a panel channel
+        # subscription when the browser session is already bound to this panel.
+        if not device_info and not await _session_can_subscribe_panel(panel_id, session_id):
             await websocket.close(1008, "Invalid device token")
             return
-        # Panel token verified – proceed with panel subscription
+        # Panel token or bound browser session verified; subscribe to panel push.
         await broadcaster.connect_panel(websocket, panel_id)
     else:
         # Non-panel: perform lightweight session validation via zoe-auth HTTP.

--- a/services/zoe-data/main.py
+++ b/services/zoe-data/main.py
@@ -1108,7 +1108,6 @@ async def _session_can_subscribe_panel(panel_id: str, session_id: str | None) ->
     except Exception as exc:
         logger.debug("push websocket panel session validation failed: %s", exc)
         return False
-    return False
 
 
 @app.websocket("/ws/push")

--- a/services/zoe-data/tests/test_push_panel_session.py
+++ b/services/zoe-data/tests/test_push_panel_session.py
@@ -1,0 +1,108 @@
+"""Tests for browser panel WebSocket session authorization."""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import main  # noqa: E402
+
+
+class _Cursor:
+    def __init__(self, row: dict | None):
+        self._row = row
+
+    async def fetchone(self):
+        return self._row
+
+
+class _Db:
+    def __init__(self, row: dict | None):
+        self.row = row
+        self.calls: list[tuple[str, tuple]] = []
+
+    async def execute(self, sql: str, params: tuple):
+        self.calls.append((sql, params))
+        return _Cursor(self.row)
+
+
+def _install_database(monkeypatch: pytest.MonkeyPatch, db: _Db):
+    module = types.ModuleType("database")
+
+    async def get_db():
+        yield db
+
+    module.get_db = get_db
+    monkeypatch.setitem(sys.modules, "database", module)
+    return db
+
+
+@pytest.mark.asyncio
+async def test_panel_push_session_allows_bound_panel_user(monkeypatch):
+    db = _install_database(monkeypatch, _Db({"user_id": "guest"}))
+
+    async def resolve(_session_id):
+        return {"user_id": "guest", "role": "guest"}
+
+    monkeypatch.setattr(main, "_resolve_ws_session", resolve)
+
+    assert await main._session_can_subscribe_panel("zoe-touch-pi", "session-1") is True
+    assert db.calls[0][1] == ("zoe-touch-pi",)
+
+
+@pytest.mark.asyncio
+async def test_panel_push_session_rejects_unbound_panel_user(monkeypatch):
+    _install_database(monkeypatch, _Db({"user_id": "other-user"}))
+
+    async def resolve(_session_id):
+        return {"user_id": "guest", "role": "guest"}
+
+    monkeypatch.setattr(main, "_resolve_ws_session", resolve)
+
+    assert await main._session_can_subscribe_panel("zoe-touch-pi", "session-1") is False
+
+
+@pytest.mark.asyncio
+async def test_panel_push_session_allows_admin_without_panel_binding(monkeypatch):
+    db = _install_database(monkeypatch, _Db(None))
+
+    async def resolve(_session_id):
+        return {"user_id": "admin-user", "role": "admin"}
+
+    monkeypatch.setattr(main, "_resolve_ws_session", resolve)
+
+    assert await main._session_can_subscribe_panel("zoe-touch-pi", "session-1") is True
+    assert db.calls == []
+
+
+@pytest.mark.asyncio
+async def test_panel_push_session_rejects_empty_user_id(monkeypatch):
+    db = _install_database(monkeypatch, _Db({"user_id": "guest"}))
+
+    async def resolve(_session_id):
+        return {"user_id": "", "role": "member"}
+
+    monkeypatch.setattr(main, "_resolve_ws_session", resolve)
+
+    assert await main._session_can_subscribe_panel("zoe-touch-pi", "session-1") is False
+    assert db.calls == []
+
+
+@pytest.mark.asyncio
+async def test_panel_push_session_rejects_invalid_session(monkeypatch):
+    db = _install_database(monkeypatch, _Db({"user_id": "guest"}))
+
+    async def resolve(_session_id):
+        return None
+
+    monkeypatch.setattr(main, "_resolve_ws_session", resolve)
+
+    assert await main._session_can_subscribe_panel("zoe-touch-pi", None) is False
+    assert db.calls == []

--- a/services/zoe-data/tests/test_skybridge_static.py
+++ b/services/zoe-data/tests/test_skybridge_static.py
@@ -36,15 +36,21 @@ def test_skybridge_page_loads_required_modules_in_order():
 def test_skybridge_push_socket_uses_authenticated_session_query():
     html = read(UI / "skybridge.html")
     sync = (ROOT / "zoe-ui" / "dist" / "js" / "websocket-sync.js").read_text(encoding="utf-8")
+    main = (ROOT / "zoe-data" / "main.py").read_text(encoding="utf-8")
 
-    assert "/js/websocket-sync.js?v=skybridge-push-session-1" in html
+    assert "/js/websocket-sync.js?v=skybridge-panel-push-1" in html
     assert "initPush(panelId, sessionId)" in sync
+    assert "params.set('panel_id', panelId)" in sync
+    assert "else params.set('channel', 'all')" in sync
     assert "params.set('session_id', sessionId)" in sync
     assert "initPush called without sessionId; push will be rejected" in sync
     assert "const pushUrl = `${protocol}//${window.location.host}/ws/push?${params.toString()}`;" in sync
     assert "window.zoePushWs = this.push;" in sync
     assert "originalConnect" not in sync
     assert "/ws/push?channel=all`" not in sync
+    assert "async def _session_can_subscribe_panel" in main
+    assert "FROM ui_panel_sessions WHERE panel_id = ?" in main
+    assert "not device_info and not await _session_can_subscribe_panel(panel_id, session_id)" in main
 
 
 def test_skybridge_uses_login_orb_to_voice_pill_layout():

--- a/services/zoe-ui/dist/js/websocket-sync.js
+++ b/services/zoe-ui/dist/js/websocket-sync.js
@@ -290,8 +290,12 @@ window.ZoeWebSockets = {
         // Connect directly to /ws/push with the session query expected by the
         // authenticated push endpoint. Browser WebSockets cannot send the
         // X-Session-ID header used by fetch(), so the query param is required.
+        // Touch panels use their dedicated panel channel so panel-scoped voice
+        // card actions are delivered without relying on global broadcasts.
         const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-        const params = new URLSearchParams({ channel: 'all' });
+        const params = new URLSearchParams();
+        if (panelId) params.set('panel_id', panelId);
+        else params.set('channel', 'all');
         if (sessionId) params.set('session_id', sessionId);
         else console.warn('[ZoeWS] initPush called without sessionId; push will be rejected');
         const pushUrl = `${protocol}//${window.location.host}/ws/push?${params.toString()}`;
@@ -433,7 +437,6 @@ window.ZoeWebSockets = {
         console.log('[ZoeWS] Panel push channel connected, panel_id:', panelId);
     }
 };
-
 
 
 

--- a/services/zoe-ui/dist/touch/calendar.html
+++ b/services/zoe-ui/dist/touch/calendar.html
@@ -2129,10 +2129,10 @@
         </div>
     </div>
 
-    <script src="/js/auth.js?v=skybridge-push-session-1"></script>
+    <script src="/js/auth.js?v=skybridge-panel-push-1"></script>
     <script src="/js/common.js?v=9.3&t=1764035000"></script>
     <script src="/js/notifications-panel.js"></script>
-    <script src="/js/websocket-sync.js?v=skybridge-push-session-1"></script>
+    <script src="/js/websocket-sync.js?v=skybridge-panel-push-1"></script>
     <script>
         // Authenticated API request wrapper
         async function authedApiRequest(endpoint, options = {}) {
@@ -4723,11 +4723,11 @@
     </script>
 
     <!-- TOUCH: gesture navigation (edge swipe) -->
-    <script src="/touch/js/gestures.js?v=skybridge-push-session-1"></script>
+    <script src="/touch/js/gestures.js?v=skybridge-panel-push-1"></script>
     <!-- TOUCH: premium nav bar with orb, tabs, theme, clock -->
-    <script src="/touch/js/touch-menu.js?v=skybridge-push-session-1"></script>
+    <script src="/touch/js/touch-menu.js?v=skybridge-panel-push-1"></script>
     <!-- TOUCH: executor for voice/backend UI actions -->
-    <script src="/js/touch-ui-executor.js?v=skybridge-push-session-1"></script>
+    <script src="/js/touch-ui-executor.js?v=skybridge-panel-push-1"></script>
     <!-- TOUCH: floating orb chat overlay -->
     <script src="/js/orb-loader.js"></script>
     <!-- TOUCH: lock gridstack to static (no drag) on kiosk -->

--- a/services/zoe-ui/dist/touch/chat.html
+++ b/services/zoe-ui/dist/touch/chat.html
@@ -2406,7 +2406,7 @@
         </div>
     </div>
 
-    <script src="/js/auth.js?v=skybridge-push-session-1"></script>
+    <script src="/js/auth.js?v=skybridge-panel-push-1"></script>
     <script src="/js/common.js?v=9.0&t=1760020000"></script>
     <script src="/js/notifications-panel.js"></script>
         <script src="/js/chat-sessions.js?v=2.1"></script>
@@ -6050,7 +6050,7 @@
         }
 
     </script>
-    <script src="/js/websocket-sync.js?v=skybridge-push-session-1"></script>
+    <script src="/js/websocket-sync.js?v=skybridge-panel-push-1"></script>
 
     <!-- Degraded mode banner -->
     <div id="zoe-degraded-banner" style="display:none;position:fixed;top:0;left:0;right:0;z-index:9999;background:rgba(220,38,38,0.9);color:white;font-size:13px;text-align:center;padding:6px 12px;backdrop-filter:blur(4px);">
@@ -6074,11 +6074,11 @@
     </script>
 
     <!-- TOUCH: gesture navigation (edge swipe) -->
-    <script src="/touch/js/gestures.js?v=skybridge-push-session-1"></script>
+    <script src="/touch/js/gestures.js?v=skybridge-panel-push-1"></script>
     <!-- TOUCH: premium nav bar with orb, tabs, theme, clock -->
-    <script src="/touch/js/touch-menu.js?v=skybridge-push-session-1"></script>
+    <script src="/touch/js/touch-menu.js?v=skybridge-panel-push-1"></script>
     <!-- TOUCH: executor for voice/backend UI actions -->
-    <script src="/js/touch-ui-executor.js?v=skybridge-push-session-1"></script>
+    <script src="/js/touch-ui-executor.js?v=skybridge-panel-push-1"></script>
     <!-- TOUCH: floating orb chat overlay -->
     <script src="/js/orb-loader.js"></script>
 

--- a/services/zoe-ui/dist/touch/cooking.html
+++ b/services/zoe-ui/dist/touch/cooking.html
@@ -357,7 +357,7 @@ html.dark-mode .addform input, html.dark-mode .addform textarea{ background:rgba
 
 <div class="toast" id="toast"></div>
 
-<script src="/touch/js/touch-menu.js?v=skybridge-push-session-1"></script>
+<script src="/touch/js/touch-menu.js?v=skybridge-panel-push-1"></script>
 <script>
 (function(){
   const STORE_KEY = 'zoe_recipes_v1';

--- a/services/zoe-ui/dist/touch/dashboard.html
+++ b/services/zoe-ui/dist/touch/dashboard.html
@@ -1734,7 +1734,7 @@
             100% { opacity: 0; transform: translate(-50%, -50%) scale(0.8); }
         }
     </style>
-    <script src="/js/auth.js?v=skybridge-push-session-1"></script>
+    <script src="/js/auth.js?v=skybridge-panel-push-1"></script>
     <script>
         // DEBUG: Log session state immediately
         console.log('🔍 Dashboard loading - Session check:');
@@ -1950,7 +1950,7 @@
 
     <script src="/js/common.js"></script>
     <script src="/js/notifications-panel.js"></script>
-    <script src="/js/websocket-sync.js?v=skybridge-push-session-1"></script>
+    <script src="/js/websocket-sync.js?v=skybridge-panel-push-1"></script>
     
     <!-- Widget System Core -->
     <script src="/js/widget-base.js"></script>
@@ -2971,11 +2971,11 @@
     </script>
 
     <!-- TOUCH: gesture navigation (edge swipe) -->
-    <script src="/touch/js/gestures.js?v=skybridge-push-session-1"></script>
+    <script src="/touch/js/gestures.js?v=skybridge-panel-push-1"></script>
     <!-- TOUCH: premium nav bar with orb, tabs, theme, clock -->
-    <script src="/touch/js/touch-menu.js?v=skybridge-push-session-1"></script>
+    <script src="/touch/js/touch-menu.js?v=skybridge-panel-push-1"></script>
     <!-- TOUCH: executor for voice/backend UI actions -->
-    <script src="/js/touch-ui-executor.js?v=skybridge-push-session-1"></script>
+    <script src="/js/touch-ui-executor.js?v=skybridge-panel-push-1"></script>
     <!-- TOUCH: floating orb chat overlay -->
     <script src="/js/orb-loader.js"></script>
     <!-- TOUCH: fit cell height and keep static mode synced with edit state -->

--- a/services/zoe-ui/dist/touch/index.html
+++ b/services/zoe-ui/dist/touch/index.html
@@ -830,7 +830,7 @@
   window.fetch=function(u,o){o=o||{};o.headers=o.headers||{};const sid=getSession();if(sid){o.headers["X-Session-ID"]=sid;} if(typeof u==="string"){u=u.replace(/[?&]user_id=[^&]*/g,"");} return origFetch(u,o);};
 })();
 </script>
-    <script src="/js/auth.js?v=skybridge-push-session-1"></script>
+    <script src="/js/auth.js?v=skybridge-panel-push-1"></script>
 <!-- PWA Meta Tags -->
     <meta name="application-name" content="Zoe AI">
     <meta name="apple-mobile-web-app-capable" content="yes">

--- a/services/zoe-ui/dist/touch/journal.html
+++ b/services/zoe-ui/dist/touch/journal.html
@@ -672,8 +672,8 @@
     <!-- Standard Zoe touch scripts -->
     <script src="/js/common.js"></script>
     <script src="/js/notifications-panel.js"></script>
-    <script src="/js/websocket-sync.js?v=skybridge-push-session-1"></script>
-    <script src="/touch/js/touch-menu.js?v=skybridge-push-session-1"></script>
+    <script src="/js/websocket-sync.js?v=skybridge-panel-push-1"></script>
+    <script src="/touch/js/touch-menu.js?v=skybridge-panel-push-1"></script>
     <script src="/js/journal-api.js"></script>
 
     <!-- FilePond -->

--- a/services/zoe-ui/dist/touch/lists.html
+++ b/services/zoe-ui/dist/touch/lists.html
@@ -1874,7 +1874,7 @@
             opacity: 0 !important;
         }
     </style>
-    <script src="/js/auth.js?v=skybridge-push-session-1"></script>
+    <script src="/js/auth.js?v=skybridge-panel-push-1"></script>
     <script>
         // DEBUG: Log session state immediately
         console.log('🔍 Dashboard loading - Session check:');
@@ -2086,7 +2086,7 @@
 
     <script src="/js/common.js"></script>
     <script src="/js/notifications-panel.js"></script>
-    <script src="/js/websocket-sync.js?v=skybridge-push-session-1"></script>
+    <script src="/js/websocket-sync.js?v=skybridge-panel-push-1"></script>
     
     <!-- Widget System Core -->
     <script src="/js/widget-base.js"></script>
@@ -2418,11 +2418,11 @@
     </script>
 
     <!-- TOUCH: gesture navigation (edge swipe) -->
-    <script src="/touch/js/gestures.js?v=skybridge-push-session-1"></script>
+    <script src="/touch/js/gestures.js?v=skybridge-panel-push-1"></script>
     <!-- TOUCH: premium nav bar with orb, tabs, theme, clock -->
-    <script src="/touch/js/touch-menu.js?v=skybridge-push-session-1"></script>
+    <script src="/touch/js/touch-menu.js?v=skybridge-panel-push-1"></script>
     <!-- TOUCH: executor for voice/backend UI actions -->
-    <script src="/js/touch-ui-executor.js?v=skybridge-push-session-1"></script>
+    <script src="/js/touch-ui-executor.js?v=skybridge-panel-push-1"></script>
     <!-- TOUCH: floating orb chat overlay -->
     <script src="/js/orb-loader.js"></script>
     <!-- TOUCH: lock gridstack to static (no drag) on kiosk -->

--- a/services/zoe-ui/dist/touch/memories.html
+++ b/services/zoe-ui/dist/touch/memories.html
@@ -1191,7 +1191,7 @@
     
     <div class="tooltip" id="tooltip"></div>
     
-    <script src="/js/auth.js?v=skybridge-push-session-1"></script>
+    <script src="/js/auth.js?v=skybridge-panel-push-1"></script>
     <script src="/js/common.js"></script>
     <script src="/js/notifications-panel.js"></script>
     <script src="/js/ai-processor.js"></script>
@@ -2337,14 +2337,14 @@
             }
         }
     </script>
-    <script src="/js/websocket-sync.js?v=skybridge-push-session-1"></script>
+    <script src="/js/websocket-sync.js?v=skybridge-panel-push-1"></script>
 
     <!-- TOUCH: gesture navigation (edge swipe) -->
-    <script src="/touch/js/gestures.js?v=skybridge-push-session-1"></script>
+    <script src="/touch/js/gestures.js?v=skybridge-panel-push-1"></script>
     <!-- TOUCH: premium nav bar with orb, tabs, theme, clock -->
-    <script src="/touch/js/touch-menu.js?v=skybridge-push-session-1"></script>
+    <script src="/touch/js/touch-menu.js?v=skybridge-panel-push-1"></script>
     <!-- TOUCH: executor for voice/backend UI actions -->
-    <script src="/js/touch-ui-executor.js?v=skybridge-push-session-1"></script>
+    <script src="/js/touch-ui-executor.js?v=skybridge-panel-push-1"></script>
     <!-- TOUCH: floating orb chat overlay -->
     <script src="/js/orb-loader.js"></script>
     <!-- TOUCH: lock gridstack to static (no drag) on kiosk -->

--- a/services/zoe-ui/dist/touch/music.html
+++ b/services/zoe-ui/dist/touch/music.html
@@ -710,7 +710,7 @@
     </div>
 
     <!-- Core Scripts -->
-    <script src="/js/auth.js?v=skybridge-push-session-1"></script>
+    <script src="/js/auth.js?v=skybridge-panel-push-1"></script>
     <script src="/js/common.js"></script>
     <script src="/js/notifications-panel.js"></script>
     <script src="/js/widget-base.js"></script>
@@ -2396,11 +2396,11 @@
     </style>
 
     <!-- TOUCH: gesture navigation (edge swipe) -->
-    <script src="/touch/js/gestures.js?v=skybridge-push-session-1"></script>
+    <script src="/touch/js/gestures.js?v=skybridge-panel-push-1"></script>
     <!-- TOUCH: premium nav bar with orb, tabs, theme, clock -->
-    <script src="/touch/js/touch-menu.js?v=skybridge-push-session-1"></script>
+    <script src="/touch/js/touch-menu.js?v=skybridge-panel-push-1"></script>
     <!-- TOUCH: executor for voice/backend UI actions -->
-    <script src="/js/touch-ui-executor.js?v=skybridge-push-session-1"></script>
+    <script src="/js/touch-ui-executor.js?v=skybridge-panel-push-1"></script>
     <!-- TOUCH: floating orb chat overlay -->
     <script src="/js/orb-loader.js"></script>
     <!-- TOUCH: lock gridstack to static (no drag) on kiosk -->

--- a/services/zoe-ui/dist/touch/notes.html
+++ b/services/zoe-ui/dist/touch/notes.html
@@ -26,7 +26,7 @@
     <!-- TOUCH: adapter (tap targets, hide desktop chrome, dark mode) -->
     <link rel="stylesheet" href="/touch/css/touch-adapter.css">
     <link rel="stylesheet" href="/touch/css/touch-premium.css">
-    <script src="/js/auth.js?v=skybridge-push-session-1"></script>
+    <script src="/js/auth.js?v=skybridge-panel-push-1"></script>
     <style>
         body { overflow-y: auto; cursor: auto; }
 
@@ -398,10 +398,10 @@
 
 <div class="toast" id="toast"></div>
 
-<script src="/js/websocket-sync.js?v=skybridge-push-session-1"></script>
-<script src="/touch/js/gestures.js?v=skybridge-push-session-1"></script>
-<script src="/touch/js/touch-menu.js?v=skybridge-push-session-1"></script>
-<script src="/js/touch-ui-executor.js?v=skybridge-push-session-1"></script>
+<script src="/js/websocket-sync.js?v=skybridge-panel-push-1"></script>
+<script src="/touch/js/gestures.js?v=skybridge-panel-push-1"></script>
+<script src="/touch/js/touch-menu.js?v=skybridge-panel-push-1"></script>
+<script src="/js/touch-ui-executor.js?v=skybridge-panel-push-1"></script>
 <script src="/js/orb-loader.js"></script>
 <script>
 const NOTE_COLORS = ['#7B61FF','#5AE0E0','#FF6B9D','#FFB347','#6BCB77','#FF6B6B'];

--- a/services/zoe-ui/dist/touch/people.html
+++ b/services/zoe-ui/dist/touch/people.html
@@ -577,8 +577,8 @@
 
     <script src="/js/common.js"></script>
     <script src="/js/notifications-panel.js"></script>
-    <script src="/js/websocket-sync.js?v=skybridge-push-session-1"></script>
-    <script src="/touch/js/touch-menu.js?v=skybridge-push-session-1"></script>
+    <script src="/js/websocket-sync.js?v=skybridge-panel-push-1"></script>
+    <script src="/touch/js/touch-menu.js?v=skybridge-panel-push-1"></script>
 
     <script>
     // 3 tiers × 2 contexts

--- a/services/zoe-ui/dist/touch/settings.html
+++ b/services/zoe-ui/dist/touch/settings.html
@@ -640,7 +640,7 @@
             .mobile-nav-menu, .mobile-nav-overlay { display: none !important; }
         }
     </style>
-    <script src="/js/auth.js?v=skybridge-push-session-1"></script>
+    <script src="/js/auth.js?v=skybridge-panel-push-1"></script>
 <!-- PWA Meta Tags -->
     <meta name="application-name" content="Zoe AI">
     <meta name="apple-mobile-web-app-capable" content="yes">
@@ -6027,14 +6027,14 @@
             checkAdminAccess();
         });
     </script>
-    <script src="/js/websocket-sync.js?v=skybridge-push-session-1"></script>
+    <script src="/js/websocket-sync.js?v=skybridge-panel-push-1"></script>
 
     <!-- TOUCH: gesture navigation (edge swipe) -->
-    <script src="/touch/js/gestures.js?v=skybridge-push-session-1"></script>
+    <script src="/touch/js/gestures.js?v=skybridge-panel-push-1"></script>
     <!-- TOUCH: premium nav bar with orb, tabs, theme, clock -->
-    <script src="/touch/js/touch-menu.js?v=skybridge-push-session-1"></script>
+    <script src="/touch/js/touch-menu.js?v=skybridge-panel-push-1"></script>
     <!-- TOUCH: executor for voice/backend UI actions -->
-    <script src="/js/touch-ui-executor.js?v=skybridge-push-session-1"></script>
+    <script src="/js/touch-ui-executor.js?v=skybridge-panel-push-1"></script>
     <!-- TOUCH: floating orb chat overlay -->
     <script src="/js/orb-loader.js"></script>
     <!-- TOUCH: PIN change modal (replaces window.prompt dialogs) -->

--- a/services/zoe-ui/dist/touch/skybridge.html
+++ b/services/zoe-ui/dist/touch/skybridge.html
@@ -4196,11 +4196,11 @@
         <button type="submit" class="primary">Send</button>
     </form>
 
-    <script src="/js/auth.js?v=skybridge-push-session-1"></script>
-    <script src="/js/websocket-sync.js?v=skybridge-push-session-1"></script>
-    <script src="/touch/js/gestures.js?v=skybridge-push-session-1"></script>
-    <script src="/touch/js/touch-menu.js?v=skybridge-push-session-1"></script>
-    <script src="/js/touch-ui-executor.js?v=skybridge-push-session-1"></script>
+    <script src="/js/auth.js?v=skybridge-panel-push-1"></script>
+    <script src="/js/websocket-sync.js?v=skybridge-panel-push-1"></script>
+    <script src="/touch/js/gestures.js?v=skybridge-panel-push-1"></script>
+    <script src="/touch/js/touch-menu.js?v=skybridge-panel-push-1"></script>
+    <script src="/js/touch-ui-executor.js?v=skybridge-panel-push-1"></script>
     <script src="/touch/js/skybridge-capabilities.js?v=skybridge-calendar-menu-6"></script>
     <script src="/touch/js/skybridge-renderer.js?v=skybridge-calendar-menu-6"></script>
     <script src="/touch/js/skybridge-voice.js?v=skybridge-calendar-menu-6"></script>

--- a/services/zoe-ui/dist/touch/smart-home.html
+++ b/services/zoe-ui/dist/touch/smart-home.html
@@ -27,7 +27,7 @@
     <!-- TOUCH: adapter (tap targets, hide desktop chrome, dark mode) -->
     <link rel="stylesheet" href="/touch/css/touch-adapter.css">
     <link rel="stylesheet" href="/touch/css/touch-premium.css">
-  <script src="/js/auth.js?v=skybridge-push-session-1"></script>
+  <script src="/js/auth.js?v=skybridge-panel-push-1"></script>
   <style>
     html.touch-scroll-root,
     body.touch-scroll-page {
@@ -444,10 +444,10 @@
 
 </div>
 
-<script src="/js/websocket-sync.js?v=skybridge-push-session-1"></script>
-<script src="/touch/js/gestures.js?v=skybridge-push-session-1"></script>
-<script src="/touch/js/touch-menu.js?v=skybridge-push-session-1"></script>
-<script src="/js/touch-ui-executor.js?v=skybridge-push-session-1"></script>
+<script src="/js/websocket-sync.js?v=skybridge-panel-push-1"></script>
+<script src="/touch/js/gestures.js?v=skybridge-panel-push-1"></script>
+<script src="/touch/js/touch-menu.js?v=skybridge-panel-push-1"></script>
+<script src="/js/touch-ui-executor.js?v=skybridge-panel-push-1"></script>
 <script src="/js/orb-loader.js"></script>
 <script>
 window.ZOE_OPEN_FORM = null;

--- a/services/zoe-ui/dist/touch/timers.html
+++ b/services/zoe-ui/dist/touch/timers.html
@@ -15,7 +15,7 @@
     <meta name="theme-color" content="#0a1628">
     <title>Zoe - Timers</title>
     <link rel="stylesheet" href="/touch/css/touch-adapter.css">
-    <script src="/js/auth.js?v=skybridge-push-session-1"></script>
+    <script src="/js/auth.js?v=skybridge-panel-push-1"></script>
     <style>
         :root { --glass: rgba(255,255,255,0.08); --line: rgba(255,255,255,0.14); --txt: #ecf0f6; --muted: #b8c2d3; }
         html, body { height: 100%; margin: 0; }
@@ -82,7 +82,7 @@
         <div id="timers" class="timers"></div>
     </div>
 
-    <script src="/touch/js/touch-menu.js?v=skybridge-push-session-1"></script>
+    <script src="/touch/js/touch-menu.js?v=skybridge-panel-push-1"></script>
     <script>
         (function () {
             const KEY = 'zoe_touch_timers_v1';

--- a/services/zoe-ui/dist/touch/updates.html
+++ b/services/zoe-ui/dist/touch/updates.html
@@ -15,7 +15,7 @@
     <meta name="theme-color" content="#0a1628">
     <title>Zoe - Updates</title>
     <link rel="stylesheet" href="/touch/css/touch-adapter.css">
-    <script src="/js/auth.js?v=skybridge-push-session-1"></script>
+    <script src="/js/auth.js?v=skybridge-panel-push-1"></script>
     <style>
         html, body { height: 100%; margin: 0; }
         body {
@@ -167,7 +167,7 @@
         <div id="components" class="tiles"></div>
     </div>
 
-    <script src="/touch/js/touch-menu.js?v=skybridge-push-session-1"></script>
+    <script src="/touch/js/touch-menu.js?v=skybridge-panel-push-1"></script>
     <script>
         (function () {
             const $components = document.getElementById('components');

--- a/services/zoe-ui/dist/touch/voice.html
+++ b/services/zoe-ui/dist/touch/voice.html
@@ -25,7 +25,7 @@
     <meta name="theme-color" content="#0a0a0f">
     <title>Zoe – Voice</title>
     <link rel="stylesheet" href="/touch/css/touch-adapter.css">
-    <script src="/js/auth.js?v=skybridge-push-session-1"></script>
+    <script src="/js/auth.js?v=skybridge-panel-push-1"></script>
     <script src="/lib/livekit/livekit-client.umd.min.js" onerror="console.warn('LiveKit client not loaded')"></script>
 <style>
   * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -161,10 +161,10 @@
 </div>
 
 <!-- ── Touch panel stack (same order as all touch pages) ──────────────────── -->
-<script src="/js/websocket-sync.js?v=skybridge-push-session-1"></script>
-<script src="/touch/js/gestures.js?v=skybridge-push-session-1"></script>
-<script src="/touch/js/touch-menu.js?v=skybridge-push-session-1"></script>
-<script src="/js/touch-ui-executor.js?v=skybridge-push-session-1"></script>
+<script src="/js/websocket-sync.js?v=skybridge-panel-push-1"></script>
+<script src="/touch/js/gestures.js?v=skybridge-panel-push-1"></script>
+<script src="/touch/js/touch-menu.js?v=skybridge-panel-push-1"></script>
+<script src="/js/touch-ui-executor.js?v=skybridge-panel-push-1"></script>
 <script src="/js/orb-loader.js"></script>
 
 <script>

--- a/services/zoe-ui/dist/touch/weather.html
+++ b/services/zoe-ui/dist/touch/weather.html
@@ -25,7 +25,7 @@
     })();
     </script>
     <link rel="stylesheet" href="/touch/css/touch-adapter.css">
-    <script src="/js/auth.js?v=skybridge-push-session-1"></script>
+    <script src="/js/auth.js?v=skybridge-panel-push-1"></script>
     <style>
         /* ── Reset & base ───────────────────────────────────────────── */
         *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -610,10 +610,10 @@
 <!-- Refresh button -->
 <button id="refreshBtn" onclick="refreshWeather()" aria-label="Refresh weather">↻</button>
 
-<script src="/js/websocket-sync.js?v=skybridge-push-session-1"></script>
-<script src="/touch/js/gestures.js?v=skybridge-push-session-1"></script>
-<script src="/touch/js/touch-menu.js?v=skybridge-push-session-1"></script>
-<script src="/js/touch-ui-executor.js?v=skybridge-push-session-1"></script>
+<script src="/js/websocket-sync.js?v=skybridge-panel-push-1"></script>
+<script src="/touch/js/gestures.js?v=skybridge-panel-push-1"></script>
+<script src="/touch/js/touch-menu.js?v=skybridge-panel-push-1"></script>
+<script src="/js/touch-ui-executor.js?v=skybridge-panel-push-1"></script>
 <script src="/js/orb-loader.js"></script>
 <script>
 (function () {


### PR DESCRIPTION
## Summary
- connect touch push WebSockets to the dedicated panel channel with panel_id + session_id
- allow /ws/push panel subscriptions for browser sessions only when bound to that panel in ui_panel_sessions
- bump touch runtime query versions so panels load the fixed socket code

## Verification
- python3 -m py_compile services/zoe-data/main.py
- python3 -m pytest services/zoe-data/tests/test_skybridge_static.py -q

## Live failure addressed
Panel browser loaded the previous fix but its push socket still closed because the touch session is guest and browser WebSockets cannot send X-Device-Token. This closes the panel-channel path for browser sessions bound to a panel.