### PR TITLE
[codex] Guard Pi eval baseline comparability

### DIFF
--- a/docs/architecture/zoe-pi-runtime-harness.md
+++ b/docs/architecture/zoe-pi-runtime-harness.md
@@ -158,25 +158,34 @@ frame before accepting idless session events, resets on timeout or task
 cancellation, and ignores response events whose request id does not match the
 current prompt. Pi intent classification launches in a stripped classifier mode
 with no tools, extensions, skills, prompt templates, themes, or context files.
-The report still remains evidence-only; `ZOE_PI_INTENT_PROMOTED_GROUPS` changes
-must pass the promotion actions and guarded apply helper described above.
+The evaluator treats fallback and extraction-failed router misses as
+`router_only_not_comparable` unless an operator supplies measured comparable
+latency with `--fallback-baseline-latency-ms` and/or
+`--extraction-failed-baseline-latency-ms`. The report still remains
+evidence-only; `ZOE_PI_INTENT_PROMOTED_GROUPS` changes must pass the promotion
+actions and guarded apply helper described above.
 
 ### Latest Local Pi/Gemma Intent Eval
 
 Measured on 2026-06-15 with the built-in eval cases, local Gemma, and RPC
-transport after the stripped classifier launch and RPC protocol fix:
+transport after the stripped classifier launch, RPC protocol fix, and baseline
+comparability guard:
 
 - eligible samples: 9;
 - Pi accuracy: 100%;
-- Zoe baseline accuracy on the same eligible samples: 33.3%;
+- Zoe router-only baseline accuracy on the same eligible samples: 33.3%;
 - Pi timeout rate on eligible samples: 0%;
-- Pi RPC p95 latency: about 3.59s;
-- Zoe comparable p95 latency: about 1.09s;
-- promotable groups: none, because Pi still fails the latency gate.
+- Pi RPC p95 latency: about 3.98s in the latest run;
+- Zoe router-only p95 latency: about 1.70s in the latest run, but fallback and
+  extraction-failed cases are now explicitly marked not comparable;
+- promotable groups: none, because the seed fallback/extraction-failed evidence
+  lacks a measured comparable Zoe fallback baseline and Pi still loses the
+  router-only latency gate.
 
-Decision: keep Pi intent routing in shadow/evidence mode. Pi is now accurate
-enough on the seed eval to justify more measurement, but it is not fast enough
-to promote into live Zoe routing.
+Decision: keep Pi intent routing in shadow/evidence mode. Pi is accurate enough
+on the seed eval to justify more measurement, but promotion requires measured
+Zoe fallback/agent latency or labeled runtime shadow records, not router-only
+miss timing.
 
 Sanitized JSONL evidence can be exported into the same eval-case format. For Pi
 shadow records this uses `text_preview` plus a trusted `outcome_label`; unlabeled,

--- a/scripts/maintenance/pi_promotion_eval.py
+++ b/scripts/maintenance/pi_promotion_eval.py
@@ -72,17 +72,44 @@ def _demo_samples() -> list[PiRouteSample]:
     return samples
 
 
-async def _run_zoe_baseline(case: PiIntentEvalCase) -> dict[str, Any]:
+async def _run_zoe_baseline(
+    case: PiIntentEvalCase,
+    *,
+    fallback_baseline_latency_ms: float | None = None,
+    extraction_failed_baseline_latency_ms: float | None = None,
+) -> dict[str, Any]:
     with _temporary_env({"ZOE_PI_INTENT_ENABLED": "false"}):
         from intent_router import detect_and_extract_intent
 
         start = time.perf_counter()
         intent = await detect_and_extract_intent(case.text)
