### PR TITLE
[codex] Add instant voice wake presence path

### DIFF
--- a/docs/guides/OPERATOR_RUNBOOK.md
+++ b/docs/guides/OPERATOR_RUNBOOK.md
@@ -44,7 +44,7 @@ systemctl --user restart openclaw-gateway # After openclaw.json changes
 | `ZOE_UNAUTHENTICATED_ROLE` | zoe-data | (admin) | Set to `guest` for kiosk/public endpoints |
 | `OPENCLAW_AGENT_TIMEOUT_S` | zoe-data | 120 | Seconds before OpenClaw CLI times out |
 | `HA_ACCESS_TOKEN` | .env | — | Home Assistant long-lived token (named `zoe-data`) |
-| `ZOE_WAKE_ACK_PHRASE` | Pi daemon | — | TTS phrase played after wake word (optional) |
+| `ZOE_WAKE_ACK_PHRASE` | zoe-data + Pi daemon | — | Instant websocket wake transcript and optional TTS phrase after wake word |
 | `ZOE_DEVICE_TOKEN_SECRET` | zoe-data | — | Secret for device token HMAC (optional extra layer) |
 | `ZOE_PIN_MAX_ATTEMPTS` | zoe-data | 5 | PIN lockout attempts |
 | `ZOE_PIN_CHALLENGE_TTL_S` | zoe-data | 120 | PIN challenge expiry in seconds |

--- a/services/zoe-data/main.py
+++ b/services/zoe-data/main.py
@@ -1694,7 +1694,7 @@ async def websocket_voice(websocket: WebSocket, session_id: str = Query("")):
                     msg = __import__("json").loads(text_data)
                 except ValueError:
                     msg = None
-                if hasattr(msg, "get"):
+                if isinstance(msg, dict):
                     if is_wake_payload(msg):
                         for event in wake_presence_events(ack_phrase=wake_ack_phrase()):
                             await websocket.send_json(event)

--- a/services/zoe-data/main.py
+++ b/services/zoe-data/main.py
@@ -44,6 +44,7 @@ from routers.system import (
 )
 from system_updates import start_zoe_update_background_tasks
 from routers.openclaw import router as openclaw_router
+from voice_presence import is_wake_payload, is_wake_text, wake_ack_phrase, wake_presence_events
 import logging
 from middleware.logging import setup_json_logging
 
@@ -1688,15 +1689,26 @@ async def websocket_voice(websocket: WebSocket, session_id: str = Query("")):
                 if text_data == "ping":
                     await websocket.send_json({"type": "pong"})
                     continue
+                msg = None
                 try:
                     msg = __import__("json").loads(text_data)
+                except ValueError:
+                    msg = None
+                if hasattr(msg, "get"):
+                    if is_wake_payload(msg):
+                        for event in wake_presence_events(ack_phrase=wake_ack_phrase()):
+                            await websocket.send_json(event)
+                        continue
                     if msg.get("type") == "text":
                         message_text = msg.get("message", "").strip()
                     elif msg.get("type") == "cancel":
                         _ws_cancelled[0] = True
                         continue
-                except Exception:
-                    pass
+                else:
+                    if is_wake_text(text_data):
+                        for event in wake_presence_events(ack_phrase=wake_ack_phrase()):
+                            await websocket.send_json(event)
+                        continue
 
             if not message_text:
                 continue

