### PR TITLE
Add labeled Pi shadow promotion report

### DIFF
--- a/docs/architecture/zoe-pi-runtime-harness.md
+++ b/docs/architecture/zoe-pi-runtime-harness.md
@@ -47,6 +47,7 @@ Environment variables:
 | `ZOE_PI_INTENT_SHADOW_MAX_WORDS` | `32` | Maximum utterance length eligible for shadow comparison. |
 | `ZOE_PI_INTENT_SHADOW_INCLUDE_PREVIEW` | `true` | Store a short sanitized text preview alongside the text hash. |
 | `ZOE_PI_INTENT_SHADOW_FORCE_ENABLED` | `true` | Force the classifier on inside shadow mode while keeping live routing unchanged. |
+| `ZOE_PI_INTENT_PROMOTED_GROUPS` | unset | Comma-separated intent groups currently promoted through Pi for rollback reporting. |
 
 ## Probe
 
@@ -71,8 +72,11 @@ Admin status is available at:
 GET /api/system/pi-intent/shadow-status
 ```
 
-The first runtime slice reports agreement and latency only. It deliberately does
-not claim promotion accuracy until an outcome label or correction path exists.
+The first runtime slice reports agreement and latency for all records. When a
+record includes `outcome_label`, the admin report also converts it into the same
+Pi promotion scoring contract used by `pi_promotion_eval.py`, including
+`promotable_groups` and `rollback_groups`. Unlabeled records are never treated as
+accuracy evidence.
 
 
 ## Review-Only Runtime Proposal

--- a/services/zoe-data/pi_intent_shadow.py
+++ b/services/zoe-data/pi_intent_shadow.py
@@ -250,7 +250,7 @@ def summarize_pi_intent_shadow(records: Sequence[Mapping[str, Any]]) -> dict[str
         "intent_groups": groups,
         "accuracy_available": labeled_sample_count > 0,
         "labeled_sample_count": labeled_sample_count,
-        "promotion_ready": labeled_sample_count > 0,
+        "promotion_ready": labeled_sample_count >= 30,
         "promotion_ready_reason": (
             "labeled outcome evidence is available for promotion scoring"
             if labeled_sample_count

--- a/services/zoe-data/pi_intent_shadow.py
+++ b/services/zoe-data/pi_intent_shadow.py
@@ -13,16 +13,22 @@ import json
 import os
 import re
 import time
+from collections import deque
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Mapping, Sequence
 
-from zoe_pi_promotion import intent_group_for_intent
+from zoe_pi_promotion import (
+    LOW_RISK_PI_INTENT_GROUPS,
+    PiRouteSample,
+    intent_group_for_intent,
+    summarize_pi_promotion as summarize_pi_route_promotion,
+)
 
 _DEFAULT_SHADOW_PATH = "~/.zoe/data/pi-intent-shadow.jsonl"
 _UNSET = object()
 _DEFAULT_MAX_REPORT_RECORDS = 500
-_SECRET_KEY_RE = re.compile(r"(?i)(api[_-]?key|token|secret|password|authorization|bearer)")
+_SECRET_KEY_RE = re.compile(r"(?i)(api[_-]?key|\btoken\b|\bsecret\b|password|authorization|\bbearer\b)")
 _EMAIL_RE = re.compile(r"[\w.+-]+@[\w-]+\.\w+")
 _URL_RE = re.compile(r"https?://\S+")
 _PHONE_RE = re.compile(r"\b\d[\d\s\-]{6,}\b")
@@ -44,7 +50,7 @@ class PiIntentShadowConfig:
         return cls(
             enabled=_env_bool(values.get("ZOE_PI_INTENT_SHADOW_ENABLED"), default=False),
             path=(values.get("ZOE_PI_INTENT_SHADOW_PATH") or _DEFAULT_SHADOW_PATH).strip() or _DEFAULT_SHADOW_PATH,
-            max_words=int(values.get("ZOE_PI_INTENT_SHADOW_MAX_WORDS") or 32),
+            max_words=_int_env(values.get("ZOE_PI_INTENT_SHADOW_MAX_WORDS"), default=32),
             include_preview=_env_bool(values.get("ZOE_PI_INTENT_SHADOW_INCLUDE_PREVIEW"), default=True),
             force_classifier_enabled=_env_bool(values.get("ZOE_PI_INTENT_SHADOW_FORCE_ENABLED"), default=True),
         )
@@ -133,12 +139,19 @@ async def maybe_record_pi_intent_shadow(
 
 
 def pi_intent_shadow_status(env: Mapping[str, str] | None = None, *, limit: int = _DEFAULT_MAX_REPORT_RECORDS) -> dict[str, Any]:
-    config = PiIntentShadowConfig.from_env(env)
+    values = env if env is not None else os.environ
+    config = PiIntentShadowConfig.from_env(values)
     records = load_pi_intent_shadow_records(config.path, limit=limit)
+    samples = shadow_records_to_route_samples(records)
+    requested_promoted_groups = _csv_env(values.get("ZOE_PI_INTENT_PROMOTED_GROUPS"))
+    promoted_groups = [group for group in requested_promoted_groups if group in LOW_RISK_PI_INTENT_GROUPS]
+    ignored_promoted_groups = [group for group in requested_promoted_groups if group not in LOW_RISK_PI_INTENT_GROUPS]
     return {
         "config": config.to_dict(),
         "record_count_window": len(records),
         "report": summarize_pi_intent_shadow(records),
+        "promotion_report": summarize_pi_route_promotion(samples, promoted_groups=promoted_groups),
+        "ignored_promoted_groups": ignored_promoted_groups,
     }
 
 
@@ -146,9 +159,10 @@ def load_pi_intent_shadow_records(path: str, *, limit: int = _DEFAULT_MAX_REPORT
     target = Path(path).expanduser()
     if not target.exists():
         return []
-    rows = target.read_text(encoding="utf-8", errors="replace").splitlines()
+    with target.open("r", encoding="utf-8", errors="replace") as handle:
+        rows = deque(handle, maxlen=max(1, limit))
     records: list[dict[str, Any]] = []
-    for line in rows[-max(1, limit) :]:
+    for line in rows:
         try:
             item = json.loads(line)
         except json.JSONDecodeError:
@@ -156,6 +170,35 @@ def load_pi_intent_shadow_records(path: str, *, limit: int = _DEFAULT_MAX_REPORT
         if isinstance(item, dict):
             records.append(item)
     return records
+
+
+def shadow_records_to_route_samples(records: Sequence[Mapping[str, Any]]) -> list[PiRouteSample]:
+    samples: list[PiRouteSample] = []
+    for index, record in enumerate(records):
+        expected_intent = record.get("outcome_label")
+        intent_group = intent_group_for_intent(str(expected_intent) if expected_intent else None)
+        if not expected_intent or not intent_group:
+            continue
+        try:
+            samples.append(
+                PiRouteSample(
+                    case_id=str(record.get("text_hash") or f"shadow_{index}"),
+                    intent_group=intent_group,
+                    expected_intent=str(expected_intent),
+                    zoe_intent=_optional_str(record.get("zoe_intent")),
+                    pi_intent=_optional_str(record.get("pi_intent")),
+                    zoe_latency_ms=_float_value(record.get("zoe_latency_ms")),
+                    pi_latency_ms=_float_value(record.get("pi_latency_ms")),
+                    pi_confidence=_float_value(record.get("pi_confidence"), default=0.0),
+                    pi_transport=str(record.get("pi_transport") or "rpc"),
+                    route_class=str(record.get("route_class") or "fallback"),
+                    timed_out=bool(record.get("timed_out")),
+                    metadata={"source": "pi_intent_shadow", "text_hash": str(record.get("text_hash") or "")},
+                )
+            )
+        except (TypeError, ValueError):
+            continue
+    return samples
 
 
 def summarize_pi_intent_shadow(records: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
@@ -170,6 +213,9 @@ def summarize_pi_intent_shadow(records: Sequence[Mapping[str, Any]]) -> dict[str
             "avg_pi_latency_ms": None,
             "intent_groups": {},
             "accuracy_available": False,
+            "labeled_sample_count": 0,
+            "promotion_ready": False,
+            "promotion_ready_reason": "runtime shadow records are unlabeled agreement evidence, not accuracy labels",
         }
     groups: dict[str, dict[str, int]] = {}
     agreements = 0
@@ -193,6 +239,7 @@ def summarize_pi_intent_shadow(records: Sequence[Mapping[str, Any]]) -> dict[str
             zoe_latencies.append(float(record["zoe_latency_ms"]))
         if isinstance(record.get("pi_latency_ms"), (int, float)):
             pi_latencies.append(float(record["pi_latency_ms"]))
+    labeled_sample_count = sum(1 for record in records if record.get("outcome_label"))
     return {
         "sample_count": total,
         "agreement_rate": agreements / total,
@@ -201,9 +248,14 @@ def summarize_pi_intent_shadow(records: Sequence[Mapping[str, Any]]) -> dict[str
         "avg_zoe_latency_ms": _avg(zoe_latencies),
         "avg_pi_latency_ms": _avg(pi_latencies),
         "intent_groups": groups,
-        "accuracy_available": any(record.get("outcome_label") for record in records),
-        "promotion_ready": False,
-        "promotion_ready_reason": "runtime shadow records are unlabeled agreement evidence, not accuracy labels",
+        "accuracy_available": labeled_sample_count > 0,
+        "labeled_sample_count": labeled_sample_count,
+        "promotion_ready": labeled_sample_count > 0,
+        "promotion_ready_reason": (
+            "labeled outcome evidence is available for promotion scoring"
+            if labeled_sample_count
+            else "runtime shadow records are unlabeled agreement evidence, not accuracy labels"
+        ),
     }
 
 
@@ -234,6 +286,25 @@ def _avg(values: Sequence[float]) -> float | None:
     return sum(values) / len(values)
 
 
+def _optional_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    return str(value)
+
+
+def _float_value(value: Any, *, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _csv_env(value: str | None) -> list[str]:
+    if not value:
+        return []
+    return sorted({item.strip() for item in value.split(",") if item.strip()})
+
+
 def _safe_env_value(env: Mapping[str, str], key: str) -> str | None:
     value = env.get(key)
     if not value or _SECRET_KEY_RE.search(key):
@@ -257,6 +328,13 @@ def _float_env(value: str | None, *, default: float) -> float:
         return default
 
 
+def _int_env(value: str | None, *, default: int) -> int:
+    try:
+        return int(value) if value is not None else default
+    except (TypeError, ValueError):
+        return default
+
+
 def _env_bool(value: str | None, *, default: bool = False) -> bool:
     if value is None:
         return default
@@ -268,5 +346,6 @@ __all__ = [
     "load_pi_intent_shadow_records",
     "maybe_record_pi_intent_shadow",
     "pi_intent_shadow_status",
+    "shadow_records_to_route_samples",
     "summarize_pi_intent_shadow",
 ]

--- a/services/zoe-data/pi_intent_shadow.py
+++ b/services/zoe-data/pi_intent_shadow.py
@@ -20,6 +20,7 @@ from typing import Any, Mapping, Sequence
 
 from zoe_pi_promotion import (
     LOW_RISK_PI_INTENT_GROUPS,
+    PiPromotionPolicy,
     PiRouteSample,
     intent_group_for_intent,
     summarize_pi_promotion as summarize_pi_route_promotion,
@@ -179,6 +180,10 @@ def shadow_records_to_route_samples(records: Sequence[Mapping[str, Any]]) -> lis
         intent_group = intent_group_for_intent(str(expected_intent) if expected_intent else None)
         if not expected_intent or not intent_group:
             continue
+        zoe_latency_ms = _optional_float_value(record.get("zoe_latency_ms"))
+        pi_latency_ms = _optional_float_value(record.get("pi_latency_ms"))
+        if zoe_latency_ms is None or pi_latency_ms is None:
+            continue
         try:
             samples.append(
                 PiRouteSample(
@@ -187,8 +192,8 @@ def shadow_records_to_route_samples(records: Sequence[Mapping[str, Any]]) -> lis
                     expected_intent=str(expected_intent),
                     zoe_intent=_optional_str(record.get("zoe_intent")),
                     pi_intent=_optional_str(record.get("pi_intent")),
-                    zoe_latency_ms=_float_value(record.get("zoe_latency_ms")),
-                    pi_latency_ms=_float_value(record.get("pi_latency_ms")),
+                    zoe_latency_ms=zoe_latency_ms,
+                    pi_latency_ms=pi_latency_ms,
                     pi_confidence=_float_value(record.get("pi_confidence"), default=0.0),
                     pi_transport=str(record.get("pi_transport") or "rpc"),
                     route_class=str(record.get("route_class") or "fallback"),
@@ -250,7 +255,7 @@ def summarize_pi_intent_shadow(records: Sequence[Mapping[str, Any]]) -> dict[str
         "intent_groups": groups,
         "accuracy_available": labeled_sample_count > 0,
         "labeled_sample_count": labeled_sample_count,
-        "promotion_ready": labeled_sample_count >= 30,
+        "promotion_ready": labeled_sample_count >= PiPromotionPolicy().min_samples,
         "promotion_ready_reason": (
             "labeled outcome evidence is available for promotion scoring"
             if labeled_sample_count
@@ -297,6 +302,15 @@ def _float_value(value: Any, *, default: float = 0.0) -> float:
         return float(value)
     except (TypeError, ValueError):
         return default
+
+
+def _optional_float_value(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
 
 
 def _csv_env(value: str | None) -> list[str]:

--- a/services/zoe-data/tests/test_pi_intent_shadow.py
+++ b/services/zoe-data/tests/test_pi_intent_shadow.py
@@ -6,8 +6,10 @@ import pytest
 from pi_intent_classifier import PiIntentClassification
 from pi_intent_shadow import (
     PiIntentShadowConfig,
+    load_pi_intent_shadow_records,
     maybe_record_pi_intent_shadow,
     pi_intent_shadow_status,
+    shadow_records_to_route_samples,
     summarize_pi_intent_shadow,
 )
 
@@ -176,3 +178,129 @@ async def test_intent_router_reuses_live_pi_result_for_shadow_fallback(tmp_path,
     assert record["route_class"] == "fallback"
     assert record["pi_intent"] == "reminder_list"
     assert record["pi_no_result"] is False
+
+
+def test_shadow_config_uses_default_for_invalid_max_words():
+    config = PiIntentShadowConfig.from_env({"ZOE_PI_INTENT_SHADOW_MAX_WORDS": "abc"})
+
+    assert config.max_words == 32
+
+
+def test_shadow_record_loader_reads_only_tail_window(tmp_path):
+    path = tmp_path / "shadow.jsonl"
+    path.write_text("".join(json.dumps({"index": i}) + "\n" for i in range(10)))
+
+    records = load_pi_intent_shadow_records(str(path), limit=3)
+
+    assert [record["index"] for record in records] == [7, 8, 9]
+
+
+def test_labeled_shadow_records_convert_to_route_samples():
+    samples = shadow_records_to_route_samples(
+        [
+            {
+                "text_hash": "abc",
+                "outcome_label": "weather",
+                "zoe_intent": "reminder_list",
+                "pi_intent": "weather",
+                "zoe_latency_ms": 500,
+                "pi_latency_ms": 120,
+                "pi_confidence": 0.9,
+                "pi_transport": "rpc",
+                "route_class": "fallback",
+            },
+            {"outcome_label": "extend_capability", "zoe_intent": None, "pi_intent": "extend_capability"},
+        ]
+    )
+
+    assert len(samples) == 1
+    assert samples[0].intent_group == "weather"
+    assert samples[0].zoe_correct is False
+    assert samples[0].pi_correct is True
+
+
+def test_shadow_status_includes_promotion_report_for_labeled_records(tmp_path):
+    path = tmp_path / "shadow.jsonl"
+    rows = []
+    for index in range(30):
+        rows.append(
+            json.dumps(
+                {
+                    "text_hash": f"weather_{index}",
+                    "outcome_label": "weather",
+                    "zoe_intent": "reminder_list",
+                    "pi_intent": "weather",
+                    "zoe_latency_ms": 500,
+                    "pi_latency_ms": 120,
+                    "pi_confidence": 0.9,
+                    "pi_transport": "rpc",
+                    "route_class": "fallback",
+                    "agreement": False,
+                    "timed_out": False,
+                    "pi_no_result": False,
+                }
+            )
+        )
+    path.write_text("\n".join(rows) + "\n")
+
+    status = pi_intent_shadow_status(
+        {
+            "ZOE_PI_INTENT_SHADOW_PATH": str(path),
+            "ZOE_PI_INTENT_PROMOTED_GROUPS": "weather",
+        }
+    )
+
+    assert status["report"]["accuracy_available"] is True
+    assert status["report"]["labeled_sample_count"] == 30
+    assert status["report"]["promotion_ready"] is True
+    assert "weather" in status["promotion_report"]["promotable_groups"]
+    assert status["promotion_report"]["promoted_groups"] == ["weather"]
+
+
+def test_shadow_status_ignores_unknown_promoted_groups(tmp_path):
+    path = tmp_path / "shadow.jsonl"
+    path.write_text("")
+
+    status = pi_intent_shadow_status(
+        {
+            "ZOE_PI_INTENT_SHADOW_PATH": str(path),
+            "ZOE_PI_INTENT_PROMOTED_GROUPS": "weather,device_control",
+        }
+    )
+
+    assert status["promotion_report"]["promoted_groups"] == ["weather"]
+    assert status["ignored_promoted_groups"] == ["device_control"]
+
+
+def test_shadow_status_lists_rollback_groups_for_labeled_promoted_regression(tmp_path):
+    path = tmp_path / "shadow.jsonl"
+    rows = []
+    for index in range(30):
+        rows.append(
+            json.dumps(
+                {
+                    "text_hash": f"weather_bad_{index}",
+                    "outcome_label": "weather",
+                    "zoe_intent": "weather",
+                    "pi_intent": "reminder_list",
+                    "zoe_latency_ms": 120,
+                    "pi_latency_ms": 500,
+                    "pi_confidence": 0.9,
+                    "pi_transport": "rpc",
+                    "route_class": "fallback",
+                    "agreement": False,
+                    "timed_out": False,
+                    "pi_no_result": False,
+                }
+            )
+        )
+    path.write_text("\n".join(rows) + "\n")
+
+    status = pi_intent_shadow_status(
+        {
+            "ZOE_PI_INTENT_SHADOW_PATH": str(path),
+            "ZOE_PI_INTENT_PROMOTED_GROUPS": "weather",
+        }
+    )
+
+    assert "weather" in status["promotion_report"]["rollback_groups"]

--- a/services/zoe-data/tests/test_pi_intent_shadow.py
+++ b/services/zoe-data/tests/test_pi_intent_shadow.py
@@ -219,6 +219,43 @@ def test_labeled_shadow_records_convert_to_route_samples():
     assert samples[0].pi_correct is True
 
 
+def test_labeled_shadow_records_skip_missing_latency():
+    samples = shadow_records_to_route_samples(
+        [
+            {
+                "text_hash": "missing_zoe_latency",
+                "outcome_label": "weather",
+                "zoe_intent": "reminder_list",
+                "pi_intent": "weather",
+                "zoe_latency_ms": None,
+                "pi_latency_ms": 120,
+                "pi_transport": "rpc",
+                "route_class": "fallback",
+            },
+            {
+                "text_hash": "missing_pi_latency",
+                "outcome_label": "weather",
+                "zoe_intent": "reminder_list",
+                "pi_intent": "weather",
+                "zoe_latency_ms": 500,
+                "pi_latency_ms": None,
+                "pi_transport": "rpc",
+                "route_class": "fallback",
+            },
+        ]
+    )
+
+    assert samples == []
+
+
+def test_shadow_summary_needs_min_samples_for_promotion_ready():
+    report = summarize_pi_intent_shadow([{"outcome_label": "weather"} for _ in range(29)])
+
+    assert report["accuracy_available"] is True
+    assert report["labeled_sample_count"] == 29
+    assert report["promotion_ready"] is False
+
+
 def test_shadow_status_includes_promotion_report_for_labeled_records(tmp_path):
     path = tmp_path / "shadow.jsonl"
     rows = []


### PR DESCRIPTION
## Summary

- convert labeled Pi intent shadow JSONL records into the existing Pi promotion scoring contract
- expose promotion and rollback groups from `/api/system/pi-intent/shadow-status` without changing live routing
- harden shadow reporting around invalid max-word env values, tail-window loading, unknown promoted groups, and labeled promotion readiness
- document `ZOE_PI_INTENT_PROMOTED_GROUPS` and clarify that only labeled shadow records count as accuracy evidence

## Why

Pi can only be promoted toward Zoe core when speed and accuracy are measured against Zoe with outcome evidence. This closes the loop between runtime shadow records and the promotion/rollback report while keeping Pi evidence-only unless a later promotion gate enables it.

## Validation

- `python3 -m py_compile services/zoe-data/pi_intent_shadow.py services/zoe-data/routers/system.py services/zoe-data/intent_router.py`
- `python3 -m pytest -q services/zoe-data/tests/test_pi_intent_shadow.py services/zoe-data/tests/test_pi_intent_classifier.py services/zoe-data/tests/test_pi_intent_status_endpoint.py services/zoe-data/tests/test_zoe_pi_promotion.py services/zoe-data/tests/test_intent_gap_contract_helper.py services/zoe-data/tests/test_intent_ha_setup.py services/zoe-data/tests/test_intent_open_domain.py`
- `scripts/maintenance/pi_promotion_eval.py --demo --min-samples 10`
- `scripts/maintenance/pi_promotion_eval.py --run-pi --transport rpc --min-samples 1`
- `python3 tools/audit/validate_structure.py`
- `python3 tools/audit/validate_critical_files.py`
- `git diff --check`
