### PR TITLE
[codex] Measure Zoe Agent fallback baseline for Pi eval

### DIFF
--- a/docs/architecture/zoe-pi-runtime-harness.md
+++ b/docs/architecture/zoe-pi-runtime-harness.md
@@ -167,9 +167,13 @@ with no tools, extensions, skills, prompt templates, themes, or context files.
 The evaluator treats fallback and extraction-failed router misses as
 `router_only_not_comparable` unless an operator supplies measured comparable
 latency with `--fallback-baseline-latency-ms` and/or
-`--extraction-failed-baseline-latency-ms`. The report still remains
-evidence-only; `ZOE_PI_INTENT_PROMOTED_GROUPS` changes must pass the promotion
-actions and guarded apply helper described above.
+`--extraction-failed-baseline-latency-ms`, or explicitly opts into live Zoe Agent
+fallback measurement with `--measure-zoe-agent-baseline`. Zoe Agent baseline
+measurement runs `run_zoe_agent()` for fallback/extraction_failed cases with a
+per-case timeout and max-token cap, and only marks the baseline comparable when
+Zoe Agent returns before timeout. The report still remains evidence-only;
+`ZOE_PI_INTENT_PROMOTED_GROUPS` changes must pass the promotion actions and
+guarded apply helper described above.
 
 ### Latest Local Pi/Gemma Intent Eval
 
@@ -192,6 +196,12 @@ Decision: keep Pi intent routing in shadow/evidence mode. Pi is accurate enough
 on the seed eval to justify more measurement, but promotion requires measured
 Zoe fallback/agent latency or labeled runtime shadow records, not router-only
 miss timing.
+
+Single-case measured fallback smoke on 2026-06-15 using `rain later`, local
+Gemma, RPC transport, `--measure-zoe-agent-baseline`, 20s timeout, and 128-token
+Zoe Agent cap: Zoe Agent fallback returned in about 6.75s with 260 response
+characters; Pi RPC classified `weather` in about 4.09s. This is useful evidence,
+but not enough sample volume for promotion.
 
 Sanitized JSONL evidence can be exported into the same eval-case format. For Pi
 shadow records this uses `text_preview` plus a trusted `outcome_label`; unlabeled,

--- a/scripts/maintenance/pi_promotion_eval.py
+++ b/scripts/maintenance/pi_promotion_eval.py
@@ -14,6 +14,7 @@ import json
 import os
 import sys
 import time
+import uuid
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
@@ -77,6 +78,9 @@ async def _run_zoe_baseline(
     *,
     fallback_baseline_latency_ms: float | None = None,
     extraction_failed_baseline_latency_ms: float | None = None,
+    measure_zoe_agent_baseline: bool = False,
+    zoe_agent_baseline_timeout_seconds: float = 30.0,
+    zoe_agent_baseline_max_tokens: int = 256,
 ) -> dict[str, Any]:
     with _temporary_env({"ZOE_PI_INTENT_ENABLED": "false"}):
         from intent_router import detect_and_extract_intent
