### PR TITLE
fix(implement-prompt): require shipping a PR; forbid block-for-review

### DIFF
--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -824,6 +824,15 @@ class KanbanAdapter:
             # call kanban_show and read SCOUT_SUMMARY= from scout metadata when present.
             return common + overnight_hint + (
                 "You are the implementer (zoe-coder).\n"
+                "- COMPLETION MEANS YOU SHIP A PR (read this first): when your edits are made and"
+                " focused tests pass, you MUST commit, publish the branch, and open ONE PR (exact"
+                " push/PR commands are given below), then call `kanban_complete` with PR_URL=. Greptile"
+                " and CI review the PR automatically — there is NO separate human-review step to wait"
+                " for. Stopping with a finished diff and calling `kanban_block` to 'block for review',"
+                " 'hand off for review', or because a human should look at it is a PROTOCOL VIOLATION"
+                " that wastes the run: open the PR yourself instead. `kanban_block` is ONLY for genuine"
+                " blockers where you cannot ship (dirty tree, missing auth, ambiguous product decision,"
+                " repeated test failure, scope too broad).\n"
                 f"{code_audit_hint}"
                 f"{harness_hint}"
                 f"{intent_gap_hint}"

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -1117,6 +1117,20 @@ async def test_implement_body_mentions_scope_split_packet():
 
 
 @pytest.mark.asyncio
+async def test_implement_body_requires_shipping_a_pr_not_blocking_for_review():
+    body = ka.KanbanAdapter()._build_body(
+        "implement",
+        {"id": "uuid-1", "identifier": "ZOE-9", "title": "Fix thing", "description": ""},
+        "ZOE-9",
+    )
+    # The worker must ship a PR on completion, not present a finished diff and
+    # block "for review" (observed failure mode with conservative models).
+    assert "COMPLETION MEANS YOU SHIP A PR" in body
+    assert "block for review" in body
+    assert "PROTOCOL VIOLATION" in body
+
+
+@pytest.mark.asyncio
 async def test_retro_body_prefers_cheap_summary_models():
     body = ka.KanbanAdapter()._build_body(
         "retro",


### PR DESCRIPTION
## Why
The bounded autonomous test (MiniMax M3 on ZOE-5797) produced a **correct** multi-file diff with passing tests — then called `kanban_block` "for review" instead of pushing + opening a PR, so the run never completed end-to-end. The prompt already said "don't block merely because a reviewer should inspect the PR," but it was buried at the end of the implement body.

## What
Adds an emphatic instruction at the **top** of the implement prompt: completion means commit → push → open ONE PR → `kanban_complete` with `PR_URL=`; Greptile + CI review the PR automatically, so presenting a finished diff and calling `kanban_block` "for review" is a protocol violation. `kanban_block` stays for genuine blockers only. The literal push/PR commands remain in their existing worktree-pinned location so the ordering guard (`test_implement_body_requires_pinned_worktree_before_git_or_pr_commands`) still holds.

## Tests
`pytest tests/test_kanban_adapter.py -k implement_body` → **29 passed** (incl. new `test_implement_body_requires_shipping_a_pr_not_blocking_for_review`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)