### PR TITLE
fix(multica-poll): bound blocked-resume scan to a rotating per-cycle budget

### DIFF
--- a/services/zoe-data/main.py
+++ b/services/zoe-data/main.py
@@ -85,6 +85,32 @@ for _handler in logging.getLogger().handlers:
     _handler.addFilter(RequestIdFilter())
 
 
+# Rotating cursor for the blocked-resume scan (see _bounded_blocked_resume_window).
+_BLOCKED_RESUME_CURSOR: dict[str, int] = {"offset": 0}
+
+
+def _bounded_blocked_resume_window(
+    blocked: list[dict], offset: int, budget: int
+) -> tuple[list[dict], int]:
+    """Return a rotating slice of at most ``budget`` blocked issues, plus the next offset.
+
+    Resuming a blocked chain requires an expensive (and memory-heavy) executor
+    poll, so polling *every* blocked chain each 30s cycle can starve admission and
+    dispatch — and on constrained hardware it can OOM. Bound the work per cycle to
+    ``budget`` chains and rotate the starting offset so, across consecutive cycles,
+    every blocked chain is still eventually polled (no chain is permanently
+    skipped). Returns the whole list when ``budget`` covers it.
+    """
+    count = len(blocked)
+    if count == 0 or budget <= 0:
+        return [], 0
+    if budget >= count:
+        return list(blocked), 0
+    start = offset % count
+    window = [blocked[(start + step) % count] for step in range(budget)]
+    return window, (start + budget) % count
+
+
 async def _poll_chain_guarded(ref: str, *, issue: dict | None, timeout: float) -> dict:
     """Poll a chain without letting one dead ref wedge the whole poll loop.
 
@@ -846,8 +872,22 @@ async def lifespan(app: FastAPI):
                                     break
                         # Resume blocked issues only when the journal says a non-terminal next
                         # phase is ready; terminal/fingerprint blocks remain operator-visible.
+                        # Each resume check is an expensive executor poll, so bound how many
+                        # blocked chains we probe per cycle (rotating across cycles) — probing
+                        # all of them every cycle can starve admission and OOM the host.
                         if _wh_dispatched < _wh_limit:
-                            for _blocked in blocked_issues or []:
+                            try:
+                                _blk_budget = int(
+                                    os.environ.get("ZOE_MULTICA_BLOCKED_RESUME_BUDGET", "4") or "4"
+                                )
+                            except ValueError:
+                                _blk_budget = 4
+                            _blk_window, _BLOCKED_RESUME_CURSOR["offset"] = _bounded_blocked_resume_window(
+                                list(blocked_issues or []),
+                                _BLOCKED_RESUME_CURSOR["offset"],
+                                _blk_budget,
+                            )
+                            for _blocked in _blk_window:
                                 if str(_blocked.get("id") or "") in _wh_dispatched_ids:
                                     continue
                                 await _maybe_dispatch_hermes_issue(_blocked, from_todo=False)

--- a/services/zoe-data/main.py
+++ b/services/zoe-data/main.py
@@ -105,7 +105,9 @@ def _bounded_blocked_resume_window(
     if count == 0 or budget <= 0:
         return [], 0
     if budget >= count:
-        return list(blocked), 0
+        # Whole list covered this cycle; preserve the caller's place so a list
+        # that briefly shrinks below budget and grows back keeps rotating.
+        return list(blocked), offset % count
     start = offset % count
     window = [blocked[(start + step) % count] for step in range(budget)]
     return window, (start + budget) % count
@@ -882,6 +884,12 @@ async def lifespan(app: FastAPI):
                                 )
                             except ValueError:
                                 _blk_budget = 4
+                            if _blk_budget <= 0:
+                                logger.warning(
+                                    "multica_poll: ZOE_MULTICA_BLOCKED_RESUME_BUDGET=%s is not "
+                                    "positive; blocked-resume polling disabled this cycle",
+                                    _blk_budget,
+                                )
                             _blk_window, _BLOCKED_RESUME_CURSOR["offset"] = _bounded_blocked_resume_window(
                                 list(blocked_issues or []),
                                 _BLOCKED_RESUME_CURSOR["offset"],

--- a/services/zoe-data/tests/test_main_multica_poll.py
+++ b/services/zoe-data/tests/test_main_multica_poll.py
@@ -62,7 +62,7 @@ def test_poll_dispatches_ready_work_only_when_runtime_pause_is_inactive():
 def test_poll_dispatch_backfills_ready_blocked_pipeline_before_todo():
     source = (Path(__file__).resolve().parents[1] / "main.py").read_text(encoding="utf-8")
     blocked_fetch = source.index('blocked_issues = await client.list_issues(status="blocked")')
-    blocked_loop = source.index('for _blocked in blocked_issues or []:', blocked_fetch)
+    blocked_loop = source.index('for _blocked in _blk_window:', blocked_fetch)
     todo_loop = source.index('for _todo in stale_todos or []:', blocked_loop)
     clear_blocker = source.index(
         'clear_blocker=True',

--- a/services/zoe-data/tests/test_main_multica_poll.py
+++ b/services/zoe-data/tests/test_main_multica_poll.py
@@ -878,3 +878,43 @@ async def test_recover_stale_in_progress_keeps_issue_when_reset_fails():
         _FailingClient(), [zombie], hermes_id="hermes", poll_chain=_poll, now=now, max_age_hours=6
     )
     assert live == [zombie]
+
+
+def test_bounded_blocked_resume_window_empty_or_zero_budget():
+    from main import _bounded_blocked_resume_window
+
+    assert _bounded_blocked_resume_window([], 0, 4) == ([], 0)
+    assert _bounded_blocked_resume_window([{"id": "a"}], 0, 0) == ([], 0)
+
+
+def test_bounded_blocked_resume_window_returns_all_when_budget_covers():
+    from main import _bounded_blocked_resume_window
+
+    items = [{"id": "a"}, {"id": "b"}]
+    window, nxt = _bounded_blocked_resume_window(items, 5, 4)
+    assert window == items
+    assert nxt == 0
+
+
+def test_bounded_blocked_resume_window_rotates_and_covers_all_across_cycles():
+    from main import _bounded_blocked_resume_window
+
+    items = [{"id": x} for x in "abcde"]  # 5 items, budget 2
+    offset = 0
+    seen: list[str] = []
+    for _ in range(3):
+        window, offset = _bounded_blocked_resume_window(items, offset, 2)
+        assert len(window) == 2
+        seen.extend(i["id"] for i in window)
+    assert set("abcde").issubset(set(seen))
+    # Offset advances by budget modulo length: 0 -> 2 -> 4 -> 1.
+    assert offset == 1
+
+
+def test_bounded_blocked_resume_window_wraps_at_end():
+    from main import _bounded_blocked_resume_window
+
+    items = [{"id": x} for x in "abcd"]  # 4 items, budget 3, start near end
+    window, nxt = _bounded_blocked_resume_window(items, 3, 3)
+    assert [i["id"] for i in window] == ["d", "a", "b"]
+    assert nxt == 2

--- a/services/zoe-data/tests/test_main_multica_poll.py
+++ b/services/zoe-data/tests/test_main_multica_poll.py
@@ -880,20 +880,23 @@ async def test_recover_stale_in_progress_keeps_issue_when_reset_fails():
     assert live == [zombie]
 
 
-def test_bounded_blocked_resume_window_empty_or_zero_budget():
+def test_bounded_blocked_resume_window_empty_or_nonpositive_budget():
     from main import _bounded_blocked_resume_window
 
     assert _bounded_blocked_resume_window([], 0, 4) == ([], 0)
     assert _bounded_blocked_resume_window([{"id": "a"}], 0, 0) == ([], 0)
+    assert _bounded_blocked_resume_window([{"id": "a"}], 0, -1) == ([], 0)
 
 
-def test_bounded_blocked_resume_window_returns_all_when_budget_covers():
+def test_bounded_blocked_resume_window_returns_all_and_preserves_offset_when_budget_covers():
     from main import _bounded_blocked_resume_window
 
     items = [{"id": "a"}, {"id": "b"}]
+    # budget covers the whole list -> return all, but keep the caller's place
+    # (mod length) so rotation survives a list that shrinks then grows back.
     window, nxt = _bounded_blocked_resume_window(items, 5, 4)
     assert window == items
-    assert nxt == 0
+    assert nxt == 1  # 5 % 2
 
 
 def test_bounded_blocked_resume_window_rotates_and_covers_all_across_cycles():


### PR DESCRIPTION
## Problem

The poll loop checks **every** Hermes-assigned blocked chain for resumability on each 30s cycle, and each check is an expensive, memory-heavy executor `poll_ref`. With many blocked tickets this starves admission/dispatch and can OOM the host — observed live on the Jetson (~19 blocked chains × 20s poll each per cycle; `poll_ref` OOM-killed probes). After PR #474 a dead chain no longer *wedges* the loop, but many dead chains still make each cycle pathologically slow.

## Fix

Bound the blocked-resume scan to `ZOE_MULTICA_BLOCKED_RESUME_BUDGET` (default **4**) chains per cycle, **rotating** the starting offset across cycles so every blocked chain is still eventually polled and none is permanently skipped. Pure helper `_bounded_blocked_resume_window(blocked, offset, budget) -> (window, next_offset)` + a module cursor; wired into the blocked-resume loop.

This composes with the existing fixes: #474 caps per-poll cost (timeout), this caps per-cycle poll *count*.

## Tests
4 focused tests for the window helper: empty/zero-budget, budget-covers-all, rotation-covers-all-across-cycles, and end wrap-around. `pytest -k "bounded_blocked_resume or poll_chain_guarded or recover_stale"` → 10 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)