### PR TITLE
docs: refresh Multica->Hermes harness guides

### DIFF
--- a/docs/guides/ENGINEERING_HARNESS_LOOP.md
+++ b/docs/guides/ENGINEERING_HARNESS_LOOP.md
@@ -58,6 +58,31 @@ Individual `gate_blocked` rows are counted in `gate_blocked_count` for triage bu
 a machine-readable `split_packet`; create a smaller child ticket or escalate to an
 operator instead of redispatching the same broad implement phase.
 
+### Worker block fingerprints (kanban_adapter guards)
+
+Phase workers fail closed by calling `kanban_block` with a `BLOCKER=` fingerprint
+rather than drifting. Watch for these in pipeline JSONL / Kanban rows:
+
+- `IMPLEMENT_HANDOFF_DRIFT` — implement burned its pre-edit explore budget instead
+  of using the scout handoff (classified with `IMPLEMENT_BUDGET`).
+- `WORKTREE_PATH_VIOLATION` — a command touched the live checkout
+  (`/home/zoe/assistant`) instead of the task `workspace_path` (`~/.worktrees/<id>`).
+  Every phase runs in an isolated worktree; only `retro` runs in the live checkout
+  (read-only, `workspace_kind=dir`).
+- `IMPLEMENT_EDIT_SAFETY` — a malformed/unsafe edit; the worker blocks instead of
+  committing.
+- `ITERATION_BUDGET` — per-phase turn/iteration budget exceeded.
+
+**Evidence gate:** implement must record a `pr` evidence item (`PR_URL=` on a pushed
+branch) before verify/review advance; audit-only tickets use `AUDIT_ONLY=1` /
+`evidence_profile: audit`.
+
+**Capture-on-exit:** if implement finishes a diff but exits before pushing, the
+adapter's `_maybe_recover_unshipped_diff` commits + pushes the `wt/<task_id>` branch
+and opens a PR (only inside the task's own worktree branch; never main, never the
+live checkout, never `--force`, never an empty PR). See
+[MULTICA_HERMES_PR_LOOP.md](./MULTICA_HERMES_PR_LOOP.md).
+
 ## Usage
 
 ```bash
@@ -93,6 +118,7 @@ when pipeline JSONL shows repeated blocks.
 - 2026-06-01: Stuck Multica issue `6dfb0e14` repeats scout `gate_blocked` (missing tool evidence) and implement `fingerprint_abort` — use `skip_scout` on audit-only issues or clear the chain before re-dispatch.
 - 2026-06-01: `pipeline_store.sync_pipeline_from_chain` now passes `block_reason` into `transition()` history; older JSONL rows may still fail `block_reason_null` until archived.
 - 2026-06-01: Pytest fixture refs (`multica:u`, `multica:uuid-*`) in operator JSONL are ignored by the harness scanner; isolate tests with `ZOE_PIPELINE_STORE_PATH`.
+- 2026-06-15: The Hermes gateway has no Multica integration — it only executes ready+assigned Kanban tasks the Zoe adapter (`created_by=zoe-bridge`) creates. `kanban.dispatch_in_gateway` must stay `true` (it is the executor) but `kanban.auto_decompose` is kept `false` so the gateway never auto-creates/fans-out tickets out of band. Engineering tasks are worktree-isolated; only `retro` runs in the live checkout (read-only).
 
 ## Operator pause (stop Multica spend during manual work)
 

--- a/docs/guides/ENGINEERING_HARNESS_LOOP.md
+++ b/docs/guides/ENGINEERING_HARNESS_LOOP.md
@@ -79,7 +79,7 @@ branch) before verify/review advance; audit-only tickets use `AUDIT_ONLY=1` /
 
 **Capture-on-exit:** if implement finishes a diff but exits before pushing, the
 adapter's `_maybe_recover_unshipped_diff` commits + pushes the `wt/<task_id>` branch
-and opens a PR (only inside the task's own worktree branch; never main, never the
+and opens a PR (only inside the task's own worktree branch; never main/master, never the
 live checkout, never `--force`, never an empty PR). See
 [MULTICA_HERMES_PR_LOOP.md](./MULTICA_HERMES_PR_LOOP.md).
 

--- a/docs/guides/MULTICA_HERMES_PR_LOOP.md
+++ b/docs/guides/MULTICA_HERMES_PR_LOOP.md
@@ -3,6 +3,22 @@
 Multica is the operator-visible source of truth. Zoe owns deterministic phase
 control and the append-only journal; Hermes executes one bounded phase at a time.
 
+The Hermes worker that runs the `implement` phase loads the `zoe-engineering`
+skill (`~/.hermes/skills/zoe-engineering/SKILL.md` plus profile copies). That
+skill's **Harness Operating Model** section mirrors this guide: stay in the task
+worktree, terminal protocol (`kanban_complete`/`kanban_block`), one small PR per
+implement task. Keep the two in sync.
+
+> **Dispatch architecture.** The Hermes gateway (`hermes gateway run`, systemd
+> `hermes-agent.service`) is the *executor*: it spawns `work kanban task <id>`
+> worker subprocesses for **ready, assigned** tasks already on the Hermes Kanban
+> board (`kanban.dispatch_in_gateway: true` — required; disabling it stops all
+> worker execution). The gateway has **no Multica integration** — it never pulls
+> issues directly. The Zoe adapter (`services/zoe-data/executors/kanban_adapter.py`,
+> `created_by=zoe-bridge`) is the **only** authorized creator of engineering tasks
+> and emits worktree-isolated phase tasks. Gateway `kanban.auto_decompose` is kept
+> **false** so the gateway never auto-creates/fans-out tickets out of band.
+
 ## Required Setup
 
 - `ZOE_MULTICA=true`
@@ -90,6 +106,56 @@ Expected journal phase progression (one Kanban task exists at a time):
 - `closeout` (`zoe-planner`) — Greptile grep loop, squash merge when ready, Multica status update.
 - `retro` (`zoe-planner`) — learnings + optional follow-up issue; pipeline completes when retro finishes.
 - Engineering mode: `ZOE_ENGINEERING_MODE=interactive|overnight|quality-escalation` (or issue metadata) adjusts worker runtime and cost preference.
+
+### Worktree isolation (every task runs in its own checkout)
+
+Each phase task runs in an **isolated git worktree**, never the live checkout
+(`/home/zoe/assistant`):
+
+- The Zoe adapter pins `workspace_kind=worktree` and a `workspace_path` of
+  `~/.worktrees/<kanban_task_id>` on the Kanban row at dispatch (override root with
+  `ZOE_WORKTREE_ROOT`). `worktree_bootstrap.py` creates the worktree from
+  `origin/main` (fresh base), on branch `wt/<task_id>`.
+- The only phase that runs in the live checkout is `retro` (`workspace_kind=dir`,
+  `dir:<repo_root>`) — it is read-only orchestration/learning work, so it does not
+  spawn a phantom worktree after closeout has already merged.
+- Workers must run **all** git/test/validator/patch/PR commands from their
+  `workspace_path`. A single command that references `/home/zoe/assistant` trips the
+  `WORKTREE_PATH_VIOLATION` guard and ends the run. The worker prompts and the
+  `zoe-engineering` skill enforce this.
+
+### Budget and safety guards (kanban_adapter.py)
+
+The implement/verify/review/closeout prompts and `poll()` enforce fail-closed guards.
+A worker blocks (`kanban_block`) with a `BLOCKER=` fingerprint rather than drifting:
+
+| Guard / `BLOCKER` | Phase | What it prevents |
+|-------------------|-------|------------------|
+| `IMPLEMENT_HANDOFF_DRIFT` | implement | Burning the pre-edit explore budget hunting context instead of using the scout handoff; classified with `IMPLEMENT_BUDGET`. |
+| `WORKTREE_PATH_VIOLATION` | all | Any command run against the live checkout (`/home/zoe/assistant`) instead of the task `workspace_path`. |
+| `IMPLEMENT_EDIT_SAFETY` | implement | Committing/continuing with a malformed or unsafe edit; the worker blocks instead. |
+| `ITERATION_BUDGET` | all | Exceeding the per-phase turn/iteration budget; the run blocks instead of looping. |
+
+### Evidence gate (fail-closed advancement)
+
+`poll()` advances the journal only when `pipeline_evidence` requirements pass.
+Crucially, **implement must record a `pr` evidence item** (a `PR_URL=` on a pushed
+branch) before verify/review can run. Missing the `pr` evidence blocks advancement.
+Audit/doc-only tickets opt out with `AUDIT_ONLY=1` (blank `PR_URL`) or
+`evidence_profile: audit`.
+
+### Capture-on-exit (unshipped-diff salvage)
+
+If an implement worker finishes a complete diff but runs out of turns before
+`git commit`/`push`/`gh pr create`, the adapter's
+`_maybe_recover_unshipped_diff` salvages it: it commits the worktree diff,
+pushes branch `wt/<task_id>`, and opens a PR so the chain advances to verify
+instead of a fresh-worktree resume discarding the work and re-spending. Hard
+safety gates: it operates **only** inside the task's own `wt/<task_id>` branch
+(never `main`/`master`, never the live checkout, never `--force`) and never opens
+an empty PR. A sibling recovery, `_maybe_recover_pushed_pr`, handles the case
+where the worker pushed but lost the `PR_URL` handoff. Workers should still
+push + open the PR themselves; salvage is a backstop, not the plan.
 
 ### Hard-ticket split policy
 

--- a/docs/guides/MULTICA_HERMES_PR_LOOP.md
+++ b/docs/guides/MULTICA_HERMES_PR_LOOP.md
@@ -132,7 +132,7 @@ A worker blocks (`kanban_block`) with a `BLOCKER=` fingerprint rather than drift
 | Guard / `BLOCKER` | Phase | What it prevents |
 |-------------------|-------|------------------|
 | `IMPLEMENT_HANDOFF_DRIFT` | implement | Burning the pre-edit explore budget hunting context instead of using the scout handoff; classified with `IMPLEMENT_BUDGET`. |
-| `WORKTREE_PATH_VIOLATION` | all | Any command run against the live checkout (`/home/zoe/assistant`) instead of the task `workspace_path`. |
+| `WORKTREE_PATH_VIOLATION` | all except `retro` | Any command run against the live checkout (`/home/zoe/assistant`) instead of the task `workspace_path`. (`retro` is exempt — it runs read-only in the live checkout via `workspace_kind=dir`.) |
 | `IMPLEMENT_EDIT_SAFETY` | implement | Committing/continuing with a malformed or unsafe edit; the worker blocks instead. |
 | `ITERATION_BUDGET` | all | Exceeding the per-phase turn/iteration budget; the run blocks instead of looping. |
 


### PR DESCRIPTION
## Summary

Refreshes the two harness guides (both were dated Jun 6 and stale) to match the current Multica→Hermes autonomous engineering system. Docs-only; no production behavior change.

### `MULTICA_HERMES_PR_LOOP.md`
- New **Worktree isolation** section: every phase runs in an isolated `~/.worktrees/<task_id>` checkout pinned by the Zoe adapter (`worktree_bootstrap.py`, branch `wt/<task_id>`); only `retro` runs in the live checkout (read-only, `workspace_kind=dir`).
- New **Budget and safety guards** table: `IMPLEMENT_HANDOFF_DRIFT` (pre-edit explore budget), `WORKTREE_PATH_VIOLATION`, `IMPLEMENT_EDIT_SAFETY`, `ITERATION_BUDGET`.
- New **Evidence gate** section: implement must record a `pr` evidence item before verify/review advance.
- New **Capture-on-exit** section: `kanban_adapter._maybe_recover_unshipped_diff` salvages a finished-but-unpushed diff into a PR (own worktree branch only; never main/live/`--force`/empty PR).
- New **Dispatch architecture** note: the gateway is the executor (`dispatch_in_gateway` must stay true) with no Multica integration; `auto_decompose` kept false. Pointer to the `zoe-engineering` skill's Harness Operating Model.

### `ENGINEERING_HARNESS_LOOP.md`
- New **Worker block fingerprints** subsection (same guards), evidence-gate + capture-on-exit notes, and a 2026-06-15 learnings entry on dispatch architecture.

## Test
Docs-only change. Pre-commit validation passed on push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)