### PR TITLE
[codex] Fix Skybridge list voice add visibility

### DIFF
--- a/services/zoe-data/skybridge_service.py
+++ b/services/zoe-data/skybridge_service.py
@@ -327,7 +327,7 @@ def _clean_action_text(value: str) -> str:
 
 def _list_add_from_text(message: str) -> tuple[str, str] | None:
     match = re.search(
-        r"\badd\s+(?P<item>.+?)\s+to\s+(?:the\s+|my\s+)?(?P<list>shopping list|grocery list|groceries|list|task list|todo list|tasks|todos)\b",
+        r"\badd\s+(?P<item>.+?)\s+to\s+(?:the\s+|my\s+)?(?P<list>shopping list|grocery list|groceries|work list|personal list|list|task list|todo list|tasks|todos)\b",
         message,
         re.IGNORECASE,
     )
@@ -336,6 +336,23 @@ def _list_add_from_text(message: str) -> tuple[str, str] | None:
     item = _clean_action_text(match.group("item"))
     list_phrase = f" {match.group('list').lower()} "
     list_type = _list_type_from_text(list_phrase) or ("shopping" if "grocery" in list_phrase else "")
+    return item, list_type or "shopping"
+
+
+def _contextual_list_add_from_text(message: str, context: dict[str, Any] | None) -> tuple[str, str] | None:
+    if _context_domain(context) != "lists":
+        return None
+    match = re.search(r"\badd\s+(?P<item>.+?)\s*$", message, re.IGNORECASE)
+    if not match:
+        return None
+    if re.search(r"\b(?:at|for)\s+\d{1,2}(?::\d{2})?\s*(?:a\.?m\.?|p\.?m\.?)?\b", message, re.IGNORECASE):
+        return None
+    if re.search(r"\bto\s+", message, re.IGNORECASE):
+        return None
+    item = _clean_action_text(match.group("item"))
+    if not item or item.lower() in {"item", "something", "this", "that"}:
+        return None
+    _list_id, list_type = _context_list_hint(context)
     return item, list_type or "shopping"
 
 
@@ -462,6 +479,10 @@ def classify_skybridge_intent(message: str, context: dict[str, Any] | None = Non
     if list_create:
         list_name, list_type = list_create
         return SkybridgeIntent(domain="lists", action="create_list", list_name=list_name, list_type=list_type)
+    contextual_list_add = _contextual_list_add_from_text(raw_message, context)
+    if contextual_list_add:
+        item, list_type = contextual_list_add
+        return SkybridgeIntent(domain="lists", action="add_item", item_text=item, list_type=list_type)
     calendar_create = _calendar_create_from_text(raw_message, context)
     if calendar_create:
         title, target_time = calendar_create
@@ -926,9 +947,9 @@ async def _ensure_default_lists(user_id: str, db: Any) -> None:
         user_id,
     )
     existing_rows = [dict(row) for row in rows]
-    existing = {(str(row.get("list_type") or ""), str(row.get("name") or "").strip().lower()) for row in existing_rows}
+    existing_types = {str(row.get("list_type") or "").strip().lower() for row in existing_rows}
     for list_type, name, description, visibility in DEFAULT_USER_LISTS:
-        if (list_type, name.lower()) in existing:
+        if list_type in existing_types:
             continue
         await db.execute(
             """
@@ -1087,7 +1108,9 @@ async def _find_or_create_list(intent: SkybridgeIntent, user_id: str, db: Any, c
         FROM lists
         WHERE list_type = $2 AND deleted = 0
           AND (visibility = 'family' OR user_id = $1)
-        ORDER BY updated_at DESC
+        ORDER BY
+          CASE WHEN user_id = $1 THEN 0 ELSE 1 END,
+          updated_at DESC
         LIMIT 1
         """,
         user_id,
@@ -1109,7 +1132,7 @@ async def _find_or_create_list(intent: SkybridgeIntent, user_id: str, db: Any, c
         list_name,
         list_type,
         "",
-        "family",
+        "family" if list_type == "shopping" else "personal",
     )
     await _maybe_commit(db)
     rows = await db.fetch(
@@ -1145,6 +1168,7 @@ async def _resolve_list_add_item(intent: SkybridgeIntent, user_id: str, db: Any,
             "cards": [_status_card("What should I add?", "Say the item and the list, for example: add bread to the shopping list.")],
             "actions": [],
         }
+    await _ensure_default_lists(user_id, db)
     list_target = await _find_or_create_list(intent, user_id, db, context)
     if not list_target:
         return {
@@ -1172,6 +1196,30 @@ async def _resolve_list_add_item(intent: SkybridgeIntent, user_id: str, db: Any,
     )
     await _maybe_commit(db)
     refreshed = await _resolve_lists(SkybridgeIntent(domain="lists", action="show", list_type=list_type), user_id, db)
+    card_content = refreshed.get("cards", [{}])[0].get("content", {}) if refreshed.get("cards") else {}
+    items = card_content.get("items")
+    if isinstance(items, list):
+        found_recent = False
+        for item in items:
+            if isinstance(item, dict) and str(item.get("id") or "") == item_id:
+                item["recent"] = True
+                found_recent = True
+        if not found_recent:
+            items.insert(
+                0,
+                {
+                    "id": item_id,
+                    "list_id": list_id,
+                    "text": intent.item_text,
+                    "completed": False,
+                    "priority": "normal",
+                    "category": "",
+                    "quantity": "",
+                    "recent": True,
+                },
+            )
+        items.sort(key=lambda row: 0 if isinstance(row, dict) and str(row.get("id") or "") == item_id else 1)
+        card_content["recent_item_id"] = item_id
     refreshed["intent"] = {"domain": "lists", "action": "add_item", "list_type": list_type, "item_id": item_id}
     refreshed["spoken_summary"] = f"Added {intent.item_text} to the {list_type} list."
     refreshed["actions"] = [{"type": "created", "domain": "lists", "id": item_id, "list_id": list_id}]

--- a/services/zoe-data/tests/test_skybridge_service.py
+++ b/services/zoe-data/tests/test_skybridge_service.py
@@ -46,6 +46,22 @@ class FakeDb:
                 user_id = args[1]
                 name = str(args[2]).lower()
                 return [row for row in self.lists if row.get("user_id") == user_id and str(row.get("name", "")).lower() == name]
+            if "list_type = $2" in sql:
+                user_id = args[1]
+                list_type = args[2]
+                rows = [
+                    row for row in self.lists
+                    if row.get("list_type") == list_type
+                    and (row.get("visibility") == "family" or row.get("user_id") == user_id)
+                    and not row.get("deleted")
+                ]
+                return sorted(
+                    rows,
+                    key=lambda row: (
+                        0 if row.get("user_id") == user_id else 1,
+                        -(row.get("updated_at") or 0),
+                    ),
+                )
             return self.lists
         if "FROM list_items" in sql:
             self.list_item_fetch_count += 1
@@ -159,8 +175,23 @@ def test_classify_calendar_and_weather_requests():
     assert classify_skybridge_intent("show my shopping list").domain == "lists"
     assert classify_skybridge_intent("what's on my shopping list").domain == "lists"
     assert classify_skybridge_intent("whats on my grocery list").domain == "lists"
+    work_add = classify_skybridge_intent("add bread to the work list")
+    assert work_add.action == "add_item"
+    assert work_add.item_text == "bread"
+    assert work_add.list_type == "work"
     assert classify_skybridge_intent("show my lists").action == "overview"
     assert classify_skybridge_intent("new list").action == "create_list"
+    list_context = {"intent": {"domain": "lists", "action": "show", "list_type": "shopping"}, "cards": []}
+    contextual_create = classify_skybridge_intent("add a personal list", list_context)
+    assert contextual_create.action == "create_list"
+    assert contextual_create.list_type == "personal"
+    assert classify_skybridge_intent("add dentist at 2pm", list_context) is None
+    ambiguous_list_add = classify_skybridge_intent("add bread to the project list", list_context)
+    assert ambiguous_list_add.action != "add_item"
+    calendar_destination = classify_skybridge_intent("add a meeting to my calendar", list_context)
+    contacts_destination = classify_skybridge_intent("add Sarah to my contacts", list_context)
+    assert calendar_destination.action != "add_item"
+    assert contacts_destination.action != "add_item"
     assert classify_skybridge_intent("create a work list called Projects").list_name == "Projects"
     assert classify_skybridge_intent("show my contacts").domain == "people"
     assert classify_skybridge_intent("find Sarah").domain == "people"
@@ -564,7 +595,112 @@ async def test_list_add_item_persists_and_refreshes_list_card():
     assert result["intent"]["action"] == "add_item"
     assert result["actions"][0]["domain"] == "lists"
     assert result["cards"][0]["content"]["items"][0]["text"] == "bread"
+    assert result["cards"][0]["content"]["items"][0]["recent"] is True
+    assert result["cards"][0]["content"]["recent_item_id"] == result["intent"]["item_id"]
     assert result["skybridge_context"]["cards"][0]["content"]["items"][0]["text"] == "bread"
+
+
+@pytest.mark.asyncio
+async def test_contextual_list_add_uses_visible_list_card():
+    list_row = {
+        "id": "work-list",
+        "user_id": "jason",
+        "name": "Work",
+        "list_type": "work",
+        "description": "Work tasks",
+        "visibility": "personal",
+    }
+    db = FakeDb(lists=[list_row], items_by_list={"work-list": []})
+    context = {
+        "intent": {"domain": "lists", "action": "show", "list_type": "work"},
+        "cards": [{"content": {"source": "list_show", "list_id": "work-list", "list_type": "work"}}],
+    }
+
+    result = await resolve_skybridge_request("add send proposal", "jason", context=context, db=db)
+
+    assert result["handled"] is True
+    assert result["intent"]["action"] == "add_item"
+    assert result["intent"]["list_type"] == "work"
+    assert result["cards"][0]["content"]["list_name"] == "Work"
+    assert result["cards"][0]["content"]["items"][0]["text"] == "send proposal"
+    assert result["cards"][0]["content"]["items"][0]["recent"] is True
+
+
+@pytest.mark.asyncio
+async def test_list_add_item_is_visible_when_list_is_already_long():
+    list_row = {
+        "id": "list-1",
+        "user_id": "family-admin",
+        "name": "Groceries",
+        "list_type": "shopping",
+        "description": "Weekly shop",
+        "visibility": "family",
+    }
+    existing_items = [
+        {"id": f"old-{index}", "list_id": "list-1", "text": f"old item {index}", "completed": False}
+        for index in range(30)
+    ]
+    db = FakeDb(lists=[list_row], items_by_list={"list-1": existing_items})
+
+    result = await resolve_skybridge_request("add bread to the shopping list", "family-admin", db=db)
+
+    first_item = result["cards"][0]["content"]["items"][0]
+    assert first_item["text"] == "bread"
+    assert first_item["recent"] is True
+    assert first_item["id"] == result["intent"]["item_id"]
+
+
+@pytest.mark.asyncio
+async def test_list_add_uses_existing_same_type_list_with_custom_name():
+    rows = [
+        {
+            "id": "groceries-list",
+            "user_id": "jason",
+            "name": "Groceries",
+            "list_type": "shopping",
+            "visibility": "family",
+            "deleted": 0,
+            "updated_at": 10,
+        },
+    ]
+    db = FakeDb(lists=rows, items_by_list={"groceries-list": []})
+
+    result = await resolve_skybridge_request("add apples to the shopping list", "jason", db=db)
+
+    assert result["handled"] is True
+    assert result["actions"][0]["list_id"] == "groceries-list"
+    assert db.items_by_list["groceries-list"][0]["text"] == "apples"
+    assert not any(item["name"] == "Shopping" and item["id"] != "groceries-list" for item in db.lists)
+
+
+@pytest.mark.asyncio
+async def test_list_add_prefers_speaking_users_default_list_over_shared_lists():
+    rows = [
+        {
+            "id": "guest-shopping",
+            "user_id": "guest",
+            "name": "Shopping",
+            "list_type": "shopping",
+            "visibility": "family",
+            "deleted": 0,
+        },
+        {
+            "id": "jason-shopping",
+            "user_id": "jason",
+            "name": "Shopping",
+            "list_type": "shopping",
+            "visibility": "family",
+            "deleted": 0,
+        },
+    ]
+    db = FakeDb(lists=rows, items_by_list={"guest-shopping": [], "jason-shopping": []})
+
+    result = await resolve_skybridge_request("add mangoes to the shopping list", "jason", db=db)
+
+    assert result["handled"] is True
+    assert result["actions"][0]["list_id"] == "jason-shopping"
+    assert db.items_by_list["jason-shopping"][0]["text"] == "mangoes"
+    assert db.items_by_list["guest-shopping"] == []
 
 
 @pytest.mark.asyncio

--- a/services/zoe-data/tests/test_skybridge_static.py
+++ b/services/zoe-data/tests/test_skybridge_static.py
@@ -378,6 +378,9 @@ def test_skybridge_list_renderer_has_switcher_columns_and_new_list_action():
     assert 'data-query="new list"' in renderer
     assert "renderListColumn" in renderer
     assert "sky-list-columns" in renderer
+    assert "items.slice(0, 16)" in renderer
+    assert "is-list-detail" in renderer
+    assert "is-recent" in renderer
     assert "sky-list-create-prompt" in renderer
     assert "sky-list-rings" not in renderer
     assert "sky-list-hero" not in renderer
@@ -386,6 +389,8 @@ def test_skybridge_list_renderer_has_switcher_columns_and_new_list_action():
     assert ".sky-list-tab.shopping" in css
     assert ".sky-list-tab.work" in css
     assert ".sky-list-tab.personal" in css
+    assert ".sky-list-items.is-list-detail" in css
+    assert ".sky-list-item-row.is-recent" in css
     assert ".sky-list-create-prompt" in css
 
 
@@ -596,9 +601,11 @@ def test_skybridge_has_touch_panel_fit_overrides():
     assert 'left: calc(50% - 425px)' in html
     assert 'left: calc(50% - 350px)' in html
     assert 'person-profile-card.sky-premium-card' in html
-    assert 'sky-list-item-row:nth-child(n+10)' in html
-    assert 'min-height: 44px !important' in html
+    assert 'sky-list-item-row:nth-child(n+17)' in html
+    assert 'min-height: 48px !important' in html
     assert 'sky-list-switcher' in html
+    assert 'min-height: 56px !important' in html
+    assert 'font-size: 18px !important' in html
     assert 'sky-list-column li:nth-child(n+4)' in html
     assert 'sky-card.list-card.sky-premium-card' in html
     assert 'grid-template-columns: repeat(2, minmax(0, 1fr)) !important' in html

--- a/services/zoe-ui/dist/touch/css/skybridge-data-widgets.css
+++ b/services/zoe-ui/dist/touch/css/skybridge-data-widgets.css
@@ -96,13 +96,13 @@ body:not(.sky-empty) .sky-list-switcher {
 }
 
 body:not(.sky-empty) .sky-list-tab {
-    min-height: 42px;
+    min-height: 56px;
     display: flex;
     align-items: center;
     justify-content: center;
     border-radius: 16px;
     border: 1px solid rgba(255,255,255,0.14);
-    padding: 8px 10px;
+    padding: 12px 14px;
     color: rgba(255,255,255,0.88);
     background: rgba(255,255,255,0.08);
     font: inherit;
@@ -113,7 +113,7 @@ body:not(.sky-empty) .sky-list-tab span {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    font-size: 0.86rem;
+    font-size: 1rem;
     font-weight: 850;
 }
 
@@ -320,6 +320,11 @@ body:not(.sky-empty) .sky-people-list {
     gap: 10px;
 }
 
+body:not(.sky-empty) .sky-list-items.is-list-detail {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    align-content: start;
+}
+
 body:not(.sky-empty) .sky-list-item-row,
 body:not(.sky-empty) .sky-list-overview-row,
 body:not(.sky-empty) .sky-person-row {
@@ -335,6 +340,17 @@ body:not(.sky-empty) .sky-person-row {
 
 body:not(.sky-empty) .sky-list-item-row {
     grid-template-columns: auto minmax(0, 1fr) auto;
+}
+
+body:not(.sky-empty) .sky-list-item-row.is-recent {
+    border-color: rgba(90,224,224,0.42);
+    background: linear-gradient(145deg, rgba(90,224,224,0.18), rgba(255,255,255,0.09));
+    box-shadow: inset 0 1px 0 rgba(255,255,255,0.16), 0 12px 28px rgba(90,224,224,0.08);
+}
+
+body:not(.sky-empty) .sky-list-item-row.is-recent .sky-list-check {
+    border-color: rgba(90,224,224,0.74);
+    background: rgba(90,224,224,0.14);
 }
 
 body:not(.sky-empty) .sky-person-row {

--- a/services/zoe-ui/dist/touch/js/skybridge-renderer.js
+++ b/services/zoe-ui/dist/touch/js/skybridge-renderer.js
@@ -359,11 +359,12 @@
         const isObject = typeof item === 'object' && item;
         const title = isObject ? (item.text || item.title || item.label || 'List item') : String(item || 'List item');
         const completed = !!(isObject && item.completed);
+        const recent = !!(isObject && item.recent);
         const detail = isObject ? [item.quantity, item.category, item.assigned_to].filter(Boolean).join(' · ') : '';
         const priorityValue = isObject && item.priority ? String(item.priority).trim().toLowerCase() : '';
         const priority = priorityValue && priorityValue !== 'normal' ? '<b>' + escapeHtml(item.priority) + '</b>' : '';
         return [
-            '<div class="sky-list-item-row' + (completed ? ' is-done' : '') + '">',
+            '<div class="sky-list-item-row' + (completed ? ' is-done' : '') + (recent ? ' is-recent' : '') + '">',
             '<div class="sky-list-check" aria-hidden="true">' + (completed ? '✓' : '') + '</div>',
             '<div class="sky-list-item-main"><strong>' + escapeHtml(title) + '</strong>' + (detail ? '<em>' + escapeHtml(detail) + '</em>' : '') + '</div>',
             priority ? '<div class="sky-list-item-meta">' + priority + '</div>' : '',
@@ -394,9 +395,10 @@
         const listType = props.list_type || (lists[0] && lists[0].list_type) || 'all';
         const accent = listAccentClass(listType);
         const selectedId = props.list_id && props.list_id !== 'lists-overview' ? props.list_id : '';
-        const visibleItems = items.slice(0, 12);
+        const visibleItems = items.slice(0, 16);
         const rows = visibleItems.map(renderListItemRow).join('');
         const overviewRows = !items.length && lists.length ? '<div class="sky-list-columns">' + lists.slice(0, 6).map(renderListColumn).join('') + '</div>' : '';
+        const itemsClass = 'sky-list-items ' + (rows ? 'is-list-detail' : 'is-list-overview');
         const empty = [
             '<div class="sky-empty-data sky-list-empty">',
             '<strong>No items in ' + escapeHtml(props.list_name || 'this list') + '</strong>',
@@ -406,7 +408,7 @@
         const body = [
             '<div class="sky-list-scene ' + escapeHtml(accent) + '">',
             renderListSwitcher(lists, selectedId),
-            '<div class="sky-list-items">' + (rows || overviewRows || empty) + '</div>',
+            '<div class="' + itemsClass + '">' + (rows || overviewRows || empty) + '</div>',
             '</div>'
         ].join('');
         return cardFrame(Object.assign({ status: 'Lists', icon: 'L' }, props), body, { wide: true, tone: 'zoe-list-card ' + accent, hideHeader: true, hideStatus: true, hideActions: true });

--- a/services/zoe-ui/dist/touch/skybridge.html
+++ b/services/zoe-ui/dist/touch/skybridge.html
@@ -4149,17 +4149,17 @@
 
             body:not(.sky-empty) .zoe-list-card .sky-list-switcher {
                 grid-template-columns: repeat(4, minmax(0, 1fr)) !important;
-                gap: 7px !important;
+                gap: 9px !important;
             }
 
             body:not(.sky-empty) .zoe-list-card .sky-list-tab {
-                min-height: 42px !important;
-                padding: 8px 10px !important;
-                border-radius: 14px !important;
+                min-height: 56px !important;
+                padding: 12px 14px !important;
+                border-radius: 16px !important;
             }
 
             body:not(.sky-empty) .zoe-list-card .sky-list-tab span {
-                font-size: 14px !important;
+                font-size: 18px !important;
             }
 
             body:not(.sky-empty) .zoe-list-card .sky-list-items,
@@ -4171,10 +4171,14 @@
             }
 
             body:not(.sky-empty) .zoe-list-card .sky-list-items {
-                gap: 6px !important;
+                gap: 8px !important;
             }
 
-            body:not(.sky-empty) .zoe-list-card .sky-list-item-row:nth-child(n+10),
+            body:not(.sky-empty) .zoe-list-card .sky-list-items.is-list-detail {
+                grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+            }
+
+            body:not(.sky-empty) .zoe-list-card .sky-list-item-row:nth-child(n+17),
             body:not(.sky-empty) .zoe-list-card .sky-list-overview-row:nth-child(n+7),
             body:not(.sky-empty) .people-card .sky-person-row:nth-child(n+6) {
                 display: none !important;
@@ -4190,8 +4194,8 @@
 
             body:not(.sky-empty) .zoe-list-card .sky-list-item-row,
             body:not(.sky-empty) .zoe-list-card .sky-list-overview-row {
-                min-height: 44px !important;
-                padding: 7px 12px !important;
+                min-height: 48px !important;
+                padding: 8px 12px !important;
                 border-radius: 16px !important;
             }
 


### PR DESCRIPTION
## Summary
- route short follow-up list add commands through the visible Skybridge list context
- prefer the speaking user\047s default list over another shared family list when adding items
- keep newly added list items visible and highlighted, with larger list tabs and two-column touch-panel item rows

## Why
Voice adds could succeed in the backend but not appear on the visible card, especially when the panel context was already on a list or when a shared guest/family list was selected ahead of the speaking user\047s own list.

## Validation
- `python3 -m pytest services/zoe-data/tests/test_skybridge_service.py services/zoe-data/tests/test_skybridge_static.py services/zoe-data/tests/test_card_service.py services/zoe-data/tests/test_voice_weather_queue.py -q`
- live Skybridge render check on Zoe host confirmed the newly added shopping item appears first, highlighted, in a two-column panel layout; test item was soft-deleted afterward
