### PR TITLE
Gate Pi runtime routing by promoted groups

### DIFF
--- a/docs/architecture/zoe-pi-runtime-harness.md
+++ b/docs/architecture/zoe-pi-runtime-harness.md
@@ -47,7 +47,7 @@ Environment variables:
 | `ZOE_PI_INTENT_SHADOW_MAX_WORDS` | `32` | Maximum utterance length eligible for shadow comparison. |
 | `ZOE_PI_INTENT_SHADOW_INCLUDE_PREVIEW` | `true` | Store a short sanitized text preview alongside the text hash. |
 | `ZOE_PI_INTENT_SHADOW_FORCE_ENABLED` | `true` | Force the classifier on inside shadow mode while keeping live routing unchanged. |
-| `ZOE_PI_INTENT_PROMOTED_GROUPS` | unset | Comma-separated intent groups currently promoted through Pi for rollback reporting. |
+| `ZOE_PI_INTENT_PROMOTED_GROUPS` | unset | Comma-separated low-risk intent groups promoted through Pi for live fallback execution and rollback reporting. Unknown or privileged groups are ignored. |
 
 ## Probe
 
@@ -76,7 +76,9 @@ The first runtime slice reports agreement and latency for all records. When a
 record includes `outcome_label`, the admin report also converts it into the same
 Pi promotion scoring contract used by `pi_promotion_eval.py`, including
 `promotable_groups` and `rollback_groups`. Unlabeled records are never treated as
-accuracy evidence.
+accuracy evidence. Pi live execution remains separately gated by
+`ZOE_PI_INTENT_PROMOTED_GROUPS`, so enabling the classifier alone does not promote
+all Pi classifications into executable Zoe routes.
 
 
 ## Review-Only Runtime Proposal

