### PR TITLE
[codex] Add Pi runtime readiness requirements

### DIFF
--- a/docs/architecture/zoe-pi-runtime-harness.md
+++ b/docs/architecture/zoe-pi-runtime-harness.md
@@ -27,6 +27,17 @@ On the clean Zoe worktree:
 - execution status: disabled and acceptable;
 - enabled execution status: blocked until runtime prerequisites and local model config exist.
 
+Current Pi install/readiness facts from upstream docs:
+
+- Pi is distributed as `@earendil-works/pi-coding-agent` and the safe npm install command is
+  `npm install -g --ignore-scripts @earendil-works/pi-coding-agent`.
+- Current Pi requires Node.js `>=22.19.0` based on the Pi 0.75.0 release notes.
+- Zoe's probe may execute `node --version` and `npm --version` for readiness, but it does not
+  execute `pi`, install packages, or run agent/model tasks.
+- Installing Node/Pi remains a Multica-governed runtime change, not an automatic probe action.
+
+Sources checked 2026-06-15: https://pi.dev/docs/latest/quickstart and https://pi.dev/news.
+
 ## Configuration
 
 Environment variables:
@@ -52,6 +63,14 @@ Environment variables:
 | `ZOE_PI_INTENT_AUTO_PROMOTE` | `false` | Report whether automatic Pi promotion was requested. Current runtime remains evidence-only and requires the guarded apply helper. |
 | `ZOE_PI_INTENT_PROMOTED_GROUPS` | unset | Comma-separated low-risk intent groups promoted through Pi for live fallback execution and rollback reporting. Unknown or privileged groups are ignored. |
 
+Readiness report fields:
+
+- `tool_versions.node` / `tool_versions.npm`: read-only version snapshots from `--version`.
+- `requirements.node.minimum`: current Pi Node minimum, currently `22.19.0`.
+- `requirements.node.status`: `missing`, `unknown`, `too_old`, or `ok`.
+- `install_plan.install_command`: the operator-reviewed npm install command.
+- `install_plan.requires_multica_approval`: always `true` for runtime installation.
+
 ## Probe
 
 ```bash
@@ -59,7 +78,8 @@ PYTHONPATH=services/zoe-data python3 scripts/maintenance/pi_runtime_probe.py --j
 ```
 
 The probe is safe to run in production-adjacent environments because it only
-uses filesystem and `PATH` checks. It does not execute `pi`.
+uses filesystem and `PATH` checks plus `node --version` and `npm --version`.
+It does not execute `pi`, install packages, or run agent/model tasks.
 
 ## Intent Shadow Evidence
 

--- a/services/zoe-data/pi_runtime_probe.py
+++ b/services/zoe-data/pi_runtime_probe.py
@@ -126,8 +126,8 @@ def probe_pi_runtime(env: Mapping[str, str] | None = None) -> PiRuntimeProbeResu
         )
 
     tools = _tool_snapshot(config.command, env)
-    tool_versions = _tool_version_snapshot(tools, env)
-    requirements = _pi_requirements_snapshot(node_version=tool_versions.get("node"))
+    tool_versions = _tool_version_snapshot(tools, env, timeout_seconds=config.timeout_seconds)
+    requirements = _pi_requirements_snapshot(node_version=tool_versions.get("node"), node_found=bool(tools.get("node")))
     install_plan = _pi_install_plan_snapshot()
 
     if not config.enabled:
@@ -280,15 +280,25 @@ def _tool_snapshot(pi_command: str, env: Mapping[str, str] | None = None) -> dic
     }
 
 
-def _tool_version_snapshot(tools: Mapping[str, str | None], env: Mapping[str, str] | None = None) -> dict[str, str | None]:
+def _tool_version_snapshot(
+    tools: Mapping[str, str | None],
+    env: Mapping[str, str] | None = None,
+    *,
+    timeout_seconds: float = 1.0,
+) -> dict[str, str | None]:
     return {
-        "node": _command_version(tools.get("node"), env),
-        "npm": _command_version(tools.get("npm"), env),
+        "node": _command_version(tools.get("node"), env, timeout_seconds=timeout_seconds),
+        "npm": _command_version(tools.get("npm"), env, timeout_seconds=timeout_seconds),
         "pi": None,
     }
 
 
