### PR TITLE
Fix stale implement-phase evidence assertions in test_pipeline_evidence

### DIFF
--- a/services/zoe-data/tests/test_pipeline_evidence.py
+++ b/services/zoe-data/tests/test_pipeline_evidence.py
@@ -56,11 +56,15 @@ def test_implement_requires_tool_evidence_before_complete():
     state = PipelineState(task_ref="multica:1", phase="implement")
 
     assert can_complete_phase(state) is False
-    assert missing_required_evidence(state) == {"tool"}
-    with pytest.raises(ValueError, match="missing required evidence"):
+    assert missing_required_evidence(state) == {"pr", "tool"}
+    with pytest.raises(ValueError, match="implement is missing required evidence: pr, tool"):
         transition(state, "complete")
 
-    state = with_evidence(state, EvidenceItem(kind="tool", summary="graphify query ran", passed=True))
+    state = with_evidence(
+        state,
+        EvidenceItem(kind="tool", summary="graphify query ran", passed=True),
+        EvidenceItem(kind="pr", summary="PR URL recorded", passed=True),
+    )
     next_state = transition(state, "complete")
 
     assert next_state.phase == "verify"
@@ -294,7 +298,7 @@ def test_skip_implementation_rejects_implement_without_evidence():
         status="blocked",
     )
 
-    with pytest.raises(ValueError, match="implement is missing required evidence: tool"):
+    with pytest.raises(ValueError, match="implement is missing required evidence: pr, tool"):
         transition(state, "skip_implementation")
 
 


### PR DESCRIPTION
## Summary
Two tests in `services/zoe-data/tests/test_pipeline_evidence.py` were failing on `origin/main`:
- `test_implement_requires_tool_evidence_before_complete`
- `test_skip_implementation_rejects_implement_without_evidence`

They asserted that the `implement` phase was missing only `tool` evidence, but `_REQUIRED_EVIDENCE` for `implement` has required `{pr, tool}` since #231 (`11ea87f0`). The tests went silently stale because the `validate` CI workflow (`.github/workflows/validate.yml`) only runs an explicit allowlist of test files that does **not** include `test_pipeline_evidence.py`.

## Change
- Update the expected missing-evidence set to `{"pr", "tool"}` and the `pytest.raises` regex to `"implement is missing required evidence: pr, tool"`.
- Supply a `pr` `EvidenceItem` in the can-complete-after-evidence path so the positive case still reaches `verify`.
- **No change** to `pipeline_evidence.py`'s `_REQUIRED_EVIDENCE` — only the stale tests.

## Verification
```
PYTHONPATH=services/zoe-data python3 -m pytest services/zoe-data/tests/test_pipeline_evidence.py -q
26 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)