### PR TITLE
[codex] Render Skybridge auth challenges as cards

### DIFF
--- a/services/zoe-data/routers/voice_tts.py
+++ b/services/zoe-data/routers/voice_tts.py
@@ -1233,6 +1233,12 @@ async def _request_auth_ui(panel_id: str, challenge_id: str, reason: str) -> boo
             "panel_id": panel_id,
             "challenge_id": challenge_id,
             "action_context": reason,
+            "summary": "Please authenticate on the touch panel to continue.",
+            "title": "Confirm it is you",
+            "message": "Zoe needs to know who is speaking before showing or changing personal data.",
+            "domain": "Private data",
+            "intent_action": "continue",
+            "cta": "Continue",
         },
     }
     delivered = False

--- a/services/zoe-data/skybridge_service.py
+++ b/services/zoe-data/skybridge_service.py
@@ -557,7 +557,16 @@ def _auth_required_result(intent: SkybridgeIntent) -> dict[str, Any]:
         "auth_required": True,
         "intent": _intent_dict(intent),
         "spoken_summary": "Please authenticate on the touch panel to continue.",
-        "cards": [_status_card(title, body, status="Authentication")],
+        "cards": [{
+            "component": "auth_challenge",
+            "props": {
+                "title": title,
+                "body": body,
+                "domain": domain,
+                "action": intent.action,
+                "actions": [{"type": "auth", "label": "Sign in", "route": ""}],
+            },
+        }],
         "actions": [{"type": "auth_required", "domain": intent.domain, "action": intent.action}],
     }
 

--- a/services/zoe-data/tests/test_skybridge_service.py
+++ b/services/zoe-data/tests/test_skybridge_service.py
@@ -466,7 +466,9 @@ async def test_guest_calendar_request_does_not_fetch_family_events():
     assert result["handled"] is True
     assert result["auth_required"] is True
     assert result["actions"][0]["type"] == "auth_required"
-    assert result["cards"][0]["props"]["status"] == "Authentication"
+    assert result["cards"][0]["component"] == "auth_challenge"
+    assert result["cards"][0]["props"]["actions"][0]["type"] == "auth"
+    assert result["cards"][0]["props"]["actions"][0]["route"] == ""
 
 
 @pytest.mark.asyncio
@@ -616,7 +618,9 @@ async def test_guest_lists_request_does_not_fetch_private_lists():
     assert result["handled"] is True
     assert result["auth_required"] is True
     assert result["actions"][0]["domain"] == "lists"
-    assert result["cards"][0]["props"]["status"] == "Authentication"
+    assert result["cards"][0]["component"] == "auth_challenge"
+    assert result["cards"][0]["props"]["actions"][0]["type"] == "auth"
+    assert result["cards"][0]["props"]["actions"][0]["route"] == ""
 
 
 @pytest.mark.asyncio
@@ -673,7 +677,9 @@ async def test_guest_people_request_does_not_fetch_private_people():
     assert result["handled"] is True
     assert result["auth_required"] is True
     assert result["actions"][0]["domain"] == "people"
-    assert result["cards"][0]["props"]["status"] == "Authentication"
+    assert result["cards"][0]["component"] == "auth_challenge"
+    assert result["cards"][0]["props"]["actions"][0]["type"] == "auth"
+    assert result["cards"][0]["props"]["actions"][0]["route"] == ""
 
 
 @pytest.mark.asyncio

--- a/services/zoe-data/tests/test_skybridge_static.py
+++ b/services/zoe-data/tests/test_skybridge_static.py
@@ -41,7 +41,9 @@ def test_skybridge_push_socket_uses_authenticated_session_query():
     main = (ROOT / "zoe-data" / "main.py").read_text(encoding="utf-8")
 
     assert "/js/websocket-sync.js?v=skybridge-auth-ready-1" in html
-    assert "/touch/js/skybridge.js?v=skybridge-render-ack-1" in html
+    assert "/touch/js/skybridge.js?v=skybridge-auth-card-1" in html
+    assert "/touch/js/skybridge-renderer.js?v=skybridge-auth-card-1" in html
+    assert "/js/touch-ui-executor.js?v=skybridge-auth-card-1" in html
     assert "initPush(panelId, sessionId)" in sync
     assert "params.set('panel_id', panelId)" in sync
     assert "else params.set('channel', 'all')" in sync
