### PR TITLE
Expose Pi auto-promote status

### DIFF
--- a/docs/architecture/zoe-pi-runtime-harness.md
+++ b/docs/architecture/zoe-pi-runtime-harness.md
@@ -49,6 +49,7 @@ Environment variables:
 | `ZOE_PI_INTENT_SHADOW_FORCE_ENABLED` | `true` | Force the classifier on inside shadow mode while keeping live routing unchanged. |
 | `ZOE_PI_INTENT_MISS_EVIDENCE_ENABLED` | `false` | Write sanitized intent-miss candidate rows for later review/labeling. |
 | `ZOE_PI_INTENT_MISS_EVIDENCE_PATH` | `~/.zoe/data/pi-intent-miss-evidence.jsonl` | JSONL path for structured intent-miss candidates. |
+| `ZOE_PI_INTENT_AUTO_PROMOTE` | `false` | Report whether automatic Pi promotion was requested. Current runtime remains evidence-only and requires the guarded apply helper. |
 | `ZOE_PI_INTENT_PROMOTED_GROUPS` | unset | Comma-separated low-risk intent groups promoted through Pi for live fallback execution and rollback reporting. Unknown or privileged groups are ignored. |
 
 ## Probe
@@ -87,6 +88,8 @@ as accuracy evidence. Pi live execution remains separately gated by
 promote all Pi classifications into executable Zoe routes. The report includes a read-only
 `promotion_actions.env.ZOE_PI_INTENT_PROMOTED_GROUPS` recommendation for operator
 review; Zoe does not rewrite env or auto-promote groups from shadow evidence.
