### PR TITLE
Refine Skybridge people cards and shared accents

### DIFF
--- a/services/zoe-data/card_service.py
+++ b/services/zoe-data/card_service.py
@@ -24,14 +24,18 @@ def build_calendar_timeline_content(slots: dict[str, Any] | None = None) -> dict
     events = slots.get("events") or []
     if not isinstance(events, list):
         events = [events]
-    return {
+    content = {
         "title": f"Calendar for {qualifier}",
-        "summary": "Showing calendar",
+        "summary": _text(slots.get("summary"), "Showing calendar"),
         "qualifier": qualifier,
         "events": events,
         "view": "timeline",
         "source": "calendar_show",
     }
+    for key in ("date", "start_date", "end_date"):
+        if slots.get(key):
+            content[key] = slots[key]
+    return content
 
 
 def build_weather_current_content(slots: dict[str, Any] | None = None) -> dict[str, Any]:

--- a/services/zoe-data/routers/skybridge.py
+++ b/services/zoe-data/routers/skybridge.py
@@ -28,10 +28,10 @@ async def get_skybridge_status():
         "entrypoint": "/touch/skybridge.html",
         "version": 1,
         "card_contract": {
-            "status": "wired_for_calendar_weather_lists_people_actions_v1",
+            "status": "wired_for_calendar_weather_lists_people_clock_actions_v1",
             "supported_major": 1,
-            "data_domains": ["calendar", "weather", "lists", "people"],
-            "voice_ws_domains": ["calendar", "weather", "lists", "people"],
+            "data_domains": ["calendar", "weather", "lists", "people", "clock"],
+            "voice_ws_domains": ["calendar", "weather", "lists", "people", "clock"],
             "action_domains": ["calendar", "lists", "people"],
             "context_refresh": True,
             "client_capability_cards": True,
@@ -43,7 +43,7 @@ async def get_skybridge_status():
         "capabilities": {
             "pages": 15,
             "settings": 22,
-            "dynamic_cards": "calendar_weather_lists_people_data_and_action_cards",
+            "dynamic_cards": "calendar_weather_lists_people_clock_data_and_action_cards",
         },
     }
 

--- a/services/zoe-data/routers/voice_tts.py
+++ b/services/zoe-data/routers/voice_tts.py
@@ -3005,9 +3005,10 @@ async def voice_command(
 
         _voice_entry = _VOICE_SESSIONS.get(panel_id, {})
         _skybridge_context = _voice_entry.get("skybridge_context") or {}
+        _skybridge_user = _scope_identity_user or "guest"
         _skybridge_result = await resolve_skybridge_request(
             text,
-            effective_user,
+            _skybridge_user,
             context=_skybridge_context,
             db=db,
         )
@@ -3067,8 +3068,8 @@ async def voice_command(
                 await _bc_sky.broadcast("all", "voice:done", {"panel_id": panel_id})
             except Exception:
                 pass
-            await _schedule_voice_chat_save(session_id, text, _skybridge_reply, effective_user)
-            asyncio.ensure_future(_run_voice_memory_passes(text, _skybridge_reply, effective_user, session_id))
+            await _schedule_voice_chat_save(session_id, text, _skybridge_reply, _skybridge_user)
+            asyncio.ensure_future(_run_voice_memory_passes(text, _skybridge_reply, _skybridge_user, session_id))
             return {
                 "ok": True,
                 "panel_id": panel_id,

--- a/services/zoe-data/routers/voice_tts.py
+++ b/services/zoe-data/routers/voice_tts.py
@@ -437,6 +437,36 @@ def _should_supersede_voice_weather_action(row, nav_key: str, card_key: str) -> 
     )
 
 
+def _should_supersede_voice_skybridge_action(row, nav_key: str, card_key: str) -> bool:
+    if row["idempotency_key"] in {nav_key, card_key}:
+        return False
+    try:
+        payload = json.loads(row["payload"] or "{}")
+    except Exception:
+        payload = {}
+    action_type = row["action_type"]
+    source = str(payload.get("source") or "").lower()
+    if source == "voice:skybridge":
+        return True
+    if action_type == "panel_navigate":
+        url = str(payload.get("url") or "").split("?", 1)[0]
+        return url in {
+            "/touch/calendar.html",
+            "/touch/weather.html",
+            "/touch/lists.html",
+            "/touch/chat.html",
+        }
+    if action_type == "show_card":
+        return str(payload.get("type") or "").lower() in {
+            "calendar",
+            "weather",
+            "list",
+            "lists",
+            "skybridge",
+        }
+    return False
+
+
 def _split_sentences(text: str) -> list[str]:
     """Split text into spoken sentences for streaming TTS.
 
@@ -699,23 +729,34 @@ async def _broadcast_skybridge_ui(
                 broadcast=False,
                 commit=False,
             )
-            current_card_id = card_message.get("action_id") or card_message.get("id")
-            if current_card_id:
-                await _db.execute(
-                    """UPDATE ui_actions
-                       SET status = 'skipped',
-                           error_code = 'superseded',
-                           error_message = 'Superseded by newer Skybridge voice card',
-                           updated_at = NOW()
-                       WHERE user_id = ?
-                         AND panel_id = ?
+            nav_key = f"voice_skybridge_nav_{panel_id}_{delivery_key}"
+            card_key = f"voice_skybridge_card_{panel_id}_{delivery_key}"
+            try:
+                _cur = await _db.execute(
+                    """SELECT id, action_type, payload, idempotency_key
+                       FROM ui_actions
+                       WHERE panel_id = ?
+                         AND user_id = ?
                          AND requested_by = 'voice'
-                         AND action_type = 'show_card'
-                         AND status IN ('queued', 'running')
-                         AND id != ?
-                         AND payload::jsonb->>'source' = 'voice:skybridge'""",
-                    (_panel_user_id, panel_id, current_card_id),
+                         AND status IN ('queued', 'running')""",
+                    (panel_id, _panel_user_id),
                 )
+                _rows = await _cur.fetchall()
+                _superseded_at = datetime.now(timezone.utc).isoformat()
+                for _row in _rows:
+                    if not _should_supersede_voice_skybridge_action(_row, nav_key, card_key):
+                        continue
+                    await _db.execute(
+                        """UPDATE ui_actions
+                           SET status = 'skipped',
+                               error_code = 'superseded',
+                               error_message = 'Superseded by newer Skybridge voice request',
+                               updated_at = ?
+                           WHERE id = ?""",
+                        (_superseded_at, _row["id"]),
+                    )
+            except Exception as _sup_exc:
+                logger.debug("voice skybridge stale-action cleanup failed (non-fatal): %s", _sup_exc)
             await _db.commit()
             nav_delivered = await broadcaster.broadcast_to_panel(
                 panel_id,

--- a/services/zoe-data/skybridge_service.py
+++ b/services/zoe-data/skybridge_service.py
@@ -7,6 +7,7 @@ import re
 import uuid
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta
+from pathlib import Path
 from typing import Any
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
@@ -85,11 +86,39 @@ LIST_TYPE_ALIASES = {
 }
 PEOPLE_CONTEXTS = ("personal", "work")
 PEOPLE_CIRCLES = ("inner", "circle", "public")
-DEFAULT_CLOCK_TIMEZONE = "Australia/Perth"
+
+
+def _host_clock_timezone() -> str | None:
+    tz_env = (os.environ.get("TZ") or "").strip()
+    if tz_env and not tz_env.startswith(":"):
+        return tz_env
+
+    try:
+        timezone_file = Path("/etc/timezone")
+        if timezone_file.exists():
+            timezone_name = timezone_file.read_text(encoding="utf-8").strip()
+            if timezone_name:
+                return timezone_name
+    except OSError:
+        pass
+
+    try:
+        localtime = Path("/etc/localtime")
+        if localtime.is_symlink():
+            target = str(localtime.resolve())
+            marker = "/zoneinfo/"
+            if marker in target:
+                timezone_name = target.split(marker, 1)[1]
+                if timezone_name:
+                    return timezone_name
+    except OSError:
+        pass
+
+    return None
 
 
 def _default_clock_timezone() -> str:
-    return os.environ.get("ZOE_SKYBRIDGE_TIMEZONE") or DEFAULT_CLOCK_TIMEZONE
+    return os.environ.get("ZOE_SKYBRIDGE_TIMEZONE") or _host_clock_timezone() or "UTC"
 
 
 def _today() -> date:

--- a/services/zoe-data/skybridge_service.py
+++ b/services/zoe-data/skybridge_service.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import os
 import re
 import uuid
 from dataclasses import dataclass
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta
 from typing import Any
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from calendar_utils import row_to_event
 from card_service import card_service
@@ -83,10 +85,25 @@ LIST_TYPE_ALIASES = {
 }
 PEOPLE_CONTEXTS = ("personal", "work")
 PEOPLE_CIRCLES = ("inner", "circle", "public")
+DEFAULT_CLOCK_TIMEZONE = "Australia/Perth"
+
+
+def _default_clock_timezone() -> str:
+    return os.environ.get("ZOE_SKYBRIDGE_TIMEZONE") or DEFAULT_CLOCK_TIMEZONE
 
 
 def _today() -> date:
     return date.today()
+
+
+def _clock_now(timezone_name: str | None = None) -> tuple[datetime, str]:
+    name = timezone_name or _default_clock_timezone()
+    try:
+        tz = ZoneInfo(name)
+    except ZoneInfoNotFoundError:
+        name = "UTC"
+        tz = ZoneInfo("UTC")
+    return datetime.now(tz), name
 
 
 async def _get_current(lat, lon, city, country):
@@ -489,6 +506,14 @@ def classify_skybridge_intent(message: str, context: dict[str, Any] | None = Non
         parsed_range = _calendar_date_from_text(text, _today())
         start = parsed_range[1] if parsed_range else _context_calendar_date(context)
         return SkybridgeIntent(domain="calendar", action="create_event", title=title, target_time=target_time, range_label=start.isoformat(), start_date=start, end_date=start)
+    if (
+        " clock " in text
+        or re.search(r"\bwhat(?:'s| is)?\s+the\s+time\b", text)
+        or re.search(r"\bwhat\s+time\s+is\s+it\b", text)
+        or re.search(r"\bshow\s+(?:me\s+)?(?:the\s+)?time\b", text)
+        or re.search(r"\bcurrent\s+time\b", text)
+    ):
+        return SkybridgeIntent(domain="clock", action="show")
     if any(term in text for term in (" weather", " forecast", " temperature", " rain", " windy", " wind ")):
         action = "forecast" if any(term in text for term in ("forecast", "tomorrow", "week", "next few days")) else "current"
         return SkybridgeIntent(domain="weather", action=action)
@@ -550,6 +575,9 @@ async def resolve_skybridge_request(
     if skybridge_intent_requires_identity(intent) and _is_guest_user(user_id):
         return _attach_skybridge_context(_auth_required_result(intent))
 
+    if intent.domain == "clock":
+        return _attach_skybridge_context(_resolve_clock(intent))
+
     if db is not None:
         return _attach_skybridge_context(await _resolve_with_db(intent, user_id, db, context=context))
 
@@ -576,6 +604,8 @@ def skybridge_intent_requires_identity(intent: SkybridgeIntent | None) -> bool:
 
 
 async def _resolve_with_db(intent: SkybridgeIntent, user_id: str, db: Any, *, context: dict[str, Any] | None = None) -> dict[str, Any]:
+    if intent.domain == "clock":
+        return _resolve_clock(intent)
     if intent.domain == "calendar":
         if intent.action == "create_event":
             return await _resolve_calendar_create(intent, user_id, db)
@@ -595,6 +625,32 @@ async def _resolve_with_db(intent: SkybridgeIntent, user_id: str, db: Any, *, co
             return await _resolve_people_remember_fact(intent, user_id, db)
         return await _resolve_people(intent, user_id, db)
     return {"handled": False, "intent": None, "spoken_summary": "", "cards": []}
+
+
+def _resolve_clock(intent: SkybridgeIntent) -> dict[str, Any]:
+    now, timezone_name = _clock_now()
+    hour_str = str(now.hour % 12 or 12)
+    spoken = f"It is {hour_str}:{now.strftime('%M %p')}."
+    return {
+        "handled": True,
+        "intent": {"domain": "clock", "action": intent.action, "timezone": timezone_name},
+        "spoken_summary": spoken,
+        "cards": [{
+            "component": "status",
+            "props": {
+                "source": "clock_show",
+                "title": "Clock",
+                "summary": spoken,
+                "timezone": timezone_name,
+                "iso": now.isoformat(),
+                "hour": hour_str,
+                "minute": now.strftime("%M"),
+                "meridiem": now.strftime("%p"),
+                "weekday": now.strftime("%A"),
+                "date_label": now.strftime("%d %B"),
+            },
+        }],
+    }
 
 
 async def _maybe_commit(db: Any) -> None:

--- a/services/zoe-data/tests/test_skybridge_service.py
+++ b/services/zoe-data/tests/test_skybridge_service.py
@@ -171,6 +171,8 @@ class GuardedGuestDb(FakeDb):
 def test_classify_calendar_and_weather_requests():
     assert classify_skybridge_intent("show my calendar").domain == "calendar"
     assert classify_skybridge_intent("show me the weather").domain == "weather"
+    assert classify_skybridge_intent("show me the clock").domain == "clock"
+    assert classify_skybridge_intent("what time is it").domain == "clock"
     assert classify_skybridge_intent("what is happening this week").domain == "calendar"
     assert classify_skybridge_intent("show my shopping list").domain == "lists"
     assert classify_skybridge_intent("what's on my shopping list").domain == "lists"
@@ -197,6 +199,21 @@ def test_classify_calendar_and_weather_requests():
     assert classify_skybridge_intent("find Sarah").domain == "people"
     assert classify_skybridge_intent("what is there to do this week") is None
     assert classify_skybridge_intent("open settings") is None
+
+
+@pytest.mark.asyncio
+async def test_clock_request_returns_public_live_clock_card():
+    result = await resolve_skybridge_request("show me the clock", "guest", db=GuardedGuestDb())
+
+    assert result["handled"] is True
+    assert result["intent"]["domain"] == "clock"
+    assert result["intent"]["action"] == "show"
+    assert result["cards"][0]["component"] == "status"
+    props = result["cards"][0]["props"]
+    assert props["source"] == "clock_show"
+    assert props["timezone"]
+    assert props["iso"]
+    assert "auth_required" not in result
 
 
 def test_classify_skybridge_action_requests():

--- a/services/zoe-data/tests/test_skybridge_service.py
+++ b/services/zoe-data/tests/test_skybridge_service.py
@@ -201,6 +201,27 @@ def test_classify_calendar_and_weather_requests():
     assert classify_skybridge_intent("open settings") is None
 
 
+def test_clock_timezone_prefers_env(monkeypatch):
+    monkeypatch.setenv("ZOE_SKYBRIDGE_TIMEZONE", "Australia/Melbourne")
+    monkeypatch.setenv("TZ", "UTC")
+
+    assert skybridge_service._default_clock_timezone() == "Australia/Melbourne"
+
+
+def test_clock_timezone_uses_host_timezone_before_utc(monkeypatch):
+    monkeypatch.delenv("ZOE_SKYBRIDGE_TIMEZONE", raising=False)
+    monkeypatch.setenv("TZ", "Europe/London")
+
+    assert skybridge_service._default_clock_timezone() == "Europe/London"
+
+
+def test_clock_timezone_falls_back_to_utc(monkeypatch):
+    monkeypatch.delenv("ZOE_SKYBRIDGE_TIMEZONE", raising=False)
+    monkeypatch.setattr(skybridge_service, "_host_clock_timezone", lambda: None)
+
+    assert skybridge_service._default_clock_timezone() == "UTC"
+
+
 @pytest.mark.asyncio
 async def test_clock_request_returns_public_live_clock_card():
     result = await resolve_skybridge_request("show me the clock", "guest", db=GuardedGuestDb())

--- a/services/zoe-data/tests/test_skybridge_service.py
+++ b/services/zoe-data/tests/test_skybridge_service.py
@@ -493,7 +493,11 @@ async def test_calendar_explicit_date_queries_requested_day(monkeypatch):
     assert result["intent"]["range"] == "17 June 2026"
     assert db.fetch_args[2] == "2026-06-17"
     assert db.fetch_args[3] == "2026-06-17"
-    assert result["cards"][0]["content"]["qualifier"] == "17 June 2026"
+    content = result["cards"][0]["content"]
+    assert content["qualifier"] == "17 June 2026"
+    assert content["date"] == "2026-06-17"
+    assert content["start_date"] == "2026-06-17"
+    assert content["end_date"] == "2026-06-17"
 
 
 @pytest.mark.asyncio
@@ -512,6 +516,9 @@ async def test_calendar_happening_this_week_queries_range(monkeypatch):
     assert result["intent"]["range"] == "this week"
     assert db.fetch_args[2] == "2026-06-11"
     assert db.fetch_args[3] == (date(2026, 6, 11) + timedelta(days=7)).isoformat()
+    content = result["cards"][0]["content"]
+    assert content["start_date"] == "2026-06-11"
+    assert content["end_date"] == "2026-06-18"
 
 
 @pytest.mark.asyncio

--- a/services/zoe-data/tests/test_skybridge_static.py
+++ b/services/zoe-data/tests/test_skybridge_static.py
@@ -655,6 +655,18 @@ def test_skybridge_has_touch_panel_fit_overrides():
     assert '.sky-orb-button span' in html
     assert '.sky-orb-button::before' in html
     assert 'display: none !important' in html
+    assert 'skybridge-native-panel-fit-final' in html
+    assert 'inset: 24px 24px 112px !important' in html
+    assert 'Native Zoe touch panel: 1280x720 rotated DSI display' in html
+
+
+def test_skybridge_weather_renderer_accepts_temperature_aliases():
+    renderer = read(UI / "js" / "skybridge-renderer.js")
+
+    assert "function weatherValue(source, keys)" in renderer
+    assert "['temp', 'temperature', 'temperature_c', 'temp_c', 'current_temp']" in renderer
+    assert "['feels_like', 'feels_like_c', 'apparent_temperature']" in renderer
+    assert "['temp', 'temperature', 'temperature_c', 'temp_c', 'high']" in renderer
 
 
 def test_skybridge_list_create_has_database_conflict_guard():

--- a/services/zoe-data/tests/test_skybridge_static.py
+++ b/services/zoe-data/tests/test_skybridge_static.py
@@ -327,8 +327,13 @@ def test_skybridge_renderer_supports_real_data_cards():
     assert "/touch/css/skybridge-data-widgets.css?v=skybridge-panel-session-2" in html
     assert "skybridge-lists-people-widgets" not in html
     assert "sky-list-item-row" in data_widgets_css
-    assert "sky-person-row" in data_widgets_css
+    assert "sky-person-card" in renderer
+    assert "sky-person-card" in data_widgets_css
+    assert "sky-people-grid" in renderer
+    assert "sky-people-grid" in data_widgets_css
     assert "sky-profile-health" in data_widgets_css
+    assert "--sky-accent-work: 37, 99, 235" in data_widgets_css
+    assert "--sky-accent-personal: 147, 51, 234" in data_widgets_css
     assert "sky-weather-scene" in html
     assert "weather-sunny" in html
     assert "skybridge-runtime-overrides" in html
@@ -411,7 +416,10 @@ def test_skybridge_calendar_renderer_handles_datetime_dates_and_ordering():
     assert "const detail = [item.location].filter(Boolean).join(' · ');" in renderer
     assert "const detail = [item.location, calendarAccentLabel(item.category)]" not in renderer
     assert "calendarAccentLabel" not in renderer
-    assert "return known.indexOf(token) >= 0 ? token : 'general';" in renderer
+    assert "function accentClass(value, fallback)" in renderer
+    assert "return accentClass(value, 'general');" in renderer
+    assert "'medical'" in renderer
+    assert "'household'" in renderer
 
 
 def test_skybridge_is_registered_in_touch_menu():

--- a/services/zoe-data/tests/test_skybridge_static.py
+++ b/services/zoe-data/tests/test_skybridge_static.py
@@ -315,9 +315,11 @@ def test_skybridge_renderer_supports_real_data_cards():
     assert "props.source === 'list_show'" in renderer
     assert "props.source === 'people_directory'" in renderer
     assert "props.source === 'person_profile'" in renderer
+    assert "props.source === 'clock_show'" in renderer
     assert "renderZoeList(props)" in renderer
     assert "renderPeopleDirectory(props)" in renderer
     assert "renderPersonProfile(props)" in renderer
+    assert "renderClock(props)" in renderer
     assert "sky-list-scene" in renderer
     assert "sky-people-scene" in renderer
     assert "sky-profile-scene" in renderer
@@ -334,6 +336,10 @@ def test_skybridge_renderer_supports_real_data_cards():
     assert "sky-profile-health" in data_widgets_css
     assert "--sky-accent-work: 37, 99, 235" in data_widgets_css
     assert "--sky-accent-personal: 147, 51, 234" in data_widgets_css
+    assert "sky-clock-scene" in data_widgets_css
+    assert "sky-live-clock" in renderer
+    assert "skyAmbientClock" in html
+    assert "sky-ambient-clock" in html
     assert "sky-weather-scene" in html
     assert "weather-sunny" in html
     assert "skybridge-runtime-overrides" in html
@@ -344,6 +350,24 @@ def test_skybridge_renderer_supports_real_data_cards():
     assert "skybridge-push-ack-1" in html
     assert "backdrop-filter: none !important" in html
     assert "No events " in renderer
+
+
+def test_skybridge_returns_to_ambient_clock_after_card_idle():
+    app = read(UI / "js" / "skybridge.js")
+    html = read(UI / "skybridge.html")
+
+    assert "CARD_IDLE_MS" in app
+    assert "skybridge_idle_return_ms" in app
+    assert "function scheduleIdleReturn()" in app
+    assert "function returnToAmbientClock()" in app
+    assert "renderHome({ idle: true })" in app
+    assert "function updateAllClocks()" in app
+    assert "document.querySelectorAll('.sky-live-clock')" in app
+    assert "id=\"skyAmbientClock\"" in html
+    ambient_start = html.index("id=\"skyAmbientClock\"")
+    ambient_tag = html[html.rfind("<div", 0, ambient_start):html.find(">", ambient_start) + 1]
+    assert "aria-live" not in ambient_tag
+    assert "body.sky-empty.sky-ambient-clock .sky-ambient-clock" in html
 
 
 def test_skybridge_weather_renderer_uses_widget_forecast_structure():

--- a/services/zoe-data/tests/test_skybridge_static.py
+++ b/services/zoe-data/tests/test_skybridge_static.py
@@ -441,9 +441,13 @@ def test_skybridge_calendar_renderer_handles_datetime_dates_and_ordering():
     assert "const detail = [item.location, calendarAccentLabel(item.category)]" not in renderer
     assert "calendarAccentLabel" not in renderer
     assert "function accentClass(value, fallback)" in renderer
-    assert "return accentClass(value, 'general');" in renderer
+    assert "const category = accentClass(value, 'general');" in renderer
+    assert "return ['tasks', 'all'].indexOf(category) >= 0 ? 'general' : category;" in renderer
     assert "'medical'" in renderer
     assert "'household'" in renderer
+    assert "personAccentClass(person) === 'personal'" in renderer
+    assert "const otherCount = Math.max(0, people.length - workCount - personalCount);" in renderer
+    assert " + ' other</span>'" in renderer
 
 
 def test_skybridge_is_registered_in_touch_menu():

--- a/services/zoe-data/tests/test_skybridge_status.py
+++ b/services/zoe-data/tests/test_skybridge_status.py
@@ -27,13 +27,13 @@ def test_skybridge_status_endpoint_returns_runtime_contract():
     assert data["surface"] == "skybridge"
     assert data["status"] == "ready"
     assert data["entrypoint"] == "/touch/skybridge.html"
-    assert data["card_contract"]["status"] == "wired_for_calendar_weather_lists_people_actions_v1"
+    assert data["card_contract"]["status"] == "wired_for_calendar_weather_lists_people_clock_actions_v1"
     assert data["card_contract"]["supported_major"] == 1
-    assert data["card_contract"]["data_domains"] == ["calendar", "weather", "lists", "people"]
-    assert data["card_contract"]["voice_ws_domains"] == ["calendar", "weather", "lists", "people"]
+    assert data["card_contract"]["data_domains"] == ["calendar", "weather", "lists", "people", "clock"]
+    assert data["card_contract"]["voice_ws_domains"] == ["calendar", "weather", "lists", "people", "clock"]
     assert data["card_contract"]["action_domains"] == ["calendar", "lists", "people"]
     assert data["card_contract"]["context_refresh"] is True
     assert data["transports"]["local_ws"] is True
     assert "livekit" in data["transports"]
     assert data["capabilities"]["settings"] == 22
-    assert data["capabilities"]["dynamic_cards"] == "calendar_weather_lists_people_data_and_action_cards"
+    assert data["capabilities"]["dynamic_cards"] == "calendar_weather_lists_people_clock_data_and_action_cards"

--- a/services/zoe-data/tests/test_voice_presence.py
+++ b/services/zoe-data/tests/test_voice_presence.py
@@ -293,6 +293,9 @@ def test_websocket_wake_returns_presence_events_without_reasoning(monkeypatch):
 
     monkeypatch.setattr(main, "_resolve_voice_cards", _unexpected_resolve)
     monkeypatch.delenv("ZOE_WAKE_ACK_PHRASE", raising=False)
+    monkeypatch.delenv("ZOE_WAKE_ACK_PHRASES", raising=False)
+    monkeypatch.delenv("ZOE_WAKE_ACK_AUDIO_PATH", raising=False)
+    monkeypatch.delenv("ZOE_WAKE_ACK_AUDIO_PATHS", raising=False)
 
     with TestClient(main.app) as client:
         with client.websocket_connect("/ws/voice/") as ws:
@@ -312,6 +315,9 @@ def test_websocket_hey_zoe_can_emit_configured_ack_phrase(monkeypatch):
         raise AssertionError("wake phrase must not enter Skybridge/card resolution")
 
     monkeypatch.setattr(main, "_resolve_voice_cards", _unexpected_resolve)
+    monkeypatch.delenv("ZOE_WAKE_ACK_PHRASES", raising=False)
+    monkeypatch.delenv("ZOE_WAKE_ACK_AUDIO_PATH", raising=False)
+    monkeypatch.delenv("ZOE_WAKE_ACK_AUDIO_PATHS", raising=False)
     monkeypatch.setenv("ZOE_WAKE_ACK_PHRASE", "Yes Jason?")
 
     with TestClient(main.app) as client:
@@ -333,6 +339,9 @@ def test_websocket_raw_text_hey_zoe_can_emit_configured_ack_phrase(monkeypatch):
         raise AssertionError("raw wake phrase must not enter Skybridge/card resolution")
 
     monkeypatch.setattr(main, "_resolve_voice_cards", _unexpected_resolve)
+    monkeypatch.delenv("ZOE_WAKE_ACK_PHRASES", raising=False)
+    monkeypatch.delenv("ZOE_WAKE_ACK_AUDIO_PATH", raising=False)
+    monkeypatch.delenv("ZOE_WAKE_ACK_AUDIO_PATHS", raising=False)
     monkeypatch.setenv("ZOE_WAKE_ACK_PHRASE", "Yes Jason?")
 
     with TestClient(main.app) as client:

--- a/services/zoe-data/tests/test_voice_weather_queue.py
+++ b/services/zoe-data/tests/test_voice_weather_queue.py
@@ -575,6 +575,9 @@ async def test_voice_skybridge_private_request_challenges_guest_before_cards(mon
     async def no_user(*_args, **_kwargs):
         return None
 
+    async def default_user(*_args, **_kwargs):
+        return "panel-default-user"
+
     skybridge_module = types.SimpleNamespace(resolve_skybridge_request=resolve_skybridge_request)
     monkeypatch.setitem(sys.modules, "skybridge_service", skybridge_module)
     monkeypatch.setattr(skybridge_service, "resolve_skybridge_request", resolve_skybridge_request)
@@ -582,7 +585,7 @@ async def test_voice_skybridge_private_request_challenges_guest_before_cards(mon
     monkeypatch.setattr(voice_tts, "_broadcast_skybridge_ui", broadcast_skybridge_ui)
     monkeypatch.setattr(voice_tts, "_request_voice_identity_challenge", request_voice_identity_challenge)
     monkeypatch.setattr(voice_tts, "_resolve_recent_panel_session_user", no_user)
-    monkeypatch.setattr(voice_tts, "_resolve_panel_default_user", no_user)
+    monkeypatch.setattr(voice_tts, "_resolve_panel_default_user", default_user)
     monkeypatch.setattr(voice_tts, "_VOICE_SESSIONS", {})
 
     response = await voice_command(

--- a/services/zoe-data/tests/test_voice_weather_queue.py
+++ b/services/zoe-data/tests/test_voice_weather_queue.py
@@ -726,6 +726,9 @@ async def test_voice_command_stream_emits_processing_ack_before_slow_response(mo
     async def no_user(*_args, **_kwargs):
         return None
 
+    async def panel_user(*_args, **_kwargs):
+        return "panel-user"
+
     async def resolve_skybridge_request(*_args, **_kwargs):
         return None
 
@@ -743,7 +746,7 @@ async def test_voice_command_stream_emits_processing_ack_before_slow_response(mo
         return b"RIFF-final"
 
     monkeypatch.setenv("ZOE_PROCESSING_ACK_PHRASE", "Let me check.")
-    monkeypatch.setattr(voice_tts, "_resolve_recent_panel_session_user", no_user)
+    monkeypatch.setattr(voice_tts, "_resolve_recent_panel_session_user", panel_user)
     monkeypatch.setattr(voice_tts, "_resolve_panel_default_user", no_user)
     monkeypatch.setattr(voice_tts, "_load_voice_history", load_voice_history)
     monkeypatch.setattr(voice_tts, "_synthesize_kokoro_sidecar", synthesize_sentence)

--- a/services/zoe-data/tests/test_voice_weather_queue.py
+++ b/services/zoe-data/tests/test_voice_weather_queue.py
@@ -9,6 +9,7 @@ import routers.voice_tts as voice_tts
 from routers.voice_tts import (
     _broadcast_skybridge_ui,
     _broadcast_weather_ui,
+    _should_supersede_voice_skybridge_action,
     _should_supersede_voice_weather_action,
     voice_command,
 )
@@ -56,6 +57,34 @@ def test_ignores_non_weather_actions() -> None:
     )
     assert not _should_supersede_voice_weather_action(
         _row("show_card", {"type": "calendar"}),
+        "new-nav",
+        "new-card",
+    )
+
+
+def test_supersedes_stale_voice_actions_for_skybridge_surface() -> None:
+    assert _should_supersede_voice_skybridge_action(
+        _row("panel_navigate", {"url": "/touch/calendar.html"}),
+        "new-nav",
+        "new-card",
+    )
+    assert _should_supersede_voice_skybridge_action(
+        _row("panel_navigate", {"url": "/touch/weather.html?panel_id=panel-1"}),
+        "new-nav",
+        "new-card",
+    )
+    assert _should_supersede_voice_skybridge_action(
+        _row("show_card", {"type": "calendar"}),
+        "new-nav",
+        "new-card",
+    )
+    assert _should_supersede_voice_skybridge_action(
+        _row("show_card", {"source": "voice:skybridge"}),
+        "new-nav",
+        "new-card",
+    )
+    assert not _should_supersede_voice_skybridge_action(
+        _row("panel_navigate", {"url": "/touch/skybridge.html"}, key="new-nav"),
         "new-nav",
         "new-card",
     )
@@ -306,6 +335,13 @@ async def test_broadcast_skybridge_ui_opens_skybridge_with_card_payload(monkeypa
     assert [call["action_type"] for call in enqueue_calls] == ["panel_navigate", "show_card"]
     assert enqueue_calls[0]["payload"]["url"] == "/touch/skybridge.html?q=show+weather"
     assert enqueue_calls[0]["broadcast"] is False
+    assert {call["user_id"] for call in enqueue_calls} == {"panel-user"}
+    cleanup_selects = [
+        params
+        for sql, params in db.executed
+        if "FROM ui_actions" in sql and "user_id = ?" in sql
+    ]
+    assert cleanup_selects == [("panel-1", "panel-user")]
     assert enqueue_calls[1]["payload"]["type"] == "skybridge"
     assert enqueue_calls[1]["payload"]["card"] == card
     assert enqueue_calls[1]["payload"]["result"] == result
@@ -313,10 +349,16 @@ async def test_broadcast_skybridge_ui_opens_skybridge_with_card_payload(monkeypa
     assert [item[1] for item in broadcasts] == ["ui_action"]
     assert [item[2]["action_id"] for item in broadcasts] == ["db-panel_navigate"]
     assert [item[2]["action_type"] for item in broadcasts] == ["panel_navigate"]
-    assert db.updated_ids == ["panel-1", "db-panel_navigate"]
+    assert db.updated_ids == [
+        "old-nav-null-key",
+        "old-card",
+        "current-nav",
+        "current-card",
+        "calendar",
+        "db-panel_navigate",
+    ]
     assert "commit" in db.events
-    cleanup_sql = next(sql for sql, _params in db.executed if "payload::jsonb" in sql)
-    assert "payload::jsonb->>'source' = 'voice:skybridge'" in cleanup_sql
+    assert not any("payload::jsonb" in sql for sql, _params in db.executed)
 
 
 @pytest.mark.asyncio
@@ -371,18 +413,20 @@ async def test_broadcast_skybridge_ui_skips_supersession_when_card_id_missing(mo
 
     assert [call["action_type"] for call in enqueue_calls] == ["panel_navigate", "show_card"]
     assert [item[1] for item in broadcasts] == ["ui_action"]
+    assert "calendar" in db.updated_ids
     assert not any("payload::jsonb" in sql for sql, _params in db.executed)
 
 
 @pytest.mark.parametrize(
-    ("utterance", "resolver_text"),
+    ("utterance", "resolver_text", "domain", "reply"),
     [
-        ("show weather", "show weather"),
-        ("show whether", "show weather"),
+        ("show weather", "show weather", "weather", "It is sunny in Perth."),
+        ("show whether", "show weather", "weather", "It is sunny in Perth."),
+        ("show my calendar", "show my calendar", "calendar", "Here is your calendar."),
     ],
 )
 @pytest.mark.asyncio
-async def test_voice_command_uses_skybridge_fast_path(monkeypatch, utterance, resolver_text) -> None:
+async def test_voice_command_uses_skybridge_fast_path(monkeypatch, utterance, resolver_text, domain, reply) -> None:
     calls: dict[str, object] = {"broadcast": [], "events": []}
 
     async def resolve_skybridge_request(text, user_id, *, context=None, db=None):
@@ -394,15 +438,15 @@ async def test_voice_command_uses_skybridge_fast_path(monkeypatch, utterance, re
         }
         return {
             "handled": True,
-            "spoken_summary": "It is sunny in Perth.",
-            "intent": {"domain": "weather", "action": "current"},
-            "skybridge_context": {"domain": "weather"},
+            "spoken_summary": reply,
+            "intent": {"domain": domain, "action": "current"},
+            "skybridge_context": {"domain": domain},
             "cards": [
                 {
                     "schema_version": "1.0.0",
                     "card_type": "generic",
                     "card_id": "22222222-2222-2222-2222-222222222222",
-                    "content": {"title": "Weather", "source": "weather_current"},
+                    "content": {"title": domain.title(), "source": f"{domain}_current"},
                     "producer": "test",
                     "producer_version": "1",
                     "created_at": "2026-06-14T00:00:00Z",
@@ -467,19 +511,19 @@ async def test_voice_command_uses_skybridge_fast_path(monkeypatch, utterance, re
 
     assert response["ok"] is True
     assert response["panel_id"] == "panel-sky"
-    assert response["reply"] == "It is sunny in Perth."
-    assert response["intent"] == "skybridge:weather"
+    assert response["reply"] == reply
+    assert response["intent"] == f"skybridge:{domain}"
     assert response["skybridge"] is True
     assert response["audio_base64"]
     assert calls["resolver"]["text"] == resolver_text
     assert calls["resolver"]["user_id"] == "guest"
     assert calls["broadcast_skybridge_ui"]["panel_id"] == "panel-sky"
     assert calls["broadcast_skybridge_ui"]["utterance"] == resolver_text
-    assert calls["synthesize"] == {"text": "It is sunny in Perth."}
-    assert ("all", "voice:responding", {"panel_id": "panel-sky", "text": "It is sunny in Perth."}) in calls["broadcast"]
+    assert calls["synthesize"] == {"text": reply}
+    assert ("all", "voice:responding", {"panel_id": "panel-sky", "text": reply}) in calls["broadcast"]
     assert ("all", "voice:done", {"panel_id": "panel-sky"}) in calls["broadcast"]
     assert calls["events"].index("synthesize") < calls["events"].index("voice:done")
-    assert voice_tts._VOICE_SESSIONS["panel-sky"]["skybridge_context"] == {"domain": "weather"}
+    assert voice_tts._VOICE_SESSIONS["panel-sky"]["skybridge_context"] == {"domain": domain}
 
 
 @pytest.mark.asyncio

--- a/services/zoe-ui/dist/touch/css/skybridge-data-widgets.css
+++ b/services/zoe-ui/dist/touch/css/skybridge-data-widgets.css
@@ -1,29 +1,65 @@
+body:not(.sky-empty) {
+    --sky-accent-work: 37, 99, 235;
+    --sky-accent-personal: 147, 51, 234;
+    --sky-accent-family: 147, 51, 234;
+    --sky-accent-bucket: 5, 150, 105;
+    --sky-accent-social: 22, 163, 74;
+    --sky-accent-shopping: 234, 88, 12;
+    --sky-accent-health: 190, 24, 93;
+    --sky-accent-medical: 239, 68, 68;
+    --sky-accent-routine: 55, 65, 81;
+    --sky-accent-household: 107, 114, 128;
+    --sky-accent-tasks: 90, 224, 224;
+    --sky-accent-general: 90, 224, 224;
+    --sky-accent-all: 90, 224, 224;
+}
+
+body:not(.sky-empty) .sky-accent-work { --sky-card-accent: var(--sky-accent-work); }
+body:not(.sky-empty) .sky-accent-personal { --sky-card-accent: var(--sky-accent-personal); }
+body:not(.sky-empty) .sky-accent-family { --sky-card-accent: var(--sky-accent-family); }
+body:not(.sky-empty) .sky-accent-bucket { --sky-card-accent: var(--sky-accent-bucket); }
+body:not(.sky-empty) .sky-accent-social { --sky-card-accent: var(--sky-accent-social); }
+body:not(.sky-empty) .sky-accent-shopping { --sky-card-accent: var(--sky-accent-shopping); }
+body:not(.sky-empty) .sky-accent-health { --sky-card-accent: var(--sky-accent-health); }
+body:not(.sky-empty) .sky-accent-medical { --sky-card-accent: var(--sky-accent-medical); }
+body:not(.sky-empty) .sky-accent-routine { --sky-card-accent: var(--sky-accent-routine); }
+body:not(.sky-empty) .sky-accent-household { --sky-card-accent: var(--sky-accent-household); }
+body:not(.sky-empty) .sky-accent-tasks { --sky-card-accent: var(--sky-accent-tasks); }
+body:not(.sky-empty) .sky-accent-general,
+body:not(.sky-empty) .sky-accent-all {
+    --sky-card-accent: var(--sky-accent-general);
+}
+
 body:not(.sky-empty) .zoe-list-card {
+    --sky-card-accent: var(--sky-accent-shopping);
     background:
-        radial-gradient(circle at 18% 8%, rgba(251,146,60,0.24), transparent 34%),
-        radial-gradient(circle at 92% 20%, rgba(34,197,94,0.18), transparent 32%),
+        radial-gradient(circle at 18% 8%, rgba(var(--sky-card-accent),0.24), transparent 34%),
+        radial-gradient(circle at 92% 20%, rgba(var(--sky-accent-social),0.18), transparent 32%),
         linear-gradient(145deg, rgba(18,22,30,0.96), rgba(8,10,16,0.98)) !important;
     border-color: rgba(255,255,255,0.15) !important;
 }
 
 body:not(.sky-empty) .zoe-list-card.work {
+    --sky-card-accent: var(--sky-accent-work);
     background:
-        radial-gradient(circle at 16% 8%, rgba(59,130,246,0.24), transparent 34%),
-        radial-gradient(circle at 92% 20%, rgba(90,224,224,0.14), transparent 32%),
+        radial-gradient(circle at 16% 8%, rgba(var(--sky-card-accent),0.24), transparent 34%),
+        radial-gradient(circle at 92% 20%, rgba(var(--sky-accent-tasks),0.14), transparent 32%),
         linear-gradient(145deg, rgba(17,24,39,0.96), rgba(7,11,19,0.98)) !important;
 }
 
 body:not(.sky-empty) .zoe-list-card.personal {
+    --sky-card-accent: var(--sky-accent-personal);
     background:
-        radial-gradient(circle at 16% 8%, rgba(168,85,247,0.24), transparent 34%),
-        radial-gradient(circle at 92% 20%, rgba(236,72,153,0.16), transparent 32%),
+        radial-gradient(circle at 16% 8%, rgba(var(--sky-card-accent),0.24), transparent 34%),
+        radial-gradient(circle at 92% 20%, rgba(var(--sky-accent-health),0.16), transparent 32%),
         linear-gradient(145deg, rgba(24,18,34,0.96), rgba(10,8,16,0.98)) !important;
 }
 
 body:not(.sky-empty) .zoe-list-card.tasks {
+    --sky-card-accent: var(--sky-accent-tasks);
     background:
-        radial-gradient(circle at 16% 8%, rgba(90,224,224,0.2), transparent 34%),
-        radial-gradient(circle at 92% 20%, rgba(34,197,94,0.14), transparent 32%),
+        radial-gradient(circle at 16% 8%, rgba(var(--sky-card-accent),0.2), transparent 34%),
+        radial-gradient(circle at 92% 20%, rgba(var(--sky-accent-social),0.14), transparent 32%),
         linear-gradient(145deg, rgba(12,25,28,0.96), rgba(6,12,16,0.98)) !important;
 }
 
@@ -66,29 +102,6 @@ body:not(.sky-empty) .sky-profile-title h3 {
     letter-spacing: 0;
 }
 
-body:not(.sky-empty) .sky-people-count {
-    width: 96px;
-    height: 96px;
-    border-radius: 32px;
-    display: grid;
-    place-items: center;
-    background: linear-gradient(180deg, rgba(255,255,255,0.18), rgba(255,255,255,0.07));
-    border: 1px solid rgba(255,255,255,0.18);
-    box-shadow: inset 0 1px 0 rgba(255,255,255,0.18), 0 18px 45px rgba(0,0,0,0.24);
-}
-
-body:not(.sky-empty) .sky-people-count strong {
-    color: white;
-    font-size: 2.05rem;
-    line-height: 1;
-}
-
-body:not(.sky-empty) .sky-people-count span {
-    color: rgba(255,255,255,0.58);
-    font-size: 0.76rem;
-    font-weight: 800;
-}
-
 body:not(.sky-empty) .sky-list-switcher {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(124px, 1fr));
@@ -119,26 +132,30 @@ body:not(.sky-empty) .sky-list-tab span {
 
 body:not(.sky-empty) .sky-list-tab.shopping,
 body:not(.sky-empty) .sky-list-column.shopping {
-    border-color: rgba(251,146,60,0.42);
-    background: linear-gradient(145deg, rgba(251,146,60,0.18), rgba(255,255,255,0.07));
+    --sky-card-accent: var(--sky-accent-shopping);
+    border-color: rgba(var(--sky-card-accent),0.42);
+    background: linear-gradient(145deg, rgba(var(--sky-card-accent),0.18), rgba(255,255,255,0.07));
 }
 
 body:not(.sky-empty) .sky-list-tab.work,
 body:not(.sky-empty) .sky-list-column.work {
-    border-color: rgba(59,130,246,0.46);
-    background: linear-gradient(145deg, rgba(59,130,246,0.2), rgba(255,255,255,0.07));
+    --sky-card-accent: var(--sky-accent-work);
+    border-color: rgba(var(--sky-card-accent),0.46);
+    background: linear-gradient(145deg, rgba(var(--sky-card-accent),0.2), rgba(255,255,255,0.07));
 }
 
 body:not(.sky-empty) .sky-list-tab.personal,
 body:not(.sky-empty) .sky-list-column.personal {
-    border-color: rgba(168,85,247,0.48);
-    background: linear-gradient(145deg, rgba(168,85,247,0.2), rgba(255,255,255,0.07));
+    --sky-card-accent: var(--sky-accent-personal);
+    border-color: rgba(var(--sky-card-accent),0.48);
+    background: linear-gradient(145deg, rgba(var(--sky-card-accent),0.2), rgba(255,255,255,0.07));
 }
 
 body:not(.sky-empty) .sky-list-tab.tasks,
 body:not(.sky-empty) .sky-list-column.tasks {
-    border-color: rgba(90,224,224,0.42);
-    background: linear-gradient(145deg, rgba(90,224,224,0.18), rgba(255,255,255,0.07));
+    --sky-card-accent: var(--sky-accent-tasks);
+    border-color: rgba(var(--sky-card-accent),0.42);
+    background: linear-gradient(145deg, rgba(var(--sky-card-accent),0.18), rgba(255,255,255,0.07));
 }
 
 body:not(.sky-empty) .sky-list-tab.is-active {
@@ -315,9 +332,14 @@ body:not(.sky-empty) .sky-profile-grid span {
 }
 
 body:not(.sky-empty) .sky-list-items,
-body:not(.sky-empty) .sky-people-list {
+body:not(.sky-empty) .sky-people-grid {
     display: grid;
     gap: 10px;
+}
+
+body:not(.sky-empty) .sky-people-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    align-content: start;
 }
 
 body:not(.sky-empty) .sky-list-items.is-list-detail {
@@ -327,7 +349,7 @@ body:not(.sky-empty) .sky-list-items.is-list-detail {
 
 body:not(.sky-empty) .sky-list-item-row,
 body:not(.sky-empty) .sky-list-overview-row,
-body:not(.sky-empty) .sky-person-row {
+body:not(.sky-empty) .sky-person-card {
     display: grid;
     align-items: center;
     gap: 12px;
@@ -353,8 +375,20 @@ body:not(.sky-empty) .sky-list-item-row.is-recent .sky-list-check {
     background: rgba(90,224,224,0.14);
 }
 
-body:not(.sky-empty) .sky-person-row {
-    grid-template-columns: auto minmax(0, 1fr) minmax(72px, 0.22fr);
+body:not(.sky-empty) .sky-person-card {
+    grid-template-columns: auto minmax(0, 1fr);
+    grid-template-rows: auto auto;
+    min-height: 116px;
+    align-content: start;
+    text-align: left;
+    color: inherit;
+    font: inherit;
+    border-left: 5px solid rgba(var(--sky-card-accent),0.95);
+    background:
+        radial-gradient(circle at 12% 0%, rgba(var(--sky-card-accent),0.22), transparent 44%),
+        linear-gradient(145deg, rgba(255,255,255,0.10), rgba(255,255,255,0.055));
+    box-shadow: inset 0 1px 0 rgba(255,255,255,0.13);
+    cursor: pointer;
 }
 
 body:not(.sky-empty) .sky-list-overview-row {
@@ -362,9 +396,9 @@ body:not(.sky-empty) .sky-list-overview-row {
     border-left: 4px solid rgba(251,146,60,0.9);
 }
 
-body:not(.sky-empty) .sky-list-overview-row.work { border-left-color: rgba(59,130,246,0.9); }
-body:not(.sky-empty) .sky-list-overview-row.personal { border-left-color: rgba(168,85,247,0.9); }
-body:not(.sky-empty) .sky-list-overview-row.tasks { border-left-color: rgba(90,224,224,0.9); }
+body:not(.sky-empty) .sky-list-overview-row.work { border-left-color: rgba(var(--sky-accent-work),0.9); }
+body:not(.sky-empty) .sky-list-overview-row.personal { border-left-color: rgba(var(--sky-accent-personal),0.9); }
+body:not(.sky-empty) .sky-list-overview-row.tasks { border-left-color: rgba(var(--sky-accent-tasks),0.9); }
 
 body:not(.sky-empty) .sky-list-check {
     width: 28px;
@@ -417,7 +451,8 @@ body:not(.sky-empty) .sky-person-main em {
 body:not(.sky-empty) .sky-list-item-meta b,
 body:not(.sky-empty) .sky-list-item-meta span,
 body:not(.sky-empty) .sky-list-overview-row > span,
-body:not(.sky-empty) .sky-people-filter-row span {
+body:not(.sky-empty) .sky-people-filter-row span,
+body:not(.sky-empty) .sky-people-chips span {
     display: inline-flex;
     align-items: center;
     border-radius: 999px;
@@ -428,12 +463,54 @@ body:not(.sky-empty) .sky-people-filter-row span {
     font-weight: 800;
 }
 
+body:not(.sky-empty) .sky-people-chips .sky-accent-personal,
+body:not(.sky-empty) .sky-people-chips .sky-accent-work {
+    border: 1px solid rgba(var(--sky-card-accent),0.34);
+    background: rgba(var(--sky-card-accent),0.15);
+    color: rgba(255,255,255,0.88);
+}
+
 body:not(.sky-empty) .people-card,
 body:not(.sky-empty) .person-profile-card {
+    --sky-card-accent: var(--sky-accent-personal);
     background:
-        radial-gradient(circle at 18% 10%, rgba(90,224,224,0.22), transparent 34%),
-        radial-gradient(circle at 90% 18%, rgba(168,85,247,0.18), transparent 32%),
+        radial-gradient(circle at 18% 10%, rgba(var(--sky-accent-tasks),0.18), transparent 34%),
+        radial-gradient(circle at 90% 18%, rgba(var(--sky-card-accent),0.20), transparent 32%),
         linear-gradient(145deg, rgba(13,20,25,0.96), rgba(8,9,15,0.98)) !important;
+}
+
+body:not(.sky-empty) .people-card {
+    padding: clamp(18px, 2.5vw, 26px) !important;
+}
+
+body:not(.sky-empty) .sky-people-toolbar {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 14px;
+}
+
+body:not(.sky-empty) .sky-people-title span {
+    display: block;
+    color: rgba(255,255,255,0.58);
+    font-size: 0.72rem;
+    font-weight: 850;
+    letter-spacing: 0;
+    text-transform: uppercase;
+}
+
+body:not(.sky-empty) .sky-people-title strong {
+    display: block;
+    color: white;
+    font-size: clamp(1.25rem, 2.4vw, 2.1rem);
+    line-height: 1.02;
+}
+
+body:not(.sky-empty) .sky-people-chips {
+    display: flex;
+    justify-content: flex-end;
+    flex-wrap: wrap;
+    gap: 8px;
 }
 
 body:not(.sky-empty) .sky-people-filter-row {
@@ -450,9 +527,9 @@ body:not(.sky-empty) .sky-profile-avatar {
     color: white;
     font-weight: 900;
     background:
-        linear-gradient(145deg, rgba(90,224,224,0.9), rgba(168,85,247,0.76)),
+        linear-gradient(145deg, rgba(var(--sky-accent-tasks),0.88), rgba(var(--sky-card-accent),0.76)),
         rgba(255,255,255,0.08);
-    box-shadow: inset 0 1px 0 rgba(255,255,255,0.28), 0 14px 35px rgba(90,224,224,0.14);
+    box-shadow: inset 0 1px 0 rgba(255,255,255,0.28), 0 14px 35px rgba(var(--sky-card-accent),0.16);
 }
 
 body:not(.sky-empty) .sky-person-avatar {
@@ -470,6 +547,7 @@ body:not(.sky-empty) .sky-profile-avatar {
 }
 
 body:not(.sky-empty) .sky-person-health {
+    grid-column: 1 / -1;
     display: grid;
     grid-template-columns: minmax(0, 1fr) auto;
     align-items: center;
@@ -490,7 +568,7 @@ body:not(.sky-empty) .sky-person-health i {
     grid-row: 1;
     height: 7px;
     border-radius: 999px;
-    background: linear-gradient(90deg, #5AE0E0, #A78BFA);
+    background: linear-gradient(90deg, rgba(var(--sky-accent-tasks),0.92), rgba(var(--sky-card-accent),0.92));
 }
 
 body:not(.sky-empty) .sky-person-health span {
@@ -555,16 +633,17 @@ body:not(.sky-empty) .sky-profile-notes {
 
 @media (max-width: 780px) {
     body:not(.sky-empty) .sky-people-hero,
+    body:not(.sky-empty) .sky-people-toolbar,
     body:not(.sky-empty) .sky-profile-hero {
         grid-template-columns: 1fr;
     }
 
-    body:not(.sky-empty) .sky-person-row {
-        grid-template-columns: auto minmax(0, 1fr);
+    body:not(.sky-empty) .sky-people-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
     }
 
-    body:not(.sky-empty) .sky-person-health {
-        grid-column: 1 / -1;
+    body:not(.sky-empty) .sky-people-chips {
+        justify-content: flex-start;
     }
 
     body:not(.sky-empty) .sky-profile-grid {

--- a/services/zoe-ui/dist/touch/css/skybridge-data-widgets.css
+++ b/services/zoe-ui/dist/touch/css/skybridge-data-widgets.css
@@ -30,6 +30,78 @@ body:not(.sky-empty) .sky-accent-all {
     --sky-card-accent: var(--sky-accent-general);
 }
 
+body:not(.sky-empty) .clock-card.sky-premium-card {
+    background:
+        radial-gradient(circle at 13% 10%, rgba(90,224,224,0.2), transparent 34%),
+        radial-gradient(circle at 88% 12%, rgba(147,51,234,0.2), transparent 36%),
+        linear-gradient(145deg, rgba(14,19,30,0.96), rgba(5,7,12,0.99)) !important;
+    border-color: rgba(255,255,255,0.15) !important;
+    min-height: min(610px, calc(100dvh - 110px)) !important;
+    padding: clamp(24px, 2.5vw, 34px) !important;
+    position: relative;
+    overflow: hidden !important;
+}
+
+body:not(.sky-empty) .sky-clock-scene {
+    height: 100%;
+    min-height: 100%;
+    position: static;
+    text-align: center;
+}
+
+body:not(.sky-empty) .sky-clock-main {
+    position: static;
+}
+
+body:not(.sky-empty) .sky-clock-time {
+    position: absolute;
+    top: 53%;
+    left: 0;
+    right: 0;
+    transform: translateY(-50%);
+    display: flex;
+    align-items: baseline;
+    justify-content: center;
+    gap: clamp(10px, 1.4vw, 18px);
+    color: white;
+    font-variant-numeric: tabular-nums;
+    line-height: 0.78;
+}
+
+body:not(.sky-empty) .sky-clock-time span {
+    font-size: clamp(12.2rem, 23.5vw, 20.2rem);
+    font-weight: 860;
+    letter-spacing: 0;
+}
+
+body:not(.sky-empty) .sky-clock-time i {
+    font-size: clamp(9.4rem, 18vw, 15.4rem);
+    font-style: normal;
+    opacity: 0.42;
+}
+
+body:not(.sky-empty) .sky-clock-time b {
+    margin-left: clamp(6px, 0.9vw, 12px);
+    color: rgba(255,255,255,0.56);
+    font-size: clamp(2.1rem, 3.5vw, 3.15rem);
+    font-weight: 850;
+    letter-spacing: 0;
+    text-transform: uppercase;
+}
+
+body:not(.sky-empty) .sky-clock-date {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: clamp(28px, 5vh, 42px);
+    z-index: 8;
+    color: rgba(255,255,255,0.66);
+    font-size: clamp(1.7rem, 3.2vw, 2.65rem);
+    font-weight: 800;
+    line-height: 1;
+}
+
+
 body:not(.sky-empty) .zoe-list-card {
     --sky-card-accent: var(--sky-accent-shopping);
     background:

--- a/services/zoe-ui/dist/touch/js/skybridge-renderer.js
+++ b/services/zoe-ui/dist/touch/js/skybridge-renderer.js
@@ -88,6 +88,7 @@
         if (props.source === 'list_show') return renderZoeList(props);
         if (props.source === 'people_directory') return renderPeopleDirectory(props);
         if (props.source === 'person_profile') return renderPersonProfile(props);
+        if (props.source === 'clock_show') return renderClock(props);
         const body = [
             props.metric ? '<div class="sky-widget-metric"><strong>' + escapeHtml(props.metric) + '</strong><span>' + escapeHtml(props.metric_label || '') + '</span></div>' : '',
             '<div class="sky-card-body">' + escapeHtml(props.body || props.message || '') + '</div>'
@@ -342,6 +343,39 @@
             '</div>'
         ].join('');
         return cardFrame(Object.assign({ status: 'Weather', icon: 'W' }, props), body, { wide: true, tone: 'weather-card ' + weatherClass(props, current) });
+    }
+
+    function clockParts(timezone) {
+        const options = timezone ? { timeZone: timezone } : {};
+        const now = new Date();
+        const time = new Intl.DateTimeFormat(undefined, Object.assign({
+            hour: 'numeric',
+            minute: '2-digit',
+            hour12: true
+        }, options)).formatToParts(now);
+        const date = new Intl.DateTimeFormat(undefined, Object.assign({
+            weekday: 'long',
+            day: 'numeric',
+            month: 'long'
+        }, options)).format(now);
+        const hour = (time.find(part => part.type === 'hour') || {}).value || '';
+        const minute = (time.find(part => part.type === 'minute') || {}).value || '';
+        const dayPeriod = (time.find(part => part.type === 'dayPeriod') || {}).value || '';
+        return { hour, minute, dayPeriod, date };
+    }
+
+    function renderClock(props) {
+        const timezone = props.timezone || '';
+        const parts = clockParts(timezone);
+        const body = [
+            '<div class="sky-clock-scene sky-live-clock" data-timezone="' + escapeHtml(timezone) + '">',
+            '<div class="sky-clock-main">',
+            '<div class="sky-clock-time"><span data-clock-hour>' + escapeHtml(parts.hour || props.hour || '') + '</span><i>:</i><span data-clock-minute>' + escapeHtml(parts.minute || props.minute || '') + '</span><b data-clock-meridiem>' + escapeHtml(parts.dayPeriod || props.meridiem || '') + '</b></div>',
+            '<div class="sky-clock-date" data-clock-date>' + escapeHtml(parts.date || [props.weekday, props.date_label].filter(Boolean).join(', ')) + '</div>',
+            '</div>',
+            '</div>'
+        ].join('');
+        return cardFrame(Object.assign({ status: 'Clock', icon: 'C' }, props), body, { wide: true, tone: 'clock-card', hideHeader: true, hideStatus: true, hideActions: true });
     }
 
     function normalizeListItems(items) {

--- a/services/zoe-ui/dist/touch/js/skybridge-renderer.js
+++ b/services/zoe-ui/dist/touch/js/skybridge-renderer.js
@@ -290,6 +290,13 @@
         };
     }
 
+    function weatherValue(source, keys) {
+        for (const key of keys) {
+            if (source && source[key] != null && source[key] !== '') return source[key];
+        }
+        return null;
+    }
+
     function renderWeather(props) {
         const current = props.current || {};
         const forecast = props.forecast || {};
@@ -318,13 +325,13 @@
                 '<div class="sky-weather-hour-tile">',
                 '<span>' + escapeHtml(label) + '</span>',
                 '<b aria-hidden="true">' + escapeHtml(weatherEmoji(item)) + '</b>',
-                '<strong>' + escapeHtml(formatTemp(item.temp != null ? item.temp : item.high)) + '</strong>',
+                '<strong>' + escapeHtml(formatTemp(weatherValue(item, ['temp', 'temperature', 'temperature_c', 'temp_c', 'high']))) + '</strong>',
                 '</div>'
             ].join('');
         }).join('');
         const dayList = dailyRows;
         const meta = [
-            ['🌡', 'Feels ' + formatTemp(current.feels_like)],
+            ['🌡', 'Feels ' + formatTemp(weatherValue(current, ['feels_like', 'feels_like_c', 'apparent_temperature']))],
             ['💧', current.humidity == null ? 'Humidity --' : current.humidity + '% humidity'],
             ['💨', formatWind(current.wind_speed)]
         ].map(pair => '<div class="sky-weather-pill"><span>' + escapeHtml(pair[0]) + '</span>' + escapeHtml(pair[1]) + '</div>').join('');
@@ -332,7 +339,7 @@
             '<div class="sky-weather-scene">',
             '<div class="sky-weather-main">',
             '<div class="sky-weather-location">📍 ' + escapeHtml(place) + '</div>',
-            '<div class="sky-weather-hero"><div class="sky-weather-temp">' + escapeHtml(formatTemp(current.temp)) + '</div><div class="sky-weather-icon" aria-hidden="true">' + escapeHtml(weatherEmoji(current)) + '</div></div>',
+            '<div class="sky-weather-hero"><div class="sky-weather-temp">' + escapeHtml(formatTemp(weatherValue(current, ['temp', 'temperature', 'temperature_c', 'temp_c', 'current_temp']))) + '</div><div class="sky-weather-icon" aria-hidden="true">' + escapeHtml(weatherEmoji(current)) + '</div></div>',
             '<div class="sky-weather-condition">' + escapeHtml(description) + '</div>',
             '<div class="sky-weather-meta">' + meta + '</div>',
             '</div>',

--- a/services/zoe-ui/dist/touch/js/skybridge-renderer.js
+++ b/services/zoe-ui/dist/touch/js/skybridge-renderer.js
@@ -146,7 +146,8 @@
     }
 
     function calendarCategoryClass(value) {
-        return accentClass(value, 'general');
+        const category = accentClass(value, 'general');
+        return ['tasks', 'all'].indexOf(category) >= 0 ? 'general' : category;
     }
 
     function renderCalendar(props) {
@@ -484,7 +485,8 @@
     function renderPeopleDirectory(props) {
         const people = Array.isArray(props.people) ? props.people : [];
         const workCount = people.filter(person => personAccentClass(person) === 'work').length;
-        const personalCount = people.filter(person => personAccentClass(person) !== 'work').length;
+        const personalCount = people.filter(person => personAccentClass(person) === 'personal').length;
+        const otherCount = Math.max(0, people.length - workCount - personalCount);
         const rows = people.slice(0, 12).map(person => {
             const health = healthPercent(person.health_score);
             const accent = personAccentClass(person);
@@ -504,6 +506,7 @@
             '<div class="sky-people-chips">',
             '<span class="sky-accent-personal">' + escapeHtml(personalCount) + ' personal</span>',
             '<span class="sky-accent-work">' + escapeHtml(workCount) + ' work</span>',
+            otherCount ? '<span>' + escapeHtml(otherCount) + ' other</span>' : '',
             '<span>' + escapeHtml(props.count == null ? people.length : props.count) + ' found</span>',
             '</div>',
             '</div>',

--- a/services/zoe-ui/dist/touch/js/skybridge-renderer.js
+++ b/services/zoe-ui/dist/touch/js/skybridge-renderer.js
@@ -126,10 +126,26 @@
         return Number.isNaN(timestamp) ? Number.MAX_SAFE_INTEGER : timestamp;
     }
 
+    function accentClass(value, fallback) {
+        const token = safeClassTokens(String(value || fallback || 'general').toLowerCase()) || 'general';
+        const aliases = {
+            task: 'tasks',
+            todo: 'tasks',
+            todos: 'tasks',
+            grocery: 'shopping',
+            groceries: 'shopping',
+            friend: 'social',
+            friends: 'social',
+            contact: 'personal',
+            contacts: 'personal'
+        };
+        const normalized = aliases[token] || token;
+        const known = ['work', 'personal', 'bucket', 'shopping', 'health', 'routine', 'social', 'family', 'medical', 'household', 'tasks', 'all', 'general'];
+        return known.indexOf(normalized) >= 0 ? normalized : (fallback || 'general');
+    }
+
     function calendarCategoryClass(value) {
-        const token = safeClassTokens(String(value || 'general').toLowerCase()) || 'general';
-        const known = ['work', 'personal', 'bucket', 'shopping', 'health', 'routine', 'social', 'family', 'general'];
-        return known.indexOf(token) >= 0 ? token : 'general';
+        return accentClass(value, 'general');
     }
 
     function renderCalendar(props) {
@@ -333,9 +349,7 @@
     }
 
     function listAccentClass(value) {
-        const token = safeClassTokens(String(value || 'list').toLowerCase()) || 'list';
-        const known = ['shopping', 'work', 'personal', 'bucket', 'tasks', 'all'];
-        return known.indexOf(token) >= 0 ? token : 'list';
+        return accentClass(value, 'general');
     }
 
     function listLabel(list) {
@@ -429,28 +443,42 @@
         return [person.relationship, person.context, person.circle].filter(Boolean).join(' · ') || 'Contact';
     }
 
+    function personAccentClass(person) {
+        return accentClass(person.context || person.circle || 'personal', 'personal');
+    }
+
     function renderPeopleDirectory(props) {
         const people = Array.isArray(props.people) ? props.people : [];
-        const rows = people.slice(0, 8).map(person => {
+        const workCount = people.filter(person => personAccentClass(person) === 'work').length;
+        const personalCount = people.filter(person => personAccentClass(person) !== 'work').length;
+        const rows = people.slice(0, 12).map(person => {
             const health = healthPercent(person.health_score);
+            const accent = personAccentClass(person);
             return [
-                '<div class="sky-person-row">',
+                '<button type="button" class="sky-person-card sky-accent-' + escapeHtml(accent) + '" data-sky-action="query" data-query="' + escapeHtml('find ' + (person.name || 'person')) + '">',
                 '<div class="sky-person-avatar" aria-hidden="true">' + initialsFor(person.name) + '</div>',
                 '<div class="sky-person-main"><strong>' + escapeHtml(person.name || 'Person') + '</strong><em>' + escapeHtml(personSubline(person)) + '</em></div>',
-                '<div class="sky-person-health"><i style="width:' + health + '%"></i><span>' + health + '</span></div>',
-                '</div>'
+                '<div class="sky-person-health" aria-label="Connection score ' + health + '"><i style="width:' + health + '%"></i><span>' + health + '</span></div>',
+                '</button>'
             ].join('');
         }).join('');
         const empty = '<div class="sky-empty-data sky-people-empty"><strong>No matching people</strong><span>Zoe did not find contacts for this request.</span></div>';
         const body = [
             '<div class="sky-people-scene">',
-            '<div class="sky-people-hero"><div><span>PEOPLE</span><h3>' + escapeHtml(props.title || 'People') + '</h3></div><div class="sky-people-count"><strong>' + escapeHtml(props.count == null ? people.length : props.count) + '</strong><span>found</span></div></div>',
+            '<div class="sky-people-toolbar">',
+            '<div class="sky-people-title"><span>People</span><strong>' + escapeHtml(props.title || 'People') + '</strong></div>',
+            '<div class="sky-people-chips">',
+            '<span class="sky-accent-personal">' + escapeHtml(personalCount) + ' personal</span>',
+            '<span class="sky-accent-work">' + escapeHtml(workCount) + ' work</span>',
+            '<span>' + escapeHtml(props.count == null ? people.length : props.count) + ' found</span>',
+            '</div>',
+            '</div>',
             '<div class="sky-people-filter-row">',
             props.query ? '<span>Search ' + escapeHtml(props.query) + '</span>' : '',
             props.context ? '<span>' + escapeHtml(props.context) + '</span>' : '',
             props.circle ? '<span>' + escapeHtml(props.circle) + '</span>' : '',
             '</div>',
-            '<div class="sky-people-list">' + (rows || empty) + '</div>',
+            '<div class="sky-people-grid">' + (rows || empty) + '</div>',
             '</div>'
         ].join('');
         return cardFrame(Object.assign({ status: 'People', icon: 'P' }, props), body, { wide: true, tone: 'people-card', hideHeader: true, hideStatus: true });
@@ -459,6 +487,7 @@
     function renderPersonProfile(props) {
         const person = props.person || {};
         const health = healthPercent(person.health_score);
+        const accent = personAccentClass(person);
         const contactRows = [
             ['Phone', person.phone],
             ['Email', person.email],
@@ -476,7 +505,7 @@
             person.notes ? '<p class="sky-profile-notes">' + escapeHtml(person.notes) + '</p>' : '',
             '</div>'
         ].join('');
-        return cardFrame(Object.assign({ status: 'Person', icon: 'P' }, props), body, { wide: true, tone: 'person-profile-card', hideHeader: true, hideStatus: true });
+        return cardFrame(Object.assign({ status: 'Person', icon: 'P' }, props), body, { wide: true, tone: 'person-profile-card sky-accent-' + accent, hideHeader: true, hideStatus: true });
     }
 
 

--- a/services/zoe-ui/dist/touch/js/skybridge.js
+++ b/services/zoe-ui/dist/touch/js/skybridge.js
@@ -15,6 +15,12 @@
     let skybridgeContext = {};
     let authProfiles = [];
     let authHydrationSequence = 0;
+    let idleTimer = null;
+    let clockTicker = null;
+
+    const queryParams = new URLSearchParams(location.search);
+    const configuredIdleMs = Number(queryParams.get('idle_ms') || localStorage.getItem('skybridge_idle_return_ms') || 75000);
+    const CARD_IDLE_MS = Number.isFinite(configuredIdleMs) ? Math.max(15000, configuredIdleMs) : 75000;
 
     const colors = {
         ambient: ['#5fc6ff', '#66d19e'],
@@ -27,6 +33,7 @@
         cacheEls();
         bindEvents();
         startOrb();
+        startClockTicker();
         renderHome();
         loadBackendStatus();
         setMode(mode);
@@ -58,6 +65,7 @@
         els.transcript = document.getElementById('skyTranscript');
         els.copy = document.getElementById('skyListeningCopy');
         els.form = document.getElementById('skyCommandForm');
+        els.commandCopy = document.getElementById('skyCommandCopy');
         els.input = document.getElementById('skyCommandInput');
         els.mic = document.getElementById('skyMicBtn');
         els.home = document.getElementById('skyHomeBtn');
@@ -67,6 +75,11 @@
         els.voiceTitle = document.getElementById('skyVoiceTitle');
         els.voiceDetail = document.getElementById('skyVoiceDetail');
         els.voiceAction = document.getElementById('skyVoiceAction');
+        els.ambientClock = document.getElementById('skyAmbientClock');
+        els.ambientClockHour = document.getElementById('skyAmbientClockHour');
+        els.ambientClockMinute = document.getElementById('skyAmbientClockMinute');
+        els.ambientClockMeridiem = document.getElementById('skyAmbientClockMeridiem');
+        els.ambientClockDate = document.getElementById('skyAmbientClockDate');
         els.canvas = document.getElementById('skyOrb');
         els.ctx = els.canvas.getContext('2d');
     }
@@ -93,6 +106,9 @@
         els.orbButton.addEventListener('click', toggleVoiceCapture);
         els.voiceAction.addEventListener('click', toggleVoiceCapture);
         els.home.addEventListener('click', () => renderHome({ showCards: true }));
+        ['pointerdown', 'keydown', 'touchstart'].forEach(type => {
+            document.addEventListener(type, noteUserActivity, { passive: true });
+        });
         els.cards.addEventListener('click', event => {
             const btn = event.target.closest('button[data-sky-action]');
             if (!btn) return;
@@ -179,6 +195,7 @@
             addTranscript(event.role, event.text);
         } else if (event.type === 'card') {
             addCard(event.card, true);
+            scheduleIdleReturn();
         } else if (event.type === 'cards') {
             renderSkybridgeResult(event.result || event);
         } else if (event.type === 'skybridge_context') {
@@ -201,7 +218,7 @@
             return;
         }
         currentUtterance = 'Heard: ' + query;
-        els.copy.textContent = currentUtterance;
+        setVoiceLayerText(currentUtterance);
         addTranscript('user', query);
         setState('thinking');
         const resolved = await resolveCommand(query);
@@ -267,7 +284,7 @@
         skybridgeContext = data.skybridge_context || skybridgeContext || {};
         setContext(contextLabelFor(intent), data.spoken_summary || 'Showing live data.');
         currentUtterance = data.spoken_summary || currentUtterance;
-        els.copy.textContent = currentUtterance;
+        setVoiceLayerText(currentUtterance);
         cards.forEach((card, index) => addCard(card, false, index * 90));
         if (!cards.length) {
             addCard({
@@ -279,6 +296,7 @@
                 }
             }, true);
         }
+        scheduleIdleReturn();
     }
 
     async function retireRenderedVoiceCards(data) {
@@ -331,6 +349,7 @@
             return;
         }
         clearCards();
+        scheduleIdleReturn();
         const top = matches[0];
         if (top.kind === 'setting') {
             setContext('Settings', top.title + ' is active for follow-up commands.');
@@ -354,15 +373,19 @@
 
     function renderHome(options) {
         const showCards = options && options.showCards;
+        clearIdleTimer();
         document.body.classList.add('sky-empty');
+        document.body.classList.add('sky-ambient-clock');
         commandFallbackOpen = false;
         document.body.classList.remove('sky-command-open');
+        document.body.classList.remove('sky-typing-fallback');
         syncVoiceFallbackState();
         currentUtterance = '';
         skybridgeContext = {};
         setContext('Listening', 'The surface will build itself when Zoe understands what you need.');
         clearCards();
-        els.copy.textContent = 'Listening. Ask Zoe for anything.';
+        setVoiceLayerText('Listening. Ask Zoe for anything.');
+        updateAllClocks();
         if (showCards && window.SkybridgeCapabilities && typeof window.SkybridgeCapabilities.getHomeCards === 'function') {
             setContext('Skybridge home', 'Start with voice, then keep the useful cards in reach.');
             window.SkybridgeCapabilities.getHomeCards().forEach((card, index) => {
@@ -377,11 +400,13 @@
         cardSequence = 0;
         els.cards.innerHTML = '';
         document.body.classList.add('sky-empty');
+        document.body.classList.add('sky-ambient-clock');
         requestAnimationFrame(resizeOrb);
     }
 
     function addCard(card, prepend, delayMs) {
         document.body.classList.remove('sky-empty');
+        document.body.classList.remove('sky-ambient-clock');
         requestAnimationFrame(resizeOrb);
         const wrapper = document.createElement('div');
         wrapper.innerHTML = window.SkybridgeRenderer.render(card);
@@ -395,9 +420,85 @@
             els.cards.appendChild(node);
         }
         hydrateAuthCard(node, card);
+        updateAllClocks();
+        scheduleIdleReturn();
         while (els.cards.children.length > 8) {
             els.cards.removeChild(els.cards.lastElementChild);
         }
+    }
+
+    function clearIdleTimer() {
+        if (idleTimer) {
+            clearTimeout(idleTimer);
+            idleTimer = null;
+        }
+    }
+
+    function noteUserActivity() {
+        if (!document.body.classList.contains('sky-empty')) {
+            scheduleIdleReturn();
+        }
+    }
+
+    function scheduleIdleReturn() {
+        clearIdleTimer();
+        if (document.body.classList.contains('sky-empty')) return;
+        idleTimer = setTimeout(returnToAmbientClock, CARD_IDLE_MS);
+    }
+
+    function returnToAmbientClock() {
+        idleTimer = null;
+        const voiceBusy = voice && (voice.isRecording || voice.speaking || voice.serverBusy);
+        if (voiceBusy || orbState === 'listening' || orbState === 'thinking' || orbState === 'responding') {
+            scheduleIdleReturn();
+            return;
+        }
+        renderHome({ idle: true });
+        setStatus('Ambient');
+    }
+
+    function startClockTicker() {
+        updateAllClocks();
+        clockTicker = setInterval(updateAllClocks, 1000);
+    }
+
+    function clockParts(timezone) {
+        const options = timezone ? { timeZone: timezone } : {};
+        const now = new Date();
+        const timeParts = new Intl.DateTimeFormat(undefined, Object.assign({
+            hour: 'numeric',
+            minute: '2-digit',
+            hour12: true
+        }, options)).formatToParts(now);
+        const dateLabel = new Intl.DateTimeFormat(undefined, Object.assign({
+            weekday: 'long',
+            day: 'numeric',
+            month: 'long'
+        }, options)).format(now);
+        return {
+            hour: (timeParts.find(part => part.type === 'hour') || {}).value || '',
+            minute: (timeParts.find(part => part.type === 'minute') || {}).value || '',
+            meridiem: (timeParts.find(part => part.type === 'dayPeriod') || {}).value || '',
+            date: dateLabel
+        };
+    }
+
+    function updateClockElement(root, timezone) {
+        if (!root) return;
+        const parts = clockParts(timezone || root.dataset.timezone || '');
+        const hour = root.querySelector('[data-clock-hour]');
+        const minute = root.querySelector('[data-clock-minute]');
+        const meridiem = root.querySelector('[data-clock-meridiem]');
+        const dateLabel = root.querySelector('[data-clock-date]');
+        if (hour) hour.textContent = parts.hour;
+        if (minute) minute.textContent = parts.minute;
+        if (meridiem) meridiem.textContent = parts.meridiem;
+        if (dateLabel) dateLabel.textContent = parts.date;
+    }
+
+    function updateAllClocks() {
+        if (els.ambientClock) updateClockElement(els.ambientClock);
+        document.querySelectorAll('.sky-live-clock').forEach(node => updateClockElement(node));
     }
 
     async function hydrateAuthCard(node, card) {
@@ -500,7 +601,7 @@
     function addTranscript(role, text) {
         if (!text) return;
         currentUtterance = (role === 'user' ? 'Heard: ' : 'Zoe: ') + text;
-        els.copy.textContent = currentUtterance;
+        setVoiceLayerText(currentUtterance);
         const line = document.createElement('div');
         line.className = 'sky-line';
         line.innerHTML = '<strong>' + (role === 'user' ? 'You' : 'Zoe') + ':</strong> ' + window.SkybridgeRenderer.escapeHtml(text);
@@ -522,16 +623,16 @@
         if (transportNotice && (document.body.classList.contains('sky-empty') || currentUtterance)) return;
         if (!document.body.classList.contains('sky-empty')) {
             const previous = currentUtterance;
-            els.copy.textContent = 'Notice: ' + text;
+            setVoiceLayerText('Notice: ' + text);
             if (previous) {
                 setTimeout(() => {
                     if (!document.body.classList.contains('sky-empty') && currentUtterance === previous) {
-                        els.copy.textContent = previous;
+                        setVoiceLayerText(previous);
                     }
                 }, 4500);
             }
         } else {
-            els.copy.textContent = text;
+            setVoiceLayerText(text);
         }
     }
 
@@ -548,7 +649,7 @@
             responding: 'Zoe is speaking. You can interrupt when needed.'
         };
         if (document.body.classList.contains('sky-empty') || !currentUtterance) {
-            els.copy.textContent = copy[state] || copy.ambient;
+            setVoiceLayerText(copy[state] || copy.ambient);
         }
         setStatus(state.charAt(0).toUpperCase() + state.slice(1));
         updateVoiceControl(state);
@@ -566,10 +667,17 @@
     function openCommandFallback(message) {
         commandFallbackOpen = true;
         document.body.classList.add('sky-command-open');
+        document.body.classList.add('sky-typing-fallback');
         document.body.classList.toggle('sky-voice-fallback', !canUseMicrophone());
         if (message) els.input.placeholder = message;
         updateVoiceHint('Type to Zoe', message || 'Voice is unavailable here. The same resolver will render cards from typed requests.', 'Type');
         requestAnimationFrame(() => els.input.focus({ preventScroll: true }));
+    }
+
+    function setVoiceLayerText(text) {
+        const value = text || 'Listening';
+        els.copy.textContent = value;
+        if (els.commandCopy) els.commandCopy.textContent = value;
     }
 
     function getMicGuidance() {
@@ -711,6 +819,8 @@
 
     window.addEventListener('beforeunload', () => {
         if (animationFrame) cancelAnimationFrame(animationFrame);
+        if (clockTicker) clearInterval(clockTicker);
+        clearIdleTimer();
         if (voice) voice.stop();
     });
 

--- a/services/zoe-ui/dist/touch/skybridge.html
+++ b/services/zoe-ui/dist/touch/skybridge.html
@@ -3913,7 +3913,12 @@
     <style id="skybridge-touch-panel-fit">
         @media (min-width: 900px) and (max-height: 760px) {
             body:not(.sky-empty) .sky-stage {
-                inset: 10px 0 76px !important;
+                inset: 10px 0 92px !important;
+                width: min(1232px, calc(100vw - 32px)) !important;
+            }
+
+            body.sky-command-open:not(.sky-empty) .sky-stage {
+                inset: 10px 0 92px !important;
                 width: min(1232px, calc(100vw - 32px)) !important;
             }
 
@@ -4074,15 +4079,36 @@
             }
 
             body:not(.sky-empty) .calendar-card.sky-premium-card,
+            body:not(.sky-empty) .clock-card.sky-premium-card,
             body:not(.sky-empty) .zoe-list-card.sky-premium-card,
             body:not(.sky-empty) .sky-card.list-card.sky-premium-card,
             body:not(.sky-empty) .people-card.sky-premium-card,
             body:not(.sky-empty) .person-profile-card.sky-premium-card,
             body:not(.sky-empty) .sky-card.auth-challenge {
-                height: min(604px, calc(100dvh - 92px)) !important;
+                height: min(610px, calc(100dvh - 110px)) !important;
                 min-height: 0 !important;
-                max-height: min(604px, calc(100dvh - 92px)) !important;
+                max-height: min(610px, calc(100dvh - 110px)) !important;
                 overflow: hidden !important;
+            }
+
+            body:not(.sky-empty) .clock-card.sky-premium-card {
+                border-radius: 28px !important;
+                overflow: hidden !important;
+            }
+
+            body:not(.sky-empty) .sky-command {
+                bottom: 18px !important;
+                width: min(920px, calc(100vw - 180px)) !important;
+                min-height: 66px !important;
+                padding: 8px 10px !important;
+                border-radius: 999px !important;
+                opacity: 0.88 !important;
+                background:
+                    linear-gradient(145deg, rgba(255,255,255,0.13), rgba(255,255,255,0.05)),
+                    rgba(12, 16, 30, 0.78) !important;
+                box-shadow:
+                    0 18px 54px rgba(0,0,0,0.34),
+                    inset 0 1px 0 rgba(255,255,255,0.16) !important;
             }
 
             body:not(.sky-empty) .calendar-card .sky-calendar-scene,
@@ -4650,6 +4676,242 @@
             }
 
         }
+
+        .sky-ambient-clock {
+            position: fixed;
+            top: clamp(54px, 7.5vh, 84px);
+            left: 50%;
+            transform: translateX(-50%);
+            z-index: 2;
+            display: grid;
+            justify-items: center;
+            gap: 8px;
+            opacity: 0;
+            pointer-events: none;
+            transition: opacity 420ms ease, transform 420ms ease;
+            color: rgba(255,255,255,0.76);
+            text-shadow: 0 18px 70px rgba(0,0,0,0.55);
+        }
+
+        body.sky-empty.sky-ambient-clock .sky-ambient-clock {
+            opacity: 1;
+            transform: translateX(-50%) translateY(0);
+        }
+
+        body:not(.sky-empty) .sky-ambient-clock {
+            opacity: 0;
+            transform: translateX(-50%) translateY(-10px);
+        }
+
+        .sky-ambient-time {
+            display: flex;
+            align-items: baseline;
+            gap: clamp(8px, 1.2vw, 16px);
+            font-variant-numeric: tabular-nums;
+            font-weight: 850;
+            letter-spacing: 0;
+            line-height: 0.86;
+            color: rgba(255,255,255,0.82);
+        }
+
+        .sky-ambient-time span {
+            font-size: clamp(124px, 18vw, 214px);
+        }
+
+        .sky-ambient-time i {
+            font-style: normal;
+            font-size: clamp(100px, 14vw, 170px);
+            opacity: 0.5;
+        }
+
+        .sky-ambient-time b {
+            margin-left: 6px;
+            font-size: clamp(30px, 3.7vw, 44px);
+            opacity: 0.56;
+            text-transform: uppercase;
+        }
+
+        .sky-ambient-date {
+            color: rgba(255,255,255,0.5);
+            font-size: clamp(28px, 3.4vw, 42px);
+            font-weight: 800;
+        }
+    </style>
+
+    <style id="skybridge-voice-layer-final">
+        @media (min-width: 900px) and (max-height: 760px) {
+            body:not(.sky-empty) .sky-stage,
+            body.sky-command-open:not(.sky-empty) .sky-stage {
+                inset: 16px !important;
+                width: auto !important;
+                overflow: visible !important;
+            }
+
+            body:not(.sky-empty) .sky-card-stack {
+                height: 100% !important;
+                max-height: none !important;
+                overflow: visible !important;
+                padding-bottom: 0 !important;
+            }
+
+            body:not(.sky-empty) .sky-card-shell {
+                height: 100% !important;
+            }
+
+            body:not(.sky-empty) .clock-card.sky-premium-card {
+                height: calc(100dvh - 32px) !important;
+                max-height: calc(100dvh - 32px) !important;
+                min-height: 0 !important;
+                border-radius: 30px !important;
+                overflow: hidden !important;
+            }
+
+            body:not(.sky-empty) .sky-clock-time {
+                top: 50% !important;
+            }
+
+            body:not(.sky-empty) .sky-clock-date {
+                bottom: 92px !important;
+                color: rgba(255,255,255,0.58) !important;
+                font-size: clamp(1.45rem, 2.65vw, 2.15rem) !important;
+            }
+
+            body:not(.sky-empty) .sky-command,
+            body.sky-command-open .sky-command,
+            body.sky-voice-fallback.sky-empty .sky-command {
+                position: fixed !important;
+                left: 24px !important;
+                right: auto !important;
+                bottom: 22px !important;
+                width: 68px !important;
+                height: 68px !important;
+                min-height: 68px !important;
+                transform: none !important;
+                display: grid !important;
+                grid-template-columns: 1fr !important;
+                align-items: center !important;
+                justify-items: center !important;
+                gap: 0 !important;
+                padding: 0 !important;
+                border: 1px solid rgba(255,255,255,0.18) !important;
+                border-radius: 999px !important;
+                background:
+                    radial-gradient(circle at 34% 24%, rgba(255,255,255,0.48), transparent 24%),
+                    linear-gradient(135deg, rgba(123,97,255,0.95), rgba(90,224,224,0.95)) !important;
+                box-shadow:
+                    0 18px 54px rgba(0,0,0,0.42),
+                    0 0 52px rgba(90,224,224,0.22),
+                    inset 0 1px 0 rgba(255,255,255,0.24) !important;
+                opacity: 1 !important;
+                pointer-events: auto !important;
+                z-index: 30 !important;
+                overflow: hidden !important;
+                transition:
+                    left 260ms ease,
+                    width 260ms ease,
+                    height 260ms ease,
+                    background 260ms ease,
+                    box-shadow 260ms ease !important;
+            }
+
+            body:not(.sky-empty) .sky-command::before,
+            body.sky-command-open .sky-command::before,
+            body.sky-voice-fallback.sky-empty .sky-command::before {
+                content: "" !important;
+                width: 68px !important;
+                height: 68px !important;
+                border-radius: 999px !important;
+                background:
+                    radial-gradient(circle at 34% 24%, rgba(255,255,255,0.5), transparent 24%),
+                    linear-gradient(135deg, #7B61FF 0%, #5AE0E0 100%) !important;
+                box-shadow: none !important;
+                animation: sky-panel-orb-float 3.4s ease-in-out infinite !important;
+            }
+
+            body:not(.sky-empty) .sky-command-copy {
+                display: block !important;
+                min-width: 0 !important;
+                overflow: hidden !important;
+                text-overflow: ellipsis !important;
+                white-space: nowrap !important;
+                color: rgba(255,255,255,0.88) !important;
+                font-size: clamp(17px, 1.55vw, 22px) !important;
+                font-weight: 650 !important;
+                line-height: 1.1 !important;
+                opacity: 0 !important;
+                transform: translateX(-8px) !important;
+                transition: opacity 180ms ease, transform 220ms ease !important;
+            }
+
+            body:not(.sky-empty) .sky-command input,
+            body:not(.sky-empty) .sky-command button,
+            body.sky-command-open .sky-command input,
+            body.sky-command-open .sky-command button {
+                display: none !important;
+            }
+
+            body.sky-state-listening:not(.sky-empty) .sky-command,
+            body.sky-state-thinking:not(.sky-empty) .sky-command,
+            body.sky-state-responding:not(.sky-empty) .sky-command {
+                left: 50% !important;
+                width: min(860px, calc(100vw - 96px)) !important;
+                height: 76px !important;
+                min-height: 76px !important;
+                transform: translateX(-50%) !important;
+                grid-template-columns: 68px minmax(0, 1fr) !important;
+                justify-items: stretch !important;
+                gap: 16px !important;
+                padding: 4px 24px 4px 4px !important;
+                background:
+                    linear-gradient(145deg, rgba(255,255,255,0.16), rgba(255,255,255,0.055)),
+                    rgba(8, 13, 28, 0.82) !important;
+                box-shadow:
+                    0 24px 78px rgba(0,0,0,0.48),
+                    0 0 58px rgba(90,224,224,0.16),
+                    inset 0 1px 0 rgba(255,255,255,0.16) !important;
+                backdrop-filter: blur(26px) saturate(1.15) !important;
+                -webkit-backdrop-filter: blur(26px) saturate(1.15) !important;
+            }
+
+            body.sky-state-listening:not(.sky-empty) .sky-command-copy,
+            body.sky-state-thinking:not(.sky-empty) .sky-command-copy,
+            body.sky-state-responding:not(.sky-empty) .sky-command-copy {
+                opacity: 1 !important;
+                transform: translateX(0) !important;
+                align-self: center !important;
+            }
+
+            body.sky-typing-fallback .sky-command,
+            body.sky-voice-fallback.sky-empty .sky-command {
+                left: 50% !important;
+                width: min(860px, calc(100vw - 96px)) !important;
+                height: 76px !important;
+                transform: translateX(-50%) !important;
+                grid-template-columns: 58px minmax(0, 1fr) auto !important;
+                gap: 12px !important;
+                padding: 8px 10px !important;
+                background: rgba(9, 13, 27, 0.82) !important;
+            }
+
+            body.sky-typing-fallback .sky-command-copy {
+                display: none !important;
+            }
+
+            body.sky-typing-fallback .sky-command input,
+            body.sky-typing-fallback .sky-command .primary,
+            body.sky-voice-fallback.sky-empty .sky-command input,
+            body.sky-voice-fallback.sky-empty .sky-command .primary {
+                display: inline-flex !important;
+            }
+
+            body:not(.sky-empty) .sky-orb-panel::before,
+            body:not(.sky-empty) .sky-orb-panel::after,
+            body:not(.sky-empty) .sky-orb-button,
+            body:not(.sky-empty) .sky-listening-copy {
+                opacity: 0 !important;
+                pointer-events: none !important;
+            }
+        }
     </style>
 </head>
 <body>
@@ -4673,6 +4935,10 @@
 
 	    <main class="sky-shell">
 	        <section class="sky-orb-panel" aria-label="Voice state">
+	            <div class="sky-ambient-clock" id="skyAmbientClock" aria-label="Ambient clock">
+	                <div class="sky-ambient-time"><span data-clock-hour id="skyAmbientClockHour">--</span><i>:</i><span data-clock-minute id="skyAmbientClockMinute">--</span><b data-clock-meridiem id="skyAmbientClockMeridiem"></b></div>
+	                <div class="sky-ambient-date" data-clock-date id="skyAmbientClockDate"></div>
+	            </div>
 	            <canvas id="skyOrb"></canvas>
 	            <button type="button" class="sky-orb-button" id="skyOrbButton" aria-label="Start voice">
 	                <span id="skyOrbButtonText">Tap to talk</span>
@@ -4705,6 +4971,7 @@
     </main>
 
     <form class="sky-command" id="skyCommandForm">
+        <div class="sky-command-copy" id="skyCommandCopy" aria-live="polite">Listening</div>
         <button type="button" id="skyHomeBtn" title="Show home cards">Home</button>
         <input id="skyCommandInput" autocomplete="off" placeholder="Ask Zoe to show or change anything..." aria-label="Ask Zoe">
 	        <button type="button" id="skyMicBtn">Mic</button>

--- a/services/zoe-ui/dist/touch/skybridge.html
+++ b/services/zoe-ui/dist/touch/skybridge.html
@@ -4130,16 +4130,15 @@
                 gap: 12px !important;
             }
 
-            body:not(.sky-empty) .people-card .sky-people-hero h3,
+            body:not(.sky-empty) .people-card .sky-people-title strong,
             body:not(.sky-empty) .person-profile-card .sky-profile-title h3 {
-                font-size: 42px !important;
+                font-size: 34px !important;
                 line-height: 1 !important;
             }
 
-            body:not(.sky-empty) .people-card .sky-people-count {
-                width: 104px !important;
-                height: 104px !important;
-                border-radius: 30px !important;
+            body:not(.sky-empty) .people-card .sky-people-toolbar {
+                grid-template-columns: minmax(0, 1fr) auto !important;
+                gap: 12px !important;
             }
 
             body:not(.sky-empty) .person-profile-card .sky-profile-grid div {
@@ -4163,11 +4162,15 @@
             }
 
             body:not(.sky-empty) .zoe-list-card .sky-list-items,
-            body:not(.sky-empty) .people-card .sky-people-list {
+            body:not(.sky-empty) .people-card .sky-people-grid {
                 align-content: start !important;
                 gap: 10px !important;
                 min-height: 0 !important;
                 overflow: hidden !important;
+            }
+
+            body:not(.sky-empty) .people-card .sky-people-grid {
+                grid-template-columns: repeat(3, minmax(0, 1fr)) !important;
             }
 
             body:not(.sky-empty) .zoe-list-card .sky-list-items {
@@ -4180,15 +4183,15 @@
 
             body:not(.sky-empty) .zoe-list-card .sky-list-item-row:nth-child(n+17),
             body:not(.sky-empty) .zoe-list-card .sky-list-overview-row:nth-child(n+7),
-            body:not(.sky-empty) .people-card .sky-person-row:nth-child(n+6) {
+            body:not(.sky-empty) .people-card .sky-person-card:nth-child(n+10) {
                 display: none !important;
             }
 
             body:not(.sky-empty) .zoe-list-card .sky-list-item-row,
             body:not(.sky-empty) .zoe-list-card .sky-list-overview-row,
-            body:not(.sky-empty) .people-card .sky-person-row {
-                min-height: 62px !important;
-                padding: 12px 14px !important;
+            body:not(.sky-empty) .people-card .sky-person-card {
+                min-height: 124px !important;
+                padding: 13px !important;
                 border-radius: 18px !important;
             }
 
@@ -4218,7 +4221,7 @@
             body:not(.sky-empty) .zoe-list-card .sky-list-item-main strong,
             body:not(.sky-empty) .zoe-list-card .sky-list-overview-row strong,
             body:not(.sky-empty) .people-card .sky-person-main strong {
-                font-size: 18px !important;
+                font-size: 17px !important;
                 line-height: 1.12 !important;
             }
 
@@ -4586,15 +4589,17 @@
             white-space: nowrap;
         }
 
-        body:not(.sky-empty) .sky-calendar-event.work { --sky-cal-accent: #3B82F6; }
-        body:not(.sky-empty) .sky-calendar-event.personal { --sky-cal-accent: #A855F7; }
-        body:not(.sky-empty) .sky-calendar-event.bucket { --sky-cal-accent: #10B981; }
-        body:not(.sky-empty) .sky-calendar-event.shopping { --sky-cal-accent: #FB923C; }
-        body:not(.sky-empty) .sky-calendar-event.health { --sky-cal-accent: #EC4899; }
-        body:not(.sky-empty) .sky-calendar-event.routine { --sky-cal-accent: #9CA3AF; }
-        body:not(.sky-empty) .sky-calendar-event.social { --sky-cal-accent: #22C55E; }
-        body:not(.sky-empty) .sky-calendar-event.family { --sky-cal-accent: #9333EA; }
-        body:not(.sky-empty) .sky-calendar-event.general { --sky-cal-accent: #5AE0E0; }
+        body:not(.sky-empty) .sky-calendar-event.work { --sky-cal-accent: rgb(37, 99, 235); }
+        body:not(.sky-empty) .sky-calendar-event.personal { --sky-cal-accent: rgb(147, 51, 234); }
+        body:not(.sky-empty) .sky-calendar-event.bucket { --sky-cal-accent: rgb(5, 150, 105); }
+        body:not(.sky-empty) .sky-calendar-event.shopping { --sky-cal-accent: rgb(234, 88, 12); }
+        body:not(.sky-empty) .sky-calendar-event.health { --sky-cal-accent: rgb(190, 24, 93); }
+        body:not(.sky-empty) .sky-calendar-event.routine { --sky-cal-accent: rgb(55, 65, 81); }
+        body:not(.sky-empty) .sky-calendar-event.social { --sky-cal-accent: rgb(22, 163, 74); }
+        body:not(.sky-empty) .sky-calendar-event.family { --sky-cal-accent: rgb(147, 51, 234); }
+        body:not(.sky-empty) .sky-calendar-event.medical { --sky-cal-accent: rgb(239, 68, 68); }
+        body:not(.sky-empty) .sky-calendar-event.household { --sky-cal-accent: rgb(107, 114, 128); }
+        body:not(.sky-empty) .sky-calendar-event.general { --sky-cal-accent: rgb(90, 224, 224); }
 
         body:not(.sky-empty) .sky-calendar-empty {
             min-height: 210px;

--- a/services/zoe-ui/dist/touch/skybridge.html
+++ b/services/zoe-ui/dist/touch/skybridge.html
@@ -4913,6 +4913,98 @@
             }
         }
     </style>
+
+    <style id="skybridge-native-panel-fit-final">
+        /* Native Zoe touch panel: 1280x720 rotated DSI display. Keep cards above the voice layer. */
+        @media (min-width: 900px) and (max-height: 760px) {
+            body:not(.sky-empty) .sky-stage,
+            body.sky-command-open:not(.sky-empty) .sky-stage {
+                inset: 24px 24px 112px !important;
+                width: auto !important;
+                overflow: visible !important;
+            }
+
+            body:not(.sky-empty) .sky-card-stack {
+                height: 100% !important;
+                max-height: 100% !important;
+                align-content: stretch !important;
+                padding-bottom: 0 !important;
+                overflow: visible !important;
+            }
+
+            body:not(.sky-empty) .sky-card-stack > .sky-card:first-child,
+            body:not(.sky-empty) .weather-card.sky-premium-card,
+            body:not(.sky-empty) .calendar-card.sky-premium-card,
+            body:not(.sky-empty) .clock-card.sky-premium-card,
+            body:not(.sky-empty) .zoe-list-card.sky-premium-card,
+            body:not(.sky-empty) .sky-card.list-card.sky-premium-card,
+            body:not(.sky-empty) .people-card.sky-premium-card,
+            body:not(.sky-empty) .person-profile-card.sky-premium-card,
+            body:not(.sky-empty) .sky-card.auth-challenge {
+                height: 100% !important;
+                max-height: 100% !important;
+                min-height: 0 !important;
+                overflow: hidden !important;
+            }
+
+            body:not(.sky-empty) .sky-card.auth-challenge {
+                width: min(980px, calc(100vw - 96px)) !important;
+                margin-inline: auto !important;
+            }
+
+            body:not(.sky-empty) .weather-card .sky-weather-scene {
+                height: 100% !important;
+                grid-template-columns: minmax(0, 0.78fr) minmax(520px, 1fr) !important;
+                gap: 18px !important;
+                padding: 24px !important;
+            }
+
+            body:not(.sky-empty) .weather-card .sky-weather-main {
+                gap: 14px !important;
+            }
+
+            body:not(.sky-empty) .weather-card .sky-weather-temp {
+                font-size: 142px !important;
+            }
+
+            body:not(.sky-empty) .weather-card .sky-weather-icon {
+                font-size: 82px !important;
+            }
+
+            body:not(.sky-empty) .weather-card .sky-weather-forecast {
+                gap: 9px !important;
+                padding: 14px !important;
+            }
+
+            body:not(.sky-empty) .weather-card .sky-weather-hour-tile {
+                min-height: 86px !important;
+                padding: 8px 7px !important;
+            }
+
+            body:not(.sky-empty) .weather-card .sky-weather-day-list {
+                gap: 7px !important;
+            }
+
+            body:not(.sky-empty) .weather-card .sky-weather-day-row {
+                min-height: 52px !important;
+                padding: 8px 13px !important;
+            }
+
+            body:not(.sky-empty) .weather-card .sky-weather-day-temp strong {
+                font-size: 26px !important;
+            }
+
+            body:not(.sky-empty) .calendar-card .sky-calendar-scene,
+            body:not(.sky-empty) .zoe-list-card .sky-list-scene,
+            body:not(.sky-empty) .people-card .sky-people-scene,
+            body:not(.sky-empty) .person-profile-card .sky-profile-scene,
+            body:not(.sky-empty) .clock-card .sky-clock-scene {
+                height: 100% !important;
+                min-height: 0 !important;
+            }
+        }
+    </style>
+
 </head>
 <body>
     <header class="sky-topbar">


### PR DESCRIPTION
## Summary
- Adds a shared Skybridge accent palette aligned to the existing calendar category colors.
- Converts people directory cards from large rows into compact multi-column touch cards.
- Updates panel-specific Skybridge overrides so the 1280x720 touch panel uses the new grid and color treatment.

## Verification
- python3 -m pytest tests/test_skybridge_static.py tests/test_skybridge_service.py tests/test_skybridge_status.py -q
- git diff --check
- Physical panel render at 192.168.1.61 with patched renderer/CSS injection: peopleCards=9

## Screenshot
Physical touch panel capture saved locally by Codex: /Users/jasonbertelsen/Documents/Codex/skybridge-universal-card-colors-visual/people_grid_fixed.png