-        latency_ms = (time.perf_counter() - start) * 1000
+        router_latency_ms = (time.perf_counter() - start) * 1000
+
+    latency_ms = router_latency_ms
+    baseline_kind = "router"
+    baseline_comparable = True
+    if case.route_class == "fallback":
+        if fallback_baseline_latency_ms is None:
+            baseline_kind = "router_only_not_comparable"
+            baseline_comparable = False
+        else:
+            latency_ms = fallback_baseline_latency_ms
+            baseline_kind = "operator_fallback_override"
+    elif case.route_class == "extraction_failed":
+        if extraction_failed_baseline_latency_ms is None:
+            baseline_kind = "router_only_not_comparable"
+            baseline_comparable = False
+        else:
+            latency_ms = extraction_failed_baseline_latency_ms
+            baseline_kind = "operator_extraction_failed_override"
+
     return {
         "intent": intent.name if intent else None,
         "confidence": getattr(intent, "confidence", None) if intent else None,
         "latency_ms": latency_ms,
+        "router_latency_ms": router_latency_ms,
+        "baseline_kind": baseline_kind,
+        "baseline_comparable": baseline_comparable,
         "correct": (intent.name if intent else None) == case.expected_intent,
     }
 
@@ -115,12 +142,18 @@ async def _run_cases(
     transport: str,
     enable_execution: bool,
     local_model_configured: bool,
+    fallback_baseline_latency_ms: float | None = None,
+    extraction_failed_baseline_latency_ms: float | None = None,
 ) -> tuple[list[dict[str, Any]], list[PiRouteSample]]:
     comparisons: list[dict[str, Any]] = []
     samples: list[PiRouteSample] = []
     for case in cases:
         case.validate()
-        zoe = await _run_zoe_baseline(case)
+        zoe = await _run_zoe_baseline(
+            case,
+            fallback_baseline_latency_ms=fallback_baseline_latency_ms,
+            extraction_failed_baseline_latency_ms=extraction_failed_baseline_latency_ms,
+        )
         pi = await _run_pi(
             case,
             transport=transport,
@@ -142,6 +175,11 @@ async def _run_cases(
                     pi_transport=transport,
                     route_class=case.route_class,
                     timed_out=bool(pi["timed_out"]),
+                    metadata={
+                        "baseline_kind": zoe["baseline_kind"],
+                        "baseline_comparable": zoe["baseline_comparable"],
+                        "router_latency_ms": zoe["router_latency_ms"],
+                    },
                 )
             )
     return comparisons, samples
@@ -154,6 +192,18 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--transport", choices=["print", "rpc"], default="rpc")
     parser.add_argument("--allow-execution", action="store_true", help="Temporarily set ZOE_PI_ALLOW_EXECUTION=true")
     parser.add_argument("--local-model-configured", action="store_true", help="Temporarily set ZOE_PI_LOCAL_MODEL_CONFIGURED=true")
+    parser.add_argument(
+        "--fallback-baseline-latency-ms",
+        type=float,
+        default=None,
+        help="Measured Zoe fallback/agent latency to use for fallback route-class speed comparisons",
+    )
+    parser.add_argument(
+        "--extraction-failed-baseline-latency-ms",
+        type=float,
+        default=None,
+        help="Measured Zoe fallback latency after deterministic slot extraction fails",
+    )
     parser.add_argument("--min-samples", type=int, default=30)
     parser.add_argument(
         "--cases-file",
@@ -186,6 +236,8 @@ def main(argv: list[str] | None = None) -> int:
                 transport=args.transport,
                 enable_execution=args.allow_execution,
                 local_model_configured=args.local_model_configured,
+                fallback_baseline_latency_ms=args.fallback_baseline_latency_ms,
+                extraction_failed_baseline_latency_ms=args.extraction_failed_baseline_latency_ms,
             )
         )
         samples.extend(measured_samples)

--- a/services/zoe-data/tests/test_pi_promotion_eval_script.py
+++ b/services/zoe-data/tests/test_pi_promotion_eval_script.py
@@ -1,6 +1,8 @@
+import asyncio
 import importlib.util
 import json
 import sys
+import types
 from pathlib import Path
 
 
@@ -15,6 +17,18 @@ def _load_module():
     finally:
         sys.path[:] = old_path
     return module
+
+
+def _install_fake_intent_router(monkeypatch, *, intent_name="weather", confidence=0.75):
+    module = types.ModuleType("intent_router")
+
+    async def detect_and_extract_intent(_text):
+        if intent_name is None:
+            return None
+        return types.SimpleNamespace(name=intent_name, confidence=confidence)
+
+    module.detect_and_extract_intent = detect_and_extract_intent
+    monkeypatch.setitem(sys.modules, "intent_router", module)
 
 
 def test_cli_loads_cases_file_without_default_cases(tmp_path, capsys):
