### PR TITLE
Add Pi promotion transport breakdown

### DIFF
--- a/docs/architecture/zoe-pi-runtime-harness.md
+++ b/docs/architecture/zoe-pi-runtime-harness.md
@@ -82,8 +82,9 @@ Pi promotion scoring contract used by `pi_promotion_eval.py`, including
 `user_corrected=true` or `rollback_blocked=true`; those fields feed the same
 rollback gates as synthetic promotion samples. The promotion report includes
 `route_class_breakdown` for deterministic, fallback, and extraction_failed
-baselines, plus compact `failure_examples` with IDs, intents, latency,
-transport, and reason flags, but not raw text or text previews. Unlabeled
+baselines, `transport_breakdown` for print vs RPC latency and accuracy, plus
+compact `failure_examples` with IDs, intents, latency, transport, and reason
+flags, but not raw text or text previews. Unlabeled
 records are never treated as accuracy evidence. Pi live execution remains
 separately gated by
 `ZOE_PI_INTENT_PROMOTED_GROUPS`, so enabling the classifier alone does not

--- a/services/zoe-data/tests/test_zoe_pi_promotion.py
+++ b/services/zoe-data/tests/test_zoe_pi_promotion.py
@@ -7,6 +7,7 @@ from zoe_pi_promotion import (
     PiRouteSample,
     build_pi_failure_examples,
     build_pi_route_class_breakdown,
+    build_pi_transport_breakdown,
     build_pi_promotion_actions,
     eval_cases_to_dict,
     evaluate_pi_promotion,
@@ -317,6 +318,36 @@ def test_route_class_breakdown_compares_baselines_independently():
     assert breakdown["extraction_failed"]["zoe_p95_latency_ms"] is None
 
 
+def test_transport_breakdown_separates_print_and_rpc_latency():
+    samples = [
+        _sample(1, pi_transport="print", zoe_ms=900, pi_ms=700),
+        _sample(2, pi_transport="rpc", zoe_ms=900, pi_ms=300),
+        _sample(3, pi_transport="rpc", zoe="weather", pi="weather", zoe_ms=50, pi_ms=80),
+    ]
+
+    breakdown = build_pi_transport_breakdown(samples)
+
+    assert sorted(breakdown) == ["print", "rpc"]
+    assert breakdown["print"] == {
+        "sample_count": 1,
+        "zoe_accuracy": 0.0,
+        "pi_accuracy": 1.0,
+        "accuracy_delta": 1.0,
+        "zoe_p95_latency_ms": 900.0,
+        "pi_p95_latency_ms": 700.0,
+        "latency_delta_ms": 200.0,
+        "timeout_rate": 0.0,
+        "correction_rate": 0.0,
+    }
+    assert breakdown["rpc"]["sample_count"] == 2
+    assert breakdown["rpc"]["zoe_accuracy"] == 0.5
+    assert breakdown["rpc"]["pi_accuracy"] == 1.0
+    assert breakdown["rpc"]["accuracy_delta"] == 0.5
+    assert breakdown["rpc"]["zoe_p95_latency_ms"] == 857.5
+    assert breakdown["rpc"]["pi_p95_latency_ms"] == 289.0
+    assert breakdown["rpc"]["latency_delta_ms"] == 568.5
+
+
 def test_summary_lists_promotable_groups():
     samples = [_sample(i) for i in range(10)]
     report = summarize_pi_promotion(samples, policy=PiPromotionPolicy(min_samples=10))
@@ -327,6 +358,8 @@ def test_summary_lists_promotable_groups():
     assert report["policy"]["accuracy_win_margin"] == 0.05
     assert report["route_class_breakdown"]["fallback"]["sample_count"] == 10
     assert report["route_class_breakdown"]["fallback"]["latency_delta_ms"] > 0
+    assert report["transport_breakdown"]["rpc"]["sample_count"] == 10
+    assert report["transport_breakdown"]["rpc"]["latency_delta_ms"] > 0
 
 
 def test_summary_lists_rollback_groups_for_active_promotions():

--- a/services/zoe-data/tests/test_zoe_pi_promotion.py
+++ b/services/zoe-data/tests/test_zoe_pi_promotion.py
@@ -322,7 +322,16 @@ def test_transport_breakdown_separates_print_and_rpc_latency():
     samples = [
         _sample(1, pi_transport="print", zoe_ms=900, pi_ms=700),
         _sample(2, pi_transport="rpc", zoe_ms=900, pi_ms=300),
-        _sample(3, pi_transport="rpc", zoe="weather", pi="weather", zoe_ms=50, pi_ms=80),
+        _sample(
+            3,
+            pi_transport="rpc",
+            zoe="weather",
+            pi="weather",
+            zoe_ms=50,
+            pi_ms=1200,
+            timed_out=True,
+            user_corrected=True,
+        ),
     ]
 
     breakdown = build_pi_transport_breakdown(samples)
@@ -341,11 +350,13 @@ def test_transport_breakdown_separates_print_and_rpc_latency():
     }
     assert breakdown["rpc"]["sample_count"] == 2
     assert breakdown["rpc"]["zoe_accuracy"] == 0.5
