### PR TITLE
fix(pipeline): converge already-covered runs instead of review→implement loop

### DIFF
--- a/services/zoe-data/pipeline_store.py
+++ b/services/zoe-data/pipeline_store.py
@@ -488,6 +488,25 @@ def _protocol_only_block(detail: dict[str, Any]) -> bool:
     return protocol_seen
 
 
+def _run_is_already_covered(state: PipelineState) -> bool:
+    """True when this run already proved no code change is needed.
+
+    When ``implement`` finds the work already covered it records a
+    ``skip_implementation`` transition carrying an ``ALREADY_COVERED`` reason and
+    flips the run to the ``audit`` profile. History is append-only — unlike
+    ``evidence``, which ``transition`` clears on ``request_changes`` /
+    ``verification_failed`` — so it is the reliable marker across the loop-back
+    transitions. Such a run has nothing left to implement/verify/review/merge, so
+    its downstream no-op phases must converge to ``complete`` instead of bouncing
+    review -> implement forever.
+    """
+    return any(
+        record.outcome == "skip_implementation"
+        and "ALREADY_COVERED" in str(getattr(record, "reason", "") or "").upper()
+        for record in state.history
+    )
+
+
 def _append_audit_protocol_recovery_evidence(state: PipelineState, phase: PipelinePhase) -> PipelineState:
     kind_by_phase = {
         "scout": "tool",
@@ -709,8 +728,12 @@ async def _sync_pipeline_from_chain_once(
         if (
             state.evidence_profile == "audit"
             and outcome in {"block", "verification_failed", "request_changes", "merge_blocked"}
-            and _protocol_only_block(detail)
+            and (_protocol_only_block(detail) or _run_is_already_covered(state))
         ):
+            # An already-covered run has no diff to verify/review/merge, so a
+            # no-op downstream block (e.g. review request_changes with no PR) is
+            # recovered to completion. Without this it bounces review -> implement
+            # forever, never reaching a terminal handoff and holding the lane.
             state = _append_audit_protocol_recovery_evidence(state, phase)  # type: ignore[arg-type]
             if can_complete_phase(state):
                 state = await _run_io(

--- a/services/zoe-data/tests/test_pipeline_store.py
+++ b/services/zoe-data/tests/test_pipeline_store.py
@@ -1075,6 +1075,55 @@ async def test_sync_pipeline_recovers_audit_protocol_only_block(isolated_store):
     assert "audit_protocol_recovered" in isolated_store.read_text(encoding="utf-8")
 
 
+@pytest.mark.asyncio
+async def test_already_covered_run_converges_instead_of_review_implement_loop(isolated_store):
+    # Regression: an already-covered run (implementation proven unnecessary) used
+    # to bounce review -> implement forever, because review's no-PR request_changes
+    # is not "protocol-only" and so was never recovered. It must now converge.
+    ref = "multica:already-covered-converge"
+    await store.bootstrap_state(ref, issue={"metadata": {"evidence_profile": "code"}})
+
+    async def fetch_impl(_task_id):
+        return {
+            "latest_summary": "BLOCKER=ALREADY_COVERED: focused tests passed; no PR required",
+            "comments": [],
+        }
+
+    # 1) implement proves the work already covered -> skip to verify, audit profile.
+    state = await store.sync_pipeline_from_chain(
+        ref,
+        {"implement": {"id": "t_impl", "status": "blocked",
+                       "block_reason": "ALREADY_COVERED: focused tests passed; no PR required"}},
+        fetch_impl,
+    )
+    assert state.phase == "verify"
+    assert state.evidence_profile == "audit"
+    assert _run_is_already_covered_marker(state)
+
+    async def fetch_plain(_task_id):
+        return {"latest_summary": "", "comments": []}
+
+    # 2) verify completes for the audit no-op run.
+    state = await store.sync_pipeline_from_chain(
+        ref, {"verify": {"id": "t_verify", "status": "done"}}, fetch_plain
+    )
+
+    # 3) review on an already-covered run has no PR -> normally request_changes ->
+    # implement (the loop). With the fix it recovers to complete and moves forward.
+    state = await store.sync_pipeline_from_chain(
+        ref,
+        {"review": {"id": "t_review", "status": "blocked", "block_reason": "no PR to review"}},
+        fetch_plain,
+    )
+    assert state.phase != "implement", "already-covered run must not loop back to implement"
+    assert store.PHASE_ORDER.index(state.phase) >= store.PHASE_ORDER.index("review")
+
+
+def _run_is_already_covered_marker(state) -> bool:
+    return any(
+        r.outcome == "skip_implementation" and "ALREADY_COVERED" in str(getattr(r, "reason", "") or "").upper()
+        for r in state.history
+    )
 
 
 @pytest.mark.asyncio

--- a/services/zoe-data/tests/test_pipeline_store.py
+++ b/services/zoe-data/tests/test_pipeline_store.py
@@ -1107,6 +1107,7 @@ async def test_already_covered_run_converges_instead_of_review_implement_loop(is
     state = await store.sync_pipeline_from_chain(
         ref, {"verify": {"id": "t_verify", "status": "done"}}, fetch_plain
     )
+    assert state.phase == "review", f"expected verify to advance to review, got {state.phase!r}"
 
     # 3) review on an already-covered run has no PR -> normally request_changes ->
     # implement (the loop). With the fix it recovers to complete and moves forward.


### PR DESCRIPTION
## Problem (root cause of the autonomy stall)

When `implement` proves the work is **already covered** (no diff needed — e.g. a harness follow-up whose fix already landed, like ZOE-5684/ZOE-5733 turned out to be), the run flips to the `audit` profile and skips implementation. But its downstream phases then bounce **review → implement forever**:

1. `implement` → already-covered → skip → `verify` (recovers) → `review`
2. `review` has no PR → emits `request_changes` → which is **not** "protocol-only", so the existing audit recovery never fires
3. → transitions back to `implement` → which again finds the work already covered → loop

Crucially the attempt counters never advance (every cycle resets the loop-detection state), so the iteration-budget abort never trips. The chain spins **indefinitely**, holding the single ticket lane.

Observed live: **ZOE-5744** (and ZOE-5456) stuck this way — and this loop is the engine behind the whole self-referential `PROTOCOL_VIOLATION`/`ITERATION_BUDGET` follow-up-ticket pile-up.

## Fix

An already-covered run (detected via the **append-only history marker** — `evidence` is cleared on `request_changes`/`verification_failed`, so history is the reliable signal) now recovers its no-op downstream blocks to `complete`, exactly as protocol-only blocks already do. Such a run has nothing to verify/review/merge, so each `audit`-profile phase auto-recovers with its required evidence kind (review→`human`, closeout→`log`, retro→`log`) and reaches a terminal `done` as a genuine no-op — instead of looping. The change can only **complete or block**, never loop.

## Tests
- New regression test drives implement(already-covered) → verify(done) → review(block) and asserts the run converges past `review`. **Verified it fails without the fix** (lands back at `phase='implement'`, the exact loop) and passes with it.
- Full pipeline suite: 364 passed. (2 unrelated pre-existing failures in `test_pipeline_evidence.py` exist on `main` independent of this change — stale since #231; not run by CI `validate`. Flagged separately.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)