### PR TITLE
[codex] Add fast reminder slot parsing

### DIFF
--- a/services/zoe-data/intent_router.py
+++ b/services/zoe-data/intent_router.py
@@ -1310,6 +1310,8 @@ def _extract_simple_reminder_slots(text: str) -> Optional[dict]:
             break
     if not body:
         return None
+    if re.search(r"\bin\s+\d+\s+(?:min(?:ute)?s?|hours?|days?|weeks?)\b", body, flags=re.IGNORECASE):
+        return None
 
     def _pop_time(value: str) -> tuple[str, str]:
         value = value.strip()

--- a/services/zoe-data/intent_router.py
+++ b/services/zoe-data/intent_router.py
@@ -1313,7 +1313,7 @@ def _extract_simple_reminder_slots(text: str) -> Optional[dict]:
     if re.search(r"\bin\s+\d+\s+(?:min(?:ute)?s?|hours?|days?|weeks?)\b", body, flags=re.IGNORECASE):
         return None
     if re.search(
-        r"\bin\s+(?:a\s+few|a\s+couple(?:\s+of)?|an?\s+hour|one|two|three|four|five|six|seven|eight|nine|ten)\s+(?:min(?:ute)?s?|hours?|days?|weeks?)\b",
+        r"\bin\s+(?:(?:a\s+few|a\s+couple(?:\s+of)?|one|two|three|four|five|six|seven|eight|nine|ten)\s+(?:min(?:ute)?s?|hours?|days?|weeks?)|an?\s+(?:min(?:ute)?|hour|day|week)|half\s+an\s+hour)\b",
         body,
         flags=re.IGNORECASE,
     ):

--- a/services/zoe-data/intent_router.py
+++ b/services/zoe-data/intent_router.py
@@ -1332,6 +1332,12 @@ def _extract_simple_reminder_slots(text: str) -> Optional[dict]:
         flags=re.IGNORECASE,
     ):
         return None
+    if re.search(
+        r"\bon\s+(?:the\s+)?(?:\d{1,2}(?:st|nd|rd|th)?|(?:my|your|his|her|their)\s+birthday|new\s+year'?s?|christmas|easter|thanksgiving)$",
+        body,
+        flags=re.IGNORECASE,
+    ):
+        return None
 
     def _pop_time(value: str) -> tuple[str, str]:
         value = value.strip()

--- a/services/zoe-data/intent_router.py
+++ b/services/zoe-data/intent_router.py
@@ -1341,6 +1341,12 @@ def _extract_simple_reminder_slots(text: str) -> Optional[dict]:
     ):
         return None
     if re.search(
+        r"\s+(?:monday|tuesday|wednesday|thursday|friday|saturday|sunday)\s+(?:at\s+)?\d{1,2}(?::\d{2})?\s*(?:am|pm)\b",
+        body,
+        flags=re.IGNORECASE,
+    ):
+        return None
+    if re.search(
         r"\b(?:noon|midnight|morning|afternoon|evening|(?:to)?night|bedtime|lunchtime|dinnertime)\b",
         body,
         flags=re.IGNORECASE,

--- a/services/zoe-data/intent_router.py
+++ b/services/zoe-data/intent_router.py
@@ -1319,12 +1319,18 @@ def _extract_simple_reminder_slots(text: str) -> Optional[dict]:
     ):
         return None
     if re.search(
-        r"\b(?:noon|midnight|morning|afternoon|evening|night|bedtime|lunchtime|dinnertime)\b",
+        r"\b(?:noon|midnight|morning|afternoon|evening|(?:to)?night|bedtime|lunchtime|dinnertime)\b",
         body,
         flags=re.IGNORECASE,
     ):
         return None
     if re.search(r"\bat\s+\d{1,4}(?::\d{2})?\b(?!\s*(?:am|pm))", body, flags=re.IGNORECASE):
+        return None
+    if re.match(
+        r"^(?:today|tomorrow|monday|tuesday|wednesday|thursday|friday|saturday|sunday)$",
+        body,
+        flags=re.IGNORECASE,
+    ):
         return None
 
     def _pop_time(value: str) -> tuple[str, str]:

--- a/services/zoe-data/intent_router.py
+++ b/services/zoe-data/intent_router.py
@@ -1324,13 +1324,14 @@ def _extract_simple_reminder_slots(text: str) -> Optional[dict]:
         flags=re.IGNORECASE,
     ):
         return None
+    if re.search(r"\bat\s+\d{1,4}(?::\d{2})?\b(?!\s*(?:am|pm))", body, flags=re.IGNORECASE):
+        return None
 
     def _pop_time(value: str) -> tuple[str, str]:
         value = value.strip()
         time_patterns = [
-            r"\s+at\s+(\d{1,2}(?::\d{2})?\s*(?:am|pm)?)$",
+            r"\s+at\s+(\d{1,2}(?::\d{2})?\s*(?:am|pm))$",
             r"\s+(\d{1,2}(?::\d{2})\s*(?:am|pm)|\d{1,2}\s*(?:am|pm))$",
-            r"\s+at\s+(\d{3,4})$",
         ]
         for pattern in time_patterns:
             m = re.search(pattern, value, flags=re.IGNORECASE)