-def _command_version(command_path: str | None, env: Mapping[str, str] | None = None) -> str | None:
+def _command_version(
+    command_path: str | None,
+    env: Mapping[str, str] | None = None,
+    *,
+    timeout_seconds: float = 1.0,
+) -> str | None:
     if not command_path:
         return None
     values = dict(os.environ if env is None else env)
@@ -298,7 +308,7 @@ def _command_version(command_path: str | None, env: Mapping[str, str] | None = N
             check=False,
             capture_output=True,
             text=True,
-            timeout=1.0,
+            timeout=timeout_seconds,
             env=values,
         )
     except (OSError, subprocess.SubprocessError):
@@ -307,8 +317,8 @@ def _command_version(command_path: str | None, env: Mapping[str, str] | None = N
     return output[0].strip() if output else None
 
 
-def _pi_requirements_snapshot(*, node_version: str | None = None) -> dict[str, Any]:
-    node_status = "missing" if node_version is None else "unknown"
+def _pi_requirements_snapshot(*, node_version: str | None = None, node_found: bool = False) -> dict[str, Any]:
+    node_status = "unknown" if node_found else "missing"
     parsed = _parse_semver(node_version)
     if parsed is not None:
         node_status = "ok" if parsed >= PI_MIN_NODE_VERSION else "too_old"
@@ -342,7 +352,8 @@ def _parse_semver(value: str | None) -> tuple[int, int, int] | None:
     match = re.search(r"(\d+)\.(\d+)\.(\d+)", value)
     if not match:
         return None
-    return tuple(int(part) for part in match.groups())
+    major, minor, patch = match.groups()
+    return (int(major), int(minor), int(patch))
 
 
 def _format_semver(version: tuple[int, int, int]) -> str:

--- a/services/zoe-data/pi_runtime_probe.py
+++ b/services/zoe-data/pi_runtime_probe.py
@@ -10,9 +10,15 @@ from __future__ import annotations
 import os
 import re
 import shutil
+import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Mapping
+
+
+PI_MIN_NODE_VERSION = (22, 19, 0)
+PI_INSTALL_PACKAGE = "@earendil-works/pi-coding-agent"
+PI_INSTALL_COMMAND = "npm install -g --ignore-scripts @earendil-works/pi-coding-agent"
 
 
 class PiRuntimeConfigError(ValueError):
@@ -82,6 +88,9 @@ class PiRuntimeProbeResult:
     tools: dict[str, str | None]
     agent_files: tuple[dict[str, str | None], ...]
     reason: str | None = None
+    tool_versions: dict[str, str | None] | None = None
+    requirements: dict[str, Any] | None = None
+    install_plan: dict[str, Any] | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -90,6 +99,9 @@ class PiRuntimeProbeResult:
             "status": self.status,
             "config": self.config,
             "tools": self.tools,
+            "tool_versions": self.tool_versions or {},
+            "requirements": self.requirements or _pi_requirements_snapshot(),
+            "install_plan": self.install_plan or _pi_install_plan_snapshot(),
             "agent_files": list(self.agent_files),
             "reason": self.reason,
         }
@@ -107,11 +119,16 @@ def probe_pi_runtime(env: Mapping[str, str] | None = None) -> PiRuntimeProbeResu
             status="misconfigured",
             config=snapshot,
             tools=_tool_snapshot(snapshot.get("command") or "pi", env),
+            requirements=_pi_requirements_snapshot(),
+            install_plan=_pi_install_plan_snapshot(),
             agent_files=(),
             reason=str(exc),
         )
 
     tools = _tool_snapshot(config.command, env)
+    tool_versions = _tool_version_snapshot(tools, env)
+    requirements = _pi_requirements_snapshot(node_version=tool_versions.get("node"))
+    install_plan = _pi_install_plan_snapshot()
 
     if not config.enabled:
         return PiRuntimeProbeResult(
@@ -120,6 +137,9 @@ def probe_pi_runtime(env: Mapping[str, str] | None = None) -> PiRuntimeProbeResu
             status="disabled",
             config=config.to_dict(),
             tools=tools,
+            tool_versions=tool_versions,
+            requirements=requirements,
+            install_plan=install_plan,
             agent_files=(),
             reason="ZOE_PI_ENABLED is false",
         )
@@ -133,8 +153,25 @@ def probe_pi_runtime(env: Mapping[str, str] | None = None) -> PiRuntimeProbeResu
             status="missing_node",
             config=config.to_dict(),
             tools=tools,
