### PR TITLE
fix(handoff): recover PR URL from prose so a shipped PR satisfies the pr-evidence gate

### DIFF
--- a/services/zoe-data/pipeline_handoff.py
+++ b/services/zoe-data/pipeline_handoff.py
@@ -78,6 +78,19 @@ _SURFACED_BLOCKER_RE = re.compile(rf"\b(?:{'|'.join(_SURFACED_BLOCKER_TOKENS)})\
 
 
 _REAL_PR_URL_RE = re.compile(r"^https://github\.com/[^/\s]+/[^/\s]+/pull/\d+(?:[/?#].*)?$", re.I)
+# Non-anchored variant for recovering a PR URL mentioned in prose (e.g. a worker
+# that opened a PR but only wrote "PR opened: <url>" instead of a structured
+# PR_URL= field). Stops at whitespace / sentence punctuation.
+_EMBEDDED_PR_URL_RE = re.compile(r"https://github\.com/[^/\s]+/[^/\s]+/pull/\d+", re.I)
+
+
+def _pr_url_from_haystacks(detail: dict[str, Any]) -> str:
+    """Recover a GitHub PR URL mentioned anywhere in the handoff text."""
+    for chunk in _haystacks(detail):
+        match = _EMBEDDED_PR_URL_RE.search(str(chunk or ""))
+        if match:
+            return match.group(0)
+    return ""
 
 
 def _usable_pr_url(raw: str | None) -> str:
@@ -654,6 +667,12 @@ def evidence_from_handoff(
         items.append(EvidenceItem(kind="log", summary=retro_raw[:500], passed=True, metadata=metadata))
 
     pr_url = _usable_pr_url(fields.get("PR_URL")) or _usable_pr_url(ticket_pr_url)
+    if not pr_url and phase in {"implement", "verify", "closeout"}:
+        # The worker opened a PR but did not echo it in a structured PR_URL=
+        # field (observed: a worker that wrote "PR opened: <url>" in prose).
+        # Recover it from the handoff text so a real, opened PR still satisfies
+        # the pr-evidence gate instead of GATE_BLOCKED: missing required evidence pr.
+        pr_url = _usable_pr_url(_pr_url_from_haystacks(detail))
     if pr_url and phase in {"implement", "verify", "closeout"}:
         items.append(EvidenceItem(kind="pr", summary=pr_url[:500], artifact=pr_url, passed=True))
 

--- a/services/zoe-data/tests/test_pipeline_handoff.py
+++ b/services/zoe-data/tests/test_pipeline_handoff.py
@@ -39,6 +39,24 @@ def test_implement_evidence_recovers_pr_url_from_prose_without_structured_field(
     assert pr_items[0].artifact == "https://github.com/o/r/pull/514"
 
 
+def test_closeout_evidence_recovers_pr_url_from_prose_without_structured_field():
+    # The prose-recovery path guards on phase in {implement, verify, closeout}.
+    # closeout also runs the inferred_audit computation, so confirm a PR mentioned
+    # only in prose still yields a 'pr' EvidenceItem in the closeout phase.
+    detail = {
+        "latest_summary": (
+            "Closeout summary\n- Verified tests pass.\n"
+            "- PR merged against main: https://github.com/o/r/pull/520\n"
+            "- kanban_complete recorded."
+        ),
+        "comments": [],
+    }
+    items = evidence_from_handoff("closeout", detail)
+    pr_items = [i for i in items if i.kind == "pr"]
+    assert pr_items, "a PR mentioned only in prose must still yield pr evidence at closeout"
+    assert pr_items[0].artifact == "https://github.com/o/r/pull/520"
+
+
 def test_implement_evidence_recovers_live_run_metadata_and_ticket_pr_url():
     detail = {
         "latest_summary": (

--- a/services/zoe-data/tests/test_pipeline_handoff.py
+++ b/services/zoe-data/tests/test_pipeline_handoff.py
@@ -19,6 +19,26 @@ def test_evidence_from_implement_handoff_parses_tools_and_tests():
     assert "pr" in kinds
 
 
+def test_implement_evidence_recovers_pr_url_from_prose_without_structured_field():
+    # Observed with MiniMax M3 (ZOE-5798): the worker opened a real PR but
+    # reported it in prose ("PR opened: <url>") instead of a structured PR_URL=
+    # field, so the pr-evidence gate wrongly blocked. The handoff text URL must
+    # still produce a 'pr' EvidenceItem.
+    detail = {
+        "latest_summary": (
+            "TOOLS_USED=graphify\nTESTS=pytest -q passed\n"
+            "Shipped\n- Branch pushed to origin.\n"
+            "- PR opened against main: https://github.com/o/r/pull/514\n"
+            "- kanban_complete recorded with PR URL and tests."
+        ),
+        "comments": [],
+    }
+    items = evidence_from_handoff("implement", detail)
+    pr_items = [i for i in items if i.kind == "pr"]
+    assert pr_items, "a PR mentioned only in prose must still yield pr evidence"
+    assert pr_items[0].artifact == "https://github.com/o/r/pull/514"
+
+
 def test_implement_evidence_recovers_live_run_metadata_and_ticket_pr_url():
     detail = {
         "latest_summary": (


### PR DESCRIPTION
## The wrinkle (from the autonomous M3 run)
M3 autonomously opened a correct PR (#514 for ZOE-5798), but the implement phase still blocked with `GATE_BLOCKED: missing required evidence pr`. Root cause: the worker reported the PR **in prose** ("PR opened against main: …/pull/514") instead of a structured `PR_URL=` field, and `evidence_from_handoff` only reads `PR_URL=` / the ticket block. So a genuinely-shipped PR failed the `{pr, tool}` completion gate.

## Fix
Add `_EMBEDDED_PR_URL_RE` (non-anchored) + `_pr_url_from_haystacks()`. When no structured `PR_URL` is present on `implement`/`verify`/`closeout`, recover a GitHub PR URL from the handoff text so a real opened PR yields the `pr` `EvidenceItem` and the phase completes.

## Tests
`pytest tests/test_pipeline_handoff.py` → **65 passed** (incl. new `test_implement_evidence_recovers_pr_url_from_prose_without_structured_field`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)