@@ -210,6 +212,8 @@ def test_skybridge_uses_backend_status_contract():
     assert "contextLabelFor(intent)" in app
     assert "isDataQuery(query)" in app
     assert "resp.status === 401 || resp.status === 503" in app
+    assert "const panelId = new URLSearchParams(location.search).get('panel_id')" in app
+    assert app.count("if (!route) route = '/touch/index.html' + (panelId ? '?panel_id=' + encodeURIComponent(panelId) : '');") >= 2
     assert "if (voice) voice.sendText(query)" in app
     assert "event.role === 'user') projectCards" not in app
     assert "projectCommand(query);\n        if (voice) voice.sendText(query);" not in app
@@ -286,7 +290,7 @@ def test_skybridge_renderer_supports_real_data_cards():
     assert "sky-event-row" in html
     assert "sky-weather-hour-tile" in html
     assert "sky-weather-day-row" in html
-    assert "/touch/css/skybridge-data-widgets.css?v=skybridge-lists-people-1" in html
+    assert "/touch/css/skybridge-data-widgets.css?v=skybridge-auth-card-1" in html
     assert "skybridge-lists-people-widgets" not in html
     assert "sky-list-item-row" in data_widgets_css
     assert "sky-person-row" in data_widgets_css
@@ -394,6 +398,38 @@ def test_touch_executor_renders_skybridge_card_contracts():
     assert "payload && payload.card ? [payload.card]" in executor
     assert "sanitizeSkybridgeHtml(window.SkybridgeRenderer.render(card))" in executor
     assert "if (renderSkybridgeCardPayload(payload))" in executor
+
+
+def test_skybridge_auth_challenge_card_contract():
+    html = read(UI / "skybridge.html")
+    app = read(UI / "js" / "skybridge.js")
+    renderer = read(UI / "js" / "skybridge-renderer.js")
+    executor = (ROOT / "zoe-ui" / "dist" / "js" / "touch-ui-executor.js").read_text(encoding="utf-8")
+    css = read(UI / "css" / "skybridge-data-widgets.css")
+    service = read(DATA / "skybridge_service.py")
+    voice = read(DATA / "routers" / "voice_tts.py")
+
+    assert "auth_challenge: renderAuthChallenge" in renderer
+    assert "function renderAuthChallenge(props)" in renderer
+    assert "data-challenge-id" in renderer
+    assert "data-action-context" in renderer
+    assert "btn.dataset.skyAction === 'auth'" in app
+    assert "if (!route) route = '/touch/index.html'" in app
+    assert "encodeURIComponent(panelId)" in app
+    assert "storedChallenge.panel_id" in app
+    assert "zoe_panel_auth_challenge" in app
+    assert "zoe_redirect_after_login" in app
+    assert "function renderSkybridgeAuthChallenge(payload)" in executor
+    assert "renderSkybridgeAuthChallenge(payload)" in executor
+    assert "component: 'auth_challenge'" in executor
+    assert "buildTouchLoginRoute(panelId)" in executor
+    assert "redirectToTouchLogin" in executor
+    assert "sky-card.auth-challenge" in css
+    assert "sky-auth-scene" in css
+    assert '"component": "auth_challenge"' in service
+    assert '"route": ""' in service
+    assert '"summary": "Please authenticate on the touch panel to continue."' in voice
+    assert '"challenge_id": challenge_id' in voice
 
 
 def test_voice_command_has_skybridge_first_touch_path():

--- a/services/zoe-data/tests/test_voice_weather_queue.py
+++ b/services/zoe-data/tests/test_voice_weather_queue.py
@@ -61,6 +61,54 @@ def test_ignores_non_weather_actions() -> None:
     )
 
 
