### PR TITLE
fix(voice): make faster-whisper startup warmup non-blocking (ZOE-5799)

### DIFF
--- a/services/zoe-data/routers/voice_tts.py
+++ b/services/zoe-data/routers/voice_tts.py
@@ -2052,6 +2052,61 @@ def _voice_stt_warmup_enabled() -> bool:
     }
 
 
+def _available_memory_mb() -> Optional[int]:
+    """Return roughly available system memory in MB, or None if undetectable.
+
+    Reads /proc/meminfo (Linux-only) so we don't add a new dependency. This is
+    used as a soft guard for the optional faster-whisper startup warmup so it
+    can be skipped when the host is under memory pressure.
+    """
+    try:
+        meminfo = Path("/proc/meminfo")
+        if not meminfo.is_file():
+            return None
+        available_kb: Optional[int] = None
+        total_kb: Optional[int] = None
+        free_kb: Optional[int] = None
+        buffers_kb: Optional[int] = None
+        cached_kb: Optional[int] = None
+        for raw in meminfo.read_text(errors="ignore").splitlines():
+            if raw.startswith("MemAvailable:"):
+                available_kb = int(raw.split()[1])
+            elif raw.startswith("MemTotal:"):
+                total_kb = int(raw.split()[1])
+            elif raw.startswith("MemFree:"):
+                free_kb = int(raw.split()[1])
+            elif raw.startswith("Buffers:"):
+                buffers_kb = int(raw.split()[1])
+            elif raw.startswith("Cached:"):
+                cached_kb = int(raw.split()[1])
+        if available_kb is not None:
+            return available_kb // 1024
+        if total_kb is not None and free_kb is not None:
+            extras = (buffers_kb or 0) + (cached_kb or 0)
+            return (free_kb + extras) // 1024
+        return None
+    except (OSError, ValueError, IndexError):
+        return None
+
+
+def _should_skip_warmup_for_low_memory() -> Optional[str]:
+    """Return a skip-reason string if warmup should be skipped for low memory, else None.
+
+    Configurable via ZOE_WHISPER_WARMUP_MIN_AVAIL_MB (default 1024 MB). Set to 0
+    to disable the guard. Returns None when memory is healthy or undetectable —
+    we never block the warmup solely because we couldn't read /proc/meminfo.
+    """
+    threshold_mb = _env_float("ZOE_WHISPER_WARMUP_MIN_AVAIL_MB", 1024.0)
+    if threshold_mb <= 0:
+        return None
+    avail_mb = _available_memory_mb()
+    if avail_mb is None:
+        return None
+    if avail_mb < threshold_mb:
+        return f"available memory {avail_mb}MB below threshold {int(threshold_mb)}MB"
+    return None
+
+
 def _write_warmup_silence_wav(path: str, *, seconds: float = 1.0, sample_rate: int = 16000) -> None:
     frame_count = max(1, int(sample_rate * seconds))
     with wave.open(path, "wb") as wf:
@@ -2061,21 +2116,44 @@ def _write_warmup_silence_wav(path: str, *, seconds: float = 1.0, sample_rate: i
         wf.writeframes(b"\x00\x00" * frame_count)
 
 
+def _create_warmup_wav_path() -> str:
+    """Create an empty temp wav file and return its path. Sync helper.
+
+    Runs in a worker thread via ``asyncio.to_thread`` so it never blocks the
+    event loop while allocating a temp file on disk.
+    """
+    with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
+        return tmp.name
+
+
 async def warm_faster_whisper_worker() -> bool:
-    """Prime the persistent faster-whisper worker without blocking API startup."""
+    """Prime the persistent faster-whisper worker without blocking API startup.
+
+    This coroutine is scheduled as a background task during lifespan startup
+    (see ``main.py``). To guarantee it can never stall zoe-data's :8000 bind
+    we (1) early-return when available system memory is below the configured
+    threshold and (2) offload every synchronous I/O step (tempfile creation,
+    silence-wav write) to a worker thread via ``asyncio.to_thread``. The
+    subprocess model load itself already runs in a child process, not on the
+    event-loop thread.
+    """
     if not _voice_stt_warmup_enabled():
         logger.info("faster-whisper warmup disabled by ZOE_WHISPER_WARMUP")
         return False
     if _use_in_process_faster_whisper() or not _use_persistent_faster_whisper_worker():
         logger.info("faster-whisper warmup skipped; persistent worker is not active")
         return False
+    skip_reason = _should_skip_warmup_for_low_memory()
+    if skip_reason is not None:
+        logger.warning("faster-whisper warmup skipped (%s); will warm lazily on first use", skip_reason)
+        return False
     timeout = _env_float("ZOE_WHISPER_WARMUP_TIMEOUT_S", 45.0)
     tmp_path = ""
     started = time.monotonic()
     try:
-        with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
-            tmp_path = tmp.name
-        _write_warmup_silence_wav(tmp_path)
+        # Offload all sync I/O to a worker thread so this coroutine is pure async I/O.
+        tmp_path = await asyncio.to_thread(_create_warmup_wav_path)
+        await asyncio.to_thread(_write_warmup_silence_wav, tmp_path)
         await asyncio.wait_for(_run_faster_whisper_worker(tmp_path), timeout=timeout)
         logger.info("faster-whisper worker warmup completed in %.2fs", time.monotonic() - started)
         return True
@@ -2089,6 +2167,7 @@ async def warm_faster_whisper_worker() -> bool:
     finally:
         if tmp_path:
             try:
+                # ``os.unlink`` is sync but tiny; safe to run inline.
                 os.unlink(tmp_path)
             except OSError:
                 pass

--- a/services/zoe-data/tests/test_voice_warmup_nonblocking.py
+++ b/services/zoe-data/tests/test_voice_warmup_nonblocking.py
@@ -116,7 +116,7 @@ def test_warmup_low_memory_guard_falls_open_when_meminfo_unreadable(monkeypatch)
 # ---------------------------------------------------------------------------
 
 
-def test_available_memory_mb_parses_memavailable(tmp_path):
+def test_available_memory_mb_parses_memavailable(tmp_path, monkeypatch):
     from routers import voice_tts
 
     fake_meminfo = tmp_path / "meminfo"
@@ -128,15 +128,11 @@ def test_available_memory_mb_parses_memavailable(tmp_path):
         "Cached:          2048000 kB\n"
     )
 
-    real_path = voice_tts.Path
-    try:
-        voice_tts.Path = lambda *_args, **_kw: fake_meminfo
-        assert voice_tts._available_memory_mb() == 8000
-    finally:
-        voice_tts.Path = real_path
+    monkeypatch.setattr(voice_tts, "Path", lambda *_args, **_kw: fake_meminfo)
+    assert voice_tts._available_memory_mb() == 8000
 
 
-def test_available_memory_mb_falls_back_to_free_plus_buffers_cached(tmp_path):
+def test_available_memory_mb_falls_back_to_free_plus_buffers_cached(tmp_path, monkeypatch):
     from routers import voice_tts
 
     fake_meminfo = tmp_path / "meminfo"
@@ -148,13 +144,9 @@ def test_available_memory_mb_falls_back_to_free_plus_buffers_cached(tmp_path):
         "Cached:         1024000 kB\n"
     )
 
-    real_path = voice_tts.Path
-    try:
-        voice_tts.Path = lambda *_args, **_kw: fake_meminfo
-        # (2_048_000 + 512_000 + 1_024_000) kB = 3_584_000 kB // 1024 = 3500 MB
-        assert voice_tts._available_memory_mb() == 3500
-    finally:
-        voice_tts.Path = real_path
+    monkeypatch.setattr(voice_tts, "Path", lambda *_args, **_kw: fake_meminfo)
+    # (2_048_000 + 512_000 + 1_024_000) kB = 3_584_000 kB // 1024 = 3500 MB
+    assert voice_tts._available_memory_mb() == 3500
 
 
 def test_should_skip_warmup_for_low_memory_returns_reason_string(monkeypatch):
@@ -230,15 +222,20 @@ def test_warmup_offloads_tempfile_create_and_wav_write_to_thread(monkeypatch):
 
 
 def test_warmup_does_not_block_event_loop_during_slow_io(monkeypatch):
-    """A blocking tempfile create must not delay other event-loop tasks."""
+    """A blocking tempfile create must not stall concurrent event-loop tasks.
+
+    A heartbeat coroutine ticks every 20ms for the duration of the warmup while
+    the offloaded ``_create_warmup_wav_path`` sleeps 0.3s. If that sleep ran on
+    the event-loop thread instead of a worker thread, one heartbeat interval
+    would balloon to ~0.3s; with the ``asyncio.to_thread`` offload every gap
+    stays close to 20ms. This genuinely exercises concurrency (unlike awaiting a
+    no-await coroutine, which would complete before the warmup task is even
+    scheduled and pass regardless of blocking).
+    """
     from routers import voice_tts
 
