### PR TITLE
Add guarded Pi promotion apply helper

### DIFF
--- a/docs/architecture/zoe-pi-runtime-harness.md
+++ b/docs/architecture/zoe-pi-runtime-harness.md
@@ -81,6 +81,16 @@ accuracy evidence. Pi live execution remains separately gated by
 all Pi classifications into executable Zoe routes. The report includes a read-only
 `promotion_actions.env.ZOE_PI_INTENT_PROMOTED_GROUPS` recommendation for operator
 review; Zoe does not rewrite env or auto-promote groups from shadow evidence.
+Operators can inspect or explicitly apply that single env update with:
+
+```bash
+scripts/maintenance/pi_promotion_eval.py --demo --min-samples 10 \
+  | scripts/maintenance/pi_promotion_apply.py --env-file /path/to/.env
+scripts/maintenance/pi_promotion_eval.py --demo --min-samples 10 \
+  | scripts/maintenance/pi_promotion_apply.py --env-file /path/to/.env --apply --confirm APPLY_PI_PROMOTION
+```
+
+The apply helper only writes `ZOE_PI_INTENT_PROMOTED_GROUPS`; it rejects any other env key in the report.
 
 
 ## Review-Only Runtime Proposal

--- a/scripts/maintenance/pi_promotion_apply.py
+++ b/scripts/maintenance/pi_promotion_apply.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Plan or apply Pi promoted intent groups from a promotion report.
+
+Default mode is dry-run and side-effect free. Applying requires both --apply and
+--confirm APPLY_PI_PROMOTION, and only writes ZOE_PI_INTENT_PROMOTED_GROUPS to the
+specified env file.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Mapping
+
+ROOT = Path(__file__).resolve().parents[2]
+PROMOTION_ENV_KEY = "ZOE_PI_INTENT_PROMOTED_GROUPS"
+CONFIRM_TOKEN = "APPLY_PI_PROMOTION"
+
+
+class PiPromotionApplyError(ValueError):
+    pass
+
+
+def load_promotion_report(path: str) -> dict[str, Any]:
+    raw = sys.stdin.read() if path == "-" else Path(path).read_text(encoding="utf-8")
+    data = json.loads(raw)
+    if not isinstance(data, dict):
+        raise PiPromotionApplyError("promotion report JSON must be an object")
+    report = data.get("promotion_report", data)
+    if not isinstance(report, dict):
+        raise PiPromotionApplyError("promotion_report must be an object")
+    return report
+
+
+def promotion_env_value(report: Mapping[str, Any]) -> str:
+    actions = report.get("promotion_actions")
+    if not isinstance(actions, Mapping):
+        raise PiPromotionApplyError("promotion_actions missing from report")
+    env = actions.get("env")
+    if not isinstance(env, Mapping):
+        raise PiPromotionApplyError("promotion_actions.env missing from report")
+    extra_keys = sorted(set(env) - {PROMOTION_ENV_KEY})
+    if extra_keys:
+        raise PiPromotionApplyError(f"unsupported promotion env keys: {', '.join(extra_keys)}")
+    value = env.get(PROMOTION_ENV_KEY)
+    if value is None:
+        raise PiPromotionApplyError(f"{PROMOTION_ENV_KEY} missing from promotion_actions.env")
+    return _normalize_group_value(str(value))
+
+
+def build_env_update(existing_text: str, value: str) -> tuple[str, dict[str, Any]]:
+    normalized_value = _normalize_group_value(value)
+    lines = existing_text.splitlines()
+    changed = False
+    found = False
+    old_value: str | None = None
+    next_lines: list[str] = []
+    for line in lines:
+        if _line_key(line) == PROMOTION_ENV_KEY:
+            found = True
+            old_value = line.split("=", 1)[1].strip().strip('"').strip("'") if "=" in line else ""
+            replacement = f"{PROMOTION_ENV_KEY}={normalized_value}"
+            next_lines.append(replacement)
+            changed = changed or line != replacement
+        else:
+            next_lines.append(line)
+    if not found:
+        next_lines.append(f"{PROMOTION_ENV_KEY}={normalized_value}")
+        changed = True
+    output = "\n".join(next_lines).rstrip("\n") + "\n"
+    return output, {
+        "key": PROMOTION_ENV_KEY,
+        "old_value": old_value,
+        "next_value": normalized_value,
+        "line_present": found,
+        "changed": changed,
+    }
+
+
+def plan_pi_promotion_apply(report: Mapping[str, Any], env_path: Path) -> dict[str, Any]:
+    next_value = promotion_env_value(report)
+    existing = env_path.read_text(encoding="utf-8") if env_path.exists() else ""
+    _updated, update = build_env_update(existing, next_value)
+    actions = report.get("promotion_actions") if isinstance(report.get("promotion_actions"), Mapping) else {}
+    return {
+        "ok": True,
+        "mode": "dry_run",
+        "env_file": str(env_path),
+        "update": update,
+        "promotion_actions": actions,
+    }
+
+
+def apply_pi_promotion_report(report: Mapping[str, Any], env_path: Path, *, apply: bool, confirm: str | None) -> dict[str, Any]:
+    next_value = promotion_env_value(report)
+    existing = env_path.read_text(encoding="utf-8") if env_path.exists() else ""
+    updated, update = build_env_update(existing, next_value)
+    actions = report.get("promotion_actions") if isinstance(report.get("promotion_actions"), Mapping) else {}
+    if not apply:
+        return {
+            "ok": True,
+            "mode": "dry_run",
+            "env_file": str(env_path),
+            "update": update,
+            "promotion_actions": actions,
+        }
+    if confirm != CONFIRM_TOKEN:
+        return {
+            "ok": False,
+            "mode": "apply_rejected",
+            "env_file": str(env_path),
+            "error": f"--confirm {CONFIRM_TOKEN} is required with --apply",
+            "update": update,
+            "promotion_actions": actions,
+        }
+    env_path.parent.mkdir(parents=True, exist_ok=True)
+    env_path.write_text(updated, encoding="utf-8")
+    return {
+        "ok": True,
+        "mode": "applied",
+        "env_file": str(env_path),
+        "update": update,
+        "promotion_actions": actions,
+    }
+
+
+def _line_key(line: str) -> str | None:
+    stripped = line.strip()
+    if not stripped or stripped.startswith("#") or "=" not in stripped:
+        return None
+    return stripped.split("=", 1)[0].strip()
+
+
+def _normalize_group_value(value: str) -> str:
+    groups = sorted({item.strip() for item in value.split(",") if item.strip()})
+    return ",".join(groups)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--report", default="-", help="Promotion report JSON path, or - for stdin")
+    parser.add_argument("--env-file", default=str(ROOT / ".env"), help="Env file to plan/update")
+    parser.add_argument("--apply", action="store_true", help="Write the env-file update")
+    parser.add_argument("--confirm", help=f"Required with --apply: {CONFIRM_TOKEN}")
+    args = parser.parse_args(argv)
+    try:
+        report = load_promotion_report(args.report)
+        result = apply_pi_promotion_report(report, Path(args.env_file), apply=args.apply, confirm=args.confirm)
+    except (OSError, json.JSONDecodeError, PiPromotionApplyError) as exc:
+        result = {"ok": False, "mode": "error", "error": str(exc), "env_file": args.env_file}
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0 if result.get("ok") else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/maintenance/pi_promotion_apply.py
+++ b/scripts/maintenance/pi_promotion_apply.py
@@ -14,7 +14,6 @@ import sys
 from pathlib import Path
 from typing import Any, Mapping
 