+@pytest.mark.asyncio
+async def test_request_auth_ui_includes_skybridge_card_metadata(monkeypatch):
+    calls = {"broadcast": None, "enqueue": None}
+
+    class Cursor:
+        async def fetchone(self):
+            return {"user_id": "family-admin"}
+
+    class Db:
+        async def execute(self, *_args, **_kwargs):
+            return Cursor()
+
+    async def get_db():
+        yield Db()
+
+    async def enqueue_ui_action(_db, **kwargs):
+        calls["enqueue"] = kwargs
+        return {"action_id": "auth-action"}
+
+    async def broadcast(channel, event_type, payload):
+        calls["broadcast"] = {"channel": channel, "event_type": event_type, "payload": payload}
+        return True
+
+    monkeypatch.setitem(sys.modules, "database", types.SimpleNamespace(get_db=get_db))
+    monkeypatch.setitem(sys.modules, "ui_orchestrator", types.SimpleNamespace(enqueue_ui_action=enqueue_ui_action))
+    monkeypatch.setitem(sys.modules, "push", types.SimpleNamespace(broadcaster=types.SimpleNamespace(broadcast=broadcast)))
+
+    delivered = await voice_tts._request_auth_ui(
+        panel_id="panel-auth",
+        challenge_id="challenge-123",
+        reason="Private list request",
+    )
+
+    assert delivered is True
+    payload = calls["broadcast"]["payload"]["action"]["payload"]
+    assert payload["panel_id"] == "panel-auth"
+    assert payload["challenge_id"] == "challenge-123"
+    assert payload["action_context"] == "Private list request"
+    assert payload["title"] == "Confirm it is you"
+    assert payload["message"] == "Zoe needs to know who is speaking before showing or changing personal data."
+    assert payload["domain"] == "Private data"
+    assert payload["intent_action"] == "continue"
+    assert payload["cta"] == "Continue"
+    assert payload["summary"] == "Please authenticate on the touch panel to continue."
+    assert calls["enqueue"]["action_type"] == "panel_request_auth"
+    assert calls["enqueue"]["payload"] == payload
+
+
 class _Cursor:
     def __init__(self, *, row: dict | None = None, rows: list[dict] | None = None):
         self._row = row

--- a/services/zoe-ui/dist/js/touch-ui-executor.js
+++ b/services/zoe-ui/dist/js/touch-ui-executor.js
@@ -623,6 +623,52 @@ body.light-mode #zvo-header { border-bottom-color: rgba(0,0,0,0.07); }
         return template.innerHTML;
     }
 
