### PR TITLE
[codex] Add fast relative reminder parsing

### DIFF
--- a/services/zoe-data/intent_router.py
+++ b/services/zoe-data/intent_router.py
@@ -1332,7 +1332,7 @@ def _parse_relative_reminder_duration(raw: str):
 
     qty_text = m.group("qty").lower()
     quantity = int(qty_text) if qty_text.isdigit() else quantity_words.get(qty_text)
-    if not quantity or quantity < 1:
+    if not quantity or quantity < 1 or quantity > 999:
         return None
 
     unit = m.group("unit").lower()
@@ -1391,7 +1391,10 @@ def _extract_relative_reminder_slots(text: str) -> Optional[dict]:
 
 
 def _extract_simple_reminder_slots(text: str) -> Optional[dict]:
-    """Fast slots for common reminder phrases; complex relative phrasing still uses NLU."""
+    """Fast slots for common reminder phrases, including bounded relative durations.
+
+    Recurring, modified-weekday, named-time, and other complex phrases fall back to NLU.
+    """
 
     raw = re.sub(r"\s+", " ", str(text or "")).strip()
     if not raw:

--- a/services/zoe-data/intent_router.py
+++ b/services/zoe-data/intent_router.py
@@ -1288,12 +1288,117 @@ def detect_intent(
     return None
 
 
+def _relative_reminder_now():
+    from datetime import datetime
+
+    return datetime.now().replace(second=0, microsecond=0)
+
+
+def _parse_relative_reminder_duration(raw: str):
+    from datetime import timedelta
+
+    value = re.sub(r"\s+", " ", str(raw or "").strip().lower())
+    if not value:
+        return None
+
+    if value == "half an hour":
+        return timedelta(minutes=30)
+
+    quantity_words = {
+        "a": 1,
+        "an": 1,
+        "one": 1,
+        "two": 2,
+        "three": 3,
+        "four": 4,
+        "five": 5,
+        "six": 6,
+        "seven": 7,
+        "eight": 8,
+        "nine": 9,
+        "ten": 10,
+        "a few": 3,
+        "a couple": 2,
+        "a couple of": 2,
+    }
+    m = re.match(
+        r"^(?P<qty>\d+|a\s+few|a\s+couple(?:\s+of)?|an?|one|two|three|four|five|six|seven|eight|nine|ten)\s+"
+        r"(?P<unit>min(?:ute)?s?|hours?|days?|weeks?)$",
+        value,
+        flags=re.IGNORECASE,
+    )
+    if not m:
+        return None
+
+    qty_text = m.group("qty").lower()
+    quantity = int(qty_text) if qty_text.isdigit() else quantity_words.get(qty_text)
+    if not quantity or quantity < 1:
+        return None
+
+    unit = m.group("unit").lower()
+    if unit.startswith("min"):
+        return timedelta(minutes=quantity)
+    if unit.startswith("hour"):
+        return timedelta(hours=quantity)
+    if unit.startswith("day"):
+        return timedelta(days=quantity)
+    if unit.startswith("week"):
+        return timedelta(weeks=quantity)
+    return None
+
+
+def _extract_relative_reminder_slots(text: str) -> Optional[dict]:
+    raw = re.sub(r"\s+", " ", str(text or "")).strip()
+    if not raw:
+        return None
+
+    duration_pattern = (
+        r"(?P<duration>"
+        r"\d+\s+(?:min(?:ute)?s?|hours?|days?|weeks?)|"
+        r"half\s+an\s+hour|"
+        r"(?:a\s+few|a\s+couple(?:\s+of)?|an?|one|two|three|four|five|six|seven|eight|nine|ten)\s+"
+        r"(?:min(?:ute)?s?|hours?|days?|weeks?)"
+        r")"
+    )
+    patterns = [
+        rf"^remind me in {duration_pattern}\s+(?:to|about)\s+(?P<title>.+)$",
+        rf"^remind me (?:to|about)\s+(?P<title>.+?)\s+in {duration_pattern}$",
+        rf"^remember to\s+(?P<title>.+?)\s+in {duration_pattern}$",
+        rf"^set a reminder in {duration_pattern}\s+(?:to|for|about)\s+(?P<title>.+)$",
+        rf"^set a reminder (?:to|for|about)\s+(?P<title>.+?)\s+in {duration_pattern}$",
+    ]
+    title = ""
+    duration_text = ""
+    for pattern in patterns:
+        match = re.match(pattern, raw, flags=re.IGNORECASE)
+        if match:
+            title = match.group("title").strip(" ,.-")
+            duration_text = match.group("duration")
+            break
+    if not title or not duration_text:
+        return None
+
+    if re.search(r"\bevery\s+(?:monday|tuesday|wednesday|thursday|friday|saturday|sunday|day|week|month|year)\b", title, flags=re.IGNORECASE):
+        return None
+    if re.search(r"\b(?:next|this|coming|last)\s+(?:monday|tuesday|wednesday|thursday|friday|saturday|sunday)\b", title, flags=re.IGNORECASE):
+        return None
+
+    delta = _parse_relative_reminder_duration(duration_text)
+    if not delta:
+        return None
+    due = _relative_reminder_now() + delta
+    return {"title": title, "date": due.date().isoformat(), "time": due.strftime("%H:%M")}
+
+
 def _extract_simple_reminder_slots(text: str) -> Optional[dict]:
     """Fast slots for common reminder phrases; complex relative phrasing still uses NLU."""
 
     raw = re.sub(r"\s+", " ", str(text or "")).strip()
     if not raw:
         return None
+    relative_slots = _extract_relative_reminder_slots(raw)
+    if relative_slots:
+        return relative_slots
 
     patterns = [
         r"^remind me (?:to|about)\s+(.+)$",

--- a/services/zoe-data/tests/test_intent_reminder_latency.py
+++ b/services/zoe-data/tests/test_intent_reminder_latency.py
@@ -128,6 +128,35 @@ async def test_word_relative_reminder_skips_llm_extractor(monkeypatch, text, exp
     assert intent.slots["title"]
 
 
+@pytest.mark.parametrize(
+    "text",
+    [
+        "remind me in 1000 weeks to rotate credentials",
+        "remind me to rotate credentials in 99999 days",
+    ],
+)
+@pytest.mark.asyncio
+async def test_absurd_relative_reminder_still_uses_existing_extractor(monkeypatch, text):
+    calls = []
+    module = types.ModuleType("nlu_extractor")
+
+    async def fake_extract(intent_name, raw):
+        calls.append((intent_name, raw))
+        return {"title": "rotate credentials", "date": "2026-06-22"}
+
+    module.extract_slots_for_intent = fake_extract
+    monkeypatch.setitem(sys.modules, "nlu_extractor", module)
+
+    from intent_router import detect_and_extract_intent
+
+    intent = await detect_and_extract_intent(text, user_id="guest")
+
+    assert calls == [("reminder_create", text)]
+    assert intent is not None
+    assert intent.name == "reminder_create"
+    assert intent.slots == {"title": "rotate credentials", "date": "2026-06-22"}
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "text",

--- a/services/zoe-data/tests/test_intent_reminder_latency.py
+++ b/services/zoe-data/tests/test_intent_reminder_latency.py
@@ -1,6 +1,7 @@
 import sys
 import time
 import types
+from datetime import datetime
 
 import pytest
 
@@ -51,81 +52,80 @@ async def test_bare_simple_reminder_defaults_to_today_without_llm(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_relative_reminder_still_uses_existing_extractor(monkeypatch):
-    calls = []
+async def test_leading_relative_reminder_skips_llm_extractor(monkeypatch):
     module = types.ModuleType("nlu_extractor")
 
-    async def fake_extract(intent_name, raw):
-        calls.append((intent_name, raw))
-        return {"title": "check the oven", "date": "2026-06-15", "time": "20:10"}
+    async def fail_extract(_intent_name, _raw):
+        raise AssertionError("safe relative reminder should not call the LLM slot extractor")
 
-    module.extract_slots_for_intent = fake_extract
+    module.extract_slots_for_intent = fail_extract
     monkeypatch.setitem(sys.modules, "nlu_extractor", module)
 
+    import intent_router
     from intent_router import detect_and_extract_intent
 
+    monkeypatch.setattr(intent_router, "_relative_reminder_now", lambda: datetime(2026, 6, 15, 20, 5))
     intent = await detect_and_extract_intent("remind me in 5 minutes to check the oven", user_id="guest")
 
-    assert calls == [("reminder_create", "remind me in 5 minutes to check the oven")]
     assert intent is not None
     assert intent.name == "reminder_create"
     assert intent.slots == {"title": "check the oven", "date": "2026-06-15", "time": "20:10"}
 
 
 @pytest.mark.asyncio
-async def test_trailing_relative_reminder_still_uses_existing_extractor(monkeypatch):
-    calls = []
+async def test_trailing_relative_reminder_skips_llm_extractor(monkeypatch):
     module = types.ModuleType("nlu_extractor")
 
-    async def fake_extract(intent_name, raw):
-        calls.append((intent_name, raw))
-        return {"title": "check the oven", "date": "2026-06-15", "time": "20:30"}
+    async def fail_extract(_intent_name, _raw):
+        raise AssertionError("safe trailing relative reminder should not call the LLM slot extractor")
 
-    module.extract_slots_for_intent = fake_extract
+    module.extract_slots_for_intent = fail_extract
     monkeypatch.setitem(sys.modules, "nlu_extractor", module)
 
+    import intent_router
     from intent_router import detect_and_extract_intent
 
+    monkeypatch.setattr(intent_router, "_relative_reminder_now", lambda: datetime(2026, 6, 15, 20, 0))
     text = "remind me to check the oven in 30 minutes"
     intent = await detect_and_extract_intent(text, user_id="guest")
 
-    assert calls == [("reminder_create", text)]
     assert intent is not None
     assert intent.name == "reminder_create"
     assert intent.slots == {"title": "check the oven", "date": "2026-06-15", "time": "20:30"}
 
 
 @pytest.mark.parametrize(
-    "text",
+    ("text", "expected_date", "expected_time"),
     [
-        "remind me to call mum in a few days",
-        "remind me to call mum in two hours",
-        "remind me to check the filter in a couple of weeks",
-        "remind me to check the oven in an hour",
-        "remind me to check the oven in half an hour",
-        "remind me to call mum in a day",
+        ("remind me to call mum in a few days", "2026-06-18", "20:00"),
+        ("remind me to call mum in two hours", "2026-06-15", "22:00"),
+        ("remind me to check the filter in a couple of weeks", "2026-06-29", "20:00"),
+        ("remind me to check the oven in an hour", "2026-06-15", "21:00"),
+        ("remind me to check the oven in half an hour", "2026-06-15", "20:30"),
+        ("remind me to call mum in a day", "2026-06-16", "20:00"),
     ],
 )
 @pytest.mark.asyncio
-async def test_word_relative_reminder_still_uses_existing_extractor(monkeypatch, text):
-    calls = []
+async def test_word_relative_reminder_skips_llm_extractor(monkeypatch, text, expected_date, expected_time):
     module = types.ModuleType("nlu_extractor")
 
-    async def fake_extract(intent_name, raw):
-        calls.append((intent_name, raw))
-        return {"title": "word relative reminder", "date": "2026-06-18"}
+    async def fail_extract(_intent_name, _raw):
+        raise AssertionError("safe word-relative reminder should not call the LLM slot extractor")
 
-    module.extract_slots_for_intent = fake_extract
+    module.extract_slots_for_intent = fail_extract
     monkeypatch.setitem(sys.modules, "nlu_extractor", module)
 
+    import intent_router
     from intent_router import detect_and_extract_intent
 
+    monkeypatch.setattr(intent_router, "_relative_reminder_now", lambda: datetime(2026, 6, 15, 20, 0))
     intent = await detect_and_extract_intent(text, user_id="guest")
 
-    assert calls == [("reminder_create", text)]
     assert intent is not None
     assert intent.name == "reminder_create"
-    assert intent.slots == {"title": "word relative reminder", "date": "2026-06-18"}
+    assert intent.slots["date"] == expected_date
+    assert intent.slots["time"] == expected_time
+    assert intent.slots["title"]
 
 
 @pytest.mark.asyncio

--- a/services/zoe-data/tests/test_pi_intent_classifier.py
+++ b/services/zoe-data/tests/test_pi_intent_classifier.py
@@ -789,7 +789,7 @@ async def test_detect_and_extract_intent_uses_pi_when_slot_extraction_fails(tmp_
 
     from intent_router import detect_and_extract_intent
 
-    intent = await detect_and_extract_intent("remind me in 5 minutes to call mum")
+    intent = await detect_and_extract_intent("remind me to call mum every Monday")
 
     assert intent is not None
     assert intent.name == "reminder_create"

--- a/services/zoe-data/tests/test_pi_intent_shadow.py
+++ b/services/zoe-data/tests/test_pi_intent_shadow.py
@@ -183,7 +183,7 @@ async def test_intent_router_shadow_extraction_failed_records_pre_pi_latency_and
     monkeypatch.setattr("pi_intent_classifier.classify_with_pi_intent_governor", fake_classify)
     monkeypatch.setattr("pi_intent_shadow.maybe_record_pi_intent_shadow", fake_shadow)
 
-    intent = await detect_and_extract_intent("remind me in 5 minutes to call mum", user_id="jason")
+    intent = await detect_and_extract_intent("remind me to call mum every Monday", user_id="jason")
     await asyncio.sleep(0)
 
     assert intent is not None


### PR DESCRIPTION
## Summary
- Add a bounded relative-duration reminder parser for safe phrases like `in 5 minutes`, `in an hour`, and `in a couple of weeks`
- Keep recurring, modified weekday, named-time, and other complex phrases on the existing NLU/Pi fallback path
- Update Pi fallback fixtures so extraction-failure coverage still uses a guarded complex reminder phrase

## Evidence
- Focused reminder/Pi tests: 37 passed
- Broad conversation/Pi fleet: 613 passed
- Validators: validate_structure, validate_critical_files, git diff --check
- Branch latency probe: safe relative reminders p50 ~0.126-0.136ms, p95 ~0.139-0.167ms; recurring fallback remains on NLU path