### PR TITLE
[codex] Add Graphify shard merge validation gate

### DIFF
--- a/docs/architecture/zoe-graphify-refresh-evidence.md
+++ b/docs/architecture/zoe-graphify-refresh-evidence.md
@@ -46,7 +46,12 @@ evidence and a future sharded sync implementation. It consumes a
 malformed shard evidence, and distinguishes `artifact_capture_ready` from
 `artifact_sync_ready` so copied per-shard `graphify-out` artifacts do not imply
 that deterministic graph merge handling, merged cluster/report generation, and
-inventory reconciliation are already proven.
+inventory reconciliation are already proven. `graphify_shard_merge_validate.py`
+now performs the first no-write merge gate over captured shard artifacts: it
+loads each shard `graph.json`, adds per-node/link shard provenance, rejects
+conflicting duplicate nodes and missing link endpoints, writes deterministic
+merged graph JSON only to an operator-supplied output path, and still leaves
+committed `graphify-out` untouched.
 
 Acceptance is fail-closed. The status JSON is rejected when Graphify times out,
 exits nonzero, omits `graphify-out/graph.json`, writes an empty graph, emits
@@ -139,6 +144,12 @@ Current evidence:
   this artifact evidence returned `artifact_capture_ready=true`,
   `artifact_report_ready=false`, and `artifact_sync_ready=false` because the run
   was non-clustered and no merged graph/report has been produced.
+- The shard merge validator is now covered by fixture tests for clean merges,
+  duplicate identical node provenance, deterministic ordering independent of
+  shard status order, conflicting duplicate node rejection, missing endpoint
+  rejection, and CLI output writing. This proves the merge gate contract without
+  replacing committed `graphify-out`; the next Graphify PR still needs temporary
+  merged cluster/report generation and inventory reconciliation.
 
 ## Refresh 2026-06-09 Foundation Pass
 

--- a/scripts/maintenance/graphify_shard_merge_validate.py
+++ b/scripts/maintenance/graphify_shard_merge_validate.py
@@ -54,7 +54,8 @@ def validate_shard_merge(status: Mapping[str, Any]) -> GraphifyShardMergeValidat
         blockers.append("unexpected_probe_type")
     if status.get("all_accepted") is not True:
         blockers.append("not_all_shards_accepted")
-    if int(status.get("rejected_count") or 0) != 0:
+    rejected_count = _coerce_int(status.get("rejected_count"), "rejected_count", blockers)
+    if rejected_count != 0:
         blockers.append("rejected_shards_present")
     if status.get("blocked_shards"):
         blockers.append("blocked_shards_present")
@@ -252,9 +253,17 @@ def _load_graph(path: Path) -> dict[str, Any]:
     return payload
 
 
