### PR TITLE
Expose Pi intent status endpoint

### DIFF
--- a/services/zoe-data/routers/system.py
+++ b/services/zoe-data/routers/system.py
@@ -173,6 +173,14 @@ async def get_memory_router_status(user: dict = Depends(require_admin)):
     return memory_router_runtime_status()
 
 
+@router.get("/pi-intent/status")
+async def get_pi_intent_status(user: dict = Depends(require_admin)):
+    """Read-only status for Zoe's Pi/Gemma ambiguous-intent governor."""
+    from pi_intent_classifier import pi_intent_status
+
+    return pi_intent_status()
+
+
 def _load_skills_and_cron():
     skills = []
     skills_dir = os.path.expanduser("~/.openclaw/workspace/skills")

--- a/services/zoe-data/tests/test_pi_intent_status_endpoint.py
+++ b/services/zoe-data/tests/test_pi_intent_status_endpoint.py
@@ -71,6 +71,25 @@ def test_pi_intent_status_endpoint_reports_execution_disabled_when_tools_exist(t
     assert data["probe"]["config"]["local_model_configured"] is True
 
 
+def test_pi_intent_status_endpoint_reports_available_execution_disabled_when_tools_exist_and_allow_execution_false(tmp_path, monkeypatch):
+    bindir = _fake_pi_runtime(tmp_path)
+    monkeypatch.setenv("PATH", str(bindir))
+    monkeypatch.setenv("ZOE_PI_INTENT_ENABLED", "true")
+    monkeypatch.setenv("ZOE_PI_CWD", str(tmp_path))
+    monkeypatch.setenv("ZOE_PI_LOCAL_MODEL_CONFIGURED", "true")
+    monkeypatch.setenv("ZOE_PI_ALLOW_EXECUTION", "false")
+    app = _admin_app()
+
+    resp = TestClient(app).get("/api/system/pi-intent/status")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["ok"] is False
+    assert data["status"] == "available_execution_disabled"
+    assert data["probe"]["config"]["allow_execution"] is False
+    assert data["probe"]["config"]["local_model_configured"] is True
+
+
 def test_pi_intent_status_endpoint_reports_missing_pi_when_tools_absent(tmp_path, monkeypatch):
     bindir = _fake_node_runtime(tmp_path)
     monkeypatch.setenv("PATH", str(bindir))

--- a/services/zoe-data/tests/test_pi_intent_status_endpoint.py
+++ b/services/zoe-data/tests/test_pi_intent_status_endpoint.py
@@ -1,0 +1,98 @@
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+from auth import require_admin
+from routers.system import router as system_router
+
+
+def _write_exe(path, body):
+    path.write_text(body, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def _fake_pi_runtime(tmp_path):
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    _write_exe(bindir / "node", "#!/bin/sh\nexit 0\n")
+    _write_exe(bindir / "npm", "#!/bin/sh\nexit 0\n")
+    _write_exe(bindir / "pi", "#!/bin/sh\nexit 0\n")
+    return bindir
+
+
+def _admin_app():
+    app = FastAPI()
+    app.include_router(system_router)
+
+    async def fake_admin():
+        return {"user_id": "admin", "role": "family-admin"}
+
+    app.dependency_overrides[require_admin] = fake_admin
+    return app
+
+
+def test_pi_intent_status_endpoint_is_admin_scoped_and_disabled_by_default(monkeypatch):
+    monkeypatch.delenv("ZOE_PI_INTENT_ENABLED", raising=False)
+    app = _admin_app()
+
+    resp = TestClient(app).get("/api/system/pi-intent/status")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["ok"] is False
+    assert data["status"] == "disabled"
+    assert data["config"]["enabled"] is False
+    assert data["config"]["transport"] == "print"
+
+
+def test_pi_intent_status_endpoint_reports_execution_disabled_when_tools_exist(tmp_path, monkeypatch):
+    bindir = _fake_pi_runtime(tmp_path)
+    monkeypatch.setenv("PATH", str(bindir))
+    monkeypatch.setenv("ZOE_PI_INTENT_ENABLED", "true")
+    monkeypatch.setenv("ZOE_PI_CWD", str(tmp_path))
+    monkeypatch.setenv("ZOE_PI_LOCAL_MODEL_CONFIGURED", "true")
+    monkeypatch.delenv("ZOE_PI_ALLOW_EXECUTION", raising=False)
+    app = _admin_app()
+
+    resp = TestClient(app).get("/api/system/pi-intent/status")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["ok"] is False
+    assert data["status"] == "available_execution_disabled"
+    assert data["probe"]["config"]["allow_execution"] is False
+    assert data["probe"]["config"]["local_model_configured"] is True
+
+
+def test_pi_intent_status_endpoint_reports_available_with_explicit_gates(tmp_path, monkeypatch):
+    bindir = _fake_pi_runtime(tmp_path)
+    monkeypatch.setenv("PATH", str(bindir))
+    monkeypatch.setenv("ZOE_PI_INTENT_ENABLED", "true")
+    monkeypatch.setenv("ZOE_PI_INTENT_TRANSPORT", "rpc")
+    monkeypatch.setenv("ZOE_PI_CWD", str(tmp_path))
+    monkeypatch.setenv("ZOE_PI_ALLOW_EXECUTION", "true")
+    monkeypatch.setenv("ZOE_PI_LOCAL_MODEL_CONFIGURED", "true")
+    app = _admin_app()
+
+    resp = TestClient(app).get("/api/system/pi-intent/status")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["ok"] is True
+    assert data["status"] == "available"
+    assert data["config"]["transport"] == "rpc"
+    assert data["probe"]["config"]["allow_execution"] is True
+    assert data["probe"]["config"]["local_model_configured"] is True
+
+
+def test_pi_intent_status_endpoint_rejects_non_admin():
+    app = FastAPI()
+    app.include_router(system_router)
+
+    async def fake_non_admin():
+        raise HTTPException(status_code=403, detail="Admin access required")
+
+    app.dependency_overrides[require_admin] = fake_non_admin
+
+    resp = TestClient(app).get("/api/system/pi-intent/status")
+
+    assert resp.status_code == 403

--- a/services/zoe-data/tests/test_pi_intent_status_endpoint.py
+++ b/services/zoe-data/tests/test_pi_intent_status_endpoint.py
@@ -19,6 +19,14 @@ def _fake_pi_runtime(tmp_path):
     return bindir
 
 
+def _fake_node_runtime(tmp_path):
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    _write_exe(bindir / "node", "#!/bin/sh\nexit 0\n")
+    _write_exe(bindir / "npm", "#!/bin/sh\nexit 0\n")
+    return bindir
+
+
 def _admin_app():
     app = FastAPI()
     app.include_router(system_router)
@@ -64,10 +72,12 @@ def test_pi_intent_status_endpoint_reports_execution_disabled_when_tools_exist(t
 
 
 def test_pi_intent_status_endpoint_reports_missing_pi_when_tools_absent(tmp_path, monkeypatch):
+    bindir = _fake_node_runtime(tmp_path)
+    monkeypatch.setenv("PATH", str(bindir))
     monkeypatch.setenv("ZOE_PI_INTENT_ENABLED", "true")
     monkeypatch.setenv("ZOE_PI_CWD", str(tmp_path))
     monkeypatch.setenv("ZOE_PI_LOCAL_MODEL_CONFIGURED", "true")
-    monkeypatch.delenv("ZOE_PI_ALLOW_EXECUTION", raising=False)
+    monkeypatch.setenv("ZOE_PI_ALLOW_EXECUTION", "true")
     app = _admin_app()
 
     resp = TestClient(app).get("/api/system/pi-intent/status")

--- a/services/zoe-data/tests/test_pi_intent_status_endpoint.py
+++ b/services/zoe-data/tests/test_pi_intent_status_endpoint.py
@@ -63,6 +63,21 @@ def test_pi_intent_status_endpoint_reports_execution_disabled_when_tools_exist(t
     assert data["probe"]["config"]["local_model_configured"] is True
 
 
+def test_pi_intent_status_endpoint_reports_missing_pi_when_tools_absent(tmp_path, monkeypatch):
+    monkeypatch.setenv("ZOE_PI_INTENT_ENABLED", "true")
+    monkeypatch.setenv("ZOE_PI_CWD", str(tmp_path))
+    monkeypatch.setenv("ZOE_PI_LOCAL_MODEL_CONFIGURED", "true")
+    monkeypatch.delenv("ZOE_PI_ALLOW_EXECUTION", raising=False)
+    app = _admin_app()
+
+    resp = TestClient(app).get("/api/system/pi-intent/status")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["ok"] is False
+    assert data["status"] == "missing_pi"
+
+
 def test_pi_intent_status_endpoint_reports_available_with_explicit_gates(tmp_path, monkeypatch):
     bindir = _fake_pi_runtime(tmp_path)
     monkeypatch.setenv("PATH", str(bindir))


### PR DESCRIPTION
## Summary
- add admin-only GET /api/system/pi-intent/status
- reuse pi_intent_status() so readiness, transport, and operator gates are reported from the same contract used by the classifier
- add endpoint tests for disabled default, explicit local execution gates, and non-admin rejection

## Verification
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_pi_intent_status_endpoint.py services/zoe-data/tests/test_zoe_memory_router_runtime.py -> 25 passed
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_pi_intent_classifier.py services/zoe-data/tests/test_pi_runtime_probe.py tests/unit/test_intent_router.py services/zoe-data/tests/test_intent_open_domain.py services/zoe-data/tests/test_intent_ha_setup.py -> 54 passed
- python3 -m py_compile services/zoe-data/routers/system.py services/zoe-data/pi_intent_classifier.py services/zoe-data/intent_router.py scripts/maintenance/pi_intent_probe.py
- python3 tools/audit/validate_structure.py
- python3 tools/audit/validate_critical_files.py
- git diff --check

Stacked on #489, which is stacked on #487. Do not merge before the lower PRs land.