### PR TITLE
[codex] Add time-aware cached wake acknowledgements

### DIFF
--- a/docs/guides/OPERATOR_RUNBOOK.md
+++ b/docs/guides/OPERATOR_RUNBOOK.md
@@ -47,6 +47,7 @@ systemctl --user restart openclaw-gateway # After openclaw.json changes
 | `ZOE_WAKE_ACK_PHRASE` | zoe-data + Pi daemon | — | Instant websocket wake transcript and optional TTS phrase after wake word |
 | `ZOE_WAKE_ACK_AUDIO_PATH` | zoe-data + Pi daemon | — | Pre-generated wake ack audio file served from cache before live TTS |
 | `ZOE_WAKE_ACK_PHRASES` / `ZOE_WAKE_ACK_AUDIO_PATHS` | zoe-data + Pi daemon | — | Pipe-separated cached wake response bank; phrase/audio entries are index-aligned |
+| `ZOE_WAKE_ACK_VARIANT_LABELS` | zoe-data + Pi daemon | — | Optional pipe-aligned labels (`default`, `morning`, `afternoon`, `evening`, `night`) for deterministic time-aware wake acks |
 | `ZOE_DEVICE_TOKEN_SECRET` | zoe-data | — | Secret for device token HMAC (optional extra layer) |
 | `ZOE_PIN_MAX_ATTEMPTS` | zoe-data | 5 | PIN lockout attempts |
 | `ZOE_PIN_CHALLENGE_TTL_S` | zoe-data | 120 | PIN challenge expiry in seconds |

--- a/services/zoe-data/.env.example
+++ b/services/zoe-data/.env.example
@@ -46,11 +46,13 @@
 # Leave empty to use only the wake beep. Set AUDIO_PATH to a pre-generated
 # wav/mp3 file for instant websocket/Pi wake acknowledgement without live TTS.
 # Use pipe-separated PHRASES/PATHS for a small cached response bank; entries are
-# index-aligned, e.g. Yes Jason?|Good morning Jason.|Hi there, how can I help?
+# index-aligned, e.g. Yes Jason?|Good morning Jason.|Good evening Jason.
+# Optional labels prefer time-aware variants: default|morning|evening
 # ZOE_WAKE_ACK_PHRASE=
 # ZOE_WAKE_ACK_AUDIO_PATH=
 # ZOE_WAKE_ACK_PHRASES=
 # ZOE_WAKE_ACK_AUDIO_PATHS=
+# ZOE_WAKE_ACK_VARIANT_LABELS=
 #
 # ── Voice: barge-in ──────────────────────────────────────────────────────
 # BARGE_IN_ENABLED=true

--- a/services/zoe-data/tests/test_voice_presence.py
+++ b/services/zoe-data/tests/test_voice_presence.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 import sys
 from pathlib import Path
 
@@ -14,7 +15,9 @@ from voice_presence import (
     wake_ack_audio_payload,
     wake_ack_events,
     wake_ack_phrase,
+    wake_ack_time_period,
     wake_ack_variant,
+    wake_ack_variant_labels,
     wake_presence_events,
 )
 
@@ -116,7 +119,61 @@ def test_wake_ack_variant_selects_index_aligned_phrase_and_audio(tmp_path):
         index=1,
     )
 
