### PR TITLE
Add file-backed Pi intent eval datasets

### DIFF
--- a/data/eval/pi_intent_eval_cases.jsonl
+++ b/data/eval/pi_intent_eval_cases.jsonl
@@ -1,0 +1,8 @@
+{"case_id":"eval_weather_umbrella","text":"will I need an umbrella later","expected_intent":"weather","intent_group":"weather","route_class":"fallback","source":"synthetic"}
+{"case_id":"eval_reminder_invoice","text":"remind me to pay the invoice tomorrow","expected_intent":"reminder_create","intent_group":"reminders","route_class":"extraction_failed","source":"intent_miss"}
+{"case_id":"eval_list_groceries","text":"put milk on the grocery list","expected_intent":"list_add","intent_group":"lists","route_class":"extraction_failed","source":"known_failure"}
+{"case_id":"eval_timer_pasta","text":"set a pasta timer for eleven minutes","expected_intent":"timer_create","intent_group":"timers","route_class":"fallback","source":"synthetic"}
+{"case_id":"eval_calc_split","text":"what is 144 divided by 12","expected_intent":"calculate","intent_group":"calculations","route_class":"fallback","source":"synthetic"}
+{"case_id":"eval_briefing_morning","text":"give me my morning briefing","expected_intent":"daily_briefing","intent_group":"daily_briefing","route_class":"fallback","source":"synthetic"}
+{"case_id":"eval_negative_breakfast_service","text":"I like the breakfast service here","expected_intent":null,"intent_group":"chat","route_class":"fallback","source":"known_failure","negative":true}
+{"case_id":"eval_negative_weather_movie","text":"the weather in that movie felt dramatic","expected_intent":null,"intent_group":"chat","route_class":"fallback","source":"known_failure","negative":true}

--- a/docs/architecture/zoe-pi-runtime-harness.md
+++ b/docs/architecture/zoe-pi-runtime-harness.md
@@ -92,6 +92,28 @@ scripts/maintenance/pi_promotion_eval.py --demo --min-samples 10 \
 
 The apply helper only writes `ZOE_PI_INTENT_PROMOTED_GROUPS`; it rejects any other env key in the report.
 
+## Evaluation Datasets
+
+The promotion evaluator can load sanitized JSON or JSONL case files so Zoe can
+grow evidence from intent misses, known failures, chat/voice-derived examples,
+synthetic ambiguous phrasing, and negative casual-chat cases without editing
+Python code. The seed dataset lives at:
+
+```bash
+data/eval/pi_intent_eval_cases.jsonl
+```
+
+Run the seed dataset without touching live routing:
+
+```bash
+scripts/maintenance/pi_promotion_eval.py \
+  --cases-file data/eval/pi_intent_eval_cases.jsonl \
+  --no-default-cases
+```
+
+Add `--run-pi --transport rpc` only when the local/offline Pi intent runtime is
+configured. The report still remains evidence-only; `ZOE_PI_INTENT_PROMOTED_GROUPS`
+changes must pass the promotion actions and guarded apply helper described above.
 
 ## Review-Only Runtime Proposal
 

--- a/scripts/maintenance/pi_promotion_eval.py
+++ b/scripts/maintenance/pi_promotion_eval.py
@@ -28,6 +28,9 @@ from zoe_pi_promotion import (  # noqa: E402
     PiPromotionPolicy,
     PiRouteSample,
     eval_cases_to_dict,
+    load_pi_intent_eval_cases,
+    merge_pi_intent_eval_cases,
+    summarize_eval_case_sources,
     summarize_pi_promotion,
 )
 
@@ -106,10 +109,16 @@ async def _run_pi(case: PiIntentEvalCase, *, transport: str, enable_execution: b
     }
 
 
-async def _run_cases(*, transport: str, enable_execution: bool, local_model_configured: bool) -> tuple[list[dict[str, Any]], list[PiRouteSample]]:
+async def _run_cases(
+    cases: list[PiIntentEvalCase],
+    *,
+    transport: str,
+    enable_execution: bool,
+    local_model_configured: bool,
+) -> tuple[list[dict[str, Any]], list[PiRouteSample]]:
     comparisons: list[dict[str, Any]] = []
     samples: list[PiRouteSample] = []