-    assert breakdown["rpc"]["pi_accuracy"] == 1.0
-    assert breakdown["rpc"]["accuracy_delta"] == 0.5
+    assert breakdown["rpc"]["pi_accuracy"] == 0.5
+    assert breakdown["rpc"]["accuracy_delta"] == 0.0
     assert breakdown["rpc"]["zoe_p95_latency_ms"] == 857.5
-    assert breakdown["rpc"]["pi_p95_latency_ms"] == 289.0
-    assert breakdown["rpc"]["latency_delta_ms"] == 568.5
+    assert breakdown["rpc"]["pi_p95_latency_ms"] == 1155.0
+    assert breakdown["rpc"]["latency_delta_ms"] == -297.5
+    assert breakdown["rpc"]["timeout_rate"] == 0.5
+    assert breakdown["rpc"]["correction_rate"] == 0.5
 
 
 def test_summary_lists_promotable_groups():

--- a/services/zoe-data/zoe_pi_promotion.py
+++ b/services/zoe-data/zoe_pi_promotion.py
@@ -35,6 +35,7 @@ PRIVILEGED_INTENTS = {
 
 EVAL_SOURCES = {"synthetic", "intent_miss", "chat_log", "voice_log", "known_failure"}
 ROUTE_CLASSES = {"deterministic", "fallback", "extraction_failed"}
+PI_TRANSPORTS = {"print", "rpc"}
 DECISION_STATES = {"promote", "keep_shadow", "rollback", "blocked"}
 
 
@@ -132,7 +133,7 @@ class PiRouteSample:
             raise ValueError(f"{self.case_id}: pi_confidence must be between 0 and 1")
         if self.route_class not in ROUTE_CLASSES:
             raise ValueError(f"{self.case_id}: unknown route_class {self.route_class!r}")
-        if self.pi_transport not in {"print", "rpc"}:
+        if self.pi_transport not in PI_TRANSPORTS:
             raise ValueError(f"{self.case_id}: unknown pi_transport {self.pi_transport!r}")
         _reject_secret_keys(self.metadata, sample_id=self.case_id)
 
@@ -345,6 +346,7 @@ def summarize_pi_promotion(
         "promotable_groups": promotable_groups,
         "rollback_groups": rollback_groups,
         "route_class_breakdown": build_pi_route_class_breakdown(samples),
+        "transport_breakdown": build_pi_transport_breakdown(samples),
         "failure_examples": build_pi_failure_examples(samples),
         "promotion_actions": build_pi_promotion_actions(
             current_promoted_groups=sorted(active_promoted_groups),
@@ -374,6 +376,30 @@ def build_pi_route_class_breakdown(samples: Sequence[PiRouteSample]) -> dict[str
             "latency_delta_ms": None if zoe_p95 is None or pi_p95 is None else zoe_p95 - pi_p95,
             "timeout_rate": _rate(sample.timed_out for sample in route_samples),
             "correction_rate": _rate(sample.user_corrected for sample in route_samples),
+        }
+    return breakdown
+
+
+def build_pi_transport_breakdown(samples: Sequence[PiRouteSample]) -> dict[str, dict[str, Any]]:
+    breakdown: dict[str, dict[str, Any]] = {}
+    for transport in sorted(PI_TRANSPORTS):
+        transport_samples = [sample for sample in samples if sample.pi_transport == transport]
+        for sample in transport_samples:
+            sample.validate()
+        zoe_p95 = _percentile([sample.zoe_latency_ms for sample in transport_samples], 95)
+        pi_p95 = _percentile([sample.pi_latency_ms for sample in transport_samples], 95)
+        zoe_accuracy = _rate(sample.zoe_correct for sample in transport_samples)
+        pi_accuracy = _rate(sample.pi_correct for sample in transport_samples)
+        breakdown[transport] = {
+            "sample_count": len(transport_samples),
+            "zoe_accuracy": zoe_accuracy,
+            "pi_accuracy": pi_accuracy,
+            "accuracy_delta": pi_accuracy - zoe_accuracy,
+            "zoe_p95_latency_ms": zoe_p95,
+            "pi_p95_latency_ms": pi_p95,
+            "latency_delta_ms": None if zoe_p95 is None or pi_p95 is None else zoe_p95 - pi_p95,
+            "timeout_rate": _rate(sample.timed_out for sample in transport_samples),
+            "correction_rate": _rate(sample.user_corrected for sample in transport_samples),
         }
     return breakdown
 
@@ -594,12 +620,14 @@ __all__ = [
     "DEFAULT_PI_INTENT_EVAL_CASES",
     "LOW_RISK_PI_INTENT_GROUPS",
     "PRIVILEGED_INTENTS",
+    "PI_TRANSPORTS",
     "PiIntentEvalCase",
     "PiPromotionDecision",
     "PiPromotionPolicy",
     "PiRouteSample",
     "build_pi_failure_examples",
     "build_pi_route_class_breakdown",
+    "build_pi_transport_breakdown",
     "build_pi_promotion_actions",
     "eval_cases_to_dict",
     "evaluate_pi_promotion",

--- a/services/zoe-data/zoe_pi_promotion.py
+++ b/services/zoe-data/zoe_pi_promotion.py
@@ -381,6 +381,11 @@ def build_pi_route_class_breakdown(samples: Sequence[PiRouteSample]) -> dict[str
 
 
 def build_pi_transport_breakdown(samples: Sequence[PiRouteSample]) -> dict[str, dict[str, Any]]:
+    """Summarize Pi print and RPC evidence separately.
+
+    Empty buckets retain the existing promotion-report convention: rates and
+    accuracy fields are 0.0, while sample_count=0 is the no-evidence signal.
+    """
     breakdown: dict[str, dict[str, Any]] = {}
     for transport in sorted(PI_TRANSPORTS):
         transport_samples = [sample for sample in samples if sample.pi_transport == transport]


### PR DESCRIPTION
## Summary
- add transport_breakdown to Pi promotion reports so print and RPC evidence are judged separately
- export the new helper and cover mixed latency/accuracy behavior
- document the new report field in the Pi runtime harness

## Tests
- python3 -m py_compile services/zoe-data/zoe_pi_promotion.py
- python3 -m pytest -q services/zoe-data/tests/test_zoe_pi_promotion.py
- python3 -m pytest -q services/zoe-data/tests/test_pi_intent_evidence.py services/zoe-data/tests/test_pi_eval_export.py services/zoe-data/tests/test_pi_promotion_eval_script.py services/zoe-data/tests/test_zoe_pi_promotion.py services/zoe-data/tests/test_pi_promotion_apply.py services/zoe-data/tests/test_pi_intent_shadow.py services/zoe-data/tests/test_pi_intent_classifier.py services/zoe-data/tests/test_pi_intent_status_endpoint.py services/zoe-data/tests/test_pi_runtime_probe.py
- git diff --check
- python3 tools/audit/validate_structure.py
- python3 tools/audit/validate_critical_files.py
- python3 scripts/maintenance/pi_promotion_eval.py --demo --min-samples 10