-    assert variant == {"phrase": "Good morning Jason.", "audio_path": str(second), "index": 1}
+    assert variant == {"phrase": "Good morning Jason.", "audio_path": str(second), "index": 1, "label": ""}
+
+
+def test_wake_ack_variant_labels_are_pipe_aligned():
+    assert wake_ack_variant_labels({}) == []
+    assert wake_ack_variant_labels({"ZOE_WAKE_ACK_VARIANT_LABELS": " default | Morning | evening,night "}) == [
+        "default",
+        "morning",
+        "evening,night",
+    ]
+
+
+def test_wake_ack_time_period_uses_local_hour_buckets():
+    assert wake_ack_time_period(datetime(2026, 1, 1, 8, 0)) == "morning"
+    assert wake_ack_time_period(datetime(2026, 1, 1, 13, 0)) == "afternoon"
+    assert wake_ack_time_period(datetime(2026, 1, 1, 20, 0)) == "evening"
+    assert wake_ack_time_period(datetime(2026, 1, 1, 2, 0)) == "night"
+
+
+def test_wake_ack_variant_prefers_matching_time_label():
+    env = {
+        "ZOE_WAKE_ACK_PHRASES": "Yes Jason?|Good morning Jason.|Good evening Jason.",
+        "ZOE_WAKE_ACK_VARIANT_LABELS": "default|morning|evening",
+    }
+
+    assert wake_ack_variant(env, now=datetime(2026, 1, 1, 8, 0))["phrase"] == "Good morning Jason."
+    assert wake_ack_variant(env, now=datetime(2026, 1, 1, 19, 0))["phrase"] == "Good evening Jason."
+
+
+def test_wake_ack_variant_falls_back_to_default_label_when_period_missing():
+    env = {
+        "ZOE_WAKE_ACK_PHRASES": "Yes Jason?|Good morning Jason.",
+        "ZOE_WAKE_ACK_VARIANT_LABELS": "default|morning",
+    }
+
+    variant = wake_ack_variant(env, now=datetime(2026, 1, 1, 14, 0))
+
+    assert variant == {"phrase": "Yes Jason?", "audio_path": "", "index": 0, "label": "default"}
+
+
+def test_wake_ack_events_can_use_time_aware_variant():
+    events = wake_ack_events(
+        {
+            "ZOE_WAKE_ACK_PHRASES": "Yes Jason?|Good morning Jason.",
+            "ZOE_WAKE_ACK_VARIANT_LABELS": "default|morning",
+        },
+        now=datetime(2026, 1, 1, 7, 0),
+    )
+
+    assert events == [
+        {"type": "state", "state": "wake"},
+        {"type": "transcript", "role": "zoe", "text": "Good morning Jason."},
+        {"type": "state", "state": "listening"},
+        {"type": "done"},
+    ]
 
 
 def test_wake_ack_events_uses_selected_cached_variant(tmp_path):

--- a/services/zoe-data/tests/test_voice_presence.py
+++ b/services/zoe-data/tests/test_voice_presence.py
@@ -135,6 +135,7 @@ def test_wake_ack_time_period_uses_local_hour_buckets():
     assert wake_ack_time_period(datetime(2026, 1, 1, 8, 0)) == "morning"
     assert wake_ack_time_period(datetime(2026, 1, 1, 13, 0)) == "afternoon"
     assert wake_ack_time_period(datetime(2026, 1, 1, 20, 0)) == "evening"
+    assert wake_ack_time_period(datetime(2026, 1, 1, 23, 0)) == "evening"
     assert wake_ack_time_period(datetime(2026, 1, 1, 2, 0)) == "night"
 
 
@@ -146,6 +147,27 @@ def test_wake_ack_variant_prefers_matching_time_label():
 
     assert wake_ack_variant(env, now=datetime(2026, 1, 1, 8, 0))["phrase"] == "Good morning Jason."
     assert wake_ack_variant(env, now=datetime(2026, 1, 1, 19, 0))["phrase"] == "Good evening Jason."
+
+
+def test_wake_ack_variant_selects_comma_combined_label_for_period():
+    env = {
+        "ZOE_WAKE_ACK_PHRASES": "Yes Jason?|Good night, Jason.",
+        "ZOE_WAKE_ACK_VARIANT_LABELS": "default|evening,night",
+    }
+
+    assert wake_ack_variant(env, now=datetime(2026, 1, 1, 23, 0))["phrase"] == "Good night, Jason."
+    assert wake_ack_variant(env, now=datetime(2026, 1, 1, 2, 0))["phrase"] == "Good night, Jason."
+
+
+def test_wake_ack_variant_ignores_extra_labels_without_content_slots():
+    env = {
+        "ZOE_WAKE_ACK_PHRASES": "Yes Jason?",
+        "ZOE_WAKE_ACK_VARIANT_LABELS": "default|morning",
+    }
+
+    variant = wake_ack_variant(env, now=datetime(2026, 1, 1, 8, 0))
+
+    assert variant == {"phrase": "Yes Jason?", "audio_path": "", "index": 0, "label": "default"}
 
 
 def test_wake_ack_variant_falls_back_to_default_label_when_period_missing():

