### PR TITLE
fix(kanban-budget): allow editing other allowlisted files after a Python patch

### DIFF
--- a/services/zoe-data/kanban_phase_budget.py
+++ b/services/zoe-data/kanban_phase_budget.py
@@ -244,12 +244,19 @@ def implement_edit_safety_reason_from_log(task_id: str, phase: str, *, session: 
     for line in session.splitlines():
         if not _STEP_LINE_RE.match(line):
             continue
-        patch_match = _PATCH_PATH_RE.search(line) if _PYTHON_PATCH_RE.search(line) else None
-        if patch_match:
+        any_patch = _PATCH_PATH_RE.search(line)
+        if any_patch and _PYTHON_PATCH_RE.search(line):
             pending_python_patch = True
-            path_key = _read_path_key(patch_match.group("path"))
+            path_key = _read_path_key(any_patch.group("path"))
             patched_python_paths.add(path_key)
             post_patch_read_counts.pop(path_key, None)
+            continue
+        if any_patch:
+            # A patch/edit of another file (e.g. a .yml or .md) is productive
+            # work, not the "patch then keep reading/grepping" failure this guard
+            # targets — multi-file tasks routinely edit a .py then a config file.
+            # Allow it; the pending Python patch still requires its syntax/test
+            # check before any *exploration* (reads beyond budget / greps).
             continue
         if not pending_python_patch:
             continue

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -2475,6 +2475,26 @@ def test_implement_edit_safety_still_blocks_read_exploration_after_multifile_edi
     )
 
 
+def test_implement_edit_safety_still_blocks_grep_exploration_after_multifile_edits(tmp_path, monkeypatch):
+    # The relaxation covers edits only; a grep (like read/find) after a Python
+    # patch with no syntax check yet is still the exploration we block.
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    log_dir = tmp_path / "kanban" / "logs"
+    log_dir.mkdir(parents=True)
+    (log_dir / "t_impl.log").write_text(
+        "Query: work kanban task t_impl\n"
+        "  ┊ 🔧 patch     /work/services/zoe-data/tests/test_pipeline_evidence.py  5.9s\n"
+        "  ┊ 🔧 patch     /work/.github/workflows/validate.yml  1.2s\n"
+        "  ┊ 🔎 grep      required_evidence  0.1s\n",
+        encoding="utf-8",
+    )
+
+    assert kb.implement_edit_safety_reason_from_log("t_impl", "implement") == (
+        "BLOCKER=IMPLEMENT_EDIT_SAFETY: Python patch was followed by more "
+        "exploration before py_compile/focused tests"
+    )
+
+
 def test_implement_edit_safety_allows_live_patch_review_shape(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     log_dir = tmp_path / "kanban" / "logs"

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -2437,6 +2437,44 @@ def test_implement_edit_safety_repatch_resets_patched_file_read_budget(tmp_path,
     assert kb.implement_edit_safety_reason_from_log("t_impl", "implement") is None
 
 
+def test_implement_edit_safety_allows_editing_another_file_after_python_patch(tmp_path, monkeypatch):
+    # Multi-file tasks legitimately patch a .py then a config file before running
+    # checks; editing another allowlisted file is productive work, not the
+    # patch-then-keep-exploring failure this guard targets.
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    log_dir = tmp_path / "kanban" / "logs"
+    log_dir.mkdir(parents=True)
+    (log_dir / "t_impl.log").write_text(
+        "Query: work kanban task t_impl\n"
+        "  ┊ 🔧 patch     /work/services/zoe-data/tests/test_pipeline_evidence.py  5.9s\n"
+        "  ┊ 🔧 patch     /work/.github/workflows/validate.yml  1.2s\n"
+        "  ┊ 💻 $         python3 -m pytest services/zoe-data/tests/test_pipeline_evidence.py  0.2s\n",
+        encoding="utf-8",
+    )
+
+    assert kb.implement_edit_safety_reason_from_log("t_impl", "implement") is None
+
+
+def test_implement_edit_safety_still_blocks_read_exploration_after_multifile_edits(tmp_path, monkeypatch):
+    # The relaxation only covers edits — a read/grep of an unrelated file after a
+    # Python patch (with no syntax check yet) is still the failure mode we block.
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    log_dir = tmp_path / "kanban" / "logs"
+    log_dir.mkdir(parents=True)
+    (log_dir / "t_impl.log").write_text(
+        "Query: work kanban task t_impl\n"
+        "  ┊ 🔧 patch     /work/services/zoe-data/tests/test_pipeline_evidence.py  5.9s\n"
+        "  ┊ 🔧 patch     /work/.github/workflows/validate.yml  1.2s\n"
+        "  ┊ 📖 read      /work/services/zoe-data/main.py  0.1s\n",
+        encoding="utf-8",
+    )
+
+    assert kb.implement_edit_safety_reason_from_log("t_impl", "implement") == (
+        "BLOCKER=IMPLEMENT_EDIT_SAFETY: Python patch was followed by more "
+        "exploration before py_compile/focused tests"
+    )
+
+
 def test_implement_edit_safety_allows_live_patch_review_shape(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     log_dir = tmp_path / "kanban" / "logs"


### PR DESCRIPTION
## Problem (observed live)

`IMPLEMENT_EDIT_SAFETY` blocks an implement run that patches Python then keeps exploring before a syntax/test check — good. But it treated a **patch/edit of any other file** (e.g. `.github/workflows/validate.yml`, a `.md`) as "exploration" and blocked it. So a normal **multi-file task** — edit a `.py`, then a config file, then run tests — tripped the guard mid-edit.

Seen in a live autonomous run: a worker fixing stale test assertions **and** adding files to the CI allowlist patched `test_pipeline_evidence.py`, then patched `validate.yml`, and was blocked before it could run pytest.

## Fix

While a Python syntax/test check is pending, a **patch/edit of another file is allowed** (productive work, not the patch-then-keep-reading failure the guard targets). The pending Python patch still requires its check before any **read/grep exploration** — reads of unrelated files after a patch remain blocked.

## Tests
+2 (15 edit-safety tests total):
- multi-file `patch .py → patch .yml → pytest` is allowed
- a read of an unrelated file after multi-file edits is still blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)