### PR TITLE
[codex] Route selected Skybridge auth profile into PIN login

### DIFF
--- a/services/zoe-data/tests/test_skybridge_static.py
+++ b/services/zoe-data/tests/test_skybridge_static.py
@@ -213,8 +213,10 @@ def test_skybridge_uses_backend_status_contract():
     assert "isDataQuery(query)" in app
     assert "resp.status === 401 || resp.status === 503" in app
     assert "function prepareAuthRoute" in app
-    assert "function buildLoginRoute(panelId)" in app
-    assert "return route || buildLoginRoute(panelId)" in app
+    assert "function buildLoginRoute(panelId, selectedUserId)" in app
+    assert "params.set('user_id', selectedUserId)" in app
+    assert "params.set('auth', 'skybridge')" in app
+    assert "return route || buildLoginRoute(panelId, selectedUserId)" in app
     assert "if (voice) voice.sendText(query)" in app
     assert "event.role === 'user') projectCards" not in app
     assert "projectCommand(query);\n        if (voice) voice.sendText(query);" not in app
@@ -434,7 +436,9 @@ def test_skybridge_auth_challenge_card_contract():
     assert "trySelectAuthProfile" in app
     assert "selected_user_id" in app
     assert "if (!route) route = '/touch/index.html'" not in app
-    assert "return route || buildLoginRoute(panelId)" in app
+    assert "params.set('user_id', selectedUserId)" in app
+    assert "params.set('auth', 'skybridge')" in app
+    assert "return route || buildLoginRoute(panelId, selectedUserId)" in app
     assert "encodeURIComponent(panelId)" in app
     assert "storedChallenge.panel_id" in app
     assert "zoe_panel_auth_challenge" in app
@@ -453,7 +457,9 @@ def test_skybridge_auth_challenge_card_contract():
     assert '"route": ""' in service
     touch_index = read(UI / "index.html")
     assert "parsed && (parsed.challenge_id || parsed.selected_user_id)" in touch_index
-    assert "const preferredUserId = pending && pending.selected_user_id" in touch_index
+    assert "const routeUserId = params.get('user_id') || ''" in touch_index
+    assert "params.get('auth') === 'skybridge'" in touch_index
+    assert "const preferredUserId = routeUserId" in touch_index
     assert "!pending.challenge_id" in touch_index
     assert '"summary": "Please authenticate on the touch panel to continue."' in voice
     assert '"challenge_id": challenge_id' in voice

--- a/services/zoe-ui/dist/touch/index.html
+++ b/services/zoe-ui/dist/touch/index.html
@@ -1097,10 +1097,12 @@
 
             renderProfiles();
 
+            const params = new URLSearchParams(window.location.search);
+            const routeUserId = params.get('user_id') || '';
             const pending = getPendingPanelChallenge();
-            const preferredUserId = pending && pending.selected_user_id
-                ? pending.selected_user_id
-                : panelContext.default_user_id;
+            const preferredUserId = routeUserId
+                || (pending && pending.selected_user_id ? pending.selected_user_id : '')
+                || panelContext.default_user_id;
             if (preferredUserId) {
                 const preferredProfile = userProfiles.find(p => p.user_id === preferredUserId);
                 if (preferredProfile) {
@@ -1625,8 +1627,8 @@
             }
             
             const pendingChallenge = getPendingPanelChallenge();
-            if (pendingChallenge) {
-                // Force auth UI when resuming a voice challenge; do not auto-redirect.
+            if (pendingChallenge || params.get('auth') === 'skybridge' || params.get('user_id')) {
+                // Force auth UI when resuming a voice/Skybridge auth handoff; do not auto-redirect.
                 showProfiles();
                 return;
             }

--- a/services/zoe-ui/dist/touch/js/skybridge.js
+++ b/services/zoe-ui/dist/touch/js/skybridge.js
@@ -119,8 +119,13 @@
             || '';
     }
 
-    function buildLoginRoute(panelId) {
-        return '/touch/index.html' + (panelId ? '?panel_id=' + encodeURIComponent(panelId) : '');
+    function buildLoginRoute(panelId, selectedUserId) {
+        const params = new URLSearchParams();
+        if (panelId) params.set('panel_id', panelId);
+        if (selectedUserId) params.set('user_id', selectedUserId);
+        if (selectedUserId) params.set('auth', 'skybridge');
+        const query = params.toString();
+        return '/touch/index.html' + (query ? '?' + query : '');
     }
 
     function prepareAuthRoute(btn, route) {
@@ -146,7 +151,7 @@
         } catch (_) {
             // Route still preserves panel id even when storage is unavailable.
         }
-        return route || buildLoginRoute(panelId);
+        return route || buildLoginRoute(panelId, selectedUserId);
     }
 
     function setMode(nextMode) {


### PR DESCRIPTION
## Summary
- include selected Skybridge auth profile in the touch login URL as a fallback to sessionStorage
- force the touch login auth overlay open for Skybridge auth handoffs
- auto-select the routed profile before PIN entry

## Tests
- python3 -m pytest -q services/zoe-data/tests/test_skybridge_static.py services/zoe-data/tests/test_skybridge_service.py services/zoe-data/tests/test_voice_weather_queue.py services/zoe-data/tests/test_ui_actions_ack.py services/zoe-data/tests/test_ui_orchestrator_types.py
- cd services/zoe-auth && PYTHONPATH=tests:. python3 -m pytest -q tests/test_auth.py