### PR TITLE
[codex] Render Skybridge auth as identity picker

### DIFF
--- a/services/zoe-auth/tests/test_auth.py
+++ b/services/zoe-auth/tests/test_auth.py
@@ -37,6 +37,24 @@ def _init_auth_tables(db_path: str) -> None:
         )
         """
     )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS panels (
+            panel_id TEXT PRIMARY KEY,
+            name TEXT,
+            allow_guest INTEGER DEFAULT 1
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS panel_user_bindings (
+            panel_id TEXT,
+            user_id TEXT,
+            binding_type TEXT
+        )
+        """
+    )
     conn.commit()
     conn.close()
 
@@ -85,6 +103,43 @@ def test_profiles_endpoint_returns_non_system_users(sqlite_auth_db):
     assert len(profiles) == 1
     assert profiles[0]["user_id"] == "jason"
     assert profiles[0]["avatar"] == "J"
+
+
+def test_profiles_endpoint_returns_panel_scoped_identity_picker_shape(sqlite_auth_db):
+    conn = sqlite3.connect(sqlite_auth_db)
+    conn.executemany(
+        "INSERT INTO auth_users(user_id, username, role, password_hash) VALUES (?, ?, ?, ?)",
+        [
+            ("jason", "Jason", "admin", "hash"),
+            ("sarah", "Sarah", "user", "hash"),
+            ("guestish", "Guestish", "user", "hash"),
+        ],
+    )
+    conn.execute(
+        "INSERT INTO panels(panel_id, name, allow_guest) VALUES (?, ?, ?)",
+        ("zoe-touch-pi", "Kitchen", 0),
+    )
+    conn.executemany(
+        "INSERT INTO panel_user_bindings(panel_id, user_id, binding_type) VALUES (?, ?, ?)",
+        [
+            ("zoe-touch-pi", "jason", "default"),
+            ("zoe-touch-pi", "sarah", "allowed"),
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+    client = TestClient(app)
+    response = client.get("/api/auth/profiles?panel_id=zoe-touch-pi")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["panel_id"] == "zoe-touch-pi"
+    assert payload["panel_name"] == "Kitchen"
+    assert payload["allow_guest"] is False
+    assert payload["default_user_id"] == "jason"
+    assert [p["user_id"] for p in payload["profiles"]] == ["jason", "sarah"]
+    assert payload["profiles"][0]["avatar"] == "J"
 
 
 def test_login_requires_initial_password_setup_marker(sqlite_auth_db):

--- a/services/zoe-data/tests/test_skybridge_static.py
+++ b/services/zoe-data/tests/test_skybridge_static.py
@@ -41,9 +41,9 @@ def test_skybridge_push_socket_uses_authenticated_session_query():
     main = (ROOT / "zoe-data" / "main.py").read_text(encoding="utf-8")
 
     assert "/js/websocket-sync.js?v=skybridge-auth-ready-1" in html
-    assert "/touch/js/skybridge.js?v=skybridge-auth-card-1" in html
-    assert "/touch/js/skybridge-renderer.js?v=skybridge-auth-card-1" in html
-    assert "/js/touch-ui-executor.js?v=skybridge-auth-card-1" in html
+    assert "/touch/js/skybridge.js?v=skybridge-auth-identity-1" in html
+    assert "/touch/js/skybridge-renderer.js?v=skybridge-auth-identity-1" in html
+    assert "/js/touch-ui-executor.js?v=skybridge-auth-identity-1" in html
     assert "initPush(panelId, sessionId)" in sync
     assert "params.set('panel_id', panelId)" in sync
     assert "else params.set('channel', 'all')" in sync
@@ -212,8 +212,9 @@ def test_skybridge_uses_backend_status_contract():
     assert "contextLabelFor(intent)" in app
     assert "isDataQuery(query)" in app
     assert "resp.status === 401 || resp.status === 503" in app
-    assert "const panelId = new URLSearchParams(location.search).get('panel_id')" in app
-    assert app.count("if (!route) route = '/touch/index.html' + (panelId ? '?panel_id=' + encodeURIComponent(panelId) : '');") >= 2
+    assert "function prepareAuthRoute" in app
+    assert "function buildLoginRoute(panelId)" in app
+    assert "return route || buildLoginRoute(panelId)" in app
     assert "if (voice) voice.sendText(query)" in app
     assert "event.role === 'user') projectCards" not in app
     assert "projectCommand(query);\n        if (voice) voice.sendText(query);" not in app
@@ -290,7 +291,7 @@ def test_skybridge_renderer_supports_real_data_cards():
     assert "sky-event-row" in html
     assert "sky-weather-hour-tile" in html
     assert "sky-weather-day-row" in html
-    assert "/touch/css/skybridge-data-widgets.css?v=skybridge-auth-card-1" in html
+    assert "/touch/css/skybridge-data-widgets.css?v=skybridge-auth-identity-1" in html
     assert "skybridge-lists-people-widgets" not in html
     assert "sky-list-item-row" in data_widgets_css
     assert "sky-person-row" in data_widgets_css
@@ -414,10 +415,26 @@ def test_skybridge_auth_challenge_card_contract():
     assert "const finalStep = props.final_step || 'Return to Zoe'" in renderer
     assert "escapeHtml(finalStep)" in renderer
     assert "escapeHtml(action)" not in renderer[renderer.index("function renderAuthChallenge"):renderer.index("function renderStatus")]
+    assert "data-auth-profiles" in renderer
+    assert "sky-auth-profile-grid" in renderer
+    assert "data-user-id" in renderer
+    assert "data-user-name" in renderer
+    assert "data-user-avatar" in renderer
     assert "data-challenge-id" in renderer
     assert "data-action-context" in renderer
     assert "btn.dataset.skyAction === 'auth'" in app
-    assert "if (!route) route = '/touch/index.html'" in app
+    assert "function hydrateAuthCard" in app
+    assert "AbortController" in app
+    assert "node.dataset.authHydrationId" in app
+    assert "!node.isConnected" in app
+    assert "function authNameMatches" in app
+    assert "wanted.includes(name)" not in app
+    assert "/api/auth/profiles?panel_id=" in app
+    assert "window.SkybridgeHydrateAuthCard = hydrateAuthCard" in app
+    assert "trySelectAuthProfile" in app
+    assert "selected_user_id" in app
+    assert "if (!route) route = '/touch/index.html'" not in app
+    assert "return route || buildLoginRoute(panelId)" in app
     assert "encodeURIComponent(panelId)" in app
     assert "storedChallenge.panel_id" in app
     assert "zoe_panel_auth_challenge" in app
@@ -426,11 +443,18 @@ def test_skybridge_auth_challenge_card_contract():
     assert "renderSkybridgeAuthChallenge(payload)" in executor
     assert "component: 'auth_challenge'" in executor
     assert "buildTouchLoginRoute(panelId)" in executor
+    assert "window.SkybridgeHydrateAuthCard" in executor
     assert "redirectToTouchLogin" in executor
     assert "sky-card.auth-challenge" in css
     assert "sky-auth-scene" in css
+    assert "sky-auth-profile" in css
+    assert "sky-auth-footer" in css
     assert '"component": "auth_challenge"' in service
     assert '"route": ""' in service
+    touch_index = read(UI / "index.html")
+    assert "parsed && (parsed.challenge_id || parsed.selected_user_id)" in touch_index
+    assert "const preferredUserId = pending && pending.selected_user_id" in touch_index
+    assert "!pending.challenge_id" in touch_index
     assert '"summary": "Please authenticate on the touch panel to continue."' in voice
     assert '"challenge_id": challenge_id' in voice
 

--- a/services/zoe-ui/dist/js/touch-ui-executor.js
+++ b/services/zoe-ui/dist/js/touch-ui-executor.js
@@ -687,6 +687,10 @@ body.light-mode #zvo-header { border-bottom-color: rgba(0,0,0,0.07); }
             wrap.style.animationDelay = `${Math.min(index * 90, 360)}ms`;
             wrap.innerHTML = sanitizeSkybridgeHtml(window.SkybridgeRenderer.render(card));
             cardRoot.appendChild(wrap);
+            try {
+                const node = wrap.firstElementChild;
+                if (window.SkybridgeHydrateAuthCard && node) window.SkybridgeHydrateAuthCard(node, card);
+            } catch (_) {}
         });
         try {
             document.body.classList.remove('sky-empty');

--- a/services/zoe-ui/dist/touch/css/skybridge-data-widgets.css
+++ b/services/zoe-ui/dist/touch/css/skybridge-data-widgets.css
@@ -487,3 +487,249 @@ body:not(.sky-empty) .sky-auth-steps span {
         grid-template-columns: minmax(0, 1fr);
     }
 }
