### PR TITLE
[codex] Execute reminders in process

### DIFF
--- a/services/zoe-data/intent_router.py
+++ b/services/zoe-data/intent_router.py
@@ -21,6 +21,8 @@ import unicodedata
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Optional
 
+from fastapi import HTTPException
+
 if TYPE_CHECKING:
     from conversation_context import ConversationContext
 
@@ -1781,6 +1783,8 @@ async def _execute_reminder_create_direct(intent: Intent, user_id: str) -> Optio
             )
             reminder = await create_reminder_record(payload, user=user, db=db)
         return _format_response(intent, json.dumps(reminder, default=str))
+    except HTTPException:
+        raise
     except Exception as exc:
         logger.warning("reminder_create direct execution unavailable; falling back to mcporter: %s", exc)
         return None

--- a/services/zoe-data/intent_router.py
+++ b/services/zoe-data/intent_router.py
@@ -1781,7 +1781,7 @@ async def _execute_reminder_create_direct(intent: Intent, user_id: str) -> Optio
             reminder = await create_reminder_record(payload, user=user, db=db)
         return _format_response(intent, json.dumps(reminder, default=str))
     except Exception as exc:
-        logger.debug("reminder_create direct execution unavailable: %s", exc)
+        logger.warning("reminder_create direct execution unavailable; falling back to mcporter: %s", exc)
         return None
 
 

--- a/services/zoe-data/intent_router.py
+++ b/services/zoe-data/intent_router.py
@@ -1746,6 +1746,45 @@ async def _run_mcporter(cmd: str) -> Optional[str]:
         return None
 
 
+async def _load_direct_execution_user(db, user_id: str) -> Optional[dict]:
+    cursor = await db.execute("SELECT id, role, name FROM users WHERE id = ?", (user_id,))
+    row = await cursor.fetchone()
+    if not row:
+        return None
+    return {
+        "user_id": row["id"],
+        "role": row.get("role", "user") if hasattr(row, "get") else row["role"],
+        "username": row.get("name", "") if hasattr(row, "get") else "",
+    }
+
+
+async def _execute_reminder_create_direct(intent: Intent, user_id: str) -> Optional[str]:
+    slots = intent.slots or {}
+    title = str(slots.get("title") or "").strip()
+    if not title:
+        return None
+    try:
+        from database import get_db_ctx
+        from models import ReminderCreate
+        from reminder_service import create_reminder_record
+
+        async with get_db_ctx() as db:
+            user = await _load_direct_execution_user(db, user_id)
+            if not user:
+                return None
+            payload = ReminderCreate(
+                title=title,
+                due_date=slots.get("date") or None,
+                due_time=slots.get("time") or None,
+                category=slots.get("category") or "general",
+            )
+            reminder = await create_reminder_record(payload, user=user, db=db)
+        return _format_response(intent, json.dumps(reminder, default=str))
+    except Exception as exc:
+        logger.debug("reminder_create direct execution unavailable: %s", exc)
+        return None
+
+
 async def execute_intent(intent: Intent, user_id: str = "family-admin") -> Optional[str]:
     if intent.name == "lets_talk":
         # Navigation is handled by _broadcast_intent_nav via _INTENT_PANEL_NAV in chat.py.
@@ -2309,6 +2348,11 @@ async def execute_intent(intent: Intent, user_id: str = "family-admin") -> Optio
     # Route directly to the weather backend helpers for deterministic voice UX.
     if intent.name == "weather":
         return await _execute_weather_direct(user_id=user_id, forecast=bool(intent.slots.get("forecast")))
+
+    if intent.name == "reminder_create":
+        direct_result = await _execute_reminder_create_direct(intent, user_id)
+        if direct_result:
+            return direct_result
 
     try:
         cmd = _build_command(intent, user_id)

--- a/services/zoe-data/intent_router.py
+++ b/services/zoe-data/intent_router.py
@@ -1751,9 +1751,10 @@ async def _load_direct_execution_user(db, user_id: str) -> Optional[dict]:
     row = await cursor.fetchone()
     if not row:
         return None
+    raw_role = row.get("role") if hasattr(row, "get") else row["role"]
     return {
         "user_id": row["id"],
-        "role": row.get("role", "user") if hasattr(row, "get") else row["role"],
+        "role": raw_role or "user",
         "username": row.get("name", "") if hasattr(row, "get") else "",
     }
 

