### PR TITLE
Polish Skybridge auth identity picker

### DIFF
--- a/services/zoe-data/tests/test_skybridge_static.py
+++ b/services/zoe-data/tests/test_skybridge_static.py
@@ -3,6 +3,10 @@
 from __future__ import annotations
 
 from pathlib import Path
+import shutil
+import subprocess
+
+import pytest
 
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -12,6 +16,20 @@ DATA = ROOT / "zoe-data"
 
 def read(path: Path) -> str:
     return path.read_text(encoding="utf-8")
+
+
+def test_skybridge_runtime_scripts_parse_as_javascript():
+    node = shutil.which("node") or shutil.which("nodejs")
+    if not node:
+        pytest.skip("Node.js is not installed on this host")
+    for script in [
+        UI / "js" / "skybridge-renderer.js",
+        UI / "js" / "skybridge.js",
+        UI / "js" / "skybridge-voice.js",
+        UI / "js" / "skybridge-capabilities.js",
+        ROOT / "zoe-ui" / "dist" / "js" / "touch-ui-executor.js",
+    ]:
+        subprocess.run([node, "--check", str(script)], check=True, capture_output=True, text=True)
 
 
 def test_skybridge_page_loads_required_modules_in_order():
@@ -41,9 +59,9 @@ def test_skybridge_push_socket_uses_authenticated_session_query():
     main = (ROOT / "zoe-data" / "main.py").read_text(encoding="utf-8")
 
     assert "/js/websocket-sync.js?v=skybridge-auth-ready-1" in html
-    assert "/touch/js/skybridge.js?v=skybridge-auth-identity-1" in html
-    assert "/touch/js/skybridge-renderer.js?v=skybridge-auth-identity-1" in html
-    assert "/js/touch-ui-executor.js?v=skybridge-auth-identity-1" in html
+    assert "/touch/js/skybridge.js?v=skybridge-auth-premium-1" in html
+    assert "/touch/js/skybridge-renderer.js?v=skybridge-auth-premium-1" in html
+    assert "/js/touch-ui-executor.js?v=skybridge-auth-premium-1" in html
     assert "initPush(panelId, sessionId)" in sync
     assert "params.set('panel_id', panelId)" in sync
     assert "else params.set('channel', 'all')" in sync
@@ -293,7 +311,7 @@ def test_skybridge_renderer_supports_real_data_cards():
     assert "sky-event-row" in html
     assert "sky-weather-hour-tile" in html
     assert "sky-weather-day-row" in html
-    assert "/touch/css/skybridge-data-widgets.css?v=skybridge-auth-identity-1" in html
+    assert "/touch/css/skybridge-data-widgets.css?v=skybridge-auth-premium-1" in html
     assert "skybridge-lists-people-widgets" not in html
     assert "sky-list-item-row" in data_widgets_css
     assert "sky-person-row" in data_widgets_css
@@ -414,8 +432,9 @@ def test_skybridge_auth_challenge_card_contract():
 
     assert "auth_challenge: renderAuthChallenge" in renderer
     assert "function renderAuthChallenge(props)" in renderer
-    assert "const finalStep = props.final_step || 'Return to Zoe'" in renderer
-    assert "escapeHtml(finalStep)" in renderer
+    assert "<strong>Who's speaking?</strong>" in renderer
+    assert "sky-auth-request" in renderer
+    assert "PIN or password appears after selection." in renderer
     assert "escapeHtml(action)" not in renderer[renderer.index("function renderAuthChallenge"):renderer.index("function renderStatus")]
     assert "data-auth-profiles" in renderer
     assert "sky-auth-profile-grid" in renderer
@@ -424,6 +443,10 @@ def test_skybridge_auth_challenge_card_contract():
     assert "data-user-avatar" in renderer
     assert "data-challenge-id" in renderer
     assert "data-action-context" in renderer
+    assert "Choose who is speaking" in renderer
+    assert "PIN / Password" in app
+    assert "data-route=\"" in app
+    assert "buildLoginRoute(panelId, profile.user_id)" in app
     assert "btn.dataset.skyAction === 'auth'" in app
     assert "function hydrateAuthCard" in app
     assert "AbortController" in app
@@ -453,6 +476,10 @@ def test_skybridge_auth_challenge_card_contract():
     assert "sky-auth-scene" in css
     assert "sky-auth-profile" in css
     assert "sky-auth-footer" in css
+    assert "Skybridge premium auth picker" in css
+    assert "grid-template-columns: repeat(auto-fit, minmax(154px, 1fr))" in css
+    assert "sky-auth-request" in css
+    assert "filter: blur" not in css[css.index("/* Skybridge premium auth picker */"):]
     assert '"component": "auth_challenge"' in service
     assert '"route": ""' in service
     touch_index = read(UI / "index.html")

