### PR TITLE
feat(multica): auto-reclaim task worktrees on merge + daily sweep

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,8 +71,12 @@ Trunk-based development off protected `main`. No permanent `develop` or `staging
 - One branch per issue or Multica task, created from fresh `origin/main`.
 - Naming: `codex/<slug>` (agent work), `feature/<slug>`, `fix/<slug>`, `verify/<slug>` (throwaway validation).
 - Use a dedicated git worktree under `~/.worktrees/<slug>` for development; do not switch the live checkout (`/home/zoe/assistant`) to feature branches for agent work.
-- Branches die at merge: remote branches auto-delete (`delete_branch_on_merge`); remove the local worktree when done.
-- Prune stale worktrees with `scripts/maintenance/prune_worktrees.sh` (dry-run first, `--execute` after operator review). Never prune dirty, locked, or unmerged worktrees.
+- Branches die at merge: remote branches auto-delete (`delete_branch_on_merge`); local task worktrees are reclaimed automatically — see below.
+- Automatic cleanup (Multica owns its worktrees):
+  - On chain completion, the harness removes each task's worktree + `wt/<id>` branch once merged (`worktree_bootstrap.remove_task_worktree`, called from `kanban_adapter`).
+  - A daily safety-net sweep in the Multica poll loop reclaims orphaned merged worktrees (`worktree_bootstrap.prune_merged_worktrees`). Interval via `ZOE_WORKTREE_PRUNE_INTERVAL_S` (default 86400).
+  - Both detect **squash-merged** branches via `gh pr view` (not just git-ancestor merges) and never touch dirty, locked, unmerged, or the live checkout.
+- Manual prune still available: `scripts/maintenance/prune_worktrees.sh` (dry-run first, `--execute` after operator review).
 
 # DOX framework
 

--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -1845,8 +1845,14 @@ class KanbanAdapter:
         affect reported chain status.
         """
         try:
-            from worktree_bootstrap import remove_task_worktree
+            from worktree_bootstrap import remove_task_worktree, resolve_base_ref
         except Exception:  # noqa: BLE001 - cleanup is optional, never fatal.
+            return
+        try:
+            # Resolve (and fetch) the base ref once per chain, not once per phase.
+            base_ref = await asyncio.to_thread(resolve_base_ref)
+        except Exception as exc:  # noqa: BLE001 - skip cleanup, never fatal.
+            logger.warning("kanban_adapter: base ref resolve failed, skipping cleanup: %s", exc)
             return
         seen: set[str] = set()
         for row in phases.values():
@@ -1855,7 +1861,7 @@ class KanbanAdapter:
                 continue
             seen.add(task_id)
             try:
-                await asyncio.to_thread(remove_task_worktree, task_id)
+                await asyncio.to_thread(remove_task_worktree, task_id, base_ref=base_ref)
             except Exception as exc:  # noqa: BLE001 - log and continue.
                 logger.warning(
                     "kanban_adapter: worktree cleanup failed for %s: %s", task_id, exc

--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -1824,6 +1824,9 @@ class KanbanAdapter:
                 agg = "blocked"
                 blocker = blocker or "pipeline_store_unavailable"
 
+        if agg == "done":
+            await self._cleanup_chain_worktrees(phases)
+
         return {
             "found": True,
             "status": agg,
@@ -1832,6 +1835,31 @@ class KanbanAdapter:
             "blocker": blocker,
             "pipeline": pipeline_info,
         }
+
+    async def _cleanup_chain_worktrees(self, phases: dict[str, dict]) -> None:
+        """Remove task worktrees once a chain reaches terminal ``done``.
+
+        Best-effort and idempotent: ``remove_task_worktree`` only acts when the
+        task branch is merged (ancestor or squash-merged PR) and the worktree is
+        clean, so repeated calls across polls are no-ops. Failures here must never
+        affect reported chain status.
+        """
+        try:
+            from worktree_bootstrap import remove_task_worktree
+        except Exception:  # noqa: BLE001 - cleanup is optional, never fatal.
+            return
+        seen: set[str] = set()
+        for row in phases.values():
+            task_id = str(row.get("id") or "").strip()
+            if not task_id or task_id in seen:
+                continue
+            seen.add(task_id)
+            try:
+                await asyncio.to_thread(remove_task_worktree, task_id)
+            except Exception as exc:  # noqa: BLE001 - log and continue.
+                logger.warning(
+                    "kanban_adapter: worktree cleanup failed for %s: %s", task_id, exc
+                )
 
     async def _extract_pr_url(
         self,

--- a/services/zoe-data/main.py
+++ b/services/zoe-data/main.py
@@ -666,6 +666,8 @@ async def lifespan(app: FastAPI):
     # Multica board polling loop (30s interval, no-op if ZOE_MULTICA=false)
     async def _multica_poll_loop():
         import time as _t
+        _last_worktree_prune = 0.0
+        _prune_interval_s = float(os.environ.get("ZOE_WORKTREE_PRUNE_INTERVAL_S", "86400") or "86400")
         while True:
             try:
                 await asyncio.sleep(30)
@@ -681,6 +683,21 @@ async def lifespan(app: FastAPI):
                         logger.info("multica_poll: close_stale_autopilot_wrappers closed %d", _n_stale)
                 except Exception as _stale_exc:
                     logger.debug("multica_poll: stale wrapper cleanup failed: %s", _stale_exc)
+                # Daily safety-net: reclaim merged/squash-merged task worktrees that
+                # crashed or lost their terminal handoff and never self-cleaned.
+                if _t.time() - _last_worktree_prune >= _prune_interval_s:
+                    _last_worktree_prune = _t.time()
+                    try:
+                        from worktree_bootstrap import prune_merged_worktrees
+
+                        _pruned = await asyncio.to_thread(prune_merged_worktrees)
+                        _removed = [r for r in _pruned if r.get("decision") == "removed"]
+                        if _removed:
+                            logger.info(
+                                "multica_poll: pruned %d stale merged worktree(s)", len(_removed)
+                            )
+                    except Exception as _prune_exc:
+                        logger.warning("multica_poll: worktree prune sweep failed: %s", _prune_exc)
                 # Fast-path: auto-close stale autopilot tracker todos (no agent needed)
                 stale_todos = await client.list_issues(status="todo")
                 _now_ts = _t.time()

--- a/services/zoe-data/main.py
+++ b/services/zoe-data/main.py
@@ -667,7 +667,14 @@ async def lifespan(app: FastAPI):
     async def _multica_poll_loop():
         import time as _t
         _last_worktree_prune = 0.0
-        _prune_interval_s = float(os.environ.get("ZOE_WORKTREE_PRUNE_INTERVAL_S", "86400") or "86400")
+        try:
+            _prune_interval_s = float(os.environ.get("ZOE_WORKTREE_PRUNE_INTERVAL_S", "86400") or "86400")
+        except ValueError:
+            logger.warning(
+                "multica_poll: invalid ZOE_WORKTREE_PRUNE_INTERVAL_S=%r; using 86400",
+                os.environ.get("ZOE_WORKTREE_PRUNE_INTERVAL_S"),
+            )
+            _prune_interval_s = 86400.0
         while True:
             try:
                 await asyncio.sleep(30)

--- a/services/zoe-data/tests/test_worktree_bootstrap.py
+++ b/services/zoe-data/tests/test_worktree_bootstrap.py
@@ -307,6 +307,31 @@ def test_prune_merged_worktrees_respects_min_age(git_repo):
     assert wt.exists()
 
 
+def test_prune_classifies_detached_head_before_dirty(git_repo):
+    wt = wb.ensure_worktree("t_detach")
+    _commit_on_worktree(wt, "extra.txt")
+    head = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=wt, capture_output=True, text=True, check=True
+    ).stdout.strip()
+    subprocess.run(["git", "checkout", "--detach", head], cwd=wt, check=True, capture_output=True)
+
+    results = wb.prune_merged_worktrees(min_age_days=0, consult_pr=False)
+    decisions = {r["worktree"]: r["decision"] for r in results}
+    assert decisions[str(wt.resolve())] == "skip:detached HEAD"
+    assert wt.exists()
+
+
+def test_remove_task_worktree_skips_fetch_when_base_ref_passed(git_repo, monkeypatch):
+    wb.ensure_worktree("t_nofetch")
+
+    def _no_fetch(repo, base_branch):
+        raise AssertionError("_base_ref should not be called when base_ref is provided")
+
+    monkeypatch.setattr(wb, "_base_ref", _no_fetch)
+    # Fresh wt branch off main is an ancestor of main → merged with the passed ref.
+    assert wb.remove_task_worktree("t_nofetch", base_ref="main", consult_pr=False) is True
+
+
 def test_prune_merged_worktrees_dry_run_reports_without_removing(git_repo):
     wt = wb.ensure_worktree("t_dryrun")
     results = wb.prune_merged_worktrees(min_age_days=0, execute=False, consult_pr=False)

--- a/services/zoe-data/tests/test_worktree_bootstrap.py
+++ b/services/zoe-data/tests/test_worktree_bootstrap.py
@@ -225,6 +225,96 @@ def test_kanban_db_path_default_board(monkeypatch):
     assert path.parent.name == ".hermes"
 
 
+def _commit_on_worktree(wt: Path, name: str) -> None:
+    (wt / name).write_text("change\n", encoding="utf-8")
+    subprocess.run(["git", "add", name], cwd=wt, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", name], cwd=wt, check=True, capture_output=True)
+
+
+def test_remove_task_worktree_removes_merged_worktree(git_repo):
+    wt = wb.ensure_worktree("t_merged")
+    # Fresh wt/<id> off main with no new commits is an ancestor of main → merged.
+    assert wb.remove_task_worktree("t_merged", consult_pr=False) is True
+    assert not wt.exists()
+    branches = subprocess.run(
+        ["git", "branch", "--list", "wt/t_merged"],
+        cwd=git_repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    assert "wt/t_merged" not in branches
+
+
+def test_remove_task_worktree_keeps_unmerged_worktree(git_repo):
+    wt = wb.ensure_worktree("t_ahead")
+    _commit_on_worktree(wt, "feature.txt")  # now ahead of main → not merged
+    assert wb.remove_task_worktree("t_ahead", consult_pr=False) is False
+    assert wt.exists()
+
+
+def test_remove_task_worktree_keeps_dirty_worktree(git_repo):
+    wt = wb.ensure_worktree("t_dirty")
+    (wt / "scratch.txt").write_text("uncommitted\n", encoding="utf-8")  # dirty
+    assert wb.remove_task_worktree("t_dirty", consult_pr=False) is False
+    assert wt.exists()
+
+
+def test_remove_task_worktree_noop_when_not_registered(git_repo):
+    assert wb.remove_task_worktree("t_absent", consult_pr=False) is False
+
+
+def test_remove_task_worktree_uses_pr_merge_for_squash(git_repo, monkeypatch):
+    wt = wb.ensure_worktree("t_squash")
+    _commit_on_worktree(wt, "squash.txt")  # ahead of main, not an ancestor
+    # Simulate a squash-merged PR: not a git ancestor, but gh reports MERGED.
+    monkeypatch.setattr(wb, "_pr_is_merged", lambda branch, *, cwd: True)
+    assert wb.remove_task_worktree("t_squash", consult_pr=True) is True
+    assert not wt.exists()
+    # Without consulting the PR, the same branch must be kept.
+    wt2 = wb.ensure_worktree("t_squash2")
+    _commit_on_worktree(wt2, "squash2.txt")
+    assert wb.remove_task_worktree("t_squash2", consult_pr=False) is False
+    assert wt2.exists()
+
+
+def test_prune_merged_worktrees_removes_merged_keeps_others(git_repo):
+    merged = wb.ensure_worktree("t_sweep_merged")
+    ahead = wb.ensure_worktree("t_sweep_ahead")
+    _commit_on_worktree(ahead, "ahead.txt")
+    dirty = wb.ensure_worktree("t_sweep_dirty")
+    (dirty / "scratch.txt").write_text("x\n", encoding="utf-8")
+
+    results = wb.prune_merged_worktrees(min_age_days=0, consult_pr=False)
+    decisions = {r["worktree"]: r["decision"] for r in results}
+
+    assert decisions[str(merged.resolve())] == "removed"
+    assert not merged.exists()
+    assert decisions[str(ahead.resolve())] == "skip:branch not merged"
+    assert ahead.exists()
+    assert decisions[str(dirty.resolve())] == "skip:dirty"
+    assert dirty.exists()
+    # Never touches the live checkout.
+    assert decisions[str(git_repo.resolve())] == "skip:live checkout"
+
+
+def test_prune_merged_worktrees_respects_min_age(git_repo):
+    wt = wb.ensure_worktree("t_recent")
+    # Recent commit (just now) with a 7-day idle floor → kept.
+    results = wb.prune_merged_worktrees(min_age_days=7, consult_pr=False)
+    decisions = {r["worktree"]: r["decision"] for r in results}
+    assert decisions[str(wt.resolve())].startswith("skip:too recent")
+    assert wt.exists()
+
+
+def test_prune_merged_worktrees_dry_run_reports_without_removing(git_repo):
+    wt = wb.ensure_worktree("t_dryrun")
+    results = wb.prune_merged_worktrees(min_age_days=0, execute=False, consult_pr=False)
+    decisions = {r["worktree"]: r["decision"] for r in results}
+    assert decisions[str(wt.resolve())] == "would-remove"
+    assert wt.exists()
+
+
 def test_pin_kanban_workspace_falls_back_without_worktree_kind(tmp_path, monkeypatch):
     import sqlite3
 

--- a/services/zoe-data/worktree_bootstrap.py
+++ b/services/zoe-data/worktree_bootstrap.py
@@ -212,6 +212,222 @@ def prepare_kanban_worktree(task_id: str, *, base_branch: str = "main") -> Path:
     return wt_path
 
 
+def _is_ancestor(repo: Path, ref: str, base_ref: str) -> bool:
+    """True when ``ref`` is reachable from ``base_ref`` (a real, non-squash merge)."""
+    result = _run_git(
+        ["git", "merge-base", "--is-ancestor", ref, base_ref],
+        cwd=str(repo),
+        timeout=30,
+    )
+    return result.returncode == 0
+
+
+def _pr_is_merged(branch: str, *, cwd: str) -> bool:
+    """Best-effort: True when ``branch`` has a merged GitHub PR (squash-merge case).
+
+    Squash-merged branches are not git ancestors of ``main``, so the ancestor
+    check alone never reclaims them — that is what let hundreds of stale task
+    worktrees accumulate. ``gh`` is optional; any failure (gh absent, no PR,
+    network) is treated as "not known-merged" so we fail safe and keep the tree.
+    """
+    try:
+        result = subprocess.run(
+            ["gh", "pr", "view", branch, "--json", "state,mergedAt"],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    if result.returncode != 0:
+        return False
+    try:
+        import json
+
+        data = json.loads(result.stdout or "{}")
+    except ValueError:
+        return False
+    return (data.get("state") or "").upper() == "MERGED" and bool(data.get("mergedAt"))
+
+
+def _branch_merged(repo: Path, branch: str, base_ref: str, *, consult_pr: bool) -> bool:
+    """True when ``branch`` is merged into ``base_ref`` (ancestor or squash-merged PR)."""
+    tip = _run_git(["git", "rev-parse", "--verify", branch], cwd=str(repo), timeout=30)
+    if tip.returncode != 0:
+        # No local branch ref (e.g. detached worktree); treat as not-merged here.
+        return False
+    if _is_ancestor(repo, branch, base_ref):
+        return True
+    return consult_pr and _pr_is_merged(branch, cwd=str(repo))
+
+
+def _worktree_is_dirty(wt_path: Path) -> bool:
+    status = _run_git(["git", "status", "--porcelain"], cwd=str(wt_path), timeout=30)
+    # On any error, be conservative and treat as dirty so we never discard work.
+    return status.returncode != 0 or bool(status.stdout.strip())
+
+
+def remove_task_worktree(
+    task_id: str,
+    *,
+    base_branch: str = "main",
+    require_merged: bool = True,
+    consult_pr: bool = True,
+) -> bool:
+    """Remove a task's worktree and its ``wt/<task_id>`` branch once merged.
+
+    Self-guarding and idempotent: safe to call from the poll loop on any task
+    that reached terminal ``done``. It only removes when the worktree is
+    registered, has no uncommitted changes, and (when ``require_merged``) the
+    branch is merged into ``origin/<base_branch>`` — a true ancestor merge or a
+    squash-merged PR. Otherwise it is a no-op and returns ``False``.
+
+    Returns ``True`` only when the worktree was actually removed.
+    """
+    task_id = _validate_task_id(task_id)
+    repo = Path(zoe_repo_root())
+    wt_path = worktree_path(task_id)
+    branch = worktree_branch(task_id)
+
+    if not _worktree_registered(repo, wt_path):
+        return False
+
+    if _worktree_is_dirty(wt_path):
+        logger.info("worktree_bootstrap: keeping %s — uncommitted changes", wt_path)
+        return False
+
+    if require_merged:
+        base_ref = _base_ref(repo, base_branch)
+        if not _branch_merged(repo, branch, base_ref, consult_pr=consult_pr):
+            logger.info(
+                "worktree_bootstrap: keeping %s — %s not merged into %s",
+                wt_path,
+                branch,
+                base_ref,
+            )
+            return False
+
+    removed = _run_git(
+        ["git", "worktree", "remove", "--force", str(wt_path)],
+        cwd=str(repo),
+        timeout=60,
+    )
+    if removed.returncode != 0:
+        logger.warning(
+            "worktree_bootstrap: could not remove worktree %s: %s",
+            wt_path,
+            (removed.stderr or removed.stdout or "").strip() or "unknown error",
+        )
+        return False
+
+    deleted = _run_git(["git", "branch", "-D", branch], cwd=str(repo), timeout=30)
+    if deleted.returncode != 0:
+        logger.warning(
+            "worktree_bootstrap: removed worktree %s but could not delete branch %s: %s",
+            wt_path,
+            branch,
+            (deleted.stderr or deleted.stdout or "").strip() or "unknown error",
+        )
+    logger.info("worktree_bootstrap: pruned task worktree %s (%s)", wt_path, branch)
+    return True
+
+
+def prune_merged_worktrees(
+    *,
+    base_branch: str = "main",
+    min_age_days: int = 7,
+    execute: bool = True,
+    consult_pr: bool = True,
+) -> list[dict[str, str]]:
+    """Sweep stale worktrees whose branches are merged into ``origin/<base>``.
+
+    Orphan safety net for tasks that crashed or lost their terminal handoff and
+    never self-cleaned. Mirrors ``scripts/maintenance/prune_worktrees.sh`` but in
+    process so the Multica harness can run it on its maintenance tick. Skips the
+    live checkout, locked worktrees, dirty worktrees, branches not merged into
+    ``origin/<base>`` (ancestor or squash-merged PR), and worktrees with activity
+    newer than ``min_age_days``.
+
+    Returns one record per worktree acted on or considered, with a ``decision``
+    of ``removed`` / ``would-remove`` / ``skip:<reason>``.
+    """
+    repo = Path(zoe_repo_root())
+    base_ref = _base_ref(repo, base_branch)
+    live_root = _run_git(["git", "rev-parse", "--show-toplevel"], cwd=str(repo), timeout=30)
+    live_path = (live_root.stdout or "").strip()
+    min_age_seconds = max(0, min_age_days) * 86400
+
+    import time
+
+    now = time.time()
+    listed = _run_git(["git", "worktree", "list", "--porcelain"], cwd=str(repo), timeout=60)
+    if listed.returncode != 0:
+        raise RuntimeError(
+            f"git worktree list failed: {(listed.stderr or '').strip() or 'unknown error'}"
+        )
+
+    results: list[dict[str, str]] = []
+    path = ""
+    branch = ""
+    locked = False
+
+    def _flush() -> None:
+        nonlocal path, branch, locked
+        if not path:
+            return
+        record = {"worktree": path, "branch": branch}
+        reason = ""
+        if path == live_path:
+            reason = "live checkout"
+        elif locked:
+            reason = "locked"
+        elif _worktree_is_dirty(Path(path)):
+            reason = "dirty"
+        elif not branch:
+            reason = "detached HEAD"
+        else:
+            age_src = _run_git(["git", "log", "-1", "--format=%ct"], cwd=path, timeout=30)
+            try:
+                activity = float((age_src.stdout or "0").strip() or 0)
+            except ValueError:
+                activity = 0.0
+            if now - activity < min_age_seconds:
+                reason = f"too recent (<{min_age_days}d idle)"
+            elif not _branch_merged(repo, branch, base_ref, consult_pr=consult_pr):
+                reason = "branch not merged"
+        if reason:
+            record["decision"] = f"skip:{reason}"
+        elif not execute:
+            record["decision"] = "would-remove"
+        else:
+            rm = _run_git(
+                ["git", "worktree", "remove", "--force", path], cwd=str(repo), timeout=60
+            )
+            if rm.returncode != 0:
+                record["decision"] = "skip:remove-failed"
+            else:
+                _run_git(["git", "branch", "-D", branch], cwd=str(repo), timeout=30)
+                record["decision"] = "removed"
+        results.append(record)
+        path, branch, locked = "", "", False
+
+    for line in listed.stdout.splitlines():
+        if line.startswith("worktree "):
+            _flush()
+            path = line.removeprefix("worktree ").strip()
+        elif line.startswith("branch refs/heads/"):
+            branch = line.removeprefix("branch refs/heads/").strip()
+        elif line.startswith("locked"):
+            locked = True
+    _flush()
+
+    if execute:
+        _run_git(["git", "worktree", "prune"], cwd=str(repo), timeout=60)
+    return results
+
+
 def _extract_pr_number(pr_url: str) -> str:
     match = _GITHUB_PR_RE.search((pr_url or "").strip())
     if not match:

--- a/services/zoe-data/worktree_bootstrap.py
+++ b/services/zoe-data/worktree_bootstrap.py
@@ -269,10 +269,21 @@ def _worktree_is_dirty(wt_path: Path) -> bool:
     return status.returncode != 0 or bool(status.stdout.strip())
 
 
+def resolve_base_ref(base_branch: str = "main") -> str:
+    """Public wrapper: fetch+resolve ``origin/<base_branch>`` once.
+
+    Callers cleaning several task worktrees in one pass (e.g. a completed chain)
+    should resolve the base ref once and pass it to ``remove_task_worktree`` via
+    ``base_ref`` so each removal does not re-run ``git fetch``.
+    """
+    return _base_ref(Path(zoe_repo_root()), base_branch)
+
+
 def remove_task_worktree(
     task_id: str,
     *,
     base_branch: str = "main",
+    base_ref: str | None = None,
     require_merged: bool = True,
     consult_pr: bool = True,
 ) -> bool:
@@ -283,6 +294,9 @@ def remove_task_worktree(
     registered, has no uncommitted changes, and (when ``require_merged``) the
     branch is merged into ``origin/<base_branch>`` — a true ancestor merge or a
     squash-merged PR. Otherwise it is a no-op and returns ``False``.
+
+    Pass ``base_ref`` (from :func:`resolve_base_ref`) to skip the per-call
+    ``git fetch`` when cleaning many worktrees at once.
 
     Returns ``True`` only when the worktree was actually removed.
     """
@@ -299,7 +313,7 @@ def remove_task_worktree(
         return False
 
     if require_merged:
-        base_ref = _base_ref(repo, base_branch)
+        base_ref = base_ref or _base_ref(repo, base_branch)
         if not _branch_merged(repo, branch, base_ref, consult_pr=consult_pr):
             logger.info(
                 "worktree_bootstrap: keeping %s — %s not merged into %s",
@@ -383,10 +397,12 @@ def prune_merged_worktrees(
             reason = "live checkout"
         elif locked:
             reason = "locked"
+        elif not branch:
+            # Classify detached HEADs before touching the tree — a missing/half-
+            # removed path would otherwise read as "dirty" and hide the real state.
+            reason = "detached HEAD"
         elif _worktree_is_dirty(Path(path)):
             reason = "dirty"
-        elif not branch:
-            reason = "detached HEAD"
         else:
             age_src = _run_git(["git", "log", "-1", "--format=%ct"], cwd=path, timeout=30)
             try:


### PR DESCRIPTION
## Problem
Multica creates a git worktree per task (`worktree_bootstrap.ensure_worktree`) but nothing ever removed them. Merged and **squash-merged** task worktrees piled up — a recent cleanup found ~400 stale `~/.worktrees` entries and ~390 leftover branches. The existing `scripts/maintenance/prune_worktrees.sh` only matched true git-ancestor merges, so squash-merged PRs (the harness default) were never reclaimed — the root cause of the accumulation.

## Fix — make cleanup Multica's own responsibility
- **`worktree_bootstrap.remove_task_worktree(task_id)`** — self-guarding, idempotent removal of a task's worktree + `wt/<id>` branch. Only acts when the branch is merged (git ancestor **or** squash-merged PR via `gh pr view`) and the worktree is clean; otherwise a no-op. Safe to call repeatedly from the poll loop.
- **`worktree_bootstrap.prune_merged_worktrees()`** — in-process port of `prune_worktrees.sh` as an orphan safety net. Skips live checkout, locked, dirty, unmerged, and recently-active (`min_age_days`) worktrees. Returns a per-worktree decision log.
- **`kanban_adapter`** — on chain terminal `done`, best-effort cleanup of each phase task's worktree. Wrapped so it never affects reported chain status.
- **`main.py` Multica poll loop** — daily-throttled sweep (`ZOE_WORKTREE_PRUNE_INTERVAL_S`, default 86400).
- **`AGENTS.md`** — documents automatic cleanup and the squash-merge detection.

## Safety
Never removes dirty, locked, unmerged, or the live checkout. Squash-merge detection via `gh` is best-effort and fails closed (keeps the worktree if merge state is unknown).

## Tests
8 new cases in `test_worktree_bootstrap.py` (merged / unmerged / dirty / not-registered / squash-merged / dry-run / min-age / live-checkout). Full `test_worktree_bootstrap.py` (19) and `test_kanban_adapter.py` (230) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)