### PR TITLE
[codex] Skip Pi intent model for casual fallback misses

### DIFF
--- a/docs/architecture/zoe-pi-runtime-harness.md
+++ b/docs/architecture/zoe-pi-runtime-harness.md
@@ -164,6 +164,11 @@ frame before accepting idless session events, resets on timeout or task
 cancellation, and ignores response events whose request id does not match the
 current prompt. Pi intent classification launches in a stripped classifier mode
 with no tools, extensions, skills, prompt templates, themes, or context files.
+A local low-risk task prefilter is enabled by default through
+`ZOE_PI_INTENT_PREFILTER_ENABLED=true`; it allows weather, reminder, list,
+timer, calculation, and daily-briefing signals through to Pi while skipping
+casual fallback misses before runtime probing. Operators can disable it for
+experiments with `ZOE_PI_INTENT_PREFILTER_ENABLED=false`.
 The evaluator treats fallback and extraction-failed router misses as
 `router_only_not_comparable` unless an operator supplies measured comparable
 latency with `--fallback-baseline-latency-ms` and/or
@@ -202,6 +207,16 @@ Gemma, RPC transport, `--measure-zoe-agent-baseline`, 20s timeout, and 128-token
 Zoe Agent cap: Zoe Agent fallback returned in about 6.75s with 260 response
 characters; Pi RPC classified `weather` in about 4.09s. This is useful evidence,
 but not enough sample volume for promotion.
+
+Low-risk prefilter benchmark on 2026-06-15 with three repeated RPC runs over the
+same seed set: positive low-risk cases stayed at 100% seed accuracy, with average
+positive latency effectively unchanged (about 2788ms without prefilter vs about
+2785ms with prefilter). Negative casual fallback examples dropped from about
+2303ms average latency without prefilter to about 0.06ms with prefilter, with no
+timeouts reported. End-to-end seed pass time dropped from about 31-32s to about
+26-28s. This protects normal chat from paying a model/RPC cost when there is no
+low-risk task signal, but does not solve the remaining 2.5-4.0s positive Pi
+classification cost.
 
 Sanitized JSONL evidence can be exported into the same eval-case format. For Pi
 shadow records this uses `text_preview` plus a trusted `outcome_label`; unlabeled,

