### PR TITLE
[codex] Warm up voice STT worker at startup

### DIFF
--- a/services/zoe-data/main.py
+++ b/services/zoe-data/main.py
@@ -583,6 +583,13 @@ async def lifespan(app: FastAPI):
     _consolidation_bg_task = start_memory_consolidation_background()
     _zoe_update_bg_task = start_zoe_update_background_tasks()
 
+    try:
+        from routers.voice_tts import warm_faster_whisper_worker
+        asyncio.create_task(warm_faster_whisper_worker(), name="faster_whisper_warmup")
+        logger.info("Voice STT worker warmup scheduled")
+    except Exception as _voice_warmup_exc:
+        logger.warning("Voice STT worker warmup scheduling failed (non-fatal): %s", _voice_warmup_exc)
+
     # Runtime health probe — run once immediately, then refresh every 5 min
     await _probe_runtimes()
     _runtime_health_task = asyncio.create_task(_runtime_health_refresh_loop(), name="runtime_health_refresh")

--- a/services/zoe-data/routers/voice_tts.py
+++ b/services/zoe-data/routers/voice_tts.py
@@ -2029,6 +2029,65 @@ async def _run_faster_whisper_worker(wav_path: str) -> str:
     return await _faster_whisper_worker.transcribe(wav_path)
 
 
