### PR TITLE
Add Pi promotion scoring harness

### DIFF
--- a/scripts/maintenance/pi_promotion_eval.py
+++ b/scripts/maintenance/pi_promotion_eval.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Run or report Pi-vs-Zoe intent promotion evidence.
+
+Default mode is side-effect free and prints the built-in eval fixture plus an
+empty policy report. Use --demo for deterministic promotion-gate smoke data, or
+--run-pi to compare Zoe's current router with the configured local Pi runtime.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+import time
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "services" / "zoe-data"))
+
+from intent_router import detect_and_extract_intent  # noqa: E402
+from pi_intent_classifier import classify_with_pi_intent_governor  # noqa: E402
+from zoe_pi_promotion import (  # noqa: E402
+    DEFAULT_PI_INTENT_EVAL_CASES,
+    PiIntentEvalCase,
+    PiPromotionPolicy,
+    PiRouteSample,
+    eval_cases_to_dict,
+    summarize_pi_promotion,
+)
+
+
+@contextmanager
+def _temporary_env(updates: dict[str, str | None]):
+    old_values = {key: os.environ.get(key) for key in updates}
+    try:
+        for key, value in updates.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+        yield
+    finally:
+        for key, value in old_values.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+
+def _demo_samples() -> list[PiRouteSample]:
+    samples: list[PiRouteSample] = []
+    for index in range(30):
+        samples.append(
+            PiRouteSample(
+                case_id=f"demo_weather_{index}",
+                intent_group="weather",
+                expected_intent="weather",
+                zoe_intent="reminder_list" if index < 20 else "weather",
+                pi_intent="weather",
+                zoe_latency_ms=850,
+                pi_latency_ms=320,
+                pi_confidence=0.9,
+                pi_transport="rpc",
+            )
+        )
+    return samples
+
+
+async def _run_zoe_baseline(case: PiIntentEvalCase) -> dict[str, Any]:
+    with _temporary_env({"ZOE_PI_INTENT_ENABLED": "false"}):
+        start = time.perf_counter()
+        intent = await detect_and_extract_intent(case.text)
+        latency_ms = (time.perf_counter() - start) * 1000
+    return {
+        "intent": intent.name if intent else None,
+        "confidence": getattr(intent, "confidence", None) if intent else None,
+        "latency_ms": latency_ms,
+        "correct": (intent.name if intent else None) == case.expected_intent,
+    }
+
+
+async def _run_pi(case: PiIntentEvalCase, *, transport: str, enable_execution: bool, local_model_configured: bool) -> dict[str, Any]:
+    updates = {
+        "ZOE_PI_INTENT_ENABLED": "true",
+        "ZOE_PI_INTENT_TRANSPORT": transport,
+        "ZOE_PI_ALLOW_EXECUTION": "true" if enable_execution else "false",
+        "ZOE_PI_LOCAL_MODEL_CONFIGURED": "true" if local_model_configured else "false",
+    }
+    with _temporary_env(updates):
+        start = time.perf_counter()
+        result = await classify_with_pi_intent_governor(case.text)
+        latency_ms = (time.perf_counter() - start) * 1000
+    return {
+        "intent": result.intent if result else None,
+        "confidence": result.confidence if result else 0.0,
+        "latency_ms": latency_ms,
+        "correct": (result.intent if result else None) == case.expected_intent,
+        "timed_out": result is None,
+    }
+
+
+async def _run_cases(*, run_pi: bool, transport: str, enable_execution: bool, local_model_configured: bool) -> tuple[list[dict[str, Any]], list[PiRouteSample]]:
+    comparisons: list[dict[str, Any]] = []
+    samples: list[PiRouteSample] = []
+    for case in DEFAULT_PI_INTENT_EVAL_CASES:
+        case.validate()
+        zoe = await _run_zoe_baseline(case)
+        pi = None
+        if run_pi:
+            pi = await _run_pi(
+                case,
+                transport=transport,
+                enable_execution=enable_execution,
+                local_model_configured=local_model_configured,
+            )
+        comparisons.append({"case": case.to_dict(), "zoe": zoe, "pi": pi})
+        if pi and not case.negative and case.intent_group != "chat":
+            samples.append(
+                PiRouteSample(
+                    case_id=case.case_id,
+                    intent_group=case.intent_group,
+                    expected_intent=case.expected_intent,
+                    zoe_intent=zoe["intent"],
+                    pi_intent=pi["intent"],
+                    zoe_latency_ms=float(zoe["latency_ms"]),
+                    pi_latency_ms=float(pi["latency_ms"]),
+                    pi_confidence=float(pi["confidence"] or 0),
+                    pi_transport=transport,
+                    route_class=case.route_class,
+                    timed_out=bool(pi["timed_out"]),
+                )
+            )
+    return comparisons, samples
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Report Pi intent promotion gates")
+    parser.add_argument("--demo", action="store_true", help="Include deterministic demo samples for policy smoke testing")
+    parser.add_argument("--run-pi", action="store_true", help="Run configured local Pi against built-in eval cases")
+    parser.add_argument("--transport", choices=["print", "rpc"], default="rpc")
+    parser.add_argument("--allow-execution", action="store_true", help="Temporarily set ZOE_PI_ALLOW_EXECUTION=true")
+    parser.add_argument("--local-model-configured", action="store_true", help="Temporarily set ZOE_PI_LOCAL_MODEL_CONFIGURED=true")
+    parser.add_argument("--min-samples", type=int, default=30)
+    args = parser.parse_args()
+
+    policy = PiPromotionPolicy(min_samples=args.min_samples)
+    comparisons: list[dict[str, Any]] = []
+    samples: list[PiRouteSample] = []
+    if args.demo:
+        samples.extend(_demo_samples())
+    if args.run_pi:
+        comparisons, measured_samples = asyncio.run(
+            _run_cases(
+                run_pi=True,
+                transport=args.transport,
+                enable_execution=args.allow_execution,
+                local_model_configured=args.local_model_configured,
+            )
+        )
+        samples.extend(measured_samples)
+    payload = {
+        "eval_cases": eval_cases_to_dict(DEFAULT_PI_INTENT_EVAL_CASES),
+        "comparisons": comparisons,
+        "promotion_report": summarize_pi_promotion(samples, policy=policy),
+    }
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/maintenance/pi_promotion_eval.py
+++ b/scripts/maintenance/pi_promotion_eval.py
@@ -21,8 +21,6 @@ from typing import Any
 ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT / "services" / "zoe-data"))
 