--- a/services/zoe-data/voice_presence.py
+++ b/services/zoe-data/voice_presence.py
@@ -8,6 +8,7 @@ or the Zoe Agent path.
 from __future__ import annotations
 
 import base64
+from datetime import datetime
 import mimetypes
 import os
 import re
@@ -62,31 +63,74 @@ def wake_ack_audio_paths(env: Mapping[str, str] | None = None) -> list[str]:
     return [audio_path] if audio_path else []
 
 
+def wake_ack_variant_labels(env: Mapping[str, str] | None = None) -> list[str]:
+    """Resolve optional pipe-aligned labels for time-aware wake variants."""
+    values = env if env is not None else os.environ
+    return [label.lower() for label in _split_variants(values.get("ZOE_WAKE_ACK_VARIANT_LABELS"))]
+
+
+def wake_ack_time_period(now: datetime | None = None) -> str:
+    """Return the coarse local period used for deterministic wake acks."""
+    current = now if now is not None else datetime.now().astimezone()
+    hour = current.hour
+    if 5 <= hour < 12:
+        return "morning"
+    if 12 <= hour < 17:
+        return "afternoon"
+    if 17 <= hour < 23:
+        return "evening"
+    return "night"
+
+
+def _label_matches(label: str, period: str) -> bool:
+    return period in {part.strip() for part in label.split(",") if part.strip()}
+
+
+def _select_wake_ack_index(labels: list[str], variant_count: int, now: datetime | None = None) -> int:
+    global _VARIANT_CURSOR
+    period = wake_ack_time_period(now)
+    candidates = [idx for idx, label in enumerate(labels[:variant_count]) if _label_matches(label, period)]
+    if not candidates:
+        candidates = [idx for idx, label in enumerate(labels[:variant_count]) if _label_matches(label, "default")]
+    with _VARIANT_LOCK:
+        if candidates:
+            selected = candidates[_VARIANT_CURSOR % len(candidates)]
+        else:
+            selected = _VARIANT_CURSOR % variant_count
+        _VARIANT_CURSOR += 1
+    return selected
+
+
 def wake_ack_phrase(env: Mapping[str, str] | None = None) -> str:
     """Resolve the optional short phrase Zoe can display/speak on wake."""
     phrases = wake_ack_phrases(env)
     return phrases[0] if phrases else ""
 
 
-def wake_ack_variant(env: Mapping[str, str] | None = None, *, index: int | None = None) -> dict[str, Any]:
+def wake_ack_variant(
+    env: Mapping[str, str] | None = None,
+    *,
+    index: int | None = None,
+    now: datetime | None = None,
+) -> dict[str, Any]:
     """Pick one configured wake acknowledgement variant.
 
     Multiple variants are index-aligned across ZOE_WAKE_ACK_PHRASES and
-    ZOE_WAKE_ACK_AUDIO_PATHS. The default hot path cycles through variants.
+    ZOE_WAKE_ACK_AUDIO_PATHS. Optional ZOE_WAKE_ACK_VARIANT_LABELS entries can
+    prefer local-time variants such as morning, afternoon, evening, or default.
     """
-    global _VARIANT_CURSOR
     phrases = wake_ack_phrases(env)
     audio_paths = wake_ack_audio_paths(env)