--- a/scripts/maintenance/pi_promotion_eval.py
+++ b/scripts/maintenance/pi_promotion_eval.py
@@ -208,15 +208,17 @@ async def _run_pi(case: PiIntentEvalCase, *, transport: str, enable_execution: b
     with _temporary_env(updates):
         from pi_intent_classifier import classify_with_pi_intent_governor
 
+        timeout_seconds = float(os.environ.get("ZOE_PI_INTENT_TIMEOUT_SECONDS") or 4.0)
         start = time.perf_counter()
         result = await classify_with_pi_intent_governor(case.text)
         latency_ms = (time.perf_counter() - start) * 1000
+    timed_out = result is None and latency_ms >= (timeout_seconds * 1000 * 0.95)
     return {
         "intent": result.intent if result else None,
         "confidence": result.confidence if result else 0.0,
         "latency_ms": latency_ms,
         "correct": (result.intent if result else None) == case.expected_intent,
-        "timed_out": result is None,
+        "timed_out": timed_out,
     }
 
 

--- a/scripts/maintenance/pi_promotion_eval.py
+++ b/scripts/maintenance/pi_promotion_eval.py
@@ -199,11 +199,13 @@ async def _run_zoe_agent_baseline(
         }
 
 async def _run_pi(case: PiIntentEvalCase, *, transport: str, enable_execution: bool, local_model_configured: bool) -> dict[str, Any]:
+    prefilter_enabled = os.environ.get("ZOE_PI_INTENT_PREFILTER_ENABLED", "true")
     updates = {
         "ZOE_PI_INTENT_ENABLED": "true",
         "ZOE_PI_INTENT_TRANSPORT": transport,
         "ZOE_PI_ALLOW_EXECUTION": "true" if enable_execution else "false",
         "ZOE_PI_LOCAL_MODEL_CONFIGURED": "true" if local_model_configured else "false",
+        "ZOE_PI_INTENT_PREFILTER_ENABLED": prefilter_enabled,
     }
     with _temporary_env(updates):
         from pi_intent_classifier import classify_with_pi_intent_governor
@@ -218,6 +220,7 @@ async def _run_pi(case: PiIntentEvalCase, *, transport: str, enable_execution: b
         "confidence": result.confidence if result else 0.0,
         "latency_ms": latency_ms,
         "correct": (result.intent if result else None) == case.expected_intent,
+        "prefilter_enabled": prefilter_enabled,
         "timed_out": timed_out,
     }
 

--- a/services/zoe-data/pi_intent_classifier.py
+++ b/services/zoe-data/pi_intent_classifier.py
@@ -31,6 +31,7 @@ PI_INTENT_HINT_THRESHOLD = 0.55
 PI_INTENT_DEFAULT_TIMEOUT_S = 4.0
 PI_INTENT_MAX_WORDS = 32
 PI_RUNTIME_PROBE_CACHE_TTL_S = 5.0
+PI_INTENT_PREFILTER_ENABLED = True
 _RUNTIME_PROBE_CACHE_MAX_ENTRIES = 32
 
 _ALLOWED_EXECUTABLE_INTENTS = {
@@ -103,6 +104,30 @@ _PI_CLASSIFIER_SYSTEM_PROMPT = (
     "Never create memory-write intents from ambiguous phrasing."
 )
 
+_LOW_RISK_TASK_SIGNAL_RE = re.compile(
+    r"\b("
+    r"rain|umbrella|forecast|weather|jacket|temperature|temp|storm|windy|humid|"
+    r"remember|remind|reminder|due|todo|"
+    r"list|shopping|groceries|"
+    r"timer|alarm|minute|minutes|hour|hours|"
+    r"calculate|math|multiplied|divided|percent|"
+    r"briefing|agenda"
+    r")\b",
+    re.I,
+)
+_LOW_RISK_TASK_PHRASE_RE = re.compile(
+    r"("
+    r"\bwhat(?:'s| is) my day\b|"
+    r"\bmy day looking\b|"
+    r"\bwhat(?:'s| is) on (?:my |the )?(?:shopping )?list\b|"
+    r"\b(?:add|remove)\b.+\b(?:list|shopping|grocer(?:y|ies)|reminder|todo)\b|"
+    r"\b(?:is it|will it be)\s+(?:hot|cold)\b|"
+    r"\b(?:hot|cold)\s+(?:today|tonight|tomorrow|outside)\b|"
+    r"\b\d+\s*(?:\+|-|x|×|\*|/|÷|plus|minus|times)\s*\d+\b"
+    r")",
+    re.I,
+)
+
 
 @dataclass(frozen=True)
 class PiIntentClassifierConfig:
@@ -116,6 +141,7 @@ class PiIntentClassifierConfig:
     offline_only: bool = True
     no_approve: bool = True
     transport: str = "print"
+    prefilter_enabled: bool = PI_INTENT_PREFILTER_ENABLED
     runtime_probe_cache_ttl_seconds: float = PI_RUNTIME_PROBE_CACHE_TTL_S
 
     @classmethod
@@ -133,6 +159,7 @@ class PiIntentClassifierConfig:
             offline_only=_env_bool(values.get("ZOE_PI_OFFLINE_ONLY"), default=True),
             no_approve=_env_bool(values.get("ZOE_PI_INTENT_NO_APPROVE"), default=True),
             transport=(values.get("ZOE_PI_INTENT_TRANSPORT") or "print").strip().lower() or "print",
+            prefilter_enabled=_env_bool(values.get("ZOE_PI_INTENT_PREFILTER_ENABLED"), default=PI_INTENT_PREFILTER_ENABLED),
             runtime_probe_cache_ttl_seconds=float(
                 values.get("ZOE_PI_INTENT_RUNTIME_PROBE_CACHE_TTL_SECONDS")
                 or values.get("ZOE_PI_RUNTIME_PROBE_CACHE_TTL_SECONDS")
@@ -165,6 +192,7 @@ class PiIntentClassifierConfig:
             "offline_only": self.offline_only,
             "no_approve": self.no_approve,
             "transport": self.transport,
+            "prefilter_enabled": self.prefilter_enabled,
             "runtime_probe_cache_ttl_seconds": self.runtime_probe_cache_ttl_seconds,
         }
 
@@ -256,6 +284,9 @@ async def classify_with_pi_intent_governor(
     if not active_config.enabled:
         return None
     if len((text or "").split()) > active_config.max_words:
+        return None
+    if active_config.prefilter_enabled and not pi_intent_prefilter_allows(text):
+        logger.debug("Pi intent governor skipped: no low-risk task signal")
         return None
 
     runtime_env = _runtime_probe_env(env, active_config)
@@ -717,6 +748,11 @@ def _env_bool(value: str | None, *, default: bool) -> bool:
     raise ValueError(f"Unrecognized boolean env var value: {value!r}")
 
 
+def pi_intent_prefilter_allows(text: str) -> bool:
+    normalized = str(text or "")
+    return bool(_LOW_RISK_TASK_SIGNAL_RE.search(normalized) or _LOW_RISK_TASK_PHRASE_RE.search(normalized))
+
+
 __all__ = [
     "PI_INTENT_EXECUTE_THRESHOLD",
     "PI_INTENT_HINT_THRESHOLD",
@@ -726,4 +762,5 @@ __all__ = [
     "pi_intent_promotion_status",
     "classify_with_pi_intent_governor",
     "pi_intent_status",
+    "pi_intent_prefilter_allows",
 ]

--- a/services/zoe-data/tests/test_pi_intent_classifier.py
+++ b/services/zoe-data/tests/test_pi_intent_classifier.py
@@ -616,6 +616,7 @@ async def test_pi_intent_governor_rejects_unknown_intent(tmp_path):
         "ZOE_PI_CWD": str(tmp_path),
         "ZOE_PI_ALLOW_EXECUTION": "true",
         "ZOE_PI_LOCAL_MODEL_CONFIGURED": "true",
+        "ZOE_PI_INTENT_PREFILTER_ENABLED": "false",
     }
 
     assert await classify_with_pi_intent_governor("please do something weird", env=env) is None

--- a/services/zoe-data/tests/test_pi_intent_classifier.py
+++ b/services/zoe-data/tests/test_pi_intent_classifier.py
@@ -14,6 +14,7 @@ from pi_intent_classifier import (
     _rpc_response_matches_request,
     classify_with_pi_intent_governor,
     pi_intent_is_promoted,
+    pi_intent_prefilter_allows,
     pi_intent_promotion_status,
     pi_intent_status,
 )
@@ -189,6 +190,26 @@ def test_pi_intent_config_rejects_unknown_transport():
 
     with pytest.raises(ValueError, match="TRANSPORT"):
         config.validate()
+
+
+def test_pi_intent_config_exposes_prefilter_default():
+    config = PiIntentClassifierConfig.from_env({})
+
+    assert config.prefilter_enabled is True
+    assert config.to_dict()["prefilter_enabled"] is True
+
+
+def test_pi_intent_prefilter_allows_low_risk_tasks_and_rejects_casual_chat():
+    assert pi_intent_prefilter_allows("rain later") is True
+    assert pi_intent_prefilter_allows("what is 18 times 7") is True
+    assert pi_intent_prefilter_allows("18 plus 7") is True
+    assert pi_intent_prefilter_allows("is it cold outside") is True
+    assert pi_intent_prefilter_allows("add bread to shopping") is True
+    assert pi_intent_prefilter_allows("anything I should remember right now") is True
+    assert pi_intent_prefilter_allows("I like the breakfast service") is False
+    assert pi_intent_prefilter_allows("that is a hot take") is False
+    assert pi_intent_prefilter_allows("add to that point") is False
+    assert pi_intent_prefilter_allows("minus any drama") is False
 
 
 def test_pi_rpc_response_match_requires_prompt_command():
@@ -635,6 +656,47 @@ async def test_pi_intent_governor_times_out_without_exception(tmp_path):
     }
 
     assert await classify_with_pi_intent_governor("weather later", env=env) is None
+
+
+@pytest.mark.asyncio
+async def test_pi_intent_governor_prefilter_skips_casual_chat_before_runtime_probe(tmp_path, monkeypatch):
+    calls = 0
+
+    def fake_probe(_env):
+        nonlocal calls
+        calls += 1
+        raise AssertionError("runtime probe should not run for prefiltered casual chat")
+
+    monkeypatch.setattr(pi_intent_classifier, "probe_pi_runtime", fake_probe)
+    env = {
+        "PATH": str(tmp_path),
+        "ZOE_PI_INTENT_ENABLED": "true",
+        "ZOE_PI_ALLOW_EXECUTION": "true",
+        "ZOE_PI_LOCAL_MODEL_CONFIGURED": "true",
+    }
+
+    result = await classify_with_pi_intent_governor("that movie was pretty good", env=env)
+
+    assert result is None
+    assert calls == 0
+
+
+@pytest.mark.asyncio
+async def test_pi_intent_governor_prefilter_can_be_disabled(tmp_path):
+    bindir = _fake_runtime(tmp_path)
+    env = {
+        "PATH": str(bindir),
+        "ZOE_PI_INTENT_ENABLED": "true",
+        "ZOE_PI_INTENT_PREFILTER_ENABLED": "false",
+        "ZOE_PI_CWD": str(tmp_path),
+        "ZOE_PI_ALLOW_EXECUTION": "true",
+        "ZOE_PI_LOCAL_MODEL_CONFIGURED": "true",
+    }
+
+    result = await classify_with_pi_intent_governor("that movie was pretty good", env=env)
+
+    assert result is not None
+    assert result.intent == "weather"
 
 
 @pytest.mark.asyncio

--- a/services/zoe-data/tests/test_pi_promotion_eval_script.py
+++ b/services/zoe-data/tests/test_pi_promotion_eval_script.py
@@ -46,6 +46,18 @@ def _install_fake_zoe_agent(monkeypatch, calls, *, response="agent answer", slee
     monkeypatch.setitem(sys.modules, "zoe_agent", module)
 
 
+def _install_fake_pi_classifier(monkeypatch, *, result=None, sleep_seconds=0):
+    module = types.ModuleType("pi_intent_classifier")
+
+    async def classify_with_pi_intent_governor(_text):
+        if sleep_seconds:
+            await asyncio.sleep(sleep_seconds)
+        return result
+
+    module.classify_with_pi_intent_governor = classify_with_pi_intent_governor
+    monkeypatch.setitem(sys.modules, "pi_intent_classifier", module)
+
+
 def test_cli_loads_cases_file_without_default_cases(tmp_path, capsys):
     module = _load_module()
     cases_path = tmp_path / "cases.jsonl"
@@ -180,6 +192,21 @@ def test_zoe_baseline_timeout_is_not_comparable(monkeypatch):
 
     assert result["baseline_timed_out"] is True
     assert result["baseline_response_chars"] == 0
+
+def test_run_pi_fast_no_result_is_not_timeout(monkeypatch):
+    _install_fake_pi_classifier(monkeypatch, result=None)
+    module = _load_module()
+    case = module.PiIntentEvalCase("casual", "that movie was good", None, "chat", "fallback", negative=True)
+
+    result = asyncio.run(
+        module._run_pi(case, transport="rpc", enable_execution=True, local_model_configured=True)
+    )
+
+    assert result["intent"] is None
+    assert result["timed_out"] is False
+    assert result["correct"] is True
+
+
 
 def test_cli_combines_default_and_cases_file(tmp_path, capsys):
     module = _load_module()

--- a/services/zoe-data/tests/test_pi_promotion_eval_script.py
+++ b/services/zoe-data/tests/test_pi_promotion_eval_script.py
@@ -195,6 +195,7 @@ def test_zoe_baseline_timeout_is_not_comparable(monkeypatch):
 
 def test_run_pi_fast_no_result_is_not_timeout(monkeypatch):
     _install_fake_pi_classifier(monkeypatch, result=None)
+    monkeypatch.setenv("ZOE_PI_INTENT_PREFILTER_ENABLED", "false")
     module = _load_module()
     case = module.PiIntentEvalCase("casual", "that movie was good", None, "chat", "fallback", negative=True)
 
@@ -204,6 +205,7 @@ def test_run_pi_fast_no_result_is_not_timeout(monkeypatch):
 
     assert result["intent"] is None
     assert result["timed_out"] is False
+    assert result["prefilter_enabled"] == "false"
     assert result["correct"] is True
 
 


### PR DESCRIPTION
## Summary
- Add a default-on Pi intent prefilter for low-risk task signals.
- Skip the Pi runtime/model call for casual fallback misses so normal chat does not pay Pi latency.
- Fix Pi eval timeout labeling so a fast None result is not treated as a timeout.
- Record the prefilter env state in eval results for reproducible comparisons.

## Why
This is the speed side of the Pi promotion plan: Pi should be evaluated and promoted where it wins, but casual chat misses should not spend seconds probing or invoking Pi.

## Supersedes
Supersedes PR #538, which has the same intended code changes but became stuck because the required Greptile check stopped attaching to the latest head after rebases.

## Validation
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_pi_intent_evidence.py services/zoe-data/tests/test_pi_eval_export.py services/zoe-data/tests/test_pi_promotion_eval_script.py services/zoe-data/tests/test_zoe_pi_promotion.py services/zoe-data/tests/test_pi_promotion_apply.py services/zoe-data/tests/test_pi_intent_shadow.py services/zoe-data/tests/test_pi_intent_classifier.py services/zoe-data/tests/test_pi_intent_status_endpoint.py services/zoe-data/tests/test_pi_runtime_probe.py services/zoe-data/tests/test_zoe_evolution_runtime_intake.py -> 162 passed
- git diff --check
- python3 tools/audit/validate_structure.py
- python3 tools/audit/validate_critical_files.py
