### PR TITLE
Refine Skybridge auth name tiles

### DIFF
--- a/services/zoe-data/tests/test_skybridge_static.py
+++ b/services/zoe-data/tests/test_skybridge_static.py
@@ -59,9 +59,9 @@ def test_skybridge_push_socket_uses_authenticated_session_query():
     main = (ROOT / "zoe-data" / "main.py").read_text(encoding="utf-8")
 
     assert "/js/websocket-sync.js?v=skybridge-auth-ready-1" in html
-    assert "/touch/js/skybridge.js?v=skybridge-auth-premium-1" in html
-    assert "/touch/js/skybridge-renderer.js?v=skybridge-auth-premium-1" in html
-    assert "/js/touch-ui-executor.js?v=skybridge-auth-premium-1" in html
+    assert "/touch/js/skybridge.js?v=skybridge-auth-nametiles-1" in html
+    assert "/touch/js/skybridge-renderer.js?v=skybridge-auth-nametiles-1" in html
+    assert "/js/touch-ui-executor.js?v=skybridge-auth-nametiles-1" in html
     assert "initPush(panelId, sessionId)" in sync
     assert "params.set('panel_id', panelId)" in sync
     assert "else params.set('channel', 'all')" in sync
@@ -311,7 +311,7 @@ def test_skybridge_renderer_supports_real_data_cards():
     assert "sky-event-row" in html
     assert "sky-weather-hour-tile" in html
     assert "sky-weather-day-row" in html
-    assert "/touch/css/skybridge-data-widgets.css?v=skybridge-auth-premium-1" in html
+    assert "/touch/css/skybridge-data-widgets.css?v=skybridge-auth-nametiles-1" in html
     assert "skybridge-lists-people-widgets" not in html
     assert "sky-list-item-row" in data_widgets_css
     assert "sky-person-row" in data_widgets_css
@@ -444,12 +444,12 @@ def test_skybridge_auth_challenge_card_contract():
     assert "sky-auth-profile-grid" in renderer
     assert "data-user-id" in renderer
     assert "data-user-name" in renderer
-    assert "data-user-avatar" in renderer
     assert "data-challenge-id" in renderer
     assert "data-action-context" in renderer
     assert "Choose your profile" in renderer
     assert "PIN / Password" not in app
     assert 'aria-label="Sign in as ' in app
+    assert '<span class="sky-auth-avatar">' not in app
     assert "data-route=\"" in app
     assert "buildLoginRoute(panelId, profile.user_id)" in app
     assert "btn.dataset.skyAction === 'auth'" in app
@@ -484,7 +484,10 @@ def test_skybridge_auth_challenge_card_contract():
     assert "Skybridge premium auth picker" in css
     assert "grid-template-columns: repeat(auto-fit, minmax(154px, 1fr))" in css
     assert "Skybridge profile-tile auth picker" in css
+    assert "Skybridge name-only auth tiles" in css
     assert "sky-auth-people-only" in css
+    assert "sky-auth-avatar" in css
+    assert "display: none !important" in css[css.index("/* Skybridge name-only auth tiles */"):]
     assert "filter: blur" not in css[css.index("/* Skybridge premium auth picker */"):]
     assert '"component": "auth_challenge"' in service
     assert '"route": ""' in service

--- a/services/zoe-data/tests/test_skybridge_static.py
+++ b/services/zoe-data/tests/test_skybridge_static.py
@@ -450,6 +450,7 @@ def test_skybridge_auth_challenge_card_contract():
     assert "PIN / Password" not in app
     assert 'aria-label="Sign in as ' in app
     assert '<span class="sky-auth-avatar">' not in app
+    assert "data-user-avatar" in app
     assert "data-route=\"" in app
     assert "buildLoginRoute(panelId, profile.user_id)" in app
     assert "btn.dataset.skyAction === 'auth'" in app

--- a/services/zoe-ui/dist/touch/css/skybridge-data-widgets.css
+++ b/services/zoe-ui/dist/touch/css/skybridge-data-widgets.css
@@ -1172,3 +1172,127 @@ body:not(.sky-empty) .sky-auth-people-only .sky-auth-person small {
         font-size: 1.18rem;
     }
 }
