### PR TITLE
Add Pi promotion failure examples

### DIFF
--- a/docs/architecture/zoe-pi-runtime-harness.md
+++ b/docs/architecture/zoe-pi-runtime-harness.md
@@ -79,7 +79,9 @@ record includes `outcome_label`, the admin report also converts it into the same
 Pi promotion scoring contract used by `pi_promotion_eval.py`, including
 `promotable_groups` and `rollback_groups`. Reviewed records may also set
 `user_corrected=true` or `rollback_blocked=true`; those fields feed the same
-rollback gates as synthetic promotion samples. Unlabeled records are never treated
+rollback gates as synthetic promotion samples. The promotion report includes
+compact `failure_examples` with IDs, intents, latency, transport, and reason
+flags, but not raw text or text previews. Unlabeled records are never treated
 as accuracy evidence. Pi live execution remains separately gated by
 `ZOE_PI_INTENT_PROMOTED_GROUPS`, so enabling the classifier alone does not
 promote all Pi classifications into executable Zoe routes. The report includes a read-only

--- a/services/zoe-data/tests/test_pi_intent_shadow.py
+++ b/services/zoe-data/tests/test_pi_intent_shadow.py
@@ -438,3 +438,37 @@ def test_shadow_status_blocks_promoted_group_on_reviewed_rollback_block(tmp_path
         "env": {"ZOE_PI_INTENT_PROMOTED_GROUPS": "weather"},
         "requires_operator_apply": False,
     }
+
+
+def test_shadow_status_includes_failure_examples_without_text(tmp_path):
+    path = tmp_path / "shadow.jsonl"
+    path.write_text(
+        json.dumps(
+            {
+                "text_hash": "weather_failure_hash",
+                "outcome_label": "weather",
+                "zoe_intent": "weather",
+                "pi_intent": "reminder_list",
+                "zoe_latency_ms": 120,
+                "pi_latency_ms": 500,
+                "pi_confidence": 0.9,
+                "pi_transport": "rpc",
+                "route_class": "fallback",
+                "agreement": False,
+                "timed_out": False,
+                "pi_no_result": False,
+                "text_preview": "rain later",
+            }
+        )
+        + "\n"
+    )
+
+    status = pi_intent_shadow_status({"ZOE_PI_INTENT_SHADOW_PATH": str(path)})
+
+    examples = status["promotion_report"]["failure_examples"]
+    assert len(examples) == 1
+    assert examples[0]["case_id"] == "weather_failure_hash"
+    assert examples[0]["reasons"] == ["pi_wrong_intent"]
+    assert examples[0]["source"] == "pi_intent_shadow"
+    assert "text_preview" not in examples[0]
+    assert "rain later" not in json.dumps(examples)

--- a/services/zoe-data/tests/test_zoe_pi_promotion.py
+++ b/services/zoe-data/tests/test_zoe_pi_promotion.py
@@ -277,6 +277,12 @@ def test_failure_examples_prioritize_review_and_timeout_signals():
     assert "text" not in examples[0]
 
 
+def test_failure_examples_separate_timeout_from_wrong_intent():
+    examples = build_pi_failure_examples([_sample(1, pi="weather", timed_out=True)])
+
+    assert examples[0]["reasons"] == ["timed_out"]
+
+
 def test_summary_lists_promotable_groups():
     samples = [_sample(i) for i in range(10)]
     report = summarize_pi_promotion(samples, policy=PiPromotionPolicy(min_samples=10))