-def _without_merge_only_fields(payload: dict[str, Any]) -> dict[str, Any]:
-    payload.pop("graphify_shards", None)
-    return payload
+def _coerce_int(value: Any, field: str, blockers: list[str]) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        blockers.append(f"invalid_{field}")
+        return -1
+
+
+def _without_merge_only_fields(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Return payload without merge-only bookkeeping keys."""
+    return {key: value for key, value in payload.items() if key != "graphify_shards"}
 
 
 def _add_provenance(payload: dict[str, Any], shard: str) -> None:

--- a/scripts/maintenance/graphify_shard_merge_validate.py
+++ b/scripts/maintenance/graphify_shard_merge_validate.py
@@ -1,0 +1,358 @@
+#!/usr/bin/env python3
+"""Validate deterministic merging of Zoe Graphify shard artifacts.
+
+This is a no-write-to-repo gate. It consumes the observe-only shard matrix
+status JSON plus captured per-shard `graphify-out/graph.json` artifacts and
+proves that they can be merged with deterministic ordering, endpoint integrity,
+and shard provenance before any future `graphify-out` replacement PR.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+REQUIRED_PROBE = "graphify_local_shard_matrix"
+REQUIRED_SCHEMA_VERSION = 1
+MERGE_SCHEMA_VERSION = 1
+
+
+@dataclass(frozen=True)
+class GraphifyShardMergeValidation:
+    accepted: bool
+    status: str
+    blockers: tuple[str, ...]
+    warnings: tuple[str, ...]
+    summary: dict[str, Any]
+    merged_graph: dict[str, Any] | None = None
+
+    def to_dict(self, *, include_graph: bool = False) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "accepted": self.accepted,
+            "status": self.status,
+            "blockers": list(self.blockers),
+            "warnings": list(self.warnings),
+            "summary": self.summary,
+        }
+        if include_graph and self.merged_graph is not None:
+            payload["merged_graph"] = self.merged_graph
+        return payload
+
+
+def validate_shard_merge(status: Mapping[str, Any]) -> GraphifyShardMergeValidation:
+    blockers: list[str] = []
+    warnings: list[str] = []
+
+    if status.get("schema_version") != REQUIRED_SCHEMA_VERSION:
+        blockers.append("unsupported_schema_version")
+    if status.get("probe") != REQUIRED_PROBE:
+        blockers.append("unexpected_probe_type")
+    if status.get("all_accepted") is not True:
+        blockers.append("not_all_shards_accepted")
+    if int(status.get("rejected_count") or 0) != 0:
+        blockers.append("rejected_shards_present")
+    if status.get("blocked_shards"):
+        blockers.append("blocked_shards_present")
+
+    results = status.get("results")
+    if not isinstance(results, list) or not results:
+        blockers.append("missing_shard_results")
+        results = []
+
+    merged_nodes: dict[str, dict[str, Any]] = {}
+    node_fingerprints: dict[str, str] = {}
+    merged_links: dict[str, dict[str, Any]] = {}
+    link_fingerprints: dict[str, str] = {}
+    merged_hyperedges: dict[str, dict[str, Any]] = {}
+    hyperedge_fingerprints: dict[str, str] = {}
+    graph_flags: tuple[bool, bool] | None = None
+    shard_names: list[str] = []
+    source_paths: dict[str, str] = {}
+
+    for index, raw_result in enumerate(results):
+        if not isinstance(raw_result, Mapping):
+            blockers.append(f"shard_{index}_not_object")
+            continue
+        shard = str(raw_result.get("shard") or "").strip()
+        if not shard:
+            blockers.append(f"shard_{index}_missing_name")
+            shard = f"shard_{index}"
+        if shard in shard_names:
+            blockers.append(f"duplicate_shard_name:{shard}")
+        shard_names.append(shard)
+
+        if raw_result.get("accepted") is not True:
+            blockers.append(f"{shard}_not_accepted")
+        if raw_result.get("artifact_graph_json_exists") is not True:
+            blockers.append(f"{shard}_missing_artifact_graph_json")
+            continue
+
+        graph_path = _graph_path_for_result(raw_result, shard, blockers)
+        if graph_path is None:
+            continue
+        source_paths[shard] = str(graph_path)
+        try:
+            graph = _load_graph(graph_path)
+        except (OSError, TypeError, ValueError) as exc:
+            blockers.append(f"{shard}_invalid_graph_json:{exc}")
+            continue
+
+        directed = graph.get("directed")
+        multigraph = graph.get("multigraph")
+        if not isinstance(directed, bool) or not isinstance(multigraph, bool):
+            blockers.append(f"{shard}_missing_graph_flags")
+        else:
+            flags = (directed, multigraph)
+            if graph_flags is None:
+                graph_flags = flags
+            elif graph_flags != flags:
+                blockers.append(f"{shard}_graph_flags_conflict")
+
+        nodes = graph.get("nodes")
+        links = graph.get("links")
+        hyperedges = graph.get("hyperedges", [])
+        if not isinstance(nodes, list):
+            blockers.append(f"{shard}_nodes_not_list")
+            nodes = []
+        if not isinstance(links, list):
+            blockers.append(f"{shard}_links_not_list")
+            links = []
+        if not isinstance(hyperedges, list):
+            blockers.append(f"{shard}_hyperedges_not_list")
+            hyperedges = []
+        if not nodes:
+            blockers.append(f"{shard}_empty_nodes")
+        if not links:
+            warnings.append(f"{shard}_empty_links")
+
+        for node_index, node in enumerate(nodes):
+            if not isinstance(node, Mapping):
+                blockers.append(f"{shard}_node_{node_index}_not_object")
+                continue
+            node_id = str(node.get("id") or "").strip()
+            if not node_id:
+                blockers.append(f"{shard}_node_{node_index}_missing_id")
+                continue
+            fingerprint = _fingerprint(_without_merge_only_fields(dict(node)))
+            if node_id in merged_nodes:
+                if node_fingerprints[node_id] != fingerprint:
+                    blockers.append(f"node_conflict:{node_id}")
+                    continue
+                _add_provenance(merged_nodes[node_id], shard)
+            else:
+                merged = copy.deepcopy(dict(node))
+                merged["graphify_shards"] = [shard]
+                merged_nodes[node_id] = merged
+                node_fingerprints[node_id] = fingerprint
+
+        for link_index, link in enumerate(links):
+            if not isinstance(link, Mapping):
+                blockers.append(f"{shard}_link_{link_index}_not_object")
+                continue
+            source = str(link.get("source") or "").strip()
+            target = str(link.get("target") or "").strip()
+            if not source or not target:
+                blockers.append(f"{shard}_link_{link_index}_missing_endpoint")
+                continue
+            key = _edge_key(link)
+            fingerprint = _fingerprint(_without_merge_only_fields(dict(link)))
+            if key in merged_links:
+                if link_fingerprints[key] != fingerprint:
+                    blockers.append(f"link_conflict:{key}")
+                    continue
+                _add_provenance(merged_links[key], shard)
+            else:
+                merged = copy.deepcopy(dict(link))
+                merged["graphify_shards"] = [shard]
+                merged_links[key] = merged
+                link_fingerprints[key] = fingerprint
+
+        for hyperedge_index, hyperedge in enumerate(hyperedges):
+            if not isinstance(hyperedge, Mapping):
+                blockers.append(f"{shard}_hyperedge_{hyperedge_index}_not_object")
+                continue
+            key = _hyperedge_key(hyperedge)
+            fingerprint = _fingerprint(_without_merge_only_fields(dict(hyperedge)))
+            if key in merged_hyperedges:
+                if hyperedge_fingerprints[key] != fingerprint:
+                    blockers.append(f"hyperedge_conflict:{key}")
+                    continue
+                _add_provenance(merged_hyperedges[key], shard)
+            else:
+                merged = copy.deepcopy(dict(hyperedge))
+                merged["graphify_shards"] = [shard]
+                merged_hyperedges[key] = merged
+                hyperedge_fingerprints[key] = fingerprint
+
+    for key, link in merged_links.items():
+        source = str(link.get("source") or "")
+        target = str(link.get("target") or "")
+        if source not in merged_nodes:
+            blockers.append(f"link_missing_source:{key}:{source}")
+        if target not in merged_nodes:
+            blockers.append(f"link_missing_target:{key}:{target}")
+
+    merged_graph = _build_merged_graph(
+        status=status,
+        graph_flags=graph_flags,
+        nodes=merged_nodes,
+        links=merged_links,
+        hyperedges=merged_hyperedges,
+        shard_names=shard_names,
+        source_paths=source_paths,
+    )
+    deterministic_hash = _fingerprint(merged_graph)
+    accepted = not blockers
+    summary = {
+        "schema_version": MERGE_SCHEMA_VERSION,
+        "source_ref": status.get("ref"),
+        "model": status.get("model"),
+        "artifact_dir": status.get("artifact_dir"),
+        "shard_count": len(shard_names),
+        "shards": sorted(shard_names),
+        "source_graph_paths": source_paths,
+        "node_count": len(merged_nodes),
+        "link_count": len(merged_links),
+        "hyperedge_count": len(merged_hyperedges),
+        "deterministic_hash": deterministic_hash,
+        "write_ready": accepted,
+    }
+    return GraphifyShardMergeValidation(
+        accepted=accepted,
+        status="ready_for_merged_cluster_report" if accepted else "blocked",
+        blockers=tuple(dict.fromkeys(blockers)),
+        warnings=tuple(dict.fromkeys(warnings)),
+        summary=summary,
+        merged_graph=merged_graph if accepted else None,
+    )
+
+
+def _graph_path_for_result(result: Mapping[str, Any], shard: str, blockers: list[str]) -> Path | None:
+    artifact_path = str(result.get("artifact_path") or "").strip()
+    if artifact_path:
+        path = Path(artifact_path) / "graph.json"
+    else:
+        blockers.append(f"{shard}_missing_artifact_path")
+        return None
+    if not path.exists():
+        blockers.append(f"{shard}_artifact_graph_json_not_found")
+        return None
+    return path
+
+
+def _load_graph(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("graph JSON must contain an object")
+    return payload
+
+
+def _without_merge_only_fields(payload: dict[str, Any]) -> dict[str, Any]:
+    payload.pop("graphify_shards", None)
+    return payload
+
+
+def _add_provenance(payload: dict[str, Any], shard: str) -> None:
+    existing = payload.get("graphify_shards")
+    shards = list(existing) if isinstance(existing, list) else []
+    if shard not in shards:
+        shards.append(shard)
+    payload["graphify_shards"] = sorted(shards)
+
+
+def _edge_key(link: Mapping[str, Any]) -> str:
+    key = {
+        "source": link.get("source"),
+        "target": link.get("target"),
+        "relation": link.get("relation"),
+        "source_file": link.get("source_file"),
+        "source_location": link.get("source_location"),
+    }
+    return _fingerprint(key)
+
+
+def _hyperedge_key(hyperedge: Mapping[str, Any]) -> str:
+    candidate = hyperedge.get("id") or hyperedge.get("key") or hyperedge
+    return _fingerprint(candidate)
+
+
+def _build_merged_graph(
+    *,
+    status: Mapping[str, Any],
+    graph_flags: tuple[bool, bool] | None,
+    nodes: Mapping[str, dict[str, Any]],
+    links: Mapping[str, dict[str, Any]],
+    hyperedges: Mapping[str, dict[str, Any]],
+    shard_names: Sequence[str],
+    source_paths: Mapping[str, str],
+) -> dict[str, Any]:
+    directed, multigraph = graph_flags if graph_flags is not None else (True, False)
+    return {
+        "directed": directed,
+        "multigraph": multigraph,
+        "graph": {},
+        "nodes": sorted((copy.deepcopy(node) for node in nodes.values()), key=lambda item: str(item.get("id") or "")),
+        "links": sorted((copy.deepcopy(link) for link in links.values()), key=_edge_key),
+        "hyperedges": sorted((copy.deepcopy(edge) for edge in hyperedges.values()), key=_hyperedge_key),
+        "built_at_commit": status.get("ref"),
+        "merged_from_shards": {
+            "schema_version": MERGE_SCHEMA_VERSION,
+            "probe": REQUIRED_PROBE,
+            "source_ref": status.get("ref"),
+            "model": status.get("model"),
+            "shards": sorted(shard_names),
+            "source_graph_paths": dict(sorted(source_paths.items())),
+        },
+    }
+
+
+def _fingerprint(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+def load_status(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("status file must contain a JSON object")
+    return payload
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Validate deterministic merging of captured Graphify shard artifacts.")
+    parser.add_argument("status_json", type=Path, help="graphify_local_shard_matrix status JSON with artifact paths")
+    parser.add_argument("--output-json", type=Path, help="Write validation result JSON")
+    parser.add_argument("--merged-graph-json", type=Path, help="Write merged graph JSON when validation is accepted")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        result = validate_shard_merge(load_status(args.status_json))
+    except (OSError, TypeError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    if args.merged_graph_json and result.accepted and result.merged_graph is not None:
+        args.merged_graph_json.parent.mkdir(parents=True, exist_ok=True)
+        args.merged_graph_json.write_text(
+            json.dumps(result.merged_graph, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+
+    output = result.to_dict(include_graph=False)
+    text = json.dumps(output, indent=2, sort_keys=True)
+    if args.output_json:
+        args.output_json.parent.mkdir(parents=True, exist_ok=True)
+        args.output_json.write_text(f"{text}\n", encoding="utf-8")
+    print(text)
+    return 0 if result.accepted else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/maintenance/graphify_shard_sync_plan.py
+++ b/scripts/maintenance/graphify_shard_sync_plan.py
@@ -114,8 +114,8 @@ def build_shard_sync_plan(status: Mapping[str, Any]) -> ShardSyncPlan:
     required_next_steps = (
         "run shard matrix with --artifact-dir when artifact_capture_ready is false",
         "validate each artifact directory has graph.json and GRAPH_REPORT.md when clustering is enabled",
-        "merge graph JSON with deterministic namespace/conflict handling and provenance per shard",
-        "run cluster/report generation on the merged graph in a temporary output directory",
+        "run graphify_shard_merge_validate.py over captured artifacts for deterministic merge/provenance/conflict checks",
+        "run cluster/report generation on the validated merged graph in a temporary output directory",
         "compare merged report against current inventory before any graphify-out replacement PR",
     )
     return ShardSyncPlan(

--- a/services/zoe-data/tests/test_graphify_shard_merge_validate.py
+++ b/services/zoe-data/tests/test_graphify_shard_merge_validate.py
@@ -191,6 +191,27 @@ def test_validate_shard_merge_blocks_links_with_missing_endpoints(tmp_path):
     assert any(blocker.endswith(":missing_func") for blocker in result.blockers)
 
 
+def test_validate_shard_merge_blocks_malformed_rejected_count(tmp_path):
+    graph = _graph([_node("data_file"), _node("data_func")], [_link("data_file", "data_func")])
+    status = _status([_result("data-core", _write_artifact(tmp_path, "data-core", graph))])
+    status["rejected_count"] = "unknown"
+
+    result = MODULE.validate_shard_merge(status)
+
+    assert result.accepted is False
+    assert "invalid_rejected_count" in result.blockers
+    assert "rejected_shards_present" in result.blockers
+
+
+def test_without_merge_only_fields_does_not_mutate_input():
+    payload = {"id": "node", "graphify_shards": ["data-core"]}
+
+    projected = MODULE._without_merge_only_fields(payload)
+
+    assert projected == {"id": "node"}
+    assert payload == {"id": "node", "graphify_shards": ["data-core"]}
+
+
 def test_main_writes_validation_and_merged_graph_json(tmp_path, capsys):
     graph = _graph([_node("data_file"), _node("data_func")], [_link("data_file", "data_func")])
     status = _status([_result("data-core", _write_artifact(tmp_path, "data-core", graph))])

--- a/services/zoe-data/tests/test_graphify_shard_merge_validate.py
+++ b/services/zoe-data/tests/test_graphify_shard_merge_validate.py
@@ -1,0 +1,229 @@
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+
+def _load_module():
+    path = Path(__file__).resolve().parents[3] / "scripts" / "maintenance" / "graphify_shard_merge_validate.py"
+    spec = importlib.util.spec_from_file_location("graphify_shard_merge_validate_test", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+MODULE = _load_module()
+
+
+def _graph(nodes, links):
+    return {
+        "directed": True,
+        "multigraph": False,
+        "graph": {},
+        "nodes": nodes,
+        "links": links,
+        "hyperedges": [],
+        "built_at_commit": "fixture",
+    }
+
+
+def _node(node_id, *, label=None):
+    return {
+        "id": node_id,
+        "label": label or node_id,
+        "source_file": f"/home/zoe/assistant/{node_id}.py",
+        "source_location": "L1",
+        "file_type": "code",
+    }
+
+
+def _link(source, target, *, relation="contains"):
+    return {
+        "source": source,
+        "target": target,
+        "relation": relation,
+        "source_file": f"/home/zoe/assistant/{source}.py",
+        "source_location": "L1",
+        "confidence": "EXTRACTED",
+    }
+
+
+def _write_artifact(tmp_path, shard, graph):
+    graphify_out = tmp_path / shard / "graphify-out"
+    graphify_out.mkdir(parents=True)
+    (graphify_out / "graph.json").write_text(json.dumps(graph), encoding="utf-8")
+    return graphify_out
+
+
+def _result(shard, graphify_out):
+    graph_json = graphify_out / "graph.json"
+    return {
+        "shard": shard,
+        "include_paths": [f"fixture/{shard}"],
+        "accepted": True,
+        "artifact_path": str(graphify_out),
+        "artifact_graph_json_exists": graph_json.exists(),
+        "artifact_graph_json_bytes": graph_json.stat().st_size if graph_json.exists() else 0,
+        "blockers": [],
+        "warnings": [],
+        "invalid_json_chunks": 0,
+        "context_splits": 0,
+        "truncated_chunks": 0,
+        "nodes": 2,
+        "edges": 1,
+        "model_file_exists": True,
+        "base_url_localhost": True,
+        "offline_cloud_keys_scrubbed": True,
+    }
+
+
+def _status(results):
+    return {
+        "schema_version": 1,
+        "probe": "graphify_local_shard_matrix",
+        "ref": "origin/main",
+        "model": "gemma-4-e4b-it-Q4_K_M.gguf",
+        "artifact_dir": "/tmp/graphify-artifacts",
+        "shard_count": len(results),
+        "accepted_count": len(results),
+        "rejected_count": 0,
+        "all_accepted": True,
+        "blocked_shards": [],
+        "cluster": True,
+        "results": results,
+    }
+
+
+def test_validate_shard_merge_accepts_clean_artifacts(tmp_path):
+    data_graph = _graph([_node("data_file"), _node("data_func")], [_link("data_file", "data_func")])
+    ops_graph = _graph([_node("ops_file"), _node("ops_func")], [_link("ops_file", "ops_func")])
+    status = _status([
+        _result("data-core", _write_artifact(tmp_path, "data-core", data_graph)),
+        _result("operators", _write_artifact(tmp_path, "operators", ops_graph)),
+    ])
+
+    result = MODULE.validate_shard_merge(status)
+
+    assert result.accepted is True
+    assert result.status == "ready_for_merged_cluster_report"
+    assert result.blockers == ()
+    assert result.summary["node_count"] == 4
+    assert result.summary["link_count"] == 2
+    assert result.summary["write_ready"] is True
+    assert [node["id"] for node in result.merged_graph["nodes"]] == ["data_file", "data_func", "ops_file", "ops_func"]
+    assert result.merged_graph["merged_from_shards"]["shards"] == ["data-core", "operators"]
+
+
+def test_validate_shard_merge_adds_provenance_for_duplicate_identical_nodes(tmp_path):
+    shared = _node("shared_helper")
+    data_graph = _graph([_node("data_file"), shared], [_link("data_file", "shared_helper")])
+    ops_graph = _graph([_node("ops_file"), shared], [_link("ops_file", "shared_helper")])
+    status = _status([
+        _result("data-core", _write_artifact(tmp_path, "data-core", data_graph)),
+        _result("operators", _write_artifact(tmp_path, "operators", ops_graph)),
+    ])
+
+    result = MODULE.validate_shard_merge(status)
+
+    assert result.accepted is True
+    shared_node = next(node for node in result.merged_graph["nodes"] if node["id"] == "shared_helper")
+    assert shared_node["graphify_shards"] == ["data-core", "operators"]
+
+
+def test_validate_shard_merge_is_deterministic_when_status_order_changes(tmp_path):
+    data_graph = _graph([_node("data_file"), _node("data_func")], [_link("data_file", "data_func")])
+    ops_graph = _graph([_node("ops_file"), _node("ops_func")], [_link("ops_file", "ops_func")])
+    data_result = _result("data-core", _write_artifact(tmp_path, "data-core", data_graph))
+    ops_result = _result("operators", _write_artifact(tmp_path, "operators", ops_graph))
+
+    first = MODULE.validate_shard_merge(_status([data_result, ops_result]))
+    second = MODULE.validate_shard_merge(_status([ops_result, data_result]))
+
+    assert first.accepted is True
+    assert second.accepted is True
+    assert first.summary["deterministic_hash"] == second.summary["deterministic_hash"]
+    assert first.merged_graph == second.merged_graph
+
+
+def test_validate_shard_merge_blocks_conflicting_duplicate_nodes(tmp_path):
+    data_graph = _graph([_node("shared_helper", label="Shared")], [])
+    ops_graph = _graph([_node("shared_helper", label="Different")], [])
+    status = _status([
+        _result("data-core", _write_artifact(tmp_path, "data-core", data_graph)),
+        _result("operators", _write_artifact(tmp_path, "operators", ops_graph)),
+    ])
+
+    result = MODULE.validate_shard_merge(status)
+
+    assert result.accepted is False
+    assert "node_conflict:shared_helper" in result.blockers
+    assert result.merged_graph is None
+
+
+
+
+def test_validate_shard_merge_blocks_conflicting_duplicate_links(tmp_path):
+    first_link = _link("data_file", "shared_helper")
+    second_link = _link("data_file", "shared_helper")
+    second_link["confidence"] = "DIFFERENT"
+    data_graph = _graph([_node("data_file"), _node("shared_helper")], [first_link])
+    ops_graph = _graph([_node("data_file"), _node("shared_helper")], [second_link])
+    status = _status([
+        _result("data-core", _write_artifact(tmp_path, "data-core", data_graph)),
+        _result("operators", _write_artifact(tmp_path, "operators", ops_graph)),
+    ])
+
+    result = MODULE.validate_shard_merge(status)
+
+    assert result.accepted is False
+    assert any(blocker.startswith("link_conflict:") for blocker in result.blockers)
+
+
+def test_validate_shard_merge_blocks_links_with_missing_endpoints(tmp_path):
+    graph = _graph([_node("data_file")], [_link("data_file", "missing_func")])
+    status = _status([_result("data-core", _write_artifact(tmp_path, "data-core", graph))])
+
+    result = MODULE.validate_shard_merge(status)
+
+    assert result.accepted is False
+    assert any(blocker.endswith(":missing_func") for blocker in result.blockers)
+
+
+def test_main_writes_validation_and_merged_graph_json(tmp_path, capsys):
+    graph = _graph([_node("data_file"), _node("data_func")], [_link("data_file", "data_func")])
+    status = _status([_result("data-core", _write_artifact(tmp_path, "data-core", graph))])
+    status_json = tmp_path / "status.json"
+    result_json = tmp_path / "result.json"
+    merged_json = tmp_path / "merged" / "graph.json"
+    status_json.write_text(json.dumps(status), encoding="utf-8")
+
+    rc = MODULE.main([str(status_json), "--output-json", str(result_json), "--merged-graph-json", str(merged_json)])
+
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "ready_for_merged_cluster_report" in captured.out
+    written_result = json.loads(result_json.read_text(encoding="utf-8"))
+    written_graph = json.loads(merged_json.read_text(encoding="utf-8"))
+    assert written_result["accepted"] is True
+    assert written_graph["merged_from_shards"]["probe"] == "graphify_local_shard_matrix"
+
+
+def test_main_returns_1_for_blocked_merge(tmp_path):
+    graph = _graph([_node("data_file")], [_link("data_file", "missing_func")])
+    status_json = tmp_path / "status.json"
+    status_json.write_text(json.dumps(_status([_result("data-core", _write_artifact(tmp_path, "data-core", graph))])), encoding="utf-8")
+
+    assert MODULE.main([str(status_json)]) == 1
+
+
+def test_main_returns_2_for_invalid_status_json(tmp_path, capsys):
+    status_json = tmp_path / "status.json"
+    status_json.write_text("not json", encoding="utf-8")
+
+    rc = MODULE.main([str(status_json)])
+
+    captured = capsys.readouterr()
+    assert rc == 2
+    assert "error:" in captured.err

--- a/services/zoe-data/tests/test_graphify_shard_sync_plan.py
+++ b/services/zoe-data/tests/test_graphify_shard_sync_plan.py
@@ -71,6 +71,7 @@ def test_build_shard_sync_plan_accepts_clean_current_shards():
     assert plan.summary["artifact_sync_ready"] is False
     assert plan.summary["shards"] == ["data-core", "operators"]
     assert "--artifact-dir" in plan.required_next_steps[0]
+    assert any("graphify_shard_merge_validate.py" in step for step in plan.required_next_steps)
 
 
 def test_build_shard_sync_plan_reports_artifact_capture_and_sync_readiness():


### PR DESCRIPTION
## Summary

Adds a no-write Graphify shard merge validation gate for captured local shard artifacts.

- adds `scripts/maintenance/graphify_shard_merge_validate.py`
- validates `graphify_local_shard_matrix` status packets and per-shard `graphify-out/graph.json` artifacts
- merges nodes, links, and hyperedges deterministically with `graphify_shards` provenance
- fails closed on duplicate shard names, node conflicts, link conflicts, hyperedge conflicts, missing graph files, malformed graph JSON, and missing link endpoints
- can write merged graph JSON only to an explicit operator-supplied output path, never to committed `graphify-out`
- updates the shard sync plan and Graphify evidence doc to point at this concrete gate

## Why

The Zoe evolution plan says the committed full Graphify map remains stale until sharded local Graphify evidence can be safely merged, clustered, reported, and reconciled. This PR closes the first merge contract loop: captured shard artifacts can now be validated and merged deterministically before any future replacement of committed graph outputs.

## Validation

- `python3 -m pytest -q services/zoe-data/tests/test_graphify_shard_merge_validate.py services/zoe-data/tests/test_graphify_shard_sync_plan.py services/zoe-data/tests/test_graphify_local_shard_matrix.py services/zoe-data/tests/test_graphify_local_probe.py services/zoe-data/tests/test_graphify_local_refresh.py` — 54 passed
- `git diff --check`
- `python3 tools/audit/validate_structure.py`
- `python3 tools/audit/validate_critical_files.py`
