### PR TITLE
Refresh touch guest sessions on auth 404

### DIFF
--- a/services/zoe-data/tests/test_skybridge_static.py
+++ b/services/zoe-data/tests/test_skybridge_static.py
@@ -54,7 +54,7 @@ def test_skybridge_push_socket_uses_authenticated_session_query():
     assert "FROM ui_panel_sessions WHERE panel_id = ?" in main
     assert "not device_info and not await _session_can_subscribe_panel(panel_id, session_id)" in main
     assert "Touch guest session was rejected; refreshing guest session" in auth
-    assert "profile.status === 401 || profile.status === 403" in auth
+    assert "profile.status === 401 || profile.status === 403 || profile.status === 404" in auth
     assert "keeping existing session" in auth
     assert "window.zoeAuthReady = new Promise" in auth
     assert "await window.zoeAuthReady" in executor

--- a/services/zoe-ui/dist/js/auth.js
+++ b/services/zoe-ui/dist/js/auth.js
@@ -120,7 +120,7 @@
                     headers: { 'X-Session-ID': getSession() }
                 });
                 if (profile.ok) return;
-                if (profile.status === 401 || profile.status === 403) {
+                if (profile.status === 401 || profile.status === 403 || profile.status === 404) {
                     console.warn('[auth] Touch guest session was rejected; refreshing guest session');
                     setSession(null);
                 } else {


### PR DESCRIPTION
## Summary
- treat /api/auth/profile 404 as an explicit stale touch guest session response
- still keep existing guest sessions on transient 5xx or network errors

## Verification
- python3 -m pytest services/zoe-data/tests/test_skybridge_static.py -q

## Live failure addressed
The physical panel retained a stale guest session because Zoe auth reports invalid profile lookups as 404; the panel then bound/pushed with a dead session and cards did not render.