+
+
+/* Skybridge identity auth card */
+body:not(.sky-empty) .sky-card.auth-challenge {
+    background:
+        radial-gradient(circle at 14% 10%, rgba(106, 231, 255, 0.34), transparent 30%),
+        radial-gradient(circle at 88% 4%, rgba(149, 116, 255, 0.30), transparent 34%),
+        linear-gradient(150deg, rgba(28, 34, 52, 0.94), rgba(8, 10, 18, 0.98) 58%, rgba(4, 7, 14, 0.99)) !important;
+    border: 1px solid rgba(255,255,255,0.18) !important;
+    box-shadow: 0 28px 88px rgba(0,0,0,0.38), inset 0 1px 0 rgba(255,255,255,0.14) !important;
+    padding: clamp(22px, 3vw, 34px) !important;
+}
+
+body:not(.sky-empty) .sky-auth-scene {
+    display: grid;
+    grid-template-columns: minmax(0, 0.92fr) minmax(320px, 1.08fr);
+    gap: clamp(22px, 3vw, 36px);
+    align-items: stretch;
+}
+
+body:not(.sky-empty) .sky-auth-hero {
+    min-height: 330px;
+    border-radius: 34px;
+    padding: clamp(24px, 3vw, 34px);
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    background:
+        linear-gradient(150deg, rgba(255,255,255,0.14), rgba(255,255,255,0.045)),
+        radial-gradient(circle at 28% 22%, rgba(90,224,224,0.24), transparent 42%);
+    border: 1px solid rgba(255,255,255,0.16);
+    box-shadow: inset 0 1px 0 rgba(255,255,255,0.14);
+}
+
+body:not(.sky-empty) .sky-auth-orb {
+    width: clamp(118px, 15vw, 168px);
+    height: clamp(118px, 15vw, 168px);
+    border-radius: 50%;
+    display: grid;
+    place-items: center;
+    background:
+        radial-gradient(circle at 30% 24%, rgba(255,255,255,0.98), rgba(104,238,234,0.88) 23%, rgba(124,91,255,0.76) 57%, rgba(16,23,38,0.95) 100%);
+    box-shadow: 0 0 74px rgba(90,224,224,0.32), 0 18px 54px rgba(0,0,0,0.32), inset 0 1px 22px rgba(255,255,255,0.48);
+}
+
+body:not(.sky-empty) .sky-auth-orb span {
+    width: 39%;
+    height: 39%;
+    border-radius: 36%;
+    background: rgba(5,9,17,0.46);
+    border: 1px solid rgba(255,255,255,0.26);
+}
+
+body:not(.sky-empty) .sky-auth-copy span {
+    display: inline-flex;
+    width: fit-content;
+    border-radius: 999px;
+    padding: 8px 12px;
+    background: rgba(255,255,255,0.12);
+    border: 1px solid rgba(255,255,255,0.14);
+    color: rgba(255,255,255,0.78);
+    font-size: 0.72rem;
+    font-weight: 850;
+    text-transform: uppercase;
+}
+
+body:not(.sky-empty) .sky-auth-copy strong {
+    display: block;
+    max-width: 11ch;
+    margin-top: 18px;
+    color: #fff;
+    font-size: clamp(2.4rem, 5vw, 4.8rem);
+    line-height: 0.92;
+    letter-spacing: 0;
+}
+
+body:not(.sky-empty) .sky-auth-copy p {
+    max-width: 35ch;
+    margin: 18px 0 0;
+    color: rgba(255,255,255,0.72);
+    font-size: clamp(1rem, 1.6vw, 1.22rem);
+    line-height: 1.45;
+}
+
+body:not(.sky-empty) .sky-auth-profile-grid {
+    display: grid;
+    align-content: center;
+    gap: 14px;
+    min-height: 330px;
+}
+
+body:not(.sky-empty) .sky-auth-profile {
+    appearance: none;
+    width: 100%;
+    min-height: 92px;
+    border: 1px solid rgba(255,255,255,0.15);
+    border-radius: 28px;
+    padding: 14px 16px;
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    gap: 16px;
+    align-items: center;
+    color: #fff;
+    text-align: left;
+    cursor: pointer;
+    background:
+        linear-gradient(135deg, rgba(255,255,255,0.15), rgba(255,255,255,0.055)),
+        rgba(255,255,255,0.055);
+    box-shadow: inset 0 1px 0 rgba(255,255,255,0.12), 0 14px 34px rgba(0,0,0,0.18);
+    transition: transform 180ms ease, border-color 180ms ease, background 180ms ease, box-shadow 180ms ease;
+}
+
+body:not(.sky-empty) .sky-auth-profile:hover,
+body:not(.sky-empty) .sky-auth-profile:focus-visible {
+    transform: translateY(-2px);
+    border-color: rgba(108, 235, 241, 0.52);
+    background:
+        linear-gradient(135deg, rgba(112,232,238,0.22), rgba(137,112,255,0.12)),
+        rgba(255,255,255,0.075);
+    box-shadow: 0 18px 48px rgba(74, 209, 226, 0.12), inset 0 1px 0 rgba(255,255,255,0.18);
+}
+
+body:not(.sky-empty) .sky-auth-profile.is-default {
+    border-color: rgba(122, 246, 230, 0.42);
+}
+
+body:not(.sky-empty) .sky-auth-avatar {
+    width: 62px;
+    height: 62px;
+    border-radius: 23px;
+    display: grid;
+    place-items: center;
+    color: rgba(5,9,18,0.94);
+    font-size: 1.45rem;
+    font-weight: 950;
+    background: linear-gradient(135deg, #7df3ef, #8e7cff 62%, #f7fbff);
+    box-shadow: inset 0 1px 0 rgba(255,255,255,0.58), 0 12px 28px rgba(0,0,0,0.24);
+}
+
+body:not(.sky-empty) .sky-auth-person {
+    min-width: 0;
+    display: grid;
+    gap: 4px;
+}
+
+body:not(.sky-empty) .sky-auth-person strong {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: clamp(1.1rem, 2.1vw, 1.55rem);
+    line-height: 1.05;
+    font-weight: 900;
+}
+
+body:not(.sky-empty) .sky-auth-person small {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: rgba(255,255,255,0.58);
+    font-size: 0.82rem;
+    font-weight: 800;
+    text-transform: capitalize;
+}
+
+body:not(.sky-empty) .sky-auth-enter {
+    min-width: 58px;
+    border-radius: 999px;
+    padding: 9px 12px;
+    text-align: center;
+    color: rgba(6,10,18,0.96);
+    background: linear-gradient(135deg, #8ff8f2, #a7b6ff);
+    font-weight: 950;
+    font-size: 0.78rem;
+}
+
+body:not(.sky-empty) .sky-auth-loading,
+body:not(.sky-empty) .sky-auth-empty {
+    min-height: 180px;
+    border-radius: 28px;
+    display: grid;
+    place-items: center;
+    gap: 14px;
+    text-align: center;
+    color: rgba(255,255,255,0.68);
+    background: rgba(255,255,255,0.07);
+    border: 1px solid rgba(255,255,255,0.12);
+    font-weight: 800;
+}
+
+body:not(.sky-empty) .sky-auth-loading i {
+    width: 42px;
+    height: 42px;
+    border-radius: 50%;
+    border: 3px solid rgba(255,255,255,0.18);
+    border-top-color: rgba(122,246,230,0.88);
+    animation: sky-auth-spin 900ms linear infinite;
+}
+
+body:not(.sky-empty) .sky-auth-footer {
+    grid-column: 1 / -1;
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 10px;
+}
+
+body:not(.sky-empty) .sky-auth-footer span {
+    min-height: 48px;
+    border-radius: 18px;
+    display: grid;
+    place-items: center;
+    padding: 10px;
+    color: rgba(255,255,255,0.68);
+    background: rgba(255,255,255,0.07);
+    border: 1px solid rgba(255,255,255,0.10);
+    font-size: 0.82rem;
+    font-weight: 850;
+    text-align: center;
+}
+
+@keyframes sky-auth-spin {
+    to { transform: rotate(360deg); }
+}
+
+@media (max-width: 900px) {
+    body:not(.sky-empty) .sky-auth-scene {
+        grid-template-columns: minmax(0, 1fr);
+    }
+    body:not(.sky-empty) .sky-auth-hero {
+        min-height: 250px;
+    }
+    body:not(.sky-empty) .sky-auth-profile-grid {
+        min-height: 0;
+    }
+}
+
+@media (max-width: 620px) {
+    body:not(.sky-empty) .sky-auth-profile {
+        grid-template-columns: auto minmax(0, 1fr);
+    }
+    body:not(.sky-empty) .sky-auth-enter {
+        grid-column: 1 / -1;
+    }
+    body:not(.sky-empty) .sky-auth-footer {
+        grid-template-columns: minmax(0, 1fr);
+    }
+}

--- a/services/zoe-ui/dist/touch/index.html
+++ b/services/zoe-ui/dist/touch/index.html
@@ -1097,14 +1097,17 @@
 
             renderProfiles();
 
-            // If the panel declares a default user and that user is present,
-            // skip the picker and jump straight to PIN entry.
-            if (panelContext.default_user_id) {
-                const defaultProfile = userProfiles.find(p => p.user_id === panelContext.default_user_id);
-                if (defaultProfile) {
-                    const avatar = defaultProfile.avatar
-                        || (defaultProfile.username ? defaultProfile.username.charAt(0).toUpperCase() : '?');
-                    selectProfile(defaultProfile.user_id, defaultProfile.username, avatar);
+            const pending = getPendingPanelChallenge();
+            const preferredUserId = pending && pending.selected_user_id
+                ? pending.selected_user_id
+                : panelContext.default_user_id;
+            if (preferredUserId) {
+                const preferredProfile = userProfiles.find(p => p.user_id === preferredUserId);
+                if (preferredProfile) {
+                    const avatar = pending && pending.selected_avatar
+                        ? pending.selected_avatar
+                        : (preferredProfile.avatar || (preferredProfile.username ? preferredProfile.username.charAt(0).toUpperCase() : '?'));
+                    selectProfile(preferredProfile.user_id, preferredProfile.username, avatar);
                 }
             }
         }
@@ -1160,7 +1163,7 @@
                 const raw = sessionStorage.getItem('zoe_panel_auth_challenge');
                 if (!raw) return null;
                 const parsed = JSON.parse(raw);
-                return parsed && parsed.challenge_id ? parsed : null;
+                return parsed && (parsed.challenge_id || parsed.selected_user_id) ? parsed : null;
             } catch (_) {
                 return null;
             }
@@ -1168,7 +1171,7 @@
 
         async function resolvePendingPanelChallenge(pinValue) {
             const pending = getPendingPanelChallenge();
-            if (!pending || !pinValue) return true;
+            if (!pending || !pending.challenge_id || !pinValue) return true;
             try {
                 const payload = {
                     challenge_id: pending.challenge_id,

--- a/services/zoe-ui/dist/touch/js/skybridge-renderer.js
+++ b/services/zoe-ui/dist/touch/js/skybridge-renderer.js
@@ -19,8 +19,11 @@
         const route = escapeHtml(action.route || '');
         const challengeId = escapeHtml(action.challenge_id || '');
         const actionContext = escapeHtml(action.action_context || action.reason || '');
+        const userId = escapeHtml(action.user_id || '');
+        const userName = escapeHtml(action.username || action.name || '');
+        const userAvatar = escapeHtml(action.avatar || '');
         const kind = action.kind === 'warn' ? ' warn' : (index === 0 ? ' primary' : '');
-        return '<button type="button" class="' + kind.trim() + '" data-sky-action="' + escapeHtml(action.type || 'query') + '" data-query="' + query + '" data-route="' + route + '" data-challenge-id="' + challengeId + '" data-action-context="' + actionContext + '">' + label + '</button>';
+        return '<button type="button" class="' + kind.trim() + '" data-sky-action="' + escapeHtml(action.type || 'query') + '" data-query="' + query + '" data-route="' + route + '" data-challenge-id="' + challengeId + '" data-action-context="' + actionContext + '" data-user-id="' + userId + '" data-user-name="' + userName + '" data-user-avatar="' + userAvatar + '">' + label + '</button>';
     }
 
     function safeClassTokens(value) {
@@ -75,17 +78,18 @@
         const finalStep = props.final_step || 'Return to Zoe';
         const bodyHtml = [
             '<div class="sky-auth-scene">',
+            '<div class="sky-auth-hero">',
             '<div class="sky-auth-orb" aria-hidden="true"><span></span></div>',
             '<div class="sky-auth-copy">',
             '<span>' + escapeHtml(domain) + '</span>',
             '<strong>' + escapeHtml(title) + '</strong>',
             '<p>' + escapeHtml(body) + '</p>',
             '</div>',
-            '<div class="sky-auth-steps" aria-label="Authentication steps">',
-            '<div><b>1</b><span>Choose profile</span></div>',
-            '<div><b>2</b><span>Enter PIN</span></div>',
-            '<div><b>3</b><span>' + escapeHtml(finalStep) + '</span></div>',
             '</div>',
+            '<div class="sky-auth-profile-grid" data-auth-profiles aria-label="Choose profile">',
+            '<div class="sky-auth-loading"><i></i><span>Finding people for this panel...</span></div>',
+            '</div>',
+            '<div class="sky-auth-footer"><span>Say a name or tap a profile.</span><span>PIN opens next.</span><span>' + escapeHtml(finalStep) + '</span></div>',
             '</div>'
         ].join('');
         return cardFrame(props, bodyHtml, { wide: true, tone: 'auth-challenge', hideHeader: true, hideStatus: true });

--- a/services/zoe-ui/dist/touch/js/skybridge.js
+++ b/services/zoe-ui/dist/touch/js/skybridge.js
@@ -13,6 +13,8 @@
     let voiceStartedByUser = false;
     let commandFallbackOpen = false;
     let skybridgeContext = {};
+    let authProfiles = [];
+    let authHydrationSequence = 0;
 
     const colors = {
         ambient: ['#5fc6ff', '#66d19e'],
@@ -97,24 +99,7 @@
             let route = btn.dataset.route;
             const query = btn.dataset.query;
             if (btn.dataset.skyAction === 'auth') {
-                let storedChallenge = {};
-                try { storedChallenge = JSON.parse(sessionStorage.getItem('zoe_panel_auth_challenge') || '{}') || {}; } catch (_) {}
-                const panelId = new URLSearchParams(location.search).get('panel_id') || localStorage.getItem('zoe_touch_panel_id') || storedChallenge.panel_id || '';
-                try {
-                    const challengeId = btn.dataset.challengeId || '';
-                    const actionContext = btn.dataset.actionContext || 'Enter PIN';
-                    if (challengeId) {
-                        sessionStorage.setItem('zoe_panel_auth_challenge', JSON.stringify({
-                            challenge_id: challengeId,
-                            panel_id: panelId,
-                            action_context: actionContext
-                        }));
-                    }
-                    sessionStorage.setItem('zoe_redirect_after_login', location.pathname + location.search);
-                    if (!route) route = '/touch/index.html' + (panelId ? '?panel_id=' + encodeURIComponent(panelId) : '');
-                } catch (_) {
-                    if (!route) route = '/touch/index.html' + (panelId ? '?panel_id=' + encodeURIComponent(panelId) : '');
-                }
+                route = prepareAuthRoute(btn, route);
             }
             if (route && route.startsWith('/')) {
                 location.href = route;
@@ -124,6 +109,44 @@
                 submitCommand(query);
             }
         });
+    }
+
+    function currentPanelId(storedChallenge) {
+        return new URLSearchParams(location.search).get('panel_id')
+            || localStorage.getItem('zoe_touch_panel_id')
+            || localStorage.getItem('zoe_panel_id')
+            || (storedChallenge && storedChallenge.panel_id)
+            || '';
+    }
+
+    function buildLoginRoute(panelId) {
+        return '/touch/index.html' + (panelId ? '?panel_id=' + encodeURIComponent(panelId) : '');
+    }
+
+    function prepareAuthRoute(btn, route) {
+        let storedChallenge = {};
+        try { storedChallenge = JSON.parse(sessionStorage.getItem('zoe_panel_auth_challenge') || '{}') || {}; } catch (_) {}
+        const panelId = currentPanelId(storedChallenge);
+        const challengeId = btn.dataset.challengeId || storedChallenge.challenge_id || '';
+        const actionContext = btn.dataset.actionContext || storedChallenge.action_context || 'Enter PIN';
+        const selectedUserId = btn.dataset.userId || storedChallenge.selected_user_id || '';
+        const selectedUsername = btn.dataset.userName || storedChallenge.selected_username || '';
+        const selectedAvatar = btn.dataset.userAvatar || storedChallenge.selected_avatar || '';
+        const authState = Object.assign({}, storedChallenge, {
+            challenge_id: challengeId,
+            panel_id: panelId,
+            action_context: actionContext,
+            selected_user_id: selectedUserId,
+            selected_username: selectedUsername,
+            selected_avatar: selectedAvatar
+        });
+        try {
+            sessionStorage.setItem('zoe_panel_auth_challenge', JSON.stringify(authState));
+            sessionStorage.setItem('zoe_redirect_after_login', location.pathname + location.search);
+        } catch (_) {
+            // Route still preserves panel id even when storage is unavailable.
+        }
+        return route || buildLoginRoute(panelId);
     }
 
     function setMode(nextMode) {
@@ -147,6 +170,7 @@
         } else if (event.type === 'state') {
             setState(event.state || 'ambient');
         } else if (event.type === 'transcript') {
+            if (event.role === 'user' && trySelectAuthProfile(event.text)) return;
             addTranscript(event.role, event.text);
         } else if (event.type === 'card') {
             addCard(event.card, true);
@@ -167,6 +191,10 @@
     async function submitCommand(text) {
         const query = String(text || '').trim();
         if (!query) return;
+        if (trySelectAuthProfile(query)) {
+            els.input.value = '';
+            return;
+        }
         currentUtterance = 'Heard: ' + query;
         els.copy.textContent = currentUtterance;
         addTranscript('user', query);
@@ -361,9 +389,103 @@
         } else {
             els.cards.appendChild(node);
         }
+        hydrateAuthCard(node, card);
         while (els.cards.children.length > 8) {
             els.cards.removeChild(els.cards.lastElementChild);
         }
+    }
+
+    async function hydrateAuthCard(node, card) {
+        if (!node || !node.classList || !node.classList.contains('auth-challenge')) return;
+        const target = node.querySelector('[data-auth-profiles]');
+        if (!target) return;
+        const hydrationId = String(++authHydrationSequence);
+        node.dataset.authHydrationId = hydrationId;
+        const props = (card && card.props) || {};
+        const panelId = currentPanelId({});
+        let profiles = Array.isArray(props.profiles) ? props.profiles : [];
+        let defaultUserId = props.default_user_id || '';
+        const controller = typeof AbortController !== 'undefined' ? new AbortController() : null;
+        const timeoutId = controller ? setTimeout(() => controller.abort(), 8000) : null;
+        try {
+            const url = panelId ? '/api/auth/profiles?panel_id=' + encodeURIComponent(panelId) : '/api/auth/profiles';
+            const resp = await fetch(url, {
+                headers: { 'Accept': 'application/json' },
+                signal: controller ? controller.signal : undefined
+            });
+            if (resp.ok) {
+                const data = await resp.json();
+                if (Array.isArray(data)) {
+                    profiles = data;
+                } else if (data && Array.isArray(data.profiles)) {
+                    profiles = data.profiles;
+                    defaultUserId = data.default_user_id || defaultUserId;
+                }
+            }
+        } catch (_) {
+            // Keep any profiles already supplied with the card.
+        } finally {
+            if (timeoutId) clearTimeout(timeoutId);
+        }
+        if (!node.isConnected || node.dataset.authHydrationId !== hydrationId) return;
+        const nextProfiles = profiles.filter(profile => profile && profile.user_id && profile.user_id !== 'guest');
+        authProfiles = nextProfiles;
+        renderAuthProfiles(target, nextProfiles, defaultUserId, props);
+    }
+
+    function authInitials(profile) {
+        const raw = String(profile.avatar || profile.username || profile.name || profile.user_id || '?').trim();
+        return raw.charAt(0).toUpperCase() || '?';
+    }
+
+    function renderAuthProfiles(target, profiles, defaultUserId, props) {
+        if (!profiles.length) {
+            target.innerHTML = '<div class="sky-auth-empty">No profiles are linked to this panel yet.</div>';
+            return;
+        }
+        const baseAction = props.actions && props.actions[0] ? props.actions[0] : {};
+        target.innerHTML = profiles.map(profile => {
+            const name = window.SkybridgeRenderer.escapeHtml(profile.username || profile.name || profile.user_id);
+            const role = window.SkybridgeRenderer.escapeHtml(profile.role || (profile.user_id === defaultUserId ? 'Default profile' : 'Profile'));
+            const avatar = window.SkybridgeRenderer.escapeHtml(authInitials(profile));
+            const userId = window.SkybridgeRenderer.escapeHtml(profile.user_id);
+            const selected = profile.user_id === defaultUserId ? ' is-default' : '';
+            const challengeId = window.SkybridgeRenderer.escapeHtml(baseAction.challenge_id || '');
+            const actionContext = window.SkybridgeRenderer.escapeHtml(baseAction.action_context || 'Enter PIN');
+            return '<button type="button" class="sky-auth-profile' + selected + '" data-sky-action="auth" data-route="" data-challenge-id="' + challengeId + '" data-action-context="' + actionContext + '" data-user-id="' + userId + '" data-user-name="' + name + '" data-user-avatar="' + avatar + '">' +
+                '<span class="sky-auth-avatar">' + avatar + '</span>' +
+                '<span class="sky-auth-person"><strong>' + name + '</strong><small>' + role + '</small></span>' +
+                '<span class="sky-auth-enter">PIN</span>' +
+                '</button>';
+        }).join('');
+    }
+
+    function normalizeProfileName(value) {
+        return String(value || '').trim().toLowerCase().replace(/[^a-z0-9]+/g, ' ' ).trim();
+    }
+
+    function authNameMatches(wanted, profile) {
+        const name = normalizeProfileName(profile.username || profile.name || profile.user_id);
+        const userId = normalizeProfileName(profile.user_id);
+        if (!name) return false;
+        if (wanted === name || wanted === userId) return true;
+        const spoken = wanted.replace(/^(i am|i'm|this is|it is|it's|its|select|choose|use|as)\s+/, '').replace(/\s+(please|thanks)$/,'').trim();
+        if (spoken === name || spoken === userId) return true;
+        const tokens = wanted.split(/\s+/).filter(Boolean);
+        if (!name.includes(' ') && name.length >= 2 && tokens.includes(name)) return true;
+        return name.includes(' ') && (' ' + wanted + ' ').includes(' ' + name + ' ');
+    }
+
+    function trySelectAuthProfile(text) {
+        if (!document.querySelector('.sky-card.auth-challenge') || !authProfiles.length) return false;
+        const wanted = normalizeProfileName(text);
+        if (!wanted) return false;
+        const match = authProfiles.find(profile => authNameMatches(wanted, profile));
+        if (!match) return false;
+        const button = els.cards.querySelector('button.sky-auth-profile[data-user-id="' + CSS.escape(match.user_id) + '"]');
+        if (!button) return false;
+        button.click();
+        return true;
     }
 
     function setContext(title, detail) {
@@ -580,6 +702,8 @@
         };
         draw();
     }
+
+    window.SkybridgeHydrateAuthCard = hydrateAuthCard;
 
     window.addEventListener('beforeunload', () => {
         if (animationFrame) cancelAnimationFrame(animationFrame);

--- a/services/zoe-ui/dist/touch/skybridge.html
+++ b/services/zoe-ui/dist/touch/skybridge.html
@@ -23,7 +23,7 @@
     <meta name="theme-color" content="#0b0d12">
     <title>Zoe Skybridge</title>
     <link rel="stylesheet" href="/touch/css/touch-adapter.css">
-    <link rel="stylesheet" href="/touch/css/skybridge-data-widgets.css?v=skybridge-auth-card-1">
+    <link rel="stylesheet" href="/touch/css/skybridge-data-widgets.css?v=skybridge-auth-identity-1">
     <script src="/lib/livekit/livekit-client.umd.min.js" onerror="console.warn('LiveKit client not loaded')"></script>
     <style>
         :root {
@@ -4396,10 +4396,10 @@
     <script src="/js/websocket-sync.js?v=skybridge-auth-ready-1"></script>
     <script src="/touch/js/gestures.js?v=skybridge-auth-ready-1"></script>
     <script src="/touch/js/touch-menu.js?v=skybridge-auth-ready-1"></script>
-    <script src="/js/touch-ui-executor.js?v=skybridge-auth-card-1"></script>
+    <script src="/js/touch-ui-executor.js?v=skybridge-auth-identity-1"></script>
     <script src="/touch/js/skybridge-capabilities.js?v=skybridge-push-ack-1"></script>
-    <script src="/touch/js/skybridge-renderer.js?v=skybridge-auth-card-1"></script>
+    <script src="/touch/js/skybridge-renderer.js?v=skybridge-auth-identity-1"></script>
     <script src="/touch/js/skybridge-voice.js?v=skybridge-push-ack-1"></script>
-    <script src="/touch/js/skybridge.js?v=skybridge-auth-card-1"></script>
+    <script src="/touch/js/skybridge.js?v=skybridge-auth-identity-1"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace the generic Skybridge auth challenge with a profile picker card hydrated from /api/auth/profiles for the current panel
- allow tapping a profile or saying/typing a visible profile name to continue into PIN auth
- carry selected profile context into the touch login page so PIN entry opens for the chosen user
- hook the same hydration path into voice-pushed auth cards and bump Skybridge asset versions

## Tests
- python3 -m pytest -q services/zoe-data/tests/test_skybridge_static.py services/zoe-data/tests/test_skybridge_service.py services/zoe-data/tests/test_voice_weather_queue.py services/zoe-data/tests/test_ui_actions_ack.py services/zoe-data/tests/test_ui_orchestrator_types.py