@@ -33,6 +47,45 @@ def test_cli_loads_cases_file_without_default_cases(tmp_path, capsys):
     assert [case["case_id"] for case in payload["eval_cases"]] == ["weather_file"]
     assert payload["eval_case_source_counts"] == {"intent_miss": 1}
     assert payload["promotion_report"]["sample_count"] == 0
+
+
+def test_zoe_baseline_marks_fallback_router_only_as_not_comparable(monkeypatch):
+    _install_fake_intent_router(monkeypatch)
+    module = _load_module()
+    case = module.PiIntentEvalCase("weather", "rain later", "weather", "weather", "fallback")
+
+    result = asyncio.run(module._run_zoe_baseline(case))
+
+    assert result["baseline_kind"] == "router_only_not_comparable"
+    assert result["baseline_comparable"] is False
+    assert result["latency_ms"] == result["router_latency_ms"]
+
+
+def test_zoe_baseline_uses_operator_fallback_latency_override(monkeypatch):
+    _install_fake_intent_router(monkeypatch)
+    module = _load_module()
+    case = module.PiIntentEvalCase("weather", "rain later", "weather", "weather", "fallback")
+
+    result = asyncio.run(module._run_zoe_baseline(case, fallback_baseline_latency_ms=4321.0))
+
+    assert result["baseline_kind"] == "operator_fallback_override"
+    assert result["baseline_comparable"] is True
+    assert result["latency_ms"] == 4321.0
+    assert result["router_latency_ms"] >= 0
+
+
+def test_zoe_baseline_uses_operator_extraction_failed_latency_override(monkeypatch):
+    _install_fake_intent_router(monkeypatch, intent_name=None)
+    module = _load_module()
+    case = module.PiIntentEvalCase(
+        "reminder", "remind me to call mum", "reminder_create", "reminders", "extraction_failed"
+    )
+
+    result = asyncio.run(module._run_zoe_baseline(case, extraction_failed_baseline_latency_ms=987.0))
+
+    assert result["baseline_kind"] == "operator_extraction_failed_override"
+    assert result["baseline_comparable"] is True
+    assert result["latency_ms"] == 987.0
 
 
 def test_cli_combines_default_and_cases_file(tmp_path, capsys):

--- a/services/zoe-data/tests/test_zoe_pi_promotion.py
+++ b/services/zoe-data/tests/test_zoe_pi_promotion.py
@@ -155,6 +155,48 @@ def test_intent_group_for_intent_maps_low_risk_groups_only():
     assert intent_group_for_intent("extend_capability") is None
 
 
+def test_non_comparable_baseline_blocks_promotion():
+    samples = [
+        _sample(
+            i,
+            metadata={"baseline_comparable": False, "baseline_kind": "router_only_not_comparable"},
+        )
+        for i in range(10)
+    ]
+    policy = PiPromotionPolicy(min_samples=10)
+
+    decision = evaluate_pi_promotion(samples, intent_group="weather", policy=policy)
+
+    assert decision.state == "keep_shadow"
+    assert "baseline_not_comparable" in decision.blockers
+
+
+def test_non_comparable_baseline_does_not_roll_back_promoted_group_without_regression():
+    samples = [
+        _sample(
+            i,
+            metadata={"baseline_comparable": False, "baseline_kind": "router_only_not_comparable"},
+        )
+        for i in range(10)
+    ]
+    policy = PiPromotionPolicy(min_samples=10)
+
+    decision = evaluate_pi_promotion(samples, intent_group="weather", policy=policy, promoted=True)
+
+    assert decision.state == "keep_shadow"
+    assert "baseline_not_comparable" in decision.blockers
+
+
+def test_policy_can_disable_comparable_baseline_requirement_for_smoke_data():
+    samples = [_sample(i, metadata={"baseline_comparable": False}) for i in range(10)]
+    policy = PiPromotionPolicy(min_samples=10, require_comparable_baseline=False)
+
+    decision = evaluate_pi_promotion(samples, intent_group="weather", policy=policy)
+
+    assert decision.state == "promote"
+    assert "baseline_not_comparable" not in decision.blockers
+
+
 def test_promotion_requires_five_percent_accuracy_win_and_latency_win():
     samples = [_sample(i) for i in range(10)]
     policy = PiPromotionPolicy(min_samples=10, accuracy_win_margin=0.05)