+async def _reset_faster_whisper_worker() -> None:
+    global _faster_whisper_worker
+    worker = _faster_whisper_worker
+    _faster_whisper_worker = None
+    if worker is not None:
+        await worker.stop()
+
+
+def _voice_stt_warmup_enabled() -> bool:
+    return (os.environ.get("ZOE_WHISPER_WARMUP") or "true").strip().lower() not in {
+        "0",
+        "false",
+        "no",
+        "off",
+    }
+
+
+def _write_warmup_silence_wav(path: str, *, seconds: float = 1.0, sample_rate: int = 16000) -> None:
+    frame_count = max(1, int(sample_rate * seconds))
+    with wave.open(path, "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(sample_rate)
+        wf.writeframes(b"\x00\x00" * frame_count)
+
+
+async def warm_faster_whisper_worker() -> bool:
+    """Prime the persistent faster-whisper worker without blocking API startup."""
+    if not _voice_stt_warmup_enabled():
+        logger.info("faster-whisper warmup disabled by ZOE_WHISPER_WARMUP")
+        return False
+    if _use_in_process_faster_whisper() or not _use_persistent_faster_whisper_worker():
+        logger.info("faster-whisper warmup skipped; persistent worker is not active")
+        return False
+    timeout = _env_float("ZOE_WHISPER_WARMUP_TIMEOUT_S", 45.0)
+    tmp_path = ""
+    started = time.monotonic()
+    try:
+        with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
+            tmp_path = tmp.name
+        _write_warmup_silence_wav(tmp_path)
+        await asyncio.wait_for(_run_faster_whisper_worker(tmp_path), timeout=timeout)
+        logger.info("faster-whisper worker warmup completed in %.2fs", time.monotonic() - started)
+        return True
+    except asyncio.CancelledError:
+        await _reset_faster_whisper_worker()
+        raise
+    except Exception as exc:
+        await _reset_faster_whisper_worker()
+        logger.warning("faster-whisper worker warmup failed: %s", exc)
+        return False
+    finally:
+        if tmp_path:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+
+
 async def _run_faster_whisper_in_process(wav_path: str) -> str:
     """Transcribe using the faster-whisper Python library in the API worker."""
     model = await _get_faster_whisper_model()

--- a/services/zoe-data/tests/test_voice_transcribe.py
+++ b/services/zoe-data/tests/test_voice_transcribe.py
@@ -197,6 +197,82 @@ def test_faster_whisper_in_process_opt_in(monkeypatch):
     assert asyncio.run(voice_tts._run_faster_whisper("/tmp/audio.wav")) == "in-process:/tmp/audio.wav"
 
 
+def test_warm_faster_whisper_worker_primes_persistent_worker(monkeypatch):
+    from routers import voice_tts
+
+    calls = []
+
+    async def _fake_worker(path: str) -> str:
+        calls.append(Path(path).exists())
+        return ""
+
+    monkeypatch.delenv("ZOE_WHISPER_WARMUP", raising=False)
+    monkeypatch.delenv("ZOE_WHISPER_IN_PROCESS", raising=False)
+    monkeypatch.delenv("ZOE_WHISPER_PERSISTENT_WORKER", raising=False)
+    monkeypatch.setenv("ZOE_WHISPER_WARMUP_TIMEOUT_S", "2")
+    monkeypatch.setattr(voice_tts, "_run_faster_whisper_worker", _fake_worker)
+
+    assert asyncio.run(voice_tts.warm_faster_whisper_worker()) is True
+    assert calls == [True]
+
+
+def test_warm_faster_whisper_worker_respects_opt_out(monkeypatch):
+    from routers import voice_tts
+
+    async def _unexpected_worker(path: str) -> str:
+        raise AssertionError("worker should not be called")
+
+    monkeypatch.setenv("ZOE_WHISPER_WARMUP", "false")
+    monkeypatch.setattr(voice_tts, "_run_faster_whisper_worker", _unexpected_worker)
+
+    assert asyncio.run(voice_tts.warm_faster_whisper_worker()) is False
+
+
+def test_warm_faster_whisper_worker_resets_worker_after_timeout(monkeypatch):
+    from routers import voice_tts
+
+    stopped = []
+
+    class _Worker:
+        async def stop(self):
+            stopped.append(True)
+
+    async def _timeout_worker(path: str) -> str:
+        raise asyncio.TimeoutError("warmup timed out")
+
+    monkeypatch.delenv("ZOE_WHISPER_WARMUP", raising=False)
+    monkeypatch.delenv("ZOE_WHISPER_IN_PROCESS", raising=False)
+    monkeypatch.delenv("ZOE_WHISPER_PERSISTENT_WORKER", raising=False)
+    monkeypatch.setattr(voice_tts, "_run_faster_whisper_worker", _timeout_worker)
+    monkeypatch.setattr(voice_tts, "_faster_whisper_worker", _Worker())
+
+    assert asyncio.run(voice_tts.warm_faster_whisper_worker()) is False
+    assert stopped == [True]
+    assert voice_tts._faster_whisper_worker is None
+
+
+@pytest.mark.parametrize(
+    "env_name",
+    ["ZOE_WHISPER_IN_PROCESS", "ZOE_WHISPER_PERSISTENT_WORKER"],
+)
+def test_warm_faster_whisper_worker_skips_when_persistent_path_inactive(monkeypatch, env_name):
+    from routers import voice_tts
+
+    async def _unexpected_worker(path: str) -> str:
+        raise AssertionError("worker should not be called")
+
+    monkeypatch.delenv("ZOE_WHISPER_WARMUP", raising=False)
+    monkeypatch.delenv("ZOE_WHISPER_IN_PROCESS", raising=False)
+    monkeypatch.delenv("ZOE_WHISPER_PERSISTENT_WORKER", raising=False)
+    monkeypatch.setattr(voice_tts, "_run_faster_whisper_worker", _unexpected_worker)
+    if env_name == "ZOE_WHISPER_IN_PROCESS":
+        monkeypatch.setenv(env_name, "true")
+    else:
+        monkeypatch.setenv(env_name, "false")
+
+    assert asyncio.run(voice_tts.warm_faster_whisper_worker()) is False
+
+
 def test_faster_whisper_worker_reuses_process(monkeypatch):
     from routers import voice_tts
 


### PR DESCRIPTION
## Summary

Warms the persistent faster-whisper worker in the background when `zoe-data` starts so the first real panel voice request does not pay the model-load penalty.

## Root Cause

The persistent STT worker fixed repeated per-turn model startup, but the first voiced request after service start or worker restart could still spend 6-8 seconds loading the faster-whisper model. Warm requests were already fast, around 0.5-0.6 seconds for STT.

## Changes

- Add `warm_faster_whisper_worker()` to prime the persistent worker with a tiny silence WAV.
- Schedule the warm-up from FastAPI lifespan without blocking API readiness.
- Keep the behavior opt-out via `ZOE_WHISPER_WARMUP=false` and skip it when the persistent worker path is not active.
- Add focused tests for warm-up execution and opt-out behavior.

## Validation

- `python3 -m pytest -q services/zoe-data/tests/test_voice_transcribe.py`
- `python3 -m pytest -q services/zoe-data/tests/test_voice_transcribe.py services/zoe-data/tests/test_voice_weather_queue.py services/zoe-data/tests/test_skybridge_service.py`
- `git diff --check`
EOF'