### PR TITLE
[codex] Fix Pi RPC intent protocol

### DIFF
--- a/docs/architecture/zoe-pi-runtime-harness.md
+++ b/docs/architecture/zoe-pi-runtime-harness.md
@@ -6,26 +6,29 @@ Pi is a candidate external runtime for Zoe capability reuse. Zoe should use Pi
 where it provides proven agent/runtime/package leverage, but Pi execution must
 enter through Zoe governance rather than bypass it.
 
-This first slice is intentionally read-only:
+The harness is gated by default:
 
 - detect whether `node`, `npm`, and `pi` are present;
 - discover project-local `.pi/agents/*.md` files;
 - expose execution policy config;
 - fail closed when execution is requested without a local/offline model path;
-- avoid installing Pi, installing packages, or running Pi agent tasks.
+- avoid installing Pi, installing packages, or running privileged Pi agent tasks;
+- allow explicitly gated local/offline intent probes for shadow and bake-off evidence.
 
 ## Current Zoe Host Result
 
-Date: 2026-06-09
+Date: 2026-06-15
 
-On the clean Zoe worktree:
+On the Zoe host, Pi is installed under `nvm` rather than the default non-login service PATH:
 
-- `node`: not found;
-- `npm`: not found;
-- `pi`: not found;
-- `.pi/agents`: not present in the Zoe repo;
-- execution status: disabled and acceptable;
-- enabled execution status: blocked until runtime prerequisites and local model config exist.
+- `node`: `/home/zoe/.nvm/versions/node/v22.22.0/bin/node`;
+- `npm`: `/home/zoe/.nvm/versions/node/v22.22.0/bin/npm`;
+- `pi`: `/home/zoe/.nvm/versions/node/v22.22.0/bin/pi`;
+- Pi version: `0.79.3`;
+- model config: `/home/zoe/.pi/agent/models.json` points at local `http://127.0.0.1:11434/v1`;
+- default policy: `ZOE_PI_ENABLED=false`, `ZOE_PI_INTENT_AUTO_PROMOTE=false`, and no promoted intent groups.
+
+The readiness probe checks `PATH` plus `~/.nvm/versions/node/*/bin`, so it can report this install truthfully without requiring service PATH changes. Pi remains disabled by default and any live execution still requires the explicit local/offline execution gates.
 
 Current Pi install/readiness facts from upstream docs:
 
