### PR TITLE
Close Skybridge push delivery loop

### DIFF
--- a/services/zoe-data/push.py
+++ b/services/zoe-data/push.py
@@ -114,18 +114,21 @@ class PushBroadcaster:
 
         return delivered
 
-    async def broadcast_to_panel(self, panel_id: str, event_type: str, data: dict):
-        """Send an event only to the named panel's dedicated channel.
+    async def broadcast_to_panel(self, panel_id: str, event_type: str, data: dict) -> int:
+        """Send an event to the named panel's dedicated channel.
 
-        Falls back to 'all' channel broadcast if the panel has no dedicated channel
-        (e.g. it connected with plain connect() before this feature was deployed).
+        Returns only confirmed delivery to the panel-specific channel. A legacy
+        fallback still broadcasts to all so older clients can opportunistically
+        receive the event, but that fallback is not proof the target panel saw it.
         """
         panel_channel = f"panel_{panel_id}"
         if panel_channel in self._connections and self._connections[panel_channel]:
-            await self.broadcast(panel_channel, event_type, data)
-        else:
-            # Fallback: broadcast to all with panel_id in data so clients can filter.
-            await self.broadcast("all", event_type, data)
+            return await self.broadcast(panel_channel, event_type, data)
+
+        # Fallback: broadcast to all with panel_id in data so clients can filter,
+        # but report zero dedicated panel deliveries for durable queue semantics.
+        await self.broadcast("all", event_type, data)
+        return 0
 
     async def broadcast_all(self, event_type: str, data: dict):
         """Broadcast to all channels."""

--- a/services/zoe-data/routers/voice_tts.py
+++ b/services/zoe-data/routers/voice_tts.py
@@ -646,15 +646,11 @@ async def _broadcast_skybridge_ui(
     url = "/touch/skybridge.html" + (f"?q={query}" if query else "")
     cards = skybridge_result.get("cards") if isinstance(skybridge_result.get("cards"), list) else []
     summary = str(skybridge_result.get("spoken_summary") or "Showing this in Skybridge.")
-    nav_action = {
-        "id": f"voice_skybridge_nav_{panel_id}_{delivery_key}",
-        "action_type": "panel_navigate",
-        "payload": {
-            "url": url,
-            "label": "Opening Skybridge",
-            "panel_id": panel_id,
-            "source": "voice:skybridge",
-        },
+    nav_payload = {
+        "url": url,
+        "label": "Opening Skybridge",
+        "panel_id": panel_id,
+        "source": "voice:skybridge",
     }
     card_payload = {
         "type": "skybridge",
@@ -664,19 +660,9 @@ async def _broadcast_skybridge_ui(
         "panel_id": panel_id,
         "source": "voice:skybridge",
     }
-    card_action = {
-        "id": f"voice_skybridge_card_{panel_id}_{delivery_key}",
-        "action_type": "show_card",
-        "payload": card_payload,
-    }
-    try:
-        from push import broadcaster
-        await broadcaster.broadcast("all", "ui_action", {"action": nav_action})
-        await broadcaster.broadcast("all", "ui_action", {"action": card_action})
-    except Exception as exc:
-        logger.debug("voice skybridge ui broadcast failed (non-fatal): %s", exc)
     try:
         from database import get_db as _get_db
+        from push import broadcaster
         from ui_orchestrator import enqueue_ui_action as _enqueue_ui_action
         async for _db in _get_db():
             _panel_user_id = "family-admin"
@@ -690,16 +676,17 @@ async def _broadcast_skybridge_ui(
                     _panel_user_id = str(_row["user_id"])
             except Exception:
                 pass
-            await _enqueue_ui_action(
+            nav_message = await _enqueue_ui_action(
                 _db,
                 user_id=_panel_user_id,
                 panel_id=panel_id,
                 action_type="panel_navigate",
-                payload=nav_action["payload"],
+                payload=nav_payload,
                 requested_by="voice",
                 idempotency_key=f"voice_skybridge_nav_{panel_id}_{delivery_key}",
+                broadcast=False,
             )
-            await _enqueue_ui_action(
+            card_message = await _enqueue_ui_action(
                 _db,
                 user_id=_panel_user_id,
                 panel_id=panel_id,
@@ -707,7 +694,36 @@ async def _broadcast_skybridge_ui(
                 payload={**card_payload, "result": skybridge_result},
                 requested_by="voice",
                 idempotency_key=f"voice_skybridge_card_{panel_id}_{delivery_key}",
+                broadcast=False,
             )
+            nav_delivered = await broadcaster.broadcast_to_panel(
+                panel_id,
+                "ui_action",
+                {**nav_message, "payload": nav_payload},
+            )
+            card_delivered = await broadcaster.broadcast_to_panel(
+                panel_id,
+                "ui_action",
+                {**card_message, "payload": card_payload},
+            )
+            delivered_ids = []
+            if nav_delivered:
+                delivered_ids.append(nav_message["action_id"])
+            if card_delivered:
+                delivered_ids.append(card_message["action_id"])
+            if delivered_ids:
+                for _action_id in delivered_ids:
+                    await _db.execute(
+                        """UPDATE ui_actions
+                           SET status = 'success',
+                               error_code = NULL,
+                               error_message = 'Delivered over panel push',
+                               updated_at = NOW(),
+                               acked_at = NOW()
+                           WHERE id = ?""",
+                        (_action_id,),
+                    )
+                await _db.commit()
             break
     except Exception as exc:
         logger.debug("voice skybridge ui enqueue failed (non-fatal): %s", exc)

--- a/services/zoe-data/tests/test_push_broadcast_user_id.py
+++ b/services/zoe-data/tests/test_push_broadcast_user_id.py
@@ -99,3 +99,40 @@ async def test_broadcast_empty_channel_returns_zero(bc):
     """broadcast() on an empty or missing channel returns 0."""
     result = await bc.broadcast("nonexistent", "evt", {}, user_id="u1")
     assert result == 0
+
+
+async def _connect_panel(bc, ws, panel_id='panel-1'):
+    ws.accept = AsyncMock()
+    ws.send_json = AsyncMock()
+    await bc.connect_panel(ws, panel_id=panel_id)
+    ws.send_json.reset_mock()
+
+
+@pytest.mark.asyncio
+async def test_broadcast_to_panel_reports_dedicated_panel_delivery(bc):
+    """Dedicated panel channel delivery is counted for durable action retirement."""
+    ws = _make_ws()
+    await _connect_panel(bc, ws, panel_id='panel-1')
+
+    delivered = await bc.broadcast_to_panel('panel-1', 'ui_action', {'panel_id': 'panel-1'})
+
+    assert delivered == 1
+    ws.send_json.assert_awaited_once()
+    message = ws.send_json.await_args.args[0]
+    assert message['channel'] == 'panel_panel-1'
+    assert message['type'] == 'ui_action'
+
+
+@pytest.mark.asyncio
+async def test_broadcast_to_panel_fallback_does_not_report_delivery(bc):
+    """Global fallback is not proof the target panel received the action."""
+    ws = _make_ws()
+    await _connect(bc, ws, channel='all', user_id=None)
+
+    delivered = await bc.broadcast_to_panel('panel-1', 'ui_action', {'panel_id': 'panel-1'})
+
+    assert delivered == 0
+    ws.send_json.assert_awaited_once()
+    message = ws.send_json.await_args.args[0]
+    assert message['channel'] == 'all'
+    assert message['type'] == 'ui_action'

--- a/services/zoe-data/tests/test_skybridge_static.py
+++ b/services/zoe-data/tests/test_skybridge_static.py
@@ -41,6 +41,7 @@ def test_skybridge_push_socket_uses_authenticated_session_query():
     main = (ROOT / "zoe-data" / "main.py").read_text(encoding="utf-8")
 
     assert "/js/websocket-sync.js?v=skybridge-auth-ready-1" in html
+    assert "/touch/js/skybridge.js?v=skybridge-push-ack-1" in html
     assert "initPush(panelId, sessionId)" in sync
     assert "params.set('panel_id', panelId)" in sync
     assert "else params.set('channel', 'all')" in sync
@@ -198,6 +199,9 @@ def test_skybridge_uses_backend_status_contract():
     assert "function renderSkybridgeResult" in app
     assert "Voice is still connecting. Type here and Zoe will still render cards." in app
     assert "Microphone is not available here. Type a request and Zoe will still render cards." in app
+    assert "Type here while voice reconnects..." in app
+    assert "Voice reconnecting" in app
+    assert "Voice needs attention" not in app
     assert "contextLabelFor(intent)" in app
     assert "isDataQuery(query)" in app
     assert "resp.status === 401 || resp.status === 503" in app
@@ -280,7 +284,7 @@ def test_skybridge_renderer_supports_real_data_cards():
     assert "skybridge-calendar-widget-overrides" in html
     assert "skybridge-forecast-widget-overrides" in html
     assert "skybridge-weather-widget-v2" in html
-    assert "skybridge-calendar-menu-6" in html
+    assert "skybridge-push-ack-1" in html
     assert "backdrop-filter: none !important" in html
     assert "No events " in renderer
 

--- a/services/zoe-data/tests/test_ui_orchestrator_types.py
+++ b/services/zoe-data/tests/test_ui_orchestrator_types.py
@@ -2,10 +2,13 @@
 
 import sys
 import os
+import json
+
+import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from ui_orchestrator import ALLOWED_ACTION_TYPES
+from ui_orchestrator import ALLOWED_ACTION_TYPES, enqueue_ui_action
 
 
 def test_panel_navigate_allowed():
@@ -51,3 +54,54 @@ def test_panel_list_update_allowed():
 
 def test_panel_close_action_form_allowed():
     assert "panel_close_action_form" in ALLOWED_ACTION_TYPES
+
+
+class _Cursor:
+    def __init__(self, row=None):
+        self._row = row
+
+    async def fetchone(self):
+        return self._row
+
+
+class _DedupDb:
+    def __init__(self):
+        self.queries = []
+
+    async def execute(self, sql, params=()):
+        self.queries.append((sql, params))
+        if 'FROM ui_panel_sessions' in sql:
+            return _Cursor({'user_id': 'panel-user'})
+        if 'FROM ui_actions' in sql:
+            return _Cursor({
+                'id': 'existing-action',
+                'status': 'queued',
+                'action_type': 'show_card',
+                'payload': json.dumps({'type': 'skybridge', 'card': {'content': {'title': 'Weather'}}}),
+                'panel_id': 'panel-1',
+                'chat_session_id': None,
+                'requires_confirmation': 0,
+                'confirmation_token': None,
+            })
+        raise AssertionError(f'unexpected SQL: {sql}')
+
+
+@pytest.mark.asyncio
+async def test_enqueue_ui_action_dedup_returns_broadcast_message_shape():
+    result = await enqueue_ui_action(
+        _DedupDb(),
+        user_id='voice-user',
+        panel_id='panel-1',
+        action_type='show_card',
+        payload={'type': 'skybridge'},
+        idempotency_key='same-turn',
+        broadcast=False,
+    )
+
+    assert result['id'] == 'existing-action'
+    assert result['action_id'] == 'existing-action'
+    assert result['action_type'] == 'show_card'
+    assert result['panel_id'] == 'panel-1'
+    assert result['payload']['type'] == 'skybridge'
+    assert result['requires_confirmation'] is False
+    assert result['deduped'] is True

--- a/services/zoe-data/tests/test_voice_weather_queue.py
+++ b/services/zoe-data/tests/test_voice_weather_queue.py
@@ -131,8 +131,9 @@ class _Db:
         if "FROM ui_actions" in sql:
             return _Cursor(rows=self.voice_rows)
         if "UPDATE ui_actions" in sql:
-            self.updated_ids.append(params[1])
-            self.events.append(f"updated:{params[1]}")
+            updated_id = params[1] if len(params) > 1 else params[0]
+            self.updated_ids.append(updated_id)
+            self.events.append(f"updated:{updated_id}")
             return _Cursor()
         raise AssertionError(f"unexpected SQL: {sql}")
 
@@ -205,14 +206,18 @@ async def test_broadcast_skybridge_ui_opens_skybridge_with_card_payload(monkeypa
     async def enqueue_ui_action(_db, **kwargs):
         enqueue_calls.append(kwargs)
         return {
-            "id": kwargs["idempotency_key"],
+            "action_id": f"db-{kwargs['action_type']}",
             "status": "queued",
             "panel_id": kwargs["panel_id"],
+            "action_type": kwargs["action_type"],
+            "payload": kwargs["payload"],
         }
 
     class Broadcaster:
-        async def broadcast(self, channel, event, payload):
-            broadcasts.append((channel, event, payload))
+        async def broadcast_to_panel(self, panel_id, event, payload):
+            assert panel_id == "panel-1"
+            broadcasts.append((panel_id, event, payload))
+            return 1
 
     monkeypatch.setitem(sys.modules, "database", types.SimpleNamespace(get_db=get_db))
     monkeypatch.setitem(
@@ -246,14 +251,19 @@ async def test_broadcast_skybridge_ui_opens_skybridge_with_card_payload(monkeypa
 
     assert [call["action_type"] for call in enqueue_calls] == ["panel_navigate", "show_card"]
     assert enqueue_calls[0]["payload"]["url"] == "/touch/skybridge.html?q=show+weather"
+    assert enqueue_calls[0]["broadcast"] is False
     assert enqueue_calls[1]["payload"]["type"] == "skybridge"
     assert enqueue_calls[1]["payload"]["card"] == card
     assert enqueue_calls[1]["payload"]["result"] == result
-    assert [item[2]["action"]["action_type"] for item in broadcasts] == ["panel_navigate", "show_card"]
-    broadcast_card = broadcasts[1][2]["action"]["payload"]
+    assert enqueue_calls[1]["broadcast"] is False
+    assert [item[1] for item in broadcasts] == ["ui_action", "ui_action"]
+    assert [item[2]["action_id"] for item in broadcasts] == ["db-panel_navigate", "db-show_card"]
+    assert [item[2]["action_type"] for item in broadcasts] == ["panel_navigate", "show_card"]
+    broadcast_card = broadcasts[1][2]["payload"]
     assert broadcast_card["card"] == card
     assert broadcast_card["cards"] == [card]
     assert "result" not in broadcast_card
+    assert db.updated_ids == ["db-panel_navigate", "db-show_card"]
 
 
 @pytest.mark.asyncio

--- a/services/zoe-data/ui_orchestrator.py
+++ b/services/zoe-data/ui_orchestrator.py
@@ -113,7 +113,8 @@ async def enqueue_ui_action(
 
     if idempotency_key:
         cursor = await db.execute(
-            """SELECT id, status
+            """SELECT id, status, action_type, payload, panel_id, chat_session_id,
+                      requires_confirmation, confirmation_token
                FROM ui_actions
                WHERE user_id = ? AND idempotency_key = ?
                LIMIT 1""",