--- a/services/zoe-data/tests/test_voice_presence.py
+++ b/services/zoe-data/tests/test_voice_presence.py
@@ -1,0 +1,120 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from voice_presence import is_wake_payload, is_wake_text, wake_ack_phrase, wake_presence_events
+
+
+def test_is_wake_text_matches_only_wake_phrase():
+    assert is_wake_text("hey zoe") is True
+    assert is_wake_text("Hi Zoe!") is True
+    assert is_wake_text("hello zoe ") is True
+    assert is_wake_text("hey zoe do I need a jacket") is False
+    assert is_wake_text("zoe") is False
+
+
+def test_is_wake_payload_accepts_explicit_wake_and_text_phrase():
+    assert is_wake_payload({"type": "wake"}) is True
+    assert is_wake_payload({"type": "text", "message": "hey zoe"}) is True
+    assert is_wake_payload({"type": "text", "message": "hey zoe set a timer"}) is False
+    assert is_wake_payload({"type": "cancel"}) is False
+    assert is_wake_payload(None) is False
+
+
+def test_wake_presence_events_are_instant_and_non_reasoning():
+    events = wake_presence_events()
+
+    assert events == [
+        {"type": "state", "state": "wake"},
+        {"type": "state", "state": "listening"},
+        {"type": "done"},
+    ]
+
+
+def test_wake_presence_events_can_include_short_ack_phrase():
+    events = wake_presence_events(ack_phrase="Yeah?")
+
+    assert events == [
+        {"type": "state", "state": "wake"},
+        {"type": "transcript", "role": "zoe", "text": "Yeah?"},
+        {"type": "state", "state": "listening"},
+        {"type": "done"},
+    ]
+
+
+def test_wake_ack_phrase_uses_env_mapping():
+    assert wake_ack_phrase({}) == ""
+    assert wake_ack_phrase({"ZOE_WAKE_ACK_PHRASE": "  Yeah? "}) == "Yeah?"
+
+
+def test_presence_event_builder_is_sub_millisecond_for_hot_path():
+    import time
+
+    started = time.perf_counter()
+    for _ in range(1000):
+        wake_presence_events(ack_phrase="Yeah?")
+    elapsed_ms = (time.perf_counter() - started) * 1000
+
+    assert elapsed_ms < 5.0
+
+
+def test_websocket_wake_returns_presence_events_without_reasoning(monkeypatch):
+    from fastapi.testclient import TestClient
+    import main
+
+    async def _unexpected_resolve(*_args, **_kwargs):
+        raise AssertionError("wake must not enter Skybridge/card resolution")
+
+    monkeypatch.setattr(main, "_resolve_voice_cards", _unexpected_resolve)
+    monkeypatch.delenv("ZOE_WAKE_ACK_PHRASE", raising=False)
+
+    with TestClient(main.app) as client:
+        with client.websocket_connect("/ws/voice/") as ws:
+            assert ws.receive_json() == {"type": "state", "state": "ambient"}
+            ws.send_json({"type": "wake"})
+
+            assert ws.receive_json() == {"type": "state", "state": "wake"}
+            assert ws.receive_json() == {"type": "state", "state": "listening"}
+            assert ws.receive_json() == {"type": "done"}
+
+
+def test_websocket_hey_zoe_can_emit_configured_ack_phrase(monkeypatch):
+    from fastapi.testclient import TestClient
+    import main
+
+    async def _unexpected_resolve(*_args, **_kwargs):
+        raise AssertionError("wake phrase must not enter Skybridge/card resolution")
+
+    monkeypatch.setattr(main, "_resolve_voice_cards", _unexpected_resolve)
+    monkeypatch.setenv("ZOE_WAKE_ACK_PHRASE", "Yes Jason?")
+
+    with TestClient(main.app) as client:
+        with client.websocket_connect("/ws/voice/") as ws:
+            assert ws.receive_json() == {"type": "state", "state": "ambient"}
+            ws.send_json({"type": "text", "message": "hey zoe"})
+
+            assert ws.receive_json() == {"type": "state", "state": "wake"}
+            assert ws.receive_json() == {"type": "transcript", "role": "zoe", "text": "Yes Jason?"}
+            assert ws.receive_json() == {"type": "state", "state": "listening"}
+            assert ws.receive_json() == {"type": "done"}
+
+
+def test_websocket_ignores_non_object_json_and_stays_alive(monkeypatch):
+    from fastapi.testclient import TestClient
+    import main
+
+    async def _unexpected_resolve(*_args, **_kwargs):
+        raise AssertionError("non-message payload must not enter Skybridge/card resolution")
+
+    monkeypatch.setattr(main, "_resolve_voice_cards", _unexpected_resolve)
+
+    with TestClient(main.app) as client:
+        with client.websocket_connect("/ws/voice/") as ws:
+            assert ws.receive_json() == {"type": "state", "state": "ambient"}
+            ws.send_text("[]")
+            ws.send_text("ping")
+
+            assert ws.receive_json() == {"type": "pong"}

--- a/services/zoe-data/tests/test_voice_presence.py
+++ b/services/zoe-data/tests/test_voice_presence.py
@@ -102,6 +102,27 @@ def test_websocket_hey_zoe_can_emit_configured_ack_phrase(monkeypatch):
             assert ws.receive_json() == {"type": "done"}
 
 