--- a/services/zoe-data/reminder_service.py
+++ b/services/zoe-data/reminder_service.py
@@ -75,6 +75,6 @@ async def create_reminder_record(payload: ReminderCreate, *, user: Mapping[str, 
 
     cursor = await db.execute("SELECT * FROM reminders WHERE id = ?", [reminder_id])
     row = await cursor.fetchone()
-    reminder = row_to_dict(row)
+    reminder = row_to_dict(row) or {}
     await broadcaster.broadcast("reminders", "reminder_created", reminder, user_id=user_id)
-    return reminder or {}
+    return reminder

--- a/services/zoe-data/reminder_service.py
+++ b/services/zoe-data/reminder_service.py
@@ -1,0 +1,80 @@
+"""Shared reminder persistence helpers for API and intent execution."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from typing import Mapping
+
+from guest_policy import require_feature_access
+from models import ReminderCreate
+from push import broadcaster
+
+
+def row_to_dict(row) -> dict | None:
+    """Convert asyncpg/compat rows to a plain reminder dict."""
+    if row is None:
+        return None
+    data = dict(row)
+    for key in ("is_active", "acknowledged", "deleted"):
+        if key in data and data[key] is not None:
+            data[key] = bool(data[key])
+    return data
+
+
+async def _create_notification(db, *, user_id: str, notif_type: str, title: str, message: str, data: dict) -> None:
+    await db.execute(
+        """INSERT INTO notifications (id, user_id, type, title, message, data, delivered, created_at)
+           VALUES (?, ?, ?, ?, ?, ?, 0, NOW())""",
+        (
+            str(uuid.uuid4()),
+            user_id,
+            notif_type,
+            title,
+            message,
+            json.dumps(data or {}),
+        ),
+    )
+
+
+async def create_reminder_record(payload: ReminderCreate, *, user: Mapping[str, object], db) -> dict:
+    """Create a reminder with the same policy, notification, and broadcast behavior as the API route."""
+    await require_feature_access(db, user, feature="reminders", action="create")
+    user_id = str(user["user_id"])
+    reminder_id = str(uuid.uuid4())
+
+    await db.execute(
+        """INSERT INTO reminders (
+            id, user_id, title, description, reminder_type, category, priority,
+            due_date, due_time, recurring_pattern, is_active, acknowledged,
+            snoozed_until, visibility, deleted
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, 0, NULL, ?, 0)""",
+        (
+            reminder_id,
+            user_id,
+            payload.title,
+            payload.description,
+            payload.reminder_type,
+            payload.category,
+            payload.priority,
+            payload.due_date,
+            payload.due_time,
+            payload.recurring_pattern,
+            payload.visibility,
+        ),
+    )
+    await _create_notification(
+        db,
+        user_id=user_id,
+        notif_type="reminder_created",
+        title="Reminder Created",
+        message=f"Reminder added: {payload.title}",
+        data={"reminder_id": reminder_id, "due_date": payload.due_date, "due_time": payload.due_time},
+    )
+    await db.commit()
+
+    cursor = await db.execute("SELECT * FROM reminders WHERE id = ?", [reminder_id])
+    row = await cursor.fetchone()
+    reminder = row_to_dict(row)
+    await broadcaster.broadcast("reminders", "reminder_created", reminder, user_id=user_id)
+    return reminder or {}

--- a/services/zoe-data/routers/reminders.py
+++ b/services/zoe-data/routers/reminders.py
@@ -2,8 +2,6 @@
 FastAPI router for reminders.
 Mounted at prefix="/api/reminders" with tag "reminders".
 """
-import json
-import uuid
 from datetime import date, datetime, timedelta
 from typing import Optional
 
@@ -14,42 +12,14 @@ from database import get_db
 from guest_policy import require_feature_access
 from models import ReminderCreate, ReminderUpdate, SnoozeBody
 from push import broadcaster
+from reminder_service import create_reminder_record, row_to_dict
 
 router = APIRouter(prefix="/api/reminders", tags=["reminders"])
-
-
-def _row_to_dict(row) -> dict:
-    """Convert asyncpg Row to dict."""
-    if row is None:
-        return None
-    d = dict(row)
-    if "is_active" in d and d["is_active"] is not None:
-        d["is_active"] = bool(d["is_active"])
-    if "acknowledged" in d and d["acknowledged"] is not None:
-        d["acknowledged"] = bool(d["acknowledged"])
-    if "deleted" in d and d["deleted"] is not None:
-        d["deleted"] = bool(d["deleted"])
-    return d
 
 
 def _visibility_filter_sql() -> str:
     """SQL fragment: (visibility='family' OR user_id=?) AND deleted=0"""
     return "(visibility = 'family' OR user_id = ?) AND deleted = 0"
-
-
-async def _create_notification(db, user_id: str, notif_type: str, title: str, message: str, data: dict):
-    await db.execute(
-        """INSERT INTO notifications (id, user_id, type, title, message, data, delivered, created_at)
-           VALUES (?, ?, ?, ?, ?, ?, 0, NOW())""",
-        (
-            str(uuid.uuid4()),
-            user_id,
-            notif_type,
-            title,
-            message,
-            json.dumps(data or {}),
-        ),
-    )
 
 
 @router.post("/", response_model=dict)
@@ -59,46 +29,7 @@ async def create_reminder(
     db=Depends(get_db),
 ):
     """Create a new reminder."""
-    await require_feature_access(db, user, feature="reminders", action="create")
-    user_id = user["user_id"]
-    reminder_id = str(uuid.uuid4())
-
-    await db.execute(
-        """INSERT INTO reminders (
-            id, user_id, title, description, reminder_type, category, priority,
-            due_date, due_time, recurring_pattern, is_active, acknowledged,
-            snoozed_until, visibility, deleted
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, 0, NULL, ?, 0)""",
-        (
-            reminder_id,
-            user_id,
-            payload.title,
-            payload.description,
-            payload.reminder_type,
-            payload.category,
-            payload.priority,
-            payload.due_date,
-            payload.due_time,
-            payload.recurring_pattern,
-            payload.visibility,
-        ),
-    )
-    await _create_notification(
-        db,
-        user_id=user_id,
-        notif_type="reminder_created",
-        title="Reminder Created",
-        message=f"Reminder added: {payload.title}",
-        data={"reminder_id": reminder_id, "due_date": payload.due_date, "due_time": payload.due_time},
-    )
-    await db.commit()
-
-    cursor = await db.execute("SELECT * FROM reminders WHERE id = ?", [reminder_id])
-    row = await cursor.fetchone()
-    reminder = _row_to_dict(row)
-
-    await broadcaster.broadcast("reminders", "reminder_created", reminder, user_id=user_id)
-    return reminder
+    return await create_reminder_record(payload, user=user, db=db)
 
 
 @router.get("/", response_model=dict)
@@ -131,7 +62,7 @@ async def list_reminders(
     params.append(limit)
     cursor = await db.execute(sql, params)
     rows = await cursor.fetchall()
-    reminders = [_row_to_dict(r) for r in rows]
+    reminders = [row_to_dict(r) for r in rows]
     return {"reminders": reminders}
 
 
@@ -152,7 +83,7 @@ async def list_today_reminders(
     """
     cursor = await db.execute(sql, [user_id, today])
     rows = await cursor.fetchall()
-    reminders = [_row_to_dict(r) for r in rows]
+    reminders = [row_to_dict(r) for r in rows]
     return {"reminders": reminders}
 
 
@@ -189,7 +120,7 @@ async def update_reminder(
             params.append(value)
 
     if not updates:
-        return _row_to_dict(row)
+        return row_to_dict(row)
 
     updates.append("updated_at = NOW()")
     params.append(reminder_id)
@@ -201,7 +132,7 @@ async def update_reminder(
 
     cursor = await db.execute("SELECT * FROM reminders WHERE id = ?", [reminder_id])
     row = await cursor.fetchone()
-    reminder = _row_to_dict(row)
+    reminder = row_to_dict(row)
 
     await broadcaster.broadcast("reminders", "reminder_updated", reminder, user_id=user_id)
     return reminder
@@ -288,7 +219,7 @@ async def snooze_reminder(
 
     cursor = await db.execute("SELECT * FROM reminders WHERE id = ?", [reminder_id])
     row = await cursor.fetchone()
-    reminder = _row_to_dict(row)
+    reminder = row_to_dict(row)
 
     await broadcaster.broadcast("reminders", "reminder_snoozed", reminder, user_id=user_id)
     return reminder
@@ -328,7 +259,7 @@ async def acknowledge_reminder(
 
     cursor = await db.execute("SELECT * FROM reminders WHERE id = ?", [reminder_id])
     row = await cursor.fetchone()
-    reminder = _row_to_dict(row)
+    reminder = row_to_dict(row)
 
     await broadcaster.broadcast("reminders", "reminder_acknowledged", reminder, user_id=user_id)
     return reminder

--- a/services/zoe-data/tests/test_reminder_direct_execution.py
+++ b/services/zoe-data/tests/test_reminder_direct_execution.py
@@ -1,0 +1,92 @@
+import pytest
+
+from intent_router import Intent, execute_intent
+from models import ReminderCreate
+from reminder_service import create_reminder_record
+
+
+class _Cursor:
+    def __init__(self, row=None):
+        self._row = row
+
+    async def fetchone(self):
+        return self._row
+
+
+class _FakeDB:
+    def __init__(self):
+        self.calls = []
+        self.committed = False
+        self.row = {
+            "id": "rem-1",
+            "user_id": "family-admin",
+            "title": "check the oven",
+            "due_date": "2026-06-15",
+            "due_time": "23:00",
+            "is_active": 1,
+            "acknowledged": 0,
+            "deleted": 0,
+        }
+
+    async def execute(self, sql, params=()):
+        self.calls.append((sql, tuple(params)))
+        if sql.strip().upper().startswith("SELECT"):
+            return _Cursor(self.row)
+        return _Cursor()
+
+    async def commit(self):
+        self.committed = True
+
+
+@pytest.mark.asyncio
+async def test_create_reminder_record_preserves_policy_write_notification_and_broadcast(monkeypatch):
+    db = _FakeDB()
+    policy_calls = []
+    broadcasts = []
+
+    async def fake_require_feature_access(db_arg, user, *, feature, action, surface="api"):
+        policy_calls.append((db_arg, user, feature, action, surface))
+
+    async def fake_broadcast(channel, event, payload, *, user_id=None):
+        broadcasts.append((channel, event, payload, user_id))
+
+    monkeypatch.setattr("reminder_service.require_feature_access", fake_require_feature_access)
+    monkeypatch.setattr("reminder_service.broadcaster.broadcast", fake_broadcast)
+
+    reminder = await create_reminder_record(
+        ReminderCreate(title="check the oven", due_date="2026-06-15", due_time="23:00"),
+        user={"user_id": "family-admin", "role": "admin"},
+        db=db,
+    )
+
+    assert policy_calls == [(db, {"user_id": "family-admin", "role": "admin"}, "reminders", "create", "api")]
+    assert db.committed is True
+    assert any("INSERT INTO reminders" in sql for sql, _ in db.calls)
+    assert any("INSERT INTO notifications" in sql for sql, _ in db.calls)
+    assert reminder["is_active"] is True
+    assert reminder["acknowledged"] is False
+    assert reminder["deleted"] is False
+    assert broadcasts == [("reminders", "reminder_created", reminder, "family-admin")]
+
+
+@pytest.mark.asyncio
+async def test_execute_reminder_create_uses_direct_path_before_mcporter(monkeypatch):
+    calls = []
+
+    async def fake_direct(intent, user_id):
+        calls.append((intent.name, dict(intent.slots), user_id))
+        return "Reminder set: check the oven."
+
+    async def fail_mcporter(_cmd):
+        raise AssertionError("reminder direct path should avoid mcporter")
+
+    monkeypatch.setattr("intent_router._execute_reminder_create_direct", fake_direct)
+    monkeypatch.setattr("intent_router._run_mcporter", fail_mcporter)
+
+    result = await execute_intent(
+        Intent("reminder_create", {"title": "check the oven", "date": "2026-06-15", "time": "23:00"}),
+        "family-admin",
+    )
+
+    assert result == "Reminder set: check the oven."
+    assert calls == [("reminder_create", {"title": "check the oven", "date": "2026-06-15", "time": "23:00"}, "family-admin")]

--- a/services/zoe-data/tests/test_reminder_direct_execution.py
+++ b/services/zoe-data/tests/test_reminder_direct_execution.py
@@ -1,6 +1,6 @@
 import pytest
 
-from intent_router import Intent, execute_intent
+from intent_router import Intent, _load_direct_execution_user, execute_intent
 from models import ReminderCreate
 from reminder_service import create_reminder_record
 
@@ -91,3 +91,47 @@ async def test_execute_reminder_create_uses_direct_path_before_mcporter(monkeypa
 
     assert result == "Reminder set: check the oven."
     assert calls == [("reminder_create", {"title": "check the oven", "date": "2026-06-15", "time": "23:00"}, "family-admin")]
+
+
+@pytest.mark.asyncio
+async def test_load_direct_execution_user_defaults_null_role_to_user():
+    class FakeUserDB:
+        async def execute(self, _sql, _params):
+            return _Cursor({"id": "zoe-user", "role": None, "name": "Zoe User"})
+
+    user = await _load_direct_execution_user(FakeUserDB(), "zoe-user")
+
+    assert user == {"user_id": "zoe-user", "role": "user", "username": "Zoe User"}
+
+
+@pytest.mark.asyncio
+async def test_execute_reminder_create_falls_back_to_mcporter_when_direct_unavailable(monkeypatch):
+    calls = []
+
+    async def fake_direct(intent, user_id):
+        calls.append(("direct", intent.name, user_id))
+        return None
+
+    def fake_build_command(intent, user_id):
+        calls.append(("build", intent.name, user_id))
+        return "mcporter-safe call zoe-data.reminder_create"
+
+    async def fake_mcporter(cmd):
+        calls.append(("mcporter", cmd))
+        return "{}"
+
+    monkeypatch.setattr("intent_router._execute_reminder_create_direct", fake_direct)
+    monkeypatch.setattr("intent_router._build_command", fake_build_command)
+    monkeypatch.setattr("intent_router._run_mcporter", fake_mcporter)
+
+    result = await execute_intent(
+        Intent("reminder_create", {"title": "check the oven", "date": "2026-06-15", "time": "23:00"}),
+        "family-admin",
+    )
+
+    assert result == "Reminder set: check the oven for 2026-06-15 at 23:00."
+    assert calls == [
+        ("direct", "reminder_create", "family-admin"),
+        ("build", "reminder_create", "family-admin"),
+        ("mcporter", "mcporter-safe call zoe-data.reminder_create"),
+    ]

--- a/services/zoe-data/tests/test_reminder_direct_execution.py
+++ b/services/zoe-data/tests/test_reminder_direct_execution.py
@@ -44,8 +44,9 @@ async def test_create_reminder_record_preserves_policy_write_notification_and_br
     policy_calls = []
     broadcasts = []
 
-    async def fake_require_feature_access(db_arg, user, *, feature, action, surface="api"):
-        policy_calls.append((db_arg, user, feature, action, surface))
+    async def fake_require_feature_access(db_arg, user, *, feature, action, **kwargs):
+        assert "surface" not in kwargs
+        policy_calls.append((db_arg, user, feature, action))
 
     async def fake_broadcast(channel, event, payload, *, user_id=None):
         broadcasts.append((channel, event, payload, user_id))
@@ -59,7 +60,7 @@ async def test_create_reminder_record_preserves_policy_write_notification_and_br
         db=db,
     )
 
-    assert policy_calls == [(db, {"user_id": "family-admin", "role": "admin"}, "reminders", "create", "api")]
+    assert policy_calls == [(db, {"user_id": "family-admin", "role": "admin"}, "reminders", "create")]
     assert db.committed is True
     assert any("INSERT INTO reminders" in sql for sql, _ in db.calls)
     assert any("INSERT INTO notifications" in sql for sql, _ in db.calls)

--- a/services/zoe-data/tests/test_reminder_direct_execution.py
+++ b/services/zoe-data/tests/test_reminder_direct_execution.py
@@ -1,4 +1,5 @@
 import pytest
+from fastapi import HTTPException
 
 from intent_router import Intent, _load_direct_execution_user, execute_intent
 from models import ReminderCreate
@@ -135,3 +136,20 @@ async def test_execute_reminder_create_falls_back_to_mcporter_when_direct_unavai
         ("build", "reminder_create", "family-admin"),
         ("mcporter", "mcporter-safe call zoe-data.reminder_create"),
     ]
+
+
+@pytest.mark.asyncio
+async def test_execute_reminder_create_policy_denial_does_not_fall_back_to_mcporter(monkeypatch):
+    async def fake_direct(_intent, _user_id):
+        raise HTTPException(status_code=403, detail="Authentication required for this action.")
+
+    async def fail_mcporter(_cmd):
+        raise AssertionError("policy denial must not fall back to mcporter")
+
+    monkeypatch.setattr("intent_router._execute_reminder_create_direct", fake_direct)
+    monkeypatch.setattr("intent_router._run_mcporter", fail_mcporter)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await execute_intent(Intent("reminder_create", {"title": "check the oven"}), "guest")
+
+    assert exc_info.value.status_code == 403


### PR DESCRIPTION
## Summary\n- extract shared reminder persistence into reminder_service\n- route the reminders API and intent execution through the shared helper\n- let reminder_create intents use in-process DB execution before falling back to mcporter\n\n## Evidence\n- python3 -m pytest -q services/zoe-data/tests/test_reminder_direct_execution.py services/zoe-data/tests/test_intent_reminder_latency.py services/zoe-data/tests/test_pi_intent_shadow.py::test_intent_router_shadow_extraction_failed_records_pre_pi_latency_and_baseline services/zoe-data/tests/test_pi_intent_classifier.py::test_detect_and_extract_intent_uses_pi_when_slot_extraction_fails -> 41 passed\n- python3 tools/audit/validate_structure.py\n- python3 tools/audit/validate_critical_files.py\n- git diff --check\n- broad intent/chat/pi/voice/memory fleet -> 638 passed\n- worktree direct execute benchmark: warm p50 3.5ms, p95 4.0ms after cold first query\n