### PR TITLE
[codex] Guard guest prompt memory reads

### DIFF
--- a/services/zoe-data/memory_service.py
+++ b/services/zoe-data/memory_service.py
@@ -334,10 +334,10 @@ class MemoryService:
         limit: int = 10,
         timeout_s: float = 2.0,
     ) -> list[MemoryRef]:
+        if is_guest_memory_user(user_id):
+            return []
         self._require(user_id, "user_id is required")
         if not query or not query.strip():
-            return []
-        if is_guest_memory_user(user_id):
             return []
         t0 = time.monotonic()
         try:

--- a/services/zoe-data/memory_service.py
+++ b/services/zoe-data/memory_service.py
@@ -82,13 +82,22 @@ _BLOCKED_READ_STATUSES = {"archived", "rejected", "superseded", "pending", "disp
 def _memory_visible_to_user(metadata: Mapping[str, Any], user_id: str) -> bool:
     """Return True only for the caller's personal rows or shared family rows."""
 
+    caller = str(user_id or "").strip().lower()
+    if is_guest_memory_user(caller):
+        return False
+
     visibility = str(metadata.get("visibility") or "").strip().lower()
     if visibility == "family":
         return True
-    caller = str(user_id or "").strip().lower()
     uid = str(metadata.get("user_id") or "").strip().lower()
     wing = str(metadata.get("wing") or "").strip().lower()
     return bool(caller and ((uid and uid == caller) or (wing and wing == caller)))
+
+
+def is_guest_memory_user(user_id: str | None) -> bool:
+    """Return True for unauthenticated identities that must not receive prompt memory."""
+
+    return str(user_id or "").strip().lower() in {"", "guest", "anonymous", "voice-guest"}
 
 
 def _memory_status_visible(metadata: Mapping[str, Any]) -> bool:
@@ -303,6 +312,8 @@ class MemoryService:
         self, user_id: str, *, limit: int = 20
     ) -> list[MemoryRef]:
         """Fast metadata-filter read for system prompt injection."""
+        if is_guest_memory_user(user_id):
+            return []
         self._require(user_id, "user_id is required")
         try:
             rows = await self._run_sync(self._metadata_read, user_id, limit)
@@ -325,6 +336,8 @@ class MemoryService:
     ) -> list[MemoryRef]:
         self._require(user_id, "user_id is required")
         if not query or not query.strip():
+            return []
+        if is_guest_memory_user(user_id):
             return []
         t0 = time.monotonic()
         try:

--- a/services/zoe-data/tests/test_memory_service_metadata.py
+++ b/services/zoe-data/tests/test_memory_service_metadata.py
@@ -231,7 +231,9 @@ async def test_guest_prompt_and_search_reads_return_no_rows_without_collection_a
     service._collection = lambda: (_ for _ in ()).throw(AssertionError("guest read should not touch storage"))
 
     assert await service.load_for_prompt("guest", limit=10) == []
+    assert await service.load_for_prompt("", limit=10) == []
     assert await service.search("remember me", user_id="guest", limit=10) == []
+    assert await service.search("remember me", user_id="", limit=10) == []
 
 
 def test_metadata_prompt_read_blocks_cross_user_disputed_and_superseded_rows():

--- a/services/zoe-data/tests/test_memory_service_metadata.py
+++ b/services/zoe-data/tests/test_memory_service_metadata.py
@@ -1,6 +1,6 @@
 import pytest
 
-from memory_service import MemoryService, MemoryServiceError, _memory_visible_to_user
+from memory_service import MemoryService, MemoryServiceError, _memory_visible_to_user, is_guest_memory_user
 
 
 class _FakeCollection:
@@ -207,6 +207,31 @@ def test_memory_visible_to_user_matches_user_id_or_wing_or_shared_visibility():
     assert _memory_visible_to_user({"user_id": "alex", "wing": "jason", "visibility": "personal"}, "jason") is True
     assert _memory_visible_to_user({"user_id": "alex", "visibility": "personal"}, "jason") is False
     assert _memory_visible_to_user({"user_id": "alex", "visibility": "family"}, "jason") is True
+
+
+def test_guest_memory_user_detection_blocks_unauthenticated_identities():
+    assert is_guest_memory_user(None) is True
+    assert is_guest_memory_user("") is True
+    assert is_guest_memory_user("guest") is True
+    assert is_guest_memory_user("anonymous") is True
+    assert is_guest_memory_user("voice-guest") is True
+    assert is_guest_memory_user("jason") is False
+
+
+def test_memory_visible_to_user_blocks_family_rows_for_guest_callers():
+    assert _memory_visible_to_user({"user_id": "jason", "visibility": "family"}, "guest") is False
+    assert _memory_visible_to_user({"wing": "jason", "visibility": "family"}, "anonymous") is False
+    assert _memory_visible_to_user({"user_id": "guest", "visibility": "family"}, "guest") is False
+    assert _memory_visible_to_user({"user_id": "guest", "visibility": "personal"}, "guest") is False
+
+
+@pytest.mark.asyncio
+async def test_guest_prompt_and_search_reads_return_no_rows_without_collection_access():
+    service = MemoryService(data_dir="/tmp/zoe-test-memory-guest")
+    service._collection = lambda: (_ for _ in ()).throw(AssertionError("guest read should not touch storage"))
+
+    assert await service.load_for_prompt("guest", limit=10) == []
+    assert await service.search("remember me", user_id="guest", limit=10) == []
 
 
 def test_metadata_prompt_read_blocks_cross_user_disputed_and_superseded_rows():

