### PR TITLE
ci: cover engineering-harness tests in validate; fix stale pipeline_evidence assertions

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -93,6 +93,10 @@ jobs:
             services/zoe-data/tests/test_greptile_client.py \
             services/zoe-data/tests/test_greploop_guard.py \
             services/zoe-data/tests/test_zoe_agent_self_url.py \
+            services/zoe-data/tests/test_pipeline_store.py \
+            services/zoe-data/tests/test_pipeline_evidence.py \
+            services/zoe-data/tests/test_multica_poll_dispatch.py \
+            services/zoe-data/tests/test_main_multica_poll.py \
             -x -q \
             --override-ini="asyncio_mode=auto"
           PYTHONPATH="${{ github.workspace }}/services/zoe-auth:${{ github.workspace }}/services/zoe-auth/tests" pytest \

--- a/services/zoe-data/tests/test_pipeline_evidence.py
+++ b/services/zoe-data/tests/test_pipeline_evidence.py
@@ -56,11 +56,13 @@ def test_implement_requires_tool_evidence_before_complete():
     state = PipelineState(task_ref="multica:1", phase="implement")
 
     assert can_complete_phase(state) is False
-    assert missing_required_evidence(state) == {"tool"}
+    assert missing_required_evidence(state) == {"pr", "tool"}
     with pytest.raises(ValueError, match="missing required evidence"):
         transition(state, "complete")
 
     state = with_evidence(state, EvidenceItem(kind="tool", summary="graphify query ran", passed=True))
+    assert missing_required_evidence(state) == {"pr"}
+    state = with_evidence(state, EvidenceItem(kind="pr", summary="opened PR for implement", passed=True))
     next_state = transition(state, "complete")
 
     assert next_state.phase == "verify"
@@ -294,7 +296,7 @@ def test_skip_implementation_rejects_implement_without_evidence():
         status="blocked",
     )
 
-    with pytest.raises(ValueError, match="implement is missing required evidence: tool"):
+    with pytest.raises(ValueError, match="implement is missing required evidence: pr, tool"):
         transition(state, "skip_implementation")
 
 


### PR DESCRIPTION
## What
- Adds the harness pipeline/poll test suites to the `validate.yml` pytest allowlist (`test_pipeline_store`, `test_pipeline_evidence`, `test_multica_poll_dispatch`, `test_main_multica_poll`) so harness regressions are caught on every PR.
- Fixes two stale assertions in `test_pipeline_evidence.py`: `implement` now requires `{pr, tool}` evidence, so both tests assert `"implement is missing required evidence: pr, tool"` (and the first test adds a matching `pr` `EvidenceItem` so completion still succeeds).

## Why
The harness pipeline/poll tests were never run in CI (the validate allowlist excluded them), so the two stale `test_pipeline_evidence` assertions had been failing unnoticed. This closes that gap.

## Provenance
The implementation was produced **autonomously** by the Multica→Hermes engineering harness — MiniMax M3 worker on ticket ZOE-5797 (scout→implement, correct multi-file edits + tests, within budget). It blocked for human review instead of self-opening the PR; this PR lands its diff verbatim.

## Tests
`PYTHONPATH=services/zoe-data pytest tests/test_pipeline_store.py tests/test_pipeline_evidence.py tests/test_multica_poll_dispatch.py tests/test_main_multica_poll.py` → **125 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)