### PR TITLE
Harden Pi RPC intent worker

### DIFF
--- a/docs/architecture/zoe-pi-runtime-harness.md
+++ b/docs/architecture/zoe-pi-runtime-harness.md
@@ -130,8 +130,11 @@ scripts/maintenance/pi_promotion_eval.py \
 ```
 
 Add `--run-pi --transport rpc` only when the local/offline Pi intent runtime is
-configured. The report still remains evidence-only; `ZOE_PI_INTENT_PROMOTED_GROUPS`
-changes must pass the promotion actions and guarded apply helper described above.
+configured. The RPC path keeps a warm worker but resets it on timeout or task
+cancellation, and ignores response events whose request id does not match the
+current prompt. The report still remains evidence-only;
+`ZOE_PI_INTENT_PROMOTED_GROUPS` changes must pass the promotion actions and
+guarded apply helper described above.
 
 Sanitized JSONL evidence can be exported into the same eval-case format. For Pi
 shadow records this uses `text_preview` plus a trusted `outcome_label`; unlabeled,

--- a/services/zoe-data/pi_intent_classifier.py
+++ b/services/zoe-data/pi_intent_classifier.py
@@ -440,7 +440,9 @@ def _rpc_event_matches_request(event: Mapping[str, Any], request_id: str) -> boo
     turn = event.get("turn")
     if isinstance(turn, Mapping):
         event_ids.extend([turn.get("id"), turn.get("request_id"), turn.get("requestId")])
-    present_ids = [str(value) for value in event_ids if value]
+    present_ids = [str(value) for value in event_ids if value is not None]
+    if event.get("type") == "agent_end" and not present_ids:
+        return False
     return not present_ids or request_id in present_ids
 
 

--- a/services/zoe-data/pi_intent_classifier.py
+++ b/services/zoe-data/pi_intent_classifier.py
@@ -371,7 +371,7 @@ class _PiRpcIntentWorker:
                 payload = json.dumps({"id": request_id, "type": "prompt", "message": prompt}, separators=(",", ":"))
                 self.proc.stdin.write((payload + "\n").encode())
                 await self.proc.stdin.drain()
-                return await asyncio.wait_for(self._read_turn(), timeout=timeout_seconds)
+                return await asyncio.wait_for(self._read_turn(request_id), timeout=timeout_seconds)
             except BaseException:
                 await self._reset_process_locked()
                 raise
@@ -403,7 +403,7 @@ class _PiRpcIntentWorker:
             env=self.env,
         )
 
-    async def _read_turn(self) -> str:
+    async def _read_turn(self, request_id: str) -> str:
         assert self.proc is not None and self.proc.stdout is not None
         latest_text = ""
         while True:
@@ -413,6 +413,8 @@ class _PiRpcIntentWorker:
             try:
                 event = json.loads(line.decode(errors="replace"))
             except json.JSONDecodeError:
+                continue
+            if not _rpc_event_matches_request(event, request_id):
                 continue
             text = _assistant_text_from_rpc_event(event)
             if text:
@@ -431,6 +433,15 @@ def _rpc_worker_for(config: PiIntentClassifierConfig, env: Mapping[str, str]) ->
         worker = _PiRpcIntentWorker(config, env)
         _RPC_WORKERS[key] = worker
     return worker
+
+
+def _rpc_event_matches_request(event: Mapping[str, Any], request_id: str) -> bool:
+    event_ids = [event.get("id"), event.get("request_id"), event.get("requestId")]
+    turn = event.get("turn")
+    if isinstance(turn, Mapping):
+        event_ids.extend([turn.get("id"), turn.get("request_id"), turn.get("requestId")])
+    present_ids = [str(value) for value in event_ids if value]
+    return not present_ids or request_id in present_ids
 
 
 def _assistant_text_from_rpc_event(event: Mapping[str, Any]) -> str:

--- a/services/zoe-data/tests/test_pi_intent_classifier.py
+++ b/services/zoe-data/tests/test_pi_intent_classifier.py
@@ -71,13 +71,15 @@ def _fake_rpc_runtime(tmp_path, *, response=None):
         "        fh.write(json.dumps({'event': 'start', 'argv': sys.argv, 'openai': os.environ.get('OPENAI_API_KEY'), 'openrouter': os.environ.get('OPENROUTER_API_KEY')}) + '\\n')\n"
         "payload = json.loads(os.environ['PI_TEST_PAYLOAD'])\n"
         "for line in sys.stdin:\n"
+        "    request = json.loads(line)\n"
         "    if record:\n"
         "        with open(record, 'a') as fh:\n"
-        "            fh.write(json.dumps({'event': 'request', 'body': json.loads(line)}) + '\\n')\n"
+        "            fh.write(json.dumps({'event': 'request', 'body': request}) + '\\n')\n"
         "    text = json.dumps(payload)\n"
-        "    print(json.dumps({'type': 'message_end', 'message': {'role': 'assistant', 'content': [{'type': 'text', 'text': text}]}}), flush=True)\n"
-        "    print(json.dumps({'type': 'turn_end', 'message': {'role': 'assistant', 'content': [{'type': 'text', 'text': text}]}}), flush=True)\n"
-        "    print(json.dumps({'type': 'agent_end', 'messages': [{'role': 'assistant', 'content': [{'type': 'text', 'text': text}]}]}), flush=True)\n",
+        "    event_id = request.get('id')\n"
+        "    print(json.dumps({'id': event_id, 'type': 'message_end', 'message': {'role': 'assistant', 'content': [{'type': 'text', 'text': text}]}}), flush=True)\n"
+        "    print(json.dumps({'id': event_id, 'type': 'turn_end', 'message': {'role': 'assistant', 'content': [{'type': 'text', 'text': text}]}}), flush=True)\n"
+        "    print(json.dumps({'id': event_id, 'type': 'agent_end', 'messages': [{'role': 'assistant', 'content': [{'type': 'text', 'text': text}]}]}), flush=True)\n",
     )
     return bindir, payload
 
@@ -326,8 +328,10 @@ async def test_pi_rpc_ignores_stale_response_with_mismatched_request_id(tmp_path
         f"fresh_payload = {json.dumps(fresh_payload)}\n"
         "for line in sys.stdin:\n"
         "    request = json.loads(line)\n"
+        "    idless = {'type': 'agent_end', 'messages': [{'role': 'assistant', 'content': [{'type': 'text', 'text': stale_payload}]}]}\n"
         "    stale = {'id': 'stale-request', 'type': 'agent_end', 'messages': [{'role': 'assistant', 'content': [{'type': 'text', 'text': stale_payload}]}]}\n"
         "    fresh = {'id': request['id'], 'type': 'agent_end', 'messages': [{'role': 'assistant', 'content': [{'type': 'text', 'text': fresh_payload}]}]}\n"
+        "    print(json.dumps(idless), flush=True)\n"
         "    print(json.dumps(stale), flush=True)\n"
         "    print(json.dumps(fresh), flush=True)\n",
     )

--- a/services/zoe-data/tests/test_pi_intent_classifier.py
+++ b/services/zoe-data/tests/test_pi_intent_classifier.py
@@ -297,15 +297,23 @@ async def test_pi_rpc_cancellation_resets_process_under_worker_lock(tmp_path, mo
     }
 
     task = asyncio.create_task(classify_with_pi_intent_governor("rain later", env=env))
-    for _ in range(100):
-        if record.exists():
-            break
-        await asyncio.sleep(0.01)
-    assert record.exists()
+    try:
+        for _ in range(100):
+            if record.exists():
+                break
+            await asyncio.sleep(0.01)
+        assert record.exists()
 
-    task.cancel()
-    with pytest.raises(asyncio.CancelledError):
-        await task
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+    finally:
+        if not task.done():
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
 
     assert len(workers) == 1
     worker = next(iter(workers.values()))

--- a/services/zoe-data/tests/test_pi_intent_classifier.py
+++ b/services/zoe-data/tests/test_pi_intent_classifier.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import os
 
@@ -260,6 +261,98 @@ async def test_pi_rpc_timeout_resets_process_under_worker_lock(tmp_path, monkeyp
     assert len(workers) == 1
     worker = next(iter(workers.values()))
     assert worker.proc is None
+
+
+@pytest.mark.asyncio
+async def test_pi_rpc_cancellation_resets_process_under_worker_lock(tmp_path, monkeypatch):
+    bindir = tmp_path / "rpc-cancel-bin"
+    bindir.mkdir()
+    _write_exe(bindir / "node", "#!/bin/sh\nexit 0\n")
+    _write_exe(bindir / "npm", "#!/bin/sh\nexit 0\n")
+    record = tmp_path / "rpc-cancel-record.jsonl"
+    _write_exe(
+        bindir / "pi",
+        "#!/usr/bin/python3\n"
+        "import json, os, sys, time\n"
+        "record = os.environ['PI_TEST_RECORD']\n"
+        "for line in sys.stdin:\n"
+        "    with open(record, 'a') as fh:\n"
+        "        fh.write(json.dumps({'event': 'request', 'body': json.loads(line)}) + '\\n')\n"
+        "    time.sleep(10)\n",
+    )
+    workers = {}
+    monkeypatch.setattr(pi_intent_classifier, "_RPC_WORKERS", workers)
+    env = {
+        "PATH": str(bindir),
+        "ZOE_PI_INTENT_ENABLED": "true",
+        "ZOE_PI_INTENT_TRANSPORT": "rpc",
+        "ZOE_PI_COMMAND": "pi",
+        "ZOE_PI_CWD": str(tmp_path),
+        "ZOE_PI_ALLOW_EXECUTION": "true",
+        "ZOE_PI_LOCAL_MODEL_CONFIGURED": "true",
+        "ZOE_PI_INTENT_TIMEOUT_SECONDS": "5",
+        "PI_TEST_RECORD": str(record),
+    }
+
+    task = asyncio.create_task(classify_with_pi_intent_governor("rain later", env=env))
+    for _ in range(100):
+        if record.exists():
+            break
+        await asyncio.sleep(0.01)
+    assert record.exists()
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert len(workers) == 1
+    worker = next(iter(workers.values()))
+    assert worker.proc is None
+
+
+@pytest.mark.asyncio
+async def test_pi_rpc_ignores_stale_response_with_mismatched_request_id(tmp_path, monkeypatch):
+    bindir = tmp_path / "rpc-stale-bin"
+    bindir.mkdir()
+    _write_exe(bindir / "node", "#!/bin/sh\nexit 0\n")
+    _write_exe(bindir / "npm", "#!/bin/sh\nexit 0\n")
+    stale_payload = json.dumps({"intent": "reminder_list", "slots": {}, "confidence": 0.99, "task_lane": "fast_tool"})
+    fresh_payload = json.dumps({"intent": "weather", "slots": {"forecast": True}, "confidence": 0.92, "task_lane": "fast_tool"})
+    _write_exe(
+        bindir / "pi",
+        "#!/usr/bin/python3\n"
+        "import json, sys\n"
+        f"stale_payload = {json.dumps(stale_payload)}\n"
+        f"fresh_payload = {json.dumps(fresh_payload)}\n"
+        "for line in sys.stdin:\n"
+        "    request = json.loads(line)\n"
+        "    stale = {'id': 'stale-request', 'type': 'agent_end', 'messages': [{'role': 'assistant', 'content': [{'type': 'text', 'text': stale_payload}]}]}\n"
+        "    fresh = {'id': request['id'], 'type': 'agent_end', 'messages': [{'role': 'assistant', 'content': [{'type': 'text', 'text': fresh_payload}]}]}\n"
+        "    print(json.dumps(stale), flush=True)\n"
+        "    print(json.dumps(fresh), flush=True)\n",
+    )
+    workers = {}
+    monkeypatch.setattr(pi_intent_classifier, "_RPC_WORKERS", workers)
+    env = {
+        "PATH": str(bindir),
+        "ZOE_PI_INTENT_ENABLED": "true",
+        "ZOE_PI_INTENT_TRANSPORT": "rpc",
+        "ZOE_PI_COMMAND": "pi",
+        "ZOE_PI_CWD": str(tmp_path),
+        "ZOE_PI_ALLOW_EXECUTION": "true",
+        "ZOE_PI_LOCAL_MODEL_CONFIGURED": "true",
+        "ZOE_PI_INTENT_TIMEOUT_SECONDS": "2",
+    }
+
+    try:
+        result = await classify_with_pi_intent_governor("rain later", env=env)
+    finally:
+        for worker in list(workers.values()):
+            await worker.reset()
+
+    assert result is not None
+    assert result.intent == "weather"
+    assert result.slots == {"forecast": True}
 
 
 def test_pi_prompt_sanitizes_user_json_braces():


### PR DESCRIPTION
## Summary
- make Pi RPC intent reads request-id aware so stale events from another turn are ignored
- add RPC cancellation-reset and stale-output regression tests
- document RPC worker reset and request-id behavior in the Pi runtime harness

## Tests
- python3 -m py_compile services/zoe-data/pi_intent_classifier.py
- python3 -m pytest -q services/zoe-data/tests/test_pi_intent_classifier.py
- python3 -m pytest -q services/zoe-data/tests/test_pi_intent_evidence.py services/zoe-data/tests/test_pi_eval_export.py services/zoe-data/tests/test_pi_promotion_eval_script.py services/zoe-data/tests/test_zoe_pi_promotion.py services/zoe-data/tests/test_pi_promotion_apply.py services/zoe-data/tests/test_pi_intent_shadow.py services/zoe-data/tests/test_pi_intent_classifier.py services/zoe-data/tests/test_pi_intent_status_endpoint.py services/zoe-data/tests/test_pi_runtime_probe.py
- git diff --check
- python3 tools/audit/validate_structure.py
- python3 tools/audit/validate_critical_files.py