### PR TITLE
Hide legacy Skybridge auth action

### DIFF
--- a/services/zoe-data/tests/test_skybridge_static.py
+++ b/services/zoe-data/tests/test_skybridge_static.py
@@ -432,9 +432,13 @@ def test_skybridge_auth_challenge_card_contract():
 
     assert "auth_challenge: renderAuthChallenge" in renderer
     assert "function renderAuthChallenge(props)" in renderer
-    assert "<strong>Who's speaking?</strong>" in renderer
-    assert "sky-auth-request" in renderer
-    assert "PIN or password appears after selection." in renderer
+    assert "sky-auth-people-only" in renderer
+    assert "Choose your profile" in renderer
+    assert "Who's speaking?" not in renderer
+    assert "sky-auth-request" not in renderer
+    assert "PIN or password appears after selection." not in renderer
+    assert "hideActions: true" in renderer
+    assert "!(options && options.hideActions)" in renderer
     assert "escapeHtml(action)" not in renderer[renderer.index("function renderAuthChallenge"):renderer.index("function renderStatus")]
     assert "data-auth-profiles" in renderer
     assert "sky-auth-profile-grid" in renderer
@@ -443,8 +447,9 @@ def test_skybridge_auth_challenge_card_contract():
     assert "data-user-avatar" in renderer
     assert "data-challenge-id" in renderer
     assert "data-action-context" in renderer
-    assert "Choose who is speaking" in renderer
-    assert "PIN / Password" in app
+    assert "Choose your profile" in renderer
+    assert "PIN / Password" not in app
+    assert 'aria-label="Sign in as ' in app
     assert "data-route=\"" in app
     assert "buildLoginRoute(panelId, profile.user_id)" in app
     assert "btn.dataset.skyAction === 'auth'" in app
@@ -478,7 +483,8 @@ def test_skybridge_auth_challenge_card_contract():
     assert "sky-auth-footer" in css
     assert "Skybridge premium auth picker" in css
     assert "grid-template-columns: repeat(auto-fit, minmax(154px, 1fr))" in css
-    assert "sky-auth-request" in css
+    assert "Skybridge profile-tile auth picker" in css
+    assert "sky-auth-people-only" in css
     assert "filter: blur" not in css[css.index("/* Skybridge premium auth picker */"):]
     assert '"component": "auth_challenge"' in service
     assert '"route": ""' in service

--- a/services/zoe-ui/dist/touch/css/skybridge-data-widgets.css
+++ b/services/zoe-ui/dist/touch/css/skybridge-data-widgets.css
@@ -1052,3 +1052,123 @@ body:not(.sky-empty) .sky-auth-steps {
         grid-template-columns: minmax(0, 1fr);
     }
 }
