### PR TITLE
[codex] Stabilize Skybridge panel card delivery

### DIFF
--- a/services/zoe-data/routers/ui_actions.py
+++ b/services/zoe-data/routers/ui_actions.py
@@ -156,12 +156,16 @@ async def ack_ui_action(
         # Unknown or missing status — treat as a no-op ack to be idempotent.
         return {"status": "already_acked", "action_id": action_id}
 
-    # Accept ack by DB uuid (id) OR by idempotency_key — the SSE broadcast uses the
-    # idempotency_key as its action id, while the DB stores a separate UUID.
+    panel_id = str((payload or {}).get("panel_id") or "").strip()
+
+    # Accept ack by DB uuid (id) OR by idempotency_key.  Kiosk pages can reload
+    # between polling and acking, so allow a panel-targeted ack when the action id
+    # matches and the payload's panel_id matches the action's panel_id.
     cursor = await db.execute(
-        """SELECT id, panel_id, status FROM ui_actions
-           WHERE (id = ? OR idempotency_key = ?) AND user_id = ?""",
-        (action_id, action_id, user_id),
+        """SELECT id, user_id, panel_id, status FROM ui_actions
+           WHERE (id = ? OR idempotency_key = ?)
+             AND (user_id = ? OR (? != '' AND panel_id = ?))""",
+        (action_id, action_id, user_id, panel_id, panel_id),
     )
     existing = await cursor.fetchone()
     if not existing:
@@ -171,6 +175,7 @@ async def ack_ui_action(
 
     # Use the real DB id for the update (in case we matched on idempotency_key)
     real_id = existing["id"]
+    action_user_id = existing["user_id"]
     error_code = payload.get("error_code")
     error_message = payload.get("error_message")
     retries = payload.get("retry_count")
@@ -183,12 +188,12 @@ async def ack_ui_action(
                updated_at = NOW(),
                acked_at = CASE WHEN ? IS NOT NULL THEN NOW() ELSE acked_at END
            WHERE id = ? AND user_id = ?""",
-        (status, error_code, error_message, retries, acked_at, real_id, user_id),
+        (status, error_code, error_message, retries, acked_at, real_id, action_user_id),
     )
     await append_ledger(
         db,
         action_id=real_id,
-        user_id=user_id,
+        user_id=action_user_id,
         panel_id=existing["panel_id"],
         event_type=f"ack:{status}",
         event_data={

--- a/services/zoe-data/routers/ui_actions.py
+++ b/services/zoe-data/routers/ui_actions.py
@@ -135,7 +135,7 @@ async def get_pending_ui_actions(
              AND requested_by = 'voice'
              AND action_type = 'show_card'
              AND status IN ('queued', 'running')
-             AND payload::text LIKE '%"source": "voice:skybridge"%'
+             AND payload::jsonb->>'source' = 'voice:skybridge'
              AND created_at::timestamptz < (
                  SELECT MAX(created_at::timestamptz)
                  FROM ui_actions
@@ -143,7 +143,7 @@ async def get_pending_ui_actions(
                    AND requested_by = 'voice'
                    AND action_type = 'show_card'
                    AND status IN ('queued', 'running')
-                   AND payload::text LIKE '%"source": "voice:skybridge"%'
+                   AND payload::jsonb->>'source' = 'voice:skybridge'
              )""",
         (panel_user_id, panel_id, panel_user_id, panel_id),
     )
@@ -184,14 +184,23 @@ async def ack_ui_action(
 
     panel_id = str((payload or {}).get("panel_id") or "").strip()
 
-    # Accept ack by DB uuid (id) OR by idempotency_key.  Kiosk pages can reload
-    # between polling and acking, so allow a panel-targeted ack when the action id
-    # matches and the payload's panel_id matches the action's panel_id.
+    # Accept ack by DB uuid (id) OR by idempotency_key. Kiosk pages can reload
+    # between polling and acking, but panel-targeted cross-user acks are only
+    # accepted from a user currently registered on that panel.
     cursor = await db.execute(
         """SELECT id, user_id, panel_id, status FROM ui_actions
            WHERE (id = ? OR idempotency_key = ?)
-             AND (user_id = ? OR (? != '' AND panel_id = ?))""",
-        (action_id, action_id, user_id, panel_id, panel_id),
+             AND (
+               user_id = ?
+               OR (
+                 ? != '' AND panel_id = ?
+                 AND EXISTS (
+                   SELECT 1 FROM ui_panel_sessions
+                   WHERE panel_id = ? AND user_id = ?
+                 )
+               )
+             )""",
+        (action_id, action_id, user_id, panel_id, panel_id, panel_id, user_id),
     )
     existing = await cursor.fetchone()
     if not existing:

--- a/services/zoe-data/routers/ui_actions.py
+++ b/services/zoe-data/routers/ui_actions.py
@@ -123,6 +123,32 @@ async def get_pending_ui_actions(
     )
     await db.commit()
 
+    # Skybridge voice cards are state replacement, not a backlog. If a page
+    # reload or lost ack leaves older cards queued, skip everything except the
+    # newest card for this panel so the surface cannot visually rewind.
+    await db.execute(
+        """UPDATE ui_actions
+           SET status = 'skipped', error_code = 'superseded',
+               error_message = 'Superseded by newer Skybridge voice card',
+               updated_at = NOW()
+           WHERE user_id = ? AND panel_id = ?
+             AND requested_by = 'voice'
+             AND action_type = 'show_card'
+             AND status IN ('queued', 'running')
+             AND payload::text LIKE '%"source": "voice:skybridge"%'
+             AND created_at::timestamptz < (
+                 SELECT MAX(created_at::timestamptz)
+                 FROM ui_actions
+                 WHERE user_id = ? AND panel_id = ?
+                   AND requested_by = 'voice'
+                   AND action_type = 'show_card'
+                   AND status IN ('queued', 'running')
+                   AND payload::text LIKE '%"source": "voice:skybridge"%'
+             )""",
+        (panel_user_id, panel_id, panel_user_id, panel_id),
+    )
+    await db.commit()
+
     cursor = await db.execute(
         """SELECT id, panel_id, chat_session_id, action_type, payload, status, requires_confirmation,
                   confirmation_token, retry_count, max_retries, created_at, updated_at

--- a/services/zoe-data/routers/voice_tts.py
+++ b/services/zoe-data/routers/voice_tts.py
@@ -685,6 +685,7 @@ async def _broadcast_skybridge_ui(
                 requested_by="voice",
                 idempotency_key=f"voice_skybridge_nav_{panel_id}_{delivery_key}",
                 broadcast=False,
+                commit=False,
             )
             card_message = await _enqueue_ui_action(
                 _db,
@@ -695,7 +696,25 @@ async def _broadcast_skybridge_ui(
                 requested_by="voice",
                 idempotency_key=f"voice_skybridge_card_{panel_id}_{delivery_key}",
                 broadcast=False,
+                commit=False,
             )
+            current_card_id = card_message.get("action_id") or card_message.get("id")
+            await _db.execute(
+                """UPDATE ui_actions
+                   SET status = 'skipped',
+                       error_code = 'superseded',
+                       error_message = 'Superseded by newer Skybridge voice card',
+                       updated_at = NOW()
+                   WHERE user_id = ?
+                     AND panel_id = ?
+                     AND requested_by = 'voice'
+                     AND action_type = 'show_card'
+                     AND status IN ('queued', 'running')
+                     AND id != ?
+                     AND payload::text LIKE '%"source": "voice:skybridge"%'""",
+                (_panel_user_id, panel_id, current_card_id),
+            )
+            await _db.commit()
             nav_delivered = await broadcaster.broadcast_to_panel(
                 panel_id,
                 "ui_action",

--- a/services/zoe-data/routers/voice_tts.py
+++ b/services/zoe-data/routers/voice_tts.py
@@ -699,21 +699,22 @@ async def _broadcast_skybridge_ui(
                 commit=False,
             )
             current_card_id = card_message.get("action_id") or card_message.get("id")
-            await _db.execute(
-                """UPDATE ui_actions
-                   SET status = 'skipped',
-                       error_code = 'superseded',
-                       error_message = 'Superseded by newer Skybridge voice card',
-                       updated_at = NOW()
-                   WHERE user_id = ?
-                     AND panel_id = ?
-                     AND requested_by = 'voice'
-                     AND action_type = 'show_card'
-                     AND status IN ('queued', 'running')
-                     AND id != ?
-                     AND payload::text LIKE '%"source": "voice:skybridge"%'""",
-                (_panel_user_id, panel_id, current_card_id),
-            )
+            if current_card_id:
+                await _db.execute(
+                    """UPDATE ui_actions
+                       SET status = 'skipped',
+                           error_code = 'superseded',
+                           error_message = 'Superseded by newer Skybridge voice card',
+                           updated_at = NOW()
+                       WHERE user_id = ?
+                         AND panel_id = ?
+                         AND requested_by = 'voice'
+                         AND action_type = 'show_card'
+                         AND status IN ('queued', 'running')
+                         AND id != ?
+                         AND payload::jsonb->>'source' = 'voice:skybridge'""",
+                    (_panel_user_id, panel_id, current_card_id),
+                )
             await _db.commit()
             nav_delivered = await broadcaster.broadcast_to_panel(
                 panel_id,

--- a/services/zoe-data/routers/voice_tts.py
+++ b/services/zoe-data/routers/voice_tts.py
@@ -701,28 +701,20 @@ async def _broadcast_skybridge_ui(
                 "ui_action",
                 {**nav_message, "payload": nav_payload},
             )
-            card_delivered = await broadcaster.broadcast_to_panel(
-                panel_id,
-                "ui_action",
-                {**card_message, "payload": card_payload},
-            )
-            delivered_ids = []
+            # Keep the card queued. Navigating the old Skybridge page immediately
+            # can unload the socket before a following show_card frame is handled;
+            # the freshly loaded page will poll /api/ui/actions/pending and render it.
             if nav_delivered:
-                delivered_ids.append(nav_message["action_id"])
-            if card_delivered:
-                delivered_ids.append(card_message["action_id"])
-            if delivered_ids:
-                for _action_id in delivered_ids:
-                    await _db.execute(
-                        """UPDATE ui_actions
-                           SET status = 'success',
-                               error_code = NULL,
-                               error_message = 'Delivered over panel push',
-                               updated_at = NOW(),
-                               acked_at = NOW()
-                           WHERE id = ?""",
-                        (_action_id,),
-                    )
+                await _db.execute(
+                    """UPDATE ui_actions
+                       SET status = 'success',
+                           error_code = NULL,
+                           error_message = 'Delivered over panel push',
+                           updated_at = NOW(),
+                           acked_at = NOW()
+                       WHERE id = ?""",
+                    (nav_message["action_id"],),
+                )
                 await _db.commit()
             break
     except Exception as exc:

--- a/services/zoe-data/tests/test_skybridge_static.py
+++ b/services/zoe-data/tests/test_skybridge_static.py
@@ -391,7 +391,9 @@ def test_voice_command_has_skybridge_first_touch_path():
     assert "\"url\": url" in voice
     assert "\"type\": \"skybridge\"" in voice
     assert "payload={**card_payload, \"result\": skybridge_result}" in voice
-    assert "\"payload\": card_payload" in voice
+    assert "Keep the card queued" in voice
+    assert "poll /api/ui/actions/pending and render it" in voice
+    assert "{**card_message, \"payload\": card_payload}" not in voice
 
 
 
@@ -420,3 +422,14 @@ def test_skybridge_has_typed_fallback_for_insecure_voice_contexts():
     assert "syncVoiceFallbackState();" in app
     assert "Microphone needs HTTPS here" in app
     assert "resp.status === 401 || resp.status === 503" in app
+
+
+
+def test_skybridge_has_touch_panel_fit_overrides():
+    html = read(UI / "skybridge.html")
+
+    assert 'id="skybridge-touch-panel-fit"' in html
+    assert '@media (min-width: 900px) and (max-height: 760px)' in html
+    assert 'height: min(472px, calc(100dvh - 154px))' in html
+    assert 'grid-template-columns: repeat(8, minmax(46px, 1fr))' in html
+    assert 'body:not(.sky-empty) .sky-command' in html

--- a/services/zoe-data/tests/test_skybridge_static.py
+++ b/services/zoe-data/tests/test_skybridge_static.py
@@ -227,6 +227,15 @@ def test_skybridge_auth_and_voice_bus_contracts_are_wired():
     assert 'skybridge_context = {}\n\n            # ── Streaming LLM' in main
 
 
+def test_skybridge_touch_executor_card_shell_spans_panel_grid():
+    html = read(UI / "skybridge.html")
+
+    assert ".sky-card-shell {" in html
+    assert "grid-column: span 12 !important;" in html
+    assert ".sky-card-shell > .sky-card" in html
+    assert "body:not(.sky-empty) .sky-card-shell" in html
+
+
 def test_skybridge_renderer_supports_real_data_cards():
     renderer = read(UI / "js" / "skybridge-renderer.js")
     html = read(UI / "skybridge.html")

--- a/services/zoe-data/tests/test_ui_actions_ack.py
+++ b/services/zoe-data/tests/test_ui_actions_ack.py
@@ -77,3 +77,72 @@ async def test_ack_ui_action_accepts_matching_panel_when_user_differs(monkeypatc
     assert len(db.updated) == 1
     assert len(db.ledger) == 1
     assert db.commits == 1
+
+
+class _RowsCursor:
+    def __init__(self, row=None, rows=None):
+        self._row = row
+        self._rows = rows or []
+
+    async def fetchone(self):
+        return self._row
+
+    async def fetchall(self):
+        return self._rows
+
+
+class _PendingDb:
+    def __init__(self):
+        self.executes = []
+        self.commits = 0
+
+    async def execute(self, sql, params=()):
+        self.executes.append((sql, params))
+        if "FROM ui_panel_sessions" in sql:
+            return _RowsCursor(row={"user_id": "guest"})
+        if "UPDATE ui_actions" in sql:
+            return _RowsCursor()
+        if "FROM ui_actions" in sql:
+            return _RowsCursor(rows=[{
+                "id": "new-card",
+                "panel_id": "zoe-touch-pi",
+                "chat_session_id": None,
+                "action_type": "show_card",
+                "payload": '{"source":"voice:skybridge","cards":[]}',
+                "status": "queued",
+                "requires_confirmation": 0,
+                "confirmation_token": None,
+                "retry_count": 0,
+                "max_retries": 3,
+                "created_at": "2026-06-14T00:00:00Z",
+                "updated_at": "2026-06-14T00:00:00Z",
+            }])
+        raise AssertionError(f"unexpected SQL: {sql}")
+
+    async def commit(self):
+        self.commits += 1
+
+
+@pytest.mark.asyncio
+async def test_pending_actions_skips_superseded_skybridge_voice_cards(monkeypatch):
+    async def allow(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(ui_actions, "require_feature_access", allow)
+
+    db = _PendingDb()
+    result = await ui_actions.get_pending_ui_actions(
+        panel_id="zoe-touch-pi",
+        limit=10,
+        user={"user_id": "guest", "role": "guest"},
+        db=db,
+    )
+
+    cleanup_sql = db.executes[2][0]
+    cleanup_params = db.executes[2][1]
+    assert "Superseded by newer Skybridge voice card" in cleanup_sql
+    assert "payload::text LIKE" in cleanup_sql
+    assert cleanup_params == ("guest", "zoe-touch-pi", "guest", "zoe-touch-pi")
+    assert result["count"] == 1
+    assert result["actions"][0]["id"] == "new-card"
+    assert db.commits == 2

--- a/services/zoe-data/tests/test_ui_actions_ack.py
+++ b/services/zoe-data/tests/test_ui_actions_ack.py
@@ -29,8 +29,17 @@ class _AckDb:
 
     async def execute(self, sql, params=()):
         if "FROM ui_actions" in sql:
-            assert "panel_id" in sql
-            assert params == ("action-1", "action-1", "browser-user", "zoe-touch-pi", "zoe-touch-pi")
+            assert "EXISTS" in sql
+            assert "FROM ui_panel_sessions" in sql
+            assert params == (
+                "action-1",
+                "action-1",
+                "browser-user",
+                "zoe-touch-pi",
+                "zoe-touch-pi",
+                "zoe-touch-pi",
+                "browser-user",
+            )
             return _Cursor({
                 "id": "action-1",
                 "user_id": "panel-owner",
@@ -77,6 +86,44 @@ async def test_ack_ui_action_accepts_matching_panel_when_user_differs(monkeypatc
     assert len(db.updated) == 1
     assert len(db.ledger) == 1
     assert db.commits == 1
+
+
+class _UnauthorizedAckDb:
+    def __init__(self):
+        self.updated = []
+        self.commits = 0
+
+    async def execute(self, sql, params=()):
+        if "FROM ui_actions" in sql:
+            assert "FROM ui_panel_sessions" in sql
+            return _Cursor(None)
+        if "UPDATE ui_actions" in sql:
+            self.updated.append((sql, params))
+            return _Cursor()
+        raise AssertionError(f"unexpected SQL: {sql}")
+
+    async def commit(self):
+        self.commits += 1
+
+
+@pytest.mark.asyncio
+async def test_ack_ui_action_rejects_panel_ack_when_user_not_registered(monkeypatch):
+    async def allow(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(ui_actions, "require_feature_access", allow)
+
+    db = _UnauthorizedAckDb()
+    result = await ack_ui_action(
+        "action-1",
+        {"status": "failed", "panel_id": "zoe-touch-pi"},
+        user={"user_id": "other-guest", "role": "guest"},
+        db=db,
+    )
+
+    assert result == {"status": "already_acked", "action_id": "action-1"}
+    assert db.updated == []
+    assert db.commits == 0
 
 
 class _RowsCursor:
@@ -141,7 +188,7 @@ async def test_pending_actions_skips_superseded_skybridge_voice_cards(monkeypatc
     cleanup_sql = db.executes[2][0]
     cleanup_params = db.executes[2][1]
     assert "Superseded by newer Skybridge voice card" in cleanup_sql
-    assert "payload::text LIKE" in cleanup_sql
+    assert "payload::jsonb->>'source' = 'voice:skybridge'" in cleanup_sql
     assert cleanup_params == ("guest", "zoe-touch-pi", "guest", "zoe-touch-pi")
     assert result["count"] == 1
     assert result["actions"][0]["id"] == "new-card"

--- a/services/zoe-data/tests/test_ui_actions_ack.py
+++ b/services/zoe-data/tests/test_ui_actions_ack.py
@@ -185,9 +185,11 @@ async def test_pending_actions_skips_superseded_skybridge_voice_cards(monkeypatc
         db=db,
     )
 
-    cleanup_sql = db.executes[2][0]
-    cleanup_params = db.executes[2][1]
-    assert "Superseded by newer Skybridge voice card" in cleanup_sql
+    cleanup_sql, cleanup_params = next(
+        (sql, params)
+        for sql, params in db.executes
+        if "Superseded by newer Skybridge voice card" in sql
+    )
     assert "payload::jsonb->>'source' = 'voice:skybridge'" in cleanup_sql
     assert cleanup_params == ("guest", "zoe-touch-pi", "guest", "zoe-touch-pi")
     assert result["count"] == 1

--- a/services/zoe-data/tests/test_ui_actions_ack.py
+++ b/services/zoe-data/tests/test_ui_actions_ack.py
@@ -1,0 +1,79 @@
+"""Tests for touch UI action acknowledgement."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import routers.ui_actions as ui_actions  # noqa: E402
+from routers.ui_actions import ack_ui_action  # noqa: E402
+
+
+class _Cursor:
+    def __init__(self, row=None):
+        self._row = row
+
+    async def fetchone(self):
+        return self._row
+
+
+class _AckDb:
+    def __init__(self):
+        self.updated = []
+        self.ledger = []
+        self.commits = 0
+
+    async def execute(self, sql, params=()):
+        if "FROM ui_actions" in sql:
+            assert "panel_id" in sql
+            assert params == ("action-1", "action-1", "browser-user", "zoe-touch-pi", "zoe-touch-pi")
+            return _Cursor({
+                "id": "action-1",
+                "user_id": "panel-owner",
+                "panel_id": "zoe-touch-pi",
+                "status": "queued",
+            })
+        if "UPDATE ui_actions" in sql:
+            self.updated.append((sql, params))
+            assert params[-2:] == ("action-1", "panel-owner")
+            return _Cursor()
+        if "INSERT INTO ui_action_ledger" in sql:
+            self.ledger.append((sql, params))
+            assert params[2] == "panel-owner"
+            assert params[3] == "zoe-touch-pi"
+            assert params[4] == "ack:success"
+            return _Cursor()
+        raise AssertionError(f"unexpected SQL: {sql}")
+
+    async def commit(self):
+        self.commits += 1
+
+
+@pytest.mark.asyncio
+async def test_ack_ui_action_accepts_matching_panel_when_user_differs(monkeypatch):
+    async def allow(*_args, **_kwargs):
+        return None
+
+    class Broadcaster:
+        async def broadcast(self, *_args, **_kwargs):
+            return 1
+
+    monkeypatch.setattr(ui_actions, "require_feature_access", allow)
+    monkeypatch.setattr(ui_actions, "broadcaster", Broadcaster())
+
+    db = _AckDb()
+    result = await ack_ui_action(
+        "action-1",
+        {"status": "success", "panel_id": "zoe-touch-pi", "ui_context": {"page": "/touch/skybridge.html"}},
+        user={"user_id": "browser-user", "role": "guest"},
+        db=db,
+    )
+
+    assert result == {"status": "ok", "action_id": "action-1", "state": "success"}
+    assert len(db.updated) == 1
+    assert len(db.ledger) == 1
+    assert db.commits == 1

--- a/services/zoe-data/tests/test_voice_weather_queue.py
+++ b/services/zoe-data/tests/test_voice_weather_queue.py
@@ -89,6 +89,7 @@ class _Db:
     def __init__(self):
         self.events: list[str] = []
         self.updated_ids: list[str] = []
+        self.executed: list[tuple[str, tuple]] = []
         self.voice_rows = [
             {
                 "id": "old-nav-null-key",
@@ -129,6 +130,7 @@ class _Db:
         self.events.append("commit")
 
     async def execute(self, sql: str, params: tuple = ()):
+        self.executed.append((sql, params))
         if "FROM ui_panel_sessions" in sql:
             return _Cursor(row={"user_id": "panel-user"})
         if "FROM ui_actions" in sql:
@@ -264,6 +266,63 @@ async def test_broadcast_skybridge_ui_opens_skybridge_with_card_payload(monkeypa
     assert [item[2]["action_type"] for item in broadcasts] == ["panel_navigate"]
     assert db.updated_ids == ["panel-1", "db-panel_navigate"]
     assert "commit" in db.events
+    cleanup_sql = next(sql for sql, _params in db.executed if "payload::jsonb" in sql)
+    assert "payload::jsonb->>'source' = 'voice:skybridge'" in cleanup_sql
+
+
+@pytest.mark.asyncio
+async def test_broadcast_skybridge_ui_skips_supersession_when_card_id_missing(monkeypatch) -> None:
+    db = _Db()
+    enqueue_calls = []
+    broadcasts = []
+
+    async def get_db():
+        yield db
+
+    async def enqueue_ui_action(_db, **kwargs):
+        enqueue_calls.append(kwargs)
+        if kwargs["action_type"] == "show_card":
+            return {
+                "status": "queued",
+                "panel_id": kwargs["panel_id"],
+                "action_type": kwargs["action_type"],
+                "payload": kwargs["payload"],
+            }
+        return {
+            "action_id": "db-panel_navigate",
+            "status": "queued",
+            "panel_id": kwargs["panel_id"],
+            "action_type": kwargs["action_type"],
+            "payload": kwargs["payload"],
+        }
+
+    class Broadcaster:
+        async def broadcast_to_panel(self, panel_id, event, payload):
+            broadcasts.append((panel_id, event, payload))
+            return 1
+
+    monkeypatch.setitem(sys.modules, "database", types.SimpleNamespace(get_db=get_db))
+    monkeypatch.setitem(
+        sys.modules,
+        "ui_orchestrator",
+        types.SimpleNamespace(enqueue_ui_action=enqueue_ui_action),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "push",
+        types.SimpleNamespace(broadcaster=Broadcaster()),
+    )
+
+    await _broadcast_skybridge_ui(
+        "panel-1",
+        {"handled": True, "spoken_summary": "Showing it.", "cards": []},
+        utterance="show weather",
+        turn_key="turn-no-card-id",
+    )
+
+    assert [call["action_type"] for call in enqueue_calls] == ["panel_navigate", "show_card"]
+    assert [item[1] for item in broadcasts] == ["ui_action"]
+    assert not any("payload::jsonb" in sql for sql, _params in db.executed)
 
 
 @pytest.mark.asyncio

--- a/services/zoe-data/tests/test_voice_weather_queue.py
+++ b/services/zoe-data/tests/test_voice_weather_queue.py
@@ -125,6 +125,9 @@ class _Db:
     def transaction(self):
         return _Transaction(self)
 
+    async def commit(self):
+        self.events.append("commit")
+
     async def execute(self, sql: str, params: tuple = ()):
         if "FROM ui_panel_sessions" in sql:
             return _Cursor(row={"user_id": "panel-user"})
@@ -259,7 +262,8 @@ async def test_broadcast_skybridge_ui_opens_skybridge_with_card_payload(monkeypa
     assert [item[1] for item in broadcasts] == ["ui_action"]
     assert [item[2]["action_id"] for item in broadcasts] == ["db-panel_navigate"]
     assert [item[2]["action_type"] for item in broadcasts] == ["panel_navigate"]
-    assert db.updated_ids == ["db-panel_navigate"]
+    assert db.updated_ids == ["panel-1", "db-panel_navigate"]
+    assert "commit" in db.events
 
 
 @pytest.mark.asyncio

--- a/services/zoe-data/tests/test_voice_weather_queue.py
+++ b/services/zoe-data/tests/test_voice_weather_queue.py
@@ -256,14 +256,10 @@ async def test_broadcast_skybridge_ui_opens_skybridge_with_card_payload(monkeypa
     assert enqueue_calls[1]["payload"]["card"] == card
     assert enqueue_calls[1]["payload"]["result"] == result
     assert enqueue_calls[1]["broadcast"] is False
-    assert [item[1] for item in broadcasts] == ["ui_action", "ui_action"]
-    assert [item[2]["action_id"] for item in broadcasts] == ["db-panel_navigate", "db-show_card"]
-    assert [item[2]["action_type"] for item in broadcasts] == ["panel_navigate", "show_card"]
-    broadcast_card = broadcasts[1][2]["payload"]
-    assert broadcast_card["card"] == card
-    assert broadcast_card["cards"] == [card]
-    assert "result" not in broadcast_card
-    assert db.updated_ids == ["db-panel_navigate", "db-show_card"]
+    assert [item[1] for item in broadcasts] == ["ui_action"]
+    assert [item[2]["action_id"] for item in broadcasts] == ["db-panel_navigate"]
+    assert [item[2]["action_type"] for item in broadcasts] == ["panel_navigate"]
+    assert db.updated_ids == ["db-panel_navigate"]
 
 
 @pytest.mark.asyncio

--- a/services/zoe-ui/dist/js/touch-ui-executor.js
+++ b/services/zoe-ui/dist/js/touch-ui-executor.js
@@ -1379,6 +1379,7 @@ body.light-mode #zvo-header { border-bottom-color: rgba(0,0,0,0.07); }
             error_code: result.error_code || null,
             error_message: result.error_message || null,
             ui_context: buildContext(),
+            panel_id: state.panelId,
         });
         const session = getSession();
         const headers = { 'Content-Type': 'application/json' };

--- a/services/zoe-ui/dist/touch/skybridge.html
+++ b/services/zoe-ui/dist/touch/skybridge.html
@@ -1973,6 +1973,11 @@
                 padding-bottom: 12px;
             }
 
+            body:not(.sky-empty) .sky-card-shell {
+                grid-column: span 12 !important;
+                width: 100% !important;
+            }
+
             body:not(.sky-empty) .sky-card,
             body:not(.sky-empty) .sky-card.page-card,
             body:not(.sky-empty) .sky-card.setting-card,
@@ -2313,6 +2318,17 @@
         .sky-card-stack::-webkit-scrollbar,
         .sky-card-stack::before {
             display: none !important;
+        }
+
+        .sky-card-shell {
+            grid-column: span 12 !important;
+            min-width: 0 !important;
+            width: 100% !important;
+        }
+
+        .sky-card-shell > .sky-card {
+            width: 100% !important;
+            height: 100% !important;
         }
 
         .sky-card,

--- a/services/zoe-ui/dist/touch/skybridge.html
+++ b/services/zoe-ui/dist/touch/skybridge.html
@@ -3895,6 +3895,189 @@
             }
         }
     </style>
+
+    <style id="skybridge-touch-panel-fit">
+        @media (min-width: 900px) and (max-height: 760px) {
+            body:not(.sky-empty) .sky-stage {
+                inset: 24px 0 112px !important;
+                width: min(1120px, calc(100vw - 80px)) !important;
+            }
+
+            body:not(.sky-empty) .sky-card-stack {
+                align-content: start !important;
+                gap: 12px !important;
+                padding-bottom: 10px !important;
+            }
+
+            body:not(.sky-empty) .sky-card,
+            body:not(.sky-empty) .sky-card.page-card,
+            body:not(.sky-empty) .sky-card.setting-card,
+            body:not(.sky-empty) .sky-card.list-card,
+            body:not(.sky-empty) .sky-card:first-child {
+                padding: 18px !important;
+                border-radius: 24px !important;
+            }
+
+            body:not(.sky-empty) .weather-card.sky-premium-card {
+                height: min(472px, calc(100dvh - 154px)) !important;
+                min-height: 0 !important;
+                max-height: 472px !important;
+            }
+
+            body:not(.sky-empty) .sky-weather-scene {
+                height: 100% !important;
+                min-height: 0 !important;
+                grid-template-columns: minmax(0, 0.86fr) minmax(430px, 1fr) !important;
+                gap: 18px !important;
+                padding: 24px !important;
+            }
+
+            body:not(.sky-empty) .sky-weather-main {
+                align-content: end !important;
+                min-height: 0 !important;
+                padding: 0 !important;
+            }
+
+            body:not(.sky-empty) .sky-weather-location {
+                max-width: 260px !important;
+                padding: 8px 13px !important;
+                font-size: 14px !important;
+            }
+
+            body:not(.sky-empty) .sky-weather-temp {
+                font-size: 118px !important;
+                line-height: 0.82 !important;
+            }
+
+            body:not(.sky-empty) .sky-weather-icon {
+                font-size: 70px !important;
+            }
+
+            body:not(.sky-empty) .sky-weather-condition {
+                font-size: 18px !important;
+                line-height: 1.05 !important;
+            }
+
+            body:not(.sky-empty) .sky-weather-meta {
+                grid-template-columns: repeat(3, minmax(0, 1fr)) !important;
+                gap: 8px !important;
+                max-width: 420px !important;
+            }
+
+            body:not(.sky-empty) .sky-weather-pill {
+                min-height: 44px !important;
+                padding: 8px 10px !important;
+                border-radius: 16px !important;
+                font-size: 13px !important;
+            }
+
+            body:not(.sky-empty) .sky-weather-forecast {
+                gap: 10px !important;
+                padding: 14px !important;
+                border-radius: 26px !important;
+                overflow: hidden !important;
+            }
+
+            body:not(.sky-empty) .sky-weather-forecast-head h4 {
+                font-size: 13px !important;
+            }
+
+            body:not(.sky-empty) .sky-weather-forecast-head span {
+                padding: 5px 9px !important;
+                font-size: 11px !important;
+            }
+
+            body:not(.sky-empty) .sky-weather-hour-strip {
+                grid-template-columns: repeat(8, minmax(46px, 1fr)) !important;
+                gap: 7px !important;
+            }
+
+            body:not(.sky-empty) .sky-weather-hour-tile {
+                min-height: 78px !important;
+                gap: 4px !important;
+                padding: 7px 5px !important;
+                border-radius: 18px !important;
+            }
+
+            body:not(.sky-empty) .sky-weather-hour-tile span {
+                font-size: 11px !important;
+            }
+
+            body:not(.sky-empty) .sky-weather-hour-tile b {
+                font-size: 20px !important;
+            }
+
+            body:not(.sky-empty) .sky-weather-hour-tile strong {
+                font-size: 15px !important;
+            }
+
+            body:not(.sky-empty) .sky-weather-day-list {
+                gap: 7px !important;
+                overflow: hidden !important;
+            }
+
+            body:not(.sky-empty) .sky-weather-day-row {
+                min-height: 48px !important;
+                grid-template-columns: minmax(82px, 0.3fr) minmax(0, 1fr) auto !important;
+                gap: 10px !important;
+                padding: 8px 11px !important;
+                border-radius: 18px !important;
+            }
+
+            body:not(.sky-empty) .sky-weather-day-label {
+                gap: 8px !important;
+            }
+
+            body:not(.sky-empty) .sky-weather-day-label span,
+            body:not(.sky-empty) .sky-weather-day-main strong {
+                font-size: 13px !important;
+            }
+
+            body:not(.sky-empty) .sky-weather-day-label b {
+                font-size: 20px !important;
+            }
+
+            body:not(.sky-empty) .sky-weather-day-main {
+                gap: 5px !important;
+            }
+
+            body:not(.sky-empty) .sky-weather-temp-band {
+                height: 6px !important;
+            }
+
+            body:not(.sky-empty) .sky-weather-day-temp strong {
+                font-size: 20px !important;
+            }
+
+            body:not(.sky-empty) .sky-weather-day-temp small {
+                font-size: 13px !important;
+            }
+
+            body:not(.sky-empty) .calendar-card.sky-premium-card,
+            body:not(.sky-empty) .zoe-list-card.sky-premium-card,
+            body:not(.sky-empty) .people-card.sky-premium-card,
+            body:not(.sky-empty) .person-card.sky-premium-card {
+                max-height: calc(100dvh - 154px) !important;
+                overflow: hidden !important;
+            }
+
+            body:not(.sky-empty) .sky-command,
+            body.sky-command-open .sky-command,
+            body.sky-voice-fallback.sky-empty .sky-command {
+                bottom: 18px !important;
+                height: 72px !important;
+            }
+
+            body:not(.sky-empty) .sky-orb-panel::after,
+            body.sky-command-open .sky-orb-panel::after,
+            body:not(.sky-empty) .sky-listening-copy,
+            body.sky-command-open .sky-listening-copy {
+                bottom: 18px !important;
+                height: 72px !important;
+                line-height: 72px !important;
+            }
+        }
+    </style>
     <style id="skybridge-calendar-widget-overrides">
         body:not(.sky-empty) .calendar-card.sky-premium-card {
             min-height: 370px !important;


### PR DESCRIPTION
## Summary

Fixes the physical touch-panel Skybridge card delivery loop after the voice bridge opens Skybridge from a spoken command.

Root causes fixed:
- pushed Skybridge cards were wrapped in `.sky-card-shell`, but the wrapper did not span the 12-column card grid, so some cards collapsed to one grid track on the 1280x720 panel
- voice-triggered `show_card` rows stayed queued after navigation, so older queued cards could overwrite the current request a few seconds later
- panel acks can come from the foreground browser session user while the action belongs to the panel-bound user, so matching acks need to use `panel_id` as well as action id
- navigating and immediately pushing a card could race the page unload; the card is now durable-queued and rendered by the fresh Skybridge page

## Changes

- Stabilize Skybridge voice delivery by queueing navigation/card actions durably and only push-delivering navigation.
- Allow panel-targeted acks to retire the correct action owner when the browser session user differs.
- Force `.sky-card-shell` to occupy the full card grid lane and preserve inner card dimensions.
- Retire older pending Skybridge voice cards whenever a new Skybridge card is queued, and clean existing stale backlog from `/api/ui/actions/pending`.
- Add focused regression coverage for delivery, ack ownership, shell sizing, and pending cleanup.

## Validation

- `python3 -m py_compile services/zoe-data/routers/voice_tts.py services/zoe-data/routers/ui_actions.py`
- `python3 -m pytest services/zoe-data/tests/test_voice_weather_queue.py services/zoe-data/tests/test_skybridge_static.py services/zoe-data/tests/test_skybridge_service.py services/zoe-data/tests/test_card_service.py services/zoe-data/tests/test_push_broadcast_user_id.py services/zoe-data/tests/test_ui_orchestrator_types.py services/zoe-data/tests/test_ui_actions_ack.py -q`
- Result: `94 passed in 1.85s`
- Physical touch panel slow verification on `zoe-touch-pi` at `1280x720`:
  - `show weather`: audio OK, final matching card, width `1120px`, ratio `0.875`
  - `show forecast tomorrow`: audio OK, final matching card, width `1120px`, ratio `0.875`
  - `show my calendar`: audio OK, final matching card, width `1120px`, ratio `0.875`
  - `show shopping list`: audio OK, final matching card, width `1120px`, ratio `0.875`
  - `show people`: audio OK, final matching card, width `1120px`, ratio `0.875`