--- a/services/zoe-data/zoe_pi_promotion.py
+++ b/services/zoe-data/zoe_pi_promotion.py
@@ -174,6 +174,7 @@ class PiPromotionPolicy:
     max_timeout_rate: float = 0.05
     max_correction_rate: float = 0.03
     require_latency_win: bool = True
+    require_comparable_baseline: bool = True
 
     def validate(self) -> None:
         if self.min_samples <= 0:
@@ -280,17 +281,23 @@ def evaluate_pi_promotion(
         blockers.append("timeout_rate_too_high")
     if correction_rate > active_policy.max_correction_rate:
         blockers.append("correction_rate_too_high")
+    if active_policy.require_comparable_baseline and any(
+        sample.metadata.get("baseline_comparable") is False for sample in group_samples
+    ):
+        blockers.append("baseline_not_comparable")
     if any(sample.rollback_blocked for sample in group_samples):
         blockers.append("rollback_blocked")
 
     state = "promote" if not blockers else "keep_shadow"
-    if promoted and {
+    rollback_blockers = {
         "accuracy_delta_below_threshold",
         "insufficient_samples",
         "timeout_rate_too_high",
         "correction_rate_too_high",
         "latency_not_faster_than_zoe",
-    }.intersection(blockers):
+    }
+    # Non-comparable baseline evidence blocks promotion, but does not prove a promoted route regressed.
+    if promoted and rollback_blockers.intersection(blockers):
         state = "rollback"
     if "rollback_blocked" in blockers:
         state = "blocked"
@@ -339,6 +346,7 @@ def summarize_pi_promotion(
             "max_timeout_rate": active_policy.max_timeout_rate,
             "max_correction_rate": active_policy.max_correction_rate,
             "require_latency_win": active_policy.require_latency_win,
+            "require_comparable_baseline": active_policy.require_comparable_baseline,
         },
         "sample_count": len(samples),
         "promoted_groups": sorted(active_promoted_groups),


### PR DESCRIPTION
## Summary

Makes Pi promotion evidence stricter by preventing router-only fallback misses from being treated as comparable Zoe fallback latency.

## What changed

- Marks fallback and extraction-failed eval baselines as `router_only_not_comparable` unless a measured fallback latency override is supplied.
- Adds `baseline_not_comparable` as a promotion blocker through `PiPromotionPolicy.require_comparable_baseline`.
- Adds evaluator flags for measured comparable baselines:
  - `--fallback-baseline-latency-ms`
  - `--extraction-failed-baseline-latency-ms`
- Records baseline kind/comparability/router latency in Pi route sample metadata.
- Updates the Pi harness doc so the latest result no longer calls router-only miss timing a comparable Zoe baseline.

## Evidence

- `python3 -m pytest -q services/zoe-data/tests/test_pi_intent_evidence.py services/zoe-data/tests/test_pi_eval_export.py services/zoe-data/tests/test_pi_promotion_eval_script.py services/zoe-data/tests/test_zoe_pi_promotion.py services/zoe-data/tests/test_pi_promotion_apply.py services/zoe-data/tests/test_pi_intent_shadow.py services/zoe-data/tests/test_pi_intent_classifier.py services/zoe-data/tests/test_pi_intent_status_endpoint.py services/zoe-data/tests/test_pi_runtime_probe.py services/zoe-data/tests/test_zoe_evolution_runtime_intake.py` -> 147 passed
- `git diff --check` -> passed
- `python3 tools/audit/validate_structure.py` -> passed
- `python3 tools/audit/validate_critical_files.py` -> passed
- Live RPC eval now reports fallback/extraction-failed seed samples as `router_only_not_comparable` and blocks promotion with `baseline_not_comparable`.

## Decision impact

This keeps Pi shadow-only until we have measured Zoe fallback/agent latency or labeled runtime shadow evidence. It prevents false promotion based on cheap router miss timing.
