### PR TITLE
Add Pi route class promotion breakdown

### DIFF
--- a/docs/architecture/zoe-pi-runtime-harness.md
+++ b/docs/architecture/zoe-pi-runtime-harness.md
@@ -81,9 +81,11 @@ Pi promotion scoring contract used by `pi_promotion_eval.py`, including
 `promotable_groups` and `rollback_groups`. Reviewed records may also set
 `user_corrected=true` or `rollback_blocked=true`; those fields feed the same
 rollback gates as synthetic promotion samples. The promotion report includes
-compact `failure_examples` with IDs, intents, latency, transport, and reason
-flags, but not raw text or text previews. Unlabeled records are never treated
-as accuracy evidence. Pi live execution remains separately gated by
+`route_class_breakdown` for deterministic, fallback, and extraction-failed
+baselines, plus compact `failure_examples` with IDs, intents, latency,
+transport, and reason flags, but not raw text or text previews. Unlabeled
+records are never treated as accuracy evidence. Pi live execution remains
+separately gated by
 `ZOE_PI_INTENT_PROMOTED_GROUPS`, so enabling the classifier alone does not
 promote all Pi classifications into executable Zoe routes. The report includes a read-only
 `promotion_actions.env.ZOE_PI_INTENT_PROMOTED_GROUPS` recommendation for operator

--- a/docs/architecture/zoe-pi-runtime-harness.md
+++ b/docs/architecture/zoe-pi-runtime-harness.md
@@ -81,7 +81,7 @@ Pi promotion scoring contract used by `pi_promotion_eval.py`, including
 `promotable_groups` and `rollback_groups`. Reviewed records may also set
 `user_corrected=true` or `rollback_blocked=true`; those fields feed the same
 rollback gates as synthetic promotion samples. The promotion report includes
-`route_class_breakdown` for deterministic, fallback, and extraction-failed
+`route_class_breakdown` for deterministic, fallback, and extraction_failed
 baselines, plus compact `failure_examples` with IDs, intents, latency,
 transport, and reason flags, but not raw text or text previews. Unlabeled
 records are never treated as accuracy evidence. Pi live execution remains

--- a/services/zoe-data/tests/test_zoe_pi_promotion.py
+++ b/services/zoe-data/tests/test_zoe_pi_promotion.py
@@ -309,6 +309,9 @@ def test_route_class_breakdown_compares_baselines_independently():
     assert breakdown["fallback"]["zoe_accuracy"] == 0.0
     assert breakdown["fallback"]["pi_accuracy"] == 0.5
     assert breakdown["fallback"]["accuracy_delta"] == 0.5
+    assert breakdown["fallback"]["zoe_p95_latency_ms"] == 895.0
+    assert breakdown["fallback"]["pi_p95_latency_ms"] == 1155.0
+    assert breakdown["fallback"]["latency_delta_ms"] == -260.0
     assert breakdown["fallback"]["timeout_rate"] == 0.5
     assert breakdown["extraction_failed"]["sample_count"] == 0
     assert breakdown["extraction_failed"]["zoe_p95_latency_ms"] is None