@@ -121,11 +122,26 @@ async def enqueue_ui_action(
         )
         existing = await cursor.fetchone()
         if existing:
+            existing_payload = existing["payload"]
+            if isinstance(existing_payload, str):
+                try:
+                    existing_payload = json.loads(existing_payload)
+                except json.JSONDecodeError:
+                    existing_payload = {}
             return {
                 "id": existing["id"],
+                "action_id": existing["id"],
+                "user_id": user_id,
+                "panel_id": existing["panel_id"] or panel_id,
+                "chat_session_id": existing["chat_session_id"],
+                "action_type": existing["action_type"],
+                "payload": existing_payload or {},
                 "status": existing["status"],
+                "requires_confirmation": bool(existing["requires_confirmation"]),
+                "confirmation_token": existing["confirmation_token"]
+                if existing["requires_confirmation"]
+                else None,
                 "deduped": True,
-                "panel_id": panel_id,
             }
 
     action_id = uuid.uuid4().hex[:16]

--- a/services/zoe-ui/dist/touch/js/skybridge.js
+++ b/services/zoe-ui/dist/touch/js/skybridge.js
@@ -137,7 +137,7 @@
         } else if (event.type === 'error') {
             showError(event.message);
             if (/voice disconnected|transport unavailable|livekit unavailable|websocket|microphone|permission/i.test(event.message || '')) {
-                openCommandFallback('Voice needs attention. Type here and Zoe will still render cards.');
+                openCommandFallback('Type here while voice reconnects...');
             }
         } else if (event.type === 'done') {
             setState('ambient');
@@ -340,7 +340,7 @@
         const text = message || 'Something needs attention.';
         setStatus(text);
         if (/microphone|secure|permission|voice upload|transport unavailable/i.test(text)) {
-            updateVoiceHint('Voice needs attention', text, 'Try again');
+            updateVoiceHint('Voice reconnecting', text, 'Try again');
         }
         const transportNotice = /voice disconnected|transport unavailable|livekit unavailable/i.test(text);
         if (transportNotice && (document.body.classList.contains('sky-empty') || currentUtterance)) return;

--- a/services/zoe-ui/dist/touch/skybridge.html
+++ b/services/zoe-ui/dist/touch/skybridge.html
@@ -4201,9 +4201,9 @@
     <script src="/touch/js/gestures.js?v=skybridge-auth-ready-1"></script>
     <script src="/touch/js/touch-menu.js?v=skybridge-auth-ready-1"></script>
     <script src="/js/touch-ui-executor.js?v=skybridge-auth-ready-1"></script>
-    <script src="/touch/js/skybridge-capabilities.js?v=skybridge-calendar-menu-6"></script>
-    <script src="/touch/js/skybridge-renderer.js?v=skybridge-calendar-menu-6"></script>
-    <script src="/touch/js/skybridge-voice.js?v=skybridge-calendar-menu-6"></script>
-    <script src="/touch/js/skybridge.js?v=skybridge-calendar-menu-6"></script>
+    <script src="/touch/js/skybridge-capabilities.js?v=skybridge-push-ack-1"></script>
+    <script src="/touch/js/skybridge-renderer.js?v=skybridge-push-ack-1"></script>
+    <script src="/touch/js/skybridge-voice.js?v=skybridge-push-ack-1"></script>
+    <script src="/touch/js/skybridge.js?v=skybridge-push-ack-1"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- send Skybridge voice UI actions over panel push using the real queued action ids
- retire queued Skybridge actions immediately after successful panel push delivery so stale cards do not replay later
- keep durable queued actions as fallback when no panel socket receives the push
- replace the alarming "Voice needs attention" fallback copy with calmer reconnect text

## Verification
- python3 -m py_compile services/zoe-data/routers/voice_tts.py services/zoe-data/push.py
- python3 -m pytest services/zoe-data/tests/test_voice_weather_queue.py services/zoe-data/tests/test_skybridge_static.py -q

## Live issue addressed
The panel could render cards after push was repaired, but old queued voice actions replayed because guest panel browsers cannot reliably ack /api/ui/actions. This made weather/calendar transitions look glitchy.