### PR TITLE
Wire Pi shadow correction rollback evidence

### DIFF
--- a/docs/architecture/zoe-pi-runtime-harness.md
+++ b/docs/architecture/zoe-pi-runtime-harness.md
@@ -77,10 +77,12 @@ GET /api/system/pi-intent/shadow-status
 The first runtime slice reports agreement and latency for all records. When a
 record includes `outcome_label`, the admin report also converts it into the same
 Pi promotion scoring contract used by `pi_promotion_eval.py`, including
-`promotable_groups` and `rollback_groups`. Unlabeled records are never treated as
-accuracy evidence. Pi live execution remains separately gated by
-`ZOE_PI_INTENT_PROMOTED_GROUPS`, so enabling the classifier alone does not promote
-all Pi classifications into executable Zoe routes. The report includes a read-only
+`promotable_groups` and `rollback_groups`. Reviewed records may also set
+`user_corrected=true` or `rollback_blocked=true`; those fields feed the same
+rollback gates as synthetic promotion samples. Unlabeled records are never treated
+as accuracy evidence. Pi live execution remains separately gated by
+`ZOE_PI_INTENT_PROMOTED_GROUPS`, so enabling the classifier alone does not
+promote all Pi classifications into executable Zoe routes. The report includes a read-only
 `promotion_actions.env.ZOE_PI_INTENT_PROMOTED_GROUPS` recommendation for operator
 review; Zoe does not rewrite env or auto-promote groups from shadow evidence.
 Operators can inspect or explicitly apply that single env update with:

--- a/services/zoe-data/pi_intent_shadow.py
+++ b/services/zoe-data/pi_intent_shadow.py
@@ -197,7 +197,9 @@ def shadow_records_to_route_samples(records: Sequence[Mapping[str, Any]]) -> lis
                     pi_confidence=_float_value(record.get("pi_confidence"), default=0.0),
                     pi_transport=str(record.get("pi_transport") or "rpc"),
                     route_class=str(record.get("route_class") or "fallback"),
-                    timed_out=bool(record.get("timed_out")),
+                    timed_out=_bool_record_value(record.get("timed_out")),
+                    user_corrected=_bool_record_value(record.get("user_corrected")),
+                    rollback_blocked=_bool_record_value(record.get("rollback_blocked")),
                     metadata={"source": "pi_intent_shadow", "text_hash": str(record.get("text_hash") or "")},
                 )
             )
@@ -311,6 +313,16 @@ def _optional_float_value(value: Any) -> float | None:
         return float(value)
     except (TypeError, ValueError):
         return None
+
+
+def _bool_record_value(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)
 
 
 def _csv_env(value: str | None) -> list[str]:

--- a/services/zoe-data/tests/test_pi_intent_shadow.py
+++ b/services/zoe-data/tests/test_pi_intent_shadow.py
@@ -12,6 +12,7 @@ from pi_intent_shadow import (
     shadow_records_to_route_samples,
     summarize_pi_intent_shadow,
 )
+from zoe_pi_promotion import PiPromotionPolicy
 
 
 @pytest.mark.asyncio
@@ -352,8 +353,10 @@ def test_shadow_status_lists_rollback_groups_for_labeled_promoted_regression(tmp
 
 def test_shadow_status_rolls_back_promoted_group_on_reviewed_corrections(tmp_path):
     path = tmp_path / "shadow.jsonl"
+    policy = PiPromotionPolicy()
+    correction_count = int(policy.max_correction_rate * policy.min_samples) + 1
     rows = []
-    for index in range(30):
+    for index in range(policy.min_samples):
         rows.append(
             json.dumps(
                 {
@@ -369,7 +372,7 @@ def test_shadow_status_rolls_back_promoted_group_on_reviewed_corrections(tmp_pat
                     "agreement": False,
                     "timed_out": False,
                     "pi_no_result": False,
-                    "user_corrected": index == 0,
+                    "user_corrected": index < correction_count,
                 }
             )
         )
@@ -386,3 +389,52 @@ def test_shadow_status_rolls_back_promoted_group_on_reviewed_corrections(tmp_pat
         decision for decision in status["promotion_report"]["decisions"] if decision["intent_group"] == "weather"
     )
     assert weather["state"] == "rollback"
+    assert "correction_rate_too_high" in weather["blockers"]
+    assert status["promotion_report"]["promotion_actions"]["rollback_groups"] == ["weather"]
+
+
+def test_shadow_status_blocks_promoted_group_on_reviewed_rollback_block(tmp_path):
+    path = tmp_path / "shadow.jsonl"
+    rows = []
+    for index in range(PiPromotionPolicy().min_samples):
+        rows.append(
+            json.dumps(
+                {
+                    "text_hash": f"weather_blocked_{index}",
+                    "outcome_label": "weather",
+                    "zoe_intent": "reminder_list",
+                    "pi_intent": "weather",
+                    "zoe_latency_ms": 500,
+                    "pi_latency_ms": 120,
+                    "pi_confidence": 0.9,
+                    "pi_transport": "rpc",
+                    "route_class": "fallback",
+                    "agreement": False,
+                    "timed_out": False,
+                    "pi_no_result": False,
+                    "rollback_blocked": index == 0,
+                }
+            )
+        )
+    path.write_text("\n".join(rows) + "\n")
+
+    status = pi_intent_shadow_status(
+        {
+            "ZOE_PI_INTENT_SHADOW_PATH": str(path),
+            "ZOE_PI_INTENT_PROMOTED_GROUPS": "weather",
+        }
+    )
+
+    weather = next(
+        decision for decision in status["promotion_report"]["decisions"] if decision["intent_group"] == "weather"
+    )
+    assert weather["state"] == "blocked"
+    assert "rollback_blocked" in weather["blockers"]
+    assert status["promotion_report"]["promotion_actions"] == {
+        "promote_groups": [],
+        "rollback_groups": [],
+        "keep_promoted_groups": ["weather"],
+        "next_promoted_groups": ["weather"],
+        "env": {"ZOE_PI_INTENT_PROMOTED_GROUPS": "weather"},
+        "requires_operator_apply": False,
+    }

--- a/services/zoe-data/tests/test_pi_intent_shadow.py
+++ b/services/zoe-data/tests/test_pi_intent_shadow.py
@@ -209,6 +209,8 @@ def test_labeled_shadow_records_convert_to_route_samples():
                 "pi_confidence": 0.9,
                 "pi_transport": "rpc",
                 "route_class": "fallback",
+                "user_corrected": "true",
+                "rollback_blocked": False,
             },
             {"outcome_label": "extend_capability", "zoe_intent": None, "pi_intent": "extend_capability"},
         ]
