### PR TITLE
[codex] Prefer current router baseline in Pi eval

### DIFF
--- a/scripts/maintenance/pi_promotion_eval.py
+++ b/scripts/maintenance/pi_promotion_eval.py
@@ -96,7 +96,11 @@ async def _run_zoe_baseline(
     baseline_response_chars: int | None = None
     baseline_error: str | None = None
     agent_baseline: dict[str, Any] | None = None
-    if case.route_class == "fallback":
+    if intent is not None:
+        # A current router hit is Zoe's comparable baseline, even when the
+        # fixture came from an older fallback/extraction-failure trace.
+        pass
+    elif case.route_class == "fallback":
         if fallback_baseline_latency_ms is not None:
             latency_ms = fallback_baseline_latency_ms
             baseline_kind = "operator_fallback_override"

--- a/services/zoe-data/tests/test_pi_promotion_eval_script.py
+++ b/services/zoe-data/tests/test_pi_promotion_eval_script.py
@@ -76,23 +76,24 @@ def test_cli_loads_cases_file_without_default_cases(tmp_path, capsys):
     assert payload["promotion_report"]["sample_count"] == 0
 
 
-def test_zoe_baseline_marks_fallback_router_only_as_not_comparable(monkeypatch):
+def test_zoe_baseline_uses_current_router_hit_for_stale_fallback_fixture(monkeypatch):
     _install_fake_intent_router(monkeypatch)
     module = _load_module()
     case = module.PiIntentEvalCase("weather", "rain later", "weather", "weather", "fallback")
 
     result = asyncio.run(module._run_zoe_baseline(case))
 
-    assert result["baseline_kind"] == "router_only_not_comparable"
-    assert result["baseline_comparable"] is False
+    assert result["baseline_kind"] == "router"
+    assert result["baseline_comparable"] is True
     assert result["latency_ms"] == result["router_latency_ms"]
+    assert result["correct"] is True
     assert result["baseline_timed_out"] is False
     assert result["baseline_response_chars"] is None
     assert result["baseline_error"] is None
 
 
 def test_zoe_baseline_uses_operator_fallback_latency_override(monkeypatch):
-    _install_fake_intent_router(monkeypatch)
+    _install_fake_intent_router(monkeypatch, intent_name=None)
     module = _load_module()
     case = module.PiIntentEvalCase("weather", "rain later", "weather", "weather", "fallback")
 
@@ -108,7 +109,7 @@ def test_zoe_baseline_uses_operator_fallback_latency_override(monkeypatch):
 
 
 def test_zoe_baseline_operator_override_wins_over_agent_measurement(monkeypatch):
-    _install_fake_intent_router(monkeypatch)
+    _install_fake_intent_router(monkeypatch, intent_name=None)
     calls = []
     _install_fake_zoe_agent(monkeypatch, calls)
     module = _load_module()
@@ -144,6 +145,25 @@ def test_zoe_baseline_uses_operator_extraction_failed_latency_override(monkeypat
     assert result["baseline_timed_out"] is False
     assert result["baseline_response_chars"] is None
     assert result["baseline_error"] is None
+
+
+def test_zoe_baseline_current_router_hit_skips_agent_for_stale_extraction_fixture(monkeypatch):
+    _install_fake_intent_router(monkeypatch, intent_name="reminder_create", confidence=0.91)
+    calls = []
+    _install_fake_zoe_agent(monkeypatch, calls)
+    module = _load_module()
+    case = module.PiIntentEvalCase(
+        "reminder", "remind me to call mum", "reminder_create", "reminders", "extraction_failed"
+    )
+
+    result = asyncio.run(module._run_zoe_baseline(case, measure_zoe_agent_baseline=True))
+
+    assert result["baseline_kind"] == "router"
+    assert result["baseline_comparable"] is True
+    assert result["latency_ms"] == result["router_latency_ms"]
+    assert result["intent"] == "reminder_create"
+    assert result["correct"] is True
+    assert calls == []
 
 
 def test_zoe_baseline_can_measure_comparable_zoe_agent_fallback(monkeypatch):

--- a/services/zoe-data/tests/test_pi_promotion_eval_script.py
+++ b/services/zoe-data/tests/test_pi_promotion_eval_script.py
@@ -78,10 +78,12 @@ def test_cli_loads_cases_file_without_default_cases(tmp_path, capsys):
 
 def test_zoe_baseline_uses_current_router_hit_for_stale_fallback_fixture(monkeypatch):
     _install_fake_intent_router(monkeypatch)
+    calls = []
+    _install_fake_zoe_agent(monkeypatch, calls)
     module = _load_module()
     case = module.PiIntentEvalCase("weather", "rain later", "weather", "weather", "fallback")
 
-    result = asyncio.run(module._run_zoe_baseline(case))
+    result = asyncio.run(module._run_zoe_baseline(case, measure_zoe_agent_baseline=True))
 
     assert result["baseline_kind"] == "router"
     assert result["baseline_comparable"] is True
@@ -90,6 +92,7 @@ def test_zoe_baseline_uses_current_router_hit_for_stale_fallback_fixture(monkeyp
     assert result["baseline_timed_out"] is False
     assert result["baseline_response_chars"] is None
     assert result["baseline_error"] is None
+    assert calls == []
 
 
 def test_zoe_baseline_uses_operator_fallback_latency_override(monkeypatch):


### PR DESCRIPTION
## Summary
- treat current Zoe router hits as the comparable baseline even when eval fixtures came from older fallback or extraction-failure traces
- keep Zoe Agent/operator fallback baselines only for true current router misses
- add regression coverage for stale fallback and extraction-failure fixtures

## Evidence
- python3 -m pytest -q services/zoe-data/tests/test_pi_promotion_eval_script.py services/zoe-data/tests/test_zoe_pi_promotion.py services/zoe-data/tests/test_pi_intent_classifier.py services/zoe-data/tests/test_pi_intent_shadow.py
- python3 tools/audit/validate_structure.py
- python3 tools/audit/validate_critical_files.py
- git diff --check
- ZOE_PI_INTENT_TIMEOUT_SECONDS=8 scripts/maintenance/pi_promotion_eval.py --cases-file data/eval/pi_intent_eval_cases.jsonl --no-default-cases --run-pi --transport rpc --allow-execution --local-model-configured --measure-zoe-agent-baseline --zoe-agent-baseline-timeout-seconds 12 --zoe-agent-baseline-max-tokens 128

## Corrected eval signal
- Pi still beats true fallback cases in this seed set: weather, timers, daily briefing
- Zoe now correctly keeps reminders/lists/calculations on the current fast router baseline instead of the stale slow fallback baseline
- no group is promotable yet because sample count is still below policy minimum