### PR TITLE
Optimize Pi intent RPC runtime

### DIFF
--- a/docs/architecture/zoe-pi-runtime-harness.md
+++ b/docs/architecture/zoe-pi-runtime-harness.md
@@ -65,6 +65,7 @@ Environment variables:
 | `ZOE_PI_INTENT_MISS_EVIDENCE_PATH` | `~/.zoe/data/pi-intent-miss-evidence.jsonl` | JSONL path for structured intent-miss candidates. |
 | `ZOE_PI_INTENT_AUTO_PROMOTE` | `false` | Report whether automatic Pi promotion was requested. Current runtime remains evidence-only and requires the guarded apply helper. |
 | `ZOE_PI_INTENT_PROMOTED_GROUPS` | unset | Comma-separated low-risk intent groups promoted through Pi for live fallback execution and rollback reporting. Unknown or privileged groups are ignored. |
+| `ZOE_PI_INTENT_RUNTIME_PROBE_CACHE_TTL_SECONDS` | `5.0` | Cache Pi readiness checks inside the intent classifier to avoid repeated `PATH`/version discovery during shadow and eval loops. Set to `0` to disable. |
 
 Readiness report fields:
 

--- a/services/zoe-data/pi_intent_classifier.py
+++ b/services/zoe-data/pi_intent_classifier.py
@@ -30,6 +30,8 @@ PI_INTENT_EXECUTE_THRESHOLD = 0.78
 PI_INTENT_HINT_THRESHOLD = 0.55
 PI_INTENT_DEFAULT_TIMEOUT_S = 4.0
 PI_INTENT_MAX_WORDS = 32
+PI_RUNTIME_PROBE_CACHE_TTL_S = 5.0
+_RUNTIME_PROBE_CACHE_MAX_ENTRIES = 32
 
 _ALLOWED_EXECUTABLE_INTENTS = {
     "time_query",
@@ -114,6 +116,7 @@ class PiIntentClassifierConfig:
     offline_only: bool = True
     no_approve: bool = True
     transport: str = "print"
+    runtime_probe_cache_ttl_seconds: float = PI_RUNTIME_PROBE_CACHE_TTL_S
 
     @classmethod
     def from_env(cls, env: Mapping[str, str] | None = None) -> "PiIntentClassifierConfig":
@@ -130,6 +133,11 @@ class PiIntentClassifierConfig:
             offline_only=_env_bool(values.get("ZOE_PI_OFFLINE_ONLY"), default=True),
             no_approve=_env_bool(values.get("ZOE_PI_INTENT_NO_APPROVE"), default=True),
             transport=(values.get("ZOE_PI_INTENT_TRANSPORT") or "print").strip().lower() or "print",
+            runtime_probe_cache_ttl_seconds=float(
+                values.get("ZOE_PI_INTENT_RUNTIME_PROBE_CACHE_TTL_SECONDS")
+                or values.get("ZOE_PI_RUNTIME_PROBE_CACHE_TTL_SECONDS")
+                or PI_RUNTIME_PROBE_CACHE_TTL_S
+            ),
         )
 
     def validate(self) -> None:
@@ -139,6 +147,8 @@ class PiIntentClassifierConfig:
             raise ValueError("ZOE_PI_INTENT_MAX_WORDS must be positive")
         if self.offline_only and self.provider.lower() not in {"ollama", "local", "llama", "llamacpp"}:
             raise ValueError("Pi intent classification requires a local/offline provider")
+        if self.runtime_probe_cache_ttl_seconds < 0:
+            raise ValueError("ZOE_PI_INTENT_RUNTIME_PROBE_CACHE_TTL_SECONDS must be zero or positive")
         if self.transport not in {"print", "rpc"}:
             raise ValueError("ZOE_PI_INTENT_TRANSPORT must be print or rpc")
 
@@ -155,6 +165,7 @@ class PiIntentClassifierConfig:
             "offline_only": self.offline_only,
             "no_approve": self.no_approve,
             "transport": self.transport,
+            "runtime_probe_cache_ttl_seconds": self.runtime_probe_cache_ttl_seconds,
         }
 
 
