### PR TITLE
[codex] Retire rendered Skybridge voice cards

### DIFF
--- a/services/zoe-data/routers/ui_actions.py
+++ b/services/zoe-data/routers/ui_actions.py
@@ -214,16 +214,15 @@ async def ack_ui_action(
     error_code = payload.get("error_code")
     error_message = payload.get("error_message")
     retries = payload.get("retry_count")
-    now_sql = "NOW()"
-    acked_at = now_sql if status in {"success", "failed", "blocked"} else None
+    should_set_acked_at = status in {"success", "failed", "blocked"}
 
     await db.execute(
         """UPDATE ui_actions
            SET status = ?, error_code = ?, error_message = ?, retry_count = COALESCE(?, retry_count),
                updated_at = NOW(),
-               acked_at = CASE WHEN ? IS NOT NULL THEN NOW() ELSE acked_at END
+               acked_at = CASE WHEN CAST(? AS boolean) THEN NOW() ELSE acked_at END
            WHERE id = ? AND user_id = ?""",
-        (status, error_code, error_message, retries, acked_at, real_id, action_user_id),
+        (status, error_code, error_message, retries, should_set_acked_at, real_id, action_user_id),
     )
     await append_ledger(
         db,

--- a/services/zoe-data/tests/test_skybridge_static.py
+++ b/services/zoe-data/tests/test_skybridge_static.py
@@ -200,6 +200,7 @@ def test_skybridge_uses_backend_status_contract():
     assert "function retireRenderedVoiceCards" in app
     assert "/api/ui/actions/pending?panel_id=" in app
     assert "action.payload.source === 'voice:skybridge'" in app
+    assert "Promise.allSettled(actions" in app
     assert "skybridge-direct-render" in app
     assert "Voice is still connecting. Type here and Zoe will still render cards." in app
     assert "Microphone is not available here. Type a request and Zoe will still render cards." in app

--- a/services/zoe-data/tests/test_skybridge_static.py
+++ b/services/zoe-data/tests/test_skybridge_static.py
@@ -41,7 +41,7 @@ def test_skybridge_push_socket_uses_authenticated_session_query():
     main = (ROOT / "zoe-data" / "main.py").read_text(encoding="utf-8")
 
     assert "/js/websocket-sync.js?v=skybridge-auth-ready-1" in html
-    assert "/touch/js/skybridge.js?v=skybridge-push-ack-1" in html
+    assert "/touch/js/skybridge.js?v=skybridge-render-ack-1" in html
     assert "initPush(panelId, sessionId)" in sync
     assert "params.set('panel_id', panelId)" in sync
     assert "else params.set('channel', 'all')" in sync
@@ -197,6 +197,10 @@ def test_skybridge_uses_backend_status_contract():
     assert "JSON.stringify({ message: query, context: skybridgeContext })" in app
     assert "renderSkybridgeResult(data)" in app
     assert "function renderSkybridgeResult" in app
+    assert "function retireRenderedVoiceCards" in app
+    assert "/api/ui/actions/pending?panel_id=" in app
+    assert "action.payload.source === 'voice:skybridge'" in app
+    assert "skybridge-direct-render" in app
     assert "Voice is still connecting. Type here and Zoe will still render cards." in app
     assert "Microphone is not available here. Type a request and Zoe will still render cards." in app
     assert "Type here while voice reconnects..." in app

--- a/services/zoe-data/tests/test_ui_actions_ack.py
+++ b/services/zoe-data/tests/test_ui_actions_ack.py
@@ -48,7 +48,8 @@ class _AckDb:
             })
         if "UPDATE ui_actions" in sql:
             self.updated.append((sql, params))
-            assert params[-2:] == ("action-1", "panel-owner")
+            assert "CAST(? AS boolean)" in sql
+            assert params == ("success", None, None, None, True, "action-1", "panel-owner")
             return _Cursor()
         if "INSERT INTO ui_action_ledger" in sql:
             self.ledger.append((sql, params))