+
+/* Skybridge profile-tile auth picker */
+body:not(.sky-empty) .sky-card.auth-challenge {
+    width: min(760px, calc(100vw - 48px));
+    margin-inline: auto;
+    padding: 22px !important;
+    background:
+        linear-gradient(145deg, rgba(255,255,255,0.17), rgba(255,255,255,0.045) 42%, rgba(255,255,255,0.08)),
+        radial-gradient(circle at 18% 12%, rgba(125,244,238,0.36), transparent 32%),
+        radial-gradient(circle at 88% 6%, rgba(166,140,255,0.28), transparent 30%),
+        linear-gradient(152deg, rgba(22,27,41,0.98), rgba(8,10,18,0.99) 64%, rgba(2,5,11,1)) !important;
+    border: 1px solid rgba(255,255,255,0.20) !important;
+    box-shadow:
+        0 30px 82px rgba(0,0,0,0.42),
+        inset 0 1px 0 rgba(255,255,255,0.18) !important;
+}
+
+body:not(.sky-empty) .sky-auth-people-only {
+    position: relative;
+    z-index: 1;
+    display: block;
+}
+
+body:not(.sky-empty) .sky-auth-people-only .sky-auth-profile-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(172px, 1fr));
+    gap: 14px;
+    min-height: 0;
+}
+
+body:not(.sky-empty) .sky-auth-people-only .sky-auth-profile {
+    min-height: 178px;
+    border-radius: 32px;
+    padding: 18px;
+    align-items: flex-start;
+    justify-content: space-between;
+    background:
+        linear-gradient(150deg, rgba(255,255,255,0.20), rgba(255,255,255,0.06) 56%, rgba(255,255,255,0.10)),
+        rgba(255,255,255,0.06);
+    border-color: rgba(255,255,255,0.16);
+    box-shadow:
+        inset 0 1px 0 rgba(255,255,255,0.18),
+        0 18px 40px rgba(0,0,0,0.24);
+}
+
+body:not(.sky-empty) .sky-auth-people-only .sky-auth-profile::before {
+    content: '';
+    position: absolute;
+    inset: 1px;
+    border-radius: 31px;
+    border: 1px solid rgba(255,255,255,0.08);
+    pointer-events: none;
+}
+
+body:not(.sky-empty) .sky-auth-people-only .sky-auth-profile::after {
+    inset: auto 14px 14px 14px;
+    height: 3px;
+    border-radius: 999px;
+    background: linear-gradient(90deg, #83f5ee, #a38dff, #eef8ff);
+    opacity: 0.58;
+}
+
+body:not(.sky-empty) .sky-auth-people-only .sky-auth-profile:hover,
+body:not(.sky-empty) .sky-auth-people-only .sky-auth-profile:focus-visible {
+    transform: translateY(-4px);
+    border-color: rgba(137,248,242,0.62);
+    background:
+        linear-gradient(150deg, rgba(138,247,241,0.24), rgba(255,255,255,0.08) 50%, rgba(172,148,255,0.18)),
+        rgba(255,255,255,0.08);
+    box-shadow:
+        0 24px 62px rgba(75,214,225,0.17),
+        inset 0 1px 0 rgba(255,255,255,0.22);
+}
+
+body:not(.sky-empty) .sky-auth-people-only .sky-auth-avatar {
+    width: 72px;
+    height: 72px;
+    border-radius: 26px;
+    font-size: 1.65rem;
+}
+
+body:not(.sky-empty) .sky-auth-people-only .sky-auth-person strong {
+    font-size: 1.55rem;
+    line-height: 1.02;
+}
+
+body:not(.sky-empty) .sky-auth-people-only .sky-auth-hero,
+body:not(.sky-empty) .sky-auth-people-only .sky-auth-footer,
+body:not(.sky-empty) .sky-auth-people-only .sky-auth-enter,
+body:not(.sky-empty) .sky-auth-people-only .sky-auth-person small {
+    display: none !important;
+}
+
+@media (max-width: 620px) {
+    body:not(.sky-empty) .sky-card.auth-challenge {
+        width: min(420px, calc(100vw - 28px));
+        padding: 14px !important;
+    }
+    body:not(.sky-empty) .sky-auth-people-only .sky-auth-profile-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 10px;
+    }
+    body:not(.sky-empty) .sky-auth-people-only .sky-auth-profile {
+        min-height: 142px;
+        border-radius: 26px;
+        padding: 14px;
+    }
+    body:not(.sky-empty) .sky-auth-people-only .sky-auth-profile::before {
+        border-radius: 25px;
+    }
+    body:not(.sky-empty) .sky-auth-people-only .sky-auth-avatar {
+        width: 58px;
+        height: 58px;
+        border-radius: 21px;
+        font-size: 1.35rem;
+    }
+    body:not(.sky-empty) .sky-auth-people-only .sky-auth-person strong {
+        font-size: 1.18rem;
+    }
+}

--- a/services/zoe-ui/dist/touch/js/skybridge-renderer.js
+++ b/services/zoe-ui/dist/touch/js/skybridge-renderer.js
@@ -50,7 +50,7 @@
         const tone = safeTone ? ' ' + safeTone : '';
         const showHeader = !(options && options.hideHeader);
         const showStatus = !(options && options.hideStatus);
