### PR TITLE
Fix Skybridge voice routing auth

### DIFF
--- a/services/zoe-data/routers/voice_tts.py
+++ b/services/zoe-data/routers/voice_tts.py
@@ -1273,6 +1273,98 @@ async def _request_auth_ui(panel_id: str, challenge_id: str, reason: str) -> boo
     return delivered
 
 
+async def _request_voice_identity_challenge(
+    *,
+    panel_id: str,
+    text: str,
+    session_id: str,
+    caller: dict | None,
+    reason: str = "Voice command needs identity. Enter your PIN to continue.",
+) -> dict:
+    """Hold a voice turn and ask the touch panel to identify the speaker."""
+    import uuid as _uuid_mod
+
+    _pending_id = _uuid_mod.uuid4().hex
+    _PENDING_VOICE_IDENT[panel_id] = {
+        "pending_id": _pending_id,
+        "transcript": text,
+        "session_id": session_id,
+        "expire_at": time.monotonic() + 120,
+    }
+    _pin_phrase = "Please authenticate on the touch panel. Choose your profile and enter your PIN to continue."
+    _pin_b64 = None
+    _pin_content_type = "audio/wav"
+    try:
+        _pin_audio_resp = await synthesize({"text": _pin_phrase}, caller=caller)
+        _pin_b64 = base64.b64encode(_pin_audio_resp.body).decode("ascii")
+        _pin_content_type = _pin_audio_resp.media_type
+    except Exception as _tts_exc:
+        logger.warning("voice/command auth challenge TTS failed: %s", _tts_exc)
+    _challenge_id = None
+    try:
+        from routers.panel_auth import create_pin_challenge_internal
+        from database import get_db as _get_db
+        async for _db in _get_db():
+            _challenge = await create_pin_challenge_internal(
+                panel_id=panel_id,
+                user_id=None,
+                action_context={
+                    "kind": "voice_turn",
+                    "pending_id": _pending_id,
+                    "panel_id": panel_id,
+                    "pending_transcript": text,
+                    "pending_session_id": session_id,
+                },
+                db=_db,
+            )
+            _challenge_id = (_challenge or {}).get("challenge_id")
+            break
+    except Exception as _challenge_exc:
+        logger.warning("voice/command PIN challenge failed: %s", _challenge_exc)
+    if not _challenge_id:
+        _fail_phrase = "I could not open the authentication screen just now. Please open the touch login page and try again."
+        _fail_audio = await synthesize({"text": _fail_phrase}, caller=caller)
+        return {
+            "ok": True,
+            "panel_id": panel_id,
+            "reply": _fail_phrase,
+            "status": "auth_unavailable",
+            "audio_base64": base64.b64encode(_fail_audio.body).decode("ascii"),
+            "content_type": _fail_audio.media_type,
+        }
+
+    _requested = await _request_auth_ui(
+        panel_id=panel_id,
+        challenge_id=_challenge_id,
+        reason=reason,
+    )
+    if not _requested:
+        logger.warning(
+            "voice/command auth challenge created but panel auth action was not delivered: panel=%s challenge=%s",
+            panel_id,
+            _challenge_id,
+        )
+    try:
+        from voice_metrics import voice_turn_count
+        voice_turn_count.labels(outcome="ok", path="awaiting_pin").inc()
+    except Exception:
+        pass
+    try:
+        from push import broadcaster as _bc_auth_state
+        await _bc_auth_state.broadcast("all", "voice:responding", {"panel_id": panel_id, "text": _pin_phrase[:200]})
+        await _bc_auth_state.broadcast("all", "voice:done", {"panel_id": panel_id})
+    except Exception:
+        pass
+    return {
+        "ok": True,
+        "panel_id": panel_id,
+        "reply": _pin_phrase,
+        "status": "awaiting_pin",
+        "audio_base64": _pin_b64,
+        "content_type": _pin_content_type,
+    }
+
+
 async def _resolve_panel_default_user(panel_id: str, db) -> Optional[str]:
     """Best-effort panel user resolution for voice fallback identity."""
     try:
@@ -2560,6 +2652,44 @@ async def voice_command(
             context=_skybridge_context,
             db=db,
         )
+        if _skybridge_result and _skybridge_result.get("auth_required"):
+            _intent = _skybridge_result.get("intent") or {}
+            try:
+                from guest_policy import record_policy_decision as _record_guest_policy
+                _record_guest_policy(
+                    "auth_required",
+                    surface="voice",
+                    resource="skybridge",
+                    action=f"{_intent.get('domain', 'unknown')}:{_intent.get('action', 'show')}",
+                )
+            except Exception as _policy_exc:
+                logger.warning("voice/command skybridge auth policy record failed: %s", _policy_exc)
+            try:
+                return await _request_voice_identity_challenge(
+                    panel_id=panel_id,
+                    text=text,
+                    session_id=session_id,
+                    caller=caller,
+                    reason="Skybridge needs to know who is speaking before showing personal data.",
+                )
+            except Exception as _auth_exc:
+                logger.warning("voice/command skybridge auth challenge failed: %s", _auth_exc)
+                _auth_fail_phrase = "Authentication is required before I can show that. I could not open the touch panel authentication screen just now."
+                try:
+                    _auth_fail_audio = await synthesize({"text": _auth_fail_phrase}, caller=caller)
+                    _auth_fail_b64 = base64.b64encode(_auth_fail_audio.body).decode("ascii")
+                    _auth_fail_type = _auth_fail_audio.media_type
+                except Exception:
+                    _auth_fail_b64 = None
+                    _auth_fail_type = "audio/wav"
+                return {
+                    "ok": True,
+                    "panel_id": panel_id,
+                    "reply": _auth_fail_phrase,
+                    "status": "auth_unavailable",
+                    "audio_base64": _auth_fail_b64,
+                    "content_type": _auth_fail_type,
+                }
         if _skybridge_result and _skybridge_result.get("handled"):
             _VOICE_SESSIONS.setdefault(panel_id, {})["skybridge_context"] = (
                 _skybridge_result.get("skybridge_context") or {}
@@ -3050,78 +3180,13 @@ async def voice_command(
                     resource="scope_gate",
                     action=_scope_action,
                 )
-                import uuid as _uuid_mod
-                _pending_id = _uuid_mod.uuid4().hex
-                _pending_payload = {
-                    "pending_id": _pending_id,
-                    "transcript": text,
-                    "session_id": session_id,
-                    "expire_at": time.monotonic() + 120,
-                }
-                _PENDING_VOICE_IDENT[panel_id] = {
-                    **_pending_payload,
-                }
-                _pin_phrase = "Please authenticate on the touch panel. Choose your profile and enter your PIN to continue."
-                _pin_audio_resp = await synthesize({"text": _pin_phrase}, caller=caller)
-                _pin_b64 = base64.b64encode(_pin_audio_resp.body).decode("ascii")
-                _challenge_id = None
-                try:
-                    from routers.panel_auth import create_pin_challenge_internal
-                    from database import get_db as _get_db
-                    async for _db in _get_db():
-                        _challenge = await create_pin_challenge_internal(
-                            panel_id=panel_id,
-                            user_id=None,
-                            action_context={
-                                "kind": "voice_turn",
-                                "pending_id": _pending_id,
-                                "panel_id": panel_id,
-                                # Durable replay fallback if process-local in-memory maps are lost.
-                                "pending_transcript": text,
-                                "pending_session_id": session_id,
-                            },
-                            db=_db,
-                        )
-                        _challenge_id = (_challenge or {}).get("challenge_id")
-                        break
-                except Exception as _challenge_exc:
-                    logger.warning("voice/command PIN challenge failed: %s", _challenge_exc)
-                if not _challenge_id:
-                    _fail_phrase = "I could not open the authentication screen just now. Please open the touch login page and try again."
-                    _fail_audio = await synthesize({"text": _fail_phrase}, caller=caller)
-                    return {
-                        "ok": True,
-                        "panel_id": panel_id,
-                        "reply": _fail_phrase,
-                        "status": "auth_unavailable",
-                        "audio_base64": base64.b64encode(_fail_audio.body).decode("ascii"),
-                        "content_type": _fail_audio.media_type,
-                    }
-
-                _requested = await _request_auth_ui(
+                return await _request_voice_identity_challenge(
                     panel_id=panel_id,
-                    challenge_id=_challenge_id,
+                    text=text,
+                    session_id=session_id,
+                    caller=caller,
                     reason="Voice command needs identity. Enter your PIN to continue.",
                 )
-                if not _requested:
-                    logger.warning(
-                        "voice/command auth challenge created but panel auth action was not delivered: panel=%s challenge=%s",
-                        panel_id,
-                        _challenge_id,
-                    )
-                try:
-                    from voice_metrics import voice_turn_count
-                    voice_turn_count.labels(outcome="ok", path="awaiting_pin").inc()
-                except Exception:
-                    pass
-                return {
-                    "ok": True,
-                    "panel_id": panel_id,
-                    "reply": _pin_phrase,
-                    "status": "awaiting_pin",
-                    "audio_base64": _pin_b64,
-                    "content_type": _pin_audio_resp.media_type,
-                }
             _record_guest_policy(
                 "guest_allowed" if not _ident_for_scope else "auth_ok",
                 surface="voice",

--- a/services/zoe-data/skybridge_service.py
+++ b/services/zoe-data/skybridge_service.py
@@ -402,6 +402,9 @@ def classify_skybridge_intent(message: str, context: dict[str, Any] | None = Non
     if any(term in text for term in (" weather", " forecast", " temperature", " rain", " windy", " wind ")):
         action = "forecast" if any(term in text for term in ("forecast", "tomorrow", "week", "next few days")) else "current"
         return SkybridgeIntent(domain="weather", action=action)
+    if any(term in text for term in (" list", " lists", " shopping", " groceries", " grocery", " tasks", " todos")):
+        list_type = _list_type_from_text(text)
+        return SkybridgeIntent(domain="lists", action="show", list_type=list_type)
     if any(
         term in text
         for term in (
@@ -421,9 +424,6 @@ def classify_skybridge_intent(message: str, context: dict[str, Any] | None = Non
             label, start, end = parsed_range
             return SkybridgeIntent("calendar", "show", label, start, end)
         return SkybridgeIntent("calendar", "show", "today", today, today)
-    if any(term in text for term in (" list", " lists", " shopping", " groceries", " grocery", " tasks", " todos")):
-        list_type = _list_type_from_text(text)
-        return SkybridgeIntent(domain="lists", action="show", list_type=list_type)
     if any(term in text for term in (" people", " contacts", " contact", " person", " profile", " family", " friends")):
         query, people_ctx, circle = _people_filters_from_text(text)
         if " family " in text and not query:
@@ -456,6 +456,9 @@ async def resolve_skybridge_request(
             "skybridge_context": context or {},
         }
 
+    if skybridge_intent_requires_identity(intent) and _is_guest_user(user_id):
+        return _attach_skybridge_context(_auth_required_result(intent))
+
     if db is not None:
         return _attach_skybridge_context(await _resolve_with_db(intent, user_id, db, context=context))
 
@@ -470,6 +473,15 @@ def _attach_skybridge_context(result: dict[str, Any]) -> dict[str, Any]:
             "cards": result.get("cards") or [],
         }
     return result
+
+
+def _is_guest_user(user_id: str | None) -> bool:
+    return (user_id or "").strip() in {"", "guest", "voice-guest"}
+
+
+def skybridge_intent_requires_identity(intent: SkybridgeIntent | None) -> bool:
+    """Return whether a Skybridge intent reads or mutates personal user data."""
+    return bool(intent and intent.domain in {"calendar", "lists", "people"})
 
 
 async def _resolve_with_db(intent: SkybridgeIntent, user_id: str, db: Any, *, context: dict[str, Any] | None = None) -> dict[str, Any]:
@@ -526,6 +538,27 @@ def _intent_dict(intent: SkybridgeIntent) -> dict[str, Any]:
         "action": intent.action,
         "list_type": intent.list_type,
         "target_time": intent.target_time,
+    }
+
+
+def _auth_required_result(intent: SkybridgeIntent) -> dict[str, Any]:
+    domain_labels = {
+        "calendar": "calendar",
+        "lists": "lists",
+        "people": "people",
+    }
+    domain = domain_labels.get(intent.domain, "this data")
+    title = f"Sign in to view {domain}"
+    if intent.action in {"create_event", "update_time", "add_item", "remember_fact"}:
+        title = f"Sign in to change {domain}"
+    body = "Zoe needs to know who is speaking before showing or changing personal data."
+    return {
+        "handled": True,
+        "auth_required": True,
+        "intent": _intent_dict(intent),
+        "spoken_summary": "Please authenticate on the touch panel to continue.",
+        "cards": [_status_card(title, body, status="Authentication")],
+        "actions": [{"type": "auth_required", "domain": intent.domain, "action": intent.action}],
     }
 
 

--- a/services/zoe-data/tests/test_skybridge_service.py
+++ b/services/zoe-data/tests/test_skybridge_service.py
@@ -153,6 +153,8 @@ def test_classify_calendar_and_weather_requests():
     assert classify_skybridge_intent("show me the weather").domain == "weather"
     assert classify_skybridge_intent("what is happening this week").domain == "calendar"
     assert classify_skybridge_intent("show my shopping list").domain == "lists"
+    assert classify_skybridge_intent("what's on my shopping list").domain == "lists"
+    assert classify_skybridge_intent("whats on my grocery list").domain == "lists"
     assert classify_skybridge_intent("show my contacts").domain == "people"
     assert classify_skybridge_intent("find Sarah").domain == "people"
     assert classify_skybridge_intent("what is there to do this week") is None
@@ -462,7 +464,9 @@ async def test_guest_calendar_request_does_not_fetch_family_events():
     result = await resolve_skybridge_request("show my calendar", "guest", db=GuardedGuestDb())
 
     assert result["handled"] is True
-    assert result["cards"][0]["content"]["events"] == []
+    assert result["auth_required"] is True
+    assert result["actions"][0]["type"] == "auth_required"
+    assert result["cards"][0]["props"]["status"] == "Authentication"
 
 
 @pytest.mark.asyncio
@@ -499,6 +503,37 @@ async def test_lists_request_returns_real_list_items():
     assert card["content"]["items"][0]["text"] == "Milk"
     assert card["content"]["open_count"] == 1
     assert "Surface" not in str(card)
+
+
+@pytest.mark.asyncio
+async def test_shopping_list_question_returns_list_card_not_calendar():
+    list_row = {
+        "id": "list-1",
+        "user_id": "family-admin",
+        "name": "Groceries",
+        "list_type": "shopping",
+        "description": "Weekly shop",
+        "visibility": "family",
+    }
+    item = {
+        "id": "item-1",
+        "list_id": "list-1",
+        "text": "Milk",
+        "completed": False,
+    }
+
+    result = await resolve_skybridge_request(
+        "What's on my shopping list?",
+        "family-admin",
+        db=FakeDb(lists=[list_row], items_by_list={"list-1": [item]}),
+    )
+
+    assert result["handled"] is True
+    assert result["intent"]["domain"] == "lists"
+    card = result["cards"][0]
+    assert card["content"]["source"] == "list_show"
+    assert card["content"]["items"][0]["text"] == "Milk"
+    assert card["producer"] != "zoe-calendar"
 
 
 @pytest.mark.asyncio
@@ -579,8 +614,9 @@ async def test_guest_lists_request_does_not_fetch_private_lists():
     result = await resolve_skybridge_request("show my shopping list", "guest", db=GuardedGuestDb())
 
     assert result["handled"] is True
-    assert result["cards"][0]["content"]["source"] == "list_show"
-    assert result["cards"][0]["content"]["items"] == []
+    assert result["auth_required"] is True
+    assert result["actions"][0]["domain"] == "lists"
+    assert result["cards"][0]["props"]["status"] == "Authentication"
 
 
 @pytest.mark.asyncio
@@ -635,8 +671,9 @@ async def test_guest_people_request_does_not_fetch_private_people():
     result = await resolve_skybridge_request("show my contacts", "guest", db=GuardedGuestDb())
 
     assert result["handled"] is True
-    assert result["cards"][0]["content"]["source"] == "people_directory"
-    assert result["cards"][0]["content"]["people"] == []
+    assert result["auth_required"] is True
+    assert result["actions"][0]["domain"] == "people"
+    assert result["cards"][0]["props"]["status"] == "Authentication"
 
 
 @pytest.mark.asyncio

--- a/services/zoe-data/tests/test_voice_weather_queue.py
+++ b/services/zoe-data/tests/test_voice_weather_queue.py
@@ -4,6 +4,7 @@ import types
 
 import pytest
 
+import skybridge_service
 import routers.voice_tts as voice_tts
 from routers.voice_tts import (
     _broadcast_skybridge_ui,
@@ -394,6 +395,12 @@ async def test_voice_command_uses_skybridge_fast_path(monkeypatch, utterance, re
 
     skybridge_module = types.SimpleNamespace(resolve_skybridge_request=resolve_skybridge_request)
     monkeypatch.setitem(sys.modules, "skybridge_service", skybridge_module)
+    monkeypatch.setattr(skybridge_service, "resolve_skybridge_request", resolve_skybridge_request)
+    monkeypatch.setitem(
+        sys.modules,
+        "guest_policy",
+        types.SimpleNamespace(record_policy_decision=lambda *_args, **_kwargs: None),
+    )
     monkeypatch.setitem(sys.modules, "push", types.SimpleNamespace(broadcaster=Broadcaster()))
     monkeypatch.setattr(voice_tts, "_broadcast_skybridge_ui", broadcast_skybridge_ui)
     monkeypatch.setattr(voice_tts, "synthesize", synthesize)
@@ -425,3 +432,188 @@ async def test_voice_command_uses_skybridge_fast_path(monkeypatch, utterance, re
     assert ("all", "voice:done", {"panel_id": "panel-sky"}) in calls["broadcast"]
     assert calls["events"].index("synthesize") < calls["events"].index("voice:done")
     assert voice_tts._VOICE_SESSIONS["panel-sky"]["skybridge_context"] == {"domain": "weather"}
+
+
+@pytest.mark.asyncio
+async def test_voice_skybridge_private_request_challenges_guest_before_cards(monkeypatch) -> None:
+    calls: dict[str, object] = {"broadcast_called": False, "challenge_called": False}
+
+    async def resolve_skybridge_request(text, user_id, *, context=None, db=None):
+        calls["resolver"] = {"text": text, "user_id": user_id, "context": context, "db": db}
+        return {
+            "handled": True,
+            "auth_required": True,
+            "spoken_summary": "Please authenticate on the touch panel to continue.",
+            "intent": {"domain": "lists", "action": "show", "list_type": "shopping"},
+            "cards": [
+                {
+                    "component": "status",
+                    "props": {"title": "Sign in to view lists", "status": "Authentication"},
+                }
+            ],
+        }
+
+    async def broadcast_skybridge_ui(*_args, **_kwargs):
+        calls["broadcast_called"] = True
+
+    async def request_voice_identity_challenge(**kwargs):
+        calls["challenge_called"] = True
+        calls["challenge"] = kwargs
+        return {
+            "ok": True,
+            "panel_id": kwargs["panel_id"],
+            "reply": "Please authenticate on the touch panel.",
+            "status": "awaiting_pin",
+            "audio_base64": "UklGRg==",
+            "content_type": "audio/wav",
+        }
+
+    class Broadcaster:
+        async def broadcast(self, *_args, **_kwargs):
+            return True
+
+    async def no_user(*_args, **_kwargs):
+        return None
+
+    skybridge_module = types.SimpleNamespace(resolve_skybridge_request=resolve_skybridge_request)
+    monkeypatch.setitem(sys.modules, "skybridge_service", skybridge_module)
+    monkeypatch.setattr(skybridge_service, "resolve_skybridge_request", resolve_skybridge_request)
+    monkeypatch.setitem(sys.modules, "push", types.SimpleNamespace(broadcaster=Broadcaster()))
+    monkeypatch.setattr(voice_tts, "_broadcast_skybridge_ui", broadcast_skybridge_ui)
+    monkeypatch.setattr(voice_tts, "_request_voice_identity_challenge", request_voice_identity_challenge)
+    monkeypatch.setattr(voice_tts, "_resolve_recent_panel_session_user", no_user)
+    monkeypatch.setattr(voice_tts, "_resolve_panel_default_user", no_user)
+    monkeypatch.setattr(voice_tts, "_VOICE_SESSIONS", {})
+
+    response = await voice_command(
+        {"text": "what's on my shopping list", "panel_id": "panel-auth", "session_id": "session-auth"},
+        caller={"user_id": "guest", "panel_id": "panel-auth"},
+        db=object(),
+    )
+
+    assert response["ok"] is True
+    assert response["status"] == "awaiting_pin"
+    assert calls["resolver"]["user_id"] == "guest"
+    assert calls["challenge_called"] is True
+    assert calls["challenge"]["text"] == "what's on my shopping list"
+    assert calls["challenge"]["session_id"] == "session-auth"
+    assert calls["broadcast_called"] is False
+
+
+@pytest.mark.asyncio
+async def test_voice_skybridge_auth_challenge_failure_does_not_fall_through(monkeypatch) -> None:
+    calls: dict[str, object] = {"broadcast_called": False}
+
+    async def resolve_skybridge_request(text, user_id, *, context=None, db=None):
+        return {
+            "handled": True,
+            "auth_required": True,
+            "spoken_summary": "Please authenticate on the touch panel to continue.",
+            "intent": {"domain": "lists", "action": "show", "list_type": "shopping"},
+            "cards": [],
+        }
+
+    async def broadcast_skybridge_ui(*_args, **_kwargs):
+        calls["broadcast_called"] = True
+
+    async def request_voice_identity_challenge(**_kwargs):
+        raise RuntimeError("panel auth unavailable")
+
+    class Broadcaster:
+        async def broadcast(self, *_args, **_kwargs):
+            return True
+
+    class Audio:
+        body = b"RIFF-test"
+        media_type = "audio/wav"
+
+    async def synthesize(payload, caller=None):
+        calls["synthesize"] = payload
+        return Audio()
+
+    async def no_user(*_args, **_kwargs):
+        return None
+
+    skybridge_module = types.SimpleNamespace(resolve_skybridge_request=resolve_skybridge_request)
+    monkeypatch.setitem(sys.modules, "skybridge_service", skybridge_module)
+    monkeypatch.setattr(skybridge_service, "resolve_skybridge_request", resolve_skybridge_request)
+    monkeypatch.setitem(
+        sys.modules,
+        "guest_policy",
+        types.SimpleNamespace(record_policy_decision=lambda *_args, **_kwargs: None),
+    )
+    monkeypatch.setitem(sys.modules, "push", types.SimpleNamespace(broadcaster=Broadcaster()))
+    monkeypatch.setattr(voice_tts, "_broadcast_skybridge_ui", broadcast_skybridge_ui)
+    monkeypatch.setattr(voice_tts, "_request_voice_identity_challenge", request_voice_identity_challenge)
+    monkeypatch.setattr(voice_tts, "synthesize", synthesize)
+    monkeypatch.setattr(voice_tts, "_resolve_recent_panel_session_user", no_user)
+    monkeypatch.setattr(voice_tts, "_resolve_panel_default_user", no_user)
+    monkeypatch.setattr(voice_tts, "_VOICE_SESSIONS", {})
+
+    response = await voice_command(
+        {"text": "what's on my shopping list", "panel_id": "panel-auth", "session_id": "session-auth"},
+        caller={"user_id": "guest", "panel_id": "panel-auth"},
+        db=object(),
+    )
+
+    assert response["ok"] is True
+    assert response["status"] == "auth_unavailable"
+    assert "Authentication is required" in response["reply"]
+    assert response["audio_base64"]
+    assert calls["broadcast_called"] is False
+
+
+@pytest.mark.asyncio
+async def test_voice_identity_challenge_survives_tts_failure(monkeypatch) -> None:
+    calls: dict[str, object] = {}
+
+    async def synthesize(_payload, caller=None):
+        raise RuntimeError("tts unavailable")
+
+    async def create_pin_challenge_internal(**kwargs):
+        calls["challenge"] = kwargs
+        return {"challenge_id": "challenge-1"}
+
+    async def get_db():
+        yield object()
+
+    async def request_auth_ui(**kwargs):
+        calls["request_auth"] = kwargs
+        return True
+
+    class Metric:
+        def labels(self, **_kwargs):
+            return self
+
+        def inc(self):
+            calls["metric"] = True
+
+    monkeypatch.setattr(voice_tts, "synthesize", synthesize)
+    monkeypatch.setattr(voice_tts, "_request_auth_ui", request_auth_ui)
+    monkeypatch.setitem(
+        sys.modules,
+        "routers.panel_auth",
+        types.SimpleNamespace(create_pin_challenge_internal=create_pin_challenge_internal),
+    )
+    monkeypatch.setitem(sys.modules, "database", types.SimpleNamespace(get_db=get_db))
+    monkeypatch.setitem(sys.modules, "voice_metrics", types.SimpleNamespace(voice_turn_count=Metric()))
+    monkeypatch.setitem(
+        sys.modules,
+        "push",
+        types.SimpleNamespace(broadcaster=types.SimpleNamespace(broadcast=lambda *_args, **_kwargs: None)),
+    )
+    monkeypatch.setattr(voice_tts, "_PENDING_VOICE_IDENT", {})
+
+    response = await voice_tts._request_voice_identity_challenge(
+        panel_id="panel-auth",
+        text="show my calendar",
+        session_id="session-auth",
+        caller={"user_id": "guest"},
+    )
+
+    assert response["status"] == "awaiting_pin"
+    assert response["audio_base64"] is None
+    assert response["content_type"] == "audio/wav"
+    assert calls["challenge"]["panel_id"] == "panel-auth"
+    assert calls["request_auth"]["challenge_id"] == "challenge-1"
+    assert voice_tts._PENDING_VOICE_IDENT["panel-auth"]["transcript"] == "show my calendar"

--- a/services/zoe-ui/dist/touch/skybridge.html
+++ b/services/zoe-ui/dist/touch/skybridge.html
@@ -1890,17 +1890,14 @@
         @keyframes sky-card-rise {
             0% {
                 opacity: 0;
-                transform: translateY(18px) scale(0.985);
-                filter: blur(8px);
+                transform: translateY(14px) scale(0.992);
             }
             60% {
                 opacity: 1;
-                filter: blur(0);
             }
             100% {
                 opacity: 1;
                 transform: translateY(0) scale(1);
-                filter: blur(0);
             }
         }
 


### PR DESCRIPTION
## Summary
- Route shopping-list show requests through Skybridge before broad calendar phrases like "what’s on"
- Return auth-required Skybridge results for guest calendar/list/people requests instead of empty private data cards
- Make the voice Skybridge fast path open the panel identity challenge before broadcasting private cards
- Remove blur from Skybridge card rise animation so settled cards stay crisp on the touch panel

## Tests
- python3 -m pytest -q services/zoe-data/tests/test_skybridge_service.py services/zoe-data/tests/test_voice_weather_queue.py
- python3 -m py_compile services/zoe-data/skybridge_service.py services/zoe-data/routers/voice_tts.py services/zoe-data/tests/test_skybridge_service.py services/zoe-data/tests/test_voice_weather_queue.py