--- a/services/zoe-data/intent_router.py
+++ b/services/zoe-data/intent_router.py
@@ -1355,7 +1355,7 @@ def _extract_simple_reminder_slots(text: str) -> Optional[dict]:
     if re.search(r"\bat\s+\d{1,4}(?::\d{2})?\b(?!\s*(?:am|pm))", body, flags=re.IGNORECASE):
         return None
     if re.match(
-        r"^(?:today|tomorrow|monday|tuesday|wednesday|thursday|friday|saturday|sunday)$",
+        r"^(?:today|tomorrow|monday|tuesday|wednesday|thursday|friday|saturday|sunday)\b",
         body,
         flags=re.IGNORECASE,
     ):

--- a/services/zoe-data/intent_router.py
+++ b/services/zoe-data/intent_router.py
@@ -1352,7 +1352,7 @@ def _extract_simple_reminder_slots(text: str) -> Optional[dict]:
         date_patterns = [
             rf"\s+(today|tomorrow|{day_names})$",
             rf"\s+on\s+(today|tomorrow|{day_names})$",
-            rf"\s+on\s+(({month_names})\s+\d{{1,2}}(?:st|nd|rd|th)?(?:\s+\d{{4}})?)$",
+            rf"\s+on\s+((?:{month_names})\s+\d{{1,2}}(?:st|nd|rd|th)?(?:\s+\d{{4}})?)$",
             rf"\s+on\s+(\d{{1,2}}(?:st|nd|rd|th)?\s+(?:of\s+)?(?:{month_names})(?:\s+\d{{4}})?)$",
             r"\s+on\s+(\d{4}-\d{2}-\d{2})$",
         ]

--- a/services/zoe-data/intent_router.py
+++ b/services/zoe-data/intent_router.py
@@ -1312,6 +1312,12 @@ def _extract_simple_reminder_slots(text: str) -> Optional[dict]:
         return None
     if re.search(r"\bin\s+\d+\s+(?:min(?:ute)?s?|hours?|days?|weeks?)\b", body, flags=re.IGNORECASE):
         return None
+    if re.search(
+        r"\b(?:next|this|coming|last)\s+(?:monday|tuesday|wednesday|thursday|friday|saturday|sunday)\b",
+        body,
+        flags=re.IGNORECASE,
+    ):
+        return None
 
     def _pop_time(value: str) -> tuple[str, str]:
         value = value.strip()