-    loop_scheduled_at: list[float] = []
-
     def _slow_create() -> str:
-        # Simulate slow disk I/O. If the warmup ran this on the event-loop
-        # thread, the other coroutine below would be delayed past 0.3s.
-        time.sleep(0.3)
+        time.sleep(0.3)  # simulate slow disk I/O
         import tempfile
 
         with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
@@ -250,17 +247,22 @@ def test_warmup_does_not_block_event_loop_during_slow_io(monkeypatch):
     async def _fake_worker(path: str) -> str:
         return ""
 
-    async def _ping_loop() -> None:
-        # Should run nearly immediately because slow_create is offloaded.
-        loop_scheduled_at.append(time.monotonic())
+    async def _heartbeat(max_gap: list[float]) -> None:
+        prev = time.monotonic()
+        # Tick well past the 0.3s slow_create window.
+        for _ in range(30):
+            await asyncio.sleep(0.02)
+            now = time.monotonic()
+            max_gap[0] = max(max_gap[0], now - prev)
+            prev = now
 
     async def _drive() -> float:
-        task_a = asyncio.create_task(voice_tts.warm_faster_whisper_worker())
-        # Schedule the ping at the same time — if warmup blocked the loop, the
-        # ping would only get to run after the 0.3s sleep.
-        await _ping_loop()
-        await task_a
-        return time.monotonic()
+        max_gap = [0.0]
+        warm = asyncio.create_task(voice_tts.warm_faster_whisper_worker())
+        beat = asyncio.create_task(_heartbeat(max_gap))
+        assert await warm is True
+        await beat
+        return max_gap[0]
 
     monkeypatch.delenv("ZOE_WHISPER_WARMUP", raising=False)
     monkeypatch.delenv("ZOE_WHISPER_IN_PROCESS", raising=False)
@@ -270,17 +272,10 @@ def test_warmup_does_not_block_event_loop_during_slow_io(monkeypatch):
     monkeypatch.setattr(voice_tts, "_write_warmup_silence_wav", _quick_write)
     monkeypatch.setattr(voice_tts, "_run_faster_whisper_worker", _fake_worker)
 
-    started = time.monotonic()
-    total = asyncio.run(_drive())
-    ping_at = loop_scheduled_at[0]
+    max_gap = asyncio.run(_drive())
 
-    # If the slow_create ran on the event-loop thread, ping_at would be
-    # roughly `started + 0.3`. With to_thread offload, ping_at should land
-    # within tens of milliseconds of `started`.
-    ping_delay = ping_at - started
-    assert ping_delay < 0.1, f"ping was delayed by {ping_delay:.3f}s; warmup blocked the event loop"
-    # Whole run will take at least 0.3s because of the slow helper.
-    assert total - started >= 0.3
+    # With the offload the loop keeps ticking; a stall would show one ~0.3s gap.
+    assert max_gap < 0.15, f"event loop stalled for {max_gap:.3f}s during warmup"
 
 
 # ---------------------------------------------------------------------------

