### PR TITLE
Add Pi promotion action recommendations

### DIFF
--- a/docs/architecture/zoe-pi-runtime-harness.md
+++ b/docs/architecture/zoe-pi-runtime-harness.md
@@ -78,7 +78,9 @@ Pi promotion scoring contract used by `pi_promotion_eval.py`, including
 `promotable_groups` and `rollback_groups`. Unlabeled records are never treated as
 accuracy evidence. Pi live execution remains separately gated by
 `ZOE_PI_INTENT_PROMOTED_GROUPS`, so enabling the classifier alone does not promote
-all Pi classifications into executable Zoe routes.
+all Pi classifications into executable Zoe routes. The report includes a read-only
+`promotion_actions.env.ZOE_PI_INTENT_PROMOTED_GROUPS` recommendation for operator
+review; Zoe does not rewrite env or auto-promote groups from shadow evidence.
 
 
 ## Review-Only Runtime Proposal

--- a/services/zoe-data/tests/test_pi_intent_shadow.py
+++ b/services/zoe-data/tests/test_pi_intent_shadow.py
@@ -293,6 +293,7 @@ def test_shadow_status_includes_promotion_report_for_labeled_records(tmp_path):
     assert status["report"]["promotion_ready"] is True
     assert "weather" in status["promotion_report"]["promotable_groups"]
     assert status["promotion_report"]["promoted_groups"] == ["weather"]
+    assert status["promotion_report"]["promotion_actions"]["next_promoted_groups"] == ["weather"]
 
 
 def test_shadow_status_ignores_unknown_promoted_groups(tmp_path):
@@ -342,3 +343,4 @@ def test_shadow_status_lists_rollback_groups_for_labeled_promoted_regression(tmp
     )
 
     assert "weather" in status["promotion_report"]["rollback_groups"]
+    assert status["promotion_report"]["promotion_actions"]["next_promoted_groups"] == []

--- a/services/zoe-data/tests/test_zoe_pi_promotion.py
+++ b/services/zoe-data/tests/test_zoe_pi_promotion.py
@@ -264,6 +264,32 @@ def test_summary_includes_operator_rollback_actions():
     assert report["promotion_actions"]["env"] == {"ZOE_PI_INTENT_PROMOTED_GROUPS": "reminders"}
 
 
