### PR TITLE
Add Pi intent shadow evidence

### DIFF
--- a/docs/architecture/zoe-pi-runtime-harness.md
+++ b/docs/architecture/zoe-pi-runtime-harness.md
@@ -43,7 +43,7 @@ Environment variables:
 | `ZOE_PI_AGENT_DIR` | unset | Optional explicit `.pi/agents` directory. |
 | `ZOE_PI_TIMEOUT_SECONDS` | `2.0` | Future runtime command timeout. |
 | `ZOE_PI_INTENT_SHADOW_ENABLED` | `false` | Collect Pi-vs-Zoe intent comparison records without executing Pi output. |
-| `ZOE_PI_INTENT_SHADOW_PATH` | `/home/zoe/training/data/pi-intent-shadow.jsonl` | JSONL evidence path for shadow records. |
+| `ZOE_PI_INTENT_SHADOW_PATH` | `~/.zoe/data/pi-intent-shadow.jsonl` | JSONL evidence path for shadow records. |
 | `ZOE_PI_INTENT_SHADOW_MAX_WORDS` | `32` | Maximum utterance length eligible for shadow comparison. |
 | `ZOE_PI_INTENT_SHADOW_INCLUDE_PREVIEW` | `true` | Store a short sanitized text preview alongside the text hash. |
 | `ZOE_PI_INTENT_SHADOW_FORCE_ENABLED` | `true` | Force the classifier on inside shadow mode while keeping live routing unchanged. |

--- a/docs/architecture/zoe-pi-runtime-harness.md
+++ b/docs/architecture/zoe-pi-runtime-harness.md
@@ -42,6 +42,11 @@ Environment variables:
 | `ZOE_PI_CWD` | `/home/zoe/assistant` | Project directory for Pi runtime discovery. |
 | `ZOE_PI_AGENT_DIR` | unset | Optional explicit `.pi/agents` directory. |
 | `ZOE_PI_TIMEOUT_SECONDS` | `2.0` | Future runtime command timeout. |
+| `ZOE_PI_INTENT_SHADOW_ENABLED` | `false` | Collect Pi-vs-Zoe intent comparison records without executing Pi output. |
+| `ZOE_PI_INTENT_SHADOW_PATH` | `/home/zoe/training/data/pi-intent-shadow.jsonl` | JSONL evidence path for shadow records. |
+| `ZOE_PI_INTENT_SHADOW_MAX_WORDS` | `32` | Maximum utterance length eligible for shadow comparison. |
+| `ZOE_PI_INTENT_SHADOW_INCLUDE_PREVIEW` | `true` | Store a short sanitized text preview alongside the text hash. |
+| `ZOE_PI_INTENT_SHADOW_FORCE_ENABLED` | `true` | Force the classifier on inside shadow mode while keeping live routing unchanged. |
 
 ## Probe
 
@@ -51,6 +56,23 @@ PYTHONPATH=services/zoe-data python3 scripts/maintenance/pi_runtime_probe.py --j
 
 The probe is safe to run in production-adjacent environments because it only
 uses filesystem and `PATH` checks. It does not execute `pi`.
+
+## Intent Shadow Evidence
+
+Pi intent shadow mode is disabled by default. When
+`ZOE_PI_INTENT_SHADOW_ENABLED=true`, Zoe's current intent route remains
+authoritative and Pi output is never executed by the shadow path. The shadow
+producer records sanitized JSONL evidence containing Zoe intent, Pi intent,
+route class, confidence, agreement, timeout, and latency fields.
+
+Admin status is available at:
+
+```bash
+GET /api/system/pi-intent/shadow-status
+```
+
+The first runtime slice reports agreement and latency only. It deliberately does
+not claim promotion accuracy until an outcome label or correction path exists.
 
 
 ## Review-Only Runtime Proposal

--- a/services/zoe-data/intent_router.py
+++ b/services/zoe-data/intent_router.py
@@ -15,6 +15,7 @@ import logging
 import os
 import re
 import shlex
+import time
 import shutil
 import unicodedata
 from dataclasses import dataclass, field