+    function buildTouchLoginRoute(panelId) {
+        return '/touch/index.html' + (panelId ? '?panel_id=' + encodeURIComponent(panelId) : '');
+    }
+
+    function renderSkybridgeAuthChallenge(payload) {
+        const cardRoot = document.getElementById('skyCards');
+        if (!cardRoot || !window.SkybridgeRenderer || typeof window.SkybridgeRenderer.render !== 'function') {
+            return false;
+        }
+        const challengeId = String(payload.challenge_id || '').trim();
+        if (!challengeId) return false;
+        const panelId = payload.panel_id || state.panelId || getPanelId();
+        const actionContext = payload.action_context || payload.reason || 'Enter PIN';
+        try {
+            sessionStorage.setItem('zoe_panel_auth_challenge', JSON.stringify({
+                challenge_id: challengeId,
+                panel_id: panelId,
+                action_context: actionContext,
+            }));
+            sessionStorage.setItem('zoe_redirect_after_login', window.location.pathname + window.location.search);
+        } catch (_) {
+            // Non-fatal: the Continue action will still open the login page.
+        }
+        const card = {
+            component: 'auth_challenge',
+            props: {
+                id: 'auth-' + challengeId,
+                title: payload.title || 'Confirm it is you',
+                body: payload.message || payload.body || 'Zoe needs to know who is speaking before showing or changing personal data.',
+                domain: payload.domain || 'Private data',
+                action: payload.intent_action || payload.action || 'Continue',
+                actions: [{
+                    type: 'auth',
+                    label: payload.cta || 'Continue',
+                    route: buildTouchLoginRoute(panelId),
+                    challenge_id: challengeId,
+                    action_context: actionContext,
+                }],
+            },
+        };
+        return renderSkybridgeCardPayload({
+            cards: [card],
+            data: { summary: payload.summary || 'Please authenticate on the touch panel to continue.' },
+        });
+    }
+
     function renderSkybridgeCardPayload(payload) {
         const result = payload && payload.result;
         const cards = (
@@ -1206,6 +1252,9 @@ body.light-mode #zvo-header { border-bottom-color: rgba(0,0,0,0.07); }
                         return { status: 'skipped', error_code: 'duplicate_challenge' };
                     }
                     rememberAuthChallenge(challengeId);
+                    if (renderSkybridgeAuthChallenge(payload)) {
+                        return { status: 'success' };
+                    }
                     redirectToTouchLogin({
                         challenge_id: challengeId,
                         action_context: payload.action_context || payload.reason || 'Enter PIN'

--- a/services/zoe-ui/dist/touch/css/skybridge-data-widgets.css
+++ b/services/zoe-ui/dist/touch/css/skybridge-data-widgets.css
@@ -361,3 +361,129 @@ body:not(.sky-empty) .sky-profile-notes {
         grid-template-columns: 1fr;
     }
 }
+
+body:not(.sky-empty) .sky-card.auth-challenge {
+    background:
+        radial-gradient(circle at 16% 12%, rgba(90,224,224,0.30), transparent 34%),
+        radial-gradient(circle at 86% 16%, rgba(123,97,255,0.28), transparent 34%),
+        linear-gradient(145deg, rgba(17,24,39,0.97), rgba(8,10,18,0.99)) !important;
+    border-color: rgba(255,255,255,0.18) !important;
+    overflow: hidden;
+}
+
+body:not(.sky-empty) .sky-auth-scene {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    gap: 22px;
+    align-items: center;
+}
+
+body:not(.sky-empty) .sky-auth-orb {
+    position: relative;
+    width: 118px;
+    height: 118px;
+    border-radius: 50%;
+    display: grid;
+    place-items: center;
+    background:
+        radial-gradient(circle at 34% 28%, rgba(255,255,255,0.95), rgba(90,224,224,0.78) 22%, rgba(123,97,255,0.72) 56%, rgba(24,32,52,0.92) 100%);
+    box-shadow: 0 0 64px rgba(90,224,224,0.28), inset 0 1px 18px rgba(255,255,255,0.40);
+}
+
+body:not(.sky-empty) .sky-auth-orb::before {
+    content: '';
+    position: absolute;
+    inset: -12px;
+    border-radius: inherit;
+    border: 1px solid rgba(255,255,255,0.20);
+    background: linear-gradient(135deg, rgba(255,255,255,0.18), transparent);
+}
+
+body:not(.sky-empty) .sky-auth-orb span {
+    width: 42px;
+    height: 42px;
+    border-radius: 18px;
+    background: rgba(6,10,18,0.45);
+    border: 1px solid rgba(255,255,255,0.28);
+    box-shadow: inset 0 1px 0 rgba(255,255,255,0.22);
+}
+
+body:not(.sky-empty) .sky-auth-copy span {
+    display: inline-flex;
+    width: fit-content;
+    border-radius: 999px;
+    padding: 7px 11px;
+    color: rgba(255,255,255,0.78);
+    background: rgba(255,255,255,0.10);
+    border: 1px solid rgba(255,255,255,0.13);
+    font-size: 0.74rem;
+    font-weight: 850;
+    text-transform: uppercase;
+}
+
+body:not(.sky-empty) .sky-auth-copy strong {
+    display: block;
+    margin-top: 12px;
+    color: white;
+    font-size: clamp(1.7rem, 3vw, 3.4rem);
+    line-height: 0.98;
+}
+
+body:not(.sky-empty) .sky-auth-copy p {
+    margin: 12px 0 0;
+    max-width: 52ch;
+    color: rgba(255,255,255,0.70);
+    font-size: 1rem;
+    line-height: 1.45;
+}
+
+body:not(.sky-empty) .sky-auth-steps {
+    grid-column: 1 / -1;
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 10px;
+    margin-top: 4px;
+}
+
+body:not(.sky-empty) .sky-auth-steps div {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    min-width: 0;
+    border-radius: 18px;
+    padding: 12px;
+    background: rgba(255,255,255,0.085);
+    border: 1px solid rgba(255,255,255,0.12);
+}
+
+body:not(.sky-empty) .sky-auth-steps b {
+    width: 28px;
+    height: 28px;
+    flex: 0 0 auto;
+    border-radius: 50%;
+    display: grid;
+    place-items: center;
+    color: rgba(9,13,22,0.95);
+    background: linear-gradient(135deg, #5AE0E0, #C7D2FE);
+    font-size: 0.82rem;
+}
+
+body:not(.sky-empty) .sky-auth-steps span {
+    color: rgba(255,255,255,0.78);
+    font-size: 0.86rem;
+    font-weight: 800;
+    overflow-wrap: anywhere;
+}
+
+@media (max-width: 720px) {
+    body:not(.sky-empty) .sky-auth-scene {
+        grid-template-columns: minmax(0, 1fr);
+    }
+    body:not(.sky-empty) .sky-auth-orb {
+        width: 92px;
+        height: 92px;
+    }
+    body:not(.sky-empty) .sky-auth-steps {
+        grid-template-columns: minmax(0, 1fr);
+    }
+}

--- a/services/zoe-ui/dist/touch/js/skybridge-renderer.js
+++ b/services/zoe-ui/dist/touch/js/skybridge-renderer.js
@@ -17,8 +17,10 @@
         const label = escapeHtml(action.label || action.title || 'Open');
         const query = escapeHtml(action.query || '');
         const route = escapeHtml(action.route || '');
+        const challengeId = escapeHtml(action.challenge_id || '');
+        const actionContext = escapeHtml(action.action_context || action.reason || '');
         const kind = action.kind === 'warn' ? ' warn' : (index === 0 ? ' primary' : '');
-        return '<button type="button" class="' + kind.trim() + '" data-sky-action="' + escapeHtml(action.type || 'query') + '" data-query="' + query + '" data-route="' + route + '">' + label + '</button>';
+        return '<button type="button" class="' + kind.trim() + '" data-sky-action="' + escapeHtml(action.type || 'query') + '" data-query="' + query + '" data-route="' + route + '" data-challenge-id="' + challengeId + '" data-action-context="' + actionContext + '">' + label + '</button>';
     }
 
     function safeClassTokens(value) {
@@ -64,6 +66,29 @@
             actions,
             '</article>'
         ].join('');
+    }
+
+    function renderAuthChallenge(props) {
+        const title = props.title || 'Confirm it is you';
+        const body = props.body || props.message || 'Zoe needs to know who is speaking before showing or changing personal data.';
+        const domain = props.domain ? String(props.domain) : 'Private data';
+        const action = props.action ? String(props.action).replace(/_/g, ' ') : 'Continue';
+        const bodyHtml = [
+            '<div class="sky-auth-scene">',
+            '<div class="sky-auth-orb" aria-hidden="true"><span></span></div>',
+            '<div class="sky-auth-copy">',
+            '<span>' + escapeHtml(domain) + '</span>',
+            '<strong>' + escapeHtml(title) + '</strong>',
+            '<p>' + escapeHtml(body) + '</p>',
+            '</div>',
+            '<div class="sky-auth-steps" aria-label="Authentication steps">',
+            '<div><b>1</b><span>Choose profile</span></div>',
+            '<div><b>2</b><span>Enter PIN</span></div>',
+            '<div><b>3</b><span>' + escapeHtml(action) + '</span></div>',
+            '</div>',
+            '</div>'
+        ].join('');
+        return cardFrame(props, bodyHtml, { wide: true, tone: 'auth-challenge', hideHeader: true, hideStatus: true });
     }
 
     function renderStatus(props) {
@@ -542,6 +567,7 @@
         media: renderList,
         smart_home: renderList,
         research_report: renderList,
+        auth_challenge: renderAuthChallenge,
         stream_text: renderStatus,
         unsupported_contract: renderUnsupportedContract
     };

--- a/services/zoe-ui/dist/touch/js/skybridge.js
+++ b/services/zoe-ui/dist/touch/js/skybridge.js
@@ -94,8 +94,28 @@
         els.cards.addEventListener('click', event => {
             const btn = event.target.closest('button[data-sky-action]');
             if (!btn) return;
-            const route = btn.dataset.route;
+            let route = btn.dataset.route;
             const query = btn.dataset.query;
+            if (btn.dataset.skyAction === 'auth') {
+                let storedChallenge = {};
+                try { storedChallenge = JSON.parse(sessionStorage.getItem('zoe_panel_auth_challenge') || '{}') || {}; } catch (_) {}
+                const panelId = new URLSearchParams(location.search).get('panel_id') || localStorage.getItem('zoe_touch_panel_id') || storedChallenge.panel_id || '';
+                try {
+                    const challengeId = btn.dataset.challengeId || '';
+                    const actionContext = btn.dataset.actionContext || 'Enter PIN';
+                    if (challengeId) {
+                        sessionStorage.setItem('zoe_panel_auth_challenge', JSON.stringify({
+                            challenge_id: challengeId,
+                            panel_id: panelId,
+                            action_context: actionContext
+                        }));
+                    }
+                    sessionStorage.setItem('zoe_redirect_after_login', location.pathname + location.search);
+                    if (!route) route = '/touch/index.html' + (panelId ? '?panel_id=' + encodeURIComponent(panelId) : '');
+                } catch (_) {
+                    if (!route) route = '/touch/index.html' + (panelId ? '?panel_id=' + encodeURIComponent(panelId) : '');
+                }
+            }
             if (route && route.startsWith('/')) {
                 location.href = route;
             } else if (route) {

--- a/services/zoe-ui/dist/touch/skybridge.html
+++ b/services/zoe-ui/dist/touch/skybridge.html
@@ -23,7 +23,7 @@
     <meta name="theme-color" content="#0b0d12">
     <title>Zoe Skybridge</title>
     <link rel="stylesheet" href="/touch/css/touch-adapter.css">
-    <link rel="stylesheet" href="/touch/css/skybridge-data-widgets.css?v=skybridge-lists-people-1">
+    <link rel="stylesheet" href="/touch/css/skybridge-data-widgets.css?v=skybridge-auth-card-1">
     <script src="/lib/livekit/livekit-client.umd.min.js" onerror="console.warn('LiveKit client not loaded')"></script>
     <style>
         :root {
@@ -4396,10 +4396,10 @@
     <script src="/js/websocket-sync.js?v=skybridge-auth-ready-1"></script>
     <script src="/touch/js/gestures.js?v=skybridge-auth-ready-1"></script>
     <script src="/touch/js/touch-menu.js?v=skybridge-auth-ready-1"></script>
-    <script src="/js/touch-ui-executor.js?v=skybridge-auth-ready-1"></script>
+    <script src="/js/touch-ui-executor.js?v=skybridge-auth-card-1"></script>
     <script src="/touch/js/skybridge-capabilities.js?v=skybridge-push-ack-1"></script>
-    <script src="/touch/js/skybridge-renderer.js?v=skybridge-push-ack-1"></script>
+    <script src="/touch/js/skybridge-renderer.js?v=skybridge-auth-card-1"></script>
     <script src="/touch/js/skybridge-voice.js?v=skybridge-push-ack-1"></script>
-    <script src="/touch/js/skybridge.js?v=skybridge-render-ack-1"></script>
+    <script src="/touch/js/skybridge.js?v=skybridge-auth-card-1"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Makes authentication requests a first-class Skybridge card experience.

## Changes

- Adds an `auth_challenge` Skybridge renderer with premium card styling.
- Updates `panel_request_auth` handling so Skybridge renders an auth card instead of immediately redirecting when the Skybridge card root is available.
- Stores the existing `challenge_id` and redirect target in session storage so the card's Continue action opens the existing secure touch login/PIN flow.
- Updates typed guest/private Skybridge resolver responses to return an `auth_challenge` card instead of a generic status card.
- Adds display metadata to voice auth UI actions so voice-triggered private requests can render the auth card.
- Bumps Skybridge asset versions.

## Validation

- `python3 -m pytest -q services/zoe-data/tests/test_skybridge_static.py services/zoe-data/tests/test_skybridge_service.py services/zoe-data/tests/test_voice_weather_queue.py`
- `python3 -m pytest -q services/zoe-data/tests/test_skybridge_static.py services/zoe-data/tests/test_skybridge_service.py services/zoe-data/tests/test_voice_weather_queue.py services/zoe-data/tests/test_ui_actions_ack.py services/zoe-data/tests/test_ui_orchestrator_types.py`
- `git diff --check`

Note: `node` is not installed on the Zoe host, so JS syntax will be covered by browser runtime verification after merge/sync.
EOF'