### PR TITLE
[codex] Add Skybridge clock ambient mode

### DIFF
--- a/services/zoe-data/routers/voice_tts.py
+++ b/services/zoe-data/routers/voice_tts.py
@@ -437,6 +437,36 @@ def _should_supersede_voice_weather_action(row, nav_key: str, card_key: str) -> 
     )
 
 
+def _should_supersede_voice_skybridge_action(row, nav_key: str, card_key: str) -> bool:
+    if row["idempotency_key"] in {nav_key, card_key}:
+        return False
+    try:
+        payload = json.loads(row["payload"] or "{}")
+    except Exception:
+        payload = {}
+    action_type = row["action_type"]
+    source = str(payload.get("source") or "").lower()
+    if source == "voice:skybridge":
+        return True
+    if action_type == "panel_navigate":
+        url = str(payload.get("url") or "").split("?", 1)[0]
+        return url in {
+            "/touch/calendar.html",
+            "/touch/weather.html",
+            "/touch/lists.html",
+            "/touch/chat.html",
+        }
+    if action_type == "show_card":
+        return str(payload.get("type") or "").lower() in {
+            "calendar",
+            "weather",
+            "list",
+            "lists",
+            "skybridge",
+        }
+    return False
+
+
 def _split_sentences(text: str) -> list[str]:
     """Split text into spoken sentences for streaming TTS.
 
@@ -699,23 +729,33 @@ async def _broadcast_skybridge_ui(
                 broadcast=False,
                 commit=False,
             )
-            current_card_id = card_message.get("action_id") or card_message.get("id")
-            if current_card_id:
-                await _db.execute(
-                    """UPDATE ui_actions
-                       SET status = 'skipped',
-                           error_code = 'superseded',
-                           error_message = 'Superseded by newer Skybridge voice card',
-                           updated_at = NOW()
-                       WHERE user_id = ?
-                         AND panel_id = ?
+            nav_key = f"voice_skybridge_nav_{panel_id}_{delivery_key}"
+            card_key = f"voice_skybridge_card_{panel_id}_{delivery_key}"
+            try:
+                _cur = await _db.execute(
+                    """SELECT id, action_type, payload, idempotency_key
+                       FROM ui_actions
+                       WHERE panel_id = ?
                          AND requested_by = 'voice'
-                         AND action_type = 'show_card'
-                         AND status IN ('queued', 'running')
-                         AND id != ?
-                         AND payload::jsonb->>'source' = 'voice:skybridge'""",
-                    (_panel_user_id, panel_id, current_card_id),
+                         AND status IN ('queued', 'running')""",
+                    (panel_id,),
                 )
+                _rows = await _cur.fetchall()
+                _superseded_at = datetime.now(timezone.utc).isoformat()
+                for _row in _rows:
+                    if not _should_supersede_voice_skybridge_action(_row, nav_key, card_key):
+                        continue
+                    await _db.execute(
+                        """UPDATE ui_actions
+                           SET status = 'skipped',
+                               error_code = 'superseded',
+                               error_message = 'Superseded by newer Skybridge voice request',
+                               updated_at = ?
+                           WHERE id = ?""",
+                        (_superseded_at, _row["id"]),
+                    )
+            except Exception as _sup_exc:
+                logger.debug("voice skybridge stale-action cleanup failed (non-fatal): %s", _sup_exc)
             await _db.commit()
             nav_delivered = await broadcaster.broadcast_to_panel(
                 panel_id,

--- a/services/zoe-data/routers/voice_tts.py
+++ b/services/zoe-data/routers/voice_tts.py
@@ -736,9 +736,10 @@ async def _broadcast_skybridge_ui(
                     """SELECT id, action_type, payload, idempotency_key
                        FROM ui_actions
                        WHERE panel_id = ?
+                         AND user_id = ?
                          AND requested_by = 'voice'
                          AND status IN ('queued', 'running')""",
-                    (panel_id,),
+                    (panel_id, _panel_user_id),
                 )
                 _rows = await _cur.fetchall()
                 _superseded_at = datetime.now(timezone.utc).isoformat()

--- a/services/zoe-data/skybridge_service.py
+++ b/services/zoe-data/skybridge_service.py
@@ -85,7 +85,11 @@ LIST_TYPE_ALIASES = {
 }
 PEOPLE_CONTEXTS = ("personal", "work")
 PEOPLE_CIRCLES = ("inner", "circle", "public")
-DEFAULT_CLOCK_TIMEZONE = os.environ.get("ZOE_SKYBRIDGE_TIMEZONE", "Australia/Perth")
+DEFAULT_CLOCK_TIMEZONE = "Australia/Perth"
+
+
+def _default_clock_timezone() -> str:
+    return os.environ.get("ZOE_SKYBRIDGE_TIMEZONE") or DEFAULT_CLOCK_TIMEZONE
 
 
 def _today() -> date:
@@ -93,7 +97,7 @@ def _today() -> date:
 
 
 def _clock_now(timezone_name: str | None = None) -> tuple[datetime, str]:
-    name = timezone_name or DEFAULT_CLOCK_TIMEZONE
+    name = timezone_name or _default_clock_timezone()
     try:
         tz = ZoneInfo(name)
     except ZoneInfoNotFoundError:

--- a/services/zoe-data/skybridge_service.py
+++ b/services/zoe-data/skybridge_service.py
@@ -625,7 +625,8 @@ async def _resolve_with_db(intent: SkybridgeIntent, user_id: str, db: Any, *, co
 
 def _resolve_clock(intent: SkybridgeIntent) -> dict[str, Any]:
     now, timezone_name = _clock_now()
-    spoken = now.strftime("It is %-I:%M %p.")
+    hour_str = str(now.hour % 12 or 12)
+    spoken = f"It is {hour_str}:{now.strftime('%M %p')}."
     return {
         "handled": True,
         "intent": {"domain": "clock", "action": intent.action, "timezone": timezone_name},
@@ -638,7 +639,7 @@ def _resolve_clock(intent: SkybridgeIntent) -> dict[str, Any]:
                 "summary": spoken,
                 "timezone": timezone_name,
                 "iso": now.isoformat(),
-                "hour": now.strftime("%-I"),
+                "hour": hour_str,
                 "minute": now.strftime("%M"),
                 "meridiem": now.strftime("%p"),
                 "weekday": now.strftime("%A"),

--- a/services/zoe-data/skybridge_service.py
+++ b/services/zoe-data/skybridge_service.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import os
 import re
 import uuid
 from dataclasses import dataclass
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta
 from typing import Any
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from calendar_utils import row_to_event
 from card_service import card_service
@@ -83,10 +85,21 @@ LIST_TYPE_ALIASES = {
 }
 PEOPLE_CONTEXTS = ("personal", "work")
 PEOPLE_CIRCLES = ("inner", "circle", "public")
+DEFAULT_CLOCK_TIMEZONE = os.environ.get("ZOE_SKYBRIDGE_TIMEZONE", "Australia/Perth")
 
 
 def _today() -> date:
     return date.today()
+
+
+def _clock_now(timezone_name: str | None = None) -> tuple[datetime, str]:
+    name = timezone_name or DEFAULT_CLOCK_TIMEZONE
+    try:
+        tz = ZoneInfo(name)
+    except ZoneInfoNotFoundError:
+        name = "UTC"
+        tz = ZoneInfo("UTC")
+    return datetime.now(tz), name
 
 
 async def _get_current(lat, lon, city, country):
@@ -489,6 +502,14 @@ def classify_skybridge_intent(message: str, context: dict[str, Any] | None = Non
         parsed_range = _calendar_date_from_text(text, _today())
         start = parsed_range[1] if parsed_range else _context_calendar_date(context)
         return SkybridgeIntent(domain="calendar", action="create_event", title=title, target_time=target_time, range_label=start.isoformat(), start_date=start, end_date=start)
+    if (
+        " clock " in text
+        or re.search(r"\bwhat(?:'s| is)?\s+the\s+time\b", text)
+        or re.search(r"\bwhat\s+time\s+is\s+it\b", text)
+        or re.search(r"\bshow\s+(?:me\s+)?(?:the\s+)?time\b", text)
+        or re.search(r"\bcurrent\s+time\b", text)
+    ):
+        return SkybridgeIntent(domain="clock", action="show")
     if any(term in text for term in (" weather", " forecast", " temperature", " rain", " windy", " wind ")):
         action = "forecast" if any(term in text for term in ("forecast", "tomorrow", "week", "next few days")) else "current"
         return SkybridgeIntent(domain="weather", action=action)
@@ -550,6 +571,9 @@ async def resolve_skybridge_request(
     if skybridge_intent_requires_identity(intent) and _is_guest_user(user_id):
         return _attach_skybridge_context(_auth_required_result(intent))
 
+    if intent.domain == "clock":
+        return _attach_skybridge_context(_resolve_clock(intent))
+
     if db is not None:
         return _attach_skybridge_context(await _resolve_with_db(intent, user_id, db, context=context))
 
@@ -576,6 +600,8 @@ def skybridge_intent_requires_identity(intent: SkybridgeIntent | None) -> bool:
 
 
 async def _resolve_with_db(intent: SkybridgeIntent, user_id: str, db: Any, *, context: dict[str, Any] | None = None) -> dict[str, Any]:
+    if intent.domain == "clock":
+        return _resolve_clock(intent)
     if intent.domain == "calendar":
         if intent.action == "create_event":
             return await _resolve_calendar_create(intent, user_id, db)
@@ -595,6 +621,31 @@ async def _resolve_with_db(intent: SkybridgeIntent, user_id: str, db: Any, *, co
             return await _resolve_people_remember_fact(intent, user_id, db)
         return await _resolve_people(intent, user_id, db)
     return {"handled": False, "intent": None, "spoken_summary": "", "cards": []}
+
+
+def _resolve_clock(intent: SkybridgeIntent) -> dict[str, Any]:
+    now, timezone_name = _clock_now()
+    spoken = now.strftime("It is %-I:%M %p.")
+    return {
+        "handled": True,
+        "intent": {"domain": "clock", "action": intent.action, "timezone": timezone_name},
+        "spoken_summary": spoken,
+        "cards": [{
+            "component": "status",
+            "props": {
+                "source": "clock_show",
+                "title": "Clock",
+                "summary": spoken,
+                "timezone": timezone_name,
+                "iso": now.isoformat(),
+                "hour": now.strftime("%-I"),
+                "minute": now.strftime("%M"),
+                "meridiem": now.strftime("%p"),
+                "weekday": now.strftime("%A"),
+                "date_label": now.strftime("%d %B"),
+            },
+        }],
+    }
 
 
 async def _maybe_commit(db: Any) -> None:

--- a/services/zoe-data/tests/test_skybridge_service.py
+++ b/services/zoe-data/tests/test_skybridge_service.py
@@ -171,6 +171,8 @@ class GuardedGuestDb(FakeDb):
 def test_classify_calendar_and_weather_requests():
     assert classify_skybridge_intent("show my calendar").domain == "calendar"
     assert classify_skybridge_intent("show me the weather").domain == "weather"
+    assert classify_skybridge_intent("show me the clock").domain == "clock"
+    assert classify_skybridge_intent("what time is it").domain == "clock"
     assert classify_skybridge_intent("what is happening this week").domain == "calendar"
     assert classify_skybridge_intent("show my shopping list").domain == "lists"
     assert classify_skybridge_intent("what's on my shopping list").domain == "lists"
@@ -197,6 +199,21 @@ def test_classify_calendar_and_weather_requests():
     assert classify_skybridge_intent("find Sarah").domain == "people"
     assert classify_skybridge_intent("what is there to do this week") is None
     assert classify_skybridge_intent("open settings") is None
+
+
+@pytest.mark.asyncio
+async def test_clock_request_returns_public_live_clock_card():
+    result = await resolve_skybridge_request("show me the clock", "guest", db=GuardedGuestDb())
+
+    assert result["handled"] is True
+    assert result["intent"]["domain"] == "clock"
+    assert result["intent"]["action"] == "show"
+    assert result["cards"][0]["component"] == "status"
+    props = result["cards"][0]["props"]
+    assert props["source"] == "clock_show"
+    assert props["timezone"]
+    assert props["iso"]
+    assert "auth_required" not in result
 
 
 def test_classify_skybridge_action_requests():

--- a/services/zoe-data/tests/test_skybridge_static.py
+++ b/services/zoe-data/tests/test_skybridge_static.py
@@ -364,6 +364,9 @@ def test_skybridge_returns_to_ambient_clock_after_card_idle():
     assert "function updateAllClocks()" in app
     assert "document.querySelectorAll('.sky-live-clock')" in app
     assert "id=\"skyAmbientClock\"" in html
+    ambient_start = html.index("id=\"skyAmbientClock\"")
+    ambient_tag = html[html.rfind("<div", 0, ambient_start):html.find(">", ambient_start) + 1]
+    assert "aria-live" not in ambient_tag
     assert "body.sky-empty.sky-ambient-clock .sky-ambient-clock" in html
 
 

--- a/services/zoe-data/tests/test_skybridge_static.py
+++ b/services/zoe-data/tests/test_skybridge_static.py
@@ -315,9 +315,11 @@ def test_skybridge_renderer_supports_real_data_cards():
     assert "props.source === 'list_show'" in renderer
     assert "props.source === 'people_directory'" in renderer
     assert "props.source === 'person_profile'" in renderer
+    assert "props.source === 'clock_show'" in renderer
     assert "renderZoeList(props)" in renderer
     assert "renderPeopleDirectory(props)" in renderer
     assert "renderPersonProfile(props)" in renderer
+    assert "renderClock(props)" in renderer
     assert "sky-list-scene" in renderer
     assert "sky-people-scene" in renderer
     assert "sky-profile-scene" in renderer
@@ -334,6 +336,10 @@ def test_skybridge_renderer_supports_real_data_cards():
     assert "sky-profile-health" in data_widgets_css
     assert "--sky-accent-work: 37, 99, 235" in data_widgets_css
     assert "--sky-accent-personal: 147, 51, 234" in data_widgets_css
+    assert "sky-clock-scene" in data_widgets_css
+    assert "sky-live-clock" in renderer
+    assert "skyAmbientClock" in html
+    assert "sky-ambient-clock" in html
     assert "sky-weather-scene" in html
     assert "weather-sunny" in html
     assert "skybridge-runtime-overrides" in html
@@ -344,6 +350,21 @@ def test_skybridge_renderer_supports_real_data_cards():
     assert "skybridge-push-ack-1" in html
     assert "backdrop-filter: none !important" in html
     assert "No events " in renderer
+
+
+def test_skybridge_returns_to_ambient_clock_after_card_idle():
+    app = read(UI / "js" / "skybridge.js")
+    html = read(UI / "skybridge.html")
+
+    assert "CARD_IDLE_MS" in app
+    assert "skybridge_idle_return_ms" in app
+    assert "function scheduleIdleReturn()" in app
+    assert "function returnToAmbientClock()" in app
+    assert "renderHome({ idle: true })" in app
+    assert "function updateAllClocks()" in app
+    assert "document.querySelectorAll('.sky-live-clock')" in app
+    assert "id=\"skyAmbientClock\"" in html
+    assert "body.sky-empty.sky-ambient-clock .sky-ambient-clock" in html
 
 
 def test_skybridge_weather_renderer_uses_widget_forecast_structure():

--- a/services/zoe-data/tests/test_voice_weather_queue.py
+++ b/services/zoe-data/tests/test_voice_weather_queue.py
@@ -335,6 +335,13 @@ async def test_broadcast_skybridge_ui_opens_skybridge_with_card_payload(monkeypa
     assert [call["action_type"] for call in enqueue_calls] == ["panel_navigate", "show_card"]
     assert enqueue_calls[0]["payload"]["url"] == "/touch/skybridge.html?q=show+weather"
     assert enqueue_calls[0]["broadcast"] is False
+    assert {call["user_id"] for call in enqueue_calls} == {"panel-user"}
+    cleanup_selects = [
+        params
+        for sql, params in db.executed
+        if "FROM ui_actions" in sql and "user_id = ?" in sql
+    ]
+    assert cleanup_selects == [("panel-1", "panel-user")]
     assert enqueue_calls[1]["payload"]["type"] == "skybridge"
     assert enqueue_calls[1]["payload"]["card"] == card
     assert enqueue_calls[1]["payload"]["result"] == result

--- a/services/zoe-data/tests/test_voice_weather_queue.py
+++ b/services/zoe-data/tests/test_voice_weather_queue.py
@@ -9,6 +9,7 @@ import routers.voice_tts as voice_tts
 from routers.voice_tts import (
     _broadcast_skybridge_ui,
     _broadcast_weather_ui,
+    _should_supersede_voice_skybridge_action,
     _should_supersede_voice_weather_action,
     voice_command,
 )
@@ -56,6 +57,34 @@ def test_ignores_non_weather_actions() -> None:
     )
     assert not _should_supersede_voice_weather_action(
         _row("show_card", {"type": "calendar"}),
+        "new-nav",
+        "new-card",
+    )
+
+
+def test_supersedes_stale_voice_actions_for_skybridge_surface() -> None:
+    assert _should_supersede_voice_skybridge_action(
+        _row("panel_navigate", {"url": "/touch/calendar.html"}),
+        "new-nav",
+        "new-card",
+    )
+    assert _should_supersede_voice_skybridge_action(
+        _row("panel_navigate", {"url": "/touch/weather.html?panel_id=panel-1"}),
+        "new-nav",
+        "new-card",
+    )
+    assert _should_supersede_voice_skybridge_action(
+        _row("show_card", {"type": "calendar"}),
+        "new-nav",
+        "new-card",
+    )
+    assert _should_supersede_voice_skybridge_action(
+        _row("show_card", {"source": "voice:skybridge"}),
+        "new-nav",
+        "new-card",
+    )
+    assert not _should_supersede_voice_skybridge_action(
+        _row("panel_navigate", {"url": "/touch/skybridge.html"}, key="new-nav"),
         "new-nav",
         "new-card",
     )
@@ -313,10 +342,16 @@ async def test_broadcast_skybridge_ui_opens_skybridge_with_card_payload(monkeypa
     assert [item[1] for item in broadcasts] == ["ui_action"]
     assert [item[2]["action_id"] for item in broadcasts] == ["db-panel_navigate"]
     assert [item[2]["action_type"] for item in broadcasts] == ["panel_navigate"]
-    assert db.updated_ids == ["panel-1", "db-panel_navigate"]
+    assert db.updated_ids == [
+        "old-nav-null-key",
+        "old-card",
+        "current-nav",
+        "current-card",
+        "calendar",
+        "db-panel_navigate",
+    ]
     assert "commit" in db.events
-    cleanup_sql = next(sql for sql, _params in db.executed if "payload::jsonb" in sql)
-    assert "payload::jsonb->>'source' = 'voice:skybridge'" in cleanup_sql
+    assert not any("payload::jsonb" in sql for sql, _params in db.executed)
 
 
 @pytest.mark.asyncio
@@ -371,18 +406,20 @@ async def test_broadcast_skybridge_ui_skips_supersession_when_card_id_missing(mo
 
     assert [call["action_type"] for call in enqueue_calls] == ["panel_navigate", "show_card"]
     assert [item[1] for item in broadcasts] == ["ui_action"]
+    assert "calendar" in db.updated_ids
     assert not any("payload::jsonb" in sql for sql, _params in db.executed)
 
 
 @pytest.mark.parametrize(
-    ("utterance", "resolver_text"),
+    ("utterance", "resolver_text", "domain", "reply"),
     [
-        ("show weather", "show weather"),
-        ("show whether", "show weather"),
+        ("show weather", "show weather", "weather", "It is sunny in Perth."),
+        ("show whether", "show weather", "weather", "It is sunny in Perth."),
+        ("show my calendar", "show my calendar", "calendar", "Here is your calendar."),
     ],
 )
 @pytest.mark.asyncio
-async def test_voice_command_uses_skybridge_fast_path(monkeypatch, utterance, resolver_text) -> None:
+async def test_voice_command_uses_skybridge_fast_path(monkeypatch, utterance, resolver_text, domain, reply) -> None:
     calls: dict[str, object] = {"broadcast": [], "events": []}
 
     async def resolve_skybridge_request(text, user_id, *, context=None, db=None):
@@ -394,15 +431,15 @@ async def test_voice_command_uses_skybridge_fast_path(monkeypatch, utterance, re
         }
         return {
             "handled": True,
-            "spoken_summary": "It is sunny in Perth.",
-            "intent": {"domain": "weather", "action": "current"},
-            "skybridge_context": {"domain": "weather"},
+            "spoken_summary": reply,
+            "intent": {"domain": domain, "action": "current"},
+            "skybridge_context": {"domain": domain},
             "cards": [
                 {
                     "schema_version": "1.0.0",
                     "card_type": "generic",
                     "card_id": "22222222-2222-2222-2222-222222222222",
-                    "content": {"title": "Weather", "source": "weather_current"},
+                    "content": {"title": domain.title(), "source": f"{domain}_current"},
                     "producer": "test",
                     "producer_version": "1",
                     "created_at": "2026-06-14T00:00:00Z",
@@ -467,19 +504,19 @@ async def test_voice_command_uses_skybridge_fast_path(monkeypatch, utterance, re
 
     assert response["ok"] is True
     assert response["panel_id"] == "panel-sky"
-    assert response["reply"] == "It is sunny in Perth."
-    assert response["intent"] == "skybridge:weather"
+    assert response["reply"] == reply
+    assert response["intent"] == f"skybridge:{domain}"
     assert response["skybridge"] is True
     assert response["audio_base64"]
     assert calls["resolver"]["text"] == resolver_text
     assert calls["resolver"]["user_id"] == "guest"
     assert calls["broadcast_skybridge_ui"]["panel_id"] == "panel-sky"
     assert calls["broadcast_skybridge_ui"]["utterance"] == resolver_text
-    assert calls["synthesize"] == {"text": "It is sunny in Perth."}
-    assert ("all", "voice:responding", {"panel_id": "panel-sky", "text": "It is sunny in Perth."}) in calls["broadcast"]
+    assert calls["synthesize"] == {"text": reply}
+    assert ("all", "voice:responding", {"panel_id": "panel-sky", "text": reply}) in calls["broadcast"]
     assert ("all", "voice:done", {"panel_id": "panel-sky"}) in calls["broadcast"]
     assert calls["events"].index("synthesize") < calls["events"].index("voice:done")
-    assert voice_tts._VOICE_SESSIONS["panel-sky"]["skybridge_context"] == {"domain": "weather"}
+    assert voice_tts._VOICE_SESSIONS["panel-sky"]["skybridge_context"] == {"domain": domain}
 
 
 @pytest.mark.asyncio

--- a/services/zoe-ui/dist/touch/css/skybridge-data-widgets.css
+++ b/services/zoe-ui/dist/touch/css/skybridge-data-widgets.css
@@ -30,6 +30,98 @@ body:not(.sky-empty) .sky-accent-all {
     --sky-card-accent: var(--sky-accent-general);
 }
 
+body:not(.sky-empty) .clock-card.sky-premium-card {
+    background:
+        radial-gradient(circle at 13% 10%, rgba(90,224,224,0.2), transparent 34%),
+        radial-gradient(circle at 88% 12%, rgba(147,51,234,0.2), transparent 36%),
+        linear-gradient(145deg, rgba(14,19,30,0.96), rgba(5,7,12,0.99)) !important;
+    border-color: rgba(255,255,255,0.15) !important;
+    min-height: min(610px, calc(100dvh - 110px)) !important;
+    padding: clamp(24px, 2.5vw, 34px) !important;
+    position: relative;
+    overflow: hidden !important;
+}
+
+body:not(.sky-empty) .sky-clock-scene {
+    height: 100%;
+    min-height: 100%;
+    position: static;
+    text-align: center;
+}
+
+body:not(.sky-empty) .sky-clock-main {
+    position: static;
+}
+
+body:not(.sky-empty) .sky-clock-time {
+    position: absolute;
+    top: 53%;
+    left: 0;
+    right: 0;
+    transform: translateY(-50%);
+    display: flex;
+    align-items: baseline;
+    justify-content: center;
+    gap: clamp(10px, 1.4vw, 18px);
+    color: white;
+    font-variant-numeric: tabular-nums;
+    line-height: 0.78;
+}
+
+body:not(.sky-empty) .sky-clock-time span {
+    font-size: clamp(12.2rem, 23.5vw, 20.2rem);
+    font-weight: 860;
+    letter-spacing: 0;
+}
+
+body:not(.sky-empty) .sky-clock-time i {
+    font-size: clamp(9.4rem, 18vw, 15.4rem);
+    font-style: normal;
+    opacity: 0.42;
+}
+
+body:not(.sky-empty) .sky-clock-time b {
+    margin-left: clamp(6px, 0.9vw, 12px);
+    color: rgba(255,255,255,0.56);
+    font-size: clamp(2.1rem, 3.5vw, 3.15rem);
+    font-weight: 850;
+    letter-spacing: 0;
+    text-transform: uppercase;
+}
+
+body:not(.sky-empty) .sky-clock-date {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: clamp(28px, 5vh, 42px);
+    z-index: 8;
+    color: rgba(255,255,255,0.66);
+    font-size: clamp(1.7rem, 3.2vw, 2.65rem);
+    font-weight: 800;
+    line-height: 1;
+}
+
+body:not(.sky-empty) .sky-clock-footer {
+    display: flex;
+    justify-content: center;
+    position: absolute;
+    left: clamp(26px, 3vw, 42px);
+    right: clamp(26px, 3vw, 42px);
+    bottom: clamp(24px, 3vh, 36px);
+}
+
+body:not(.sky-empty) .sky-clock-zone {
+    display: inline-flex;
+    width: fit-content;
+    border-radius: 999px;
+    padding: 10px 16px;
+    color: rgba(255,255,255,0.54);
+    background: rgba(255,255,255,0.065);
+    border: 1px solid rgba(255,255,255,0.095);
+    font-size: clamp(0.98rem, 1.5vw, 1.28rem);
+    font-weight: 800;
+}
+
 body:not(.sky-empty) .zoe-list-card {
     --sky-card-accent: var(--sky-accent-shopping);
     background:

--- a/services/zoe-ui/dist/touch/css/skybridge-data-widgets.css
+++ b/services/zoe-ui/dist/touch/css/skybridge-data-widgets.css
@@ -101,26 +101,6 @@ body:not(.sky-empty) .sky-clock-date {
     line-height: 1;
 }
 
-body:not(.sky-empty) .sky-clock-footer {
-    display: flex;
-    justify-content: center;
-    position: absolute;
-    left: clamp(26px, 3vw, 42px);
-    right: clamp(26px, 3vw, 42px);
-    bottom: clamp(24px, 3vh, 36px);
-}
-
-body:not(.sky-empty) .sky-clock-zone {
-    display: inline-flex;
-    width: fit-content;
-    border-radius: 999px;
-    padding: 10px 16px;
-    color: rgba(255,255,255,0.54);
-    background: rgba(255,255,255,0.065);
-    border: 1px solid rgba(255,255,255,0.095);
-    font-size: clamp(0.98rem, 1.5vw, 1.28rem);
-    font-weight: 800;
-}
 
 body:not(.sky-empty) .zoe-list-card {
     --sky-card-accent: var(--sky-accent-shopping);

--- a/services/zoe-ui/dist/touch/js/skybridge-renderer.js
+++ b/services/zoe-ui/dist/touch/js/skybridge-renderer.js
@@ -88,6 +88,7 @@
         if (props.source === 'list_show') return renderZoeList(props);
         if (props.source === 'people_directory') return renderPeopleDirectory(props);
         if (props.source === 'person_profile') return renderPersonProfile(props);
+        if (props.source === 'clock_show') return renderClock(props);
         const body = [
             props.metric ? '<div class="sky-widget-metric"><strong>' + escapeHtml(props.metric) + '</strong><span>' + escapeHtml(props.metric_label || '') + '</span></div>' : '',
             '<div class="sky-card-body">' + escapeHtml(props.body || props.message || '') + '</div>'
@@ -342,6 +343,39 @@
             '</div>'
         ].join('');
         return cardFrame(Object.assign({ status: 'Weather', icon: 'W' }, props), body, { wide: true, tone: 'weather-card ' + weatherClass(props, current) });
+    }
+
+    function clockParts(timezone) {
+        const options = timezone ? { timeZone: timezone } : {};
+        const now = new Date();
+        const time = new Intl.DateTimeFormat(undefined, Object.assign({
+            hour: 'numeric',
+            minute: '2-digit',
+            hour12: true
+        }, options)).formatToParts(now);
+        const date = new Intl.DateTimeFormat(undefined, Object.assign({
+            weekday: 'long',
+            day: 'numeric',
+            month: 'long'
+        }, options)).format(now);
+        const hour = (time.find(part => part.type === 'hour') || {}).value || '';
+        const minute = (time.find(part => part.type === 'minute') || {}).value || '';
+        const dayPeriod = (time.find(part => part.type === 'dayPeriod') || {}).value || '';
+        return { hour, minute, dayPeriod, date };
+    }
+
+    function renderClock(props) {
+        const timezone = props.timezone || '';
+        const parts = clockParts(timezone);
+        const body = [
+            '<div class="sky-clock-scene sky-live-clock" data-timezone="' + escapeHtml(timezone) + '">',
+            '<div class="sky-clock-main">',
+            '<div class="sky-clock-time"><span data-clock-hour>' + escapeHtml(parts.hour || props.hour || '') + '</span><i>:</i><span data-clock-minute>' + escapeHtml(parts.minute || props.minute || '') + '</span><b data-clock-meridiem>' + escapeHtml(parts.dayPeriod || props.meridiem || '') + '</b></div>',
+            '<div class="sky-clock-date" data-clock-date>' + escapeHtml(parts.date || [props.weekday, props.date_label].filter(Boolean).join(', ')) + '</div>',
+            '</div>',
+            '</div>'
+        ].join('');
+        return cardFrame(Object.assign({ status: 'Clock', icon: 'C' }, props), body, { wide: true, tone: 'clock-card', hideHeader: true, hideStatus: true, hideActions: true });
     }
 
     function normalizeListItems(items) {

--- a/services/zoe-ui/dist/touch/js/skybridge.js
+++ b/services/zoe-ui/dist/touch/js/skybridge.js
@@ -15,6 +15,12 @@
     let skybridgeContext = {};
     let authProfiles = [];
     let authHydrationSequence = 0;
+    let idleTimer = null;
+    let clockTicker = null;
+
+    const queryParams = new URLSearchParams(location.search);
+    const configuredIdleMs = Number(queryParams.get('idle_ms') || localStorage.getItem('skybridge_idle_return_ms') || 75000);
+    const CARD_IDLE_MS = Number.isFinite(configuredIdleMs) ? Math.max(15000, configuredIdleMs) : 75000;
 
     const colors = {
         ambient: ['#5fc6ff', '#66d19e'],
@@ -27,6 +33,7 @@
         cacheEls();
         bindEvents();
         startOrb();
+        startClockTicker();
         renderHome();
         loadBackendStatus();
         setMode(mode);
@@ -58,6 +65,7 @@
         els.transcript = document.getElementById('skyTranscript');
         els.copy = document.getElementById('skyListeningCopy');
         els.form = document.getElementById('skyCommandForm');
+        els.commandCopy = document.getElementById('skyCommandCopy');
         els.input = document.getElementById('skyCommandInput');
         els.mic = document.getElementById('skyMicBtn');
         els.home = document.getElementById('skyHomeBtn');
@@ -67,6 +75,11 @@
         els.voiceTitle = document.getElementById('skyVoiceTitle');
         els.voiceDetail = document.getElementById('skyVoiceDetail');
         els.voiceAction = document.getElementById('skyVoiceAction');
+        els.ambientClock = document.getElementById('skyAmbientClock');
+        els.ambientClockHour = document.getElementById('skyAmbientClockHour');
+        els.ambientClockMinute = document.getElementById('skyAmbientClockMinute');
+        els.ambientClockMeridiem = document.getElementById('skyAmbientClockMeridiem');
+        els.ambientClockDate = document.getElementById('skyAmbientClockDate');
         els.canvas = document.getElementById('skyOrb');
         els.ctx = els.canvas.getContext('2d');
     }
@@ -93,6 +106,9 @@
         els.orbButton.addEventListener('click', toggleVoiceCapture);
         els.voiceAction.addEventListener('click', toggleVoiceCapture);
         els.home.addEventListener('click', () => renderHome({ showCards: true }));
+        ['pointerdown', 'keydown', 'touchstart'].forEach(type => {
+            document.addEventListener(type, noteUserActivity, { passive: true });
+        });
         els.cards.addEventListener('click', event => {
             const btn = event.target.closest('button[data-sky-action]');
             if (!btn) return;
@@ -179,6 +195,7 @@
             addTranscript(event.role, event.text);
         } else if (event.type === 'card') {
             addCard(event.card, true);
+            scheduleIdleReturn();
         } else if (event.type === 'cards') {
             renderSkybridgeResult(event.result || event);
         } else if (event.type === 'skybridge_context') {
@@ -201,7 +218,7 @@
             return;
         }
         currentUtterance = 'Heard: ' + query;
-        els.copy.textContent = currentUtterance;
+        setVoiceLayerText(currentUtterance);
         addTranscript('user', query);
         setState('thinking');
         const resolved = await resolveCommand(query);
@@ -267,7 +284,7 @@
         skybridgeContext = data.skybridge_context || skybridgeContext || {};
         setContext(contextLabelFor(intent), data.spoken_summary || 'Showing live data.');
         currentUtterance = data.spoken_summary || currentUtterance;
-        els.copy.textContent = currentUtterance;
+        setVoiceLayerText(currentUtterance);
         cards.forEach((card, index) => addCard(card, false, index * 90));
         if (!cards.length) {
             addCard({
@@ -279,6 +296,7 @@
                 }
             }, true);
         }
+        scheduleIdleReturn();
     }
 
     async function retireRenderedVoiceCards(data) {
@@ -331,6 +349,7 @@
             return;
         }
         clearCards();
+        scheduleIdleReturn();
         const top = matches[0];
         if (top.kind === 'setting') {
             setContext('Settings', top.title + ' is active for follow-up commands.');
@@ -354,15 +373,19 @@
 
     function renderHome(options) {
         const showCards = options && options.showCards;
+        clearIdleTimer();
         document.body.classList.add('sky-empty');
+        document.body.classList.add('sky-ambient-clock');
         commandFallbackOpen = false;
         document.body.classList.remove('sky-command-open');
+        document.body.classList.remove('sky-typing-fallback');
         syncVoiceFallbackState();
         currentUtterance = '';
         skybridgeContext = {};
         setContext('Listening', 'The surface will build itself when Zoe understands what you need.');
         clearCards();
-        els.copy.textContent = 'Listening. Ask Zoe for anything.';
+        setVoiceLayerText('Listening. Ask Zoe for anything.');
+        updateAllClocks();
         if (showCards && window.SkybridgeCapabilities && typeof window.SkybridgeCapabilities.getHomeCards === 'function') {
             setContext('Skybridge home', 'Start with voice, then keep the useful cards in reach.');
             window.SkybridgeCapabilities.getHomeCards().forEach((card, index) => {
@@ -377,11 +400,13 @@
         cardSequence = 0;
         els.cards.innerHTML = '';
         document.body.classList.add('sky-empty');
+        document.body.classList.add('sky-ambient-clock');
         requestAnimationFrame(resizeOrb);
     }
 
     function addCard(card, prepend, delayMs) {
         document.body.classList.remove('sky-empty');
+        document.body.classList.remove('sky-ambient-clock');
         requestAnimationFrame(resizeOrb);
         const wrapper = document.createElement('div');
         wrapper.innerHTML = window.SkybridgeRenderer.render(card);
@@ -395,9 +420,85 @@
             els.cards.appendChild(node);
         }
         hydrateAuthCard(node, card);
+        updateAllClocks();
+        scheduleIdleReturn();
         while (els.cards.children.length > 8) {
             els.cards.removeChild(els.cards.lastElementChild);
         }
+    }
+
+    function clearIdleTimer() {
+        if (idleTimer) {
+            clearTimeout(idleTimer);
+            idleTimer = null;
+        }
+    }
+
+    function noteUserActivity() {
+        if (!document.body.classList.contains('sky-empty')) {
+            scheduleIdleReturn();
+        }
+    }
+
+    function scheduleIdleReturn() {
+        clearIdleTimer();
+        if (document.body.classList.contains('sky-empty')) return;
+        idleTimer = setTimeout(returnToAmbientClock, CARD_IDLE_MS);
+    }
+
+    function returnToAmbientClock() {
+        idleTimer = null;
+        const voiceBusy = voice && (voice.isRecording || voice.speaking || voice.serverBusy);
+        if (voiceBusy || orbState === 'listening' || orbState === 'thinking' || orbState === 'responding') {
+            scheduleIdleReturn();
+            return;
+        }
+        renderHome({ idle: true });
+        setStatus('Ambient');
+    }
+
+    function startClockTicker() {
+        updateAllClocks();
+        clockTicker = setInterval(updateAllClocks, 1000);
+    }
+
+    function clockParts(timezone) {
+        const options = timezone ? { timeZone: timezone } : {};
+        const now = new Date();
+        const timeParts = new Intl.DateTimeFormat(undefined, Object.assign({
+            hour: 'numeric',
+            minute: '2-digit',
+            hour12: true
+        }, options)).formatToParts(now);
+        const dateLabel = new Intl.DateTimeFormat(undefined, Object.assign({
+            weekday: 'long',
+            day: 'numeric',
+            month: 'long'
+        }, options)).format(now);
+        return {
+            hour: (timeParts.find(part => part.type === 'hour') || {}).value || '',
+            minute: (timeParts.find(part => part.type === 'minute') || {}).value || '',
+            meridiem: (timeParts.find(part => part.type === 'dayPeriod') || {}).value || '',
+            date: dateLabel
+        };
+    }
+
+    function updateClockElement(root, timezone) {
+        if (!root) return;
+        const parts = clockParts(timezone || root.dataset.timezone || '');
+        const hour = root.querySelector('[data-clock-hour]');
+        const minute = root.querySelector('[data-clock-minute]');
+        const meridiem = root.querySelector('[data-clock-meridiem]');
+        const dateLabel = root.querySelector('[data-clock-date]');
+        if (hour) hour.textContent = parts.hour;
+        if (minute) minute.textContent = parts.minute;
+        if (meridiem) meridiem.textContent = parts.meridiem;
+        if (dateLabel) dateLabel.textContent = parts.date;
+    }
+
+    function updateAllClocks() {
+        if (els.ambientClock) updateClockElement(els.ambientClock);
+        document.querySelectorAll('.sky-live-clock').forEach(node => updateClockElement(node));
     }
 
     async function hydrateAuthCard(node, card) {
@@ -500,7 +601,7 @@
     function addTranscript(role, text) {
         if (!text) return;
         currentUtterance = (role === 'user' ? 'Heard: ' : 'Zoe: ') + text;
-        els.copy.textContent = currentUtterance;
+        setVoiceLayerText(currentUtterance);
         const line = document.createElement('div');
         line.className = 'sky-line';
         line.innerHTML = '<strong>' + (role === 'user' ? 'You' : 'Zoe') + ':</strong> ' + window.SkybridgeRenderer.escapeHtml(text);
@@ -522,16 +623,16 @@
         if (transportNotice && (document.body.classList.contains('sky-empty') || currentUtterance)) return;
         if (!document.body.classList.contains('sky-empty')) {
             const previous = currentUtterance;
-            els.copy.textContent = 'Notice: ' + text;
+            setVoiceLayerText('Notice: ' + text);
             if (previous) {
                 setTimeout(() => {
                     if (!document.body.classList.contains('sky-empty') && currentUtterance === previous) {
-                        els.copy.textContent = previous;
+                        setVoiceLayerText(previous);
                     }
                 }, 4500);
             }
         } else {
-            els.copy.textContent = text;
+            setVoiceLayerText(text);
         }
     }
 
@@ -548,7 +649,7 @@
             responding: 'Zoe is speaking. You can interrupt when needed.'
         };
         if (document.body.classList.contains('sky-empty') || !currentUtterance) {
-            els.copy.textContent = copy[state] || copy.ambient;
+            setVoiceLayerText(copy[state] || copy.ambient);
         }
         setStatus(state.charAt(0).toUpperCase() + state.slice(1));
         updateVoiceControl(state);
@@ -566,10 +667,17 @@
     function openCommandFallback(message) {
         commandFallbackOpen = true;
         document.body.classList.add('sky-command-open');
+        document.body.classList.add('sky-typing-fallback');
         document.body.classList.toggle('sky-voice-fallback', !canUseMicrophone());
         if (message) els.input.placeholder = message;
         updateVoiceHint('Type to Zoe', message || 'Voice is unavailable here. The same resolver will render cards from typed requests.', 'Type');
         requestAnimationFrame(() => els.input.focus({ preventScroll: true }));
+    }
+
+    function setVoiceLayerText(text) {
+        const value = text || 'Listening';
+        els.copy.textContent = value;
+        if (els.commandCopy) els.commandCopy.textContent = value;
     }
 
     function getMicGuidance() {
@@ -711,6 +819,8 @@
 
     window.addEventListener('beforeunload', () => {
         if (animationFrame) cancelAnimationFrame(animationFrame);
+        if (clockTicker) clearInterval(clockTicker);
+        clearIdleTimer();
         if (voice) voice.stop();
     });
 

--- a/services/zoe-ui/dist/touch/skybridge.html
+++ b/services/zoe-ui/dist/touch/skybridge.html
@@ -3913,7 +3913,12 @@
     <style id="skybridge-touch-panel-fit">
         @media (min-width: 900px) and (max-height: 760px) {
             body:not(.sky-empty) .sky-stage {
-                inset: 10px 0 76px !important;
+                inset: 10px 0 92px !important;
+                width: min(1232px, calc(100vw - 32px)) !important;
+            }
+
+            body.sky-command-open:not(.sky-empty) .sky-stage {
+                inset: 10px 0 92px !important;
                 width: min(1232px, calc(100vw - 32px)) !important;
             }
 
@@ -4074,15 +4079,36 @@
             }
 
             body:not(.sky-empty) .calendar-card.sky-premium-card,
+            body:not(.sky-empty) .clock-card.sky-premium-card,
             body:not(.sky-empty) .zoe-list-card.sky-premium-card,
             body:not(.sky-empty) .sky-card.list-card.sky-premium-card,
             body:not(.sky-empty) .people-card.sky-premium-card,
             body:not(.sky-empty) .person-profile-card.sky-premium-card,
             body:not(.sky-empty) .sky-card.auth-challenge {
-                height: min(604px, calc(100dvh - 92px)) !important;
+                height: min(610px, calc(100dvh - 110px)) !important;
                 min-height: 0 !important;
-                max-height: min(604px, calc(100dvh - 92px)) !important;
+                max-height: min(610px, calc(100dvh - 110px)) !important;
                 overflow: hidden !important;
+            }
+
+            body:not(.sky-empty) .clock-card.sky-premium-card {
+                border-radius: 28px !important;
+                overflow: hidden !important;
+            }
+
+            body:not(.sky-empty) .sky-command {
+                bottom: 18px !important;
+                width: min(920px, calc(100vw - 180px)) !important;
+                min-height: 66px !important;
+                padding: 8px 10px !important;
+                border-radius: 999px !important;
+                opacity: 0.88 !important;
+                background:
+                    linear-gradient(145deg, rgba(255,255,255,0.13), rgba(255,255,255,0.05)),
+                    rgba(12, 16, 30, 0.78) !important;
+                box-shadow:
+                    0 18px 54px rgba(0,0,0,0.34),
+                    inset 0 1px 0 rgba(255,255,255,0.16) !important;
             }
 
             body:not(.sky-empty) .calendar-card .sky-calendar-scene,
@@ -4650,6 +4676,242 @@
             }
 
         }
+
+        .sky-ambient-clock {
+            position: fixed;
+            top: clamp(54px, 7.5vh, 84px);
+            left: 50%;
+            transform: translateX(-50%);
+            z-index: 2;
+            display: grid;
+            justify-items: center;
+            gap: 8px;
+            opacity: 0;
+            pointer-events: none;
+            transition: opacity 420ms ease, transform 420ms ease;
+            color: rgba(255,255,255,0.76);
+            text-shadow: 0 18px 70px rgba(0,0,0,0.55);
+        }
+
+        body.sky-empty.sky-ambient-clock .sky-ambient-clock {
+            opacity: 1;
+            transform: translateX(-50%) translateY(0);
+        }
+
+        body:not(.sky-empty) .sky-ambient-clock {
+            opacity: 0;
+            transform: translateX(-50%) translateY(-10px);
+        }
+
+        .sky-ambient-time {
+            display: flex;
+            align-items: baseline;
+            gap: clamp(8px, 1.2vw, 16px);
+            font-variant-numeric: tabular-nums;
+            font-weight: 850;
+            letter-spacing: 0;
+            line-height: 0.86;
+            color: rgba(255,255,255,0.82);
+        }
+
+        .sky-ambient-time span {
+            font-size: clamp(124px, 18vw, 214px);
+        }
+
+        .sky-ambient-time i {
+            font-style: normal;
+            font-size: clamp(100px, 14vw, 170px);
+            opacity: 0.5;
+        }
+
+        .sky-ambient-time b {
+            margin-left: 6px;
+            font-size: clamp(30px, 3.7vw, 44px);
+            opacity: 0.56;
+            text-transform: uppercase;
+        }
+
+        .sky-ambient-date {
+            color: rgba(255,255,255,0.5);
+            font-size: clamp(28px, 3.4vw, 42px);
+            font-weight: 800;
+        }
+    </style>
+
+    <style id="skybridge-voice-layer-final">
+        @media (min-width: 900px) and (max-height: 760px) {
+            body:not(.sky-empty) .sky-stage,
+            body.sky-command-open:not(.sky-empty) .sky-stage {
+                inset: 16px !important;
+                width: auto !important;
+                overflow: visible !important;
+            }
+
+            body:not(.sky-empty) .sky-card-stack {
+                height: 100% !important;
+                max-height: none !important;
+                overflow: visible !important;
+                padding-bottom: 0 !important;
+            }
+
+            body:not(.sky-empty) .sky-card-shell {
+                height: 100% !important;
+            }
+
+            body:not(.sky-empty) .clock-card.sky-premium-card {
+                height: calc(100dvh - 32px) !important;
+                max-height: calc(100dvh - 32px) !important;
+                min-height: 0 !important;
+                border-radius: 30px !important;
+                overflow: hidden !important;
+            }
+
+            body:not(.sky-empty) .sky-clock-time {
+                top: 50% !important;
+            }
+
+            body:not(.sky-empty) .sky-clock-date {
+                bottom: 92px !important;
+                color: rgba(255,255,255,0.58) !important;
+                font-size: clamp(1.45rem, 2.65vw, 2.15rem) !important;
+            }
+
+            body:not(.sky-empty) .sky-command,
+            body.sky-command-open .sky-command,
+            body.sky-voice-fallback.sky-empty .sky-command {
+                position: fixed !important;
+                left: 24px !important;
+                right: auto !important;
+                bottom: 22px !important;
+                width: 68px !important;
+                height: 68px !important;
+                min-height: 68px !important;
+                transform: none !important;
+                display: grid !important;
+                grid-template-columns: 1fr !important;
+                align-items: center !important;
+                justify-items: center !important;
+                gap: 0 !important;
+                padding: 0 !important;
+                border: 1px solid rgba(255,255,255,0.18) !important;
+                border-radius: 999px !important;
+                background:
+                    radial-gradient(circle at 34% 24%, rgba(255,255,255,0.48), transparent 24%),
+                    linear-gradient(135deg, rgba(123,97,255,0.95), rgba(90,224,224,0.95)) !important;
+                box-shadow:
+                    0 18px 54px rgba(0,0,0,0.42),
+                    0 0 52px rgba(90,224,224,0.22),
+                    inset 0 1px 0 rgba(255,255,255,0.24) !important;
+                opacity: 1 !important;
+                pointer-events: auto !important;
+                z-index: 30 !important;
+                overflow: hidden !important;
+                transition:
+                    left 260ms ease,
+                    width 260ms ease,
+                    height 260ms ease,
+                    background 260ms ease,
+                    box-shadow 260ms ease !important;
+            }
+
+            body:not(.sky-empty) .sky-command::before,
+            body.sky-command-open .sky-command::before,
+            body.sky-voice-fallback.sky-empty .sky-command::before {
+                content: "" !important;
+                width: 68px !important;
+                height: 68px !important;
+                border-radius: 999px !important;
+                background:
+                    radial-gradient(circle at 34% 24%, rgba(255,255,255,0.5), transparent 24%),
+                    linear-gradient(135deg, #7B61FF 0%, #5AE0E0 100%) !important;
+                box-shadow: none !important;
+                animation: sky-panel-orb-float 3.4s ease-in-out infinite !important;
+            }
+
+            body:not(.sky-empty) .sky-command-copy {
+                display: block !important;
+                min-width: 0 !important;
+                overflow: hidden !important;
+                text-overflow: ellipsis !important;
+                white-space: nowrap !important;
+                color: rgba(255,255,255,0.88) !important;
+                font-size: clamp(17px, 1.55vw, 22px) !important;
+                font-weight: 650 !important;
+                line-height: 1.1 !important;
+                opacity: 0 !important;
+                transform: translateX(-8px) !important;
+                transition: opacity 180ms ease, transform 220ms ease !important;
+            }
+
+            body:not(.sky-empty) .sky-command input,
+            body:not(.sky-empty) .sky-command button,
+            body.sky-command-open .sky-command input,
+            body.sky-command-open .sky-command button {
+                display: none !important;
+            }
+
+            body.sky-state-listening:not(.sky-empty) .sky-command,
+            body.sky-state-thinking:not(.sky-empty) .sky-command,
+            body.sky-state-responding:not(.sky-empty) .sky-command {
+                left: 50% !important;
+                width: min(860px, calc(100vw - 96px)) !important;
+                height: 76px !important;
+                min-height: 76px !important;
+                transform: translateX(-50%) !important;
+                grid-template-columns: 68px minmax(0, 1fr) !important;
+                justify-items: stretch !important;
+                gap: 16px !important;
+                padding: 4px 24px 4px 4px !important;
+                background:
+                    linear-gradient(145deg, rgba(255,255,255,0.16), rgba(255,255,255,0.055)),
+                    rgba(8, 13, 28, 0.82) !important;
+                box-shadow:
+                    0 24px 78px rgba(0,0,0,0.48),
+                    0 0 58px rgba(90,224,224,0.16),
+                    inset 0 1px 0 rgba(255,255,255,0.16) !important;
+                backdrop-filter: blur(26px) saturate(1.15) !important;
+                -webkit-backdrop-filter: blur(26px) saturate(1.15) !important;
+            }
+
+            body.sky-state-listening:not(.sky-empty) .sky-command-copy,
+            body.sky-state-thinking:not(.sky-empty) .sky-command-copy,
+            body.sky-state-responding:not(.sky-empty) .sky-command-copy {
+                opacity: 1 !important;
+                transform: translateX(0) !important;
+                align-self: center !important;
+            }
+
+            body.sky-typing-fallback .sky-command,
+            body.sky-voice-fallback.sky-empty .sky-command {
+                left: 50% !important;
+                width: min(860px, calc(100vw - 96px)) !important;
+                height: 76px !important;
+                transform: translateX(-50%) !important;
+                grid-template-columns: 58px minmax(0, 1fr) auto !important;
+                gap: 12px !important;
+                padding: 8px 10px !important;
+                background: rgba(9, 13, 27, 0.82) !important;
+            }
+
+            body.sky-typing-fallback .sky-command-copy {
+                display: none !important;
+            }
+
+            body.sky-typing-fallback .sky-command input,
+            body.sky-typing-fallback .sky-command .primary,
+            body.sky-voice-fallback.sky-empty .sky-command input,
+            body.sky-voice-fallback.sky-empty .sky-command .primary {
+                display: inline-flex !important;
+            }
+
+            body:not(.sky-empty) .sky-orb-panel::before,
+            body:not(.sky-empty) .sky-orb-panel::after,
+            body:not(.sky-empty) .sky-orb-button,
+            body:not(.sky-empty) .sky-listening-copy {
+                opacity: 0 !important;
+                pointer-events: none !important;
+            }
+        }
     </style>
 </head>
 <body>
@@ -4673,6 +4935,10 @@
 
 	    <main class="sky-shell">
 	        <section class="sky-orb-panel" aria-label="Voice state">
+	            <div class="sky-ambient-clock" id="skyAmbientClock" aria-live="polite">
+	                <div class="sky-ambient-time"><span data-clock-hour id="skyAmbientClockHour">--</span><i>:</i><span data-clock-minute id="skyAmbientClockMinute">--</span><b data-clock-meridiem id="skyAmbientClockMeridiem"></b></div>
+	                <div class="sky-ambient-date" data-clock-date id="skyAmbientClockDate"></div>
+	            </div>
 	            <canvas id="skyOrb"></canvas>
 	            <button type="button" class="sky-orb-button" id="skyOrbButton" aria-label="Start voice">
 	                <span id="skyOrbButtonText">Tap to talk</span>
@@ -4705,6 +4971,7 @@
     </main>
 
     <form class="sky-command" id="skyCommandForm">
+        <div class="sky-command-copy" id="skyCommandCopy" aria-live="polite">Listening</div>
         <button type="button" id="skyHomeBtn" title="Show home cards">Home</button>
         <input id="skyCommandInput" autocomplete="off" placeholder="Ask Zoe to show or change anything..." aria-label="Ask Zoe">
 	        <button type="button" id="skyMicBtn">Mic</button>

--- a/services/zoe-ui/dist/touch/skybridge.html
+++ b/services/zoe-ui/dist/touch/skybridge.html
@@ -4935,7 +4935,7 @@
 
 	    <main class="sky-shell">
 	        <section class="sky-orb-panel" aria-label="Voice state">
-	            <div class="sky-ambient-clock" id="skyAmbientClock" aria-live="polite">
+	            <div class="sky-ambient-clock" id="skyAmbientClock" aria-label="Ambient clock">
 	                <div class="sky-ambient-time"><span data-clock-hour id="skyAmbientClockHour">--</span><i>:</i><span data-clock-minute id="skyAmbientClockMinute">--</span><b data-clock-meridiem id="skyAmbientClockMeridiem"></b></div>
 	                <div class="sky-ambient-date" data-clock-date id="skyAmbientClockDate"></div>
 	            </div>


### PR DESCRIPTION
## Summary
- adds a real Skybridge clock intent and card-contract payload for voice/text requests like "what time is it" or "show me the clock"
- adds a live-rendering clock card and dimmed ambient clock state for the touch interface
- returns Skybridge to the ambient orb/clock after an idle timeout, with a query/localStorage override for testing
- tunes the clock card for the 1280x720 touch panel so the time/date use the available space cleanly

## Why
The touch panel needs a useful resting state after voice requests. A dimmed clock face gives the panel something readable and familiar when Zoe is not actively showing cards, while keeping the voice-first Skybridge surface ready for the next command.

## Validation
- `python3 -m pytest tests/test_skybridge_static.py tests/test_skybridge_service.py tests/test_skybridge_status.py -q` from `services/zoe-data`
- physical touch-panel render capture at 1280x720 with the branch clock CSS injected into the live Skybridge shell

## Screenshot
- `/Users/jasonbertelsen/Documents/Codex/skybridge-clock-ambient-visual/clock_card_branch_final.png`