@@ -88,20 +92,44 @@ async def _run_zoe_baseline(
     latency_ms = router_latency_ms
     baseline_kind = "router"
     baseline_comparable = True
+    baseline_timed_out = False
+    baseline_response_chars: int | None = None
+    baseline_error: str | None = None
+    agent_baseline: dict[str, Any] | None = None
     if case.route_class == "fallback":
-        if fallback_baseline_latency_ms is None:
-            baseline_kind = "router_only_not_comparable"
-            baseline_comparable = False
-        else:
+        if fallback_baseline_latency_ms is not None:
             latency_ms = fallback_baseline_latency_ms
             baseline_kind = "operator_fallback_override"
-    elif case.route_class == "extraction_failed":
-        if extraction_failed_baseline_latency_ms is None:
+        elif measure_zoe_agent_baseline:
+            agent_baseline = await _run_zoe_agent_baseline(
+                case,
+                timeout_seconds=zoe_agent_baseline_timeout_seconds,
+                max_tokens=zoe_agent_baseline_max_tokens,
+            )
+        else:
             baseline_kind = "router_only_not_comparable"
             baseline_comparable = False
-        else:
+    elif case.route_class == "extraction_failed":
+        if extraction_failed_baseline_latency_ms is not None:
             latency_ms = extraction_failed_baseline_latency_ms
             baseline_kind = "operator_extraction_failed_override"
+        elif measure_zoe_agent_baseline:
+            agent_baseline = await _run_zoe_agent_baseline(
+                case,
+                timeout_seconds=zoe_agent_baseline_timeout_seconds,
+                max_tokens=zoe_agent_baseline_max_tokens,
+            )
+        else:
+            baseline_kind = "router_only_not_comparable"
+            baseline_comparable = False
+
+    if agent_baseline is not None:
+        latency_ms = agent_baseline["latency_ms"]
+        baseline_kind = agent_baseline["baseline_kind"]
+        baseline_comparable = agent_baseline["baseline_comparable"]
+        baseline_timed_out = agent_baseline["timed_out"]
+        baseline_response_chars = agent_baseline["response_chars"]
+        baseline_error = agent_baseline.get("error")
 
     return {
         "intent": intent.name if intent else None,
@@ -110,9 +138,65 @@ async def _run_zoe_baseline(
         "router_latency_ms": router_latency_ms,
         "baseline_kind": baseline_kind,
         "baseline_comparable": baseline_comparable,
+        "baseline_timed_out": baseline_timed_out,
+        "baseline_response_chars": baseline_response_chars,
+        "baseline_error": baseline_error,
         "correct": (intent.name if intent else None) == case.expected_intent,
     }
 
+
+async def _run_zoe_agent_baseline(
+    case: PiIntentEvalCase,
+    *,
+    timeout_seconds: float,
+    max_tokens: int,
+) -> dict[str, Any]:
+    from zoe_agent import run_zoe_agent
+
+    session_id = f"pi-eval-baseline-{case.case_id}-{uuid.uuid4().hex[:8]}"
+    start = time.perf_counter()
+    try:
+        response = await asyncio.wait_for(
+            run_zoe_agent(
+                case.text,
+                session_id,
+                "pi-eval",
+                history=[],
+                db_memory_context="",
+                portrait="",
+                max_tokens_override=max_tokens,
+            ),
+            timeout=timeout_seconds,
+        )
+        latency_ms = (time.perf_counter() - start) * 1000
+        return {
+            "latency_ms": latency_ms,
+            "baseline_kind": f"zoe_agent_{case.route_class}_baseline",
+            "baseline_comparable": True,
+            "timed_out": False,
+            "response_chars": len(response or ""),
+            "error": None,
+        }
+    except asyncio.TimeoutError:
+        latency_ms = (time.perf_counter() - start) * 1000
+        return {
+            "latency_ms": latency_ms,
+            "baseline_kind": f"zoe_agent_{case.route_class}_timeout",
+            "baseline_comparable": False,
+            "timed_out": True,
+            "response_chars": 0,
+            "error": "TimeoutError",
+        }
+    except Exception as exc:
+        latency_ms = (time.perf_counter() - start) * 1000
+        return {
+            "latency_ms": latency_ms,
+            "baseline_kind": f"zoe_agent_{case.route_class}_error",
+            "baseline_comparable": False,
+            "timed_out": False,
+            "response_chars": 0,
+            "error": exc.__class__.__name__,
+        }
 
 async def _run_pi(case: PiIntentEvalCase, *, transport: str, enable_execution: bool, local_model_configured: bool) -> dict[str, Any]:
     updates = {
@@ -144,6 +228,9 @@ async def _run_cases(
     local_model_configured: bool,
     fallback_baseline_latency_ms: float | None = None,
     extraction_failed_baseline_latency_ms: float | None = None,
+    measure_zoe_agent_baseline: bool = False,
+    zoe_agent_baseline_timeout_seconds: float = 30.0,
+    zoe_agent_baseline_max_tokens: int = 256,
 ) -> tuple[list[dict[str, Any]], list[PiRouteSample]]:
     comparisons: list[dict[str, Any]] = []
     samples: list[PiRouteSample] = []
@@ -153,6 +240,9 @@ async def _run_cases(
             case,
             fallback_baseline_latency_ms=fallback_baseline_latency_ms,
             extraction_failed_baseline_latency_ms=extraction_failed_baseline_latency_ms,
+            measure_zoe_agent_baseline=measure_zoe_agent_baseline,
+            zoe_agent_baseline_timeout_seconds=zoe_agent_baseline_timeout_seconds,
+            zoe_agent_baseline_max_tokens=zoe_agent_baseline_max_tokens,
         )
         pi = await _run_pi(
             case,
@@ -178,6 +268,9 @@ async def _run_cases(
                     metadata={
                         "baseline_kind": zoe["baseline_kind"],
                         "baseline_comparable": zoe["baseline_comparable"],
+                        "baseline_timed_out": zoe["baseline_timed_out"],
+                        "baseline_response_chars": zoe["baseline_response_chars"],
+                        "baseline_error": zoe["baseline_error"],
                         "router_latency_ms": zoe["router_latency_ms"],
                     },
                 )
@@ -203,6 +296,23 @@ def main(argv: list[str] | None = None) -> int:
         type=float,
         default=None,
         help="Measured Zoe fallback latency after deterministic slot extraction fails",
+    )
+    parser.add_argument(
+        "--measure-zoe-agent-baseline",
+        action="store_true",
+        help="Measure comparable Zoe Agent fallback latency for fallback/extraction_failed route classes",
+    )
+    parser.add_argument(
+        "--zoe-agent-baseline-timeout-seconds",
+        type=float,
+        default=30.0,
+        help="Timeout for each measured Zoe Agent fallback baseline case",
+    )
+    parser.add_argument(
+        "--zoe-agent-baseline-max-tokens",
+        type=int,
+        default=256,
+        help="max_tokens_override passed to Zoe Agent when measuring comparable fallback baselines",
     )
     parser.add_argument("--min-samples", type=int, default=30)
     parser.add_argument(
@@ -238,6 +348,9 @@ def main(argv: list[str] | None = None) -> int:
                 local_model_configured=args.local_model_configured,
                 fallback_baseline_latency_ms=args.fallback_baseline_latency_ms,
                 extraction_failed_baseline_latency_ms=args.extraction_failed_baseline_latency_ms,
+                measure_zoe_agent_baseline=args.measure_zoe_agent_baseline,
+                zoe_agent_baseline_timeout_seconds=args.zoe_agent_baseline_timeout_seconds,
+                zoe_agent_baseline_max_tokens=args.zoe_agent_baseline_max_tokens,
             )
         )
         samples.extend(measured_samples)

--- a/services/zoe-data/tests/test_pi_promotion_eval_script.py
+++ b/services/zoe-data/tests/test_pi_promotion_eval_script.py
@@ -31,6 +31,21 @@ def _install_fake_intent_router(monkeypatch, *, intent_name="weather", confidenc
     monkeypatch.setitem(sys.modules, "intent_router", module)
 
 
+def _install_fake_zoe_agent(monkeypatch, calls, *, response="agent answer", sleep_seconds=0, raises=None):
+    module = types.ModuleType("zoe_agent")
+
+    async def run_zoe_agent(message, session_id, user_id="family-admin", **kwargs):
+        calls.append({"message": message, "session_id": session_id, "user_id": user_id, "kwargs": kwargs})
+        if sleep_seconds:
+            await asyncio.sleep(sleep_seconds)
+        if raises:
+            raise raises
+        return response
+
+    module.run_zoe_agent = run_zoe_agent
+    monkeypatch.setitem(sys.modules, "zoe_agent", module)
+
+
 def test_cli_loads_cases_file_without_default_cases(tmp_path, capsys):
     module = _load_module()
     cases_path = tmp_path / "cases.jsonl"
@@ -59,6 +74,9 @@ def test_zoe_baseline_marks_fallback_router_only_as_not_comparable(monkeypatch):
     assert result["baseline_kind"] == "router_only_not_comparable"
     assert result["baseline_comparable"] is False
     assert result["latency_ms"] == result["router_latency_ms"]
+    assert result["baseline_timed_out"] is False
+    assert result["baseline_response_chars"] is None
+    assert result["baseline_error"] is None
 
 
 def test_zoe_baseline_uses_operator_fallback_latency_override(monkeypatch):
@@ -72,6 +90,30 @@ def test_zoe_baseline_uses_operator_fallback_latency_override(monkeypatch):
     assert result["baseline_comparable"] is True
     assert result["latency_ms"] == 4321.0
     assert result["router_latency_ms"] >= 0
+    assert result["baseline_timed_out"] is False
+    assert result["baseline_response_chars"] is None
+    assert result["baseline_error"] is None
+
+
+def test_zoe_baseline_operator_override_wins_over_agent_measurement(monkeypatch):
+    _install_fake_intent_router(monkeypatch)
+    calls = []
+    _install_fake_zoe_agent(monkeypatch, calls)
+    module = _load_module()
+    case = module.PiIntentEvalCase("weather", "rain later", "weather", "weather", "fallback")
+
+    result = asyncio.run(
+        module._run_zoe_baseline(
+            case,
+            fallback_baseline_latency_ms=4321.0,
+            measure_zoe_agent_baseline=True,
+        )
+    )
+
+    assert result["baseline_kind"] == "operator_fallback_override"
+    assert result["baseline_comparable"] is True
+    assert result["latency_ms"] == 4321.0
+    assert calls == []
 
 
 def test_zoe_baseline_uses_operator_extraction_failed_latency_override(monkeypatch):
@@ -87,6 +129,57 @@ def test_zoe_baseline_uses_operator_extraction_failed_latency_override(monkeypat
     assert result["baseline_comparable"] is True
     assert result["latency_ms"] == 987.0
 
+    assert result["baseline_timed_out"] is False
+    assert result["baseline_response_chars"] is None
+    assert result["baseline_error"] is None
+
+
+def test_zoe_baseline_can_measure_comparable_zoe_agent_fallback(monkeypatch):
+    _install_fake_intent_router(monkeypatch, intent_name=None)
+    calls = []
+    _install_fake_zoe_agent(monkeypatch, calls, response="fallback answer")
+    module = _load_module()
+    case = module.PiIntentEvalCase("weather", "rain later", "weather", "weather", "fallback")
+
+    result = asyncio.run(module._run_zoe_baseline(case, measure_zoe_agent_baseline=True))
+
+    assert result["baseline_kind"] == "zoe_agent_fallback_baseline"
+    assert result["baseline_comparable"] is True
+    assert result["latency_ms"] >= 0
+    assert len(calls) == 1
+    assert calls[0]["message"] == "rain later"
+    assert result["baseline_timed_out"] is False
+    assert result["baseline_response_chars"] == len("fallback answer")
+    assert result["baseline_error"] is None
+    assert calls[0]["user_id"] == "pi-eval"
+    assert calls[0]["kwargs"]["history"] == []
+    assert calls[0]["kwargs"]["db_memory_context"] == ""
+    assert calls[0]["kwargs"]["portrait"] == ""
+    assert calls[0]["kwargs"]["max_tokens_override"] == 256
+
+
+def test_zoe_baseline_timeout_is_not_comparable(monkeypatch):
+    _install_fake_intent_router(monkeypatch, intent_name=None)
+    calls = []
+    _install_fake_zoe_agent(monkeypatch, calls, sleep_seconds=0.05)
+    module = _load_module()
+    case = module.PiIntentEvalCase("weather", "rain later", "weather", "weather", "fallback")
+
+    result = asyncio.run(
+        module._run_zoe_baseline(
+            case,
+            measure_zoe_agent_baseline=True,
+            zoe_agent_baseline_timeout_seconds=0.001,
+        )
+    )
+
+    assert result["baseline_kind"] == "zoe_agent_fallback_timeout"
+    assert result["baseline_comparable"] is False
+    assert result["latency_ms"] >= 0
+    assert len(calls) == 1
+
+    assert result["baseline_timed_out"] is True
+    assert result["baseline_response_chars"] == 0
 
 def test_cli_combines_default_and_cases_file(tmp_path, capsys):
     module = _load_module()


### PR DESCRIPTION
## Summary
- add opt-in `--measure-zoe-agent-baseline` support to the Pi promotion evaluator for fallback and extraction_failed route classes
- record measured Zoe Agent fallback latency, timeout state, response size, and comparable/non-comparable status in comparison/sample metadata
- document the measured baseline mode and the first single-case live smoke result

## Why
Fallback router misses were intentionally marked non-comparable, but we still needed a controlled way to measure the real Zoe Agent fallback baseline before deciding whether Pi is actually faster. This keeps default reports conservative while giving operators an opt-in apples-to-apples speed test.

## Validation
- `python3 -m pytest -q services/zoe-data/tests/test_pi_intent_evidence.py services/zoe-data/tests/test_pi_eval_export.py services/zoe-data/tests/test_pi_promotion_eval_script.py services/zoe-data/tests/test_zoe_pi_promotion.py services/zoe-data/tests/test_pi_promotion_apply.py services/zoe-data/tests/test_pi_intent_shadow.py services/zoe-data/tests/test_pi_intent_classifier.py services/zoe-data/tests/test_pi_intent_status_endpoint.py services/zoe-data/tests/test_pi_runtime_probe.py services/zoe-data/tests/test_zoe_evolution_runtime_intake.py` -> 157 passed
- `git diff --check`
- `python3 tools/audit/validate_structure.py`
- `python3 tools/audit/validate_critical_files.py`
- live default Pi RPC eval: 11 comparisons, 9 eligible samples, fallback/extraction_failed remained `router_only_not_comparable`
- live single-case measured fallback eval: Zoe Agent fallback comparable at ~6748.56ms, Pi RPC weather classification ~4085.69ms, response size 260 chars