+            tool_versions=tool_versions,
+            requirements=requirements,
+            install_plan=install_plan,
             agent_files=agent_files,
             reason="node is required before Pi can run",
+        )
+
+    if requirements["node"].get("status") == "too_old":
+        return PiRuntimeProbeResult(
+            ok=False,
+            acceptable=False,
+            status="node_version_too_old",
+            config=config.to_dict(),
+            tools=tools,
+            tool_versions=tool_versions,
+            requirements=requirements,
+            install_plan=install_plan,
+            agent_files=agent_files,
+            reason=f"node >= {requirements['node']['minimum']} is required for current Pi",
         )
 
     if not tools.get("npm"):
@@ -144,6 +181,9 @@ def probe_pi_runtime(env: Mapping[str, str] | None = None) -> PiRuntimeProbeResu
             status="missing_npm",
             config=config.to_dict(),
             tools=tools,
+            tool_versions=tool_versions,
+            requirements=requirements,
+            install_plan=install_plan,
             agent_files=agent_files,
             reason="npm is required before Pi can be installed or updated",
         )
@@ -155,6 +195,9 @@ def probe_pi_runtime(env: Mapping[str, str] | None = None) -> PiRuntimeProbeResu
             status="missing_pi",
             config=config.to_dict(),
             tools=tools,
+            tool_versions=tool_versions,
+            requirements=requirements,
+            install_plan=install_plan,
             agent_files=agent_files,
             reason="pi command not found",
         )
@@ -173,6 +216,9 @@ def probe_pi_runtime(env: Mapping[str, str] | None = None) -> PiRuntimeProbeResu
         status=status,
         config=config.to_dict(),
         tools=tools,
+        tool_versions=tool_versions,
+        requirements=requirements,
+        install_plan=install_plan,
         agent_files=agent_files,
         reason=reason,
     )
@@ -234,6 +280,75 @@ def _tool_snapshot(pi_command: str, env: Mapping[str, str] | None = None) -> dic
     }
 
 