@@ -218,6 +220,8 @@ def test_labeled_shadow_records_convert_to_route_samples():
     assert samples[0].intent_group == "weather"
     assert samples[0].zoe_correct is False
     assert samples[0].pi_correct is True
+    assert samples[0].user_corrected is True
+    assert samples[0].rollback_blocked is False
 
 
 def test_labeled_shadow_records_skip_missing_latency():
@@ -344,3 +348,41 @@ def test_shadow_status_lists_rollback_groups_for_labeled_promoted_regression(tmp
 
     assert "weather" in status["promotion_report"]["rollback_groups"]
     assert status["promotion_report"]["promotion_actions"]["next_promoted_groups"] == []
+
+
+def test_shadow_status_rolls_back_promoted_group_on_reviewed_corrections(tmp_path):
+    path = tmp_path / "shadow.jsonl"
+    rows = []
+    for index in range(30):
+        rows.append(
+            json.dumps(
+                {
+                    "text_hash": f"weather_corrected_{index}",
+                    "outcome_label": "weather",
+                    "zoe_intent": "reminder_list",
+                    "pi_intent": "weather",
+                    "zoe_latency_ms": 500,
+                    "pi_latency_ms": 120,
+                    "pi_confidence": 0.9,
+                    "pi_transport": "rpc",
+                    "route_class": "fallback",
+                    "agreement": False,
+                    "timed_out": False,
+                    "pi_no_result": False,
+                    "user_corrected": index == 0,
+                }
+            )
+        )
+    path.write_text("\n".join(rows) + "\n")
+
+    status = pi_intent_shadow_status(
+        {
+            "ZOE_PI_INTENT_SHADOW_PATH": str(path),
+            "ZOE_PI_INTENT_PROMOTED_GROUPS": "weather",
+        }
+    )
+
+    weather = next(
+        decision for decision in status["promotion_report"]["decisions"] if decision["intent_group"] == "weather"
+    )
+    assert weather["state"] == "rollback"


### PR DESCRIPTION
## Summary
- pass reviewed user_corrected and rollback_blocked flags from Pi shadow JSONL records into PiRouteSample scoring
- add rollback status coverage for promoted groups with reviewed correction evidence
- document reviewed correction/rollback fields in the Pi runtime harness

## Tests
- python3 -m py_compile services/zoe-data/pi_intent_shadow.py services/zoe-data/zoe_pi_promotion.py
- python3 -m pytest -q services/zoe-data/tests/test_pi_intent_shadow.py services/zoe-data/tests/test_zoe_pi_promotion.py services/zoe-data/tests/test_pi_promotion_apply.py services/zoe-data/tests/test_pi_promotion_eval_script.py services/zoe-data/tests/test_pi_intent_status_endpoint.py
- python3 tools/audit/validate_structure.py
- python3 tools/audit/validate_critical_files.py
- git diff --check
- python3 -m pytest -q services/zoe-data/tests/test_pi_intent_evidence.py services/zoe-data/tests/test_pi_eval_export.py services/zoe-data/tests/test_pi_promotion_eval_script.py services/zoe-data/tests/test_zoe_pi_promotion.py services/zoe-data/tests/test_pi_promotion_apply.py services/zoe-data/tests/test_pi_intent_shadow.py services/zoe-data/tests/test_pi_intent_classifier.py services/zoe-data/tests/test_pi_intent_status_endpoint.py services/zoe-data/tests/test_pi_runtime_probe.py