--- a/services/zoe-data/intent_router.py
+++ b/services/zoe-data/intent_router.py
@@ -1347,10 +1347,16 @@ async def detect_and_extract_intent(
     async def _try_pi_governor() -> tuple[Optional["Intent"], object | None]:
         pi_classified = None
         try:
-            from pi_intent_classifier import PI_INTENT_EXECUTE_THRESHOLD, classify_with_pi_intent_governor
+            from pi_intent_classifier import PI_INTENT_EXECUTE_THRESHOLD, classify_with_pi_intent_governor, pi_intent_is_promoted
+
             pi_classified = await classify_with_pi_intent_governor(text, context_turns=_context_turns())
             if pi_classified and pi_classified.intent and pi_classified.confidence >= PI_INTENT_EXECUTE_THRESHOLD:
-                return Intent(pi_classified.intent, dict(pi_classified.slots), confidence=pi_classified.confidence), pi_classified
+                if pi_intent_is_promoted(pi_classified.intent):
+                    return Intent(pi_classified.intent, dict(pi_classified.slots), confidence=pi_classified.confidence), pi_classified
+                logger.debug(
+                    "detect_and_extract_intent: Pi intent %s classified but not promoted for execution",
+                    pi_classified.intent,
+                )
         except Exception as exc:
             logger.debug("detect_and_extract_intent: Pi/Gemma governor failed: %s", exc)
         return None, pi_classified

--- a/services/zoe-data/pi_intent_classifier.py
+++ b/services/zoe-data/pi_intent_classifier.py
@@ -18,6 +18,7 @@ import shutil
 import time
 import uuid
 from dataclasses import dataclass
+from functools import lru_cache
 from typing import Any, Mapping
 
 from pi_runtime_probe import probe_pi_runtime
@@ -189,13 +190,13 @@ def pi_intent_status(env: Mapping[str, str] | None = None) -> dict[str, Any]:
 
 def pi_intent_promotion_status(env: Mapping[str, str] | None = None) -> dict[str, Any]:
     values = env if env is not None else os.environ
-    requested_groups = _csv_env(values.get("ZOE_PI_INTENT_PROMOTED_GROUPS"))
-    active_groups = [group for group in requested_groups if group in LOW_RISK_PI_INTENT_GROUPS]
-    ignored_groups = [group for group in requested_groups if group not in LOW_RISK_PI_INTENT_GROUPS]
+    requested_groups, active_groups, ignored_groups = _pi_intent_promotion_groups(
+        values.get("ZOE_PI_INTENT_PROMOTED_GROUPS") or ""
+    )
     return {
-        "requested_groups": requested_groups,
-        "active_groups": active_groups,
-        "ignored_groups": ignored_groups,
+        "requested_groups": list(requested_groups),
+        "active_groups": list(active_groups),
+        "ignored_groups": list(ignored_groups),
         "allowlisted_groups": sorted(LOW_RISK_PI_INTENT_GROUPS),
     }
 
@@ -579,6 +580,14 @@ def _bounded_float(value: Any, *, default: float) -> float:
     except (TypeError, ValueError):
         parsed = default
     return min(1.0, max(0.0, parsed))
+
+
+@lru_cache(maxsize=16)
+def _pi_intent_promotion_groups(value: str) -> tuple[tuple[str, ...], tuple[str, ...], tuple[str, ...]]:
+    requested_groups = tuple(_csv_env(value))
+    active_groups = tuple(group for group in requested_groups if group in LOW_RISK_PI_INTENT_GROUPS)
+    ignored_groups = tuple(group for group in requested_groups if group not in LOW_RISK_PI_INTENT_GROUPS)
+    return requested_groups, active_groups, ignored_groups
 
 
 def _csv_env(value: str | None) -> list[str]:

--- a/services/zoe-data/pi_intent_classifier.py
+++ b/services/zoe-data/pi_intent_classifier.py
@@ -21,6 +21,7 @@ from dataclasses import dataclass
 from typing import Any, Mapping
 
 from pi_runtime_probe import probe_pi_runtime
+from zoe_pi_promotion import LOW_RISK_PI_INTENT_GROUPS, intent_group_for_intent
 
 logger = logging.getLogger(__name__)
 
@@ -169,7 +170,7 @@ class PiIntentClassification:
 
 def pi_intent_status(env: Mapping[str, str] | None = None) -> dict[str, Any]:
     config = PiIntentClassifierConfig.from_env(env)
-    status = {"config": _safe_config_dict(config)}
+    status = {"config": _safe_config_dict(config), "promotion": pi_intent_promotion_status(env)}
     if not config.enabled:
         status.update({"ok": False, "status": "disabled", "reason": "ZOE_PI_INTENT_ENABLED is false"})
         return status
@@ -184,6 +185,26 @@ def pi_intent_status(env: Mapping[str, str] | None = None) -> dict[str, Any]:
         }
     )
     return status
