### PR TITLE
Add structured Pi intent miss evidence

### DIFF
--- a/docs/architecture/zoe-pi-runtime-harness.md
+++ b/docs/architecture/zoe-pi-runtime-harness.md
@@ -47,6 +47,8 @@ Environment variables:
 | `ZOE_PI_INTENT_SHADOW_MAX_WORDS` | `32` | Maximum utterance length eligible for shadow comparison. |
 | `ZOE_PI_INTENT_SHADOW_INCLUDE_PREVIEW` | `true` | Store a short sanitized text preview alongside the text hash. |
 | `ZOE_PI_INTENT_SHADOW_FORCE_ENABLED` | `true` | Force the classifier on inside shadow mode while keeping live routing unchanged. |
+| `ZOE_PI_INTENT_MISS_EVIDENCE_ENABLED` | `false` | Write sanitized intent-miss candidate rows for later review/labeling. |
+| `ZOE_PI_INTENT_MISS_EVIDENCE_PATH` | `~/.zoe/data/pi-intent-miss-evidence.jsonl` | JSONL path for structured intent-miss candidates. |
 | `ZOE_PI_INTENT_PROMOTED_GROUPS` | unset | Comma-separated low-risk intent groups promoted through Pi for live fallback execution and rollback reporting. Unknown or privileged groups are ignored. |
 
 ## Probe