+def test_websocket_raw_text_hey_zoe_can_emit_configured_ack_phrase(monkeypatch):
+    from fastapi.testclient import TestClient
+    import main
+
+    async def _unexpected_resolve(*_args, **_kwargs):
+        raise AssertionError("raw wake phrase must not enter Skybridge/card resolution")
+
+    monkeypatch.setattr(main, "_resolve_voice_cards", _unexpected_resolve)
+    monkeypatch.setenv("ZOE_WAKE_ACK_PHRASE", "Yes Jason?")
+
+    with TestClient(main.app) as client:
+        with client.websocket_connect("/ws/voice/") as ws:
+            assert ws.receive_json() == {"type": "state", "state": "ambient"}
+            ws.send_text("hey zoe")
+
+            assert ws.receive_json() == {"type": "state", "state": "wake"}
+            assert ws.receive_json() == {"type": "transcript", "role": "zoe", "text": "Yes Jason?"}
+            assert ws.receive_json() == {"type": "state", "state": "listening"}
+            assert ws.receive_json() == {"type": "done"}
+
+
 def test_websocket_ignores_non_object_json_and_stays_alive(monkeypatch):
     from fastapi.testclient import TestClient
     import main

--- a/services/zoe-data/voice_presence.py
+++ b/services/zoe-data/voice_presence.py
@@ -1,0 +1,59 @@
+"""Fast presence helpers for Zoe voice wake handling.
+
+Wake acknowledgement is deliberately separate from reasoning: a wake event
+should be acknowledged immediately and must not enter Skybridge, Pi, Graphify,
+or the Zoe Agent path.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from typing import Any, Mapping
+
+_WAKE_TEXT_RE = re.compile(r"^\s*(?:hey|hi|hello)\s+zoe[.!?\s]*$", re.I)
+
+
+def is_wake_text(text: str | None) -> bool:
+    """Return True when a transcript is only a Zoe wake phrase."""
+    return bool(_WAKE_TEXT_RE.match(str(text or "")))
+
+
+def is_wake_payload(payload: Mapping[str, Any] | None) -> bool:
+    """Return True for explicit wake payloads or text payload wake phrases."""
+    if not isinstance(payload, Mapping):
+        return False
+    payload_type = str(payload.get("type") or "").strip().lower()
+    if payload_type == "wake":
+        return True
+    if payload_type == "text":
+        return is_wake_text(str(payload.get("message") or ""))
+    return False
+
+
+def wake_ack_phrase(env: Mapping[str, str] | None = None) -> str:
+    """Resolve the optional short phrase Zoe can display/speak on wake."""
+    values = env if env is not None else os.environ
+    return str(values.get("ZOE_WAKE_ACK_PHRASE") or "").strip()
+
+
+def wake_presence_events(*, ack_phrase: str = "") -> list[dict[str, Any]]:
+    """Build the instant websocket events for a wake turn.
+
+    The event list intentionally has no audio by default. Audio synthesis can be
+    layered on by a caller after these events are sent, but the visible/listening
+    acknowledgement must stay cheap and deterministic.
+    """
+    events: list[dict[str, Any]] = [
+        {"type": "state", "state": "wake"},
+    ]
+    phrase = str(ack_phrase or "").strip()
+    if phrase:
+        events.append({"type": "transcript", "role": "zoe", "text": phrase})
+    events.extend(
+        [
+            {"type": "state", "state": "listening"},
+            {"type": "done"},
+        ]
+    )
+    return events


### PR DESCRIPTION
## Summary
- Add a fast voice wake presence helper for bare hey/hi/hello Zoe turns.
- Return immediate websocket wake, optional Zoe transcript, listening, and done events before Skybridge, Pi, Graphify, or Zoe Agent work.
- Document ZOE_WAKE_ACK_PHRASE as used by both zoe-data websocket presence and the Pi daemon.

## Why
This reduces perceived voice latency: Zoe can acknowledge the wake phrase immediately while the next user utterance or heavier task routing happens separately.

## Safety
- Only bare wake phrases are intercepted; hey Zoe what is the weather still goes through the normal message path.
- Wake events do not execute tools, write memory, call Pi, or enter the LLM path.
- Non-object websocket JSON is ignored safely and leaves the socket alive.

## Validation
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_voice_presence.py services/zoe-data/tests/test_voice_warmup_nonblocking.py services/zoe-data/tests/test_voice_livekit_health.py services/zoe-data/tests/test_voice_scope.py services/zoe-data/tests/test_voice_weather_queue.py -> 100 passed
- git diff --check
- python3 tools/audit/validate_structure.py
- python3 tools/audit/validate_critical_files.py
