### PR TITLE
Allow guest-enabled panels to subscribe to push

### DIFF
--- a/services/zoe-data/main.py
+++ b/services/zoe-data/main.py
@@ -1236,6 +1236,7 @@ async def _panel_allows_guest_push(panel_id: str) -> bool:
     except Exception as exc:
         logger.debug("push websocket guest panel validation failed: %s", exc)
         return False
+    return False
 
 
 @app.websocket("/ws/push")

--- a/services/zoe-data/main.py
+++ b/services/zoe-data/main.py
@@ -1197,7 +1197,7 @@ async def _session_can_subscribe_panel(panel_id: str, session_id: str | None) ->
     """Allow browser panel sockets only for sessions bound to that panel."""
     user = await _resolve_ws_session(session_id)
     if user is None:
-        return False
+        return await _panel_allows_guest_push(panel_id)
     user_id = str(user.get("user_id") or "")
     role = str(user.get("role") or "").lower()
     if not user_id:
@@ -1216,6 +1216,25 @@ async def _session_can_subscribe_panel(panel_id: str, session_id: str | None) ->
             return bool(row and str(row["user_id"]) == user_id)
     except Exception as exc:
         logger.debug("push websocket panel session validation failed: %s", exc)
+        return False
+
+
+async def _panel_allows_guest_push(panel_id: str) -> bool:
+    """Return true when a registered active panel explicitly allows guest use."""
+    try:
+        from database import get_db
+
+        async for db in get_db():
+            cursor = await db.execute(
+                "SELECT allow_guest, is_active FROM panels WHERE panel_id = ? LIMIT 1",
+                (panel_id,),
+            )
+            row = await cursor.fetchone()
+            if not row:
+                return False
+            return bool(row["allow_guest"]) and bool(row["is_active"])
+    except Exception as exc:
+        logger.debug("push websocket guest panel validation failed: %s", exc)
         return False
 
 

--- a/services/zoe-data/tests/test_push_panel_session.py
+++ b/services/zoe-data/tests/test_push_panel_session.py
@@ -97,7 +97,7 @@ async def test_panel_push_session_rejects_empty_user_id(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_panel_push_session_rejects_invalid_session(monkeypatch):
-    db = _install_database(monkeypatch, _Db({"user_id": "guest"}))
+    db = _install_database(monkeypatch, _Db(None))
 
     async def resolve(_session_id):
         return None
@@ -105,4 +105,42 @@ async def test_panel_push_session_rejects_invalid_session(monkeypatch):
     monkeypatch.setattr(main, "_resolve_ws_session", resolve)
 
     assert await main._session_can_subscribe_panel("zoe-touch-pi", None) is False
-    assert db.calls == []
+    assert "FROM panels WHERE panel_id = ?" in db.calls[0][0]
+
+
+@pytest.mark.asyncio
+async def test_panel_push_session_allows_registered_guest_panel_without_valid_session(monkeypatch):
+    db = _install_database(monkeypatch, _Db({"allow_guest": 1, "is_active": 1}))
+
+    async def resolve(_session_id):
+        return None
+
+    monkeypatch.setattr(main, "_resolve_ws_session", resolve)
+
+    assert await main._session_can_subscribe_panel("zoe-touch-pi", "stale-guest-session") is True
+    assert "FROM panels WHERE panel_id = ?" in db.calls[0][0]
+    assert db.calls[0][1] == ("zoe-touch-pi",)
+
+
+@pytest.mark.asyncio
+async def test_panel_push_session_rejects_guest_panel_when_guest_disabled(monkeypatch):
+    _install_database(monkeypatch, _Db({"allow_guest": 0, "is_active": 1}))
+
+    async def resolve(_session_id):
+        return None
+
+    monkeypatch.setattr(main, "_resolve_ws_session", resolve)
+
+    assert await main._session_can_subscribe_panel("zoe-touch-pi", "stale-guest-session") is False
+
+
+@pytest.mark.asyncio
+async def test_panel_push_session_rejects_inactive_guest_panel(monkeypatch):
+    _install_database(monkeypatch, _Db({"allow_guest": 1, "is_active": 0}))
+
+    async def resolve(_session_id):
+        return None
+
+    monkeypatch.setattr(main, "_resolve_ws_session", resolve)
+
+    assert await main._session_can_subscribe_panel("zoe-touch-pi", "stale-guest-session") is False

--- a/services/zoe-data/tests/test_push_panel_session.py
+++ b/services/zoe-data/tests/test_push_panel_session.py
@@ -44,6 +44,17 @@ def _install_database(monkeypatch: pytest.MonkeyPatch, db: _Db):
     return db
 
 
+def _install_empty_database(monkeypatch: pytest.MonkeyPatch):
+    module = types.ModuleType("database")
+
+    async def get_db():
+        if False:
+            yield None
+
+    module.get_db = get_db
+    monkeypatch.setitem(sys.modules, "database", module)
+
+
 @pytest.mark.asyncio
 async def test_panel_push_session_allows_bound_panel_user(monkeypatch):
     db = _install_database(monkeypatch, _Db({"user_id": "guest"}))
@@ -137,6 +148,18 @@ async def test_panel_push_session_rejects_guest_panel_when_guest_disabled(monkey
 @pytest.mark.asyncio
 async def test_panel_push_session_rejects_inactive_guest_panel(monkeypatch):
     _install_database(monkeypatch, _Db({"allow_guest": 1, "is_active": 0}))
+
+    async def resolve(_session_id):
+        return None
+
+    monkeypatch.setattr(main, "_resolve_ws_session", resolve)
+
+    assert await main._session_can_subscribe_panel("zoe-touch-pi", "stale-guest-session") is False
+
+
+@pytest.mark.asyncio
+async def test_panel_push_session_rejects_when_guest_panel_db_yields_nothing(monkeypatch):
+    _install_empty_database(monkeypatch)
 
     async def resolve(_session_id):
         return None


### PR DESCRIPTION
## Summary
- allow /ws/push panel subscriptions without a data-valid session when the registered panel is active and allow_guest=true
- keep token and bound-session paths intact
- add focused tests for guest-enabled, disabled, inactive, and unregistered panels

## Verification
- python3 -m py_compile services/zoe-data/main.py
- python3 -m pytest services/zoe-data/tests/test_push_panel_session.py -q

## Live failure addressed
Touch browser guest sessions are not accepted by Zoe data UI auth, so the panel push socket stayed closed. This narrowly permits the registered kiosk panel to receive its own push actions.