@@ -1302,21 +1303,50 @@ async def detect_and_extract_intent(
     Returns None when no intent matched OR when LLM extraction failed (caller
     should fall through to Zoe Agent).
     """
+    def _context_turns() -> str:
+        if context and context.is_fresh() and context.last_text:
+            return f"previous={context.last_text!r}; previous_intent={context.last_intent}"
+        return ""
+
+    async def _record_pi_shadow(
+        zoe_intent: Optional["Intent"],
+        *,
+        route_class: str,
+        zoe_latency_ms: float | None,
+    ) -> None:
+        shadow_enabled = str(os.environ.get("ZOE_PI_INTENT_SHADOW_ENABLED") or "").strip().lower()
+        if shadow_enabled not in {"1", "true", "yes", "on"}:
+            return
+        try:
+            from pi_intent_shadow import maybe_record_pi_intent_shadow
+
+            await maybe_record_pi_intent_shadow(
+                text,
+                zoe_intent=zoe_intent.name if zoe_intent else None,
+                zoe_confidence=zoe_intent.confidence if zoe_intent else None,
+                zoe_latency_ms=zoe_latency_ms,
+                route_class=route_class,
+                user_id=user_id,
+                context_turns=_context_turns(),
+            )
+        except Exception as exc:
+            logger.debug("detect_and_extract_intent: Pi shadow evidence failed: %s", exc)
+
     async def _try_pi_governor() -> Optional["Intent"]:
         try:
             from pi_intent_classifier import PI_INTENT_EXECUTE_THRESHOLD, classify_with_pi_intent_governor
-            context_turns = ""
-            if context and context.is_fresh() and context.last_text:
-                context_turns = f"previous={context.last_text!r}; previous_intent={context.last_intent}"
-            pi_classified = await classify_with_pi_intent_governor(text, context_turns=context_turns)
+            pi_classified = await classify_with_pi_intent_governor(text, context_turns=_context_turns())
             if pi_classified and pi_classified.intent and pi_classified.confidence >= PI_INTENT_EXECUTE_THRESHOLD:
                 return Intent(pi_classified.intent, dict(pi_classified.slots), confidence=pi_classified.confidence)
         except Exception as exc:
             logger.debug("detect_and_extract_intent: Pi/Gemma governor failed: %s", exc)
         return None
 
+    started = time.perf_counter()
     intent = detect_intent(text, context=context)
+    detect_latency_ms = (time.perf_counter() - started) * 1000
     if intent is None:
+        await _record_pi_shadow(None, route_class="fallback", zoe_latency_ms=detect_latency_ms)
         return await _try_pi_governor()
     if intent.slots and "raw" in intent.slots:
         try:
@@ -1324,6 +1354,11 @@ async def detect_and_extract_intent(
             structured = await extract_slots_for_intent(intent.name, intent.slots["raw"])
             if structured:
                 intent.slots = structured
+                await _record_pi_shadow(
+                    intent,
+                    route_class="deterministic",
+                    zoe_latency_ms=(time.perf_counter() - started) * 1000,
+                )
                 return intent
         except Exception as _exc:
             logger.warning(
@@ -1332,7 +1367,13 @@ async def detect_and_extract_intent(
                 _exc,
             )
         # Extraction failed — let Pi/Gemma classify the ambiguous utterance once before Zoe Agent fallback.
+        await _record_pi_shadow(
+            None,
+            route_class="extraction_failed",
+            zoe_latency_ms=(time.perf_counter() - started) * 1000,
+        )
         return await _try_pi_governor()
+    await _record_pi_shadow(intent, route_class="deterministic", zoe_latency_ms=detect_latency_ms)
     return intent
 
 

--- a/services/zoe-data/intent_router.py
+++ b/services/zoe-data/intent_router.py
@@ -1308,53 +1308,72 @@ async def detect_and_extract_intent(
             return f"previous={context.last_text!r}; previous_intent={context.last_intent}"
         return ""
 
-    async def _record_pi_shadow(
+    shadow_unset = object()
+
+    def _env_enabled(name: str) -> bool:
+        return str(os.environ.get(name) or "").strip().lower() in {"1", "true", "yes", "on"}
+
+    def _schedule_pi_shadow(
         zoe_intent: Optional["Intent"],
         *,
         route_class: str,
         zoe_latency_ms: float | None,
+        pi_result=shadow_unset,
     ) -> None:
-        shadow_enabled = str(os.environ.get("ZOE_PI_INTENT_SHADOW_ENABLED") or "").strip().lower()
-        if shadow_enabled not in {"1", "true", "yes", "on"}:
+        if not _env_enabled("ZOE_PI_INTENT_SHADOW_ENABLED"):
             return
-        try:
-            from pi_intent_shadow import maybe_record_pi_intent_shadow
 
-            await maybe_record_pi_intent_shadow(
-                text,
-                zoe_intent=zoe_intent.name if zoe_intent else None,
-                zoe_confidence=zoe_intent.confidence if zoe_intent else None,
-                zoe_latency_ms=zoe_latency_ms,
-                route_class=route_class,
-                user_id=user_id,
-                context_turns=_context_turns(),
-            )
-        except Exception as exc:
-            logger.debug("detect_and_extract_intent: Pi shadow evidence failed: %s", exc)
+        async def _runner() -> None:
+            try:
+                from pi_intent_shadow import maybe_record_pi_intent_shadow
 
-    async def _try_pi_governor() -> Optional["Intent"]:
+                kwargs = {
+                    "zoe_intent": zoe_intent.name if zoe_intent else None,
+                    "zoe_confidence": zoe_intent.confidence if zoe_intent else None,
+                    "zoe_latency_ms": zoe_latency_ms,
+                    "route_class": route_class,
+                    "user_id": user_id,
+                    "context_turns": _context_turns(),
+                }
+                if pi_result is not shadow_unset:
+                    kwargs["pi_result"] = pi_result
+                await maybe_record_pi_intent_shadow(text, **kwargs)
+            except Exception as exc:
+                logger.debug("detect_and_extract_intent: Pi shadow evidence failed: %s", exc)
+
+        task = asyncio.create_task(_runner())
+        task.add_done_callback(lambda done: done.exception() if not done.cancelled() else None)
+
+    async def _try_pi_governor() -> tuple[Optional["Intent"], object | None]:
+        pi_classified = None
         try:
             from pi_intent_classifier import PI_INTENT_EXECUTE_THRESHOLD, classify_with_pi_intent_governor
             pi_classified = await classify_with_pi_intent_governor(text, context_turns=_context_turns())
             if pi_classified and pi_classified.intent and pi_classified.confidence >= PI_INTENT_EXECUTE_THRESHOLD:
-                return Intent(pi_classified.intent, dict(pi_classified.slots), confidence=pi_classified.confidence)
+                return Intent(pi_classified.intent, dict(pi_classified.slots), confidence=pi_classified.confidence), pi_classified
         except Exception as exc:
             logger.debug("detect_and_extract_intent: Pi/Gemma governor failed: %s", exc)
-        return None
+        return None, pi_classified
 
     started = time.perf_counter()
     intent = detect_intent(text, context=context)
     detect_latency_ms = (time.perf_counter() - started) * 1000
     if intent is None:
-        await _record_pi_shadow(None, route_class="fallback", zoe_latency_ms=detect_latency_ms)
-        return await _try_pi_governor()
+        routed_intent, pi_classified = await _try_pi_governor()
+        _schedule_pi_shadow(
+            None,
+            route_class="fallback",
+            zoe_latency_ms=detect_latency_ms,
+            pi_result=pi_classified if _env_enabled("ZOE_PI_INTENT_ENABLED") else shadow_unset,
+        )
+        return routed_intent
     if intent.slots and "raw" in intent.slots:
         try:
             from nlu_extractor import extract_slots_for_intent  # lazy — avoids circular at load
             structured = await extract_slots_for_intent(intent.name, intent.slots["raw"])
             if structured:
                 intent.slots = structured
-                await _record_pi_shadow(
+                _schedule_pi_shadow(
                     intent,
                     route_class="deterministic",
                     zoe_latency_ms=(time.perf_counter() - started) * 1000,
@@ -1367,13 +1386,15 @@ async def detect_and_extract_intent(
                 _exc,
             )
         # Extraction failed — let Pi/Gemma classify the ambiguous utterance once before Zoe Agent fallback.
-        await _record_pi_shadow(
+        routed_intent, pi_classified = await _try_pi_governor()
+        _schedule_pi_shadow(
             None,
             route_class="extraction_failed",
             zoe_latency_ms=(time.perf_counter() - started) * 1000,
+            pi_result=pi_classified if _env_enabled("ZOE_PI_INTENT_ENABLED") else shadow_unset,
         )
-        return await _try_pi_governor()
-    await _record_pi_shadow(intent, route_class="deterministic", zoe_latency_ms=detect_latency_ms)
+        return routed_intent
+    _schedule_pi_shadow(intent, route_class="deterministic", zoe_latency_ms=detect_latency_ms)
     return intent
 
 

--- a/services/zoe-data/pi_intent_shadow.py
+++ b/services/zoe-data/pi_intent_shadow.py
@@ -1,0 +1,269 @@
+"""Runtime shadow evidence for Pi-vs-Zoe intent routing.
+
+Shadow mode is evidence-only: Zoe's current route remains authoritative and Pi
+output is never executed from this module. Records are intentionally compact,
+sanitized, and JSONL-backed so the first runtime loop can be observed without a
+schema migration or production chat behavior change.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from zoe_pi_promotion import intent_group_for_intent
+
+_DEFAULT_SHADOW_PATH = "/home/zoe/training/data/pi-intent-shadow.jsonl"
+_DEFAULT_MAX_REPORT_RECORDS = 500
+_SECRET_KEY_RE = re.compile(r"(?i)(api[_-]?key|token|secret|password|authorization|bearer)")
+_EMAIL_RE = re.compile(r"[\w.+-]+@[\w-]+\.\w+")
+_URL_RE = re.compile(r"https?://\S+")
+_PHONE_RE = re.compile(r"\b\d[\d\s\-]{6,}\b")
+_NAME_RE = re.compile(r"\b[A-Z][a-z]+ [A-Z][a-z]+\b")
+_SPACE_RE = re.compile(r"\s+")
+
+
+@dataclass(frozen=True)
+class PiIntentShadowConfig:
+    enabled: bool = False
+    path: str = _DEFAULT_SHADOW_PATH
+    max_words: int = 32
+    include_preview: bool = True
+    force_classifier_enabled: bool = True
+
+    @classmethod
+    def from_env(cls, env: Mapping[str, str] | None = None) -> "PiIntentShadowConfig":
+        values = env if env is not None else os.environ
+        return cls(
+            enabled=_env_bool(values.get("ZOE_PI_INTENT_SHADOW_ENABLED"), default=False),
+            path=(values.get("ZOE_PI_INTENT_SHADOW_PATH") or _DEFAULT_SHADOW_PATH).strip() or _DEFAULT_SHADOW_PATH,
+            max_words=int(values.get("ZOE_PI_INTENT_SHADOW_MAX_WORDS") or 32),
+            include_preview=_env_bool(values.get("ZOE_PI_INTENT_SHADOW_INCLUDE_PREVIEW"), default=True),
+            force_classifier_enabled=_env_bool(values.get("ZOE_PI_INTENT_SHADOW_FORCE_ENABLED"), default=True),
+        )
+
+    def validate(self) -> None:
+        if self.max_words <= 0:
+            raise ValueError("ZOE_PI_INTENT_SHADOW_MAX_WORDS must be positive")
+        if not self.path:
+            raise ValueError("ZOE_PI_INTENT_SHADOW_PATH is required")
+
+    def to_dict(self) -> dict[str, Any]:
+        self.validate()
+        return {
+            "enabled": self.enabled,
+            "path": self.path,
+            "max_words": self.max_words,
+            "include_preview": self.include_preview,
+            "force_classifier_enabled": self.force_classifier_enabled,
+        }
+
+
+async def maybe_record_pi_intent_shadow(
+    text: str,
+    *,
+    zoe_intent: str | None,
+    zoe_confidence: float | None = None,
+    zoe_latency_ms: float | None = None,
+    route_class: str,
+    user_id: str = "family-admin",
+    context_turns: str = "",
+    env: Mapping[str, str] | None = None,
+    config: PiIntentShadowConfig | None = None,
+) -> dict[str, Any] | None:
+    active_config = config or PiIntentShadowConfig.from_env(env)
+    active_config.validate()
+    if not active_config.enabled:
+        return None
+    if len((text or "").split()) > active_config.max_words:
+        return None
+
+    runtime_env = dict(os.environ if env is None else env)
+    if active_config.force_classifier_enabled:
+        runtime_env["ZOE_PI_INTENT_ENABLED"] = "true"
+
+    started = time.perf_counter()
+    pi_result = None
+    error: str | None = None
+    try:
+        from pi_intent_classifier import classify_with_pi_intent_governor
+
+        pi_result = await classify_with_pi_intent_governor(text, context_turns=context_turns, env=runtime_env)
+    except Exception as exc:  # pragma: no cover - defensive: shadow must never break routing
+        error = type(exc).__name__
+    elapsed_ms = (time.perf_counter() - started) * 1000
+
+    pi_intent = pi_result.intent if pi_result else None
+    pi_confidence = float(pi_result.confidence) if pi_result else 0.0
+    pi_latency_ms = float(pi_result.latency_ms) if pi_result else elapsed_ms
+    timeout_seconds = _float_env(runtime_env.get("ZOE_PI_INTENT_TIMEOUT_SECONDS"), default=4.0)
+    timed_out = pi_result is None and elapsed_ms >= (timeout_seconds * 1000 * 0.95)
+    record = {
+        "ts": time.time(),
+        "text_hash": _hash_text(text),
+        "text_preview": _sanitize_text(text) if active_config.include_preview else None,
+        "user_hash": _hash_text(user_id or "unknown")[:16],
+        "route_class": route_class,
+        "zoe_intent": zoe_intent,
+        "zoe_intent_group": intent_group_for_intent(zoe_intent),
+        "zoe_confidence": zoe_confidence,
+        "zoe_latency_ms": zoe_latency_ms,
+        "pi_intent": pi_intent,
+        "pi_intent_group": intent_group_for_intent(pi_intent),
+        "pi_confidence": pi_confidence,
+        "pi_latency_ms": pi_latency_ms,
+        "pi_transport": _safe_env_value(runtime_env, "ZOE_PI_INTENT_TRANSPORT") or "print",
+        "agreement": pi_intent == zoe_intent,
+        "pi_no_result": pi_result is None,
+        "timed_out": timed_out,
+        "error": error,
+        "outcome_label": None,
+    }
+    _append_jsonl(active_config.path, record)
+    return record
+
+
+def pi_intent_shadow_status(env: Mapping[str, str] | None = None, *, limit: int = _DEFAULT_MAX_REPORT_RECORDS) -> dict[str, Any]:
+    config = PiIntentShadowConfig.from_env(env)
+    records = load_pi_intent_shadow_records(config.path, limit=limit)
+    return {
+        "config": config.to_dict(),
+        "record_count_window": len(records),
+        "report": summarize_pi_intent_shadow(records),
+    }
+
+
+def load_pi_intent_shadow_records(path: str, *, limit: int = _DEFAULT_MAX_REPORT_RECORDS) -> list[dict[str, Any]]:
+    target = Path(path)
+    if not target.exists():
+        return []
+    rows = target.read_text(encoding="utf-8", errors="replace").splitlines()
+    records: list[dict[str, Any]] = []
+    for line in rows[-max(1, limit) :]:
+        try:
+            item = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(item, dict):
+            records.append(item)
+    return records
+
+
+def summarize_pi_intent_shadow(records: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    total = len(records)
+    if total == 0:
+        return {
+            "sample_count": 0,
+            "agreement_rate": 0.0,
+            "timeout_rate": 0.0,
+            "no_result_rate": 0.0,
+            "avg_zoe_latency_ms": None,
+            "avg_pi_latency_ms": None,
+            "intent_groups": {},
+            "accuracy_available": False,
+        }
+    groups: dict[str, dict[str, int]] = {}
+    agreements = 0
+    timeouts = 0
+    no_results = 0
+    zoe_latencies: list[float] = []
+    pi_latencies: list[float] = []
+    for record in records:
+        group = str(record.get("zoe_intent_group") or record.get("pi_intent_group") or "unmapped")
+        bucket = groups.setdefault(group, {"samples": 0, "agreements": 0, "timeouts": 0})
+        bucket["samples"] += 1
+        if record.get("agreement"):
+            agreements += 1
+            bucket["agreements"] += 1
+        if record.get("timed_out"):
+            timeouts += 1
+            bucket["timeouts"] += 1
+        if record.get("pi_no_result"):
+            no_results += 1
+        if isinstance(record.get("zoe_latency_ms"), (int, float)):
+            zoe_latencies.append(float(record["zoe_latency_ms"]))
+        if isinstance(record.get("pi_latency_ms"), (int, float)):
+            pi_latencies.append(float(record["pi_latency_ms"]))
+    return {
+        "sample_count": total,
+        "agreement_rate": agreements / total,
+        "timeout_rate": timeouts / total,
+        "no_result_rate": no_results / total,
+        "avg_zoe_latency_ms": _avg(zoe_latencies),
+        "avg_pi_latency_ms": _avg(pi_latencies),
+        "intent_groups": groups,
+        "accuracy_available": any(record.get("outcome_label") for record in records),
+        "promotion_ready": False,
+        "promotion_ready_reason": "runtime shadow records are unlabeled agreement evidence, not accuracy labels",
+    }
+
+
+def _append_jsonl(path: str, record: Mapping[str, Any]) -> None:
+    _reject_secret_keys(record)
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    with target.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(record, sort_keys=True, separators=(",", ":")) + "\n")
+
+
+def _sanitize_text(text: str) -> str:
+    clean = _EMAIL_RE.sub("[EMAIL]", text or "")
+    clean = _URL_RE.sub("[URL]", clean)
+    clean = _PHONE_RE.sub("[NUMBER]", clean)
+    clean = _NAME_RE.sub("[NAME]", clean)
+    clean = _SPACE_RE.sub(" ", clean).strip()
+    return clean[:160]
+
+
+def _hash_text(text: str) -> str:
+    return hashlib.sha256((text or "").encode("utf-8", errors="ignore")).hexdigest()
+
+
+def _avg(values: Sequence[float]) -> float | None:
+    if not values:
+        return None
+    return sum(values) / len(values)
+
+
+def _safe_env_value(env: Mapping[str, str], key: str) -> str | None:
+    value = env.get(key)
+    if not value or _SECRET_KEY_RE.search(key):
+        return None
+    return value
+
+
+def _reject_secret_keys(value: Mapping[str, Any], path: str = "") -> None:
+    for key, nested in value.items():
+        full_key = f"{path}.{key}" if path else str(key)
+        if _SECRET_KEY_RE.search(str(key)):
+            raise ValueError(f"shadow record may not contain secret field {full_key}")
+        if isinstance(nested, Mapping):
+            _reject_secret_keys(nested, full_key)
+
+
+def _float_env(value: str | None, *, default: float) -> float:
+    try:
+        return float(value) if value is not None else default
+    except (TypeError, ValueError):
+        return default
+
+
+def _env_bool(value: str | None, *, default: bool = False) -> bool:
+    if value is None:
+        return default
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
+
+__all__ = [
+    "PiIntentShadowConfig",
+    "load_pi_intent_shadow_records",
+    "maybe_record_pi_intent_shadow",
+    "pi_intent_shadow_status",
+    "summarize_pi_intent_shadow",
+]

--- a/services/zoe-data/pi_intent_shadow.py
+++ b/services/zoe-data/pi_intent_shadow.py
@@ -19,7 +19,8 @@ from typing import Any, Mapping, Sequence
 
 from zoe_pi_promotion import intent_group_for_intent
 
-_DEFAULT_SHADOW_PATH = "/home/zoe/training/data/pi-intent-shadow.jsonl"
+_DEFAULT_SHADOW_PATH = "~/.zoe/data/pi-intent-shadow.jsonl"
+_UNSET = object()
 _DEFAULT_MAX_REPORT_RECORDS = 500
 _SECRET_KEY_RE = re.compile(r"(?i)(api[_-]?key|token|secret|password|authorization|bearer)")
 _EMAIL_RE = re.compile(r"[\w.+-]+@[\w-]+\.\w+")
@@ -72,10 +73,11 @@ async def maybe_record_pi_intent_shadow(
     zoe_confidence: float | None = None,
     zoe_latency_ms: float | None = None,
     route_class: str,
-    user_id: str = "family-admin",
+    user_id: str = "unknown",
     context_turns: str = "",
     env: Mapping[str, str] | None = None,
     config: PiIntentShadowConfig | None = None,
+    pi_result: Any = _UNSET,
 ) -> dict[str, Any] | None:
     active_config = config or PiIntentShadowConfig.from_env(env)
     active_config.validate()
@@ -89,14 +91,15 @@ async def maybe_record_pi_intent_shadow(
         runtime_env["ZOE_PI_INTENT_ENABLED"] = "true"
 
     started = time.perf_counter()
-    pi_result = None
     error: str | None = None
-    try:
-        from pi_intent_classifier import classify_with_pi_intent_governor
+    if pi_result is _UNSET:
+        pi_result = None
+        try:
+            from pi_intent_classifier import classify_with_pi_intent_governor
 
-        pi_result = await classify_with_pi_intent_governor(text, context_turns=context_turns, env=runtime_env)
-    except Exception as exc:  # pragma: no cover - defensive: shadow must never break routing
-        error = type(exc).__name__
+            pi_result = await classify_with_pi_intent_governor(text, context_turns=context_turns, env=runtime_env)
+        except Exception as exc:  # pragma: no cover - defensive: shadow must never break routing
+            error = type(exc).__name__
     elapsed_ms = (time.perf_counter() - started) * 1000
 
     pi_intent = pi_result.intent if pi_result else None
@@ -140,7 +143,7 @@ def pi_intent_shadow_status(env: Mapping[str, str] | None = None, *, limit: int 
 
 
 def load_pi_intent_shadow_records(path: str, *, limit: int = _DEFAULT_MAX_REPORT_RECORDS) -> list[dict[str, Any]]:
-    target = Path(path)
+    target = Path(path).expanduser()
     if not target.exists():
         return []
     rows = target.read_text(encoding="utf-8", errors="replace").splitlines()
@@ -206,7 +209,7 @@ def summarize_pi_intent_shadow(records: Sequence[Mapping[str, Any]]) -> dict[str
 
 def _append_jsonl(path: str, record: Mapping[str, Any]) -> None:
     _reject_secret_keys(record)
-    target = Path(path)
+    target = Path(path).expanduser()
     target.parent.mkdir(parents=True, exist_ok=True)
     with target.open("a", encoding="utf-8") as handle:
         handle.write(json.dumps(record, sort_keys=True, separators=(",", ":")) + "\n")

--- a/services/zoe-data/routers/system.py
+++ b/services/zoe-data/routers/system.py
@@ -181,6 +181,14 @@ async def get_pi_intent_status(user: dict = Depends(require_admin)):
     return pi_intent_status()
 
 
+@router.get("/pi-intent/shadow-status")
+async def get_pi_intent_shadow_status(user: dict = Depends(require_admin)):
+    """Read-only status for Zoe's disabled-by-default Pi-vs-Zoe shadow evidence."""
+    from pi_intent_shadow import pi_intent_shadow_status
+
+    return pi_intent_shadow_status()
+
+
 def _load_skills_and_cron():
     skills = []
     skills_dir = os.path.expanduser("~/.openclaw/workspace/skills")

--- a/services/zoe-data/tests/test_pi_intent_shadow.py
+++ b/services/zoe-data/tests/test_pi_intent_shadow.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 
 import pytest
@@ -82,6 +83,7 @@ def test_shadow_status_summarizes_records(tmp_path):
                     {
                         "agreement": False,
                         "timed_out": True,
+                        "pi_no_result": True,
                         "pi_intent_group": "reminders",
                         "pi_latency_ms": 250,
                         "zoe_latency_ms": 6,
@@ -103,7 +105,7 @@ def test_shadow_status_summarizes_records(tmp_path):
     assert status["record_count_window"] == 2
     assert status["report"]["agreement_rate"] == 0.5
     assert status["report"]["timeout_rate"] == 0.5
-    assert status["report"]["no_result_rate"] == 0.0
+    assert status["report"]["no_result_rate"] == 0.5
     assert status["report"]["accuracy_available"] is False
     assert status["report"]["promotion_ready"] is False
 
@@ -130,6 +132,7 @@ async def test_intent_router_shadow_does_not_change_live_route(monkeypatch):
     from intent_router import detect_and_extract_intent
 
     intent = await detect_and_extract_intent("what is the weather", user_id="jason")
+    await asyncio.sleep(0)
 
     assert intent is not None
     assert intent.name == "weather"
@@ -137,3 +140,39 @@ async def test_intent_router_shadow_does_not_change_live_route(monkeypatch):
     assert calls[0]["zoe_intent"] == "weather"
     assert calls[0]["route_class"] == "deterministic"
     assert calls[0]["user_id"] == "jason"
+
+
+@pytest.mark.asyncio
+async def test_intent_router_reuses_live_pi_result_for_shadow_fallback(tmp_path, monkeypatch):
+    path = tmp_path / "shadow.jsonl"
+    calls = 0
+
+    async def fake_classify(text, *, context_turns="", env=None, config=None):
+        nonlocal calls
+        calls += 1
+        return PiIntentClassification(
+            intent="reminder_list",
+            slots={},
+            confidence=0.86,
+            task_lane="fast_tool",
+            source="pi_test",
+            latency_ms=42.0,
+        )
+
+    monkeypatch.setenv("ZOE_PI_INTENT_ENABLED", "true")
+    monkeypatch.setenv("ZOE_PI_INTENT_SHADOW_ENABLED", "true")
+    monkeypatch.setenv("ZOE_PI_INTENT_SHADOW_PATH", str(path))
+    monkeypatch.setattr("pi_intent_classifier.classify_with_pi_intent_governor", fake_classify)
+
+    from intent_router import detect_and_extract_intent
+
+    intent = await detect_and_extract_intent("anything I should remember right now", user_id="jason")
+    await asyncio.sleep(0)
+
+    assert intent is not None
+    assert intent.name == "reminder_list"
+    assert calls == 1
+    record = json.loads(path.read_text().strip())
+    assert record["route_class"] == "fallback"
+    assert record["pi_intent"] == "reminder_list"
+    assert record["pi_no_result"] is False

--- a/services/zoe-data/tests/test_pi_intent_shadow.py
+++ b/services/zoe-data/tests/test_pi_intent_shadow.py
@@ -1,0 +1,139 @@
+import json
+
+import pytest
+
+from pi_intent_classifier import PiIntentClassification
+from pi_intent_shadow import (
+    PiIntentShadowConfig,
+    maybe_record_pi_intent_shadow,
+    pi_intent_shadow_status,
+    summarize_pi_intent_shadow,
+)
+
+
+@pytest.mark.asyncio
+async def test_shadow_disabled_does_not_write(tmp_path):
+    path = tmp_path / "shadow.jsonl"
+
+    result = await maybe_record_pi_intent_shadow(
+        "rain later",
+        zoe_intent="weather",
+        route_class="deterministic",
+        config=PiIntentShadowConfig(enabled=False, path=str(path)),
+    )
+
+    assert result is None
+    assert not path.exists()
+
+
+@pytest.mark.asyncio
+async def test_shadow_records_sanitized_pi_comparison(tmp_path, monkeypatch):
+    path = tmp_path / "shadow.jsonl"
+
+    async def fake_classify(text, *, context_turns="", env=None, config=None):
+        assert text == "email jason@example.com if rain later"
+        assert env["ZOE_PI_INTENT_ENABLED"] == "true"
+        return PiIntentClassification(
+            intent="weather",
+            slots={},
+            confidence=0.91,
+            task_lane="fast_tool",
+            source="pi_test",
+            latency_ms=123.0,
+        )
+
+    monkeypatch.setattr("pi_intent_classifier.classify_with_pi_intent_governor", fake_classify)
+
+    record = await maybe_record_pi_intent_shadow(
+        "email jason@example.com if rain later",
+        zoe_intent="weather",
+        zoe_confidence=0.8,
+        zoe_latency_ms=4.0,
+        route_class="deterministic",
+        user_id="jason",
+        config=PiIntentShadowConfig(enabled=True, path=str(path)),
+        env={},
+    )
+
+    assert record is not None
+    assert record["agreement"] is True
+    assert record["pi_latency_ms"] == 123.0
+    saved = json.loads(path.read_text().strip())
+    assert saved["text_preview"] == "email [EMAIL] if rain later"
+    assert saved["text_hash"]
+    assert "jason@example.com" not in path.read_text()
+
+
+def test_shadow_status_summarizes_records(tmp_path):
+    path = tmp_path / "shadow.jsonl"
+    path.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "agreement": True,
+                        "timed_out": False,
+                        "zoe_intent_group": "weather",
+                        "pi_latency_ms": 100,
+                        "zoe_latency_ms": 5,
+                    }
+                ),
+                json.dumps(
+                    {
+                        "agreement": False,
+                        "timed_out": True,
+                        "pi_intent_group": "reminders",
+                        "pi_latency_ms": 250,
+                        "zoe_latency_ms": 6,
+                    }
+                ),
+            ]
+        )
+        + "\n"
+    )
+
+    status = pi_intent_shadow_status(
+        {
+            "ZOE_PI_INTENT_SHADOW_ENABLED": "true",
+            "ZOE_PI_INTENT_SHADOW_PATH": str(path),
+        }
+    )
+
+    assert status["config"]["enabled"] is True
+    assert status["record_count_window"] == 2
+    assert status["report"]["agreement_rate"] == 0.5
+    assert status["report"]["timeout_rate"] == 0.5
+    assert status["report"]["no_result_rate"] == 0.0
+    assert status["report"]["accuracy_available"] is False
+    assert status["report"]["promotion_ready"] is False
+
+
+def test_shadow_summary_empty_is_explicitly_not_accuracy_ready():
+    report = summarize_pi_intent_shadow([])
+
+    assert report["sample_count"] == 0
+    assert report["no_result_rate"] == 0.0
+    assert report["accuracy_available"] is False
+
+
+@pytest.mark.asyncio
+async def test_intent_router_shadow_does_not_change_live_route(monkeypatch):
+    monkeypatch.setenv("ZOE_PI_INTENT_SHADOW_ENABLED", "true")
+    calls = []
+
+    async def fake_shadow(text, **kwargs):
+        calls.append({"text": text, **kwargs})
+        return {"pi_intent": "reminder_list", "agreement": False}
+
+    monkeypatch.setattr("pi_intent_shadow.maybe_record_pi_intent_shadow", fake_shadow)
+
+    from intent_router import detect_and_extract_intent
+
+    intent = await detect_and_extract_intent("what is the weather", user_id="jason")
+
+    assert intent is not None
+    assert intent.name == "weather"
+    assert calls
+    assert calls[0]["zoe_intent"] == "weather"
+    assert calls[0]["route_class"] == "deterministic"
+    assert calls[0]["user_id"] == "jason"