+def test_build_pi_promotion_actions_reports_no_change_steady_state():
+    actions = build_pi_promotion_actions(
+        current_promoted_groups=["weather"],
+        promotable_groups=["weather"],
+        rollback_groups=[],
+    )
+
+    assert actions == {
+        "promote_groups": [],
+        "rollback_groups": [],
+        "keep_promoted_groups": ["weather"],
+        "next_promoted_groups": ["weather"],
+        "env": {"ZOE_PI_INTENT_PROMOTED_GROUPS": "weather"},
+        "requires_operator_apply": False,
+    }
+
+
+def test_build_pi_promotion_actions_rejects_conflicting_groups():
+    with pytest.raises(ValueError, match="conflicting promotion action groups"):
+        build_pi_promotion_actions(
+            current_promoted_groups=[],
+            promotable_groups=["weather"],
+            rollback_groups=["weather"],
+        )
+
+
 def test_build_pi_promotion_actions_rejects_unknown_groups():
     with pytest.raises(ValueError, match="unknown promotion action groups"):
         build_pi_promotion_actions(

--- a/services/zoe-data/tests/test_zoe_pi_promotion.py
+++ b/services/zoe-data/tests/test_zoe_pi_promotion.py
@@ -5,6 +5,7 @@ from zoe_pi_promotion import (
     PiIntentEvalCase,
     PiPromotionPolicy,
     PiRouteSample,
+    build_pi_promotion_actions,
     eval_cases_to_dict,
     evaluate_pi_promotion,
     intent_group_for_intent,
@@ -185,6 +186,91 @@ def test_summary_lists_rollback_groups_for_active_promotions():
 
     assert report["promoted_groups"] == ["weather"]
     assert "weather" in report["rollback_groups"]
+
+
+def test_summary_includes_operator_promotion_actions():
+    samples = [
+        PiRouteSample(
+            case_id=f"weather_{index}",
+            intent_group="weather",
+            expected_intent="weather",
+            zoe_intent="reminder_list",
+            pi_intent="weather",
+            zoe_latency_ms=500,
+            pi_latency_ms=100,
+            pi_confidence=0.9,
+        )
+        for index in range(30)
+    ] + [
+        PiRouteSample(
+            case_id=f"reminder_{index}",
+            intent_group="reminders",
+            expected_intent="reminder_list",
+            zoe_intent="weather",
+            pi_intent="reminder_list",
+            zoe_latency_ms=450,
+            pi_latency_ms=90,
+            pi_confidence=0.9,
+        )
+        for index in range(30)
+    ]
+
+    report = summarize_pi_promotion(samples, promoted_groups=["reminders"])
+
+    assert report["promotion_actions"]["promote_groups"] == ["weather"]
+    assert report["promotion_actions"] == {
+        "promote_groups": ["weather"],
+        "rollback_groups": [],
+        "keep_promoted_groups": ["reminders"],
+        "next_promoted_groups": ["reminders", "weather"],
+        "env": {"ZOE_PI_INTENT_PROMOTED_GROUPS": "reminders,weather"},
+        "requires_operator_apply": True,
+    }
+
+
+def test_summary_includes_operator_rollback_actions():
+    samples = [
+        PiRouteSample(
+            case_id=f"weather_bad_{index}",
+            intent_group="weather",
+            expected_intent="weather",
+            zoe_intent="weather",
+            pi_intent="reminder_list",
+            zoe_latency_ms=100,
+            pi_latency_ms=500,
+            pi_confidence=0.9,
+        )
+        for index in range(30)
+    ] + [
+        PiRouteSample(
+            case_id=f"reminder_good_{index}",
+            intent_group="reminders",
+            expected_intent="reminder_list",
+            zoe_intent="weather",
+            pi_intent="reminder_list",
+            zoe_latency_ms=450,
+            pi_latency_ms=90,
+            pi_confidence=0.9,
+        )
+        for index in range(30)
+    ]
+
+    report = summarize_pi_promotion(samples, promoted_groups=["weather", "reminders"])
+
+    assert report["rollback_groups"] == ["weather"]
+    assert report["promotion_actions"]["rollback_groups"] == ["weather"]
+    assert report["promotion_actions"]["keep_promoted_groups"] == ["reminders"]
+    assert report["promotion_actions"]["next_promoted_groups"] == ["reminders"]
+    assert report["promotion_actions"]["env"] == {"ZOE_PI_INTENT_PROMOTED_GROUPS": "reminders"}
+
+
+def test_build_pi_promotion_actions_rejects_unknown_groups():
+    with pytest.raises(ValueError, match="unknown promotion action groups"):
+        build_pi_promotion_actions(
+            current_promoted_groups=["weather"],
+            promotable_groups=["device_control"],
+            rollback_groups=[],
+        )
 
 
 def test_summary_rejects_unknown_promoted_groups():

--- a/services/zoe-data/zoe_pi_promotion.py
+++ b/services/zoe-data/zoe_pi_promotion.py
@@ -345,10 +345,13 @@ def build_pi_promotion_actions(
     unknown = sorted((current | promotable | rollback) - set(LOW_RISK_PI_INTENT_GROUPS))
     if unknown:
         raise ValueError(f"unknown promotion action groups: {', '.join(unknown)}")
+    overlap = sorted(promotable & rollback)
+    if overlap:
+        raise ValueError(f"conflicting promotion action groups: {', '.join(overlap)}")
     next_promoted = sorted((current | promotable) - rollback)
     promote = sorted(promotable - current)
     remove = sorted(rollback & current)
-    keep = sorted((current & set(LOW_RISK_PI_INTENT_GROUPS)) - set(remove))
+    keep = sorted(current - set(remove))
     return {
         "promote_groups": promote,
         "rollback_groups": remove,

--- a/services/zoe-data/zoe_pi_promotion.py
+++ b/services/zoe-data/zoe_pi_promotion.py
@@ -310,6 +310,8 @@ def summarize_pi_promotion(
         ).to_dict()
         for group in sorted(LOW_RISK_PI_INTENT_GROUPS)
     ]
+    promotable_groups = [decision["intent_group"] for decision in decisions if decision["state"] == "promote"]
+    rollback_groups = [decision["intent_group"] for decision in decisions if decision["state"] == "rollback"]
     return {
         "policy": {
             "min_samples": active_policy.min_samples,
@@ -321,8 +323,39 @@ def summarize_pi_promotion(
         "sample_count": len(samples),
         "promoted_groups": sorted(active_promoted_groups),
         "decisions": decisions,
-        "promotable_groups": [decision["intent_group"] for decision in decisions if decision["state"] == "promote"],
-        "rollback_groups": [decision["intent_group"] for decision in decisions if decision["state"] == "rollback"],
+        "promotable_groups": promotable_groups,
+        "rollback_groups": rollback_groups,
+        "promotion_actions": build_pi_promotion_actions(
+            current_promoted_groups=sorted(active_promoted_groups),
+            promotable_groups=promotable_groups,
+            rollback_groups=rollback_groups,
+        ),
+    }
+
+
+def build_pi_promotion_actions(
+    *,
+    current_promoted_groups: Sequence[str],
+    promotable_groups: Sequence[str],
+    rollback_groups: Sequence[str],
+) -> dict[str, Any]:
+    current = set(current_promoted_groups)
+    promotable = set(promotable_groups)
+    rollback = set(rollback_groups)
+    unknown = sorted((current | promotable | rollback) - set(LOW_RISK_PI_INTENT_GROUPS))
+    if unknown:
+        raise ValueError(f"unknown promotion action groups: {', '.join(unknown)}")
+    next_promoted = sorted((current | promotable) - rollback)
+    promote = sorted(promotable - current)
+    remove = sorted(rollback & current)
+    keep = sorted((current & set(LOW_RISK_PI_INTENT_GROUPS)) - set(remove))
+    return {
+        "promote_groups": promote,
+        "rollback_groups": remove,
+        "keep_promoted_groups": keep,
+        "next_promoted_groups": next_promoted,
+        "env": {"ZOE_PI_INTENT_PROMOTED_GROUPS": ",".join(next_promoted)},
+        "requires_operator_apply": bool(promote or remove),
     }
 
 
@@ -384,6 +417,7 @@ __all__ = [
     "PiPromotionDecision",
     "PiPromotionPolicy",
     "PiRouteSample",
+    "build_pi_promotion_actions",
     "eval_cases_to_dict",
     "evaluate_pi_promotion",
     "intent_group_for_intent",


### PR DESCRIPTION
## Summary

- add read-only Pi promotion action recommendations to the existing promotion report
- report which groups to promote, rollback, keep promoted, and the next `ZOE_PI_INTENT_PROMOTED_GROUPS` value
- expose the same action artifact through shadow-status and the eval script output because both use `summarize_pi_promotion`
- document that Zoe does not auto-write env or auto-promote from shadow evidence

## Why

The Pi plan needs speed/accuracy evidence to become an operator-safe promotion loop. Prior slices produced the scoring report and live promoted-group gate; this closes the next loop by turning scoring into a concrete operator recommendation without changing runtime behavior automatically.

## Validation

- `python3 -m py_compile services/zoe-data/zoe_pi_promotion.py services/zoe-data/pi_intent_shadow.py scripts/maintenance/pi_promotion_eval.py`
- `python3 -m pytest -q services/zoe-data/tests/test_zoe_pi_promotion.py services/zoe-data/tests/test_pi_intent_shadow.py services/zoe-data/tests/test_pi_intent_classifier.py services/zoe-data/tests/test_pi_intent_status_endpoint.py services/zoe-data/tests/test_intent_gap_contract_helper.py services/zoe-data/tests/test_intent_ha_setup.py services/zoe-data/tests/test_intent_open_domain.py`
- `scripts/maintenance/pi_promotion_eval.py --demo --min-samples 10`
- JSON assertion that eval output includes `promotion_report.promotion_actions.env`
- `scripts/maintenance/pi_promotion_eval.py --run-pi --transport rpc --min-samples 1`
- `python3 tools/audit/validate_structure.py`
- `python3 tools/audit/validate_critical_files.py`
- `git diff --check`