--- a/services/zoe-ui/dist/touch/css/skybridge-data-widgets.css
+++ b/services/zoe-ui/dist/touch/css/skybridge-data-widgets.css
@@ -733,3 +733,322 @@ body:not(.sky-empty) .sky-auth-footer span {
         grid-template-columns: minmax(0, 1fr);
     }
 }
+
+/* Skybridge premium auth picker */
+body:not(.sky-empty) .sky-card.auth-challenge {
+    position: relative;
+    padding: 26px !important;
+    background:
+        linear-gradient(138deg, rgba(245,249,255,0.18), rgba(255,255,255,0.035) 33%, rgba(255,255,255,0.075) 100%),
+        radial-gradient(circle at 12% 12%, rgba(112,232,238,0.42), transparent 28%),
+        radial-gradient(circle at 92% 2%, rgba(176,145,255,0.32), transparent 30%),
+        linear-gradient(150deg, rgba(21,28,44,0.98), rgba(8,10,17,0.99) 62%, rgba(3,7,13,1)) !important;
+    border: 1px solid rgba(255,255,255,0.22) !important;
+    box-shadow:
+        0 34px 90px rgba(0,0,0,0.42),
+        inset 0 1px 0 rgba(255,255,255,0.18),
+        inset 0 -1px 0 rgba(255,255,255,0.06) !important;
+}
+
+body:not(.sky-empty) .sky-card.auth-challenge::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background:
+        linear-gradient(90deg, transparent, rgba(255,255,255,0.10), transparent),
+        repeating-linear-gradient(90deg, rgba(255,255,255,0.035) 0 1px, transparent 1px 18px);
+    opacity: 0.32;
+    mask-image: linear-gradient(180deg, black, transparent 72%);
+}
+
+body:not(.sky-empty) .sky-auth-scene {
+    position: relative;
+    z-index: 1;
+    display: grid;
+    grid-template-columns: minmax(240px, 0.42fr) minmax(0, 0.58fr);
+    gap: 18px;
+    align-items: stretch;
+}
+
+body:not(.sky-empty) .sky-auth-hero {
+    min-height: 286px;
+    border-radius: 30px;
+    padding: 22px;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    background:
+        linear-gradient(145deg, rgba(255,255,255,0.16), rgba(255,255,255,0.05)),
+        radial-gradient(circle at 35% 18%, rgba(133,244,239,0.22), transparent 46%);
+    border: 1px solid rgba(255,255,255,0.16);
+    box-shadow:
+        inset 0 1px 0 rgba(255,255,255,0.18),
+        0 18px 48px rgba(0,0,0,0.18);
+}
+
+body:not(.sky-empty) .sky-auth-orb {
+    width: 116px;
+    height: 116px;
+    border-radius: 50%;
+    display: grid;
+    place-items: center;
+    background:
+        radial-gradient(circle at 30% 22%, rgba(255,255,255,0.98), rgba(130,249,241,0.92) 21%, rgba(155,132,255,0.78) 57%, rgba(16,23,38,0.95) 100%);
+    box-shadow:
+        0 0 52px rgba(107,235,238,0.28),
+        0 18px 44px rgba(0,0,0,0.30),
+        inset 0 1px 18px rgba(255,255,255,0.48);
+}
+
+body:not(.sky-empty) .sky-auth-copy span {
+    display: inline-flex;
+    width: fit-content;
+    border-radius: 999px;
+    padding: 8px 12px;
+    background: rgba(255,255,255,0.13);
+    border: 1px solid rgba(255,255,255,0.16);
+    color: rgba(255,255,255,0.76);
+    font-size: 0.72rem;
+    font-weight: 900;
+    text-transform: uppercase;
+}
+
+body:not(.sky-empty) .sky-auth-copy strong {
+    display: block;
+    max-width: 8.5ch;
+    margin-top: 14px;
+    color: #fff;
+    font-size: 3.25rem;
+    line-height: 0.94;
+    letter-spacing: 0;
+}
+
+body:not(.sky-empty) .sky-auth-copy p {
+    max-width: 31ch;
+    margin: 14px 0 0;
+    color: rgba(255,255,255,0.74);
+    font-size: 1.02rem;
+    line-height: 1.48;
+}
+
+body:not(.sky-empty) .sky-auth-request {
+    display: block;
+    width: fit-content;
+    max-width: 100%;
+    margin-top: 14px;
+    border-radius: 999px;
+    padding: 9px 12px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: rgba(255,255,255,0.70);
+    background: rgba(255,255,255,0.085);
+    border: 1px solid rgba(255,255,255,0.11);
+    font-size: 0.82rem;
+    font-weight: 800;
+}
+
+body:not(.sky-empty) .sky-auth-profile-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(154px, 1fr));
+    align-content: stretch;
+    gap: 12px;
+    min-height: 286px;
+}
+
+body:not(.sky-empty) .sky-auth-profile {
+    position: relative;
+    appearance: none;
+    width: 100%;
+    min-height: 154px;
+    border: 1px solid rgba(255,255,255,0.15);
+    border-radius: 30px;
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 12px;
+    color: #fff;
+    text-align: left;
+    cursor: pointer;
+    overflow: hidden;
+    background:
+        linear-gradient(150deg, rgba(255,255,255,0.18), rgba(255,255,255,0.055) 58%, rgba(255,255,255,0.095)),
+        rgba(255,255,255,0.055);
+    box-shadow:
+        inset 0 1px 0 rgba(255,255,255,0.16),
+        0 16px 36px rgba(0,0,0,0.22);
+    transition: transform 180ms ease, border-color 180ms ease, background 180ms ease, box-shadow 180ms ease;
+}
+
+body:not(.sky-empty) .sky-auth-profile::after {
+    content: '';
+    position: absolute;
+    inset: auto -18% -34% 20%;
+    height: 86px;
+    border-radius: 50%;
+    background: linear-gradient(90deg, rgba(111,238,236,0.22), rgba(163,141,255,0.18));
+    opacity: 0.42;
+}
+
+body:not(.sky-empty) .sky-auth-profile:hover,
+body:not(.sky-empty) .sky-auth-profile:focus-visible {
+    transform: translateY(-3px);
+    border-color: rgba(129,246,241,0.60);
+    background:
+        linear-gradient(150deg, rgba(128,244,239,0.24), rgba(255,255,255,0.075) 52%, rgba(170,148,255,0.16)),
+        rgba(255,255,255,0.08);
+    box-shadow:
+        0 22px 58px rgba(76,211,226,0.16),
+        inset 0 1px 0 rgba(255,255,255,0.20);
+    outline: none;
+}
+
+body:not(.sky-empty) .sky-auth-profile.is-default {
+    border-color: rgba(129,246,241,0.48);
+}
+
+body:not(.sky-empty) .sky-auth-avatar {
+    position: relative;
+    z-index: 1;
+    width: 64px;
+    height: 64px;
+    border-radius: 24px;
+    display: grid;
+    place-items: center;
+    color: rgba(5,9,18,0.96);
+    font-size: 1.42rem;
+    font-weight: 950;
+    background: linear-gradient(135deg, #ecfeff 0%, #83f5ee 34%, #9f8cff 74%, #ffffff 100%);
+    box-shadow: inset 0 1px 0 rgba(255,255,255,0.72), 0 14px 30px rgba(0,0,0,0.26);
+}
+
+body:not(.sky-empty) .sky-auth-person {
+    position: relative;
+    z-index: 1;
+    min-width: 0;
+    display: grid;
+    gap: 5px;
+}
+
+body:not(.sky-empty) .sky-auth-person strong {
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: 1.28rem;
+    line-height: 1.05;
+    font-weight: 900;
+}
+
+body:not(.sky-empty) .sky-auth-person small {
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: rgba(255,255,255,0.58);
+    font-size: 0.80rem;
+    font-weight: 820;
+    text-transform: capitalize;
+}
+
+body:not(.sky-empty) .sky-auth-enter {
+    position: relative;
+    z-index: 1;
+    min-width: 0;
+    border-radius: 999px;
+    padding: 9px 11px;
+    color: rgba(6,10,18,0.96);
+    background: linear-gradient(135deg, #efffff, #8df7f0 44%, #b9c3ff);
+    box-shadow: inset 0 1px 0 rgba(255,255,255,0.62), 0 10px 24px rgba(0,0,0,0.20);
+    font-weight: 950;
+    font-size: 0.76rem;
+    white-space: nowrap;
+}
+
+body:not(.sky-empty) .sky-auth-loading,
+body:not(.sky-empty) .sky-auth-empty {
+    min-height: 154px;
+    border-radius: 30px;
+    display: grid;
+    place-items: center;
+    gap: 14px;
+    text-align: center;
+    color: rgba(255,255,255,0.72);
+    background: rgba(255,255,255,0.075);
+    border: 1px solid rgba(255,255,255,0.13);
+    font-weight: 850;
+}
+
+body:not(.sky-empty) .sky-auth-footer {
+    grid-column: 1 / -1;
+    display: grid;
+    grid-template-columns: minmax(0, 1.25fr) minmax(220px, 0.75fr);
+    gap: 10px;
+}
+
+body:not(.sky-empty) .sky-auth-footer span {
+    min-height: 46px;
+    border-radius: 999px;
+    display: grid;
+    place-items: center;
+    padding: 10px 14px;
+    color: rgba(255,255,255,0.70);
+    background: rgba(255,255,255,0.075);
+    border: 1px solid rgba(255,255,255,0.11);
+    font-size: 0.82rem;
+    font-weight: 850;
+    text-align: center;
+}
+
+body:not(.sky-empty) .sky-auth-steps {
+    display: none;
+}
+
+@media (max-width: 900px) {
+    body:not(.sky-empty) .sky-auth-scene {
+        grid-template-columns: minmax(0, 1fr);
+    }
+    body:not(.sky-empty) .sky-auth-hero {
+        min-height: 218px;
+        flex-direction: row;
+        align-items: center;
+        gap: 18px;
+    }
+    body:not(.sky-empty) .sky-auth-copy strong {
+        max-width: none;
+        font-size: 2.55rem;
+    }
+    body:not(.sky-empty) .sky-auth-profile-grid {
+        min-height: 0;
+    }
+}
+
+@media (max-width: 620px) {
+    body:not(.sky-empty) .sky-card.auth-challenge {
+        padding: 18px !important;
+    }
+    body:not(.sky-empty) .sky-auth-hero {
+        min-height: 0;
+        flex-direction: column;
+        align-items: flex-start;
+    }
+    body:not(.sky-empty) .sky-auth-orb {
+        width: 88px;
+        height: 88px;
+    }
+    body:not(.sky-empty) .sky-auth-copy strong {
+        font-size: 2.25rem;
+    }
+    body:not(.sky-empty) .sky-auth-profile-grid {
+        grid-template-columns: minmax(0, 1fr);
+    }
+    body:not(.sky-empty) .sky-auth-profile {
+        min-height: 132px;
+    }
+    body:not(.sky-empty) .sky-auth-footer {
+        grid-template-columns: minmax(0, 1fr);
+    }
+}

--- a/services/zoe-ui/dist/touch/js/skybridge-renderer.js
+++ b/services/zoe-ui/dist/touch/js/skybridge-renderer.js
@@ -72,24 +72,24 @@
     }
 
     function renderAuthChallenge(props) {
-        const title = props.title || 'Confirm it is you';
+        const requestTitle = props.title || 'Private request';
         const body = props.body || props.message || 'Zoe needs to know who is speaking before showing or changing personal data.';
         const domain = props.domain ? String(props.domain) : 'Private data';
-        const finalStep = props.final_step || 'Return to Zoe';
         const bodyHtml = [
             '<div class="sky-auth-scene">',
             '<div class="sky-auth-hero">',
             '<div class="sky-auth-orb" aria-hidden="true"><span></span></div>',
             '<div class="sky-auth-copy">',
             '<span>' + escapeHtml(domain) + '</span>',
-            '<strong>' + escapeHtml(title) + '</strong>',
-            '<p>' + escapeHtml(body) + '</p>',
+            "<strong>Who's speaking?</strong>",
+            '<p>Choose your name to continue. Zoe will ask for your PIN or password next.</p>',
+            '<small class="sky-auth-request">' + escapeHtml(requestTitle) + '</small>',
             '</div>',
             '</div>',
-            '<div class="sky-auth-profile-grid" data-auth-profiles aria-label="Choose profile">',
+            '<div class="sky-auth-profile-grid" data-auth-profiles aria-label="Choose who is speaking">',
             '<div class="sky-auth-loading"><i></i><span>Finding people for this panel...</span></div>',
             '</div>',
-            '<div class="sky-auth-footer"><span>Say a name or tap a profile.</span><span>PIN opens next.</span><span>' + escapeHtml(finalStep) + '</span></div>',
+            '<div class="sky-auth-footer"><span>' + escapeHtml(body) + '</span><span>PIN or password appears after selection.</span></div>',
             '</div>'
         ].join('');
         return cardFrame(props, bodyHtml, { wide: true, tone: 'auth-challenge', hideHeader: true, hideStatus: true });

--- a/services/zoe-ui/dist/touch/js/skybridge.js
+++ b/services/zoe-ui/dist/touch/js/skybridge.js
@@ -449,18 +449,21 @@
             return;
         }
         const baseAction = props.actions && props.actions[0] ? props.actions[0] : {};
+        const panelId = currentPanelId({});
         target.innerHTML = profiles.map(profile => {
             const name = window.SkybridgeRenderer.escapeHtml(profile.username || profile.name || profile.user_id);
-            const role = window.SkybridgeRenderer.escapeHtml(profile.role || (profile.user_id === defaultUserId ? 'Default profile' : 'Profile'));
+            const roleText = profile.user_id === defaultUserId ? 'Default profile' : (profile.role || 'Profile');
+            const role = window.SkybridgeRenderer.escapeHtml(roleText);
             const avatar = window.SkybridgeRenderer.escapeHtml(authInitials(profile));
             const userId = window.SkybridgeRenderer.escapeHtml(profile.user_id);
+            const route = window.SkybridgeRenderer.escapeHtml(buildLoginRoute(panelId, profile.user_id));
             const selected = profile.user_id === defaultUserId ? ' is-default' : '';
             const challengeId = window.SkybridgeRenderer.escapeHtml(baseAction.challenge_id || '');
             const actionContext = window.SkybridgeRenderer.escapeHtml(baseAction.action_context || 'Enter PIN');
-            return '<button type="button" class="sky-auth-profile' + selected + '" data-sky-action="auth" data-route="" data-challenge-id="' + challengeId + '" data-action-context="' + actionContext + '" data-user-id="' + userId + '" data-user-name="' + name + '" data-user-avatar="' + avatar + '">' +
+            return '<button type="button" class="sky-auth-profile' + selected + '" data-sky-action="auth" data-route="' + route + '" data-challenge-id="' + challengeId + '" data-action-context="' + actionContext + '" data-user-id="' + userId + '" data-user-name="' + name + '" data-user-avatar="' + avatar + '">' +
                 '<span class="sky-auth-avatar">' + avatar + '</span>' +
                 '<span class="sky-auth-person"><strong>' + name + '</strong><small>' + role + '</small></span>' +
-                '<span class="sky-auth-enter">PIN</span>' +
+                '<span class="sky-auth-enter">PIN / Password</span>' +
                 '</button>';
         }).join('');
     }