--- a/services/zoe-data/tests/test_zoe_pi_promotion.py
+++ b/services/zoe-data/tests/test_zoe_pi_promotion.py
@@ -6,6 +6,7 @@ from zoe_pi_promotion import (
     PiPromotionPolicy,
     PiRouteSample,
     build_pi_failure_examples,
+    build_pi_route_class_breakdown,
     build_pi_promotion_actions,
     eval_cases_to_dict,
     evaluate_pi_promotion,
@@ -283,6 +284,36 @@ def test_failure_examples_separate_timeout_from_wrong_intent():
     assert examples[0]["reasons"] == ["timed_out"]
 
 
+def test_route_class_breakdown_compares_baselines_independently():
+    samples = [
+        _sample(1, route_class="deterministic", zoe="weather", pi="weather", zoe_ms=40, pi_ms=80),
+        _sample(2, route_class="fallback", zoe="reminder_list", pi="weather", zoe_ms=900, pi_ms=300),
+        _sample(3, route_class="fallback", zoe="reminder_list", pi=None, zoe_ms=800, pi_ms=1200, timed_out=True),
+    ]
+
+    breakdown = build_pi_route_class_breakdown(samples)
+
+    assert sorted(breakdown) == ["deterministic", "extraction_failed", "fallback"]
+    assert breakdown["deterministic"] == {
+        "sample_count": 1,
+        "zoe_accuracy": 1.0,
+        "pi_accuracy": 1.0,
+        "accuracy_delta": 0.0,
+        "zoe_p95_latency_ms": 40.0,
+        "pi_p95_latency_ms": 80.0,
+        "latency_delta_ms": -40.0,
+        "timeout_rate": 0.0,
+        "correction_rate": 0.0,
+    }
+    assert breakdown["fallback"]["sample_count"] == 2
+    assert breakdown["fallback"]["zoe_accuracy"] == 0.0
+    assert breakdown["fallback"]["pi_accuracy"] == 0.5
+    assert breakdown["fallback"]["accuracy_delta"] == 0.5
+    assert breakdown["fallback"]["timeout_rate"] == 0.5
+    assert breakdown["extraction_failed"]["sample_count"] == 0
+    assert breakdown["extraction_failed"]["zoe_p95_latency_ms"] is None
+
+
 def test_summary_lists_promotable_groups():
     samples = [_sample(i) for i in range(10)]
     report = summarize_pi_promotion(samples, policy=PiPromotionPolicy(min_samples=10))
@@ -291,6 +322,8 @@ def test_summary_lists_promotable_groups():
     assert report["promoted_groups"] == []
     assert report["sample_count"] == 10
     assert report["policy"]["accuracy_win_margin"] == 0.05
+    assert report["route_class_breakdown"]["fallback"]["sample_count"] == 10
+    assert report["route_class_breakdown"]["fallback"]["latency_delta_ms"] > 0
 
 
 def test_summary_lists_rollback_groups_for_active_promotions():

--- a/services/zoe-data/zoe_pi_promotion.py
+++ b/services/zoe-data/zoe_pi_promotion.py
@@ -362,12 +362,13 @@ def build_pi_route_class_breakdown(samples: Sequence[PiRouteSample]) -> dict[str
             sample.validate()
         zoe_p95 = _percentile([sample.zoe_latency_ms for sample in route_samples], 95)
         pi_p95 = _percentile([sample.pi_latency_ms for sample in route_samples], 95)
+        zoe_accuracy = _rate(sample.zoe_correct for sample in route_samples)
+        pi_accuracy = _rate(sample.pi_correct for sample in route_samples)
         breakdown[route_class] = {
             "sample_count": len(route_samples),
-            "zoe_accuracy": _rate(sample.zoe_correct for sample in route_samples),
-            "pi_accuracy": _rate(sample.pi_correct for sample in route_samples),
-            "accuracy_delta": _rate(sample.pi_correct for sample in route_samples)
-            - _rate(sample.zoe_correct for sample in route_samples),
+            "zoe_accuracy": zoe_accuracy,
+            "pi_accuracy": pi_accuracy,
+            "accuracy_delta": pi_accuracy - zoe_accuracy,
             "zoe_p95_latency_ms": zoe_p95,
             "pi_p95_latency_ms": pi_p95,
             "latency_delta_ms": None if zoe_p95 is None or pi_p95 is None else zoe_p95 - pi_p95,

--- a/services/zoe-data/zoe_pi_promotion.py
+++ b/services/zoe-data/zoe_pi_promotion.py
@@ -344,6 +344,7 @@ def summarize_pi_promotion(
         "decisions": decisions,
         "promotable_groups": promotable_groups,
         "rollback_groups": rollback_groups,
+        "route_class_breakdown": build_pi_route_class_breakdown(samples),
         "failure_examples": build_pi_failure_examples(samples),
         "promotion_actions": build_pi_promotion_actions(
             current_promoted_groups=sorted(active_promoted_groups),
@@ -351,6 +352,29 @@ def summarize_pi_promotion(
             rollback_groups=rollback_groups,
         ),
     }
+
+
+def build_pi_route_class_breakdown(samples: Sequence[PiRouteSample]) -> dict[str, dict[str, Any]]:
+    breakdown: dict[str, dict[str, Any]] = {}
+    for route_class in sorted(ROUTE_CLASSES):
+        route_samples = [sample for sample in samples if sample.route_class == route_class]
+        for sample in route_samples:
+            sample.validate()
+        zoe_p95 = _percentile([sample.zoe_latency_ms for sample in route_samples], 95)
+        pi_p95 = _percentile([sample.pi_latency_ms for sample in route_samples], 95)
+        breakdown[route_class] = {
+            "sample_count": len(route_samples),
+            "zoe_accuracy": _rate(sample.zoe_correct for sample in route_samples),
+            "pi_accuracy": _rate(sample.pi_correct for sample in route_samples),
+            "accuracy_delta": _rate(sample.pi_correct for sample in route_samples)
+            - _rate(sample.zoe_correct for sample in route_samples),
+            "zoe_p95_latency_ms": zoe_p95,
+            "pi_p95_latency_ms": pi_p95,
+            "latency_delta_ms": None if zoe_p95 is None or pi_p95 is None else zoe_p95 - pi_p95,
+            "timeout_rate": _rate(sample.timed_out for sample in route_samples),
+            "correction_rate": _rate(sample.user_corrected for sample in route_samples),
+        }
+    return breakdown
 
 
 def build_pi_failure_examples(samples: Sequence[PiRouteSample], *, limit: int = 5) -> list[dict[str, Any]]:
@@ -574,6 +598,7 @@ __all__ = [
     "PiPromotionPolicy",
     "PiRouteSample",
     "build_pi_failure_examples",
+    "build_pi_route_class_breakdown",
     "build_pi_promotion_actions",
     "eval_cases_to_dict",
     "evaluate_pi_promotion",


### PR DESCRIPTION
## Summary
- add route_class_breakdown to Pi promotion reports for deterministic, fallback, and extraction-failed baselines
- include per-route-class sample count, Zoe/Pi accuracy, accuracy delta, p95 latency, latency delta, timeout rate, and correction rate
- document the report field in the Pi runtime harness

## Tests
- python3 -m py_compile services/zoe-data/zoe_pi_promotion.py
- python3 -m pytest -q services/zoe-data/tests/test_zoe_pi_promotion.py
- python3 -m pytest -q services/zoe-data/tests/test_pi_intent_evidence.py services/zoe-data/tests/test_pi_eval_export.py services/zoe-data/tests/test_pi_promotion_eval_script.py services/zoe-data/tests/test_zoe_pi_promotion.py services/zoe-data/tests/test_pi_promotion_apply.py services/zoe-data/tests/test_pi_intent_shadow.py services/zoe-data/tests/test_pi_intent_classifier.py services/zoe-data/tests/test_pi_intent_status_endpoint.py services/zoe-data/tests/test_pi_runtime_probe.py
- python3 tools/audit/validate_structure.py
- python3 tools/audit/validate_critical_files.py
- git diff --check