--- a/services/zoe-data/tests/test_voice_warmup_nonblocking.py
+++ b/services/zoe-data/tests/test_voice_warmup_nonblocking.py
@@ -1,0 +1,288 @@
+"""Tests for ZOE-5799: faster-whisper startup warmup must not block the event loop.
+
+These tests pin two non-blocking guarantees of ``warm_faster_whisper_worker``:
+
+1. **Low-memory early return** — when available system memory is below the
+   configured threshold, the warmup skips before touching the persistent
+   worker (and therefore cannot stall startup while a model is being loaded).
+2. **Sync I/O offload** — the synchronous temp-file creation and silence-wav
+   write run in a worker thread via ``asyncio.to_thread`` rather than the
+   event-loop thread, so a slow disk cannot stall zoe-data's :8000 bind.
+
+The tests use the existing monkeypatch patterns from
+``test_voice_transcribe.py`` so they stay CI-friendly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+# ---------------------------------------------------------------------------
+# Low-memory early return
+# ---------------------------------------------------------------------------
+
+
+def test_warmup_skips_when_available_memory_below_threshold(monkeypatch):
+    from routers import voice_tts
+
+    async def _unexpected_worker(path: str) -> str:
+        raise AssertionError("worker should not be called under low memory")
+
+    monkeypatch.delenv("ZOE_WHISPER_WARMUP", raising=False)
+    monkeypatch.delenv("ZOE_WHISPER_IN_PROCESS", raising=False)
+    monkeypatch.delenv("ZOE_WHISPER_PERSISTENT_WORKER", raising=False)
+    monkeypatch.setenv("ZOE_WHISPER_WARMUP_MIN_AVAIL_MB", "1024")
+    monkeypatch.setattr(voice_tts, "_available_memory_mb", lambda: 256)
+    monkeypatch.setattr(voice_tts, "_run_faster_whisper_worker", _unexpected_worker)
+
+    assert asyncio.run(voice_tts.warm_faster_whisper_worker()) is False
+
+
+def test_warmup_runs_when_available_memory_above_threshold(monkeypatch):
+    from routers import voice_tts
+
+    calls: list[str] = []
+
+    async def _fake_worker(path: str) -> str:
+        calls.append(path)
+        return ""
+
+    monkeypatch.delenv("ZOE_WHISPER_WARMUP", raising=False)
+    monkeypatch.delenv("ZOE_WHISPER_IN_PROCESS", raising=False)
+    monkeypatch.delenv("ZOE_WHISPER_PERSISTENT_WORKER", raising=False)
+    monkeypatch.setenv("ZOE_WHISPER_WARMUP_MIN_AVAIL_MB", "512")
+    monkeypatch.setattr(voice_tts, "_available_memory_mb", lambda: 4096)
+    monkeypatch.setattr(voice_tts, "_run_faster_whisper_worker", _fake_worker)
+
+    assert asyncio.run(voice_tts.warm_faster_whisper_worker()) is True
+    assert len(calls) == 1
+
+
+def test_warmup_low_memory_guard_disabled_by_threshold_zero(monkeypatch):
+    from routers import voice_tts
+
+    calls: list[str] = []
+
+    async def _fake_worker(path: str) -> str:
+        calls.append(path)
+        return ""
+
+    monkeypatch.delenv("ZOE_WHISPER_WARMUP", raising=False)
+    monkeypatch.delenv("ZOE_WHISPER_IN_PROCESS", raising=False)
+    monkeypatch.delenv("ZOE_WHISPER_PERSISTENT_WORKER", raising=False)
+    monkeypatch.setenv("ZOE_WHISPER_WARMUP_MIN_AVAIL_MB", "0")
+    # Even with reported 0 MB the guard is disabled.
+    monkeypatch.setattr(voice_tts, "_available_memory_mb", lambda: 0)
+    monkeypatch.setattr(voice_tts, "_run_faster_whisper_worker", _fake_worker)
+
+    assert asyncio.run(voice_tts.warm_faster_whisper_worker()) is True
+    assert len(calls) == 1
+
+
+def test_warmup_low_memory_guard_falls_open_when_meminfo_unreadable(monkeypatch):
+    from routers import voice_tts
+
+    calls: list[str] = []
+
+    async def _fake_worker(path: str) -> str:
+        calls.append(path)
+        return ""
+
+    monkeypatch.delenv("ZOE_WHISPER_WARMUP", raising=False)
+    monkeypatch.delenv("ZOE_WHISPER_IN_PROCESS", raising=False)
+    monkeypatch.delenv("ZOE_WHISPER_PERSISTENT_WORKER", raising=False)
+    monkeypatch.setenv("ZOE_WHISPER_WARMUP_MIN_AVAIL_MB", "1024")
+    # Detector returns None on missing /proc/meminfo — guard must fall open.
+    monkeypatch.setattr(voice_tts, "_available_memory_mb", lambda: None)
+    monkeypatch.setattr(voice_tts, "_run_faster_whisper_worker", _fake_worker)
+
+    assert asyncio.run(voice_tts.warm_faster_whisper_worker()) is True
+    assert len(calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# /proc/meminfo parser — direct unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_available_memory_mb_parses_memavailable(tmp_path):
+    from routers import voice_tts
+
+    fake_meminfo = tmp_path / "meminfo"
+    fake_meminfo.write_text(
+        "MemTotal:       16384000 kB\n"
+        "MemFree:         4096000 kB\n"
+        "MemAvailable:    8192000 kB\n"
+        "Buffers:          512000 kB\n"
+        "Cached:          2048000 kB\n"
+    )
+
+    real_path = voice_tts.Path
+    try:
+        voice_tts.Path = lambda *_args, **_kw: fake_meminfo
+        assert voice_tts._available_memory_mb() == 8000
+    finally:
+        voice_tts.Path = real_path
+
+
+def test_available_memory_mb_falls_back_to_free_plus_buffers_cached(tmp_path):
+    from routers import voice_tts
+
+    fake_meminfo = tmp_path / "meminfo"
+    # No MemAvailable line — must fall back to MemFree + Buffers + Cached.
+    fake_meminfo.write_text(
+        "MemTotal:       8192000 kB\n"
+        "MemFree:        2048000 kB\n"
+        "Buffers:         512000 kB\n"
+        "Cached:         1024000 kB\n"
+    )
+
+    real_path = voice_tts.Path
+    try:
+        voice_tts.Path = lambda *_args, **_kw: fake_meminfo
+        # (2_048_000 + 512_000 + 1_024_000) kB = 3_584_000 kB // 1024 = 3500 MB
+        assert voice_tts._available_memory_mb() == 3500
+    finally:
+        voice_tts.Path = real_path
+
+
+def test_should_skip_warmup_for_low_memory_returns_reason_string(monkeypatch):
+    from routers import voice_tts
+
+    monkeypatch.setattr(voice_tts, "_available_memory_mb", lambda: 64)
+    # Threshold read from env defaults to 1024 MB; report 64 MB → must skip.
+    monkeypatch.setenv("ZOE_WHISPER_WARMUP_MIN_AVAIL_MB", "1024")
+    reason = voice_tts._should_skip_warmup_for_low_memory()
+    assert reason is not None
+    assert "64" in reason and "1024" in reason
+
+
+def test_should_skip_warmup_for_low_memory_returns_none_when_healthy(monkeypatch):
+    from routers import voice_tts
+
+    monkeypatch.setattr(voice_tts, "_available_memory_mb", lambda: 8192)
+    monkeypatch.setenv("ZOE_WHISPER_WARMUP_MIN_AVAIL_MB", "1024")
+    assert voice_tts._should_skip_warmup_for_low_memory() is None
+
+
+def test_should_skip_warmup_for_low_memory_returns_none_when_unreadable(monkeypatch):
+    from routers import voice_tts
+
+    monkeypatch.setattr(voice_tts, "_available_memory_mb", lambda: None)
+    monkeypatch.setenv("ZOE_WHISPER_WARMUP_MIN_AVAIL_MB", "1024")
+    assert voice_tts._should_skip_warmup_for_low_memory() is None
+
+
+# ---------------------------------------------------------------------------
+# Sync I/O offload via asyncio.to_thread
+# ---------------------------------------------------------------------------
+
+
+def test_warmup_offloads_tempfile_create_and_wav_write_to_thread(monkeypatch):
+    """The sync helpers must run on a non-main thread, proving the offload."""
+    from routers import voice_tts
+
+    main_thread_ident = threading.get_ident()
+    observed_thread_idents: dict[str, int] = {}
+
+    def _tracking_create() -> str:
+        import tempfile
+
+        with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
+            observed_thread_idents["create"] = threading.get_ident()
+            return tmp.name
+
+    def _tracking_write(path: str, **_kwargs) -> None:
+        observed_thread_idents["write"] = threading.get_ident()
+
+    async def _fake_worker(path: str) -> str:
+        observed_thread_idents["worker"] = threading.get_ident()
+        return ""
+
+    monkeypatch.delenv("ZOE_WHISPER_WARMUP", raising=False)
+    monkeypatch.delenv("ZOE_WHISPER_IN_PROCESS", raising=False)
+    monkeypatch.delenv("ZOE_WHISPER_PERSISTENT_WORKER", raising=False)
+    monkeypatch.setenv("ZOE_WHISPER_WARMUP_MIN_AVAIL_MB", "0")
+    monkeypatch.setattr(voice_tts, "_create_warmup_wav_path", _tracking_create)
+    monkeypatch.setattr(voice_tts, "_write_warmup_silence_wav", _tracking_write)
+    monkeypatch.setattr(voice_tts, "_run_faster_whisper_worker", _fake_worker)
+
+    # The actual asyncio.run thread is the main thread of the test, so any
+    # helper executed inside asyncio.to_thread will be on a different ident.
+    assert asyncio.run(voice_tts.warm_faster_whisper_worker()) is True
+    assert observed_thread_idents.get("create") != main_thread_ident, (
+        "tempfile creation must run in a worker thread, not the event loop"
+    )
+    assert observed_thread_idents.get("write") != main_thread_ident, (
+        "silence-wav write must run in a worker thread, not the event loop"
+    )
+
+
+def test_warmup_does_not_block_event_loop_during_slow_io(monkeypatch):
+    """A blocking tempfile create must not delay other event-loop tasks."""
+    from routers import voice_tts
+
+    loop_scheduled_at: list[float] = []
+
+    def _slow_create() -> str:
+        # Simulate slow disk I/O. If the warmup ran this on the event-loop
+        # thread, the other coroutine below would be delayed past 0.3s.
+        time.sleep(0.3)
+        import tempfile
+
+        with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
+            return tmp.name
+
+    def _quick_write(path: str, **_kwargs) -> None:
+        return None
+
+    async def _fake_worker(path: str) -> str:
+        return ""
+
+    async def _ping_loop() -> None:
+        # Should run nearly immediately because slow_create is offloaded.
+        loop_scheduled_at.append(time.monotonic())
+
+    async def _drive() -> float:
+        task_a = asyncio.create_task(voice_tts.warm_faster_whisper_worker())
+        # Schedule the ping at the same time — if warmup blocked the loop, the
+        # ping would only get to run after the 0.3s sleep.
+        await _ping_loop()
+        await task_a
+        return time.monotonic()
+
+    monkeypatch.delenv("ZOE_WHISPER_WARMUP", raising=False)
+    monkeypatch.delenv("ZOE_WHISPER_IN_PROCESS", raising=False)
+    monkeypatch.delenv("ZOE_WHISPER_PERSISTENT_WORKER", raising=False)
+    monkeypatch.setenv("ZOE_WHISPER_WARMUP_MIN_AVAIL_MB", "0")
+    monkeypatch.setattr(voice_tts, "_create_warmup_wav_path", _slow_create)
+    monkeypatch.setattr(voice_tts, "_write_warmup_silence_wav", _quick_write)
+    monkeypatch.setattr(voice_tts, "_run_faster_whisper_worker", _fake_worker)
+
+    started = time.monotonic()
+    total = asyncio.run(_drive())
+    ping_at = loop_scheduled_at[0]
+
+    # If the slow_create ran on the event-loop thread, ping_at would be
+    # roughly `started + 0.3`. With to_thread offload, ping_at should land
+    # within tens of milliseconds of `started`.
+    ping_delay = ping_at - started
+    assert ping_delay < 0.1, f"ping was delayed by {ping_delay:.3f}s; warmup blocked the event loop"
+    # Whole run will take at least 0.3s because of the slow helper.
+    assert total - started >= 0.3
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem
The faster-whisper STT startup warmup (`warm_faster_whisper_worker`, `services/zoe-data/routers/voice_tts.py`, scheduled at `main.py:630`) could stall zoe-data's :8000 bind under memory pressure — observed as API 000 for 90s+ on the memory-bound Jetson. It was disabled via `ZOE_WHISPER_WARMUP=false` as a stopgap.

## Fix
Make the warmup incapable of hanging startup:
- **Low-memory soft guard** — `_should_skip_warmup_for_low_memory()` reads `/proc/meminfo` (no new dependency) and skips the warmup when available memory is below `ZOE_WHISPER_WARMUP_MIN_AVAIL_MB` (default 1024MB; set 0 to disable). Undetectable memory never blocks the warmup (fails open).
- **Sync I/O offload** — the temp-file creation and silence-wav write now run in a worker thread via `asyncio.to_thread`, so the coroutine is pure async I/O and a slow disk can't stall the event loop. The model load itself already runs in a child subprocess.

## Tests
`tests/test_voice_warmup_nonblocking.py` (11 tests, all passing): low-memory early-return, healthy-memory path, threshold-zero disable, and the `to_thread` offload behavior.

## Provenance
Implemented autonomously by the Multica→Hermes harness implement worker (minimax/minimax-m3) for ZOE-5799. The operator performed the git commit/push/PR because the worker exhausted its 40-turn budget after exploration + implementation + test-writing, before reaching the push step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)