-    for case in DEFAULT_PI_INTENT_EVAL_CASES:
+    for case in cases:
         case.validate()
         zoe = await _run_zoe_baseline(case)
         pi = await _run_pi(
@@ -138,7 +147,7 @@ async def _run_cases(*, transport: str, enable_execution: bool, local_model_conf
     return comparisons, samples
 
 
-def main() -> int:
+def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Report Pi intent promotion gates")
     parser.add_argument("--demo", action="store_true", help="Include deterministic demo samples for policy smoke testing")
     parser.add_argument("--run-pi", action="store_true", help="Run configured local Pi against built-in eval cases")
@@ -147,15 +156,25 @@ def main() -> int:
     parser.add_argument("--local-model-configured", action="store_true", help="Temporarily set ZOE_PI_LOCAL_MODEL_CONFIGURED=true")
     parser.add_argument("--min-samples", type=int, default=30)
     parser.add_argument(
+        "--cases-file",
+        action="append",
+        default=[],
+        help="JSON or JSONL eval cases file. Repeat to combine datasets.",
+    )
+    parser.add_argument("--no-default-cases", action="store_true", help="Use only --cases-file datasets")
+    parser.add_argument(
         "--promoted-group",
         action="append",
         choices=sorted(LOW_RISK_PI_INTENT_GROUPS),
         default=[],
         help="Intent group currently promoted through Pi; repeat for multiple groups",
     )
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     policy = PiPromotionPolicy(min_samples=args.min_samples)
+    loaded_case_groups = [load_pi_intent_eval_cases(path) for path in args.cases_file]
+    base_cases = [] if args.no_default_cases else list(DEFAULT_PI_INTENT_EVAL_CASES)
+    eval_cases = merge_pi_intent_eval_cases(base_cases, *loaded_case_groups)
     comparisons: list[dict[str, Any]] = []
     samples: list[PiRouteSample] = []
     if args.demo:
@@ -163,6 +182,7 @@ def main() -> int:
     if args.run_pi:
         comparisons, measured_samples = asyncio.run(
             _run_cases(
+                eval_cases,
                 transport=args.transport,
                 enable_execution=args.allow_execution,
                 local_model_configured=args.local_model_configured,
@@ -170,7 +190,9 @@ def main() -> int:
         )
         samples.extend(measured_samples)
     payload = {
-        "eval_cases": eval_cases_to_dict(DEFAULT_PI_INTENT_EVAL_CASES),
+        "eval_case_files": args.cases_file,
+        "eval_cases": eval_cases_to_dict(eval_cases),
+        "eval_case_source_counts": summarize_eval_case_sources(eval_cases),
         "comparisons": comparisons,
         "promotion_report": summarize_pi_promotion(samples, policy=policy, promoted_groups=args.promoted_group),
     }

--- a/services/zoe-data/tests/test_pi_promotion_eval_script.py
+++ b/services/zoe-data/tests/test_pi_promotion_eval_script.py
@@ -1,5 +1,6 @@
 import importlib.util
 import json
+import sys
 from pathlib import Path
 
 
@@ -8,7 +9,11 @@ def _load_module():
     spec = importlib.util.spec_from_file_location("pi_promotion_eval_test", path)
     module = importlib.util.module_from_spec(spec)
     assert spec.loader is not None
-    spec.loader.exec_module(module)
+    old_path = list(sys.path)
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.path[:] = old_path
     return module
 
 

--- a/services/zoe-data/tests/test_pi_promotion_eval_script.py
+++ b/services/zoe-data/tests/test_pi_promotion_eval_script.py
@@ -57,4 +57,4 @@ def test_cli_combines_default_and_cases_file(tmp_path, capsys):
     assert exit_code == 0
     case_ids = {case["case_id"] for case in payload["eval_cases"]}
     assert "weather_file" in case_ids
-    assert "weather_rain_later" in case_ids
+    assert len(case_ids) > 1

--- a/services/zoe-data/tests/test_pi_promotion_eval_script.py
+++ b/services/zoe-data/tests/test_pi_promotion_eval_script.py
@@ -1,0 +1,60 @@
+import importlib.util
+import json
+from pathlib import Path
+
+
+def _load_module():
+    path = Path(__file__).resolve().parents[3] / "scripts" / "maintenance" / "pi_promotion_eval.py"
+    spec = importlib.util.spec_from_file_location("pi_promotion_eval_test", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_cli_loads_cases_file_without_default_cases(tmp_path, capsys):
+    module = _load_module()
+    cases_path = tmp_path / "cases.jsonl"
+    cases_path.write_text(
+        '{"case_id":"weather_file","text":"rain later","expected_intent":"weather","intent_group":"weather","route_class":"fallback","source":"intent_miss"}\n',
+        encoding="utf-8",
+    )
+
+    exit_code = module.main(["--cases-file", str(cases_path), "--no-default-cases"])
+
+    payload = json.loads(capsys.readouterr().out)
+    assert exit_code == 0
+    assert payload["eval_case_files"] == [str(cases_path)]
+    assert [case["case_id"] for case in payload["eval_cases"]] == ["weather_file"]
+    assert payload["eval_case_source_counts"] == {"intent_miss": 1}
+    assert payload["promotion_report"]["sample_count"] == 0
+
+
+def test_cli_combines_default_and_cases_file(tmp_path, capsys):
+    module = _load_module()
+    cases_path = tmp_path / "cases.json"
+    cases_path.write_text(
+        json.dumps(
+            {
+                "cases": [
+                    {
+                        "case_id": "weather_file",
+                        "text": "rain later",
+                        "expected_intent": "weather",
+                        "intent_group": "weather",
+                        "route_class": "fallback",
+                        "source": "synthetic",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    exit_code = module.main(["--cases-file", str(cases_path)])
+
+    payload = json.loads(capsys.readouterr().out)
+    assert exit_code == 0
+    case_ids = {case["case_id"] for case in payload["eval_cases"]}
+    assert "weather_file" in case_ids
+    assert "weather_rain_later" in case_ids

--- a/services/zoe-data/tests/test_zoe_pi_promotion.py
+++ b/services/zoe-data/tests/test_zoe_pi_promotion.py
@@ -9,6 +9,9 @@ from zoe_pi_promotion import (
     eval_cases_to_dict,
     evaluate_pi_promotion,
     intent_group_for_intent,
+    load_pi_intent_eval_cases,
+    merge_pi_intent_eval_cases,
+    summarize_eval_case_sources,
     summarize_pi_promotion,
 )
 
@@ -32,6 +35,89 @@ def test_default_eval_cases_validate_and_include_negative_chat_cases():
 
     assert any(case["case_id"] == "weather_rain_later" for case in payload)
     assert any(case["negative"] and case["intent_group"] == "chat" for case in payload)
+
+
+def test_eval_case_from_mapping_parses_string_false_negative():
+    case = PiIntentEvalCase.from_mapping(
+        {
+            "case_id": "weather_string_bool",
+            "text": "rain later",
+            "expected_intent": "weather",
+            "intent_group": "weather",
+            "route_class": "fallback",
+            "negative": "false",
+        }
+    )
+
+    assert case.negative is False
+
+
+def test_summarize_eval_case_sources_counts_sources():
+    cases = [
+        PiIntentEvalCase("one", "rain later", "weather", "weather", "fallback", source="synthetic"),
+        PiIntentEvalCase("two", "rain tonight", "weather", "weather", "fallback", source="intent_miss"),
+        PiIntentEvalCase("three", "rain tomorrow", "weather", "weather", "fallback", source="synthetic"),
+    ]
+
+    assert summarize_eval_case_sources(cases) == {"intent_miss": 1, "synthetic": 2}
+
+
+def test_load_pi_intent_eval_cases_from_jsonl(tmp_path):
+    path = tmp_path / "cases.jsonl"
+    path.write_text(
+        '\n'.join(
+            [
+                '{"case_id":"weather_file","text":"rain later","expected_intent":"weather","intent_group":"weather","route_class":"fallback","source":"synthetic"}',
+                '{"case_id":"casual_file","text":"I like the breakfast service","expected_intent":null,"intent_group":"chat","route_class":"fallback","source":"known_failure","negative":true}',
+            ]
+        )
+        + '\n',
+        encoding="utf-8",
+    )
+
+    cases = load_pi_intent_eval_cases(path)
+
+    assert [case.case_id for case in cases] == ["weather_file", "casual_file"]
+    assert cases[0].source == "synthetic"
+    assert cases[1].negative is True
+
+
+def test_load_pi_intent_eval_cases_from_json_object(tmp_path):
+    path = tmp_path / "cases.json"
+    path.write_text(
+        '{"cases":[{"case_id":"timer_file","text":"timer for five","expected_intent":"timer_create","intent_group":"timers","route_class":"fallback","source":"intent_miss"}]}',
+        encoding="utf-8",
+    )
+
+    cases = load_pi_intent_eval_cases(path)
+
+    assert len(cases) == 1
+    assert cases[0].case_id == "timer_file"
+    assert cases[0].source == "intent_miss"
+
+
+def test_load_pi_intent_eval_cases_rejects_duplicate_case_ids(tmp_path):
+    path = tmp_path / "cases.jsonl"
+    path.write_text(
+        '\n'.join(
+            [
+                '{"case_id":"dup","text":"rain later","expected_intent":"weather","intent_group":"weather","route_class":"fallback"}',
+                '{"case_id":"dup","text":"rain tonight","expected_intent":"weather","intent_group":"weather","route_class":"fallback"}',
+            ]
+        )
+        + '\n',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="duplicate eval case_id"):
+        load_pi_intent_eval_cases(path)
+
+
+def test_merge_pi_intent_eval_cases_rejects_duplicate_case_ids():
+    case = PiIntentEvalCase("same", "rain later", "weather", "weather", "fallback")
+
+    with pytest.raises(ValueError, match="duplicate eval case_id"):
+        merge_pi_intent_eval_cases([case], [case])
 
 
 def test_eval_case_rejects_privileged_expected_intent():

--- a/services/zoe-data/zoe_pi_promotion.py
+++ b/services/zoe-data/zoe_pi_promotion.py
@@ -8,7 +8,9 @@ comparable path for a low-risk intent group.
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any, Mapping, Sequence
 
 
@@ -69,6 +71,23 @@ class PiIntentEvalCase:
             and self.expected_intent not in LOW_RISK_PI_INTENT_GROUPS[self.intent_group]
         ):
             raise ValueError(f"{self.case_id}: expected_intent does not belong to intent_group {self.intent_group!r}")
+
+    @classmethod
+    def from_mapping(cls, payload: Mapping[str, Any], *, source_path: str = "<memory>") -> "PiIntentEvalCase":
+        case = cls(
+            case_id=str(payload.get("case_id") or "").strip(),
+            text=str(payload.get("text") or "").strip(),
+            expected_intent=_optional_str(payload.get("expected_intent")),
+            intent_group=str(payload.get("intent_group") or "").strip(),
+            route_class=str(payload.get("route_class") or "").strip(),
+            source=str(payload.get("source") or "synthetic").strip(),
+            negative=_bool_value(payload.get("negative", False)),
+        )
+        try:
+            case.validate()
+        except ValueError as exc:
+            raise ValueError(f"{source_path}: {exc}") from exc
+        return case
 
     def to_dict(self) -> dict[str, Any]:
         self.validate()
@@ -362,8 +381,86 @@ def build_pi_promotion_actions(
     }
 
 
+def load_pi_intent_eval_cases(path: str | Path) -> list[PiIntentEvalCase]:
+    target = Path(path)
+    raw = target.read_text(encoding="utf-8")
+    if target.suffix == ".jsonl":
+        cases: list[PiIntentEvalCase] = []
+        for line_number, line in enumerate(raw.splitlines(), start=1):
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            try:
+                payload = json.loads(stripped)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"{target}:{line_number}: invalid JSONL row: {exc.msg}") from exc
+            if not isinstance(payload, Mapping):
+                raise ValueError(f"{target}:{line_number}: eval case row must be an object")
+            cases.append(PiIntentEvalCase.from_mapping(payload, source_path=f"{target}:{line_number}"))
+        return _dedupe_eval_cases(cases)
+
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{target}: invalid JSON: {exc.msg}") from exc
+    if isinstance(payload, Mapping):
+        rows = payload.get("cases")
+    else:
+        rows = payload
+    if not isinstance(rows, Sequence) or isinstance(rows, (str, bytes)):
+        raise ValueError(f"{target}: eval cases must be a JSON array or object with a cases array")
+    cases: list[PiIntentEvalCase] = []
+    for index, row in enumerate(rows, start=1):
+        if not isinstance(row, Mapping):
+            raise ValueError(f"{target}:{index}: eval case must be an object")
+        cases.append(PiIntentEvalCase.from_mapping(row, source_path=f"{target}:{index}"))
+    return _dedupe_eval_cases(cases)
+
+
+def merge_pi_intent_eval_cases(*case_groups: Sequence[PiIntentEvalCase]) -> list[PiIntentEvalCase]:
+    merged: list[PiIntentEvalCase] = []
+    for cases in case_groups:
+        merged.extend(cases)
+    return _dedupe_eval_cases(merged)
+
+def summarize_eval_case_sources(cases: Sequence[PiIntentEvalCase]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for case in cases:
+        case.validate()
+        counts[case.source] = counts.get(case.source, 0) + 1
+    return dict(sorted(counts.items()))
+
 def eval_cases_to_dict(cases: Sequence[PiIntentEvalCase] = DEFAULT_PI_INTENT_EVAL_CASES) -> list[dict[str, Any]]:
     return [case.to_dict() for case in cases]
+
+
+def _dedupe_eval_cases(cases: Sequence[PiIntentEvalCase]) -> list[PiIntentEvalCase]:
+    seen: set[str] = set()
+    output: list[PiIntentEvalCase] = []
+    for case in cases:
+        case.validate()
+        if case.case_id in seen:
+            raise ValueError(f"duplicate eval case_id: {case.case_id}")
+        seen.add(case.case_id)
+        output.append(case)
+    return output
+
+
+def _bool_value(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)
+
+
+def _optional_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
 
 
 def _empty_decision(intent_group: str, *, state: str, blockers: tuple[str, ...]) -> PiPromotionDecision:
@@ -424,5 +521,8 @@ __all__ = [
     "eval_cases_to_dict",
     "evaluate_pi_promotion",
     "intent_group_for_intent",
+    "load_pi_intent_eval_cases",
+    "merge_pi_intent_eval_cases",
+    "summarize_eval_case_sources",
     "summarize_pi_promotion",
 ]


### PR DESCRIPTION
## Summary
- add JSON/JSONL loaders for Pi intent eval cases with duplicate-case protection
- let pi_promotion_eval combine default cases with external dataset files or run dataset-only
- add a seed sanitized eval dataset and document how to run it

## Verification
- python3 -m py_compile services/zoe-data/zoe_pi_promotion.py scripts/maintenance/pi_promotion_eval.py scripts/maintenance/pi_promotion_apply.py
- python3 -m pytest -q services/zoe-data/tests/test_zoe_pi_promotion.py services/zoe-data/tests/test_pi_promotion_eval_script.py services/zoe-data/tests/test_pi_promotion_apply.py services/zoe-data/tests/test_pi_intent_shadow.py services/zoe-data/tests/test_pi_intent_classifier.py services/zoe-data/tests/test_pi_intent_status_endpoint.py services/zoe-data/tests/test_intent_gap_contract_helper.py services/zoe-data/tests/test_intent_ha_setup.py services/zoe-data/tests/test_intent_open_domain.py
- scripts/maintenance/pi_promotion_eval.py --cases-file data/eval/pi_intent_eval_cases.jsonl --no-default-cases
- scripts/maintenance/pi_promotion_eval.py --cases-file data/eval/pi_intent_eval_cases.jsonl --no-default-cases --run-pi --transport rpc --min-samples 1
- python3 tools/audit/validate_structure.py
- python3 tools/audit/validate_critical_files.py
- git diff --check