### PR TITLE
[codex] Polish Skybridge auth card copy

### DIFF
--- a/services/zoe-data/tests/test_skybridge_static.py
+++ b/services/zoe-data/tests/test_skybridge_static.py
@@ -411,6 +411,9 @@ def test_skybridge_auth_challenge_card_contract():
 
     assert "auth_challenge: renderAuthChallenge" in renderer
     assert "function renderAuthChallenge(props)" in renderer
+    assert "const finalStep = props.final_step || 'Return to Zoe'" in renderer
+    assert "escapeHtml(finalStep)" in renderer
+    assert "escapeHtml(action)" not in renderer[renderer.index("function renderAuthChallenge"):renderer.index("function renderStatus")]
     assert "data-challenge-id" in renderer
     assert "data-action-context" in renderer
     assert "btn.dataset.skyAction === 'auth'" in app

--- a/services/zoe-ui/dist/touch/js/skybridge-renderer.js
+++ b/services/zoe-ui/dist/touch/js/skybridge-renderer.js
@@ -72,7 +72,7 @@
         const title = props.title || 'Confirm it is you';
         const body = props.body || props.message || 'Zoe needs to know who is speaking before showing or changing personal data.';
         const domain = props.domain ? String(props.domain) : 'Private data';
-        const action = props.action ? String(props.action).replace(/_/g, ' ') : 'Continue';
+        const finalStep = props.final_step || 'Return to Zoe';
         const bodyHtml = [
             '<div class="sky-auth-scene">',
             '<div class="sky-auth-orb" aria-hidden="true"><span></span></div>',
@@ -84,7 +84,7 @@
             '<div class="sky-auth-steps" aria-label="Authentication steps">',
             '<div><b>1</b><span>Choose profile</span></div>',
             '<div><b>2</b><span>Enter PIN</span></div>',
-            '<div><b>3</b><span>' + escapeHtml(action) + '</span></div>',
+            '<div><b>3</b><span>' + escapeHtml(finalStep) + '</span></div>',
             '</div>',
             '</div>'
         ].join('');


### PR DESCRIPTION
## Summary
- keep Skybridge auth challenge step three as user-facing copy instead of leaking the intent action
- add a static contract check for the auth card step copy

## Tests
- python3 -m pytest -q services/zoe-data/tests/test_skybridge_static.py services/zoe-data/tests/test_skybridge_service.py services/zoe-data/tests/test_voice_weather_queue.py services/zoe-data/tests/test_ui_actions_ack.py services/zoe-data/tests/test_ui_orchestrator_types.py