-from intent_router import detect_and_extract_intent  # noqa: E402
-from pi_intent_classifier import classify_with_pi_intent_governor  # noqa: E402
 from zoe_pi_promotion import (  # noqa: E402
     DEFAULT_PI_INTENT_EVAL_CASES,
     PiIntentEvalCase,

--- a/scripts/maintenance/pi_promotion_eval.py
+++ b/scripts/maintenance/pi_promotion_eval.py
@@ -70,6 +70,8 @@ def _demo_samples() -> list[PiRouteSample]:
 
 async def _run_zoe_baseline(case: PiIntentEvalCase) -> dict[str, Any]:
     with _temporary_env({"ZOE_PI_INTENT_ENABLED": "false"}):
+        from intent_router import detect_and_extract_intent
+
         start = time.perf_counter()
         intent = await detect_and_extract_intent(case.text)
         latency_ms = (time.perf_counter() - start) * 1000
@@ -82,6 +84,8 @@ async def _run_zoe_baseline(case: PiIntentEvalCase) -> dict[str, Any]:
 
 
 async def _run_pi(case: PiIntentEvalCase, *, transport: str, enable_execution: bool, local_model_configured: bool) -> dict[str, Any]:
+    from pi_intent_classifier import classify_with_pi_intent_governor
+
     updates = {
         "ZOE_PI_INTENT_ENABLED": "true",
         "ZOE_PI_INTENT_TRANSPORT": transport,
@@ -101,22 +105,20 @@ async def _run_pi(case: PiIntentEvalCase, *, transport: str, enable_execution: b
     }
 
 
-async def _run_cases(*, run_pi: bool, transport: str, enable_execution: bool, local_model_configured: bool) -> tuple[list[dict[str, Any]], list[PiRouteSample]]:
+async def _run_cases(*, transport: str, enable_execution: bool, local_model_configured: bool) -> tuple[list[dict[str, Any]], list[PiRouteSample]]:
     comparisons: list[dict[str, Any]] = []
     samples: list[PiRouteSample] = []
     for case in DEFAULT_PI_INTENT_EVAL_CASES:
         case.validate()
         zoe = await _run_zoe_baseline(case)
-        pi = None
-        if run_pi:
-            pi = await _run_pi(
-                case,
-                transport=transport,
-                enable_execution=enable_execution,
-                local_model_configured=local_model_configured,
-            )
+        pi = await _run_pi(
+            case,
+            transport=transport,
+            enable_execution=enable_execution,
+            local_model_configured=local_model_configured,
+        )
         comparisons.append({"case": case.to_dict(), "zoe": zoe, "pi": pi})
-        if pi and not case.negative and case.intent_group != "chat":
+        if not case.negative and case.intent_group != "chat":
             samples.append(
                 PiRouteSample(
                     case_id=case.case_id,
@@ -153,7 +155,6 @@ def main() -> int:
     if args.run_pi:
         comparisons, measured_samples = asyncio.run(
             _run_cases(
-                run_pi=True,
                 transport=args.transport,
                 enable_execution=args.allow_execution,
                 local_model_configured=args.local_model_configured,

--- a/scripts/maintenance/pi_promotion_eval.py
+++ b/scripts/maintenance/pi_promotion_eval.py
@@ -84,8 +84,6 @@ async def _run_zoe_baseline(case: PiIntentEvalCase) -> dict[str, Any]:
 
 
 async def _run_pi(case: PiIntentEvalCase, *, transport: str, enable_execution: bool, local_model_configured: bool) -> dict[str, Any]:
-    from pi_intent_classifier import classify_with_pi_intent_governor
-
     updates = {
         "ZOE_PI_INTENT_ENABLED": "true",
         "ZOE_PI_INTENT_TRANSPORT": transport,
@@ -93,6 +91,8 @@ async def _run_pi(case: PiIntentEvalCase, *, transport: str, enable_execution: b
         "ZOE_PI_LOCAL_MODEL_CONFIGURED": "true" if local_model_configured else "false",
     }
     with _temporary_env(updates):
+        from pi_intent_classifier import classify_with_pi_intent_governor
+
         start = time.perf_counter()
         result = await classify_with_pi_intent_governor(case.text)
         latency_ms = (time.perf_counter() - start) * 1000

--- a/scripts/maintenance/pi_promotion_eval.py
+++ b/scripts/maintenance/pi_promotion_eval.py
@@ -23,6 +23,7 @@ sys.path.insert(0, str(ROOT / "services" / "zoe-data"))
 
 from zoe_pi_promotion import (  # noqa: E402
     DEFAULT_PI_INTENT_EVAL_CASES,
+    LOW_RISK_PI_INTENT_GROUPS,
     PiIntentEvalCase,
     PiPromotionPolicy,
     PiRouteSample,
@@ -145,6 +146,13 @@ def main() -> int:
     parser.add_argument("--allow-execution", action="store_true", help="Temporarily set ZOE_PI_ALLOW_EXECUTION=true")
     parser.add_argument("--local-model-configured", action="store_true", help="Temporarily set ZOE_PI_LOCAL_MODEL_CONFIGURED=true")
     parser.add_argument("--min-samples", type=int, default=30)
+    parser.add_argument(
+        "--promoted-group",
+        action="append",
+        choices=sorted(LOW_RISK_PI_INTENT_GROUPS),
+        default=[],
+        help="Intent group currently promoted through Pi; repeat for multiple groups",
+    )
     args = parser.parse_args()
 
     policy = PiPromotionPolicy(min_samples=args.min_samples)
@@ -164,7 +172,7 @@ def main() -> int:
     payload = {
         "eval_cases": eval_cases_to_dict(DEFAULT_PI_INTENT_EVAL_CASES),
         "comparisons": comparisons,
-        "promotion_report": summarize_pi_promotion(samples, policy=policy),
+        "promotion_report": summarize_pi_promotion(samples, policy=policy, promoted_groups=args.promoted_group),
     }
     print(json.dumps(payload, indent=2, sort_keys=True))
     return 0

--- a/services/zoe-data/tests/test_zoe_pi_promotion.py
+++ b/services/zoe-data/tests/test_zoe_pi_promotion.py
@@ -92,6 +92,16 @@ def test_promotion_blocks_non_allowlisted_groups():
     assert decision.blockers == ("intent_group_not_allowlisted",)
 
 
+def test_promoted_group_rolls_back_on_accuracy_regression():
+    samples = [_sample(i, zoe="weather", pi="reminder_list") for i in range(10)]
+    policy = PiPromotionPolicy(min_samples=10, accuracy_win_margin=0.05)
+
+    decision = evaluate_pi_promotion(samples, intent_group="weather", policy=policy, promoted=True)
+
+    assert decision.state == "rollback"
+    assert "accuracy_delta_below_threshold" in decision.blockers
+
+
 def test_promoted_group_rolls_back_on_timeout_regression():
     samples = [_sample(i) for i in range(9)] + [_sample(99, timed_out=True, pi=None, pi_ms=1200)]
     policy = PiPromotionPolicy(min_samples=10, max_timeout_rate=0.05)

--- a/services/zoe-data/tests/test_zoe_pi_promotion.py
+++ b/services/zoe-data/tests/test_zoe_pi_promotion.py
@@ -122,6 +122,16 @@ def test_promoted_group_rolls_back_when_evidence_stops():
     assert decision.blockers == ("insufficient_samples",)
 
 
+def test_promoted_group_rolls_back_when_evidence_is_too_thin():
+    samples = [_sample(1)]
+    policy = PiPromotionPolicy(min_samples=10)
+
+    decision = evaluate_pi_promotion(samples, intent_group="weather", policy=policy, promoted=True)
+
+    assert decision.state == "rollback"
+    assert "insufficient_samples" in decision.blockers
+
+
 def test_promoted_group_rolls_back_on_timeout_regression():
     samples = [_sample(i) for i in range(9)] + [_sample(99, timed_out=True, pi=None, pi_ms=1200)]
     policy = PiPromotionPolicy(min_samples=10, max_timeout_rate=0.05)

--- a/services/zoe-data/tests/test_zoe_pi_promotion.py
+++ b/services/zoe-data/tests/test_zoe_pi_promotion.py
@@ -46,6 +46,19 @@ def test_eval_case_rejects_privileged_expected_intent():
         case.validate()
 
 
+def test_eval_case_rejects_expected_intent_outside_group():
+    case = PiIntentEvalCase(
+        case_id="bad_group",
+        text="rain later",
+        expected_intent="reminder_list",
+        intent_group="weather",
+        route_class="fallback",
+    )
+
+    with pytest.raises(ValueError, match="expected_intent does not belong"):
+        case.validate()
+
+
 def test_intent_group_for_intent_maps_low_risk_groups_only():
     assert intent_group_for_intent("weather") == "weather"
     assert intent_group_for_intent("reminder_create") == "reminders"
@@ -100,6 +113,13 @@ def test_promoted_group_rolls_back_on_accuracy_regression():
 
     assert decision.state == "rollback"
     assert "accuracy_delta_below_threshold" in decision.blockers
+
+
+def test_promoted_group_rolls_back_when_evidence_stops():
+    decision = evaluate_pi_promotion([], intent_group="weather", policy=PiPromotionPolicy(min_samples=10), promoted=True)
+
+    assert decision.state == "rollback"
+    assert decision.blockers == ("insufficient_samples",)
 
 
 def test_promoted_group_rolls_back_on_timeout_regression():

--- a/services/zoe-data/tests/test_zoe_pi_promotion.py
+++ b/services/zoe-data/tests/test_zoe_pi_promotion.py
@@ -1,0 +1,128 @@
+import pytest
+
+from zoe_pi_promotion import (
+    DEFAULT_PI_INTENT_EVAL_CASES,
+    PiIntentEvalCase,
+    PiPromotionPolicy,
+    PiRouteSample,
+    eval_cases_to_dict,
+    evaluate_pi_promotion,
+    intent_group_for_intent,
+    summarize_pi_promotion,
+)
+
+
+def _sample(index, *, group="weather", zoe="reminder_list", pi="weather", expected="weather", zoe_ms=900, pi_ms=300, **kwargs):
+    return PiRouteSample(
+        case_id=f"case_{index}",
+        intent_group=group,
+        expected_intent=expected,
+        zoe_intent=zoe,
+        pi_intent=pi,
+        zoe_latency_ms=zoe_ms,
+        pi_latency_ms=pi_ms,
+        pi_confidence=0.91,
+        **kwargs,
+    )
+
+
+def test_default_eval_cases_validate_and_include_negative_chat_cases():
+    payload = eval_cases_to_dict(DEFAULT_PI_INTENT_EVAL_CASES)
+
+    assert any(case["case_id"] == "weather_rain_later" for case in payload)
+    assert any(case["negative"] and case["intent_group"] == "chat" for case in payload)
+
+
+def test_eval_case_rejects_privileged_expected_intent():
+    case = PiIntentEvalCase(
+        case_id="bad",
+        text="upgrade yourself",
+        expected_intent="extend_capability",
+        intent_group="weather",
+        route_class="fallback",
+    )
+
+    with pytest.raises(ValueError, match="privileged intents"):
+        case.validate()
+
+
+def test_intent_group_for_intent_maps_low_risk_groups_only():
+    assert intent_group_for_intent("weather") == "weather"
+    assert intent_group_for_intent("reminder_create") == "reminders"
+    assert intent_group_for_intent("extend_capability") is None
+
+
+def test_promotion_requires_five_percent_accuracy_win_and_latency_win():
+    samples = [_sample(i) for i in range(10)]
+    policy = PiPromotionPolicy(min_samples=10, accuracy_win_margin=0.05)
+
+    decision = evaluate_pi_promotion(samples, intent_group="weather", policy=policy)
+
+    assert decision.state == "promote"
+    assert decision.pi_accuracy == 1.0
+    assert decision.zoe_accuracy == 0.0
+    assert decision.latency_delta_ms and decision.latency_delta_ms > 0
+    assert decision.blockers == ()
+
+
+def test_promotion_blocks_when_accuracy_delta_is_too_small():
+    samples = [_sample(i, zoe="weather", pi="weather") for i in range(10)]
+    policy = PiPromotionPolicy(min_samples=10, accuracy_win_margin=0.05)
+
+    decision = evaluate_pi_promotion(samples, intent_group="weather", policy=policy)
+
+    assert decision.state == "keep_shadow"
+    assert "accuracy_delta_below_threshold" in decision.blockers
+
+
+def test_promotion_blocks_when_pi_is_not_faster_than_zoe():
+    samples = [_sample(i, zoe_ms=250, pi_ms=450) for i in range(10)]
+    policy = PiPromotionPolicy(min_samples=10, accuracy_win_margin=0.05)
+
+    decision = evaluate_pi_promotion(samples, intent_group="weather", policy=policy)
+
+    assert decision.state == "keep_shadow"
+    assert "latency_not_faster_than_zoe" in decision.blockers
+
+
+def test_promotion_blocks_non_allowlisted_groups():
+    decision = evaluate_pi_promotion([], intent_group="device_control", policy=PiPromotionPolicy(min_samples=1))
+
+    assert decision.state == "blocked"
+    assert decision.blockers == ("intent_group_not_allowlisted",)
+
+
+def test_promoted_group_rolls_back_on_timeout_regression():
+    samples = [_sample(i) for i in range(9)] + [_sample(99, timed_out=True, pi=None, pi_ms=1200)]
+    policy = PiPromotionPolicy(min_samples=10, max_timeout_rate=0.05)
+
+    decision = evaluate_pi_promotion(samples, intent_group="weather", policy=policy, promoted=True)
+
+    assert decision.state == "rollback"
+    assert "timeout_rate_too_high" in decision.blockers
+
+
+def test_promoted_group_rolls_back_on_user_corrections():
+    samples = [_sample(i) for i in range(9)] + [_sample(99, user_corrected=True)]
+    policy = PiPromotionPolicy(min_samples=10, max_correction_rate=0.03)
+
+    decision = evaluate_pi_promotion(samples, intent_group="weather", policy=policy, promoted=True)
+
+    assert decision.state == "rollback"
+    assert "correction_rate_too_high" in decision.blockers
+
+
+def test_sample_rejects_secret_metadata():
+    sample = _sample(1, metadata={"api_key": "nope"})
+
+    with pytest.raises(ValueError, match="secret field"):
+        sample.validate()
+
+
+def test_summary_lists_promotable_groups():
+    samples = [_sample(i) for i in range(10)]
+    report = summarize_pi_promotion(samples, policy=PiPromotionPolicy(min_samples=10))
+
+    assert "weather" in report["promotable_groups"]
+    assert report["sample_count"] == 10
+    assert report["policy"]["accuracy_win_margin"] == 0.05

--- a/services/zoe-data/tests/test_zoe_pi_promotion.py
+++ b/services/zoe-data/tests/test_zoe_pi_promotion.py
@@ -152,6 +152,16 @@ def test_promoted_group_rolls_back_on_user_corrections():
     assert "correction_rate_too_high" in decision.blockers
 
 
+def test_rollback_blocked_overrides_promoted_regression():
+    samples = [_sample(i, rollback_blocked=i == 0) for i in range(10)]
+    policy = PiPromotionPolicy(min_samples=10)
+
+    decision = evaluate_pi_promotion(samples, intent_group="weather", policy=policy, promoted=True)
+
+    assert decision.state == "blocked"
+    assert "rollback_blocked" in decision.blockers
+
+
 def test_sample_rejects_secret_metadata():
     sample = _sample(1, metadata={"api_key": "nope"})
 
@@ -164,5 +174,19 @@ def test_summary_lists_promotable_groups():
     report = summarize_pi_promotion(samples, policy=PiPromotionPolicy(min_samples=10))
 
     assert "weather" in report["promotable_groups"]
+    assert report["promoted_groups"] == []
     assert report["sample_count"] == 10
     assert report["policy"]["accuracy_win_margin"] == 0.05
+
+
+def test_summary_lists_rollback_groups_for_active_promotions():
+    samples = [_sample(i, zoe="weather", pi="reminder_list") for i in range(10)]
+    report = summarize_pi_promotion(samples, policy=PiPromotionPolicy(min_samples=10), promoted_groups=["weather"])
+
+    assert report["promoted_groups"] == ["weather"]
+    assert "weather" in report["rollback_groups"]
+
+
+def test_summary_rejects_unknown_promoted_groups():
+    with pytest.raises(ValueError, match="unknown promoted_groups"):
+        summarize_pi_promotion([], promoted_groups=["device_control"])

--- a/services/zoe-data/zoe_pi_promotion.py
+++ b/services/zoe-data/zoe_pi_promotion.py
@@ -290,9 +290,26 @@ def evaluate_pi_promotion(
     )
 
 
-def summarize_pi_promotion(samples: Sequence[PiRouteSample], *, policy: PiPromotionPolicy | None = None) -> dict[str, Any]:
+def summarize_pi_promotion(
+    samples: Sequence[PiRouteSample],
+    *,
+    policy: PiPromotionPolicy | None = None,
+    promoted_groups: Sequence[str] | None = None,
+) -> dict[str, Any]:
     active_policy = policy or PiPromotionPolicy()
-    decisions = [evaluate_pi_promotion(samples, intent_group=group, policy=active_policy).to_dict() for group in sorted(LOW_RISK_PI_INTENT_GROUPS)]
+    active_promoted_groups = set(promoted_groups or ())
+    unknown_groups = sorted(active_promoted_groups - set(LOW_RISK_PI_INTENT_GROUPS))
+    if unknown_groups:
+        raise ValueError(f"unknown promoted_groups: {', '.join(unknown_groups)}")
+    decisions = [
+        evaluate_pi_promotion(
+            samples,
+            intent_group=group,
+            policy=active_policy,
+            promoted=group in active_promoted_groups,
+        ).to_dict()
+        for group in sorted(LOW_RISK_PI_INTENT_GROUPS)
+    ]
     return {
         "policy": {
             "min_samples": active_policy.min_samples,
@@ -302,6 +319,7 @@ def summarize_pi_promotion(samples: Sequence[PiRouteSample], *, policy: PiPromot
             "require_latency_win": active_policy.require_latency_win,
         },
         "sample_count": len(samples),
+        "promoted_groups": sorted(active_promoted_groups),
         "decisions": decisions,
         "promotable_groups": [decision["intent_group"] for decision in decisions if decision["state"] == "promote"],
         "rollback_groups": [decision["intent_group"] for decision in decisions if decision["state"] == "rollback"],

--- a/services/zoe-data/zoe_pi_promotion.py
+++ b/services/zoe-data/zoe_pi_promotion.py
@@ -257,7 +257,7 @@ def evaluate_pi_promotion(
         blockers.append("rollback_blocked")
 
     state = "promote" if not blockers else "keep_shadow"
-    if promoted and {"timeout_rate_too_high", "correction_rate_too_high", "latency_not_faster_than_zoe"}.intersection(blockers):
+    if promoted and {"accuracy_delta_below_threshold", "timeout_rate_too_high", "correction_rate_too_high", "latency_not_faster_than_zoe"}.intersection(blockers):
         state = "rollback"
     if "rollback_blocked" in blockers:
         state = "blocked"

--- a/services/zoe-data/zoe_pi_promotion.py
+++ b/services/zoe-data/zoe_pi_promotion.py
@@ -1,0 +1,360 @@
+"""Speed/accuracy gates for promoting Pi intent routing.
+
+This module is intentionally side-effect free. Runtime shadow collection and
+promotion writers can call these helpers, but the first contract is the judge:
+Pi only earns a route when it is more accurate and faster than Zoe's current
+comparable path for a low-risk intent group.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Sequence
+
+
+LOW_RISK_PI_INTENT_GROUPS = {
+    "weather": {"weather"},
+    "reminders": {"reminder_list", "reminder_create"},
+    "lists": {"list_show", "list_add", "list_remove"},
+    "timers": {"timer_create"},
+    "calculations": {"calculate"},
+    "daily_briefing": {"daily_briefing"},
+}
+
+PRIVILEGED_INTENTS = {
+    "extend_capability",
+    "user_issue_report",
+    "memory_write",
+    "device_control",
+    "secret_use",
+    "payment",
+    "install_runtime",
+}
+
+EVAL_SOURCES = {"synthetic", "intent_miss", "chat_log", "voice_log", "known_failure"}
+ROUTE_CLASSES = {"deterministic", "fallback", "extraction_failed"}
+DECISION_STATES = {"promote", "keep_shadow", "rollback", "blocked"}
+
+
+@dataclass(frozen=True)
+class PiIntentEvalCase:
+    case_id: str
+    text: str
+    expected_intent: str | None
+    intent_group: str
+    route_class: str
+    source: str = "synthetic"
+    negative: bool = False
+
+    def validate(self) -> None:
+        if not self.case_id:
+            raise ValueError("case_id is required")
+        if not self.text:
+            raise ValueError(f"{self.case_id}: text is required")
+        if self.intent_group not in LOW_RISK_PI_INTENT_GROUPS and self.intent_group != "chat":
+            raise ValueError(f"{self.case_id}: unknown intent_group {self.intent_group!r}")
+        if self.route_class not in ROUTE_CLASSES:
+            raise ValueError(f"{self.case_id}: unknown route_class {self.route_class!r}")
+        if self.source not in EVAL_SOURCES:
+            raise ValueError(f"{self.case_id}: unknown source {self.source!r}")
+        if self.negative and self.expected_intent is not None:
+            raise ValueError(f"{self.case_id}: negative cases must not expect an intent")
+        if not self.negative and not self.expected_intent:
+            raise ValueError(f"{self.case_id}: expected_intent is required")
+        if self.expected_intent in PRIVILEGED_INTENTS:
+            raise ValueError(f"{self.case_id}: privileged intents are not eligible for Pi auto-promotion")
+
+    def to_dict(self) -> dict[str, Any]:
+        self.validate()
+        return {
+            "case_id": self.case_id,
+            "text": self.text,
+            "expected_intent": self.expected_intent,
+            "intent_group": self.intent_group,
+            "route_class": self.route_class,
+            "source": self.source,
+            "negative": self.negative,
+        }
+
+
+@dataclass(frozen=True)
+class PiRouteSample:
+    case_id: str
+    intent_group: str
+    expected_intent: str | None
+    zoe_intent: str | None
+    pi_intent: str | None
+    zoe_latency_ms: float
+    pi_latency_ms: float
+    pi_confidence: float = 0.0
+    pi_transport: str = "rpc"
+    route_class: str = "fallback"
+    user_corrected: bool = False
+    timed_out: bool = False
+    rollback_blocked: bool = False
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def validate(self) -> None:
+        if not self.case_id:
+            raise ValueError("case_id is required")
+        if self.intent_group not in LOW_RISK_PI_INTENT_GROUPS:
+            raise ValueError(f"{self.case_id}: intent_group is not auto-promotable")
+        if self.expected_intent in PRIVILEGED_INTENTS or self.pi_intent in PRIVILEGED_INTENTS:
+            raise ValueError(f"{self.case_id}: privileged intents cannot be auto-promoted")
+        if self.zoe_latency_ms < 0 or self.pi_latency_ms < 0:
+            raise ValueError(f"{self.case_id}: latency must be non-negative")
+        if not 0 <= self.pi_confidence <= 1:
+            raise ValueError(f"{self.case_id}: pi_confidence must be between 0 and 1")
+        if self.route_class not in ROUTE_CLASSES:
+            raise ValueError(f"{self.case_id}: unknown route_class {self.route_class!r}")
+        if self.pi_transport not in {"print", "rpc"}:
+            raise ValueError(f"{self.case_id}: unknown pi_transport {self.pi_transport!r}")
+        _reject_secret_keys(self.metadata, sample_id=self.case_id)
+
+    @property
+    def zoe_correct(self) -> bool:
+        return self.zoe_intent == self.expected_intent
+
+    @property
+    def pi_correct(self) -> bool:
+        return self.pi_intent == self.expected_intent and not self.timed_out
+
+    def to_dict(self) -> dict[str, Any]:
+        self.validate()
+        return {
+            "case_id": self.case_id,
+            "intent_group": self.intent_group,
+            "expected_intent": self.expected_intent,
+            "zoe_intent": self.zoe_intent,
+            "pi_intent": self.pi_intent,
+            "zoe_latency_ms": self.zoe_latency_ms,
+            "pi_latency_ms": self.pi_latency_ms,
+            "pi_confidence": self.pi_confidence,
+            "pi_transport": self.pi_transport,
+            "route_class": self.route_class,
+            "zoe_correct": self.zoe_correct,
+            "pi_correct": self.pi_correct,
+            "user_corrected": self.user_corrected,
+            "timed_out": self.timed_out,
+            "rollback_blocked": self.rollback_blocked,
+            "metadata": dict(self.metadata),
+        }
+
+
+@dataclass(frozen=True)
+class PiPromotionPolicy:
+    min_samples: int = 30
+    accuracy_win_margin: float = 0.05
+    max_timeout_rate: float = 0.05
+    max_correction_rate: float = 0.03
+    require_latency_win: bool = True
+
+    def validate(self) -> None:
+        if self.min_samples <= 0:
+            raise ValueError("min_samples must be positive")
+        for field_name in ("accuracy_win_margin", "max_timeout_rate", "max_correction_rate"):
+            value = getattr(self, field_name)
+            if not 0 <= value <= 1:
+                raise ValueError(f"{field_name} must be between 0 and 1")
+
+
+@dataclass(frozen=True)
+class PiPromotionDecision:
+    intent_group: str
+    state: str
+    blockers: tuple[str, ...]
+    sample_count: int
+    zoe_accuracy: float
+    pi_accuracy: float
+    accuracy_delta: float
+    zoe_p95_latency_ms: float | None
+    pi_p95_latency_ms: float | None
+    latency_delta_ms: float | None
+    timeout_rate: float
+    correction_rate: float
+
+    def to_dict(self) -> dict[str, Any]:
+        if self.state not in DECISION_STATES:
+            raise ValueError(f"unknown decision state {self.state!r}")
+        return {
+            "intent_group": self.intent_group,
+            "state": self.state,
+            "blockers": list(self.blockers),
+            "sample_count": self.sample_count,
+            "zoe_accuracy": self.zoe_accuracy,
+            "pi_accuracy": self.pi_accuracy,
+            "accuracy_delta": self.accuracy_delta,
+            "zoe_p95_latency_ms": self.zoe_p95_latency_ms,
+            "pi_p95_latency_ms": self.pi_p95_latency_ms,
+            "latency_delta_ms": self.latency_delta_ms,
+            "timeout_rate": self.timeout_rate,
+            "correction_rate": self.correction_rate,
+        }
+
+
+DEFAULT_PI_INTENT_EVAL_CASES: tuple[PiIntentEvalCase, ...] = (
+    PiIntentEvalCase("weather_rain_later", "rain later", "weather", "weather", "fallback"),
+    PiIntentEvalCase("weather_jacket", "need a jacket tonight", "weather", "weather", "fallback"),
+    PiIntentEvalCase("reminder_due", "anything due today", "reminder_list", "reminders", "fallback"),
+    PiIntentEvalCase("reminder_create", "remind me to call mum", "reminder_create", "reminders", "extraction_failed"),
+    PiIntentEvalCase("list_show", "what is on the shopping list", "list_show", "lists", "deterministic"),
+    PiIntentEvalCase("list_add", "add bread to shopping", "list_add", "lists", "extraction_failed"),
+    PiIntentEvalCase("timer", "timer for ten minutes", "timer_create", "timers", "fallback"),
+    PiIntentEvalCase("calc", "what is 18 times 7", "calculate", "calculations", "fallback"),
+    PiIntentEvalCase("briefing", "what is my day looking like", "daily_briefing", "daily_briefing", "fallback"),
+    PiIntentEvalCase("casual_breakfast", "I like the breakfast service", None, "chat", "fallback", negative=True),
+    PiIntentEvalCase("casual_memory", "that movie was pretty good", None, "chat", "fallback", negative=True),
+)
+
+
+def intent_group_for_intent(intent: str | None) -> str | None:
+    if not intent:
+        return None
+    for group, intents in LOW_RISK_PI_INTENT_GROUPS.items():
+        if intent in intents:
+            return group
+    return None
+
+
+def evaluate_pi_promotion(
+    samples: Sequence[PiRouteSample],
+    *,
+    intent_group: str,
+    policy: PiPromotionPolicy | None = None,
+    promoted: bool = False,
+) -> PiPromotionDecision:
+    active_policy = policy or PiPromotionPolicy()
+    active_policy.validate()
+    if intent_group not in LOW_RISK_PI_INTENT_GROUPS:
+        return _empty_decision(intent_group, state="blocked", blockers=("intent_group_not_allowlisted",))
+    group_samples = [sample for sample in samples if sample.intent_group == intent_group]
+    for sample in group_samples:
+        sample.validate()
+    sample_count = len(group_samples)
+    if sample_count == 0:
+        return _empty_decision(intent_group, state="keep_shadow", blockers=("insufficient_samples",))
+
+    zoe_accuracy = _rate(sample.zoe_correct for sample in group_samples)
+    pi_accuracy = _rate(sample.pi_correct for sample in group_samples)
+    accuracy_delta = pi_accuracy - zoe_accuracy
+    zoe_p95 = _percentile([sample.zoe_latency_ms for sample in group_samples], 95)
+    pi_p95 = _percentile([sample.pi_latency_ms for sample in group_samples], 95)
+    latency_delta = None if zoe_p95 is None or pi_p95 is None else zoe_p95 - pi_p95
+    timeout_rate = _rate(sample.timed_out for sample in group_samples)
+    correction_rate = _rate(sample.user_corrected for sample in group_samples)
+    blockers: list[str] = []
+    if sample_count < active_policy.min_samples:
+        blockers.append("insufficient_samples")
+    if accuracy_delta < active_policy.accuracy_win_margin:
+        blockers.append("accuracy_delta_below_threshold")
+    if active_policy.require_latency_win and (latency_delta is None or latency_delta <= 0):
+        blockers.append("latency_not_faster_than_zoe")
+    if timeout_rate > active_policy.max_timeout_rate:
+        blockers.append("timeout_rate_too_high")
+    if correction_rate > active_policy.max_correction_rate:
+        blockers.append("correction_rate_too_high")
+    if any(sample.rollback_blocked for sample in group_samples):
+        blockers.append("rollback_blocked")
+
+    state = "promote" if not blockers else "keep_shadow"
+    if promoted and {"timeout_rate_too_high", "correction_rate_too_high", "latency_not_faster_than_zoe"}.intersection(blockers):
+        state = "rollback"
+    if "rollback_blocked" in blockers:
+        state = "blocked"
+    return PiPromotionDecision(
+        intent_group=intent_group,
+        state=state,
+        blockers=tuple(blockers),
+        sample_count=sample_count,
+        zoe_accuracy=zoe_accuracy,
+        pi_accuracy=pi_accuracy,
+        accuracy_delta=accuracy_delta,
+        zoe_p95_latency_ms=zoe_p95,
+        pi_p95_latency_ms=pi_p95,
+        latency_delta_ms=latency_delta,
+        timeout_rate=timeout_rate,
+        correction_rate=correction_rate,
+    )
+
+
+def summarize_pi_promotion(samples: Sequence[PiRouteSample], *, policy: PiPromotionPolicy | None = None) -> dict[str, Any]:
+    active_policy = policy or PiPromotionPolicy()
+    decisions = [evaluate_pi_promotion(samples, intent_group=group, policy=active_policy).to_dict() for group in sorted(LOW_RISK_PI_INTENT_GROUPS)]
+    return {
+        "policy": {
+            "min_samples": active_policy.min_samples,
+            "accuracy_win_margin": active_policy.accuracy_win_margin,
+            "max_timeout_rate": active_policy.max_timeout_rate,
+            "max_correction_rate": active_policy.max_correction_rate,
+            "require_latency_win": active_policy.require_latency_win,
+        },
+        "sample_count": len(samples),
+        "decisions": decisions,
+        "promotable_groups": [decision["intent_group"] for decision in decisions if decision["state"] == "promote"],
+        "rollback_groups": [decision["intent_group"] for decision in decisions if decision["state"] == "rollback"],
+    }
+
+
+def eval_cases_to_dict(cases: Sequence[PiIntentEvalCase] = DEFAULT_PI_INTENT_EVAL_CASES) -> list[dict[str, Any]]:
+    return [case.to_dict() for case in cases]
+
+
+def _empty_decision(intent_group: str, *, state: str, blockers: tuple[str, ...]) -> PiPromotionDecision:
+    return PiPromotionDecision(
+        intent_group=intent_group,
+        state=state,
+        blockers=blockers,
+        sample_count=0,
+        zoe_accuracy=0.0,
+        pi_accuracy=0.0,
+        accuracy_delta=0.0,
+        zoe_p95_latency_ms=None,
+        pi_p95_latency_ms=None,
+        latency_delta_ms=None,
+        timeout_rate=0.0,
+        correction_rate=0.0,
+    )
+
+
+def _rate(values) -> float:
+    items = list(values)
+    if not items:
+        return 0.0
+    return sum(1 for item in items if item) / len(items)
+
+
+def _percentile(values: Sequence[float], percentile: int) -> float | None:
+    clean = sorted(float(value) for value in values)
+    if not clean:
+        return None
+    if len(clean) == 1:
+        return clean[0]
+    rank = (len(clean) - 1) * (percentile / 100)
+    lower = int(rank)
+    upper = min(lower + 1, len(clean) - 1)
+    weight = rank - lower
+    return clean[lower] * (1 - weight) + clean[upper] * weight
+
+
+def _reject_secret_keys(value: Mapping[str, Any], *, sample_id: str, path: str = "") -> None:
+    for key, nested in value.items():
+        full_key = f"{path}.{key}" if path else str(key)
+        if any(marker in str(key).lower() for marker in ("api_key", "token", "password", "secret", "authorization")):
+            raise ValueError(f"{sample_id}: metadata may not contain secret field {full_key}")
+        if isinstance(nested, Mapping):
+            _reject_secret_keys(nested, sample_id=sample_id, path=full_key)
+
+
+__all__ = [
+    "DEFAULT_PI_INTENT_EVAL_CASES",
+    "LOW_RISK_PI_INTENT_GROUPS",
+    "PRIVILEGED_INTENTS",
+    "PiIntentEvalCase",
+    "PiPromotionDecision",
+    "PiPromotionPolicy",
+    "PiRouteSample",
+    "eval_cases_to_dict",
+    "evaluate_pi_promotion",
+    "intent_group_for_intent",
+    "summarize_pi_promotion",
+]

--- a/services/zoe-data/zoe_pi_promotion.py
+++ b/services/zoe-data/zoe_pi_promotion.py
@@ -63,6 +63,12 @@ class PiIntentEvalCase:
             raise ValueError(f"{self.case_id}: expected_intent is required")
         if self.expected_intent in PRIVILEGED_INTENTS:
             raise ValueError(f"{self.case_id}: privileged intents are not eligible for Pi auto-promotion")
+        if (
+            not self.negative
+            and self.intent_group != "chat"
+            and self.expected_intent not in LOW_RISK_PI_INTENT_GROUPS[self.intent_group]
+        ):
+            raise ValueError(f"{self.case_id}: expected_intent does not belong to intent_group {self.intent_group!r}")
 
     def to_dict(self) -> dict[str, Any]:
         self.validate()
@@ -232,7 +238,8 @@ def evaluate_pi_promotion(
         sample.validate()
     sample_count = len(group_samples)
     if sample_count == 0:
-        return _empty_decision(intent_group, state="keep_shadow", blockers=("insufficient_samples",))
+        state = "rollback" if promoted else "keep_shadow"
+        return _empty_decision(intent_group, state=state, blockers=("insufficient_samples",))
 
     zoe_accuracy = _rate(sample.zoe_correct for sample in group_samples)
     pi_accuracy = _rate(sample.pi_correct for sample in group_samples)

--- a/services/zoe-data/zoe_pi_promotion.py
+++ b/services/zoe-data/zoe_pi_promotion.py
@@ -264,7 +264,13 @@ def evaluate_pi_promotion(
         blockers.append("rollback_blocked")
 
     state = "promote" if not blockers else "keep_shadow"
-    if promoted and {"accuracy_delta_below_threshold", "timeout_rate_too_high", "correction_rate_too_high", "latency_not_faster_than_zoe"}.intersection(blockers):
+    if promoted and {
+        "accuracy_delta_below_threshold",
+        "insufficient_samples",
+        "timeout_rate_too_high",
+        "correction_rate_too_high",
+        "latency_not_faster_than_zoe",
+    }.intersection(blockers):
         state = "rollback"
     if "rollback_blocked" in blockers:
         state = "blocked"


### PR DESCRIPTION
## Summary
- add side-effect-free Pi promotion scoring gates for speed/accuracy decisions
- add built-in intent eval fixtures and low-risk allowlist/rollback policy
- add maintenance report runner for demo and optional local Pi-vs-Zoe comparisons

## Verification
- python3 -m pytest -q services/zoe-data/tests/test_zoe_pi_promotion.py services/zoe-data/tests/test_pi_intent_classifier.py services/zoe-data/tests/test_pi_intent_status_endpoint.py
- python3 -m pytest -q services/zoe-data/tests/test_zoe_pi_promotion.py services/zoe-data/tests/test_pi_intent_classifier.py services/zoe-data/tests/test_pi_intent_status_endpoint.py services/zoe-data/tests/test_intent_gap_contract_helper.py services/zoe-data/tests/test_intent_ha_setup.py services/zoe-data/tests/test_intent_open_domain.py
- scripts/maintenance/pi_promotion_eval.py --demo --min-samples 10
- scripts/maintenance/pi_promotion_eval.py --run-pi --transport rpc --min-samples 1
- python3 -m py_compile services/zoe-data/zoe_pi_promotion.py scripts/maintenance/pi_promotion_eval.py
- python3 tools/audit/validate_structure.py
- python3 tools/audit/validate_critical_files.py
- git diff --check