+
+/* Skybridge name-only auth tiles */
+body:not(.sky-empty) .sky-card.auth-challenge {
+    width: min(780px, calc(100vw - 48px));
+    margin-inline: auto;
+    padding: 0 !important;
+    background: transparent !important;
+    border: 0 !important;
+    box-shadow: none !important;
+}
+
+body:not(.sky-empty) .sky-card.auth-challenge::before {
+    content: none !important;
+}
+
+body:not(.sky-empty) .sky-auth-people-only .sky-auth-profile-grid {
+    grid-template-columns: repeat(auto-fit, minmax(218px, 1fr));
+    gap: 14px;
+}
+
+body:not(.sky-empty) .sky-auth-people-only .sky-auth-profile {
+    min-height: 118px;
+    border-radius: 28px;
+    padding: 18px 22px;
+    display: grid;
+    place-items: center;
+    text-align: center;
+    background:
+        linear-gradient(145deg, rgba(255,255,255,0.19), rgba(255,255,255,0.065) 52%, rgba(255,255,255,0.11)),
+        linear-gradient(165deg, rgba(123,245,238,0.13), rgba(156,136,255,0.12));
+    border: 1px solid rgba(255,255,255,0.18);
+    box-shadow:
+        0 18px 44px rgba(0,0,0,0.25),
+        inset 0 1px 0 rgba(255,255,255,0.20),
+        inset 0 -1px 0 rgba(255,255,255,0.06);
+}
+
+body:not(.sky-empty) .sky-auth-people-only .sky-auth-profile::before {
+    content: '';
+    position: absolute;
+    inset: 1px;
+    border-radius: 27px;
+    border: 1px solid rgba(255,255,255,0.08);
+    background: linear-gradient(110deg, rgba(255,255,255,0.16), transparent 42%, rgba(122,245,238,0.08));
+    pointer-events: none;
+}
+
+body:not(.sky-empty) .sky-auth-people-only .sky-auth-profile::after {
+    content: '';
+    position: absolute;
+    left: 22px;
+    right: 22px;
+    bottom: 16px;
+    height: 2px;
+    border-radius: 999px;
+    background: linear-gradient(90deg, transparent, rgba(133,246,239,0.76), rgba(166,146,255,0.72), transparent);
+    opacity: 0.48;
+}
+
+body:not(.sky-empty) .sky-auth-people-only .sky-auth-profile:hover,
+body:not(.sky-empty) .sky-auth-people-only .sky-auth-profile:focus-visible {
+    transform: translateY(-3px);
+    border-color: rgba(139,248,242,0.58);
+    background:
+        linear-gradient(145deg, rgba(255,255,255,0.23), rgba(255,255,255,0.08) 52%, rgba(255,255,255,0.13)),
+        linear-gradient(165deg, rgba(123,245,238,0.18), rgba(156,136,255,0.16));
+    box-shadow:
+        0 24px 62px rgba(73,214,226,0.15),
+        0 18px 44px rgba(0,0,0,0.27),
+        inset 0 1px 0 rgba(255,255,255,0.24);
+}
+
+body:not(.sky-empty) .sky-auth-people-only .sky-auth-profile.is-default {
+    border-color: rgba(143,248,242,0.34);
+}
+
+body:not(.sky-empty) .sky-auth-people-only .sky-auth-avatar {
+    display: none !important;
+}
+
+body:not(.sky-empty) .sky-auth-people-only .sky-auth-person {
+    display: block;
+    width: 100%;
+}
+
+body:not(.sky-empty) .sky-auth-people-only .sky-auth-person strong {
+    display: block;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: rgba(255,255,255,0.96);
+    font-size: 2rem;
+    line-height: 1;
+    font-weight: 850;
+    letter-spacing: 0;
+    text-shadow: 0 1px 18px rgba(0,0,0,0.24);
+}
+
+@media (max-width: 620px) {
+    body:not(.sky-empty) .sky-card.auth-challenge {
+        width: min(440px, calc(100vw - 28px));
+    }
+    body:not(.sky-empty) .sky-auth-people-only .sky-auth-profile-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 10px;
+    }
+    body:not(.sky-empty) .sky-auth-people-only .sky-auth-profile {
+        min-height: 104px;
+        border-radius: 24px;
+        padding: 16px 14px;
+    }
+    body:not(.sky-empty) .sky-auth-people-only .sky-auth-profile::before {
+        border-radius: 23px;
+    }
+    body:not(.sky-empty) .sky-auth-people-only .sky-auth-profile::after {
+        left: 16px;
+        right: 16px;
+        bottom: 13px;
+    }
+    body:not(.sky-empty) .sky-auth-people-only .sky-auth-person strong {
+        font-size: 1.35rem;
+    }
+}