+
+
+def pi_intent_promotion_status(env: Mapping[str, str] | None = None) -> dict[str, Any]:
+    values = env if env is not None else os.environ
+    requested_groups = _csv_env(values.get("ZOE_PI_INTENT_PROMOTED_GROUPS"))
+    active_groups = [group for group in requested_groups if group in LOW_RISK_PI_INTENT_GROUPS]
+    ignored_groups = [group for group in requested_groups if group not in LOW_RISK_PI_INTENT_GROUPS]
+    return {
+        "requested_groups": requested_groups,
+        "active_groups": active_groups,
+        "ignored_groups": ignored_groups,
+        "allowlisted_groups": sorted(LOW_RISK_PI_INTENT_GROUPS),
+    }
+
+
+def pi_intent_is_promoted(intent: str | None, env: Mapping[str, str] | None = None) -> bool:
+    group = intent_group_for_intent(intent)
+    if not group:
+        return False
+    return group in set(pi_intent_promotion_status(env)["active_groups"])
 
 
 async def classify_with_pi_intent_governor(
@@ -560,6 +581,12 @@ def _bounded_float(value: Any, *, default: float) -> float:
     return min(1.0, max(0.0, parsed))
 
 
+def _csv_env(value: str | None) -> list[str]:
+    if not value:
+        return []
+    return sorted({item.strip() for item in value.split(",") if item.strip()})
+
+
 def _env_bool(value: str | None, *, default: bool) -> bool:
     if value is None or str(value).strip() == "":
         return default
@@ -576,6 +603,8 @@ __all__ = [
     "PI_INTENT_HINT_THRESHOLD",
     "PiIntentClassification",
     "PiIntentClassifierConfig",
+    "pi_intent_is_promoted",
+    "pi_intent_promotion_status",
     "classify_with_pi_intent_governor",
     "pi_intent_status",
 ]

--- a/services/zoe-data/tests/test_pi_intent_classifier.py
+++ b/services/zoe-data/tests/test_pi_intent_classifier.py
@@ -10,6 +10,8 @@ from pi_intent_classifier import (
     _classification_prompt,
     _parse_pi_classification,
     classify_with_pi_intent_governor,
+    pi_intent_is_promoted,
+    pi_intent_promotion_status,
     pi_intent_status,
 )
 
@@ -85,6 +87,7 @@ def test_pi_intent_status_disabled_by_default():
     assert status["ok"] is False
     assert status["status"] == "disabled"
     assert status["config"]["enabled"] is False
+    assert status["promotion"]["active_groups"] == []
 
 
 def test_pi_intent_status_requires_explicit_execution_and_local_model_flags(tmp_path):
@@ -115,6 +118,15 @@ def test_pi_intent_status_is_available_with_explicit_operator_gates(tmp_path):
 
     assert status["ok"] is True
     assert status["status"] == "available"
+
+
+def test_pi_intent_promotion_status_filters_to_low_risk_groups():
+    status = pi_intent_promotion_status({"ZOE_PI_INTENT_PROMOTED_GROUPS": "weather,device_control,reminders"})
+
+    assert status["active_groups"] == ["reminders", "weather"]
+    assert status["ignored_groups"] == ["device_control"]
+    assert pi_intent_is_promoted("weather", {"ZOE_PI_INTENT_PROMOTED_GROUPS": "weather"}) is True
+    assert pi_intent_is_promoted("extend_capability", {"ZOE_PI_INTENT_PROMOTED_GROUPS": "extend_capability"}) is False
 
 
 def test_pi_intent_config_rejects_cloud_provider_when_offline_only():
@@ -331,6 +343,33 @@ async def test_pi_intent_governor_times_out_without_exception(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_detect_and_extract_intent_does_not_execute_unpromoted_pi_result(tmp_path, monkeypatch):
+    bindir = _fake_runtime(
+        tmp_path,
+        response={
+            "intent": "reminder_list",
+            "slots": {},
+            "confidence": 0.86,
+            "task_lane": "fast_tool",
+            "reason": "reminder query phrased unusually",
+        },
+    )
+    monkeypatch.setenv("PATH", str(bindir))
+    monkeypatch.setenv("ZOE_PI_INTENT_ENABLED", "true")
+    monkeypatch.setenv("ZOE_PI_CWD", str(tmp_path))
+    monkeypatch.setenv("ZOE_PI_ALLOW_EXECUTION", "true")
+    monkeypatch.setenv("ZOE_PI_LOCAL_MODEL_CONFIGURED", "true")
+    monkeypatch.setenv("ZOE_PI_INTENT_MODEL", "gemma-4-E2B-it-Q4_K_M.gguf")
+    monkeypatch.delenv("ZOE_PI_INTENT_PROMOTED_GROUPS", raising=False)
+
+    from intent_router import detect_and_extract_intent
+
+    intent = await detect_and_extract_intent("anything I should remember right now")
+
+    assert intent is None
+
+
+@pytest.mark.asyncio
 async def test_detect_and_extract_intent_uses_pi_for_deterministic_miss(tmp_path, monkeypatch):
     bindir = _fake_runtime(
         tmp_path,
@@ -348,6 +387,7 @@ async def test_detect_and_extract_intent_uses_pi_for_deterministic_miss(tmp_path
     monkeypatch.setenv("ZOE_PI_ALLOW_EXECUTION", "true")
     monkeypatch.setenv("ZOE_PI_LOCAL_MODEL_CONFIGURED", "true")
     monkeypatch.setenv("ZOE_PI_INTENT_MODEL", "gemma-4-E2B-it-Q4_K_M.gguf")
+    monkeypatch.setenv("ZOE_PI_INTENT_PROMOTED_GROUPS", "reminders")
 
     from intent_router import detect_and_extract_intent
 
@@ -376,6 +416,7 @@ async def test_detect_and_extract_intent_uses_pi_when_slot_extraction_fails(tmp_
     monkeypatch.setenv("ZOE_PI_ALLOW_EXECUTION", "true")
     monkeypatch.setenv("ZOE_PI_LOCAL_MODEL_CONFIGURED", "true")
     monkeypatch.setenv("ZOE_PI_INTENT_MODEL", "gemma-4-E2B-it-Q4_K_M.gguf")
+    monkeypatch.setenv("ZOE_PI_INTENT_PROMOTED_GROUPS", "reminders")
 
     import sys
     import types

--- a/services/zoe-data/tests/test_pi_intent_classifier.py
+++ b/services/zoe-data/tests/test_pi_intent_classifier.py
@@ -129,6 +129,16 @@ def test_pi_intent_promotion_status_filters_to_low_risk_groups():
     assert pi_intent_is_promoted("extend_capability", {"ZOE_PI_INTENT_PROMOTED_GROUPS": "extend_capability"}) is False
 
 
+def test_pi_intent_promotion_status_cache_tracks_env_value(monkeypatch):
+    monkeypatch.setenv("ZOE_PI_INTENT_PROMOTED_GROUPS", "weather")
+    first = pi_intent_promotion_status()
+    monkeypatch.setenv("ZOE_PI_INTENT_PROMOTED_GROUPS", "reminders")
+    second = pi_intent_promotion_status()
+
+    assert first["active_groups"] == ["weather"]
+    assert second["active_groups"] == ["reminders"]
+
+
 def test_pi_intent_config_rejects_cloud_provider_when_offline_only():
     config = PiIntentClassifierConfig.from_env(
         {

--- a/services/zoe-data/tests/test_pi_intent_shadow.py
+++ b/services/zoe-data/tests/test_pi_intent_shadow.py
@@ -164,6 +164,7 @@ async def test_intent_router_reuses_live_pi_result_for_shadow_fallback(tmp_path,
     monkeypatch.setenv("ZOE_PI_INTENT_ENABLED", "true")
     monkeypatch.setenv("ZOE_PI_INTENT_SHADOW_ENABLED", "true")
     monkeypatch.setenv("ZOE_PI_INTENT_SHADOW_PATH", str(path))
+    monkeypatch.setenv("ZOE_PI_INTENT_PROMOTED_GROUPS", "reminders")
     monkeypatch.setattr("pi_intent_classifier.classify_with_pi_intent_governor", fake_classify)
 
     from intent_router import detect_and_extract_intent

--- a/services/zoe-data/tests/test_pi_intent_status_endpoint.py
+++ b/services/zoe-data/tests/test_pi_intent_status_endpoint.py
@@ -41,6 +41,7 @@ def _admin_app():
 def test_pi_intent_status_endpoint_is_admin_scoped_and_disabled_by_default(monkeypatch):
     monkeypatch.delenv("ZOE_PI_INTENT_ENABLED", raising=False)
     monkeypatch.delenv("ZOE_PI_INTENT_PROMOTED_GROUPS", raising=False)
+    monkeypatch.delenv("ZOE_PI_INTENT_PROMOTED_GROUPS", raising=False)
     app = _admin_app()
 
     resp = TestClient(app).get("/api/system/pi-intent/status")

--- a/services/zoe-data/tests/test_pi_intent_status_endpoint.py
+++ b/services/zoe-data/tests/test_pi_intent_status_endpoint.py
@@ -41,7 +41,6 @@ def _admin_app():
 def test_pi_intent_status_endpoint_is_admin_scoped_and_disabled_by_default(monkeypatch):
     monkeypatch.delenv("ZOE_PI_INTENT_ENABLED", raising=False)
     monkeypatch.delenv("ZOE_PI_INTENT_PROMOTED_GROUPS", raising=False)
-    monkeypatch.delenv("ZOE_PI_INTENT_PROMOTED_GROUPS", raising=False)
     app = _admin_app()
 
     resp = TestClient(app).get("/api/system/pi-intent/status")

--- a/services/zoe-data/tests/test_pi_intent_status_endpoint.py
+++ b/services/zoe-data/tests/test_pi_intent_status_endpoint.py
@@ -50,6 +50,7 @@ def test_pi_intent_status_endpoint_is_admin_scoped_and_disabled_by_default(monke
     assert data["status"] == "disabled"
     assert data["config"]["enabled"] is False
     assert data["config"]["transport"] == "print"
+    assert data["promotion"]["active_groups"] == []
 
 
 def test_pi_intent_status_endpoint_reports_execution_disabled_when_tools_exist(tmp_path, monkeypatch):
@@ -112,6 +113,7 @@ def test_pi_intent_status_endpoint_reports_available_with_explicit_gates(tmp_pat
     monkeypatch.setenv("PATH", str(bindir))
     monkeypatch.setenv("ZOE_PI_INTENT_ENABLED", "true")
     monkeypatch.setenv("ZOE_PI_INTENT_TRANSPORT", "rpc")
+    monkeypatch.setenv("ZOE_PI_INTENT_PROMOTED_GROUPS", "weather,device_control")
     monkeypatch.setenv("ZOE_PI_CWD", str(tmp_path))
     monkeypatch.setenv("ZOE_PI_ALLOW_EXECUTION", "true")
     monkeypatch.setenv("ZOE_PI_LOCAL_MODEL_CONFIGURED", "true")
@@ -124,6 +126,8 @@ def test_pi_intent_status_endpoint_reports_available_with_explicit_gates(tmp_pat
     assert data["ok"] is True
     assert data["status"] == "available"
     assert data["config"]["transport"] == "rpc"
+    assert data["promotion"]["active_groups"] == ["weather"]
+    assert data["promotion"]["ignored_groups"] == ["device_control"]
     assert data["probe"]["config"]["allow_execution"] is True
     assert data["probe"]["config"]["local_model_configured"] is True
 

--- a/services/zoe-data/tests/test_pi_intent_status_endpoint.py
+++ b/services/zoe-data/tests/test_pi_intent_status_endpoint.py
@@ -40,6 +40,7 @@ def _admin_app():
 
 def test_pi_intent_status_endpoint_is_admin_scoped_and_disabled_by_default(monkeypatch):
     monkeypatch.delenv("ZOE_PI_INTENT_ENABLED", raising=False)
+    monkeypatch.delenv("ZOE_PI_INTENT_PROMOTED_GROUPS", raising=False)
     app = _admin_app()
 
     resp = TestClient(app).get("/api/system/pi-intent/status")


### PR DESCRIPTION
## Summary

- gate live Pi fallback/extraction routing behind `ZOE_PI_INTENT_PROMOTED_GROUPS`
- expose requested, active, ignored, and allowlisted promoted groups in Pi intent status
- keep unpromoted Pi classifications as evidence only; Zoe fallback remains authoritative
- document that enabling Pi classification alone no longer promotes all Pi outputs into executable routes

## Why

The promotion plan requires Pi to become Zoe core only where speed and accuracy evidence proves it wins. This closes the runtime safety loop: Pi can classify in shadow/eval, but live execution only happens for explicitly promoted low-risk intent groups.

## Validation

- `python3 -m py_compile services/zoe-data/pi_intent_classifier.py services/zoe-data/intent_router.py services/zoe-data/pi_intent_shadow.py services/zoe-data/routers/system.py`
- `python3 -m pytest -q services/zoe-data/tests/test_pi_intent_classifier.py services/zoe-data/tests/test_pi_intent_shadow.py services/zoe-data/tests/test_pi_intent_status_endpoint.py services/zoe-data/tests/test_zoe_pi_promotion.py services/zoe-data/tests/test_intent_gap_contract_helper.py services/zoe-data/tests/test_intent_ha_setup.py services/zoe-data/tests/test_intent_open_domain.py`
- `scripts/maintenance/pi_promotion_eval.py --demo --min-samples 10`
- `scripts/maintenance/pi_promotion_eval.py --run-pi --transport rpc --min-samples 1`
- `python3 tools/audit/validate_structure.py`
- `python3 tools/audit/validate_critical_files.py`
- `git diff --check`
