### PR TITLE
Guard Pi shadow fallback baseline evidence

### DIFF
--- a/docs/architecture/zoe-pi-runtime-harness.md
+++ b/docs/architecture/zoe-pi-runtime-harness.md
@@ -99,10 +99,15 @@ Admin status is available at:
 GET /api/system/pi-intent/shadow-status
 ```
 
-The first runtime slice reports agreement and latency for all records. When a
-record includes `outcome_label`, the admin report also converts it into the same
+The first runtime slice reports agreement and latency for all records. Shadow
+records also carry `baseline_kind`, `baseline_comparable`, and `router_latency_ms`.
+Deterministic router records are comparable by default; fallback and
+extraction_failed records are marked non-comparable unless an operator/reviewed
+producer explicitly labels them with measured Zoe fallback or agent latency. When
+a record includes `outcome_label`, the admin report also converts it into the same
 Pi promotion scoring contract used by `pi_promotion_eval.py`, including
-`promotable_groups` and `rollback_groups`. Reviewed records may also set
+`promotable_groups` and `rollback_groups`; non-comparable fallback evidence blocks
+promotion instead of being treated as a speed win. Reviewed records may also set
 `user_corrected=true` or `rollback_blocked=true`; those fields feed the same
 rollback gates as synthetic promotion samples. The promotion report includes
 `route_class_breakdown` for deterministic, fallback, and extraction_failed

--- a/services/zoe-data/intent_router.py
+++ b/services/zoe-data/intent_router.py
@@ -1326,6 +1326,9 @@ async def detect_and_extract_intent(
         route_class: str,
         zoe_latency_ms: float | None,
         pi_result=shadow_unset,
+        baseline_kind: str | None = None,
+        baseline_comparable: bool | None = None,
+        router_latency_ms: float | None = None,
     ) -> None:
         if not _env_enabled("ZOE_PI_INTENT_SHADOW_ENABLED"):
             return
@@ -1339,6 +1342,9 @@ async def detect_and_extract_intent(
                     "zoe_confidence": zoe_intent.confidence if zoe_intent else None,
                     "zoe_latency_ms": zoe_latency_ms,
                     "route_class": route_class,
+                    "baseline_kind": baseline_kind,
+                    "baseline_comparable": baseline_comparable,
+                    "router_latency_ms": router_latency_ms,
                     "user_id": user_id,
                     "context_turns": _context_turns(),
                 }
@@ -1378,6 +1384,9 @@ async def detect_and_extract_intent(
             route_class="fallback",
             zoe_latency_ms=detect_latency_ms,
             pi_result=pi_classified if _env_enabled("ZOE_PI_INTENT_ENABLED") else shadow_unset,
+            baseline_kind="router_only_not_comparable",
+            baseline_comparable=False,
+            router_latency_ms=detect_latency_ms,
         )
         return routed_intent
     if intent.slots and "raw" in intent.slots:
@@ -1390,6 +1399,9 @@ async def detect_and_extract_intent(
                     intent,
                     route_class="deterministic",
                     zoe_latency_ms=(time.perf_counter() - started) * 1000,
+                    baseline_kind="router",
+                    baseline_comparable=True,
+                    router_latency_ms=detect_latency_ms,
                 )
                 return intent
         except Exception as _exc:
@@ -1399,15 +1411,26 @@ async def detect_and_extract_intent(
                 _exc,
             )
         # Extraction failed — let Pi/Gemma classify the ambiguous utterance once before Zoe Agent fallback.
+        extraction_failed_latency_ms = (time.perf_counter() - started) * 1000
         routed_intent, pi_classified = await _try_pi_governor()
         _schedule_pi_shadow(
             None,
             route_class="extraction_failed",
-            zoe_latency_ms=(time.perf_counter() - started) * 1000,
+            zoe_latency_ms=extraction_failed_latency_ms,
             pi_result=pi_classified if _env_enabled("ZOE_PI_INTENT_ENABLED") else shadow_unset,
+            baseline_kind="router_extraction_failed_not_comparable",
+            baseline_comparable=False,
+            router_latency_ms=detect_latency_ms,
         )
         return routed_intent
-    _schedule_pi_shadow(intent, route_class="deterministic", zoe_latency_ms=detect_latency_ms)
+    _schedule_pi_shadow(
+        intent,
+        route_class="deterministic",
+        zoe_latency_ms=detect_latency_ms,
+        baseline_kind="router",
+        baseline_comparable=True,
+        router_latency_ms=detect_latency_ms,
+    )
     return intent
 
 

--- a/services/zoe-data/pi_intent_shadow.py
+++ b/services/zoe-data/pi_intent_shadow.py
@@ -80,6 +80,9 @@ async def maybe_record_pi_intent_shadow(
     zoe_confidence: float | None = None,
     zoe_latency_ms: float | None = None,
     route_class: str,
+    baseline_kind: str | None = None,
+    baseline_comparable: bool | None = None,
+    router_latency_ms: float | None = None,
     user_id: str = "unknown",
     context_turns: str = "",
     env: Mapping[str, str] | None = None,
@@ -114,6 +117,9 @@ async def maybe_record_pi_intent_shadow(
     pi_latency_ms = float(pi_result.latency_ms) if pi_result else elapsed_ms
     timeout_seconds = _float_env(runtime_env.get("ZOE_PI_INTENT_TIMEOUT_SECONDS"), default=4.0)
     timed_out = pi_result is None and elapsed_ms >= (timeout_seconds * 1000 * 0.95)
+    resolved_baseline_kind, resolved_baseline_comparable = _resolve_baseline_metadata(
+        route_class, baseline_kind=baseline_kind, baseline_comparable=baseline_comparable
+    )
     record = {
         "ts": time.time(),
         "text_hash": _hash_text(text),
@@ -124,6 +130,9 @@ async def maybe_record_pi_intent_shadow(
         "zoe_intent_group": intent_group_for_intent(zoe_intent),
         "zoe_confidence": zoe_confidence,
         "zoe_latency_ms": zoe_latency_ms,
+        "baseline_kind": resolved_baseline_kind,
+        "baseline_comparable": resolved_baseline_comparable,
+        "router_latency_ms": router_latency_ms,
         "pi_intent": pi_intent,
         "pi_intent_group": intent_group_for_intent(pi_intent),
         "pi_confidence": pi_confidence,
@@ -184,6 +193,15 @@ def shadow_records_to_route_samples(records: Sequence[Mapping[str, Any]]) -> lis
         pi_latency_ms = _optional_float_value(record.get("pi_latency_ms"))
         if zoe_latency_ms is None or pi_latency_ms is None:
             continue
+        route_class = str(record.get("route_class") or "fallback")
+        explicit_baseline_comparable = (
+            _bool_record_value(record.get("baseline_comparable")) if record.get("baseline_comparable") is not None else None
+        )
+        baseline_kind, baseline_comparable = _resolve_baseline_metadata(
+            route_class,
+            baseline_kind=_optional_str(record.get("baseline_kind")),
+            baseline_comparable=explicit_baseline_comparable,
+        )
         try:
             samples.append(
                 PiRouteSample(
@@ -196,11 +214,17 @@ def shadow_records_to_route_samples(records: Sequence[Mapping[str, Any]]) -> lis
                     pi_latency_ms=pi_latency_ms,
                     pi_confidence=_float_value(record.get("pi_confidence"), default=0.0),
                     pi_transport=str(record.get("pi_transport") or "rpc"),
-                    route_class=str(record.get("route_class") or "fallback"),
+                    route_class=route_class,
                     timed_out=_bool_record_value(record.get("timed_out")),
                     user_corrected=_bool_record_value(record.get("user_corrected")),
                     rollback_blocked=_bool_record_value(record.get("rollback_blocked")),
-                    metadata={"source": "pi_intent_shadow", "text_hash": str(record.get("text_hash") or "")},
+                    metadata={
+                        "source": "pi_intent_shadow",
+                        "text_hash": str(record.get("text_hash") or ""),
+                        "baseline_kind": baseline_kind,
+                        "baseline_comparable": baseline_comparable,
+                        "router_latency_ms": _optional_float_value(record.get("router_latency_ms")),
+                    },
                 )
             )
         except (TypeError, ValueError):
@@ -264,6 +288,40 @@ def summarize_pi_intent_shadow(records: Sequence[Mapping[str, Any]]) -> dict[str
             else "runtime shadow records are unlabeled agreement evidence, not accuracy labels"
         ),
     }
+
+
+def _resolve_baseline_metadata(
+    route_class: str,
+    *,
+    baseline_kind: str | None = None,
+    baseline_comparable: bool | None = None,
+) -> tuple[str, bool]:
+    if baseline_kind is not None:
+        resolved_kind = str(baseline_kind) if baseline_kind else _default_baseline_kind(route_class)
+    elif route_class == "deterministic":
+        resolved_kind = "router"
+    elif route_class == "extraction_failed":
+        resolved_kind = "router_extraction_failed_not_comparable"
+    else:
+        resolved_kind = "router_only_not_comparable"
+    if baseline_comparable is not None:
+        resolved_comparable = bool(baseline_comparable)
+    elif baseline_kind is not None:
+        resolved_comparable = resolved_kind not in {
+            "router_only_not_comparable",
+            "router_extraction_failed_not_comparable",
+        }
+    else:
+        resolved_comparable = route_class == "deterministic"
+    return resolved_kind, resolved_comparable
+
+
+def _default_baseline_kind(route_class: str) -> str:
+    if route_class == "deterministic":
+        return "router"
+    if route_class == "extraction_failed":
+        return "router_extraction_failed_not_comparable"
+    return "router_only_not_comparable"
 
 
 def _append_jsonl(path: str, record: Mapping[str, Any]) -> None:

--- a/services/zoe-data/tests/test_pi_intent_shadow.py
+++ b/services/zoe-data/tests/test_pi_intent_shadow.py
@@ -62,6 +62,8 @@ async def test_shadow_records_sanitized_pi_comparison(tmp_path, monkeypatch):
     assert record is not None
     assert record["agreement"] is True
     assert record["pi_latency_ms"] == 123.0
+    assert record["baseline_kind"] == "router"
+    assert record["baseline_comparable"] is True
     saved = json.loads(path.read_text().strip())
     assert saved["text_preview"] == "email [EMAIL] if rain later"
     assert saved["text_hash"]
@@ -143,6 +145,57 @@ async def test_intent_router_shadow_does_not_change_live_route(monkeypatch):
     assert calls[0]["zoe_intent"] == "weather"
     assert calls[0]["route_class"] == "deterministic"
     assert calls[0]["user_id"] == "jason"
+    assert calls[0]["baseline_kind"] == "router"
+    assert calls[0]["baseline_comparable"] is True
+    assert calls[0]["router_latency_ms"] is not None
+
+
+@pytest.mark.asyncio
+async def test_intent_router_shadow_extraction_failed_records_pre_pi_latency_and_baseline(monkeypatch):
+    monkeypatch.setenv("ZOE_PI_INTENT_ENABLED", "true")
+    monkeypatch.setenv("ZOE_PI_INTENT_SHADOW_ENABLED", "true")
+    monkeypatch.setenv("ZOE_PI_INTENT_PROMOTED_GROUPS", "reminders")
+    calls = []
+
+    async def fake_shadow(text, **kwargs):
+        calls.append({"text": text, **kwargs})
+        return {"pi_intent": "reminder_create", "agreement": False}
+
+    async def fake_extract(_intent_name, _raw):
+        return None
+
+    async def fake_classify(text, *, context_turns="", env=None, config=None):
+        return PiIntentClassification(
+            intent="reminder_create",
+            slots={"title": "call mum"},
+            confidence=0.89,
+            task_lane="fast_tool",
+            source="pi_test",
+            latency_ms=250.0,
+        )
+
+    from intent_router import detect_and_extract_intent
+    import intent_router
+
+    ticks = iter([100.0, 100.002, 100.006])
+    monkeypatch.setattr(intent_router.time, "perf_counter", lambda: next(ticks))
+    monkeypatch.setattr("nlu_extractor.extract_slots_for_intent", fake_extract)
+    monkeypatch.setattr("pi_intent_classifier.classify_with_pi_intent_governor", fake_classify)
+    monkeypatch.setattr("pi_intent_shadow.maybe_record_pi_intent_shadow", fake_shadow)
+
+    intent = await detect_and_extract_intent("remind me to call mum", user_id="jason")
+    await asyncio.sleep(0)
+
+    assert intent is not None
+    assert intent.name == "reminder_create"
+    assert calls
+    assert calls[0]["route_class"] == "extraction_failed"
+    assert calls[0]["baseline_kind"] == "router_extraction_failed_not_comparable"
+    assert calls[0]["baseline_comparable"] is False
+    assert calls[0]["zoe_latency_ms"] == pytest.approx(6.0)
+    assert calls[0]["router_latency_ms"] == pytest.approx(2.0)
+    with pytest.raises(StopIteration):
+        next(ticks)
 
 
 @pytest.mark.asyncio
@@ -180,6 +233,9 @@ async def test_intent_router_reuses_live_pi_result_for_shadow_fallback(tmp_path,
     assert record["route_class"] == "fallback"
     assert record["pi_intent"] == "reminder_list"
     assert record["pi_no_result"] is False
+    assert record["baseline_kind"] == "router_only_not_comparable"
+    assert record["baseline_comparable"] is False
+    assert record["router_latency_ms"] is not None
 
 
 def test_shadow_config_uses_default_for_invalid_max_words():
@@ -223,6 +279,31 @@ def test_labeled_shadow_records_convert_to_route_samples():
     assert samples[0].pi_correct is True
     assert samples[0].user_corrected is True
     assert samples[0].rollback_blocked is False
+    assert samples[0].metadata["baseline_kind"] == "router_only_not_comparable"
+    assert samples[0].metadata["baseline_comparable"] is False
+
+
+def test_labeled_shadow_record_with_explicit_comparable_kind_defaults_to_comparable():
+    samples = shadow_records_to_route_samples(
+        [
+            {
+                "text_hash": "reviewed_fallback",
+                "outcome_label": "weather",
+                "zoe_intent": "reminder_list",
+                "pi_intent": "weather",
+                "zoe_latency_ms": 500,
+                "pi_latency_ms": 120,
+                "pi_confidence": 0.9,
+                "pi_transport": "rpc",
+                "route_class": "fallback",
+                "baseline_kind": "operator_fallback_override",
+            }
+        ]
+    )
+
+    assert len(samples) == 1
+    assert samples[0].metadata["baseline_kind"] == "operator_fallback_override"
+    assert samples[0].metadata["baseline_comparable"] is True
 
 
 def test_labeled_shadow_records_skip_missing_latency():
@@ -262,6 +343,40 @@ def test_shadow_summary_needs_min_samples_for_promotion_ready():
     assert report["promotion_ready"] is False
 
 
+def test_labeled_shadow_fallback_without_comparable_baseline_blocks_promotion(tmp_path):
+    path = tmp_path / "shadow.jsonl"
+    rows = []
+    for index in range(PiPromotionPolicy().min_samples):
+        rows.append(
+            json.dumps(
+                {
+                    "text_hash": f"weather_router_only_{index}",
+                    "outcome_label": "weather",
+                    "zoe_intent": "reminder_list",
+                    "pi_intent": "weather",
+                    "zoe_latency_ms": 500,
+                    "pi_latency_ms": 120,
+                    "pi_confidence": 0.9,
+                    "pi_transport": "rpc",
+                    "route_class": "fallback",
+                    "agreement": False,
+                    "timed_out": False,
+                    "pi_no_result": False,
+                }
+            )
+        )
+    path.write_text("\n".join(rows) + "\n")
+
+    status = pi_intent_shadow_status({"ZOE_PI_INTENT_SHADOW_PATH": str(path)})
+
+    weather = next(
+        decision for decision in status["promotion_report"]["decisions"] if decision["intent_group"] == "weather"
+    )
+    assert weather["state"] == "keep_shadow"
+    assert "baseline_not_comparable" in weather["blockers"]
+    assert "weather" not in status["promotion_report"]["promotable_groups"]
+
+
 def test_shadow_status_includes_promotion_report_for_labeled_records(tmp_path):
     path = tmp_path / "shadow.jsonl"
     rows = []
@@ -281,6 +396,9 @@ def test_shadow_status_includes_promotion_report_for_labeled_records(tmp_path):
                     "agreement": False,
                     "timed_out": False,
                     "pi_no_result": False,
+                    "baseline_kind": "operator_fallback_override",
+                    "baseline_comparable": True,
+                    "router_latency_ms": 5,
                 }
             )
         )


### PR DESCRIPTION
## Summary
- add baseline_kind, baseline_comparable, and router_latency_ms to Pi shadow evidence records
- make fallback/extraction_failed shadow records non-comparable by default, so reviewed labels cannot accidentally promote Pi using cheap router-miss timing
- keep deterministic router records comparable by default and allow explicitly reviewed comparable fallback evidence
- record extraction_failed Zoe latency before the Pi attempt, so shadow Zoe latency does not include Pi runtime

## Evidence
- python3 -m pytest -q services/zoe-data/tests/test_pi_intent_evidence.py services/zoe-data/tests/test_pi_eval_export.py services/zoe-data/tests/test_pi_promotion_eval_script.py services/zoe-data/tests/test_zoe_pi_promotion.py services/zoe-data/tests/test_pi_promotion_apply.py services/zoe-data/tests/test_pi_intent_shadow.py services/zoe-data/tests/test_pi_intent_classifier.py services/zoe-data/tests/test_pi_intent_status_endpoint.py services/zoe-data/tests/test_pi_runtime_probe.py services/zoe-data/tests/test_zoe_evolution_runtime_intake.py: 152 passed
- git diff --check
- python3 tools/audit/validate_structure.py
- python3 tools/audit/validate_critical_files.py
- live RPC eval: seed accuracy remains good, no promotable groups; blockers still include latency_not_faster_than_zoe and baseline_not_comparable for fallback-style evidence

## Notes
This is an evidence-safety PR, not a Pi speed PR. It prevents false promotion from non-comparable runtime shadow records before we collect true Zoe fallback/agent latency.