--- a/services/zoe-ui/dist/touch/js/skybridge.js
+++ b/services/zoe-ui/dist/touch/js/skybridge.js
@@ -178,6 +178,7 @@
             const data = await resp.json();
             if (!data || !data.handled) return false;
             renderSkybridgeResult(data);
+            retireRenderedVoiceCards(data);
             return true;
         } catch (err) {
             if (isDataQuery(query)) {
@@ -224,6 +225,35 @@
                     status: 'Resolver'
                 }
             }, true);
+        }
+    }
+
+    async function retireRenderedVoiceCards(data) {
+        if (!data || !data.handled) return;
+        const panelId = new URLSearchParams(location.search).get('panel_id');
+        if (!panelId) return;
+        try {
+            const pending = await fetch(`/api/ui/actions/pending?panel_id=${encodeURIComponent(panelId)}&limit=20`, {
+                headers: { 'Accept': 'application/json' }
+            });
+            if (!pending.ok) return;
+            const payload = await pending.json();
+            const actions = Array.isArray(payload.actions) ? payload.actions : [];
+            await Promise.all(actions
+                .filter(action => action && action.action_type === 'show_card')
+                .filter(action => action.payload && action.payload.source === 'voice:skybridge')
+                .map(action => fetch(`/api/ui/actions/${encodeURIComponent(action.id)}/ack`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        status: 'success',
+                        panel_id: panelId,
+                        ui_context: { page: location.pathname, source: 'skybridge-direct-render' }
+                    }),
+                    keepalive: true
+                })));
+        } catch (_) {
+            // Non-fatal: the queued card will be superseded by the next voice turn.
         }
     }
 

--- a/services/zoe-ui/dist/touch/js/skybridge.js
+++ b/services/zoe-ui/dist/touch/js/skybridge.js
@@ -239,7 +239,7 @@
             if (!pending.ok) return;
             const payload = await pending.json();
             const actions = Array.isArray(payload.actions) ? payload.actions : [];
-            await Promise.all(actions
+            await Promise.allSettled(actions
                 .filter(action => action && action.action_type === 'show_card')
                 .filter(action => action.payload && action.payload.source === 'voice:skybridge')
                 .map(action => fetch(`/api/ui/actions/${encodeURIComponent(action.id)}/ack`, {

--- a/services/zoe-ui/dist/touch/skybridge.html
+++ b/services/zoe-ui/dist/touch/skybridge.html
@@ -4403,6 +4403,6 @@
     <script src="/touch/js/skybridge-capabilities.js?v=skybridge-push-ack-1"></script>
     <script src="/touch/js/skybridge-renderer.js?v=skybridge-push-ack-1"></script>
     <script src="/touch/js/skybridge-voice.js?v=skybridge-push-ack-1"></script>
-    <script src="/touch/js/skybridge.js?v=skybridge-push-ack-1"></script>
+    <script src="/touch/js/skybridge.js?v=skybridge-render-ack-1"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Retires durable Skybridge voice card fallbacks after the Skybridge page has already rendered the same request through the direct `?q=` resolver path.

## Why

PR #482 correctly made voice cards durable across page navigation, but the physical panel test exposed one leftover edge case: when `skybridge.html?q=...` successfully renders the backend result directly, the queued fallback `show_card` can remain in `ui_actions`. The next voice turn supersedes it, but the queue should still be clean after a successful final card render.

## Changes

- Add `retireRenderedVoiceCards()` to `touch/js/skybridge.js`.
- After successful `/api/skybridge/resolve` rendering, fetch pending panel actions and ack queued `show_card` actions with `payload.source === "voice:skybridge"`.
- Bump the Skybridge app script version to `skybridge-render-ack-1` so the panel loads the new JS.
- Add static assertions for the cleanup hook and versioned script reference.

## Validation

- `python3 -m pytest services/zoe-data/tests/test_skybridge_static.py services/zoe-data/tests/test_skybridge_service.py services/zoe-data/tests/test_card_service.py services/zoe-data/tests/test_voice_weather_queue.py services/zoe-data/tests/test_ui_actions_ack.py -q`
- Result: `77 passed in 2.20s`

Physical panel validation will be rerun against live after this branch is promoted.
