### PR TITLE
[codex] Discover nvm Pi runtime in readiness probe

### DIFF
--- a/docs/architecture/zoe-pi-runtime-harness.md
+++ b/docs/architecture/zoe-pi-runtime-harness.md
@@ -78,7 +78,7 @@ PYTHONPATH=services/zoe-data python3 scripts/maintenance/pi_runtime_probe.py --j
 ```
 
 The probe is safe to run in production-adjacent environments because it only
-uses filesystem and `PATH` checks plus `node --version` and `npm --version`.
+uses filesystem, `PATH`, and `~/.nvm/versions/node/*/bin` checks plus `node --version` and `npm --version`.
 It does not execute `pi`, install packages, or run agent/model tasks.
 
 ## Intent Shadow Evidence

--- a/services/zoe-data/pi_runtime_probe.py
+++ b/services/zoe-data/pi_runtime_probe.py
@@ -273,11 +273,43 @@ def _float_snapshot(value: str | None, *, default: float) -> float | str:
 def _tool_snapshot(pi_command: str, env: Mapping[str, str] | None = None) -> dict[str, str | None]:
     values = env if env is not None else os.environ
     path = values.get("PATH")
+    if env is None:
+        path = _path_with_nvm_node_bin(path or "")
     return {
         "node": shutil.which("node", path=path),
         "npm": shutil.which("npm", path=path),
         "pi": shutil.which(pi_command, path=path),
     }
+
+
+def _path_with_nvm_node_bin(path: str) -> str:
+    parts = [part for part in path.split(os.pathsep) if part]
+    joined = os.pathsep.join(parts)
+    if shutil.which("node", path=joined) and shutil.which("npm", path=joined) and shutil.which("pi", path=joined):
+        return joined
+    node_bin = _discover_nvm_node_bin()
+    if node_bin and node_bin not in parts:
+        parts.append(node_bin)
+    return os.pathsep.join(parts)
+
+
+def _discover_nvm_node_bin() -> str | None:
+    nvm_versions = Path.home() / ".nvm" / "versions" / "node"
+    if not nvm_versions.is_dir():
+        return None
+    candidates = [path / "bin" for path in nvm_versions.iterdir() if (path / "bin").is_dir()]
+    candidates = [path for path in candidates if (path / "node").exists() and (path / "npm").exists()]
+    if not candidates:
+        return None
+
+    def version_key(path: Path) -> tuple[int, ...]:
+        version = path.parent.name.lstrip("v")
+        try:
+            return tuple(int(part) for part in version.split("."))
+        except ValueError:
+            return (0,)
+
+    return str(sorted(candidates, key=version_key)[-1])
 
 
 def _tool_version_snapshot(
@@ -302,6 +334,10 @@ def _command_version(
     if not command_path:
         return None
     values = dict(os.environ if env is None else env)
+    command_dir = str(Path(command_path).parent)
+    path_parts = [part for part in values.get("PATH", "").split(os.pathsep) if part]
+    if command_dir not in path_parts:
+        values["PATH"] = os.pathsep.join([command_dir, *path_parts])
     try:
         completed = subprocess.run(
             [command_path, "--version"],

--- a/services/zoe-data/pi_runtime_probe.py
+++ b/services/zoe-data/pi_runtime_probe.py
@@ -285,11 +285,11 @@ def _tool_snapshot(pi_command: str, env: Mapping[str, str] | None = None) -> dic
 def _path_with_nvm_node_bin(path: str) -> str:
     parts = [part for part in path.split(os.pathsep) if part]
     joined = os.pathsep.join(parts)
-    if shutil.which("node", path=joined) and shutil.which("npm", path=joined) and shutil.which("pi", path=joined):
+    if parts and shutil.which("node", path=joined) and shutil.which("npm", path=joined) and shutil.which("pi", path=joined):
         return joined
     node_bin = _discover_nvm_node_bin()
     if node_bin and node_bin not in parts:
-        parts.append(node_bin)
+        parts.insert(0, node_bin)
     return os.pathsep.join(parts)
 
 

--- a/services/zoe-data/pi_runtime_probe.py
+++ b/services/zoe-data/pi_runtime_probe.py
@@ -274,7 +274,7 @@ def _tool_snapshot(pi_command: str, env: Mapping[str, str] | None = None) -> dic
     values = env if env is not None else os.environ
     path = values.get("PATH")
     if env is None:
-        path = _path_with_nvm_node_bin(path or "")
+        path = _path_with_nvm_node_bin(path or "", pi_command=pi_command)
     return {
         "node": shutil.which("node", path=path),
         "npm": shutil.which("npm", path=path),
@@ -282,23 +282,25 @@ def _tool_snapshot(pi_command: str, env: Mapping[str, str] | None = None) -> dic
     }
 
 
-def _path_with_nvm_node_bin(path: str) -> str:
+def _path_with_nvm_node_bin(path: str, *, pi_command: str) -> str:
     parts = [part for part in path.split(os.pathsep) if part]
-    joined = os.pathsep.join(parts)
-    if parts and shutil.which("node", path=joined) and shutil.which("npm", path=joined) and shutil.which("pi", path=joined):
-        return joined
-    node_bin = _discover_nvm_node_bin()
-    if node_bin and node_bin not in parts:
+    node_bin = _discover_nvm_node_bin(pi_command=pi_command)
+    if node_bin:
+        parts = [part for part in parts if part != node_bin]
         parts.insert(0, node_bin)
     return os.pathsep.join(parts)
 
 
-def _discover_nvm_node_bin() -> str | None:
+def _discover_nvm_node_bin(*, pi_command: str) -> str | None:
     nvm_versions = Path.home() / ".nvm" / "versions" / "node"
     if not nvm_versions.is_dir():
         return None
     candidates = [path / "bin" for path in nvm_versions.iterdir() if (path / "bin").is_dir()]
-    candidates = [path for path in candidates if (path / "node").exists() and (path / "npm").exists()]
+    candidates = [
+        path
+        for path in candidates
+        if (path / "node").exists() and (path / "npm").exists() and (path / pi_command).exists()
+    ]
     if not candidates:
         return None
 

--- a/services/zoe-data/tests/test_pi_runtime_probe.py
+++ b/services/zoe-data/tests/test_pi_runtime_probe.py
@@ -200,6 +200,36 @@ def test_default_probe_discovers_nvm_pi_install(tmp_path, monkeypatch):
     assert result.to_dict()["requirements"]["node"]["status"] == "ok"
 
 
+def test_default_probe_prefers_nvm_node_when_system_node_lacks_pi(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    nvm_bin = home / ".nvm" / "versions" / "node" / "v22.22.0" / "bin"
+    system_bin = tmp_path / "system-bin"
+    nvm_bin.mkdir(parents=True)
+    system_bin.mkdir()
+    for bindir, versions in (
+        (system_bin, {"node": "v20.11.1", "npm": "10.2.4"}),
+        (nvm_bin, {"node": "v22.22.0", "npm": "10.9.4"}),
+    ):
+        for command in ("node", "npm"):
+            path = bindir / command
+            path.write_text(f"#!/bin/sh\necho {versions[command]}\n", encoding="utf-8")
+            path.chmod(0o755)
+    pi = nvm_bin / "pi"
+    pi.write_text("#!/bin/sh\necho 0.79.3\n", encoding="utf-8")
+    pi.chmod(0o755)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("PATH", str(system_bin))
+    monkeypatch.setenv("ZOE_PI_ENABLED", "true")
+
+    result = probe_pi_runtime()
+
+    assert result.status == "available_execution_disabled"
+    assert result.tools["node"] == str(nvm_bin / "node")
+    assert result.tools["npm"] == str(nvm_bin / "npm")
+    assert result.tools["pi"] == str(pi)
+    assert result.tool_versions["node"] == "v22.22.0"
+
+
 def test_probe_reports_unknown_when_node_version_is_unreadable(tmp_path):
     bindir = tmp_path / "bin"
     bindir.mkdir()

--- a/services/zoe-data/tests/test_pi_runtime_probe.py
+++ b/services/zoe-data/tests/test_pi_runtime_probe.py
@@ -175,6 +175,31 @@ def test_probe_accepts_enabled_pi_with_supported_node_version(tmp_path):
     assert result.to_dict()["requirements"]["node"]["status"] == "ok"
 
 
+def test_default_probe_discovers_nvm_pi_install(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    bindir = home / ".nvm" / "versions" / "node" / "v22.22.0" / "bin"
+    bindir.mkdir(parents=True)
+    versions = {"node": "v22.22.0", "npm": "10.9.4"}
+    for command in ("node", "npm"):
+        path = bindir / command
+        path.write_text(f"#!/bin/sh\necho {versions[command]}\n", encoding="utf-8")
+        path.chmod(0o755)
+    pi = bindir / "pi"
+    pi.write_text("#!/bin/sh\necho 0.79.3\n", encoding="utf-8")
+    pi.chmod(0o755)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("PATH", "")
+    monkeypatch.setenv("ZOE_PI_ENABLED", "true")
+
+    result = probe_pi_runtime()
+
+    assert result.status == "available_execution_disabled"
+    assert result.tools == {"node": str(bindir / "node"), "npm": str(bindir / "npm"), "pi": str(pi)}
+    assert result.tool_versions["node"] == "v22.22.0"
+    assert result.tool_versions["npm"] == "10.9.4"
+    assert result.to_dict()["requirements"]["node"]["status"] == "ok"
+
+
 def test_probe_reports_unknown_when_node_version_is_unreadable(tmp_path):
     bindir = tmp_path / "bin"
     bindir.mkdir()

--- a/services/zoe-data/tests/test_pi_runtime_probe.py
+++ b/services/zoe-data/tests/test_pi_runtime_probe.py
@@ -230,6 +230,66 @@ def test_default_probe_prefers_nvm_node_when_system_node_lacks_pi(tmp_path, monk
     assert result.tool_versions["node"] == "v22.22.0"
 
 
+def test_default_probe_moves_existing_nvm_bin_to_front_when_system_node_lacks_pi(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    nvm_bin = home / ".nvm" / "versions" / "node" / "v22.22.0" / "bin"
+    system_bin = tmp_path / "system-bin"
+    nvm_bin.mkdir(parents=True)
+    system_bin.mkdir()
+    for bindir, versions in (
+        (system_bin, {"node": "v20.11.1", "npm": "10.2.4"}),
+        (nvm_bin, {"node": "v22.22.0", "npm": "10.9.4"}),
+    ):
+        for command in ("node", "npm"):
+            path = bindir / command
+            path.write_text(f"#!/bin/sh\necho {versions[command]}\n", encoding="utf-8")
+            path.chmod(0o755)
+    pi = nvm_bin / "pi"
+    pi.write_text("#!/bin/sh\necho 0.79.3\n", encoding="utf-8")
+    pi.chmod(0o755)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("PATH", f"{system_bin}{os.pathsep}{nvm_bin}")
+    monkeypatch.setenv("ZOE_PI_ENABLED", "true")
+
+    result = probe_pi_runtime()
+
+    assert result.status == "available_execution_disabled"
+    assert result.tools["node"] == str(nvm_bin / "node")
+    assert result.tools["npm"] == str(nvm_bin / "npm")
+    assert result.tools["pi"] == str(pi)
+    assert result.tool_versions["node"] == "v22.22.0"
+
+
+def test_default_probe_selects_latest_nvm_version_with_configured_pi_command(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    older_bin = home / ".nvm" / "versions" / "node" / "v22.22.0" / "bin"
+    newer_bin = home / ".nvm" / "versions" / "node" / "v23.1.0" / "bin"
+    older_bin.mkdir(parents=True)
+    newer_bin.mkdir(parents=True)
+    for bindir, version in ((older_bin, "v22.22.0"), (newer_bin, "v23.1.0")):
+        node = bindir / "node"
+        node.write_text(f"#!/bin/sh\necho {version}\n", encoding="utf-8")
+        node.chmod(0o755)
+        npm = bindir / "npm"
+        npm.write_text("#!/bin/sh\necho 10.9.4\n", encoding="utf-8")
+        npm.chmod(0o755)
+    custom_pi = older_bin / "zoe-pi"
+    custom_pi.write_text("#!/bin/sh\necho 0.79.3\n", encoding="utf-8")
+    custom_pi.chmod(0o755)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("PATH", "")
+    monkeypatch.setenv("ZOE_PI_ENABLED", "true")
+    monkeypatch.setenv("ZOE_PI_COMMAND", "zoe-pi")
+
+    result = probe_pi_runtime()
+
+    assert result.status == "available_execution_disabled"
+    assert result.tools["node"] == str(older_bin / "node")
+    assert result.tools["npm"] == str(older_bin / "npm")
+    assert result.tools["pi"] == str(custom_pi)
+    assert result.tool_versions["node"] == "v22.22.0"
+
+
 def test_probe_reports_unknown_when_node_version_is_unreadable(tmp_path):
     bindir = tmp_path / "bin"
     bindir.mkdir()


### PR DESCRIPTION
## Summary

Fixes the Pi readiness probe so the default maintenance probe discovers Pi/Node/npm installed under `~/.nvm/versions/node/*/bin`, matching the runtime path the Pi intent classifier can already use.

## Why

The audit found Pi was actually installed under nvm on the Zoe host:

- Node: `/home/zoe/.nvm/versions/node/v22.22.0/bin/node`
- npm: `/home/zoe/.nvm/versions/node/v22.22.0/bin/npm`
- Pi: `/home/zoe/.nvm/versions/node/v22.22.0/bin/pi`

But the plain `scripts/maintenance/pi_runtime_probe.py --json` path reported these tools as missing unless nvm was manually added to `PATH`. That caused confusing status output and made it look like Pi was not installed at all.

## What changed

- Default `probe_pi_runtime()` now checks `PATH` plus the latest valid nvm Node bin directory.
- Explicit `env={...}` probe calls remain isolated and only use the provided `PATH`, preserving test behavior.
- Version subprocesses prepend the command directory to `PATH`, so symlinked npm can find node.
- Added a focused fake-nvm test.
- Updated the Pi runtime architecture doc to mention nvm discovery.

## Validation

- `python3 -m pytest -q services/zoe-data/tests/test_pi_runtime_probe.py` — 20 passed
- `python3 -m pytest -q services/zoe-data/tests/test_pi_intent_evidence.py services/zoe-data/tests/test_pi_eval_export.py services/zoe-data/tests/test_pi_promotion_eval_script.py services/zoe-data/tests/test_zoe_pi_promotion.py services/zoe-data/tests/test_pi_promotion_apply.py services/zoe-data/tests/test_pi_intent_shadow.py services/zoe-data/tests/test_pi_intent_classifier.py services/zoe-data/tests/test_pi_intent_status_endpoint.py services/zoe-data/tests/test_pi_runtime_probe.py services/zoe-data/tests/test_zoe_evolution_runtime_intake.py` — 137 passed
- `git diff --check`
- `python3 tools/audit/validate_structure.py`
- `python3 tools/audit/validate_critical_files.py`
- `PYTHONPATH=services/zoe-data python3 scripts/maintenance/pi_runtime_probe.py --json` now reports nvm Node/npm/Pi paths on the Zoe host.

## Audit note

Pi is installed under nvm, but Zoe policy still has `ZOE_PI_ENABLED=false`. Real smoke testing showed print transport can classify simple intents through the local model at ~3.7-4.0s, while RPC currently returns null/timeouts and needs follow-up before promotion testing.