+`ZOE_PI_INTENT_AUTO_PROMOTE=true` is reported for visibility, but current runtime
+still requires the guarded apply helper rather than silently editing configuration.
 Operators can inspect or explicitly apply that single env update with:
 
 ```bash

--- a/services/zoe-data/pi_intent_classifier.py
+++ b/services/zoe-data/pi_intent_classifier.py
@@ -193,13 +193,13 @@ def pi_intent_promotion_status(env: Mapping[str, str] | None = None) -> dict[str
     requested_groups, active_groups, ignored_groups = _pi_intent_promotion_groups(
         values.get("ZOE_PI_INTENT_PROMOTED_GROUPS") or ""
     )
-    auto_promote_enabled = _env_bool(values.get("ZOE_PI_INTENT_AUTO_PROMOTE"), default=False)
+    auto_promote_requested = _env_bool(values.get("ZOE_PI_INTENT_AUTO_PROMOTE"), default=False)
     return {
-        "auto_promote_enabled": auto_promote_enabled,
-        "auto_promote_status": "evidence_only" if not auto_promote_enabled else "requires_explicit_apply_path",
+        "auto_promote_requested": auto_promote_requested,
+        "auto_promote_status": "evidence_only" if not auto_promote_requested else "requires_explicit_apply_path",
         "auto_promote_reason": (
             "ZOE_PI_INTENT_AUTO_PROMOTE is false; reports remain recommendations only"
-            if not auto_promote_enabled
+            if not auto_promote_requested
             else "auto-promote is requested but this runtime only exposes guarded promotion actions"
         ),
         "requested_groups": list(requested_groups),

--- a/services/zoe-data/pi_intent_classifier.py
+++ b/services/zoe-data/pi_intent_classifier.py
@@ -193,7 +193,15 @@ def pi_intent_promotion_status(env: Mapping[str, str] | None = None) -> dict[str
     requested_groups, active_groups, ignored_groups = _pi_intent_promotion_groups(
         values.get("ZOE_PI_INTENT_PROMOTED_GROUPS") or ""
     )
+    auto_promote_enabled = _env_bool(values.get("ZOE_PI_INTENT_AUTO_PROMOTE"), default=False)
     return {
+        "auto_promote_enabled": auto_promote_enabled,
+        "auto_promote_status": "evidence_only" if not auto_promote_enabled else "requires_explicit_apply_path",
+        "auto_promote_reason": (
+            "ZOE_PI_INTENT_AUTO_PROMOTE is false; reports remain recommendations only"
+            if not auto_promote_enabled
+            else "auto-promote is requested but this runtime only exposes guarded promotion actions"
+        ),
         "requested_groups": list(requested_groups),
         "active_groups": list(active_groups),
         "ignored_groups": list(ignored_groups),

--- a/services/zoe-data/tests/test_pi_intent_classifier.py
+++ b/services/zoe-data/tests/test_pi_intent_classifier.py
@@ -123,7 +123,7 @@ def test_pi_intent_status_is_available_with_explicit_operator_gates(tmp_path):
 def test_pi_intent_promotion_status_filters_to_low_risk_groups():
     status = pi_intent_promotion_status({"ZOE_PI_INTENT_PROMOTED_GROUPS": "weather,device_control,reminders"})
 
-    assert status["auto_promote_enabled"] is False
+    assert status["auto_promote_requested"] is False
     assert status["auto_promote_status"] == "evidence_only"
     assert status["active_groups"] == ["reminders", "weather"]
     assert status["ignored_groups"] == ["device_control"]
@@ -139,7 +139,7 @@ def test_pi_intent_promotion_status_reports_auto_promote_request_without_enablin
         }
     )
 
-    assert status["auto_promote_enabled"] is True
+    assert status["auto_promote_requested"] is True
     assert status["auto_promote_status"] == "requires_explicit_apply_path"
     assert status["active_groups"] == []
     assert status["ignored_groups"] == ["device_control"]

--- a/services/zoe-data/tests/test_pi_intent_classifier.py
+++ b/services/zoe-data/tests/test_pi_intent_classifier.py
@@ -123,10 +123,27 @@ def test_pi_intent_status_is_available_with_explicit_operator_gates(tmp_path):
 def test_pi_intent_promotion_status_filters_to_low_risk_groups():
     status = pi_intent_promotion_status({"ZOE_PI_INTENT_PROMOTED_GROUPS": "weather,device_control,reminders"})
 
+    assert status["auto_promote_enabled"] is False
+    assert status["auto_promote_status"] == "evidence_only"
     assert status["active_groups"] == ["reminders", "weather"]
     assert status["ignored_groups"] == ["device_control"]
     assert pi_intent_is_promoted("weather", {"ZOE_PI_INTENT_PROMOTED_GROUPS": "weather"}) is True
     assert pi_intent_is_promoted("extend_capability", {"ZOE_PI_INTENT_PROMOTED_GROUPS": "extend_capability"}) is False
+
+
+def test_pi_intent_promotion_status_reports_auto_promote_request_without_enabling_groups():
+    status = pi_intent_promotion_status(
+        {
+            "ZOE_PI_INTENT_AUTO_PROMOTE": "true",
+            "ZOE_PI_INTENT_PROMOTED_GROUPS": "device_control",
+        }
+    )
+
+    assert status["auto_promote_enabled"] is True
+    assert status["auto_promote_status"] == "requires_explicit_apply_path"
+    assert status["active_groups"] == []
+    assert status["ignored_groups"] == ["device_control"]
+    assert "guarded promotion actions" in status["auto_promote_reason"]
 
 
 def test_pi_intent_promotion_status_cache_tracks_env_value(monkeypatch):

--- a/services/zoe-data/tests/test_pi_intent_status_endpoint.py
+++ b/services/zoe-data/tests/test_pi_intent_status_endpoint.py
@@ -128,7 +128,7 @@ def test_pi_intent_status_endpoint_reports_available_with_explicit_gates(tmp_pat
     assert data["ok"] is True
     assert data["status"] == "available"
     assert data["config"]["transport"] == "rpc"
-    assert data["promotion"]["auto_promote_enabled"] is True
+    assert data["promotion"]["auto_promote_requested"] is True
     assert data["promotion"]["auto_promote_status"] == "requires_explicit_apply_path"
     assert data["promotion"]["active_groups"] == ["weather"]
     assert data["promotion"]["ignored_groups"] == ["device_control"]

--- a/services/zoe-data/tests/test_pi_intent_status_endpoint.py
+++ b/services/zoe-data/tests/test_pi_intent_status_endpoint.py
@@ -115,6 +115,7 @@ def test_pi_intent_status_endpoint_reports_available_with_explicit_gates(tmp_pat
     monkeypatch.setenv("ZOE_PI_INTENT_ENABLED", "true")
     monkeypatch.setenv("ZOE_PI_INTENT_TRANSPORT", "rpc")
     monkeypatch.setenv("ZOE_PI_INTENT_PROMOTED_GROUPS", "weather,device_control")
+    monkeypatch.setenv("ZOE_PI_INTENT_AUTO_PROMOTE", "true")
     monkeypatch.setenv("ZOE_PI_CWD", str(tmp_path))
     monkeypatch.setenv("ZOE_PI_ALLOW_EXECUTION", "true")
     monkeypatch.setenv("ZOE_PI_LOCAL_MODEL_CONFIGURED", "true")
@@ -127,6 +128,8 @@ def test_pi_intent_status_endpoint_reports_available_with_explicit_gates(tmp_pat
     assert data["ok"] is True
     assert data["status"] == "available"
     assert data["config"]["transport"] == "rpc"
+    assert data["promotion"]["auto_promote_enabled"] is True
+    assert data["promotion"]["auto_promote_status"] == "requires_explicit_apply_path"
     assert data["promotion"]["active_groups"] == ["weather"]
     assert data["promotion"]["ignored_groups"] == ["device_control"]
     assert data["probe"]["config"]["allow_execution"] is True


### PR DESCRIPTION
## Summary
- add ZOE_PI_INTENT_AUTO_PROMOTE to Pi promotion status as a visibility-only flag
- keep current runtime evidence-only: auto-promote requests still require guarded promotion actions/apply helper
- document the env var and cover the admin status surface

## Tests
- python3 -m py_compile services/zoe-data/pi_intent_classifier.py
- python3 -m pytest -q services/zoe-data/tests/test_pi_intent_classifier.py services/zoe-data/tests/test_pi_intent_status_endpoint.py
- python3 -m pytest -q services/zoe-data/tests/test_pi_intent_evidence.py services/zoe-data/tests/test_pi_eval_export.py services/zoe-data/tests/test_pi_promotion_eval_script.py services/zoe-data/tests/test_zoe_pi_promotion.py services/zoe-data/tests/test_pi_promotion_apply.py services/zoe-data/tests/test_pi_intent_shadow.py services/zoe-data/tests/test_pi_intent_classifier.py services/zoe-data/tests/test_pi_intent_status_endpoint.py services/zoe-data/tests/test_pi_runtime_probe.py
- python3 tools/audit/validate_structure.py
- python3 tools/audit/validate_critical_files.py
- git diff --check