--- a/services/zoe-ui/dist/touch/js/skybridge.js
+++ b/services/zoe-ui/dist/touch/js/skybridge.js
@@ -459,7 +459,6 @@
             const challengeId = window.SkybridgeRenderer.escapeHtml(baseAction.challenge_id || '');
             const actionContext = window.SkybridgeRenderer.escapeHtml(baseAction.action_context || 'Enter PIN');
             return '<button type="button" class="sky-auth-profile' + selected + '" aria-label="Sign in as ' + name + '" data-sky-action="auth" data-route="' + route + '" data-challenge-id="' + challengeId + '" data-action-context="' + actionContext + '" data-user-id="' + userId + '" data-user-name="' + name + '" data-user-avatar="' + avatar + '">' +
-                '<span class="sky-auth-avatar">' + avatar + '</span>' +
                 '<span class="sky-auth-person"><strong>' + name + '</strong></span>' +
                 '</button>';
         }).join('');

--- a/services/zoe-ui/dist/touch/skybridge.html
+++ b/services/zoe-ui/dist/touch/skybridge.html
@@ -23,7 +23,7 @@
     <meta name="theme-color" content="#0b0d12">
     <title>Zoe Skybridge</title>
     <link rel="stylesheet" href="/touch/css/touch-adapter.css">
-    <link rel="stylesheet" href="/touch/css/skybridge-data-widgets.css?v=skybridge-auth-premium-1">
+    <link rel="stylesheet" href="/touch/css/skybridge-data-widgets.css?v=skybridge-auth-nametiles-1">
     <script src="/lib/livekit/livekit-client.umd.min.js" onerror="console.warn('LiveKit client not loaded')"></script>
     <style>
         :root {
@@ -4396,10 +4396,10 @@
     <script src="/js/websocket-sync.js?v=skybridge-auth-ready-1"></script>
     <script src="/touch/js/gestures.js?v=skybridge-auth-ready-1"></script>
     <script src="/touch/js/touch-menu.js?v=skybridge-auth-ready-1"></script>
-    <script src="/js/touch-ui-executor.js?v=skybridge-auth-premium-1"></script>
+    <script src="/js/touch-ui-executor.js?v=skybridge-auth-nametiles-1"></script>
     <script src="/touch/js/skybridge-capabilities.js?v=skybridge-push-ack-1"></script>
-    <script src="/touch/js/skybridge-renderer.js?v=skybridge-auth-premium-1"></script>
+    <script src="/touch/js/skybridge-renderer.js?v=skybridge-auth-nametiles-1"></script>
     <script src="/touch/js/skybridge-voice.js?v=skybridge-push-ack-1"></script>
-    <script src="/touch/js/skybridge.js?v=skybridge-auth-premium-1"></script>
+    <script src="/touch/js/skybridge.js?v=skybridge-auth-nametiles-1"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove the large initial/avatar from Skybridge auth profile tiles
- make auth selection name-led with cleaner glass tiles and no outer card chrome
- bump Skybridge auth asset versions for panel cache refresh

## Tests
- python3 -m pytest -q services/zoe-data/tests/test_skybridge_static.py services/zoe-data/tests/test_skybridge_service.py services/zoe-data/tests/test_voice_weather_queue.py services/zoe-data/tests/test_ui_actions_ack.py services/zoe-data/tests/test_ui_orchestrator_types.py
- cd services/zoe-auth && PYTHONPATH=tests:. python3 -m pytest -q tests/test_auth.py
- git diff --check