### PR TITLE
Converge already-covered audit runs through the verify gate; enroll pipeline tests in CI

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -92,6 +92,10 @@ jobs:
             services/zoe-data/tests/test_ui_orchestrator_types.py \
             services/zoe-data/tests/test_greptile_client.py \
             services/zoe-data/tests/test_greploop_guard.py \
+            services/zoe-data/tests/test_pipeline_store.py \
+            services/zoe-data/tests/test_pipeline_evidence.py \
+            services/zoe-data/tests/test_multica_poll_dispatch.py \
+            services/zoe-data/tests/test_main_multica_poll.py \
             services/zoe-data/tests/test_zoe_agent_self_url.py \
             -x -q \
             --override-ini="asyncio_mode=auto"

--- a/services/zoe-data/pipeline_store.py
+++ b/services/zoe-data/pipeline_store.py
@@ -517,7 +517,10 @@ def _append_audit_protocol_recovery_evidence(state: PipelineState, phase: Pipeli
         "retro": "log",
     }
     kind = kind_by_phase[phase]
-    if any(item.kind == kind and item.metadata.get("phase") == phase for item in state.evidence):
+    if any(
+        item.kind == kind and item.metadata.get("phase") == phase and item.passed is True
+        for item in state.evidence
+    ):
         return state
     return with_evidence(
         state,
@@ -727,13 +730,19 @@ async def _sync_pipeline_from_chain_once(
             outcome = "skip_implementation"
         if (
             state.evidence_profile == "audit"
-            and outcome in {"block", "verification_failed", "request_changes", "merge_blocked"}
             and (_protocol_only_block(detail) or _run_is_already_covered(state))
+            and (
+                outcome in {"block", "verification_failed", "request_changes", "merge_blocked"}
+                or (outcome == "complete" and not can_complete_phase(state))
+            )
         ):
             # An already-covered run has no diff to verify/review/merge, so a
-            # no-op downstream block (e.g. review request_changes with no PR) is
-            # recovered to completion. Without this it bounces review -> implement
-            # forever, never reaching a terminal handoff and holding the lane.
+            # no-op downstream phase is recovered to completion. This covers both a
+            # no-op block (e.g. review request_changes with no PR) and a terminal
+            # "done" row whose gate evidence can't be produced (e.g. verify, where
+            # the harness validators have no diff to pass on). Without this the run
+            # either bounces review -> implement forever or stalls at the verify
+            # gate, never reaching a terminal handoff and holding the lane.
             state = _append_audit_protocol_recovery_evidence(state, phase)  # type: ignore[arg-type]
             if can_complete_phase(state):
                 state = await _run_io(

--- a/services/zoe-data/tests/test_pipeline_store.py
+++ b/services/zoe-data/tests/test_pipeline_store.py
@@ -1076,7 +1076,7 @@ async def test_sync_pipeline_recovers_audit_protocol_only_block(isolated_store):
 
 
 @pytest.mark.asyncio
-async def test_already_covered_run_converges_instead_of_review_implement_loop(isolated_store):
+async def test_already_covered_run_converges_instead_of_review_implement_loop(isolated_store, monkeypatch):
     # Regression: an already-covered run (implementation proven unnecessary) used
     # to bounce review -> implement forever, because review's no-PR request_changes
     # is not "protocol-only" and so was never recovered. It must now converge.
@@ -1103,7 +1103,18 @@ async def test_already_covered_run_converges_instead_of_review_implement_loop(is
     async def fetch_plain(_task_id):
         return {"latest_summary": "", "comments": []}
 
-    # 2) verify completes for the audit no-op run.
+    # Force the harness validators to FAIL so the verify gate cannot be satisfied
+    # the normal way. An already-covered run has no diff for validators to pass on,
+    # so this pins the audit no-op recovery path rather than passing trivially in
+    # environments where the repo validators happen to succeed.
+    from pipeline_validators import ValidatorRunResult
+
+    monkeypatch.setattr(
+        "pipeline_validators.run_repo_validators",
+        lambda: ValidatorRunResult(exit_code=1, summary="no diff", content_hash="deadbeef", passed=False),
+    )
+
+    # 2) verify converges for the audit no-op run despite failing validators.
     state = await store.sync_pipeline_from_chain(
         ref, {"verify": {"id": "t_verify", "status": "done"}}, fetch_plain
     )


### PR DESCRIPTION
> **Stacked on #499** — review/merge [#499](https://github.com/jason-easyazz/zoe-ai-assistant/pull/499) first. Base will retarget to `main` once #499 lands.

## Background
While spinning off the CI-allowlist follow-up from #499, adding the previously-excluded pipeline tests to the `validate` workflow surfaced a **second** stale failure that had been shipping red and uncaught: `test_pipeline_store.py::test_already_covered_run_converges_instead_of_review_implement_loop` (introduced with its fix in #479, `caadd05c`, but never in the CI allowlist).

## The bug
An *already-covered* run — `implement` proves no code change is needed — flips to the `audit` profile and skips to `verify`. When the `verify` Kanban row then lands `done`:
- `sync_pipeline_from_chain` infers `outcome=complete`, but the audit `verify` gate requires a **passing** `validator`. The harness validators have no diff to pass on, so no passing `validator` evidence exists.
- The existing audit no-op recovery only fired for block-like outcomes (`block`/`verification_failed`/`request_changes`/`merge_blocked`), **not** for a terminal `done` row that can't satisfy its gate. So the run stalled at the verify gate instead of converging to `review`.
- Even when reached, `_append_audit_protocol_recovery_evidence` short-circuited because a **failed** harness `validator` (phase=`verify`) already existed — its guard ignored `passed`, so it refused to add the passing recovery item.

## The fix (`pipeline_store.py`)
- Extend the audit no-op recovery to also cover `outcome == "complete" and not can_complete_phase(state)` for protocol-only / already-covered runs.
- Tighten the recovery-evidence guard to short-circuit only on a **passing** item of that kind/phase.

## CI hardening (`validate.yml`)
Add the four previously-excluded files to the allowlist so this class of drift is caught going forward: `test_pipeline_store.py`, `test_pipeline_evidence.py`, `test_multica_poll_dispatch.py`, `test_main_multica_poll.py`. All four are green with this change + #499.

## Verification
```
PYTHONPATH=services/zoe-data python3 -m pytest services/zoe-data/tests -q --override-ini="asyncio_mode=auto"
1651 passed
```
No change to `_REQUIRED_EVIDENCE` or evidence contracts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)