--- a/services/zoe-data/intent_router.py
+++ b/services/zoe-data/intent_router.py
@@ -1356,8 +1356,8 @@ def _extract_simple_reminder_slots(text: str) -> Optional[dict]:
             "jan|feb|mar|apr|jun|jul|aug|sep|oct|nov|dec"
         )
         date_patterns = [
-            rf"\s+(today|tomorrow|{day_names})$",
             rf"\s+on\s+(today|tomorrow|{day_names})$",
+            rf"\s+(today|tomorrow|{day_names})$",
             rf"\s+on\s+((?:{month_names})\s+\d{{1,2}}(?:st|nd|rd|th)?(?:\s+\d{{4}})?)$",
             rf"\s+on\s+(\d{{1,2}}(?:st|nd|rd|th)?\s+(?:of\s+)?(?:{month_names})(?:\s+\d{{4}})?)$",
             r"\s+on\s+(\d{4}-\d{2}-\d{2})$",

--- a/services/zoe-data/intent_router.py
+++ b/services/zoe-data/intent_router.py
@@ -1331,6 +1331,16 @@ def _extract_simple_reminder_slots(text: str) -> Optional[dict]:
     ):
         return None
     if re.search(
+        r"\s+(?:monday|tuesday|wednesday|thursday|friday|saturday|sunday)$",
+        body,
+        flags=re.IGNORECASE,
+    ) and not re.search(
+        r"\son\s+(?:monday|tuesday|wednesday|thursday|friday|saturday|sunday)$",
+        body,
+        flags=re.IGNORECASE,
+    ):
+        return None
+    if re.search(
         r"\b(?:noon|midnight|morning|afternoon|evening|(?:to)?night|bedtime|lunchtime|dinnertime)\b",
         body,
         flags=re.IGNORECASE,
@@ -1375,7 +1385,7 @@ def _extract_simple_reminder_slots(text: str) -> Optional[dict]:
         )
         date_patterns = [
             rf"\s+on\s+(today|tomorrow|{day_names})$",
-            rf"\s+(today|tomorrow|{day_names})$",
+            r"\s+(today|tomorrow)$",
             rf"\s+on\s+((?:{month_names})\s+\d{{1,2}}(?:st|nd|rd|th)?(?:\s+\d{{4}})?)$",
             rf"\s+on\s+(\d{{1,2}}(?:st|nd|rd|th)?\s+(?:of\s+)?(?:{month_names})(?:\s+\d{{4}})?)$",
             r"\s+on\s+(\d{4}-\d{2}-\d{2})$",

--- a/services/zoe-data/intent_router.py
+++ b/services/zoe-data/intent_router.py
@@ -1288,6 +1288,84 @@ def detect_intent(
     return None
 
 
+def _extract_simple_reminder_slots(text: str) -> Optional[dict]:
+    """Fast slots for common reminder phrases; complex relative phrasing still uses NLU."""
+
+    raw = re.sub(r"\s+", " ", str(text or "")).strip()
+    if not raw:
+        return None
+
+    patterns = [
+        r"^remind me (?:to|about)\s+(.+)$",
+        r"^remember to\s+(.+)$",
+        r"^set a reminder (?:to|for|about)\s+(.+)$",
+        r"^reminder (?:to|for|about)\s+(.+)$",
+        r"^(?:add|create|make|schedule)\s+(?:a |an )?reminder\s+(?:to|for|about)?\s*(.+)$",
+    ]
+    body = ""
+    for pattern in patterns:
+        m = re.match(pattern, raw, flags=re.IGNORECASE)
+        if m:
+            body = m.group(1).strip()
+            break
+    if not body:
+        return None
+
+    def _pop_time(value: str) -> tuple[str, str]:
+        value = value.strip()
+        time_patterns = [
+            r"\s+at\s+(\d{1,2}(?::\d{2})?\s*(?:am|pm)?)$",
+            r"\s+(\d{1,2}(?::\d{2})\s*(?:am|pm)|\d{1,2}\s*(?:am|pm))$",
+            r"\s+at\s+(\d{3,4})$",
+        ]
+        for pattern in time_patterns:
+            m = re.search(pattern, value, flags=re.IGNORECASE)
+            if not m:
+                continue
+            parsed = _parse_time(m.group(1))
+            if parsed:
+                return value[:m.start()].strip(), parsed
+        return value, ""
+
+    def _pop_date(value: str) -> tuple[str, str]:
+        value = value.strip()
+        day_names = "monday|tuesday|wednesday|thursday|friday|saturday|sunday"
+        month_names = (
+            "january|february|march|april|may|june|july|august|september|october|november|december|"
+            "jan|feb|mar|apr|jun|jul|aug|sep|oct|nov|dec"
+        )
+        date_patterns = [
+            rf"\s+(today|tomorrow|{day_names})$",
+            rf"\s+on\s+(today|tomorrow|{day_names})$",
+            rf"\s+on\s+(({month_names})\s+\d{{1,2}}(?:st|nd|rd|th)?(?:\s+\d{{4}})?)$",
+            rf"\s+on\s+(\d{{1,2}}(?:st|nd|rd|th)?\s+(?:of\s+)?(?:{month_names})(?:\s+\d{{4}})?)$",
+            r"\s+on\s+(\d{4}-\d{2}-\d{2})$",
+        ]
+        for pattern in date_patterns:
+            m = re.search(pattern, value, flags=re.IGNORECASE)
+            if not m:
+                continue
+            parsed = _parse_date(m.group(1))
+            if parsed:
+                return value[:m.start()].strip(), parsed
+        return value, ""
+
+    body, date = _pop_date(body)
+    body, time_value = _pop_time(body)
+    if not date:
+        body, date = _pop_date(body)
+
+    title = re.sub(r"\s+", " ", body).strip(" ,.-")
+    title = re.sub(r"^(?:to|for|about)\s+", "", title, flags=re.IGNORECASE).strip()
+    if not title:
+        return None
+
+    slots = {"title": title, "date": date or _parse_date("today") or ""}
+    if time_value:
+        slots["time"] = time_value
+    return slots
+
+
 async def detect_and_extract_intent(
     text: str,
     user_id: str = "family-admin",
@@ -1390,6 +1468,19 @@ async def detect_and_extract_intent(
         )
         return routed_intent
     if intent.slots and "raw" in intent.slots:
+        if intent.name == "reminder_create":
+            structured = _extract_simple_reminder_slots(intent.slots["raw"])
+            if structured:
+                intent.slots = structured
+                _schedule_pi_shadow(
+                    intent,
+                    route_class="deterministic",
+                    zoe_latency_ms=(time.perf_counter() - started) * 1000,
+                    baseline_kind="router",
+                    baseline_comparable=True,
+                    router_latency_ms=detect_latency_ms,
+                )
+                return intent
         try:
             from nlu_extractor import extract_slots_for_intent  # lazy — avoids circular at load
             structured = await extract_slots_for_intent(intent.name, intent.slots["raw"])

--- a/services/zoe-data/intent_router.py
+++ b/services/zoe-data/intent_router.py
@@ -1318,6 +1318,12 @@ def _extract_simple_reminder_slots(text: str) -> Optional[dict]:
         flags=re.IGNORECASE,
     ):
         return None
+    if re.search(
+        r"\b(?:noon|midnight|morning|afternoon|evening|night|bedtime|lunchtime|dinnertime)\b",
+        body,
+        flags=re.IGNORECASE,
+    ):
+        return None
 
     def _pop_time(value: str) -> tuple[str, str]:
         value = value.strip()

--- a/services/zoe-data/intent_router.py
+++ b/services/zoe-data/intent_router.py
@@ -1313,7 +1313,19 @@ def _extract_simple_reminder_slots(text: str) -> Optional[dict]:
     if re.search(r"\bin\s+\d+\s+(?:min(?:ute)?s?|hours?|days?|weeks?)\b", body, flags=re.IGNORECASE):
         return None
     if re.search(
+        r"\bin\s+(?:a\s+few|a\s+couple(?:\s+of)?|an?\s+hour|one|two|three|four|five|six|seven|eight|nine|ten)\s+(?:min(?:ute)?s?|hours?|days?|weeks?)\b",
+        body,
+        flags=re.IGNORECASE,
+    ):
+        return None
+    if re.search(
         r"\b(?:next|this|coming|last)\s+(?:monday|tuesday|wednesday|thursday|friday|saturday|sunday)\b",
+        body,
+        flags=re.IGNORECASE,
+    ):
+        return None
+    if re.search(
+        r"\bevery\s+(?:monday|tuesday|wednesday|thursday|friday|saturday|sunday|day|week|month|year)\b",
         body,
         flags=re.IGNORECASE,
     ):

--- a/services/zoe-data/tests/test_intent_reminder_latency.py
+++ b/services/zoe-data/tests/test_intent_reminder_latency.py
@@ -96,23 +96,30 @@ async def test_trailing_relative_reminder_still_uses_existing_extractor(monkeypa
 
 
 @pytest.mark.asyncio
-async def test_modifier_day_reminder_still_uses_existing_extractor(monkeypatch):
+@pytest.mark.parametrize(
+    "text",
+    [
+        "remind me to call mum next Tuesday",
+        "remind me to pick up kids this Saturday",
+        "remind me to submit the form coming Monday",
+    ],
+)
+async def test_modifier_day_reminder_still_uses_existing_extractor(monkeypatch, text):
     calls = []
     module = types.ModuleType("nlu_extractor")
 
     async def fake_extract(intent_name, raw):
         calls.append((intent_name, raw))
-        return {"title": "call mum", "date": "2026-06-23"}
+        return {"title": "modifier day reminder", "date": "2026-06-23"}
 
     module.extract_slots_for_intent = fake_extract
     monkeypatch.setitem(sys.modules, "nlu_extractor", module)
 
     from intent_router import detect_and_extract_intent
 
-    text = "remind me to call mum next Tuesday"
     intent = await detect_and_extract_intent(text, user_id="guest")
 
     assert calls == [("reminder_create", text)]
     assert intent is not None
     assert intent.name == "reminder_create"
-    assert intent.slots == {"title": "call mum", "date": "2026-06-23"}
+    assert intent.slots == {"title": "modifier day reminder", "date": "2026-06-23"}

--- a/services/zoe-data/tests/test_intent_reminder_latency.py
+++ b/services/zoe-data/tests/test_intent_reminder_latency.py
@@ -188,6 +188,35 @@ async def test_standalone_day_reminder_still_uses_existing_extractor(monkeypatch
 @pytest.mark.parametrize(
     "text",
     [
+        "remind me to pick up the package on the 15th",
+        "remind me to call mum on her birthday",
+    ],
+)
+@pytest.mark.asyncio
+async def test_unsupported_on_date_phrase_still_uses_existing_extractor(monkeypatch, text):
+    calls = []
+    module = types.ModuleType("nlu_extractor")
+
+    async def fake_extract(intent_name, raw):
+        calls.append((intent_name, raw))
+        return {"title": "unsupported on date reminder", "date": "2026-07-15"}
+
+    module.extract_slots_for_intent = fake_extract
+    monkeypatch.setitem(sys.modules, "nlu_extractor", module)
+
+    from intent_router import detect_and_extract_intent
+
+    intent = await detect_and_extract_intent(text, user_id="guest")
+
+    assert calls == [("reminder_create", text)]
+    assert intent is not None
+    assert intent.name == "reminder_create"
+    assert intent.slots == {"title": "unsupported on date reminder", "date": "2026-07-15"}
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
         "remind me to call mum at 5",
         "remind me to call mum at 5:30",
     ],

--- a/services/zoe-data/tests/test_intent_reminder_latency.py
+++ b/services/zoe-data/tests/test_intent_reminder_latency.py
@@ -70,3 +70,26 @@ async def test_relative_reminder_still_uses_existing_extractor(monkeypatch):
     assert intent is not None
     assert intent.name == "reminder_create"
     assert intent.slots == {"title": "check the oven", "date": "2026-06-15", "time": "20:10"}
+
+
+@pytest.mark.asyncio
+async def test_trailing_relative_reminder_still_uses_existing_extractor(monkeypatch):
+    calls = []
+    module = types.ModuleType("nlu_extractor")
+
+    async def fake_extract(intent_name, raw):
+        calls.append((intent_name, raw))
+        return {"title": "check the oven", "date": "2026-06-15", "time": "20:30"}
+
+    module.extract_slots_for_intent = fake_extract
+    monkeypatch.setitem(sys.modules, "nlu_extractor", module)
+
+    from intent_router import detect_and_extract_intent
+
+    text = "remind me to check the oven in 30 minutes"
+    intent = await detect_and_extract_intent(text, user_id="guest")
+
+    assert calls == [("reminder_create", text)]
+    assert intent is not None
+    assert intent.name == "reminder_create"
+    assert intent.slots == {"title": "check the oven", "date": "2026-06-15", "time": "20:30"}

--- a/services/zoe-data/tests/test_intent_reminder_latency.py
+++ b/services/zoe-data/tests/test_intent_reminder_latency.py
@@ -101,6 +101,9 @@ async def test_trailing_relative_reminder_still_uses_existing_extractor(monkeypa
         "remind me to call mum in a few days",
         "remind me to call mum in two hours",
         "remind me to check the filter in a couple of weeks",
+        "remind me to check the oven in an hour",
+        "remind me to check the oven in half an hour",
+        "remind me to call mum in a day",
     ],
 )
 @pytest.mark.asyncio

--- a/services/zoe-data/tests/test_intent_reminder_latency.py
+++ b/services/zoe-data/tests/test_intent_reminder_latency.py
@@ -95,6 +95,36 @@ async def test_trailing_relative_reminder_still_uses_existing_extractor(monkeypa
     assert intent.slots == {"title": "check the oven", "date": "2026-06-15", "time": "20:30"}
 
 
+@pytest.mark.parametrize(
+    "text",
+    [
+        "remind me to call mum in a few days",
+        "remind me to call mum in two hours",
+        "remind me to check the filter in a couple of weeks",
+    ],
+)
+@pytest.mark.asyncio
+async def test_word_relative_reminder_still_uses_existing_extractor(monkeypatch, text):
+    calls = []
+    module = types.ModuleType("nlu_extractor")
+
+    async def fake_extract(intent_name, raw):
+        calls.append((intent_name, raw))
+        return {"title": "word relative reminder", "date": "2026-06-18"}
+
+    module.extract_slots_for_intent = fake_extract
+    monkeypatch.setitem(sys.modules, "nlu_extractor", module)
+
+    from intent_router import detect_and_extract_intent
+
+    intent = await detect_and_extract_intent(text, user_id="guest")
+
+    assert calls == [("reminder_create", text)]
+    assert intent is not None
+    assert intent.name == "reminder_create"
+    assert intent.slots == {"title": "word relative reminder", "date": "2026-06-18"}
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "text",
@@ -123,6 +153,35 @@ async def test_modifier_day_reminder_still_uses_existing_extractor(monkeypatch, 
     assert intent is not None
     assert intent.name == "reminder_create"
     assert intent.slots == {"title": "modifier day reminder", "date": "2026-06-23"}
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "remind me to call mum every Monday",
+        "remind me to water the garden every week",
+    ],
+)
+@pytest.mark.asyncio
+async def test_recurring_reminder_still_uses_existing_extractor(monkeypatch, text):
+    calls = []
+    module = types.ModuleType("nlu_extractor")
+
+    async def fake_extract(intent_name, raw):
+        calls.append((intent_name, raw))
+        return {"title": "recurring reminder", "date": "2026-06-22", "recurrence": "weekly"}
+
+    module.extract_slots_for_intent = fake_extract
+    monkeypatch.setitem(sys.modules, "nlu_extractor", module)
+
+    from intent_router import detect_and_extract_intent
+
+    intent = await detect_and_extract_intent(text, user_id="guest")
+
+    assert calls == [("reminder_create", text)]
+    assert intent is not None
+    assert intent.name == "reminder_create"
+    assert intent.slots == {"title": "recurring reminder", "date": "2026-06-22", "recurrence": "weekly"}
 
 
 @pytest.mark.parametrize(

--- a/services/zoe-data/tests/test_intent_reminder_latency.py
+++ b/services/zoe-data/tests/test_intent_reminder_latency.py
@@ -93,3 +93,26 @@ async def test_trailing_relative_reminder_still_uses_existing_extractor(monkeypa
     assert intent is not None
     assert intent.name == "reminder_create"
     assert intent.slots == {"title": "check the oven", "date": "2026-06-15", "time": "20:30"}
+
+
+@pytest.mark.asyncio
+async def test_modifier_day_reminder_still_uses_existing_extractor(monkeypatch):
+    calls = []
+    module = types.ModuleType("nlu_extractor")
+
+    async def fake_extract(intent_name, raw):
+        calls.append((intent_name, raw))
+        return {"title": "call mum", "date": "2026-06-23"}
+
+    module.extract_slots_for_intent = fake_extract
+    monkeypatch.setitem(sys.modules, "nlu_extractor", module)
+
+    from intent_router import detect_and_extract_intent
+
+    text = "remind me to call mum next Tuesday"
+    intent = await detect_and_extract_intent(text, user_id="guest")
+
+    assert calls == [("reminder_create", text)]
+    assert intent is not None
+    assert intent.name == "reminder_create"
+    assert intent.slots == {"title": "call mum", "date": "2026-06-23"}

--- a/services/zoe-data/tests/test_intent_reminder_latency.py
+++ b/services/zoe-data/tests/test_intent_reminder_latency.py
@@ -279,6 +279,8 @@ async def test_unsupported_on_date_phrase_still_uses_existing_extractor(monkeypa
         "remind me to prepare for Black Friday",
         "remind me to shop Cyber Monday",
         "remind me to call mum Tuesday",
+        "remind me to call mum Tuesday at 5pm",
+        "remind me to call mum Friday 9am",
     ],
 )
 def test_bare_trailing_weekday_reminder_is_not_fast_path(text):

--- a/services/zoe-data/tests/test_intent_reminder_latency.py
+++ b/services/zoe-data/tests/test_intent_reminder_latency.py
@@ -182,3 +182,24 @@ async def test_bare_numeric_time_reminder_still_uses_existing_extractor(monkeypa
     assert intent is not None
     assert intent.name == "reminder_create"
     assert intent.slots == {"title": "bare numeric time reminder", "date": "2026-06-15", "time": "17:00"}
+
+
+@pytest.mark.asyncio
+async def test_time_before_day_reminder_skips_llm_extractor(monkeypatch):
+    module = types.ModuleType("nlu_extractor")
+
+    async def fail_extract(_intent_name, _raw):
+        raise AssertionError("time-before-day simple reminder should not call the LLM slot extractor")
+
+    module.extract_slots_for_intent = fail_extract
+    monkeypatch.setitem(sys.modules, "nlu_extractor", module)
+
+    from intent_router import detect_and_extract_intent
+
+    intent = await detect_and_extract_intent("remind me to call mum at 10am tomorrow", user_id="guest")
+
+    assert intent is not None
+    assert intent.name == "reminder_create"
+    assert intent.slots["title"] == "call mum"
+    assert intent.slots["time"] == "10:00"
+    assert intent.slots["date"]

--- a/services/zoe-data/tests/test_intent_reminder_latency.py
+++ b/services/zoe-data/tests/test_intent_reminder_latency.py
@@ -233,3 +233,34 @@ async def test_time_before_day_reminder_skips_llm_extractor(monkeypatch):
     assert intent.slots["title"] == "call mum"
     assert intent.slots["time"] == "10:00"
     assert intent.slots["date"]
+
+
+@pytest.mark.parametrize(
+    ("text", "expected_time"),
+    [
+        ("remind me to call mum on Tuesday", None),
+        ("remind me to call mum at 10am on Tuesday", "10:00"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_on_day_reminder_skips_llm_extractor_without_stray_on(monkeypatch, text, expected_time):
+    module = types.ModuleType("nlu_extractor")
+
+    async def fail_extract(_intent_name, _raw):
+        raise AssertionError("on-day simple reminder should not call the LLM slot extractor")
+
+    module.extract_slots_for_intent = fail_extract
+    monkeypatch.setitem(sys.modules, "nlu_extractor", module)
+
+    from intent_router import detect_and_extract_intent
+
+    intent = await detect_and_extract_intent(text, user_id="guest")
+
+    assert intent is not None
+    assert intent.name == "reminder_create"
+    assert intent.slots["title"] == "call mum"
+    assert intent.slots["date"]
+    if expected_time:
+        assert intent.slots["time"] == expected_time
+    else:
+        assert "time" not in intent.slots

--- a/services/zoe-data/tests/test_intent_reminder_latency.py
+++ b/services/zoe-data/tests/test_intent_reminder_latency.py
@@ -131,6 +131,7 @@ async def test_modifier_day_reminder_still_uses_existing_extractor(monkeypatch, 
         "remind me to call mum at noon",
         "remind me to stretch in the morning",
         "remind me to lock the door at bedtime",
+        "remind me to lock the door tonight",
     ],
 )
 @pytest.mark.asyncio
@@ -153,6 +154,35 @@ async def test_named_time_reminder_still_uses_existing_extractor(monkeypatch, te
     assert intent is not None
     assert intent.name == "reminder_create"
     assert intent.slots == {"title": "named time reminder", "date": "2026-06-15", "time": "12:00"}
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "remind me about tomorrow",
+        "remind me about Monday",
+    ],
+)
+@pytest.mark.asyncio
+async def test_standalone_day_reminder_still_uses_existing_extractor(monkeypatch, text):
+    calls = []
+    module = types.ModuleType("nlu_extractor")
+
+    async def fake_extract(intent_name, raw):
+        calls.append((intent_name, raw))
+        return {"title": "standalone day reminder", "date": "2026-06-16"}
+
+    module.extract_slots_for_intent = fake_extract
+    monkeypatch.setitem(sys.modules, "nlu_extractor", module)
+
+    from intent_router import detect_and_extract_intent
+
+    intent = await detect_and_extract_intent(text, user_id="guest")
+
+    assert calls == [("reminder_create", text)]
+    assert intent is not None
+    assert intent.name == "reminder_create"
+    assert intent.slots == {"title": "standalone day reminder", "date": "2026-06-16"}
 
 
 @pytest.mark.parametrize(

--- a/services/zoe-data/tests/test_intent_reminder_latency.py
+++ b/services/zoe-data/tests/test_intent_reminder_latency.py
@@ -1,0 +1,72 @@
+import sys
+import time
+import types
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_simple_reminder_slots_skip_llm_extractor(monkeypatch):
+    module = types.ModuleType("nlu_extractor")
+
+    async def fail_extract(_intent_name, _raw):
+        raise AssertionError("simple reminder should not call the LLM slot extractor")
+
+    module.extract_slots_for_intent = fail_extract
+    monkeypatch.setitem(sys.modules, "nlu_extractor", module)
+
+    from intent_router import detect_and_extract_intent
+
+    started = time.perf_counter()
+    intent = await detect_and_extract_intent("remind me to call mum tomorrow at 10am", user_id="guest")
+    latency_ms = (time.perf_counter() - started) * 1000
+
+    assert intent is not None
+    assert intent.name == "reminder_create"
+    assert intent.slots["title"] == "call mum"
+    assert intent.slots["time"] == "10:00"
+    assert intent.slots["date"]
+    assert latency_ms < 100
+
+
+@pytest.mark.asyncio
+async def test_bare_simple_reminder_defaults_to_today_without_llm(monkeypatch):
+    module = types.ModuleType("nlu_extractor")
+
+    async def fail_extract(_intent_name, _raw):
+        raise AssertionError("bare simple reminder should not call the LLM slot extractor")
+
+    module.extract_slots_for_intent = fail_extract
+    monkeypatch.setitem(sys.modules, "nlu_extractor", module)
+
+    from intent_router import detect_and_extract_intent
+
+    intent = await detect_and_extract_intent("remind me to check the oven", user_id="guest")
+
+    assert intent is not None
+    assert intent.name == "reminder_create"
+    assert intent.slots["title"] == "check the oven"
+    assert intent.slots["date"]
+    assert "time" not in intent.slots
+
+
+@pytest.mark.asyncio
+async def test_relative_reminder_still_uses_existing_extractor(monkeypatch):
+    calls = []
+    module = types.ModuleType("nlu_extractor")
+
+    async def fake_extract(intent_name, raw):
+        calls.append((intent_name, raw))
+        return {"title": "check the oven", "date": "2026-06-15", "time": "20:10"}
+
+    module.extract_slots_for_intent = fake_extract
+    monkeypatch.setitem(sys.modules, "nlu_extractor", module)
+
+    from intent_router import detect_and_extract_intent
+
+    intent = await detect_and_extract_intent("remind me in 5 minutes to check the oven", user_id="guest")
+
+    assert calls == [("reminder_create", "remind me in 5 minutes to check the oven")]
+    assert intent is not None
+    assert intent.name == "reminder_create"
+    assert intent.slots == {"title": "check the oven", "date": "2026-06-15", "time": "20:10"}

--- a/services/zoe-data/tests/test_intent_reminder_latency.py
+++ b/services/zoe-data/tests/test_intent_reminder_latency.py
@@ -123,3 +123,33 @@ async def test_modifier_day_reminder_still_uses_existing_extractor(monkeypatch, 
     assert intent is not None
     assert intent.name == "reminder_create"
     assert intent.slots == {"title": "modifier day reminder", "date": "2026-06-23"}
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "remind me to call mum at noon",
+        "remind me to stretch in the morning",
+        "remind me to lock the door at bedtime",
+    ],
+)
+@pytest.mark.asyncio
+async def test_named_time_reminder_still_uses_existing_extractor(monkeypatch, text):
+    calls = []
+    module = types.ModuleType("nlu_extractor")
+
+    async def fake_extract(intent_name, raw):
+        calls.append((intent_name, raw))
+        return {"title": "named time reminder", "date": "2026-06-15", "time": "12:00"}
+
+    module.extract_slots_for_intent = fake_extract
+    monkeypatch.setitem(sys.modules, "nlu_extractor", module)
+
+    from intent_router import detect_and_extract_intent
+
+    intent = await detect_and_extract_intent(text, user_id="guest")
+
+    assert calls == [("reminder_create", text)]
+    assert intent is not None
+    assert intent.name == "reminder_create"
+    assert intent.slots == {"title": "named time reminder", "date": "2026-06-15", "time": "12:00"}

--- a/services/zoe-data/tests/test_intent_reminder_latency.py
+++ b/services/zoe-data/tests/test_intent_reminder_latency.py
@@ -276,6 +276,20 @@ async def test_unsupported_on_date_phrase_still_uses_existing_extractor(monkeypa
 @pytest.mark.parametrize(
     "text",
     [
+        "remind me to prepare for Black Friday",
+        "remind me to shop Cyber Monday",
+        "remind me to call mum Tuesday",
+    ],
+)
+def test_bare_trailing_weekday_reminder_is_not_fast_path(text):
+    from intent_router import _extract_simple_reminder_slots
+
+    assert _extract_simple_reminder_slots(text) is None
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
         "remind me to call mum at 5",
         "remind me to call mum at 5:30",
     ],

--- a/services/zoe-data/tests/test_intent_reminder_latency.py
+++ b/services/zoe-data/tests/test_intent_reminder_latency.py
@@ -153,3 +153,32 @@ async def test_named_time_reminder_still_uses_existing_extractor(monkeypatch, te
     assert intent is not None
     assert intent.name == "reminder_create"
     assert intent.slots == {"title": "named time reminder", "date": "2026-06-15", "time": "12:00"}
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "remind me to call mum at 5",
+        "remind me to call mum at 5:30",
+    ],
+)
+@pytest.mark.asyncio
+async def test_bare_numeric_time_reminder_still_uses_existing_extractor(monkeypatch, text):
+    calls = []
+    module = types.ModuleType("nlu_extractor")
+
+    async def fake_extract(intent_name, raw):
+        calls.append((intent_name, raw))
+        return {"title": "bare numeric time reminder", "date": "2026-06-15", "time": "17:00"}
+
+    module.extract_slots_for_intent = fake_extract
+    monkeypatch.setitem(sys.modules, "nlu_extractor", module)
+
+    from intent_router import detect_and_extract_intent
+
+    intent = await detect_and_extract_intent(text, user_id="guest")
+
+    assert calls == [("reminder_create", text)]
+    assert intent is not None
+    assert intent.name == "reminder_create"
+    assert intent.slots == {"title": "bare numeric time reminder", "date": "2026-06-15", "time": "17:00"}

--- a/services/zoe-data/tests/test_intent_reminder_latency.py
+++ b/services/zoe-data/tests/test_intent_reminder_latency.py
@@ -223,6 +223,8 @@ async def test_named_time_reminder_still_uses_existing_extractor(monkeypatch, te
     [
         "remind me about tomorrow",
         "remind me about Monday",
+        "remind me about tomorrow at 10am",
+        "remind me about Monday at 5pm",
     ],
 )
 @pytest.mark.asyncio

--- a/services/zoe-data/tests/test_pi_intent_classifier.py
+++ b/services/zoe-data/tests/test_pi_intent_classifier.py
@@ -789,7 +789,7 @@ async def test_detect_and_extract_intent_uses_pi_when_slot_extraction_fails(tmp_
 
     from intent_router import detect_and_extract_intent
 
-    intent = await detect_and_extract_intent("remind me to call mum")
+    intent = await detect_and_extract_intent("remind me in 5 minutes to call mum")
 
     assert intent is not None
     assert intent.name == "reminder_create"

--- a/services/zoe-data/tests/test_pi_intent_shadow.py
+++ b/services/zoe-data/tests/test_pi_intent_shadow.py
@@ -183,7 +183,7 @@ async def test_intent_router_shadow_extraction_failed_records_pre_pi_latency_and
     monkeypatch.setattr("pi_intent_classifier.classify_with_pi_intent_governor", fake_classify)
     monkeypatch.setattr("pi_intent_shadow.maybe_record_pi_intent_shadow", fake_shadow)
 
-    intent = await detect_and_extract_intent("remind me to call mum", user_id="jason")
+    intent = await detect_and_extract_intent("remind me in 5 minutes to call mum", user_id="jason")
     await asyncio.sleep(0)
 
     assert intent is not None


### PR DESCRIPTION
## Summary

Adds a deterministic fast slot parser for common reminder creation phrases so simple reminders do not pay the Gemma/NLU extraction cost.

This directly targets the conversation-flow fleet finding where `remind me to check the oven` was routing correctly but taking about 2 seconds because slot extraction called the model.

## Changes

- Adds `_extract_simple_reminder_slots()` in `intent_router.py` for common reminder forms:
  - `remind me to ...`
  - `remind me about ...`
  - `remember to ...`
  - `set a reminder to/for/about ...`
  - `add/create/make/schedule a reminder ...`
- Extracts simple trailing dates and times using the existing router date/time parsers.
- Leaves relative/complex phrases such as `remind me in 5 minutes ...` on the existing NLU extractor path.
- Updates Pi fallback/shadow tests to use a relative reminder so extraction-failure coverage remains intact.

## Evidence

Latency probe on branch:

- `remind me to check the oven`: p50 0.116 ms, p95 0.145 ms, max 8.047 ms over 50 runs.
- `remind me to call mum tomorrow at 10am`: p50 0.128 ms, p95 0.146 ms, max 0.448 ms over 50 runs.

## Validation

- `python3 -m pytest -q services/zoe-data/tests/test_intent_reminder_latency.py services/zoe-data/tests/test_pi_intent_shadow.py::test_intent_router_shadow_extraction_failed_records_pre_pi_latency_and_baseline services/zoe-data/tests/test_pi_intent_classifier.py::test_detect_and_extract_intent_uses_pi_when_slot_extraction_fails` -> 5 passed
- Broad conversation-flow fleet including chat, voice, intent, Pi, pipeline, memory, and agent tests -> 581 passed
- `python3 tools/audit/validate_structure.py` -> passed
- `python3 tools/audit/validate_critical_files.py` -> passed
- `git diff --check` -> passed