@@ -150,11 +153,30 @@ scripts/maintenance/pi_promotion_eval.py \
 ```
 
 Add `--run-pi --transport rpc` only when the local/offline Pi intent runtime is
-configured. The RPC path keeps a warm worker but resets it on timeout or task
+configured. The RPC path keeps a warm worker, waits for Pi's prompt `response`
+frame before accepting idless session events, resets on timeout or task
 cancellation, and ignores response events whose request id does not match the
-current prompt. The report still remains evidence-only;
-`ZOE_PI_INTENT_PROMOTED_GROUPS` changes must pass the promotion actions and
-guarded apply helper described above.
+current prompt. Pi intent classification launches in a stripped classifier mode
+with no tools, extensions, skills, prompt templates, themes, or context files.
+The report still remains evidence-only; `ZOE_PI_INTENT_PROMOTED_GROUPS` changes
+must pass the promotion actions and guarded apply helper described above.
+
+### Latest Local Pi/Gemma Intent Eval
+
+Measured on 2026-06-15 with the built-in eval cases, local Gemma, and RPC
+transport after the stripped classifier launch and RPC protocol fix:
+
+- eligible samples: 9;
+- Pi accuracy: 100%;
+- Zoe baseline accuracy on the same eligible samples: 33.3%;
+- Pi timeout rate on eligible samples: 0%;
+- Pi RPC p95 latency: about 3.59s;
+- Zoe comparable p95 latency: about 1.09s;
+- promotable groups: none, because Pi still fails the latency gate.
+
+Decision: keep Pi intent routing in shadow/evidence mode. Pi is now accurate
+enough on the seed eval to justify more measurement, but it is not fast enough
+to promote into live Zoe routing.
 
 Sanitized JSONL evidence can be exported into the same eval-case format. For Pi
 shadow records this uses `text_preview` plus a trusted `outcome_label`; unlabeled,
@@ -200,9 +222,11 @@ Pi remains experimental until all of these are true:
 - execution evidence includes tests, rollback, and PR/Grep loop evidence for
   code-producing changes.
 
-## Why Not Execute Yet
+## Why Not Promote Yet
 
 Pi's official docs support CLI, SDK, RPC, project-local agents, and packages,
-but the Zoe host does not currently have the Node/Pi runtime needed to run it.
-Installing that runtime is a privileged environment change. The correct next
-step is a scored, approved install/runtime proposal, not silent installation.
+and the Zoe host now has a local Pi runtime available under `nvm`. The current
+blocker is not installation; it is promotion evidence. Pi intent RPC must beat
+Zoe's comparable route latency as well as its accuracy before any low-risk group
+is promoted. Current evidence shows strong seed accuracy but slower latency, so
+Pi remains shadow-only.

--- a/services/zoe-data/pi_intent_classifier.py
+++ b/services/zoe-data/pi_intent_classifier.py
@@ -83,6 +83,23 @@ _TASK_LANES = {
 }
 
 _SECRET_ENV_MARKERS = ("OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GEMINI_API_KEY", "GOOGLE_API_KEY", "OPENROUTER_API_KEY")
+_PI_CLASSIFIER_BASE_FLAGS = (
+    "--no-tools",
+    "--no-extensions",
+    "--no-skills",
+    "--no-prompt-templates",
+    "--no-themes",
+    "--no-context-files",
+    "--thinking",
+    "off",
+)
+_PI_CLASSIFIER_SYSTEM_PROMPT = (
+    "You are Zoe's offline intent classifier. Classify only; do not answer the user. "
+    "Return exactly one compact JSON object with keys intent, slots, confidence, task_lane, reason. "
+    "Use intent null and task_lane chat for casual chat, advice, research, or uncertain requests. "
+    "Use governed_agent only for self-extension, complaints, or missing capability requests. "
+    "Never create memory-write intents from ambiguous phrasing."
+)
 
 
 @dataclass(frozen=True)
@@ -294,17 +311,12 @@ async def _classify_with_pi_rpc(
 def _classification_prompt(text: str, *, context_turns: str = "") -> str:
     lanes = {lane: sorted(intents) for lane, intents in _TASK_LANES.items() if intents}
     return (
-        "You are Zoe's fast ambiguous-intent governor. Classify only; do not answer the user.\n"
-        "Return exactly one compact JSON object and no markdown.\n"
-        "Schema: {\"intent\": string|null, \"slots\": object, \"confidence\": number, \"task_lane\": \"fast_tool\"|\"governed_agent\"|\"chat\", \"reason\": string}.\n"
-        f"Executable intents: {sorted(_ALLOWED_EXECUTABLE_INTENTS)}\n"
+        "Schema: {\"intent\": string|null, \"slots\": object, \"confidence\": number, "
+        "\"task_lane\": \"fast_tool\"|\"governed_agent\"|\"chat\", \"reason\": string}.\n"
+        f"Allowed intents: {sorted(_ALLOWED_EXECUTABLE_INTENTS)}\n"
         f"Task lanes: {json.dumps(lanes, sort_keys=True)}\n"
-        "Use chat/null when this is normal conversation, advice, research, or the request needs more context.\n"
-        "Use governed_agent for self-extension, complaints, or missing capability requests.\n"
-        "Never create memory-write intents from ambiguous phrasing; only deterministic Zoe rules may write memory.\n"
-        "Short weather examples: 'rain later', 'umbrella later', and 'need a jacket tonight' are weather with task_lane fast_tool.\n"
-        "Short reminder examples: 'anything due today' and 'what do I need to do' are reminder_list if no other domain is named.\n"
-        "Keep confidence below 0.78 unless the route is obvious.\n"
+        "Hints: rain/umbrella/jacket=>weather; due/todo=>reminder_list; timer/alarm=>timer_create. "
+        "Keep confidence below 0.78 unless obvious.\n"
         f"Recent context: {_sanitize_prompt_value(context_turns) or '(none)'}\n"
         f"User message: {_sanitize_prompt_value(text)}\n"
         "JSON:"
@@ -316,6 +328,9 @@ def _pi_command(config: PiIntentClassifierConfig, prompt: str) -> list[str]:
         config.command,
         "-p",
         "--no-session",
+        *_PI_CLASSIFIER_BASE_FLAGS,
+        "--system-prompt",
+        _PI_CLASSIFIER_SYSTEM_PROMPT,
         "--provider",
         config.provider,
         "--model",
@@ -333,6 +348,9 @@ def _pi_rpc_command(config: PiIntentClassifierConfig) -> list[str]:
         "--mode",
         "rpc",
         "--no-session",
+        *_PI_CLASSIFIER_BASE_FLAGS,
+        "--system-prompt",
+        _PI_CLASSIFIER_SYSTEM_PROMPT,
         "--provider",
         config.provider,
         "--model",
@@ -406,6 +424,7 @@ class _PiRpcIntentWorker:
     async def _read_turn(self, request_id: str) -> str:
         assert self.proc is not None and self.proc.stdout is not None
         latest_text = ""
+        prompt_accepted = False
         while True:
             line = await self.proc.stdout.readline()
             if not line:
@@ -413,6 +432,13 @@ class _PiRpcIntentWorker:
             try:
                 event = json.loads(line.decode(errors="replace"))
             except json.JSONDecodeError:
+                continue
+            if _rpc_response_matches_request(event, request_id):
+                if not event.get("success"):
+                    raise RuntimeError(str(event.get("error") or "Pi RPC prompt failed"))
+                prompt_accepted = True
+                continue
+            if not prompt_accepted:
                 continue
             if not _rpc_event_matches_request(event, request_id):
                 continue
@@ -441,9 +467,15 @@ def _rpc_event_matches_request(event: Mapping[str, Any], request_id: str) -> boo
     if isinstance(turn, Mapping):
         event_ids.extend([turn.get("id"), turn.get("request_id"), turn.get("requestId")])
     present_ids = [str(value) for value in event_ids if value is not None]
-    if event.get("type") == "agent_end" and not present_ids:
-        return False
     return not present_ids or request_id in present_ids
+
+
+def _rpc_response_matches_request(event: Mapping[str, Any], request_id: str) -> bool:
+    return (
+        event.get("type") == "response"
+        and event.get("command") == "prompt"
+        and str(event.get("id") or "") == request_id
+    )
 
 
 def _assistant_text_from_rpc_event(event: Mapping[str, Any]) -> str:

--- a/services/zoe-data/tests/test_pi_intent_classifier.py
+++ b/services/zoe-data/tests/test_pi_intent_classifier.py
@@ -10,6 +10,7 @@ from pi_intent_classifier import (
     PiIntentClassifierConfig,
     _classification_prompt,
     _parse_pi_classification,
+    _rpc_response_matches_request,
     classify_with_pi_intent_governor,
     pi_intent_is_promoted,
     pi_intent_promotion_status,
@@ -77,9 +78,10 @@ def _fake_rpc_runtime(tmp_path, *, response=None):
         "            fh.write(json.dumps({'event': 'request', 'body': request}) + '\\n')\n"
         "    text = json.dumps(payload)\n"
         "    event_id = request.get('id')\n"
-        "    print(json.dumps({'id': event_id, 'type': 'message_end', 'message': {'role': 'assistant', 'content': [{'type': 'text', 'text': text}]}}), flush=True)\n"
-        "    print(json.dumps({'id': event_id, 'type': 'turn_end', 'message': {'role': 'assistant', 'content': [{'type': 'text', 'text': text}]}}), flush=True)\n"
-        "    print(json.dumps({'id': event_id, 'type': 'agent_end', 'messages': [{'role': 'assistant', 'content': [{'type': 'text', 'text': text}]}]}), flush=True)\n",
+        "    print(json.dumps({'id': event_id, 'type': 'response', 'command': 'prompt', 'success': True}), flush=True)\n"
+        "    print(json.dumps({'type': 'message_end', 'message': {'role': 'assistant', 'content': [{'type': 'text', 'text': text}]}}), flush=True)\n"
+        "    print(json.dumps({'type': 'turn_end', 'message': {'role': 'assistant', 'content': [{'type': 'text', 'text': text}]}}), flush=True)\n"
+        "    print(json.dumps({'type': 'agent_end', 'messages': [{'role': 'assistant', 'content': [{'type': 'text', 'text': text}]}]}), flush=True)\n",
     )
     return bindir, payload
 
@@ -183,6 +185,12 @@ def test_pi_intent_config_rejects_unknown_transport():
         config.validate()
 
 
+def test_pi_rpc_response_match_requires_prompt_command():
+    assert _rpc_response_matches_request({"id": "abc", "type": "response", "command": "prompt"}, "abc") is True
+    assert _rpc_response_matches_request({"id": "abc", "type": "response", "command": "get_state"}, "abc") is False
+    assert _rpc_response_matches_request({"id": "other", "type": "response", "command": "prompt"}, "abc") is False
+
+
 @pytest.mark.asyncio
 async def test_pi_intent_governor_rpc_reuses_warm_process_and_strips_cloud_keys(tmp_path, monkeypatch):
     workers = {}
@@ -227,9 +235,61 @@ async def test_pi_intent_governor_rpc_reuses_warm_process_and_strips_cloud_keys(
     assert "--mode" in starts[0]["argv"]
     assert "rpc" in starts[0]["argv"]
     assert "--offline" in starts[0]["argv"]
+    assert "--no-tools" in starts[0]["argv"]
+    assert "--no-context-files" in starts[0]["argv"]
+    assert "--no-extensions" in starts[0]["argv"]
+    assert "--no-skills" in starts[0]["argv"]
+    assert "--no-prompt-templates" in starts[0]["argv"]
+    assert "--no-themes" in starts[0]["argv"]
+    assert "--system-prompt" in starts[0]["argv"]
+    assert "--thinking" in starts[0]["argv"]
+    assert "off" in starts[0]["argv"]
     assert "-p" not in starts[0]["argv"]
     assert requests[0]["body"]["type"] == "prompt"
     assert "rain later" in requests[0]["body"]["message"]
+
+
+@pytest.mark.asyncio
+async def test_pi_rpc_failed_response_resets_process_under_worker_lock(tmp_path, monkeypatch):
+    bindir = tmp_path / "rpc-failed-response-bin"
+    bindir.mkdir()
+    _write_exe(bindir / "node", "#!/bin/sh\nexit 0\n")
+    _write_exe(bindir / "npm", "#!/bin/sh\nexit 0\n")
+    record = tmp_path / "rpc-failed-response-record.jsonl"
+    _write_exe(
+        bindir / "pi",
+        "#!/usr/bin/python3\n"
+        "import json, os, sys, time\n"
+        "record = os.environ['PI_TEST_RECORD']\n"
+        "for line in sys.stdin:\n"
+        "    request = json.loads(line)\n"
+        "    with open(record, 'a') as fh:\n"
+        "        fh.write(json.dumps({'event': 'request', 'body': request}) + '\\n')\n"
+        "    print(json.dumps({'id': request['id'], 'type': 'response', 'command': 'prompt', 'success': False, 'error': 'model unavailable'}), flush=True)\n"
+        "    time.sleep(10)\n",
+    )
+    workers = {}
+    monkeypatch.setattr(pi_intent_classifier, "_RPC_WORKERS", workers)
+    env = {
+        "PATH": str(bindir),
+        "ZOE_PI_INTENT_ENABLED": "true",
+        "ZOE_PI_INTENT_TRANSPORT": "rpc",
+        "ZOE_PI_COMMAND": "pi",
+        "ZOE_PI_CWD": str(tmp_path),
+        "ZOE_PI_ALLOW_EXECUTION": "true",
+        "ZOE_PI_LOCAL_MODEL_CONFIGURED": "true",
+        "ZOE_PI_INTENT_TIMEOUT_SECONDS": "2",
+        "PI_TEST_RECORD": str(record),
+    }
+
+    result = await classify_with_pi_intent_governor("rain later", env=env)
+
+    assert result is None
+    assert len(workers) == 1
+    worker = next(iter(workers.values()))
+    assert worker.proc is None
+    events = [json.loads(line) for line in record.read_text().splitlines()]
+    assert events[0]["body"]["type"] == "prompt"
 
 
 @pytest.mark.asyncio
@@ -340,6 +400,7 @@ async def test_pi_rpc_ignores_stale_response_with_mismatched_request_id(tmp_path
         "    stale = {'id': 'stale-request', 'type': 'agent_end', 'messages': [{'role': 'assistant', 'content': [{'type': 'text', 'text': stale_payload}]}]}\n"
         "    fresh = {'id': request['id'], 'type': 'agent_end', 'messages': [{'role': 'assistant', 'content': [{'type': 'text', 'text': fresh_payload}]}]}\n"
         "    print(json.dumps(idless), flush=True)\n"
+        "    print(json.dumps({'id': request['id'], 'type': 'response', 'command': 'prompt', 'success': True}), flush=True)\n"
         "    print(json.dumps(stale), flush=True)\n"
         "    print(json.dumps(fresh), flush=True)\n",
     )
@@ -418,6 +479,15 @@ async def test_pi_intent_governor_classifies_with_fake_pi_and_strips_cloud_keys(
     assert "-p" in called["argv"]
     assert "--no-session" in called["argv"]
     assert "--no-approve" in called["argv"]
+    assert "--no-tools" in called["argv"]
+    assert "--no-context-files" in called["argv"]
+    assert "--no-extensions" in called["argv"]
+    assert "--no-skills" in called["argv"]
+    assert "--no-prompt-templates" in called["argv"]
+    assert "--no-themes" in called["argv"]
+    assert "--system-prompt" in called["argv"]
+    assert "--thinking" in called["argv"]
+    assert "off" in called["argv"]
     assert "--provider" in called["argv"]
     assert "ollama" in called["argv"]
     assert "gemma-4-E2B-it-Q4_K_M.gguf" in called["argv"]


### PR DESCRIPTION
## Summary

Fixes Zoe's Pi intent RPC path so it follows the installed Pi CLI's real JSONL protocol and can produce usable local/offline intent evidence.

## What changed

- Wait for Pi RPC's prompt `response` frame before accepting session events.
- Accept idless Pi session events only after the current prompt has been accepted, while still ignoring mismatched request-id events.
- Launch Pi intent classification in stripped classifier mode: no tools, extensions, skills, prompt templates, themes, or context files, plus an explicit compact classifier system prompt.
- Update RPC tests to model the real response/event protocol.
- Update the Pi runtime harness doc with the current installed `nvm` runtime facts and measured local eval result.

## Evidence

- `python3 -m pytest -q services/zoe-data/tests/test_pi_intent_classifier.py services/zoe-data/tests/test_pi_promotion_eval_script.py services/zoe-data/tests/test_zoe_pi_promotion.py services/zoe-data/tests/test_pi_runtime_probe.py` -> 79 passed
- broader Pi/evolution group -> 140 passed
- `git diff --check` -> passed
- `python3 tools/audit/validate_structure.py` -> passed
- `python3 tools/audit/validate_critical_files.py` -> passed
- Live RPC probe now returns real classifications instead of null/timeouts.
- Built-in RPC eval after fix: 9 eligible samples, Pi accuracy 100%, Zoe baseline 33.3%, Pi timeout rate 0%, Pi RPC p95 about 3.59s, Zoe comparable p95 about 1.09s.

## Decision

Pi intent routing stays shadow-only. Accuracy improved enough to keep measuring, but Pi still fails the promotion latency gate.
