### PR TITLE
test(autoresearch-bridge): add focused _to_float helper test (ZOE-5798)

### DIFF
--- a/services/zoe-data/tests/test_autoresearch_bridge.py
+++ b/services/zoe-data/tests/test_autoresearch_bridge.py
@@ -1,6 +1,7 @@
 """Tests for the autoresearch -> governed-pipeline promotion bridge."""
 
 from autoresearch_bridge import (
+    _to_float,
     build_audit_ticket,
     build_pr_body,
     decide_promotion,
@@ -285,3 +286,9 @@ def test_prepare_promotion_no_keeper_is_inert(tmp_path):
     assert plan["promote"] is False
     assert "pr_body" not in plan
     assert "audit_description" not in plan
+
+
+def test_to_float_helper_parses_valid_none_and_invalid():
+    assert _to_float("3.5") == 3.5
+    assert _to_float(None) is None
+    assert _to_float("not-a-number") is None


### PR DESCRIPTION
## Summary

Add a focused unit test for the pure `_to_float` helper in
`services/zoe-data/autoresearch_bridge.py`.

The helper is the only float-coercion primitive the program/result parsers
rely on, but it had no direct test coverage. This test pins down the
three behaviors the parsers depend on:

- valid float string → float
- `None` → `None`
- unparseable string → `None`

## Changes

- `services/zoe-data/tests/test_autoresearch_bridge.py`: add
  `_to_float` to the existing import block and one new test,
  `test_to_float_helper_parses_valid_none_and_invalid`.
- `autoresearch_bridge.py`: **unchanged**.

## Verification

```bash
PYTHONPATH=services/zoe-data python3 -m pytest services/zoe-data/tests/test_autoresearch_bridge.py -q
# 17 passed in 0.33s
```

Closes ZOE-5798.