-    variant_count = max(len(phrases), len(audio_paths), 1)
+    labels = wake_ack_variant_labels(env)
+    variant_count = max(len(phrases), len(audio_paths), len(labels), 1)
     if index is None:
-        with _VARIANT_LOCK:
-            selected = _VARIANT_CURSOR % variant_count
-            _VARIANT_CURSOR += 1
+        selected = _select_wake_ack_index(labels, variant_count, now)
     else:
         selected = index % variant_count
     phrase = phrases[selected] if selected < len(phrases) else ""
     audio_path = audio_paths[selected] if selected < len(audio_paths) else ""
-    return {"phrase": phrase, "audio_path": audio_path, "index": selected}
+    label = labels[selected] if selected < len(labels) else ""
+    return {"phrase": phrase, "audio_path": audio_path, "index": selected, "label": label}
 
 
 def wake_ack_audio_payload(env: Mapping[str, str] | None = None, *, audio_path: str | None = None) -> dict[str, Any] | None:
@@ -161,8 +205,8 @@ def wake_presence_events(*, ack_phrase: str = "", ack_audio: Mapping[str, Any] |
     return events
 
 
-def wake_ack_events(env: Mapping[str, str] | None = None) -> list[dict[str, Any]]:
+def wake_ack_events(env: Mapping[str, str] | None = None, *, now: datetime | None = None) -> list[dict[str, Any]]:
     """Build wake presence events from the selected configured variant."""
-    variant = wake_ack_variant(env)
+    variant = wake_ack_variant(env, now=now)
     audio = wake_ack_audio_payload(env, audio_path=variant.get("audio_path"))
     return wake_presence_events(ack_phrase=str(variant.get("phrase") or ""), ack_audio=audio)

--- a/services/zoe-data/voice_presence.py
+++ b/services/zoe-data/voice_presence.py
@@ -77,7 +77,7 @@ def wake_ack_time_period(now: datetime | None = None) -> str:
         return "morning"
     if 12 <= hour < 17:
         return "afternoon"
-    if 17 <= hour < 23:
+    if 17 <= hour < 24:
         return "evening"
     return "night"
 
@@ -122,7 +122,7 @@ def wake_ack_variant(
     phrases = wake_ack_phrases(env)
     audio_paths = wake_ack_audio_paths(env)
     labels = wake_ack_variant_labels(env)
-    variant_count = max(len(phrases), len(audio_paths), len(labels), 1)
+    variant_count = max(len(phrases), len(audio_paths), 1)
     if index is None:
         selected = _select_wake_ack_index(labels, variant_count, now)
     else:


### PR DESCRIPTION
## Summary

Adds deterministic time-aware selection for Zoe's cached wake acknowledgement bank without invoking Pi, Skybridge, Graphify, or the Zoe Agent path.

- adds optional `ZOE_WAKE_ACK_VARIANT_LABELS` aligned with `ZOE_WAKE_ACK_PHRASES` / `ZOE_WAKE_ACK_AUDIO_PATHS`
- supports `default`, `morning`, `afternoon`, `evening`, and `night` labels, including comma-combined labels
- preserves existing round-robin behavior when labels are not configured
- documents the new env var in `.env.example` and the operator runbook

## Why

This lets Zoe respond instantly with natural phrases such as "Yes Jason?", "Good morning Jason.", or "Good evening Jason." while the real routing/model/tool path works underneath. It improves perceived speed without turning cached phrases into intent logic.

## Validation

- `python3 -m pytest -q services/zoe-data/tests/test_voice_presence.py` — 21 passed
- `python3 -m pytest -q services/zoe-data/tests/test_voice_presence.py services/zoe-data/tests/test_voice_livekit_health.py services/zoe-data/tests/test_voice_scope.py services/zoe-data/tests/test_voice_warmup_nonblocking.py services/zoe-data/tests/test_voice_weather_queue.py` — 112 passed
- `git diff --check`
- `python3 tools/audit/validate_structure.py`
- `python3 tools/audit/validate_critical_files.py`