--- a/services/zoe-ui/dist/touch/skybridge.html
+++ b/services/zoe-ui/dist/touch/skybridge.html
@@ -23,7 +23,7 @@
     <meta name="theme-color" content="#0b0d12">
     <title>Zoe Skybridge</title>
     <link rel="stylesheet" href="/touch/css/touch-adapter.css">
-    <link rel="stylesheet" href="/touch/css/skybridge-data-widgets.css?v=skybridge-auth-identity-1">
+    <link rel="stylesheet" href="/touch/css/skybridge-data-widgets.css?v=skybridge-auth-premium-1">
     <script src="/lib/livekit/livekit-client.umd.min.js" onerror="console.warn('LiveKit client not loaded')"></script>
     <style>
         :root {
@@ -4396,10 +4396,10 @@
     <script src="/js/websocket-sync.js?v=skybridge-auth-ready-1"></script>
     <script src="/touch/js/gestures.js?v=skybridge-auth-ready-1"></script>
     <script src="/touch/js/touch-menu.js?v=skybridge-auth-ready-1"></script>
-    <script src="/js/touch-ui-executor.js?v=skybridge-auth-identity-1"></script>
+    <script src="/js/touch-ui-executor.js?v=skybridge-auth-premium-1"></script>
     <script src="/touch/js/skybridge-capabilities.js?v=skybridge-push-ack-1"></script>
-    <script src="/touch/js/skybridge-renderer.js?v=skybridge-auth-identity-1"></script>
+    <script src="/touch/js/skybridge-renderer.js?v=skybridge-auth-premium-1"></script>
     <script src="/touch/js/skybridge-voice.js?v=skybridge-push-ack-1"></script>
-    <script src="/touch/js/skybridge.js?v=skybridge-auth-identity-1"></script>
+    <script src="/touch/js/skybridge.js?v=skybridge-auth-premium-1"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- make Skybridge auth challenges render as a premium pressable identity picker
- give each profile tile an explicit touch login route for PIN/password handoff
- bump Skybridge asset versions so touch panels do not keep stale auth JS/CSS

## Tests
- python3 -m pytest -q services/zoe-data/tests/test_skybridge_static.py services/zoe-data/tests/test_skybridge_service.py services/zoe-data/tests/test_voice_weather_queue.py services/zoe-data/tests/test_ui_actions_ack.py services/zoe-data/tests/test_ui_orchestrator_types.py
- cd services/zoe-auth && PYTHONPATH=tests:. python3 -m pytest -q tests/test_auth.py
- git diff --check