-ROOT = Path(__file__).resolve().parents[2]
 PROMOTION_ENV_KEY = "ZOE_PI_INTENT_PROMOTED_GROUPS"
 CONFIRM_TOKEN = "APPLY_PI_PROMOTION"
 
@@ -79,26 +78,18 @@ def build_env_update(existing_text: str, value: str) -> tuple[str, dict[str, Any
     }
 
 
-def plan_pi_promotion_apply(report: Mapping[str, Any], env_path: Path) -> dict[str, Any]:
-    next_value = promotion_env_value(report)
-    existing = env_path.read_text(encoding="utf-8") if env_path.exists() else ""
-    _updated, update = build_env_update(existing, next_value)
-    actions = report.get("promotion_actions") if isinstance(report.get("promotion_actions"), Mapping) else {}
-    return {
-        "ok": True,
-        "mode": "dry_run",
-        "env_file": str(env_path),
-        "update": update,
-        "promotion_actions": actions,
-    }
-
-
-def apply_pi_promotion_report(report: Mapping[str, Any], env_path: Path, *, apply: bool, confirm: str | None) -> dict[str, Any]:
+def apply_pi_promotion_report(
+    report: Mapping[str, Any],
+    env_path: Path,
+    *,
+    apply_changes: bool,
+    confirm: str | None,
+) -> dict[str, Any]:
     next_value = promotion_env_value(report)
     existing = env_path.read_text(encoding="utf-8") if env_path.exists() else ""
     updated, update = build_env_update(existing, next_value)
     actions = report.get("promotion_actions") if isinstance(report.get("promotion_actions"), Mapping) else {}
-    if not apply:
+    if not apply_changes:
         return {
             "ok": True,
             "mode": "dry_run",
@@ -141,13 +132,13 @@ def _normalize_group_value(value: str) -> str:
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--report", default="-", help="Promotion report JSON path, or - for stdin")
-    parser.add_argument("--env-file", default=str(ROOT / ".env"), help="Env file to plan/update")
+    parser.add_argument("--env-file", required=True, help="Env file to plan/update")
     parser.add_argument("--apply", action="store_true", help="Write the env-file update")
     parser.add_argument("--confirm", help=f"Required with --apply: {CONFIRM_TOKEN}")
     args = parser.parse_args(argv)
     try:
         report = load_promotion_report(args.report)
-        result = apply_pi_promotion_report(report, Path(args.env_file), apply=args.apply, confirm=args.confirm)
+        result = apply_pi_promotion_report(report, Path(args.env_file), apply_changes=args.apply, confirm=args.confirm)
     except (OSError, json.JSONDecodeError, PiPromotionApplyError) as exc:
         result = {"ok": False, "mode": "error", "error": str(exc), "env_file": args.env_file}
     print(json.dumps(result, indent=2, sort_keys=True))

--- a/services/zoe-data/tests/test_pi_promotion_apply.py
+++ b/services/zoe-data/tests/test_pi_promotion_apply.py
@@ -2,6 +2,8 @@ import importlib.util
 import json
 from pathlib import Path
 
+import pytest
+
 
 def _load_module():
     path = Path(__file__).resolve().parents[3] / "scripts" / "maintenance" / "pi_promotion_apply.py"
@@ -44,7 +46,7 @@ def test_dry_run_does_not_write_env_file(tmp_path):
     env_path = tmp_path / ".env"
     env_path.write_text("A=1\n", encoding="utf-8")
 
-    result = module.apply_pi_promotion_report(_report("weather"), env_path, apply=False, confirm=None)
+    result = module.apply_pi_promotion_report(_report("weather"), env_path, apply_changes=False, confirm=None)
 
     assert result["ok"] is True
     assert result["mode"] == "dry_run"
@@ -56,7 +58,7 @@ def test_apply_requires_confirmation(tmp_path):
     module = _load_module()
     env_path = tmp_path / ".env"
 
-    result = module.apply_pi_promotion_report(_report("weather"), env_path, apply=True, confirm=None)
+    result = module.apply_pi_promotion_report(_report("weather"), env_path, apply_changes=True, confirm=None)
 
     assert result["ok"] is False
     assert result["mode"] == "apply_rejected"
@@ -71,7 +73,7 @@ def test_apply_writes_only_promoted_groups_key(tmp_path):
     result = module.apply_pi_promotion_report(
         _report("weather,reminders"),
         env_path,
-        apply=True,
+        apply_changes=True,
         confirm=module.CONFIRM_TOKEN,
     )
 
@@ -85,9 +87,19 @@ def test_rejects_unexpected_env_keys():
     report = _report("weather")
     report["promotion_actions"]["env"]["OPENAI_API_KEY"] = "nope"
 
-    import pytest
     with pytest.raises(module.PiPromotionApplyError, match="unsupported promotion env keys"):
         module.promotion_env_value(report)
+
+
+def test_cli_requires_env_file(tmp_path):
+    module = _load_module()
+    report_path = tmp_path / "report.json"
+    report_path.write_text(json.dumps({"promotion_report": _report("weather")}), encoding="utf-8")
+
+    with pytest.raises(SystemExit) as excinfo:
+        module.main(["--report", str(report_path)])
+
+    assert excinfo.value.code == 2
 
 
 def test_cli_reads_full_eval_payload_and_dry_runs(tmp_path, capsys):

--- a/services/zoe-data/tests/test_pi_promotion_apply.py
+++ b/services/zoe-data/tests/test_pi_promotion_apply.py
@@ -1,0 +1,108 @@
+import importlib.util
+import json
+from pathlib import Path
+
+
+def _load_module():
+    path = Path(__file__).resolve().parents[3] / "scripts" / "maintenance" / "pi_promotion_apply.py"
+    spec = importlib.util.spec_from_file_location("pi_promotion_apply_test", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _report(value="weather,reminders", requires_apply=True):
+    return {
+        "promotion_actions": {
+            "promote_groups": ["weather"] if requires_apply else [],
+            "rollback_groups": [],
+            "keep_promoted_groups": ["reminders"],
+            "next_promoted_groups": ["reminders", "weather"],
+            "env": {"ZOE_PI_INTENT_PROMOTED_GROUPS": value},
+            "requires_operator_apply": requires_apply,
+        }
+    }
+
+
+def test_build_env_update_preserves_existing_lines_and_sorts_groups():
+    module = _load_module()
+    updated, meta = module.build_env_update("A=1\nZOE_PI_INTENT_PROMOTED_GROUPS=weather\nB=2\n", "timers,weather")
+
+    assert updated == "A=1\nZOE_PI_INTENT_PROMOTED_GROUPS=timers,weather\nB=2\n"
+    assert meta == {
+        "key": "ZOE_PI_INTENT_PROMOTED_GROUPS",
+        "old_value": "weather",
+        "next_value": "timers,weather",
+        "line_present": True,
+        "changed": True,
+    }
+
+
+def test_dry_run_does_not_write_env_file(tmp_path):
+    module = _load_module()
+    env_path = tmp_path / ".env"
+    env_path.write_text("A=1\n", encoding="utf-8")
+
+    result = module.apply_pi_promotion_report(_report("weather"), env_path, apply=False, confirm=None)
+
+    assert result["ok"] is True
+    assert result["mode"] == "dry_run"
+    assert result["update"]["next_value"] == "weather"
+    assert env_path.read_text(encoding="utf-8") == "A=1\n"
+
+
+def test_apply_requires_confirmation(tmp_path):
+    module = _load_module()
+    env_path = tmp_path / ".env"
+
+    result = module.apply_pi_promotion_report(_report("weather"), env_path, apply=True, confirm=None)
+
+    assert result["ok"] is False
+    assert result["mode"] == "apply_rejected"
+    assert not env_path.exists()
+
+
+def test_apply_writes_only_promoted_groups_key(tmp_path):
+    module = _load_module()
+    env_path = tmp_path / ".env"
+    env_path.write_text("OTHER=value\n", encoding="utf-8")
+
+    result = module.apply_pi_promotion_report(
+        _report("weather,reminders"),
+        env_path,
+        apply=True,
+        confirm=module.CONFIRM_TOKEN,
+    )
+
+    assert result["ok"] is True
+    assert result["mode"] == "applied"
+    assert env_path.read_text(encoding="utf-8") == "OTHER=value\nZOE_PI_INTENT_PROMOTED_GROUPS=reminders,weather\n"
+
+
+def test_rejects_unexpected_env_keys():
+    module = _load_module()
+    report = _report("weather")
+    report["promotion_actions"]["env"]["OPENAI_API_KEY"] = "nope"
+
+    try:
+        module.promotion_env_value(report)
+    except module.PiPromotionApplyError as exc:
+        assert "unsupported promotion env keys" in str(exc)
+    else:
+        raise AssertionError("expected PiPromotionApplyError")
+
+
+def test_cli_reads_full_eval_payload_and_dry_runs(tmp_path, capsys):
+    module = _load_module()
+    report_path = tmp_path / "report.json"
+    env_path = tmp_path / ".env"
+    report_path.write_text(json.dumps({"promotion_report": _report("weather")}), encoding="utf-8")
+
+    exit_code = module.main(["--report", str(report_path), "--env-file", str(env_path)])
+
+    out = json.loads(capsys.readouterr().out)
+    assert exit_code == 0
+    assert out["mode"] == "dry_run"
+    assert out["update"]["next_value"] == "weather"
+    assert not env_path.exists()

--- a/services/zoe-data/tests/test_pi_promotion_apply.py
+++ b/services/zoe-data/tests/test_pi_promotion_apply.py
@@ -85,12 +85,9 @@ def test_rejects_unexpected_env_keys():
     report = _report("weather")
     report["promotion_actions"]["env"]["OPENAI_API_KEY"] = "nope"
 
-    try:
+    import pytest
+    with pytest.raises(module.PiPromotionApplyError, match="unsupported promotion env keys"):
         module.promotion_env_value(report)
-    except module.PiPromotionApplyError as exc:
-        assert "unsupported promotion env keys" in str(exc)
-    else:
-        raise AssertionError("expected PiPromotionApplyError")
 
 
 def test_cli_reads_full_eval_payload_and_dry_runs(tmp_path, capsys):


### PR DESCRIPTION
## Summary

- add `scripts/maintenance/pi_promotion_apply.py`, a guarded helper for Pi promotion recommendations
- default mode is dry-run and writes nothing
- apply mode requires `--apply --confirm APPLY_PI_PROMOTION`
- helper only writes `ZOE_PI_INTENT_PROMOTED_GROUPS` and rejects any other env key in the report
- document dry-run and explicit apply usage in the Pi runtime harness doc

## Why

The previous slice produced read-only promotion actions. This closes the next loop by giving operators a safe way to inspect or explicitly apply the single promoted-group env update, without allowing shadow evidence to auto-promote Pi routes.

## Validation

- `python3 -m py_compile scripts/maintenance/pi_promotion_apply.py scripts/maintenance/pi_promotion_eval.py services/zoe-data/zoe_pi_promotion.py`
- `python3 -m pytest -q services/zoe-data/tests/test_pi_promotion_apply.py services/zoe-data/tests/test_zoe_pi_promotion.py services/zoe-data/tests/test_pi_intent_shadow.py services/zoe-data/tests/test_pi_intent_classifier.py services/zoe-data/tests/test_pi_intent_status_endpoint.py services/zoe-data/tests/test_intent_gap_contract_helper.py services/zoe-data/tests/test_intent_ha_setup.py services/zoe-data/tests/test_intent_open_domain.py`
- `scripts/maintenance/pi_promotion_eval.py --demo --min-samples 10 | scripts/maintenance/pi_promotion_apply.py --env-file /tmp/pi-promoted-test.env`
- explicit apply smoke to `/tmp/pi-promoted-test.env` with `--apply --confirm APPLY_PI_PROMOTION`
- `scripts/maintenance/pi_promotion_eval.py --run-pi --transport rpc --min-samples 1`
- `python3 tools/audit/validate_structure.py`
- `python3 tools/audit/validate_critical_files.py`
- `git diff --check`
