### PR TITLE
Add Pi RPC warm intent transport

### DIFF
--- a/scripts/maintenance/pi_intent_probe.py
+++ b/scripts/maintenance/pi_intent_probe.py
@@ -72,6 +72,10 @@ async def _run_probe(text: str) -> dict:
     }
 
 
+async def _run_probes(text: str, *, repeat: int) -> list[dict]:
+    return [await _run_probe(text) for _ in range(repeat)]
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Probe Pi/Gemma ambiguous-intent classification")
     parser.add_argument("text", nargs="?", default="anything I should remember right now")
@@ -81,6 +85,8 @@ def main() -> int:
     parser.add_argument("--local-model-configured", action="store_true", help="Temporarily set ZOE_PI_LOCAL_MODEL_CONFIGURED=true for this probe")
     parser.add_argument("--timeout", type=float, default=None, help="Override ZOE_PI_INTENT_TIMEOUT_SECONDS")
     parser.add_argument("--model", default=None, help="Override ZOE_PI_INTENT_MODEL")
+    parser.add_argument("--transport", choices=["print", "rpc"], default=None, help="Override ZOE_PI_INTENT_TRANSPORT")
+    parser.add_argument("--repeat", type=int, default=1, help="Run classification this many times in one process")
     parser.add_argument("--write-local-model-config", action="store_true", help="Write ~/.pi/agent/models.json for Zoe's local llama.cpp endpoint")
     args = parser.parse_args()
 
@@ -93,6 +99,8 @@ def main() -> int:
         os.environ["ZOE_PI_LOCAL_MODEL_CONFIGURED"] = "true"
     if args.timeout is not None:
         os.environ["ZOE_PI_INTENT_TIMEOUT_SECONDS"] = str(args.timeout)
+    if args.transport:
+        os.environ["ZOE_PI_INTENT_TRANSPORT"] = args.transport
     model = args.model or os.environ.get("ZOE_PI_INTENT_MODEL") or "gemma-4-E2B-it-Q4_K_M.gguf"
     if args.model:
         os.environ["ZOE_PI_INTENT_MODEL"] = args.model
@@ -100,9 +108,12 @@ def main() -> int:
     if args.write_local_model_config:
         written_config = str(_write_local_model_config(model=model))
 
+    repeat = max(1, args.repeat)
+    probes = asyncio.run(_run_probes(args.text, repeat=repeat))
     payload = {
         "status": pi_intent_status(),
-        "probe": asyncio.run(_run_probe(args.text)),
+        "probe": probes[-1],
+        "probes": probes,
         "written_config": written_config,
     }
     if args.json:
@@ -112,6 +123,8 @@ def main() -> int:
         probe = payload["probe"]
         print(f"Pi intent status: {status.get('status')} ({status.get('reason') or 'ok'})")
         print(f"Elapsed: {probe['elapsed_ms']:.1f} ms")
+        if repeat > 1:
+            print("Runs: " + ", ".join(f"{item['elapsed_ms']:.1f} ms" for item in payload["probes"]))
         print(f"Classification: {probe['classification']}")
         if payload.get("written_config"):
             print(f"Wrote Pi model config: {payload['written_config']}")

--- a/services/zoe-data/pi_intent_classifier.py
+++ b/services/zoe-data/pi_intent_classifier.py
@@ -16,6 +16,7 @@ import os
 import re
 import shutil
 import time
+import uuid
 from dataclasses import dataclass
 from typing import Any, Mapping
 
@@ -93,6 +94,7 @@ class PiIntentClassifierConfig:
     max_words: int = PI_INTENT_MAX_WORDS
     offline_only: bool = True
     no_approve: bool = True
+    transport: str = "print"
 
     @classmethod
     def from_env(cls, env: Mapping[str, str] | None = None) -> "PiIntentClassifierConfig":
@@ -108,6 +110,7 @@ class PiIntentClassifierConfig:
             max_words=int(values.get("ZOE_PI_INTENT_MAX_WORDS") or PI_INTENT_MAX_WORDS),
             offline_only=_env_bool(values.get("ZOE_PI_OFFLINE_ONLY"), default=True),
             no_approve=_env_bool(values.get("ZOE_PI_INTENT_NO_APPROVE"), default=True),
+            transport=(values.get("ZOE_PI_INTENT_TRANSPORT") or "print").strip().lower() or "print",
         )
 
     def validate(self) -> None:
@@ -117,6 +120,8 @@ class PiIntentClassifierConfig:
             raise ValueError("ZOE_PI_INTENT_MAX_WORDS must be positive")
         if self.offline_only and self.provider.lower() not in {"ollama", "local", "llama", "llamacpp"}:
             raise ValueError("Pi intent classification requires a local/offline provider")
+        if self.transport not in {"print", "rpc"}:
+            raise ValueError("ZOE_PI_INTENT_TRANSPORT must be print or rpc")
 
     def to_dict(self) -> dict[str, Any]:
         self.validate()
@@ -130,6 +135,7 @@ class PiIntentClassifierConfig:
             "max_words": self.max_words,
             "offline_only": self.offline_only,
             "no_approve": self.no_approve,
+            "transport": self.transport,
         }
 
 
@@ -201,6 +207,14 @@ async def classify_with_pi_intent_governor(
         return None
 
     prompt = _classification_prompt(text, context_turns=context_turns)
+    if active_config.transport == "rpc":
+        return await _classify_with_pi_rpc(active_config, runtime_env, prompt)
+    return await _classify_with_pi_print(active_config, runtime_env, prompt)
+
+
+async def _classify_with_pi_print(
+    active_config: PiIntentClassifierConfig, runtime_env: Mapping[str, str], prompt: str
+) -> PiIntentClassification | None:
     cmd = _pi_command(active_config, prompt)
     run_env = _pi_subprocess_env(runtime_env)
     start = time.perf_counter()
@@ -228,6 +242,23 @@ async def classify_with_pi_intent_governor(
         logger.debug("Pi intent governor failed rc=%s stderr=%s", proc.returncode, stderr.decode(errors="replace")[:500])
         return None
     return _parse_pi_classification(stdout.decode(errors="replace"), latency_ms=latency_ms)
+
+
+async def _classify_with_pi_rpc(
+    active_config: PiIntentClassifierConfig, runtime_env: Mapping[str, str], prompt: str
+) -> PiIntentClassification | None:
+    worker = _rpc_worker_for(active_config, runtime_env)
+    start = time.perf_counter()
+    try:
+        raw = await worker.prompt(prompt, timeout_seconds=active_config.timeout_seconds)
+    except asyncio.TimeoutError:
+        logger.debug("Pi RPC intent governor timed out after %.2fs", active_config.timeout_seconds)
+        return None
+    except Exception as exc:
+        logger.debug("Pi RPC intent governor failed: %s", exc)
+        return None
+    latency_ms = (time.perf_counter() - start) * 1000
+    return _parse_pi_classification(raw, latency_ms=latency_ms)
 
 
 def _classification_prompt(text: str, *, context_turns: str = "") -> str:
@@ -264,6 +295,142 @@ def _pi_command(config: PiIntentClassifierConfig, prompt: str) -> list[str]:
         cmd.append("--no-approve")
     cmd.append(prompt)
     return cmd
+
+
+def _pi_rpc_command(config: PiIntentClassifierConfig) -> list[str]:
+    cmd = [
+        config.command,
+        "--mode",
+        "rpc",
+        "--no-session",
+        "--provider",
+        config.provider,
+        "--model",
+        config.model,
+    ]
+    if config.no_approve:
+        cmd.append("--no-approve")
+    if config.offline_only:
+        cmd.append("--offline")
+    return cmd
+
+
+@dataclass(frozen=True)
+class _RpcWorkerKey:
+    command: str
+    provider: str
+    model: str
+    cwd: str
+    no_approve: bool
+    offline_only: bool
+
+
+class _PiRpcIntentWorker:
+    def __init__(self, config: PiIntentClassifierConfig, env: Mapping[str, str]) -> None:
+        self.config = config
+        self.env = _pi_subprocess_env(env)
+        self.proc: asyncio.subprocess.Process | None = None
+        self._lock = asyncio.Lock()
+
+    async def prompt(self, prompt: str, *, timeout_seconds: float) -> str:
+        async with self._lock:
+            try:
+                await self._ensure_started()
+                assert self.proc is not None and self.proc.stdin is not None and self.proc.stdout is not None
+                request_id = f"zoe-intent-{uuid.uuid4().hex}"
+                payload = json.dumps({"id": request_id, "type": "prompt", "message": prompt}, separators=(",", ":"))
+                self.proc.stdin.write((payload + "\n").encode())
+                await self.proc.stdin.drain()
+                return await asyncio.wait_for(self._read_turn(), timeout=timeout_seconds)
+            except Exception:
+                await self._reset_process_locked()
+                raise
+
+    async def reset(self) -> None:
+        async with self._lock:
+            await self._reset_process_locked()
+
+    async def _reset_process_locked(self) -> None:
+        proc = self.proc
+        self.proc = None
+        if proc and proc.returncode is None:
+            proc.terminate()
+            try:
+                await asyncio.wait_for(proc.wait(), timeout=1.0)
+            except asyncio.TimeoutError:
+                proc.kill()
+                await proc.wait()
+
+    async def _ensure_started(self) -> None:
+        if self.proc and self.proc.returncode is None:
+            return
+        self.proc = await asyncio.create_subprocess_exec(
+            *_pi_rpc_command(self.config),
+            cwd=self.config.cwd,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.DEVNULL,
+            env=self.env,
+        )
+
+    async def _read_turn(self) -> str:
+        assert self.proc is not None and self.proc.stdout is not None
+        latest_text = ""
+        while True:
+            line = await self.proc.stdout.readline()
+            if not line:
+                raise RuntimeError("Pi RPC process closed")
+            try:
+                event = json.loads(line.decode(errors="replace"))
+            except json.JSONDecodeError:
+                continue
+            text = _assistant_text_from_rpc_event(event)
+            if text:
+                latest_text = text
+            if event.get("type") == "agent_end":
+                return latest_text
+
+
+_RPC_WORKERS: dict[_RpcWorkerKey, _PiRpcIntentWorker] = {}
+
+
+def _rpc_worker_for(config: PiIntentClassifierConfig, env: Mapping[str, str]) -> _PiRpcIntentWorker:
+    key = _RpcWorkerKey(config.command, config.provider, config.model, config.cwd, config.no_approve, config.offline_only)
+    worker = _RPC_WORKERS.get(key)
+    if worker is None:
+        worker = _PiRpcIntentWorker(config, env)
+        _RPC_WORKERS[key] = worker
+    return worker
+
+
+def _assistant_text_from_rpc_event(event: Mapping[str, Any]) -> str:
+    message = event.get("message")
+    if isinstance(message, Mapping) and message.get("role") == "assistant":
+        text = _text_from_message_content(message.get("content"))
+        if text:
+            return text
+    if event.get("type") == "agent_end" and isinstance(event.get("messages"), list):
+        for item in reversed(event["messages"]):
+            if isinstance(item, Mapping) and item.get("role") == "assistant":
+                text = _text_from_message_content(item.get("content"))
+                if text:
+                    return text
+    assistant_event = event.get("assistantMessageEvent")
+    if isinstance(assistant_event, Mapping) and assistant_event.get("type") == "text_end":
+        return str(assistant_event.get("content") or "")
+    return ""
+
+
+def _text_from_message_content(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for item in content:
+            if isinstance(item, Mapping) and item.get("type") == "text":
+                parts.append(str(item.get("text") or ""))
+        return "".join(parts)
+    return ""
 
 
 def _parse_pi_classification(raw: str, *, latency_ms: float) -> PiIntentClassification | None:

--- a/services/zoe-data/pi_intent_classifier.py
+++ b/services/zoe-data/pi_intent_classifier.py
@@ -253,11 +253,9 @@ async def _classify_with_pi_rpc(
         raw = await worker.prompt(prompt, timeout_seconds=active_config.timeout_seconds)
     except asyncio.TimeoutError:
         logger.debug("Pi RPC intent governor timed out after %.2fs", active_config.timeout_seconds)
-        await worker.reset()
         return None
     except Exception as exc:
         logger.debug("Pi RPC intent governor failed: %s", exc)
-        await worker.reset()
         return None
     latency_ms = (time.perf_counter() - start) * 1000
     return _parse_pi_classification(raw, latency_ms=latency_ms)

--- a/services/zoe-data/pi_intent_classifier.py
+++ b/services/zoe-data/pi_intent_classifier.py
@@ -253,9 +253,11 @@ async def _classify_with_pi_rpc(
         raw = await worker.prompt(prompt, timeout_seconds=active_config.timeout_seconds)
     except asyncio.TimeoutError:
         logger.debug("Pi RPC intent governor timed out after %.2fs", active_config.timeout_seconds)
+        await worker.reset()
         return None
     except Exception as exc:
         logger.debug("Pi RPC intent governor failed: %s", exc)
+        await worker.reset()
         return None
     latency_ms = (time.perf_counter() - start) * 1000
     return _parse_pi_classification(raw, latency_ms=latency_ms)

--- a/services/zoe-data/pi_intent_classifier.py
+++ b/services/zoe-data/pi_intent_classifier.py
@@ -342,7 +342,7 @@ class _PiRpcIntentWorker:
                 self.proc.stdin.write((payload + "\n").encode())
                 await self.proc.stdin.drain()
                 return await asyncio.wait_for(self._read_turn(), timeout=timeout_seconds)
-            except Exception:
+            except BaseException:
                 await self._reset_process_locked()
                 raise
 

--- a/services/zoe-data/tests/test_pi_intent_classifier.py
+++ b/services/zoe-data/tests/test_pi_intent_classifier.py
@@ -3,6 +3,7 @@ import os
 
 import pytest
 
+import pi_intent_classifier
 from pi_intent_classifier import (
     PI_INTENT_EXECUTE_THRESHOLD,
     PiIntentClassifierConfig,
@@ -43,6 +44,39 @@ def _fake_runtime(tmp_path, *, response=None, sleep_seconds=None, exit_code=0):
         f"print({json.dumps(json.dumps(payload))})\n",
     )
     return bindir
+
+
+def _fake_rpc_runtime(tmp_path, *, response=None):
+    bindir = tmp_path / "rpc-bin"
+    bindir.mkdir()
+    _write_exe(bindir / "node", "#!/bin/sh\nexit 0\n")
+    _write_exe(bindir / "npm", "#!/bin/sh\nexit 0\n")
+    payload = response or {
+        "intent": "weather",
+        "slots": {"forecast": True},
+        "confidence": 0.92,
+        "task_lane": "fast_tool",
+        "reason": "weather request",
+    }
+    _write_exe(
+        bindir / "pi",
+        "#!/usr/bin/python3\n"
+        "import json, os, sys\n"
+        "record = os.environ.get('PI_TEST_RECORD')\n"
+        "if record:\n"
+        "    with open(record, 'a') as fh:\n"
+        "        fh.write(json.dumps({'event': 'start', 'argv': sys.argv, 'openai': os.environ.get('OPENAI_API_KEY'), 'openrouter': os.environ.get('OPENROUTER_API_KEY')}) + '\\n')\n"
+        "payload = json.loads(os.environ['PI_TEST_PAYLOAD'])\n"
+        "for line in sys.stdin:\n"
+        "    if record:\n"
+        "        with open(record, 'a') as fh:\n"
+        "            fh.write(json.dumps({'event': 'request', 'body': json.loads(line)}) + '\\n')\n"
+        "    text = json.dumps(payload)\n"
+        "    print(json.dumps({'type': 'message_end', 'message': {'role': 'assistant', 'content': [{'type': 'text', 'text': text}]}}), flush=True)\n"
+        "    print(json.dumps({'type': 'turn_end', 'message': {'role': 'assistant', 'content': [{'type': 'text', 'text': text}]}}), flush=True)\n"
+        "    print(json.dumps({'type': 'agent_end', 'messages': [{'role': 'assistant', 'content': [{'type': 'text', 'text': text}]}]}), flush=True)\n",
+    )
+    return bindir, payload
 
 
 def test_pi_intent_status_disabled_by_default():
@@ -93,6 +127,100 @@ def test_pi_intent_config_rejects_cloud_provider_when_offline_only():
 
     with pytest.raises(ValueError, match="local/offline provider"):
         config.validate()
+
+
+def test_pi_intent_config_rejects_unknown_transport():
+    config = PiIntentClassifierConfig.from_env(
+        {
+            "ZOE_PI_INTENT_ENABLED": "true",
+            "ZOE_PI_INTENT_TRANSPORT": "invalid-transport",
+        }
+    )
+
+    with pytest.raises(ValueError, match="TRANSPORT"):
+        config.validate()
+
+
+@pytest.mark.asyncio
+async def test_pi_intent_governor_rpc_reuses_warm_process_and_strips_cloud_keys(tmp_path, monkeypatch):
+    workers = {}
+    monkeypatch.setattr(pi_intent_classifier, "_RPC_WORKERS", workers)
+    bindir, payload = _fake_rpc_runtime(tmp_path)
+    record = tmp_path / "rpc-record.jsonl"
+    env = {
+        "PATH": str(bindir),
+        "ZOE_PI_INTENT_ENABLED": "true",
+        "ZOE_PI_INTENT_TRANSPORT": "rpc",
+        "ZOE_PI_COMMAND": "pi",
+        "ZOE_PI_INTENT_PROVIDER": "ollama",
+        "ZOE_PI_INTENT_MODEL": "gemma-4-E2B-it-Q4_K_M.gguf",
+        "ZOE_PI_CWD": str(tmp_path),
+        "ZOE_PI_ALLOW_EXECUTION": "true",
+        "ZOE_PI_LOCAL_MODEL_CONFIGURED": "true",
+        "ZOE_PI_INTENT_TIMEOUT_SECONDS": "2",
+        "OPENAI_API_KEY": "should-not-reach-pi",
+        "OPENROUTER_API_KEY": "should-not-reach-pi",
+        "PI_TEST_RECORD": str(record),
+        "PI_TEST_PAYLOAD": json.dumps(payload),
+    }
+
+    try:
+        first = await classify_with_pi_intent_governor("rain later", env=env)
+        second = await classify_with_pi_intent_governor("umbrella later", env=env)
+    finally:
+        for worker in list(workers.values()):
+            await worker.reset()
+
+    assert first is not None
+    assert second is not None
+    assert first.intent == "weather"
+    assert second.intent == "weather"
+    events = [json.loads(line) for line in record.read_text().splitlines()]
+    starts = [event for event in events if event["event"] == "start"]
+    requests = [event for event in events if event["event"] == "request"]
+    assert len(starts) == 1
+    assert len(requests) == 2
+    assert starts[0]["openai"] is None
+    assert starts[0]["openrouter"] is None
+    assert "--mode" in starts[0]["argv"]
+    assert "rpc" in starts[0]["argv"]
+    assert "--offline" in starts[0]["argv"]
+    assert "-p" not in starts[0]["argv"]
+    assert requests[0]["body"]["type"] == "prompt"
+    assert "rain later" in requests[0]["body"]["message"]
+
+
+@pytest.mark.asyncio
+async def test_pi_rpc_timeout_resets_process_under_worker_lock(tmp_path, monkeypatch):
+    bindir = tmp_path / "rpc-timeout-bin"
+    bindir.mkdir()
+    _write_exe(bindir / "node", "#!/bin/sh\nexit 0\n")
+    _write_exe(bindir / "npm", "#!/bin/sh\nexit 0\n")
+    _write_exe(
+        bindir / "pi",
+        "#!/usr/bin/python3\n"
+        "import time\n"
+        "time.sleep(10)\n",
+    )
+    workers = {}
+    monkeypatch.setattr(pi_intent_classifier, "_RPC_WORKERS", workers)
+    env = {
+        "PATH": str(bindir),
+        "ZOE_PI_INTENT_ENABLED": "true",
+        "ZOE_PI_INTENT_TRANSPORT": "rpc",
+        "ZOE_PI_COMMAND": "pi",
+        "ZOE_PI_CWD": str(tmp_path),
+        "ZOE_PI_ALLOW_EXECUTION": "true",
+        "ZOE_PI_LOCAL_MODEL_CONFIGURED": "true",
+        "ZOE_PI_INTENT_TIMEOUT_SECONDS": "0.01",
+    }
+
+    result = await classify_with_pi_intent_governor("rain later", env=env)
+
+    assert result is None
+    assert len(workers) == 1
+    worker = next(iter(workers.values()))
+    assert worker.proc is None
 
 
 def test_pi_prompt_sanitizes_user_json_braces():


### PR DESCRIPTION
## Summary
- add optional ZOE_PI_INTENT_TRANSPORT=rpc for a warm Pi RPC worker
- keep print subprocess transport as the default
- serialize RPC prompts through an asyncio lock and parse Pi message/agent events
- update pi_intent_probe.py with --transport and --repeat for live speed comparison

## Live evidence
- print repeat 2 on rain later: about 6.94s then 4.18s
- rpc repeat 2 on rain later after stale-event fix: about 4.18s then 3.05s
- both returned executable weather classifications using local Gemma via Pi

## Verification
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_pi_intent_classifier.py services/zoe-data/tests/test_pi_runtime_probe.py tests/unit/test_intent_router.py services/zoe-data/tests/test_intent_open_domain.py services/zoe-data/tests/test_intent_ha_setup.py -> 54 passed
- python3 -m py_compile services/zoe-data/pi_intent_classifier.py services/zoe-data/intent_router.py services/zoe-data/multica_operator.py scripts/maintenance/pi_intent_probe.py
- python3 tools/audit/validate_structure.py
- python3 tools/audit/validate_critical_files.py
- git diff --check

Stacked on #487; do not merge before #487 lands.