--- a/services/zoe-data/tests/test_zoe_agent_skills.py
+++ b/services/zoe-data/tests/test_zoe_agent_skills.py
@@ -347,6 +347,22 @@ async def test_guest_user_facts_skip_memory_service(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_guest_user_facts_fail_closed_when_memory_service_import_fails(monkeypatch):
+    import builtins
+
+    original_import = builtins.__import__
+
+    def fail_memory_service_import(name, *args, **kwargs):
+        if name == "memory_service":
+            raise RuntimeError("memory_service import failed")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fail_memory_service_import)
+
+    assert await zoe_agent._mempalace_load_user_facts("guest") == ""
+
+
+@pytest.mark.asyncio
 async def test_guest_semantic_memory_context_skips_mempalace_search(monkeypatch):
     async def fail_search(*args, **kwargs):
         raise AssertionError("guest semantic prompt context must not search memory")

--- a/services/zoe-data/tests/test_zoe_agent_skills.py
+++ b/services/zoe-data/tests/test_zoe_agent_skills.py
@@ -330,3 +330,27 @@ class TestChatCapabilityShortcutExists:
             assert cue in "is it going to rain outside today"[:len(cue)] or cue in (
                 "will it rain tomorrow is it sunny is it cloudy need an umbrella bring a jacket"
             ), f"cue missing from test string: {cue}"
+
+
+# -- Guest memory prompt guards ------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_guest_user_facts_skip_memory_service(monkeypatch):
+    import memory_service
+
+    def fail_get_memory_service():
+        raise AssertionError("guest prompt facts must not touch MemoryService")
+
+    monkeypatch.setattr(memory_service, "get_memory_service", fail_get_memory_service)
+
+    assert await zoe_agent._mempalace_load_user_facts("guest") == ""
+
+
+@pytest.mark.asyncio
+async def test_guest_semantic_memory_context_skips_mempalace_search(monkeypatch):
+    async def fail_search(*args, **kwargs):
+        raise AssertionError("guest semantic prompt context must not search memory")
+
+    monkeypatch.setattr(zoe_agent, "_mempalace_search", fail_search)
+
+    assert await zoe_agent._build_memory_context("do you remember my plan", user_id="guest") == ""

--- a/services/zoe-data/zoe_agent.py
+++ b/services/zoe-data/zoe_agent.py
@@ -1380,6 +1380,12 @@ async def _mempalace_load_user_facts(user_id: str, limit: int = 20) -> str:
     cache so freshness returns on the next turn.
     """
     now = time.monotonic()
+    try:
+        from memory_service import is_guest_memory_user
+        if is_guest_memory_user(user_id):
+            return ""
+    except Exception:
+        pass
     cached = _USER_FACTS_CACHE.get(user_id)
     if cached is not None and cached[0] > now:
         return cached[1]
@@ -1491,6 +1497,12 @@ async def _build_memory_context(message: str, user_id: str = "family-admin") -> 
     entity-type-filtered search to pull person-specific facts.
     """
     if not _message_needs_memory(message):
+        return ""
+    try:
+        from memory_service import is_guest_memory_user
+        if is_guest_memory_user(user_id):
+            return ""
+    except Exception:
         return ""
     _mp_timeout = 5.0 if _JETSON_MODE else 3.0
 

--- a/services/zoe-data/zoe_agent.py
+++ b/services/zoe-data/zoe_agent.py
@@ -1385,7 +1385,7 @@ async def _mempalace_load_user_facts(user_id: str, limit: int = 20) -> str:
         if is_guest_memory_user(user_id):
             return ""
     except Exception:
-        pass
+        return ""
     cached = _USER_FACTS_CACHE.get(user_id)
     if cached is not None and cached[0] > now:
         return cached[1]


### PR DESCRIPTION
## Summary

Guards guest and unauthenticated chat turns from receiving MemPalace prompt memory.

This fixes a conversation-flow risk found during the live smoke test: a no-session/vague chat turn could receive shared/personal memory context and answer as if it knew a specific household user.

## Changes

- Adds `is_guest_memory_user()` to centralize guest/anonymous/voice-guest memory identity checks.
- Makes `MemoryService.load_for_prompt()` and `MemoryService.search()` return no rows for guest identities without touching storage.
- Makes Zoe Agent skip prompt fact loading and semantic memory search for guest identities.
- Adds service-level and agent-level regressions proving guest prompt reads do not reach storage/search.

## Validation

- `python3 -m pytest -q services/zoe-data/tests/test_memory_service_metadata.py services/zoe-data/tests/test_zoe_agent_skills.py` -> 62 passed
- `python3 -m pytest -q services/zoe-data/tests/test_ag_ui_chat_contract.py services/zoe-data/tests/test_chat_calendar_cards.py services/zoe-data/tests/test_chat_persistence_contract.py services/zoe-data/tests/test_chat_session_title.py services/zoe-data/tests/test_chat_shopping_cards.py services/zoe-data/tests/test_intent_gap_contract_helper.py services/zoe-data/tests/test_intent_ha_setup.py services/zoe-data/tests/test_intent_open_domain.py services/zoe-data/tests/test_list_agent_tasks.py services/zoe-data/tests/test_multica_autopilot_noise.py services/zoe-data/tests/test_multica_operator_intents.py services/zoe-data/tests/test_pi_*.py services/zoe-data/tests/test_pipeline_*.py services/zoe-data/tests/test_voice_*.py services/zoe-data/tests/test_zoe_pi_promotion.py services/zoe-data/tests/test_memory_service_metadata.py services/zoe-data/tests/test_zoe_agent_skills.py` -> 577 passed
- `python3 tools/audit/validate_structure.py` -> passed
- `python3 tools/audit/validate_critical_files.py` -> passed
- `git diff --check` -> passed