--- a/services/zoe-data/tests/test_pi_intent_status_endpoint.py
+++ b/services/zoe-data/tests/test_pi_intent_status_endpoint.py
@@ -140,3 +140,33 @@ def test_pi_intent_status_endpoint_rejects_non_admin():
     resp = TestClient(app).get("/api/system/pi-intent/status")
 
     assert resp.status_code == 403
+
+
+def test_pi_intent_shadow_status_endpoint_is_admin_scoped(tmp_path, monkeypatch):
+    path = tmp_path / "shadow.jsonl"
+    path.write_text('{"agreement":true,"timed_out":false,"zoe_intent_group":"weather","pi_latency_ms":100,"zoe_latency_ms":5}\n')
+    monkeypatch.setenv("ZOE_PI_INTENT_SHADOW_ENABLED", "true")
+    monkeypatch.setenv("ZOE_PI_INTENT_SHADOW_PATH", str(path))
+    app = _admin_app()
+
+    resp = TestClient(app).get("/api/system/pi-intent/shadow-status")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["config"]["enabled"] is True
+    assert data["record_count_window"] == 1
+    assert data["report"]["agreement_rate"] == 1.0
+
+
+def test_pi_intent_shadow_status_endpoint_rejects_non_admin():
+    app = FastAPI()
+    app.include_router(system_router)
+
+    async def fake_non_admin():
+        raise HTTPException(status_code=403, detail="Admin access required")
+
+    app.dependency_overrides[require_admin] = fake_non_admin
+
+    resp = TestClient(app).get("/api/system/pi-intent/shadow-status")
+
+    assert resp.status_code == 403


### PR DESCRIPTION
## Summary
- add disabled-by-default Pi-vs-Zoe intent shadow evidence collection
- expose admin shadow status report for agreement/latency evidence
- document shadow env vars and accuracy-label limitation

## Tests
- python3 -m pytest -q services/zoe-data/tests/test_pi_intent_shadow.py services/zoe-data/tests/test_pi_intent_classifier.py services/zoe-data/tests/test_pi_intent_status_endpoint.py services/zoe-data/tests/test_zoe_pi_promotion.py services/zoe-data/tests/test_intent_gap_contract_helper.py services/zoe-data/tests/test_intent_ha_setup.py services/zoe-data/tests/test_intent_open_domain.py
- scripts/maintenance/pi_promotion_eval.py --demo --min-samples 10
- scripts/maintenance/pi_promotion_eval.py --run-pi --transport rpc --min-samples 1
- python3 tools/audit/validate_structure.py
- python3 tools/audit/validate_critical_files.py
- git diff --check