-        const actions = Array.isArray(props.actions) && props.actions.length
+        const actions = !(options && options.hideActions) && Array.isArray(props.actions) && props.actions.length
             ? '<div class="sky-actions">' + props.actions.map(buttonHtml).join('') + '</div>'
             : '';
         return [
@@ -72,27 +72,14 @@
     }
 
     function renderAuthChallenge(props) {
-        const requestTitle = props.title || 'Private request';
-        const body = props.body || props.message || 'Zoe needs to know who is speaking before showing or changing personal data.';
-        const domain = props.domain ? String(props.domain) : 'Private data';
         const bodyHtml = [
-            '<div class="sky-auth-scene">',
-            '<div class="sky-auth-hero">',
-            '<div class="sky-auth-orb" aria-hidden="true"><span></span></div>',
-            '<div class="sky-auth-copy">',
-            '<span>' + escapeHtml(domain) + '</span>',
-            "<strong>Who's speaking?</strong>",
-            '<p>Choose your name to continue. Zoe will ask for your PIN or password next.</p>',
-            '<small class="sky-auth-request">' + escapeHtml(requestTitle) + '</small>',
-            '</div>',
-            '</div>',
-            '<div class="sky-auth-profile-grid" data-auth-profiles aria-label="Choose who is speaking">',
+            '<div class="sky-auth-scene sky-auth-people-only">',
+            '<div class="sky-auth-profile-grid" data-auth-profiles aria-label="Choose your profile">',
             '<div class="sky-auth-loading"><i></i><span>Finding people for this panel...</span></div>',
             '</div>',
-            '<div class="sky-auth-footer"><span>' + escapeHtml(body) + '</span><span>PIN or password appears after selection.</span></div>',
             '</div>'
         ].join('');
-        return cardFrame(props, bodyHtml, { wide: true, tone: 'auth-challenge', hideHeader: true, hideStatus: true });
+        return cardFrame(props, bodyHtml, { wide: true, tone: 'auth-challenge', hideHeader: true, hideStatus: true, hideActions: true });
     }
 
     function renderStatus(props) {

--- a/services/zoe-ui/dist/touch/js/skybridge.js
+++ b/services/zoe-ui/dist/touch/js/skybridge.js
@@ -452,18 +452,15 @@
         const panelId = currentPanelId({});
         target.innerHTML = profiles.map(profile => {
             const name = window.SkybridgeRenderer.escapeHtml(profile.username || profile.name || profile.user_id);
-            const roleText = profile.user_id === defaultUserId ? 'Default profile' : (profile.role || 'Profile');
-            const role = window.SkybridgeRenderer.escapeHtml(roleText);
             const avatar = window.SkybridgeRenderer.escapeHtml(authInitials(profile));
             const userId = window.SkybridgeRenderer.escapeHtml(profile.user_id);
             const route = window.SkybridgeRenderer.escapeHtml(buildLoginRoute(panelId, profile.user_id));
             const selected = profile.user_id === defaultUserId ? ' is-default' : '';
             const challengeId = window.SkybridgeRenderer.escapeHtml(baseAction.challenge_id || '');
             const actionContext = window.SkybridgeRenderer.escapeHtml(baseAction.action_context || 'Enter PIN');
-            return '<button type="button" class="sky-auth-profile' + selected + '" data-sky-action="auth" data-route="' + route + '" data-challenge-id="' + challengeId + '" data-action-context="' + actionContext + '" data-user-id="' + userId + '" data-user-name="' + name + '" data-user-avatar="' + avatar + '">' +
+            return '<button type="button" class="sky-auth-profile' + selected + '" aria-label="Sign in as ' + name + '" data-sky-action="auth" data-route="' + route + '" data-challenge-id="' + challengeId + '" data-action-context="' + actionContext + '" data-user-id="' + userId + '" data-user-name="' + name + '" data-user-avatar="' + avatar + '">' +
                 '<span class="sky-auth-avatar">' + avatar + '</span>' +
-                '<span class="sky-auth-person"><strong>' + name + '</strong><small>' + role + '</small></span>' +
-                '<span class="sky-auth-enter">PIN / Password</span>' +
+                '<span class="sky-auth-person"><strong>' + name + '</strong></span>' +
                 '</button>';
         }).join('');
     }


### PR DESCRIPTION
## Summary
- hide the generic auth challenge action row so profile tiles are the only login affordance
- keep actions available for non-auth Skybridge cards
- add static contract coverage for the auth-card hideActions path

## Tests
- python3 -m pytest -q services/zoe-data/tests/test_skybridge_static.py services/zoe-data/tests/test_skybridge_service.py services/zoe-data/tests/test_voice_weather_queue.py services/zoe-data/tests/test_ui_actions_ack.py services/zoe-data/tests/test_ui_orchestrator_types.py
- cd services/zoe-auth && PYTHONPATH=tests:. python3 -m pytest -q tests/test_auth.py
- git diff --check