--- a/services/zoe-data/tests/test_zoe_pi_promotion.py
+++ b/services/zoe-data/tests/test_zoe_pi_promotion.py
@@ -5,6 +5,7 @@ from zoe_pi_promotion import (
     PiIntentEvalCase,
     PiPromotionPolicy,
     PiRouteSample,
+    build_pi_failure_examples,
     build_pi_promotion_actions,
     eval_cases_to_dict,
     evaluate_pi_promotion,
@@ -254,6 +255,26 @@ def test_sample_rejects_secret_metadata():
 
     with pytest.raises(ValueError, match="secret field"):
         sample.validate()
+
+
+def test_failure_examples_prioritize_review_and_timeout_signals():
+    examples = build_pi_failure_examples(
+        [
+            _sample(1, pi="reminder_list", pi_ms=200, metadata={"source": "synthetic"}),
+            _sample(2, pi=None, pi_ms=900, timed_out=True),
+            _sample(3, user_corrected=True, pi_ms=150),
+            _sample(4, rollback_blocked=True, pi_ms=100),
+            _sample(5, pi="weather"),
+        ],
+        limit=3,
+    )
+
+    assert [item["case_id"] for item in examples] == ["case_4", "case_3", "case_2"]
+    assert examples[0]["reasons"] == ["rollback_blocked"]
+    assert examples[1]["reasons"] == ["user_corrected"]
+    assert examples[2]["reasons"] == ["timed_out", "pi_wrong_intent"]
+    assert examples[2]["pi_intent"] is None
+    assert "text" not in examples[0]
 
 
 def test_summary_lists_promotable_groups():

--- a/services/zoe-data/zoe_pi_promotion.py
+++ b/services/zoe-data/zoe_pi_promotion.py
@@ -485,7 +485,7 @@ def _failure_reasons(sample: PiRouteSample) -> list[str]:
         reasons.append("user_corrected")
     if sample.timed_out:
         reasons.append("timed_out")
-    if not sample.pi_correct:
+    if sample.pi_intent != sample.expected_intent:
         reasons.append("pi_wrong_intent")
     return reasons
 

--- a/services/zoe-data/zoe_pi_promotion.py
+++ b/services/zoe-data/zoe_pi_promotion.py
@@ -344,12 +344,55 @@ def summarize_pi_promotion(
         "decisions": decisions,
         "promotable_groups": promotable_groups,
         "rollback_groups": rollback_groups,
+        "failure_examples": build_pi_failure_examples(samples),
         "promotion_actions": build_pi_promotion_actions(
             current_promoted_groups=sorted(active_promoted_groups),
             promotable_groups=promotable_groups,
             rollback_groups=rollback_groups,
         ),
     }
+
+
+def build_pi_failure_examples(samples: Sequence[PiRouteSample], *, limit: int = 5) -> list[dict[str, Any]]:
+    examples: list[tuple[tuple[int, float], dict[str, Any]]] = []
+    for sample in samples:
+        sample.validate()
+        reasons = _failure_reasons(sample)
+        if not reasons:
+            continue
+        severity = 0
+        if sample.rollback_blocked:
+            severity = max(severity, 4)
+        if sample.user_corrected:
+            severity = max(severity, 3)
+        if sample.timed_out:
+            severity = max(severity, 2)
+        if "pi_wrong_intent" in reasons:
+            severity = max(severity, 1)
+        source = _optional_str(sample.metadata.get("source")) if isinstance(sample.metadata, Mapping) else None
+        examples.append(
+            (
+                (severity, sample.pi_latency_ms),
+                {
+                    "case_id": sample.case_id,
+                    "intent_group": sample.intent_group,
+                    "expected_intent": sample.expected_intent,
+                    "zoe_intent": sample.zoe_intent,
+                    "pi_intent": sample.pi_intent,
+                    "route_class": sample.route_class,
+                    "pi_transport": sample.pi_transport,
+                    "reasons": reasons,
+                    "timed_out": sample.timed_out,
+                    "user_corrected": sample.user_corrected,
+                    "rollback_blocked": sample.rollback_blocked,
+                    "zoe_latency_ms": sample.zoe_latency_ms,
+                    "pi_latency_ms": sample.pi_latency_ms,
+                    "source": source,
+                },
+            )
+        )
+    ranked = sorted(examples, key=lambda item: (-item[0][0], -item[0][1], item[1]["case_id"]))
+    return [example for _, example in ranked[: max(0, limit)]]
 
 
 def build_pi_promotion_actions(
@@ -432,6 +475,19 @@ def summarize_eval_case_sources(cases: Sequence[PiIntentEvalCase]) -> dict[str, 
 
 def eval_cases_to_dict(cases: Sequence[PiIntentEvalCase] = DEFAULT_PI_INTENT_EVAL_CASES) -> list[dict[str, Any]]:
     return [case.to_dict() for case in cases]
+
+
+def _failure_reasons(sample: PiRouteSample) -> list[str]:
+    reasons: list[str] = []
+    if sample.rollback_blocked:
+        reasons.append("rollback_blocked")
+    if sample.user_corrected:
+        reasons.append("user_corrected")
+    if sample.timed_out:
+        reasons.append("timed_out")
+    if not sample.pi_correct:
+        reasons.append("pi_wrong_intent")
+    return reasons
 
 
 def _dedupe_eval_cases(cases: Sequence[PiIntentEvalCase]) -> list[PiIntentEvalCase]:
@@ -517,6 +573,7 @@ __all__ = [
     "PiPromotionDecision",
     "PiPromotionPolicy",
     "PiRouteSample",
+    "build_pi_failure_examples",
     "build_pi_promotion_actions",
     "eval_cases_to_dict",
     "evaluate_pi_promotion",


### PR DESCRIPTION
## Summary
- add compact failure_examples to Pi promotion reports for wrong Pi intents, timeouts, corrections, and rollback blocks
- keep examples evidence-oriented without raw text or text previews
- surface failure examples through Pi shadow status and document the field

## Tests
- python3 -m py_compile services/zoe-data/zoe_pi_promotion.py services/zoe-data/pi_intent_shadow.py
- python3 -m pytest -q services/zoe-data/tests/test_zoe_pi_promotion.py services/zoe-data/tests/test_pi_intent_shadow.py services/zoe-data/tests/test_pi_promotion_eval_script.py services/zoe-data/tests/test_pi_intent_status_endpoint.py
- python3 tools/audit/validate_structure.py
- python3 tools/audit/validate_critical_files.py
- git diff --check
- python3 -m pytest -q services/zoe-data/tests/test_pi_intent_evidence.py services/zoe-data/tests/test_pi_eval_export.py services/zoe-data/tests/test_pi_promotion_eval_script.py services/zoe-data/tests/test_zoe_pi_promotion.py services/zoe-data/tests/test_pi_promotion_apply.py services/zoe-data/tests/test_pi_intent_shadow.py services/zoe-data/tests/test_pi_intent_classifier.py services/zoe-data/tests/test_pi_intent_status_endpoint.py services/zoe-data/tests/test_pi_runtime_probe.py