@@ -91,6 +93,12 @@ scripts/maintenance/pi_promotion_eval.py --demo --min-samples 10 \
 ```
 
 The apply helper only writes `ZOE_PI_INTENT_PROMOTED_GROUPS`; it rejects any other env key in the report.
+
+Optional structured intent-miss evidence can be enabled with
+`ZOE_PI_INTENT_MISS_EVIDENCE_ENABLED=true`. This writes sanitized candidate rows
+to `ZOE_PI_INTENT_MISS_EVIDENCE_PATH` without changing the live route. These rows
+start unlabeled and must be reviewed by an operator before adding an
+`outcome_label` for promotion scoring.
 
 ## Evaluation Datasets
 

--- a/scripts/maintenance/pi_eval_export.py
+++ b/scripts/maintenance/pi_eval_export.py
@@ -19,16 +19,11 @@ from typing import Any, Mapping, Sequence
 ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT / "services" / "zoe-data"))
 
+from pi_intent_evidence import has_secret_evidence_text, sanitize_evidence_text  # noqa: E402
 from zoe_pi_promotion import PiIntentEvalCase, intent_group_for_intent, merge_pi_intent_eval_cases  # noqa: E402
 
 _ALLOWED_SOURCES = {"intent_miss", "chat_log", "voice_log", "known_failure", "synthetic"}
 _ALLOWED_ROUTE_CLASSES = {"deterministic", "fallback", "extraction_failed"}
-_EMAIL_RE = re.compile(r"[\w.+-]+@[\w-]+\.\w+")
-_URL_RE = re.compile(r"https?://\S+")
-_PHONE_RE = re.compile(r"\b\d[\d\s\-]{5,}\d\b")
-_NAME_RE = re.compile(r"(^|\s)(?!Call\b|Email\b|Tell\b|Ask\b|Remind\b|Show\b|Set\b|Add\b|What\b|Will\b|Can\b|Please\b)([A-Z][a-z]+ [A-Z][a-z]+\b)")
-_SPACE_RE = re.compile(r"\s+")
-_SECRET_TEXT_RE = re.compile(r"(?i)(api[\s_-]?key|authorization|bearer\s+[a-z0-9._\-]+|password\s*(is|=)|secret\s*(is|=)|token\s*(is|=))")
 
 
 def load_jsonl(path: str | Path) -> list[dict[str, Any]]:
@@ -86,10 +81,10 @@ def _case_from_row(
     raw_text = _first_text(row, ("text_preview", "text", "transcript", "message", "utterance"))
     if not raw_text:
         return None
-    if _SECRET_TEXT_RE.search(raw_text) or len(str(raw_text).split()) > max_words:
+    if has_secret_evidence_text(raw_text) or len(str(raw_text).split()) > max_words:
         return None
     text = sanitize_eval_text(raw_text)
-    if not text or _SECRET_TEXT_RE.search(text):
+    if not text or has_secret_evidence_text(text):
         return None
 
     expected_intent = _optional_str(row.get("expected_intent") or row.get("outcome_label") or row.get("label"))
@@ -124,12 +119,7 @@ def _case_from_row(
 
 
 def sanitize_eval_text(text: str) -> str:
-    clean = _EMAIL_RE.sub("[EMAIL]", str(text or ""))
-    clean = _URL_RE.sub("[URL]", clean)
-    clean = _PHONE_RE.sub("[NUMBER]", clean)
-    clean = _NAME_RE.sub(lambda match: f"{match.group(1)}[NAME]", clean)
-    clean = _SPACE_RE.sub(" ", clean).strip()
-    return clean[:160]
+    return sanitize_evidence_text(text)
 
 
 def cases_to_jsonl(cases: Sequence[PiIntentEvalCase]) -> str:

--- a/scripts/maintenance/pi_eval_export.py
+++ b/scripts/maintenance/pi_eval_export.py
@@ -26,7 +26,7 @@ _ALLOWED_ROUTE_CLASSES = {"deterministic", "fallback", "extraction_failed"}
 _EMAIL_RE = re.compile(r"[\w.+-]+@[\w-]+\.\w+")
 _URL_RE = re.compile(r"https?://\S+")
 _PHONE_RE = re.compile(r"\b\d[\d\s\-]{5,}\d\b")
-_NAME_RE = re.compile(r"(?<=\s)[A-Z][a-z]+ [A-Z][a-z]+\b")
+_NAME_RE = re.compile(r"(^|\s)(?!Call\b|Email\b|Tell\b|Ask\b|Remind\b|Show\b|Set\b|Add\b|What\b|Will\b|Can\b|Please\b)([A-Z][a-z]+ [A-Z][a-z]+\b)")
 _SPACE_RE = re.compile(r"\s+")
 _SECRET_TEXT_RE = re.compile(r"(?i)(api[\s_-]?key|authorization|bearer\s+[a-z0-9._\-]+|password\s*(is|=)|secret\s*(is|=)|token\s*(is|=))")
 
@@ -127,7 +127,7 @@ def sanitize_eval_text(text: str) -> str:
     clean = _EMAIL_RE.sub("[EMAIL]", str(text or ""))
     clean = _URL_RE.sub("[URL]", clean)
     clean = _PHONE_RE.sub("[NUMBER]", clean)
-    clean = _NAME_RE.sub("[NAME]", clean)
+    clean = _NAME_RE.sub(lambda match: f"{match.group(1)}[NAME]", clean)
     clean = _SPACE_RE.sub(" ", clean).strip()
     return clean[:160]
 

--- a/scripts/maintenance/pi_eval_export.py
+++ b/scripts/maintenance/pi_eval_export.py
@@ -25,8 +25,8 @@ _ALLOWED_SOURCES = {"intent_miss", "chat_log", "voice_log", "known_failure", "sy
 _ALLOWED_ROUTE_CLASSES = {"deterministic", "fallback", "extraction_failed"}
 _EMAIL_RE = re.compile(r"[\w.+-]+@[\w-]+\.\w+")
 _URL_RE = re.compile(r"https?://\S+")
-_PHONE_RE = re.compile(r"\b\d[\d\s\-]{6,}\b")
-_NAME_RE = re.compile(r"\b[A-Z][a-z]+ [A-Z][a-z]+\b")
+_PHONE_RE = re.compile(r"\b\d[\d\s\-]{5,}\d\b")
+_NAME_RE = re.compile(r"(?<=\s)[A-Z][a-z]+ [A-Z][a-z]+\b")
 _SPACE_RE = re.compile(r"\s+")
 _SECRET_TEXT_RE = re.compile(r"(?i)(api[\s_-]?key|authorization|bearer\s+[a-z0-9._\-]+|password\s*(is|=)|secret\s*(is|=)|token\s*(is|=))")
 

--- a/services/zoe-data/intent_router.py
+++ b/services/zoe-data/intent_router.py
@@ -502,6 +502,7 @@ def detect_intent(
     text: str,
     log_miss: bool = True,
     context: "Optional[ConversationContext]" = None,
+    user_id: str = "unknown",
 ) -> Optional[Intent]:
     t = _normalize_chat_intent_text(text)
 
@@ -1281,7 +1282,7 @@ def detect_intent(
         try:
             from pi_intent_evidence import record_intent_miss_evidence
 
-            record_intent_miss_evidence(text, route_class="fallback")
+            record_intent_miss_evidence(text, route_class="fallback", user_id=user_id if isinstance(user_id, str) else "unknown")
         except Exception:
             pass  # Never let evidence collection break intent routing
     return None
@@ -1368,7 +1369,7 @@ async def detect_and_extract_intent(
         return None, pi_classified
 
     started = time.perf_counter()
-    intent = detect_intent(text, context=context)
+    intent = detect_intent(text, context=context, user_id=user_id)
     detect_latency_ms = (time.perf_counter() - started) * 1000
     if intent is None:
         routed_intent, pi_classified = await _try_pi_governor()

--- a/services/zoe-data/intent_router.py
+++ b/services/zoe-data/intent_router.py
@@ -1278,6 +1278,12 @@ def detect_intent(
                 _f.write(_json.dumps({"text": _clean, "ts": __import__("time").time()}) + "\n")
         except Exception:
             pass  # Never let logging break intent routing
+        try:
+            from pi_intent_evidence import record_intent_miss_evidence
+
+            record_intent_miss_evidence(text, route_class="fallback")
+        except Exception:
+            pass  # Never let evidence collection break intent routing
     return None
 
 

--- a/services/zoe-data/pi_intent_evidence.py
+++ b/services/zoe-data/pi_intent_evidence.py
@@ -18,7 +18,7 @@ _DEFAULT_MISS_PATH = "~/.zoe/data/pi-intent-miss-evidence.jsonl"
 _EMAIL_RE = re.compile(r"[\w.+-]+@[\w-]+\.\w+")
 _URL_RE = re.compile(r"https?://\S+")
 _PHONE_RE = re.compile(r"\b\d[\d\s\-]{5,}\d\b")
-_NAME_RE = re.compile(r"(^|\s)(?!Call\b|Email\b|Tell\b|Ask\b|Remind\b|Show\b|Set\b|Add\b|What\b|Will\b|Can\b|Please\b)([A-Z][a-z]+ [A-Z][a-z]+\b)")
+_NAME_RE = re.compile(r"(^|\s)(?!Call\b|Email\b|Tell\b|Ask\b|Remind\b|Show\b|Set\b|Add\b|What\b|Please\b)([A-Z][a-z]+ [A-Z][a-z]+\b)")
 _SPACE_RE = re.compile(r"\s+")
 _SECRET_KEY_RE = re.compile(r"(?i)(api[_-]?key|\btoken\b|\bsecret\b|password|authorization|\bbearer\b)")
 _SECRET_TEXT_RE = re.compile(r"(?i)(api[\s_-]?key|authorization|bearer\s+[a-z0-9._\-]+|password\s*(is|=)|secret\s*(is|=)|token\s*(is|=))")
@@ -63,6 +63,10 @@ def sanitize_evidence_text(text: str) -> str:
     return clean[:160]
 
 
+def has_secret_evidence_text(text: str) -> bool:
+    return bool(_SECRET_TEXT_RE.search(str(text or "")))
+
+
 def _append_jsonl(path: str, record: Mapping[str, Any]) -> None:
     _reject_secret_keys(record)
     target = Path(path).expanduser()
@@ -90,4 +94,4 @@ def _env_bool(value: str | None, *, default: bool = False) -> bool:
     return str(value).strip().lower() in {"1", "true", "yes", "on"}
 
 
-__all__ = ["record_intent_miss_evidence", "sanitize_evidence_text"]
+__all__ = ["has_secret_evidence_text", "record_intent_miss_evidence", "sanitize_evidence_text"]

--- a/services/zoe-data/pi_intent_evidence.py
+++ b/services/zoe-data/pi_intent_evidence.py
@@ -1,0 +1,93 @@
+"""Structured evidence writers for Pi-vs-Zoe intent evaluation.
+
+These helpers are intentionally small and fail-closed. They collect sanitized
+candidate evidence only; labels still require review before promotion scoring.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import time
+from pathlib import Path
+from typing import Any, Mapping
+
+_DEFAULT_MISS_PATH = "~/.zoe/data/pi-intent-miss-evidence.jsonl"
+_EMAIL_RE = re.compile(r"[\w.+-]+@[\w-]+\.\w+")
+_URL_RE = re.compile(r"https?://\S+")
+_PHONE_RE = re.compile(r"\b\d[\d\s\-]{5,}\d\b")
+_NAME_RE = re.compile(r"(?<=\s)[A-Z][a-z]+ [A-Z][a-z]+\b")
+_SPACE_RE = re.compile(r"\s+")
+_SECRET_KEY_RE = re.compile(r"(?i)(api[_-]?key|\btoken\b|\bsecret\b|password|authorization|\bbearer\b)")
+_SECRET_TEXT_RE = re.compile(r"(?i)(api[\s_-]?key|authorization|bearer\s+[a-z0-9._\-]+|password\s*(is|=)|secret\s*(is|=)|token\s*(is|=))")
+_ALLOWED_ROUTE_CLASSES = {"deterministic", "fallback", "extraction_failed"}
+
+
+def record_intent_miss_evidence(
+    text: str,
+    *,
+    route_class: str = "fallback",
+    user_id: str = "unknown",
+    env: Mapping[str, str] | None = None,
+) -> dict[str, Any] | None:
+    values = env if env is not None else os.environ
+    if not _env_bool(values.get("ZOE_PI_INTENT_MISS_EVIDENCE_ENABLED"), default=False):
+        return None
+    preview = sanitize_evidence_text(text)
+    if not preview or _SECRET_TEXT_RE.search(str(text or "")) or _SECRET_TEXT_RE.search(preview):
+        return None
+    active_route = route_class if route_class in _ALLOWED_ROUTE_CLASSES else "fallback"
+    record = {
+        "ts": time.time(),
+        "source": "intent_miss",
+        "route_class": active_route,
+        "text": preview,
+        "text_hash": _hash_text(text),
+        "user_hash": _hash_text(user_id or "unknown")[:16],
+        "expected_intent": None,
+        "outcome_label": None,
+        "negative": False,
+    }
+    _append_jsonl(values.get("ZOE_PI_INTENT_MISS_EVIDENCE_PATH") or _DEFAULT_MISS_PATH, record)
+    return record
+
+
+def sanitize_evidence_text(text: str) -> str:
+    clean = _EMAIL_RE.sub("[EMAIL]", str(text or ""))
+    clean = _URL_RE.sub("[URL]", clean)
+    clean = _PHONE_RE.sub("[NUMBER]", clean)
+    clean = _NAME_RE.sub("[NAME]", clean)
+    clean = _SPACE_RE.sub(" ", clean).strip()
+    return clean[:160]
+
+
+def _append_jsonl(path: str, record: Mapping[str, Any]) -> None:
+    _reject_secret_keys(record)
+    target = Path(path).expanduser()
+    target.parent.mkdir(parents=True, exist_ok=True)
+    with target.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(record, sort_keys=True, separators=(",", ":")) + "\n")
+
+
+def _reject_secret_keys(value: Mapping[str, Any], path: str = "") -> None:
+    for key, nested in value.items():
+        full_key = f"{path}.{key}" if path else str(key)
+        if _SECRET_KEY_RE.search(str(key)):
+            raise ValueError(f"intent evidence may not contain secret field {full_key}")
+        if isinstance(nested, Mapping):
+            _reject_secret_keys(nested, full_key)
+
+
+def _hash_text(text: str) -> str:
+    return hashlib.sha256((text or "").encode("utf-8", errors="ignore")).hexdigest()
+
+
+def _env_bool(value: str | None, *, default: bool = False) -> bool:
+    if value is None:
+        return default
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
+
+__all__ = ["record_intent_miss_evidence", "sanitize_evidence_text"]

--- a/services/zoe-data/pi_intent_evidence.py
+++ b/services/zoe-data/pi_intent_evidence.py
@@ -18,7 +18,7 @@ _DEFAULT_MISS_PATH = "~/.zoe/data/pi-intent-miss-evidence.jsonl"
 _EMAIL_RE = re.compile(r"[\w.+-]+@[\w-]+\.\w+")
 _URL_RE = re.compile(r"https?://\S+")
 _PHONE_RE = re.compile(r"\b\d[\d\s\-]{5,}\d\b")
-_NAME_RE = re.compile(r"(?<=\s)[A-Z][a-z]+ [A-Z][a-z]+\b")
+_NAME_RE = re.compile(r"(^|\s)(?!Call\b|Email\b|Tell\b|Ask\b|Remind\b|Show\b|Set\b|Add\b|What\b|Will\b|Can\b|Please\b)([A-Z][a-z]+ [A-Z][a-z]+\b)")
 _SPACE_RE = re.compile(r"\s+")
 _SECRET_KEY_RE = re.compile(r"(?i)(api[_-]?key|\btoken\b|\bsecret\b|password|authorization|\bbearer\b)")
 _SECRET_TEXT_RE = re.compile(r"(?i)(api[\s_-]?key|authorization|bearer\s+[a-z0-9._\-]+|password\s*(is|=)|secret\s*(is|=)|token\s*(is|=))")
@@ -58,7 +58,7 @@ def sanitize_evidence_text(text: str) -> str:
     clean = _EMAIL_RE.sub("[EMAIL]", str(text or ""))
     clean = _URL_RE.sub("[URL]", clean)
     clean = _PHONE_RE.sub("[NUMBER]", clean)
-    clean = _NAME_RE.sub("[NAME]", clean)
+    clean = _NAME_RE.sub(lambda match: f"{match.group(1)}[NAME]", clean)
     clean = _SPACE_RE.sub(" ", clean).strip()
     return clean[:160]
 

--- a/services/zoe-data/tests/test_pi_eval_export.py
+++ b/services/zoe-data/tests/test_pi_eval_export.py
@@ -56,6 +56,14 @@ def test_exports_labeled_shadow_rows_as_sanitized_eval_cases():
     assert cases[0].source == "intent_miss"
 
 
+def test_sanitize_eval_text_reuses_evidence_sanitizer_for_name_prefixes():
+    module = _load_module()
+
+    assert module.sanitize_eval_text("Jason Smith asked about the weather") == "[NAME] asked about the weather"
+    assert module.sanitize_eval_text("Will Smith called about the meeting") == "[NAME] called about the meeting"
+    assert module.sanitize_eval_text("Can Chen asked about the plan") == "[NAME] asked about the plan"
+
+
 def test_exports_negative_chat_rows():
     module = _load_module()
 

--- a/services/zoe-data/tests/test_pi_intent_evidence.py
+++ b/services/zoe-data/tests/test_pi_intent_evidence.py
@@ -1,0 +1,80 @@
+import json
+from pathlib import Path
+
+from intent_router import detect_intent
+from pi_intent_evidence import record_intent_miss_evidence, sanitize_evidence_text
+
+
+def test_record_intent_miss_evidence_disabled_does_not_write(tmp_path):
+    path = tmp_path / "misses.jsonl"
+
+    result = record_intent_miss_evidence(
+        "email jason@example.com if rain later",
+        env={"ZOE_PI_INTENT_MISS_EVIDENCE_PATH": str(path)},
+    )
+
+    assert result is None
+    assert not path.exists()
+
+
+def test_record_intent_miss_evidence_writes_sanitized_jsonl(tmp_path):
+    path = tmp_path / "misses.jsonl"
+
+    result = record_intent_miss_evidence(
+        "email jason@example.com if rain later",
+        user_id="jason",
+        env={
+            "ZOE_PI_INTENT_MISS_EVIDENCE_ENABLED": "true",
+            "ZOE_PI_INTENT_MISS_EVIDENCE_PATH": str(path),
+        },
+    )
+
+    assert result is not None
+    saved = json.loads(path.read_text(encoding="utf-8"))
+    assert saved["source"] == "intent_miss"
+    assert saved["route_class"] == "fallback"
+    assert saved["text"] == "email [EMAIL] if rain later"
+    assert saved["text_hash"]
+    assert saved["user_hash"]
+    assert saved["expected_intent"] is None
+    assert saved["outcome_label"] is None
+    assert "jason@example.com" not in path.read_text(encoding="utf-8")
+
+
+def test_record_intent_miss_evidence_skips_secret_like_text(tmp_path):
+    path = tmp_path / "misses.jsonl"
+
+    result = record_intent_miss_evidence(
+        "my api key is abc123",
+        env={
+            "ZOE_PI_INTENT_MISS_EVIDENCE_ENABLED": "true",
+            "ZOE_PI_INTENT_MISS_EVIDENCE_PATH": str(path),
+        },
+    )
+
+    assert result is None
+    assert not path.exists()
+
+
+def test_sanitize_evidence_text_redacts_common_pii():
+    assert sanitize_evidence_text("Call Jason Smith on 0400 111 222 via https://example.com") == (
+        "Call [NAME] on [NUMBER] via [URL]"
+    )
+
+
+def test_detect_intent_miss_produces_pi_evidence_when_enabled(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    evidence_path = tmp_path / "pi-misses.jsonl"
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("ZOE_PI_INTENT_MISS_EVIDENCE_ENABLED", "true")
+    monkeypatch.setenv("ZOE_PI_INTENT_MISS_EVIDENCE_PATH", str(evidence_path))
+
+    intent = detect_intent("email jason@example.com if rain later", log_miss=True)
+
+    assert intent is None
+    legacy_path = home / "training" / "data" / "intent-misses.jsonl"
+    assert legacy_path.exists()
+    assert evidence_path.exists()
+    saved = json.loads(evidence_path.read_text(encoding="utf-8"))
+    assert saved["text"] == "email [EMAIL] if rain later"
+    assert saved["source"] == "intent_miss"

--- a/services/zoe-data/tests/test_pi_intent_evidence.py
+++ b/services/zoe-data/tests/test_pi_intent_evidence.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 from pathlib import Path
 
@@ -31,8 +32,9 @@ def test_record_intent_miss_evidence_writes_sanitized_jsonl(tmp_path):
 
     assert result is not None
     saved = json.loads(path.read_text(encoding="utf-8"))
+    expected_user_hash = hashlib.sha256(b"jason").hexdigest()[:16]
     assert saved["source"] == "intent_miss"
-    assert saved["user_hash"] != "b23a6a8439c0dde5"
+    assert saved["user_hash"] == expected_user_hash
     assert saved["route_class"] == "fallback"
     assert saved["text"] == "email [EMAIL] if rain later"
     assert saved["text_hash"]
@@ -78,6 +80,7 @@ def test_detect_intent_miss_produces_pi_evidence_when_enabled(tmp_path, monkeypa
     assert legacy_path.exists()
     assert evidence_path.exists()
     saved = json.loads(evidence_path.read_text(encoding="utf-8"))
+    expected_user_hash = hashlib.sha256(b"jason").hexdigest()[:16]
     assert saved["text"] == "email [EMAIL] if rain later"
     assert saved["source"] == "intent_miss"
-    assert saved["user_hash"] != "b23a6a8439c0dde5"
+    assert saved["user_hash"] == expected_user_hash

--- a/services/zoe-data/tests/test_pi_intent_evidence.py
+++ b/services/zoe-data/tests/test_pi_intent_evidence.py
@@ -64,6 +64,8 @@ def test_sanitize_evidence_text_redacts_common_pii():
         "Call [NAME] on [NUMBER] via [URL]"
     )
     assert sanitize_evidence_text("Jason Smith asked about the weather") == "[NAME] asked about the weather"
+    assert sanitize_evidence_text("Will Smith called about the meeting") == "[NAME] called about the meeting"
+    assert sanitize_evidence_text("Can Chen asked about the plan") == "[NAME] asked about the plan"
 
 
 def test_detect_intent_miss_produces_pi_evidence_when_enabled(tmp_path, monkeypatch):

--- a/services/zoe-data/tests/test_pi_intent_evidence.py
+++ b/services/zoe-data/tests/test_pi_intent_evidence.py
@@ -32,6 +32,7 @@ def test_record_intent_miss_evidence_writes_sanitized_jsonl(tmp_path):
     assert result is not None
     saved = json.loads(path.read_text(encoding="utf-8"))
     assert saved["source"] == "intent_miss"
+    assert saved["user_hash"] != "b23a6a8439c0dde5"
     assert saved["route_class"] == "fallback"
     assert saved["text"] == "email [EMAIL] if rain later"
     assert saved["text_hash"]
@@ -60,6 +61,7 @@ def test_sanitize_evidence_text_redacts_common_pii():
     assert sanitize_evidence_text("Call Jason Smith on 0400 111 222 via https://example.com") == (
         "Call [NAME] on [NUMBER] via [URL]"
     )
+    assert sanitize_evidence_text("Jason Smith asked about the weather") == "[NAME] asked about the weather"
 
 
 def test_detect_intent_miss_produces_pi_evidence_when_enabled(tmp_path, monkeypatch):
@@ -69,7 +71,7 @@ def test_detect_intent_miss_produces_pi_evidence_when_enabled(tmp_path, monkeypa
     monkeypatch.setenv("ZOE_PI_INTENT_MISS_EVIDENCE_ENABLED", "true")
     monkeypatch.setenv("ZOE_PI_INTENT_MISS_EVIDENCE_PATH", str(evidence_path))
 
-    intent = detect_intent("email jason@example.com if rain later", log_miss=True)
+    intent = detect_intent("email jason@example.com if rain later", log_miss=True, user_id="jason")
 
     assert intent is None
     legacy_path = home / "training" / "data" / "intent-misses.jsonl"
@@ -78,3 +80,4 @@ def test_detect_intent_miss_produces_pi_evidence_when_enabled(tmp_path, monkeypa
     saved = json.loads(evidence_path.read_text(encoding="utf-8"))
     assert saved["text"] == "email [EMAIL] if rain later"
     assert saved["source"] == "intent_miss"
+    assert saved["user_hash"] != "b23a6a8439c0dde5"


### PR DESCRIPTION
## Summary
- add an env-gated structured intent-miss evidence writer for Pi promotion datasets
- preserve the existing legacy intent-miss training log while optionally writing Zoe/Pi review candidates
- align eval exporter redaction with the evidence writer and document the new flags

## Verification
- python3 -m py_compile services/zoe-data/pi_intent_evidence.py scripts/maintenance/pi_eval_export.py services/zoe-data/intent_router.py
- python3 -m pytest -q services/zoe-data/tests/test_pi_intent_evidence.py services/zoe-data/tests/test_pi_eval_export.py services/zoe-data/tests/test_pi_promotion_eval_script.py services/zoe-data/tests/test_zoe_pi_promotion.py services/zoe-data/tests/test_pi_promotion_apply.py services/zoe-data/tests/test_pi_intent_shadow.py services/zoe-data/tests/test_pi_intent_classifier.py services/zoe-data/tests/test_pi_intent_status_endpoint.py
- intent miss evidence smoke: detect_intent -> labeled temp JSONL -> pi_eval_export.py -> pi_promotion_eval.py
- python3 tools/audit/validate_structure.py
- python3 tools/audit/validate_critical_files.py
- git diff --check