### PR TITLE
feat(harness): capture-on-exit — salvage a finished implement diff the worker never shipped

### DIFF
--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -1358,13 +1358,15 @@ class KanbanAdapter:
         """
         if phase != "implement" or (row.get("status") or "").lower() != "blocked":
             return None
-        # A pushed branch is the other recovery's job; a handed-off PR needs nothing.
-        log = latest_log_session(task_id, max_lines=120)
-        if "PR_URL=" in log:
-            return None
         try:
             from worktree_bootstrap import worktree_branch, worktree_path
 
+            # A pushed branch is the other recovery's job; a handed-off PR needs
+            # nothing. Kept inside the try so a latest_log_session failure can
+            # never escape into poll() (recovery is best-effort).
+            log = latest_log_session(task_id, max_lines=120)
+            if "PR_URL=" in log:
+                return None
             task = detail.get("task") if isinstance((detail or {}).get("task"), dict) else {}
             wt_path = Path(
                 row.get("workspace_path")

--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -1292,8 +1292,8 @@ class KanbanAdapter:
         """Return the worktree branch's existing PR URL, or open one. None on failure.
 
         Tries ``gh pr view`` first (a PR may already exist for the branch), then
-        falls back to ``gh pr create`` against the branch's upstream base. Shared
-        by the pushed-branch and unshipped-diff recovery paths.
+        falls back to ``gh pr create`` against the repo's default base branch.
+        Shared by the pushed-branch and unshipped-diff recovery paths.
         """
         try:
             pr_url = (
@@ -1313,24 +1313,18 @@ class KanbanAdapter:
             )
             pr_url = ""
         if not pr_url:
-            try:
-                upstream = (
-                    await self._run_worktree_command(
-                        ["git", "rev-parse", "--abbrev-ref", "HEAD@{upstream}"],
-                        cwd=wt_path,
-                        timeout=10,
-                    )
-                ).strip()
-                base_branch = upstream.split("/", 1)[-1].strip() or "main"
-            except KanbanCLIError:
-                base_branch = "main"
             identifier = (issue or {}).get("identifier") or row.get("title") or task_id
             title = str(row.get("title") or (issue or {}).get("title") or identifier)
             if not title.startswith(str(identifier)):
                 title = f"{identifier}: {title}"
+            # No --base: gh defaults to the repo's default branch (main), which is
+            # what task worktrees branch off. Do NOT derive the base from
+            # HEAD@{upstream}: `git push -u origin <branch>` sets the upstream to
+            # the task branch itself, so that would yield `gh pr create --base
+            # wt/<task_id>` (head == base) and fail.
             pr_url = (
                 await self._run_worktree_command(
-                    ["gh", "pr", "create", "--base", base_branch, "--title", title[:240], "--body", body],
+                    ["gh", "pr", "create", "--title", title[:240], "--body", body],
                     cwd=wt_path,
                     timeout=45,
                 )

--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -1178,16 +1178,18 @@ class KanbanAdapter:
         pr_url: str,
         *,
         branch: str | None = None,
+        recovery: str = "pushed_branch_without_pr_handoff",
+        summary_note: str = "Recovered PR handoff after worker interruption following git push",
     ) -> str:
         summary = (
             f"PR_URL={pr_url}\n"
             "BLOCKER=\n"
-            "TESTS=recovered after pushed branch; downstream verify/review must validate\n"
-            "SUMMARY=Recovered PR handoff after worker interruption following git push"
+            "TESTS=recovered; downstream verify/review must validate\n"
+            f"SUMMARY={summary_note}"
         )
         metadata = {
             "pr_url": pr_url,
-            "recovery": "pushed_branch_without_pr_handoff",
+            "recovery": recovery,
         }
         if branch:
             metadata["branch"] = branch
@@ -1262,59 +1264,198 @@ class KanbanAdapter:
             if not branch:
                 return None
 
-            try:
-                pr_url = (
-                    await self._run_worktree_command(
-                        ["gh", "pr", "view", "--json", "url", "--jq", ".url"],
-                        cwd=wt_path,
-                        timeout=20,
-                    )
-                ).strip()
-            except KanbanCLIError:
-                pr_url = ""
-            if pr_url and not _GITHUB_PR_URL_RE.search(pr_url):
-                logger.warning(
-                    "kanban_adapter: gh pr view returned no PR URL for recovered task %s: %s",
-                    task_id,
-                    pr_url,
-                )
-                pr_url = ""
+            body = (
+                "Recovered by Zoe after Hermes pushed the branch but was interrupted "
+                "before `gh pr create`/`kanban_complete`.\n\n"
+                f"Kanban task: `{task_id}`\n"
+                f"Branch: `{branch}`"
+            )
+            pr_url = await self._pr_url_from_worktree(
+                task_id, wt_path, issue=issue, row=row, body=body
+            )
             if not pr_url:
-                try:
-                    upstream = (
-                        await self._run_worktree_command(
-                            ["git", "rev-parse", "--abbrev-ref", "HEAD@{upstream}"],
-                            cwd=wt_path,
-                            timeout=10,
-                        )
-                    ).strip()
-                    base_branch = upstream.split("/", 1)[-1].strip() or "main"
-                except KanbanCLIError:
-                    base_branch = "main"
-                identifier = (issue or {}).get("identifier") or row.get("title") or task_id
-                title = str(row.get("title") or (issue or {}).get("title") or identifier)
-                if not title.startswith(str(identifier)):
-                    title = f"{identifier}: {title}"
-                body = (
-                    "Recovered by Zoe after Hermes pushed the branch but was interrupted "
-                    "before `gh pr create`/`kanban_complete`.\n\n"
-                    f"Kanban task: `{task_id}`\n"
-                    f"Branch: `{branch}`"
-                )
-                pr_url = (
-                    await self._run_worktree_command(
-                        ["gh", "pr", "create", "--base", base_branch, "--title", title[:240], "--body", body],
-                        cwd=wt_path,
-                        timeout=45,
-                    )
-                ).strip()
-            match = _GITHUB_PR_URL_RE.search(pr_url)
-            if not match:
                 return None
-            pr_url = match.group(0)
             return await self._complete_recovered_pr_handoff(task_id, row, pr_url, branch=branch)
         except Exception as exc:  # noqa: BLE001 - recovery must not break normal poll.
             logger.warning("kanban_adapter: pushed PR recovery failed for %s: %s", task_id, exc)
+            return None
+
+    async def _pr_url_from_worktree(
+        self,
+        task_id: str,
+        wt_path: Path,
+        *,
+        issue: dict | None,
+        row: dict[str, Any],
+        body: str,
+    ) -> str | None:
+        """Return the worktree branch's existing PR URL, or open one. None on failure.
+
+        Tries ``gh pr view`` first (a PR may already exist for the branch), then
+        falls back to ``gh pr create`` against the branch's upstream base. Shared
+        by the pushed-branch and unshipped-diff recovery paths.
+        """
+        try:
+            pr_url = (
+                await self._run_worktree_command(
+                    ["gh", "pr", "view", "--json", "url", "--jq", ".url"],
+                    cwd=wt_path,
+                    timeout=20,
+                )
+            ).strip()
+        except KanbanCLIError:
+            pr_url = ""
+        if pr_url and not _GITHUB_PR_URL_RE.search(pr_url):
+            logger.warning(
+                "kanban_adapter: gh pr view returned no PR URL for recovered task %s: %s",
+                task_id,
+                pr_url,
+            )
+            pr_url = ""
+        if not pr_url:
+            try:
+                upstream = (
+                    await self._run_worktree_command(
+                        ["git", "rev-parse", "--abbrev-ref", "HEAD@{upstream}"],
+                        cwd=wt_path,
+                        timeout=10,
+                    )
+                ).strip()
+                base_branch = upstream.split("/", 1)[-1].strip() or "main"
+            except KanbanCLIError:
+                base_branch = "main"
+            identifier = (issue or {}).get("identifier") or row.get("title") or task_id
+            title = str(row.get("title") or (issue or {}).get("title") or identifier)
+            if not title.startswith(str(identifier)):
+                title = f"{identifier}: {title}"
+            pr_url = (
+                await self._run_worktree_command(
+                    ["gh", "pr", "create", "--base", base_branch, "--title", title[:240], "--body", body],
+                    cwd=wt_path,
+                    timeout=45,
+                )
+            ).strip()
+        match = _GITHUB_PR_URL_RE.search(pr_url)
+        if not match:
+            return None
+        return match.group(0)
+
+    async def _maybe_recover_unshipped_diff(
+        self,
+        task_id: str,
+        phase: str,
+        row: dict[str, Any],
+        *,
+        issue: dict | None = None,
+        detail: dict[str, Any] | None = None,
+    ) -> str | None:
+        """Salvage a finished implement diff the worker never committed/pushed.
+
+        ``_maybe_recover_pushed_pr`` handles a worker that pushed then lost the PR
+        handoff. This handles the other interruption: the worker edited (and often
+        wrote tests) but exited — e.g. turn budget — before ``git add/commit/push``
+        or ``gh pr create``, leaving a complete diff in the isolated task worktree.
+        Rather than block (and let a fresh-worktree resume discard the work and
+        re-spend), commit + push it and open a PR so the chain advances to verify.
+
+        Safety: operates ONLY inside the task's own isolated worktree branch
+        (``wt/<task_id>``); never main/master, never the live checkout, never
+        ``--force``; and never opens an empty PR (requires real unpushed content).
+        """
+        if phase != "implement" or (row.get("status") or "").lower() != "blocked":
+            return None
+        # A pushed branch is the other recovery's job; a handed-off PR needs nothing.
+        log = latest_log_session(task_id, max_lines=120)
+        if "PR_URL=" in log:
+            return None
+        try:
+            from worktree_bootstrap import worktree_branch, worktree_path
+
+            task = detail.get("task") if isinstance((detail or {}).get("task"), dict) else {}
+            wt_path = Path(
+                row.get("workspace_path")
+                or task.get("workspace_path")
+                or worktree_path(task_id)
+            ).expanduser()
+            if not wt_path.exists():
+                return None
+            branch = (
+                await self._run_worktree_command(
+                    ["git", "branch", "--show-current"],
+                    cwd=wt_path,
+                    timeout=10,
+                )
+            ).strip()
+            # Hard safety gate: only the task's own worktree branch. The live
+            # checkout and shared branches are never named wt/<task_id>, so this
+            # fails closed if workspace_path is ever wrong.
+            if not branch or branch in {"main", "master"} or branch != worktree_branch(task_id):
+                return None
+
+            dirty = bool(
+                (
+                    await self._run_worktree_command(
+                        ["git", "status", "--porcelain"], cwd=wt_path, timeout=20
+                    )
+                ).strip()
+            )
+            if dirty:
+                await self._run_worktree_command(["git", "add", "-A"], cwd=wt_path, timeout=30)
+                commit_msg = (
+                    f"harness: salvage unshipped implement diff for {task_id}\n\n"
+                    "Auto-committed by the Multica->Hermes harness because the implement "
+                    "worker left a complete diff but exited before committing/pushing."
+                )
+                await self._run_worktree_command(
+                    ["git", "commit", "-m", commit_msg], cwd=wt_path, timeout=30
+                )
+
+            # Require real content not already on a remote, or we'd open an empty PR.
+            try:
+                unpushed = (
+                    await self._run_worktree_command(
+                        ["git", "rev-list", "--count", "HEAD", "--not", "--remotes"],
+                        cwd=wt_path,
+                        timeout=15,
+                    )
+                ).strip()
+            except KanbanCLIError:
+                unpushed = "0"
+            if unpushed in {"", "0"}:
+                return None
+
+            await self._run_worktree_command(
+                ["git", "push", "-u", "origin", branch], cwd=wt_path, timeout=120
+            )
+            body = (
+                "Recovered by Zoe after the Hermes implement worker left a complete diff "
+                "but exited before committing/pushing or opening a PR (e.g. turn budget).\n\n"
+                f"Kanban task: `{task_id}`\n"
+                f"Branch: `{branch}`\n\n"
+                "Downstream verify/review must validate."
+            )
+            pr_url = await self._pr_url_from_worktree(
+                task_id, wt_path, issue=issue, row=row, body=body
+            )
+            if not pr_url:
+                return None
+            logger.info(
+                "kanban_adapter: salvaged unshipped implement diff for %s -> %s",
+                task_id,
+                pr_url,
+            )
+            return await self._complete_recovered_pr_handoff(
+                task_id,
+                row,
+                pr_url,
+                branch=branch,
+                recovery="unshipped_diff_salvage",
+                summary_note="Recovered PR after worker left an unshipped implement diff",
+            )
+        except Exception as exc:  # noqa: BLE001 - recovery must not break normal poll.
+            logger.warning(
+                "kanban_adapter: unshipped-diff recovery failed for %s: %s", task_id, exc
+            )
             return None
 
     async def dispatch(self, issue: dict) -> dict:
@@ -1732,12 +1873,23 @@ class KanbanAdapter:
                 issue=issue,
                 detail=detail,
             )
+            if not pr_url:
+                # Worker left a finished diff but never committed/pushed (e.g. ran
+                # out of turns before shipping): commit + push it and open a PR so
+                # the work is salvaged instead of discarded by a fresh resume.
+                pr_url = await self._maybe_recover_unshipped_diff(
+                    task_id,
+                    phase,
+                    row,
+                    issue=issue,
+                    detail=detail,
+                )
             if pr_url:
                 detail["latest_summary"] = (
                     f"PR_URL={pr_url}\n"
                     "BLOCKER=\n"
-                    "TESTS=recovered after pushed branch; downstream verify/review must validate\n"
-                    "SUMMARY=Recovered PR handoff after worker interruption following git push"
+                    "TESTS=recovered; downstream verify/review must validate\n"
+                    "SUMMARY=Recovered PR handoff after worker interruption"
                 )
                 phases[phase] = row
 

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -5534,3 +5534,136 @@ def test_audit_no_pr_phases_do_not_preload_broad_skills():
     assert _phase_plan_entry("verify", code_clause_issue)[2] == ("zoe-engineering",)
     assert _phase_plan_entry("closeout", code_smoke_issue)[2] == ("github-greptile-loop",)
     assert _phase_plan_entry("closeout", code_clause_issue)[2] == ("github-greptile-loop",)
+
+
+# ---------------------------------------------------------------------------
+# Capture-on-exit: salvage a finished implement diff the worker never shipped
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_recover_unshipped_diff_commits_pushes_and_opens_pr(tmp_path, monkeypatch):
+    """Worker left a dirty worktree (no commit/push): salvage -> commit+push+PR+done."""
+    monkeypatch.setattr(ka, "latest_log_session", lambda *a, **k: "no PR handed off here")
+    wt = tmp_path / "wt"
+    wt.mkdir()
+    row = {
+        "id": "t_implement",
+        "status": "blocked",
+        "title": "ZOE-9 fix thing",
+        "workspace_path": str(wt),
+    }
+
+    class _A(_FakeAdapter):
+        def __init__(self):
+            super().__init__()
+            self.wt_cmds = []
+
+        async def _run_worktree_command(self, args, *, cwd, timeout=45.0):
+            self.wt_cmds.append(args)
+            if args[:3] == ["git", "branch", "--show-current"]:
+                return "wt/t_implement"
+            if args[:3] == ["git", "status", "--porcelain"]:
+                return " M services/zoe-data/routers/voice_tts.py"
+            if args[:2] == ["git", "add"]:
+                return ""
+            if args[:2] == ["git", "commit"]:
+                return ""
+            if args[:3] == ["git", "rev-list", "--count"]:
+                return "1"
+            if args[:2] == ["git", "push"]:
+                return ""
+            if args[:3] == ["git", "rev-parse", "--abbrev-ref"]:
+                return "origin/main"
+            if args[:3] == ["gh", "pr", "view"]:
+                raise ka.KanbanCLIError("no pull request found")
+            if args[:3] == ["gh", "pr", "create"]:
+                return "https://github.com/jason-easyazz/zoe-ai-assistant/pull/777"
+            raise AssertionError(args)
+
+    a = _A()
+    pr = await a._maybe_recover_unshipped_diff(
+        "t_implement", "implement", row, issue={"identifier": "ZOE-9", "title": "fix thing"}
+    )
+
+    assert pr == "https://github.com/jason-easyazz/zoe-ai-assistant/pull/777"
+    assert row["status"] == "done"
+    assert any(c[:2] == ["git", "commit"] for c in a.wt_cmds)
+    push = next(c for c in a.wt_cmds if c[:2] == ["git", "push"])
+    assert "--force" not in push and push == ["git", "push", "-u", "origin", "wt/t_implement"]
+    complete = next(c for c in a.calls if c[0] == "complete")
+    assert "PR_URL=https://github.com/jason-easyazz/zoe-ai-assistant/pull/777" in "\n".join(complete)
+
+
+@pytest.mark.asyncio
+async def test_recover_unshipped_diff_refuses_non_task_branch(tmp_path, monkeypatch):
+    """Hard safety gate: never commit/push when not on the task's own wt/ branch."""
+    monkeypatch.setattr(ka, "latest_log_session", lambda *a, **k: "no pr")
+    wt = tmp_path / "wt"
+    wt.mkdir()
+    row = {"id": "t_implement", "status": "blocked", "workspace_path": str(wt)}
+
+    class _A(_FakeAdapter):
+        def __init__(self):
+            super().__init__()
+            self.wt_cmds = []
+
+        async def _run_worktree_command(self, args, *, cwd, timeout=45.0):
+            self.wt_cmds.append(args)
+            if args[:3] == ["git", "branch", "--show-current"]:
+                return "main"  # not wt/t_implement -> must bail before any mutation
+            raise AssertionError(f"must not mutate on non-task branch: {args!r}")
+
+    a = _A()
+    pr = await a._maybe_recover_unshipped_diff("t_implement", "implement", row)
+
+    assert pr is None
+    assert row["status"] == "blocked"
+    assert not any(c[:2] in (["git", "add"], ["git", "commit"], ["git", "push"]) for c in a.wt_cmds)
+
+
+@pytest.mark.asyncio
+async def test_recover_unshipped_diff_skips_when_nothing_to_ship(tmp_path, monkeypatch):
+    """Clean worktree with no unpushed commits must not open an empty PR."""
+    monkeypatch.setattr(ka, "latest_log_session", lambda *a, **k: "no pr")
+    wt = tmp_path / "wt"
+    wt.mkdir()
+    row = {"id": "t_implement", "status": "blocked", "workspace_path": str(wt)}
+
+    class _A(_FakeAdapter):
+        def __init__(self):
+            super().__init__()
+            self.wt_cmds = []
+
+        async def _run_worktree_command(self, args, *, cwd, timeout=45.0):
+            self.wt_cmds.append(args)
+            if args[:3] == ["git", "branch", "--show-current"]:
+                return "wt/t_implement"
+            if args[:3] == ["git", "status", "--porcelain"]:
+                return ""  # clean
+            if args[:3] == ["git", "rev-list", "--count"]:
+                return "0"  # nothing unpushed
+            raise AssertionError(f"must not push/PR with nothing to ship: {args!r}")
+
+    a = _A()
+    pr = await a._maybe_recover_unshipped_diff("t_implement", "implement", row)
+
+    assert pr is None
+    assert not any(c[:2] == ["git", "push"] for c in a.wt_cmds)
+    assert not any(c[:3] == ["gh", "pr", "create"] for c in a.wt_cmds)
+
+
+@pytest.mark.asyncio
+async def test_recover_unshipped_diff_skips_when_pr_already_handed_off(monkeypatch):
+    """If the worker already reported a PR_URL, leave it to the normal flow."""
+    monkeypatch.setattr(
+        ka, "latest_log_session", lambda *a, **k: "PR_URL=https://github.com/o/r/pull/5\n"
+    )
+    row = {"id": "t_implement", "status": "blocked"}
+
+    class _A(_FakeAdapter):
+        async def _run_worktree_command(self, args, *, cwd, timeout=45.0):
+            raise AssertionError(f"must not touch the worktree when a PR exists: {args!r}")
+
+    a = _A()
+    assert await a._maybe_recover_unshipped_diff("t_implement", "implement", row) is None

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -1410,8 +1410,6 @@ async def test_poll_recovers_pr_after_push_then_api_interruption(tmp_path, monke
             self.worktree_commands.append(args)
             if args[:3] == ["git", "branch", "--show-current"]:
                 return "wt/t_implement"
-            if args[:3] == ["git", "rev-parse", "--abbrev-ref"]:
-                return "origin/release"
             if args[:3] == ["gh", "pr", "view"]:
                 raise ka.KanbanCLIError("no pull request found")
             if args[:3] == ["gh", "pr", "create"]:
@@ -1435,7 +1433,10 @@ async def test_poll_recovers_pr_after_push_then_api_interruption(tmp_path, monke
     complete = next(call for call in a.calls if call[0] == "complete")
     assert "PR_URL=https://github.com/jason-easyazz/zoe-ai-assistant/pull/999" in "\n".join(complete)
     create_cmd = next(cmd for cmd in a.worktree_commands if cmd[:3] == ["gh", "pr", "create"])
-    assert create_cmd[create_cmd.index("--base") + 1] == "release"
+    # No --base is passed: gh defaults to the repo's default branch. Deriving the
+    # base from HEAD@{upstream} is wrong after `git push -u` (upstream == the task
+    # branch itself), which would make head == base and fail.
+    assert "--base" not in create_cmd
 
 
 @pytest.mark.asyncio
@@ -1672,8 +1673,6 @@ async def test_poll_creates_pr_when_pr_view_returns_no_url(tmp_path, monkeypatch
             self.worktree_commands.append(args)
             if args[:3] == ["git", "branch", "--show-current"]:
                 return "wt/t_implement"
-            if args[:3] == ["git", "rev-parse", "--abbrev-ref"]:
-                return "origin/main"
             if args[:3] == ["gh", "pr", "view"]:
                 return "null"
             if args[:3] == ["gh", "pr", "create"]:
@@ -5573,8 +5572,6 @@ async def test_recover_unshipped_diff_commits_pushes_and_opens_pr(tmp_path, monk
                 return "1"
             if args[:2] == ["git", "push"]:
                 return ""
-            if args[:3] == ["git", "rev-parse", "--abbrev-ref"]:
-                return "origin/main"
             if args[:3] == ["gh", "pr", "view"]:
                 raise ka.KanbanCLIError("no pull request found")
             if args[:3] == ["gh", "pr", "create"]:


### PR DESCRIPTION
## Problem
The Multica→Hermes implement worker sometimes completes the engineering (edits + tests) but exits before `git add/commit/push`/`gh pr create` — e.g. it hits its turn budget after heavy large-file exploration. Today that parks the ticket as `blocked`, and a resume starts a **fresh worktree** and re-explores from zero, **discarding the completed work and re-spending**.

Observed live on **ZOE-5799** (the whisper-warmup non-blocking fix): the worker (minimax-m3) wrote a correct fix + 11 passing tests, then ran out of turns before pushing — the finished diff had to be shipped by hand ([#519](https://github.com/jason-easyazz/zoe-ai-assistant/pull/519)).

## Fix
The harness already recovers a *pushed* branch that lost its PR handoff (`_maybe_recover_pushed_pr`). This adds the sibling for the **never-committed/never-pushed** case:

- **`_maybe_recover_unshipped_diff`** — when an implement task is blocked and no PR was handed off, commit any uncommitted changes, push the task branch, and open a PR so the chain advances to verify instead of discarding the diff.
- **`_pr_url_from_worktree`** — shared helper (`gh pr view` → else `gh pr create` against the branch upstream), reused by both recovery paths.

## Safety
- Operates **only** on the task's own isolated worktree branch (`wt/<task_id>`); **fails closed** on main/master/detached or any non-task branch, so it can never touch the live checkout.
- Never uses `--force`; never opens an empty PR (requires real unpushed content).
- Recovery is best-effort and never breaks `poll`.

## Tests
4 focused cases — happy path (commit+push+PR+done), refuse non-task branch, skip when nothing to ship, skip when a PR was already handed off. Full `test_kanban_adapter.py` suite stays green (**235 passed**).

## Design note
Keeps the worker turn cap exactly where it is (it's the cost guard). The principle: **the final ship step shouldn't depend on the worker having spare turns.** A complementary follow-up (carry the worktree forward on resume) is noted for later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)