+def _tool_version_snapshot(tools: Mapping[str, str | None], env: Mapping[str, str] | None = None) -> dict[str, str | None]:
+    return {
+        "node": _command_version(tools.get("node"), env),
+        "npm": _command_version(tools.get("npm"), env),
+        "pi": None,
+    }
+
+
+def _command_version(command_path: str | None, env: Mapping[str, str] | None = None) -> str | None:
+    if not command_path:
+        return None
+    values = dict(os.environ if env is None else env)
+    try:
+        completed = subprocess.run(
+            [command_path, "--version"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=1.0,
+            env=values,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    output = (completed.stdout or completed.stderr or "").strip().splitlines()
+    return output[0].strip() if output else None
+
+
+def _pi_requirements_snapshot(*, node_version: str | None = None) -> dict[str, Any]:
+    node_status = "missing" if node_version is None else "unknown"
+    parsed = _parse_semver(node_version)
+    if parsed is not None:
+        node_status = "ok" if parsed >= PI_MIN_NODE_VERSION else "too_old"
+    return {
+        "node": {
+            "minimum": _format_semver(PI_MIN_NODE_VERSION),
+            "detected": node_version,
+            "status": node_status,
+        },
+        "npm": {"required": True},
+        "pi": {"required": True, "package": PI_INSTALL_PACKAGE},
+        "local_model": {"required_for_execution": True},
+        "offline_only": {"required_for_execution": True},
+    }
+
+
+def _pi_install_plan_snapshot() -> dict[str, Any]:
+    return {
+        "source": "https://pi.dev/docs/latest/quickstart",
+        "node_minimum_source": "https://pi.dev/news",
+        "install_command": PI_INSTALL_COMMAND,
+        "uninstall_command": f"npm uninstall -g {PI_INSTALL_PACKAGE}",
+        "requires_multica_approval": True,
+        "probe_executes_pi": False,
+    }
+
+
+def _parse_semver(value: str | None) -> tuple[int, int, int] | None:
+    if not value:
+        return None
+    match = re.search(r"(\d+)\.(\d+)\.(\d+)", value)
+    if not match:
+        return None
+    return tuple(int(part) for part in match.groups())
+
+
+def _format_semver(version: tuple[int, int, int]) -> str:
+    return ".".join(str(part) for part in version)
+
+
 def _discover_agent_files(config: PiRuntimeConfig) -> list[dict[str, str | None]]:
     agent_dir = Path(config.agent_dir) if config.agent_dir else Path(config.cwd) / ".pi" / "agents"
     if not agent_dir.is_dir():
@@ -266,6 +381,9 @@ def _frontmatter_value(text: str, key: str) -> str | None:
 
 
 __all__ = [
+    "PI_INSTALL_COMMAND",
+    "PI_INSTALL_PACKAGE",
+    "PI_MIN_NODE_VERSION",
     "PiRuntimeConfig",
     "PiRuntimeConfigError",
     "PiRuntimeProbeResult",

--- a/services/zoe-data/tests/test_pi_runtime_probe.py
+++ b/services/zoe-data/tests/test_pi_runtime_probe.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 
-from pi_runtime_probe import PiRuntimeConfig, PiRuntimeConfigError, probe_pi_runtime
+from pi_runtime_probe import PI_INSTALL_COMMAND, PiRuntimeConfig, PiRuntimeConfigError, probe_pi_runtime
 
 
 def test_pi_runtime_defaults_are_disabled_and_offline_only():
@@ -54,6 +54,18 @@ def test_enabled_probe_reports_missing_node_before_pi(monkeypatch):
     assert result.status == "missing_node"
     assert result.acceptable is False
     assert result.reason == "node is required before Pi can run"
+
+
+def test_probe_reports_current_pi_install_requirements_when_disabled(monkeypatch):
+    monkeypatch.setenv("PATH", "")
+
+    payload = probe_pi_runtime(env={"PATH": ""}).to_dict()
+
+    assert payload["requirements"]["node"] == {"minimum": "22.19.0", "detected": None, "status": "missing"}
+    assert payload["requirements"]["pi"]["package"] == "@earendil-works/pi-coding-agent"
+    assert payload["install_plan"]["install_command"] == PI_INSTALL_COMMAND
+    assert payload["install_plan"]["requires_multica_approval"] is True
+    assert payload["install_plan"]["probe_executes_pi"] is False
 
 
 def test_allow_execution_requires_enabled():
@@ -115,6 +127,52 @@ def test_execution_can_be_configured_with_explicit_local_model_flag(tmp_path, mo
     assert result.acceptable is True
     assert result.status == "available"
     assert result.tools["pi"] == str(bindir / "pi")
+
+
+def test_probe_blocks_enabled_pi_when_node_version_is_too_old(tmp_path):
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    versions = {"node": "v20.11.1", "npm": "10.2.4"}
+    for command in ("node", "npm"):
+        path = bindir / command
+        path.write_text(f"#!/bin/sh\necho {versions[command]}\n", encoding="utf-8")
+        path.chmod(0o755)
+    pi = bindir / "pi"
+    pi_marker = tmp_path / "pi-ran"
+    pi.write_text(f"#!/bin/sh\necho should-not-be-executed > {pi_marker}\n", encoding="utf-8")
+    pi.chmod(0o755)
+
+    result = probe_pi_runtime(env={"PATH": str(bindir), "ZOE_PI_ENABLED": "true"})
+
+    assert result.status == "node_version_too_old"
+    assert result.acceptable is False
+    assert result.tool_versions == {"node": "v20.11.1", "npm": "10.2.4", "pi": None}
+    assert result.to_dict()["requirements"]["node"] == {
+        "minimum": "22.19.0",
+        "detected": "v20.11.1",
+        "status": "too_old",
+    }
+    assert not pi_marker.exists()
+
+
+def test_probe_accepts_enabled_pi_with_supported_node_version(tmp_path):
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    versions = {"node": "v22.19.0", "npm": "10.9.3"}
+    for command in ("node", "npm"):
+        path = bindir / command
+        path.write_text(f"#!/bin/sh\necho {versions[command]}\n", encoding="utf-8")
+        path.chmod(0o755)
+    pi = bindir / "pi"
+    pi.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    pi.chmod(0o755)
+
+    result = probe_pi_runtime(env={"PATH": str(bindir), "ZOE_PI_ENABLED": "true"})
+
+    assert result.status == "available_execution_disabled"
+    assert result.acceptable is True
+    assert result.tool_versions["node"] == "v22.19.0"
+    assert result.to_dict()["requirements"]["node"]["status"] == "ok"
 
 
 def test_disabled_runtime_does_not_surface_agent_files(tmp_path):

--- a/services/zoe-data/tests/test_pi_runtime_probe.py
+++ b/services/zoe-data/tests/test_pi_runtime_probe.py
@@ -175,6 +175,53 @@ def test_probe_accepts_enabled_pi_with_supported_node_version(tmp_path):
     assert result.to_dict()["requirements"]["node"]["status"] == "ok"
 
 
+def test_probe_reports_unknown_when_node_version_is_unreadable(tmp_path):
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    node = bindir / "node"
+    node.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    node.chmod(0o755)
+    npm = bindir / "npm"
+    npm.write_text("#!/bin/sh\necho 10.9.3\n", encoding="utf-8")
+    npm.chmod(0o755)
+    pi = bindir / "pi"
+    pi.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    pi.chmod(0o755)
+
+    result = probe_pi_runtime(env={"PATH": str(bindir), "ZOE_PI_ENABLED": "true"})
+
+    assert result.status == "available_execution_disabled"
+    assert result.tools["node"] == str(node)
+    assert result.tool_versions["node"] is None
+    assert result.to_dict()["requirements"]["node"] == {
+        "minimum": "22.19.0",
+        "detected": None,
+        "status": "unknown",
+    }
+
+
+def test_probe_respects_configured_version_timeout(tmp_path):
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    node = bindir / "node"
+    node.write_text("#!/bin/sh\n/bin/sleep 0.2\necho v22.19.0\n", encoding="utf-8")
+    node.chmod(0o755)
+    npm = bindir / "npm"
+    npm.write_text("#!/bin/sh\necho 10.9.3\n", encoding="utf-8")
+    npm.chmod(0o755)
+    pi = bindir / "pi"
+    pi.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    pi.chmod(0o755)
+
+    result = probe_pi_runtime(
+        env={"PATH": str(bindir), "ZOE_PI_ENABLED": "true", "ZOE_PI_TIMEOUT_SECONDS": "0.05"}
+    )
+
+    assert result.status == "available_execution_disabled"
+    assert result.tool_versions["node"] is None
+    assert result.to_dict()["requirements"]["node"]["status"] == "unknown"
+
+
 def test_disabled_runtime_does_not_surface_agent_files(tmp_path):
     agent_dir = tmp_path / ".pi" / "agents"
     agent_dir.mkdir(parents=True)


### PR DESCRIPTION
## Summary

Adds Pi runtime readiness requirements to the Zoe probe and docs so the system can report the upstream install plan and minimum Node version before anyone tries to run Pi.

## What changed

- Reports Pi install metadata for `@earendil-works/pi-coding-agent`, including the guarded npm install command.
- Adds Node.js version capture via `node --version` and blocks enabled Pi when the detected Node version is below `22.19.0`.
- Keeps the probe read-only with `probe_executes_pi=false`; it does not invoke `pi`, install packages, or run agent/model tasks.
- Documents the new readiness report fields in the Pi runtime harness architecture note.

## Why

The current Zoe host does not have Node, npm, or Pi installed, so real Pi-vs-Zoe bakeoff work needs an explicit readiness contract before runtime installation. This keeps Pi setup governed by Multica instead of hidden inside a probe.

## Validation

- `python3 -m py_compile services/zoe-data/pi_runtime_probe.py`
- `python3 -m pytest -q services/zoe-data/tests/test_pi_runtime_probe.py` — 17 passed
- `python3 -m pytest -q services/zoe-data/tests/test_pi_intent_evidence.py services/zoe-data/tests/test_pi_eval_export.py services/zoe-data/tests/test_pi_promotion_eval_script.py services/zoe-data/tests/test_zoe_pi_promotion.py services/zoe-data/tests/test_pi_promotion_apply.py services/zoe-data/tests/test_pi_intent_shadow.py services/zoe-data/tests/test_pi_intent_classifier.py services/zoe-data/tests/test_pi_intent_status_endpoint.py services/zoe-data/tests/test_pi_runtime_probe.py services/zoe-data/tests/test_zoe_evolution_runtime_intake.py` — 134 passed
- `git diff --check`
- `python3 tools/audit/validate_structure.py`
- `python3 tools/audit/validate_critical_files.py`
- `PYTHONPATH=services/zoe-data python3 scripts/maintenance/pi_runtime_probe.py --json`