@@ -248,7 +259,7 @@ async def classify_with_pi_intent_governor(
         return None
 
     runtime_env = _runtime_probe_env(env, active_config)
-    probe = probe_pi_runtime(runtime_env)
+    probe = _probe_pi_runtime_cached(runtime_env, ttl_seconds=active_config.runtime_probe_cache_ttl_seconds)
     if not probe.ok:
         logger.debug("Pi intent governor unavailable: %s", probe.to_dict())
         return None
@@ -445,6 +456,8 @@ class _PiRpcIntentWorker:
             text = _assistant_text_from_rpc_event(event)
             if text:
                 latest_text = text
+            if event.get("type") == "turn_end" and latest_text:
+                return latest_text
             if event.get("type") == "agent_end":
                 return latest_text
 
@@ -561,6 +574,50 @@ def _task_lane_for_intent(intent: str | None) -> str:
         if intent in intents:
             return lane
     return "chat"
+
+
+_RUNTIME_PROBE_CACHE: dict[tuple[str, ...], tuple[float, Any]] = {}
+
+
+def _probe_pi_runtime_cached(runtime_env: Mapping[str, str], *, ttl_seconds: float):
+    if ttl_seconds <= 0:
+        return probe_pi_runtime(runtime_env)
+    key = _runtime_probe_cache_key(runtime_env)
+    now = time.monotonic()
+    cached = _RUNTIME_PROBE_CACHE.get(key)
+    if cached and now - cached[0] <= ttl_seconds:
+        return cached[1]
+    _evict_runtime_probe_cache(now=now, ttl_seconds=ttl_seconds, incoming_key=key)
+    probe = probe_pi_runtime(runtime_env)
+    _RUNTIME_PROBE_CACHE[key] = (now, probe)
+    return probe
+
+
+def _evict_runtime_probe_cache(*, now: float, ttl_seconds: float, incoming_key: tuple[str, ...]) -> None:
+    expired_keys = [key for key, (cached_at, _probe) in _RUNTIME_PROBE_CACHE.items() if now - cached_at > ttl_seconds]
+    for key in expired_keys:
+        _RUNTIME_PROBE_CACHE.pop(key, None)
+    if incoming_key in _RUNTIME_PROBE_CACHE or len(_RUNTIME_PROBE_CACHE) < _RUNTIME_PROBE_CACHE_MAX_ENTRIES:
+        return
+    oldest_key = min(_RUNTIME_PROBE_CACHE, key=lambda key: _RUNTIME_PROBE_CACHE[key][0])
+    _RUNTIME_PROBE_CACHE.pop(oldest_key, None)
+
+
+def _runtime_probe_cache_key(runtime_env: Mapping[str, str]) -> tuple[str, ...]:
+    fields = (
+        "ZOE_PI_ENABLED",
+        "ZOE_PI_ALLOW_EXECUTION",
+        "ZOE_PI_OFFLINE_ONLY",
+        "ZOE_PI_LOCAL_MODEL_REQUIRED",
+        "ZOE_PI_LOCAL_MODEL_CONFIGURED",
+        "ZOE_PI_COMMAND",
+        "ZOE_PI_CWD",
+        "ZOE_PI_AGENT_DIR",
+        "ZOE_PI_TIMEOUT_SECONDS",
+        "PATH",
+        "HOME",
+    )
+    return tuple(str(runtime_env.get(field) or "") for field in fields)
 
 
 def _runtime_probe_env(env: Mapping[str, str] | None, config: PiIntentClassifierConfig) -> dict[str, str]:

--- a/services/zoe-data/tests/test_pi_intent_classifier.py
+++ b/services/zoe-data/tests/test_pi_intent_classifier.py
@@ -9,6 +9,7 @@ from pi_intent_classifier import (
     PI_INTENT_EXECUTE_THRESHOLD,
     PiIntentClassifierConfig,
     _classification_prompt,
+    _probe_pi_runtime_cached,
     _parse_pi_classification,
     _rpc_response_matches_request,
     classify_with_pi_intent_governor,
@@ -16,6 +17,11 @@ from pi_intent_classifier import (
     pi_intent_promotion_status,
     pi_intent_status,
 )
+
+
+@pytest.fixture(autouse=True)
+def _reset_pi_runtime_probe_cache(monkeypatch):
+    monkeypatch.setattr(pi_intent_classifier, "_RUNTIME_PROBE_CACHE", {})
 
 
 def _write_exe(path, body):
@@ -293,6 +299,46 @@ async def test_pi_rpc_failed_response_resets_process_under_worker_lock(tmp_path,
 
 
 @pytest.mark.asyncio
+async def test_pi_rpc_returns_on_turn_end_without_waiting_for_late_agent_end(tmp_path, monkeypatch):
+    bindir = tmp_path / "rpc-turn-end-bin"
+    bindir.mkdir()
+    _write_exe(bindir / "node", "#!/bin/sh\nexit 0\n")
+    _write_exe(bindir / "npm", "#!/bin/sh\nexit 0\n")
+    payload = json.dumps({"intent": "weather", "slots": {}, "confidence": 0.91, "task_lane": "fast_tool"})
+    script = f"""#!/usr/bin/python3
+import json, sys, time
+payload = {payload!r}
+for line in sys.stdin:
+    request = json.loads(line)
+    print(json.dumps({{'id': request['id'], 'type': 'response', 'command': 'prompt', 'success': True}}), flush=True)
+    print(json.dumps({{'type': 'turn_end', 'message': {{'role': 'assistant', 'content': [{{'type': 'text', 'text': payload}}]}}}}), flush=True)
+    time.sleep(10)
+"""
+    _write_exe(bindir / "pi", script)
+    workers = {}
+    monkeypatch.setattr(pi_intent_classifier, "_RPC_WORKERS", workers)
+    env = {
+        "PATH": str(bindir),
+        "ZOE_PI_INTENT_ENABLED": "true",
+        "ZOE_PI_INTENT_TRANSPORT": "rpc",
+        "ZOE_PI_COMMAND": "pi",
+        "ZOE_PI_CWD": str(tmp_path),
+        "ZOE_PI_ALLOW_EXECUTION": "true",
+        "ZOE_PI_LOCAL_MODEL_CONFIGURED": "true",
+        "ZOE_PI_INTENT_TIMEOUT_SECONDS": "0.5",
+    }
+
+    try:
+        result = await classify_with_pi_intent_governor("rain later", env=env)
+    finally:
+        for worker in list(workers.values()):
+            await worker.reset()
+
+    assert result is not None
+    assert result.intent == "weather"
+
+
+@pytest.mark.asyncio
 async def test_pi_rpc_timeout_resets_process_under_worker_lock(tmp_path, monkeypatch):
     bindir = tmp_path / "rpc-timeout-bin"
     bindir.mkdir()
@@ -426,6 +472,53 @@ async def test_pi_rpc_ignores_stale_response_with_mismatched_request_id(tmp_path
     assert result is not None
     assert result.intent == "weather"
     assert result.slots == {"forecast": True}
+
+
+def test_pi_runtime_probe_cache_reuses_probe_until_ttl_expires(tmp_path, monkeypatch):
+    bindir = _fake_runtime(tmp_path)
+    calls = 0
+    original_probe = pi_intent_classifier.probe_pi_runtime
+    monkeypatch.setattr(pi_intent_classifier, "_RUNTIME_PROBE_CACHE", {})
+
+    def spy_probe(env):
+        nonlocal calls
+        calls += 1
+        return original_probe(env)
+
+    monkeypatch.setattr(pi_intent_classifier, "probe_pi_runtime", spy_probe)
+    env = {
+        "PATH": str(bindir),
+        "ZOE_PI_ENABLED": "true",
+        "ZOE_PI_ALLOW_EXECUTION": "true",
+        "ZOE_PI_LOCAL_MODEL_CONFIGURED": "true",
+        "ZOE_PI_COMMAND": "pi",
+        "ZOE_PI_CWD": str(tmp_path),
+    }
+
+    first = _probe_pi_runtime_cached(env, ttl_seconds=60)
+    second = _probe_pi_runtime_cached(env, ttl_seconds=60)
+    third = _probe_pi_runtime_cached(env, ttl_seconds=0)
+
+    assert first.ok is True
+    assert second is first
+    assert third.ok is True
+    assert calls == 2
+
+
+def test_pi_runtime_probe_cache_evicts_old_entries(monkeypatch):
+    calls = 0
+
+    def fake_probe(env):
+        nonlocal calls
+        calls += 1
+        return {"path": env.get("PATH")}
+
+    monkeypatch.setattr(pi_intent_classifier, "probe_pi_runtime", fake_probe)
+    for index in range(40):
+        _probe_pi_runtime_cached({"PATH": f"/tmp/pi-{index}"}, ttl_seconds=60)
+
+    assert calls == 40
+    assert len(pi_intent_classifier._RUNTIME_PROBE_CACHE) <= pi_intent_classifier._RUNTIME_PROBE_CACHE_MAX_ENTRIES
 
 
 def test_pi_prompt_sanitizes_user_json_braces():


### PR DESCRIPTION
## Summary
- cache Pi intent runtime readiness probes for a short configurable TTL to avoid repeated PATH/version discovery in eval and shadow loops
- return RPC intent classification on turn_end once assistant text is available instead of waiting for a later agent_end
- document ZOE_PI_INTENT_RUNTIME_PROBE_CACHE_TTL_SECONDS

## Evidence
- python3 -m pytest -q services/zoe-data/tests/test_pi_intent_evidence.py services/zoe-data/tests/test_pi_eval_export.py services/zoe-data/tests/test_pi_promotion_eval_script.py services/zoe-data/tests/test_zoe_pi_promotion.py services/zoe-data/tests/test_pi_promotion_apply.py services/zoe-data/tests/test_pi_intent_shadow.py services/zoe-data/tests/test_pi_intent_classifier.py services/zoe-data/tests/test_pi_intent_status_endpoint.py services/zoe-data/tests/test_pi_runtime_probe.py services/zoe-data/tests/test_zoe_evolution_runtime_intake.py: 150 passed
- git diff --check
- python3 tools/audit/validate_structure.py
- python3 tools/audit/validate_critical_files.py
- live RPC eval after safe optimization: seed accuracy recovered to 100%, but no groups promotable; Pi remains ~2.2-3.8s and blocked by latency_not_faster_than_zoe/baseline_not_comparable

## Notes
Tried a compact prompt locally during this branch, but reverted it because it reduced seed accuracy. This PR keeps only optimizations that preserved accuracy.