### PR TITLE
[codex] Report Pi shadow sample deficits

### DIFF
--- a/services/zoe-data/pi_intent_shadow.py
+++ b/services/zoe-data/pi_intent_shadow.py
@@ -235,6 +235,8 @@ def shadow_records_to_route_samples(records: Sequence[Mapping[str, Any]]) -> lis
 def summarize_pi_intent_shadow(records: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
     total = len(records)
     if total == 0:
+        labeled_counts = _labeled_counts_by_group(())
+        sample_deficits = {group: PiPromotionPolicy().min_samples for group in labeled_counts}
         return {
             "sample_count": 0,
             "agreement_rate": 0.0,
@@ -245,7 +247,10 @@ def summarize_pi_intent_shadow(records: Sequence[Mapping[str, Any]]) -> dict[str
             "intent_groups": {},
             "accuracy_available": False,
             "labeled_sample_count": 0,
+            "labeled_sample_count_by_group": labeled_counts,
+            "sample_deficit_by_group": sample_deficits,
             "promotion_ready": False,
+            "promotion_ready_groups": [],
             "promotion_ready_reason": "runtime shadow records are unlabeled agreement evidence, not accuracy labels",
         }
     groups: dict[str, dict[str, int]] = {}
@@ -270,7 +275,16 @@ def summarize_pi_intent_shadow(records: Sequence[Mapping[str, Any]]) -> dict[str
             zoe_latencies.append(float(record["zoe_latency_ms"]))
         if isinstance(record.get("pi_latency_ms"), (int, float)):
             pi_latencies.append(float(record["pi_latency_ms"]))
-    labeled_sample_count = sum(1 for record in records if record.get("outcome_label"))
+    policy = PiPromotionPolicy()
+    labeled_counts = _labeled_counts_by_group(records)
+    labeled_sample_count = sum(labeled_counts.values())
+    sample_deficits = {
+        group: max(0, policy.min_samples - labeled_counts.get(group, 0))
+        for group in sorted(LOW_RISK_PI_INTENT_GROUPS)
+    }
+    promotion_ready_groups = [
+        group for group in sorted(LOW_RISK_PI_INTENT_GROUPS) if sample_deficits[group] == 0
+    ]
     return {
         "sample_count": total,
         "agreement_rate": agreements / total,
@@ -281,13 +295,30 @@ def summarize_pi_intent_shadow(records: Sequence[Mapping[str, Any]]) -> dict[str
         "intent_groups": groups,
         "accuracy_available": labeled_sample_count > 0,
         "labeled_sample_count": labeled_sample_count,
-        "promotion_ready": labeled_sample_count >= PiPromotionPolicy().min_samples,
-        "promotion_ready_reason": (
-            "labeled outcome evidence is available for promotion scoring"
-            if labeled_sample_count
-            else "runtime shadow records are unlabeled agreement evidence, not accuracy labels"
-        ),
+        "labeled_sample_count_by_group": labeled_counts,
+        "sample_deficit_by_group": sample_deficits,
+        "promotion_ready": bool(promotion_ready_groups),
+        "promotion_ready_groups": promotion_ready_groups,
+        "promotion_ready_reason": _promotion_ready_reason(labeled_sample_count, promotion_ready_groups),
     }
+
+
+def _labeled_counts_by_group(records: Sequence[Mapping[str, Any]]) -> dict[str, int]:
+    counts = {group: 0 for group in sorted(LOW_RISK_PI_INTENT_GROUPS)}
+    for record in records:
+        intent = _optional_str(record.get("outcome_label"))
+        group = intent_group_for_intent(intent)
+        if group in counts:
+            counts[group] += 1
+    return counts
+
+
+def _promotion_ready_reason(labeled_sample_count: int, ready_groups: Sequence[str]) -> str:
+    if ready_groups:
+        return "one or more intent groups have enough labeled outcome evidence for promotion scoring"
+    if labeled_sample_count:
+        return "labeled outcome evidence exists, but no intent group has enough labels for promotion scoring"
+    return "runtime shadow records are unlabeled agreement evidence, not accuracy labels"
 
 
 def _resolve_baseline_metadata(

--- a/services/zoe-data/pi_intent_shadow.py
+++ b/services/zoe-data/pi_intent_shadow.py
@@ -235,8 +235,9 @@ def shadow_records_to_route_samples(records: Sequence[Mapping[str, Any]]) -> lis
 def summarize_pi_intent_shadow(records: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
     total = len(records)
     if total == 0:
+        policy = PiPromotionPolicy()
         labeled_counts = _labeled_counts_by_group(())
-        sample_deficits = {group: PiPromotionPolicy().min_samples for group in labeled_counts}
+        sample_deficits = {group: policy.min_samples for group in labeled_counts}
         return {
             "sample_count": 0,
             "agreement_rate": 0.0,
@@ -248,6 +249,7 @@ def summarize_pi_intent_shadow(records: Sequence[Mapping[str, Any]]) -> dict[str
             "accuracy_available": False,
             "labeled_sample_count": 0,
             "labeled_sample_count_by_group": labeled_counts,
+            "unmapped_labeled_sample_count": 0,
             "sample_deficit_by_group": sample_deficits,
             "promotion_ready": False,
             "promotion_ready_groups": [],
@@ -277,7 +279,9 @@ def summarize_pi_intent_shadow(records: Sequence[Mapping[str, Any]]) -> dict[str
             pi_latencies.append(float(record["pi_latency_ms"]))
     policy = PiPromotionPolicy()
     labeled_counts = _labeled_counts_by_group(records)
+    raw_labeled_sample_count = sum(1 for record in records if record.get("outcome_label"))
     labeled_sample_count = sum(labeled_counts.values())
+    unmapped_labeled_sample_count = max(0, raw_labeled_sample_count - labeled_sample_count)
     sample_deficits = {
         group: max(0, policy.min_samples - labeled_counts.get(group, 0))
         for group in sorted(LOW_RISK_PI_INTENT_GROUPS)
@@ -296,10 +300,15 @@ def summarize_pi_intent_shadow(records: Sequence[Mapping[str, Any]]) -> dict[str
         "accuracy_available": labeled_sample_count > 0,
         "labeled_sample_count": labeled_sample_count,
         "labeled_sample_count_by_group": labeled_counts,
+        "unmapped_labeled_sample_count": unmapped_labeled_sample_count,
         "sample_deficit_by_group": sample_deficits,
         "promotion_ready": bool(promotion_ready_groups),
         "promotion_ready_groups": promotion_ready_groups,
-        "promotion_ready_reason": _promotion_ready_reason(labeled_sample_count, promotion_ready_groups),
+        "promotion_ready_reason": _promotion_ready_reason(
+            labeled_sample_count,
+            promotion_ready_groups,
+            raw_labeled_sample_count=raw_labeled_sample_count,
+        ),
     }
 
 
@@ -313,11 +322,19 @@ def _labeled_counts_by_group(records: Sequence[Mapping[str, Any]]) -> dict[str, 
     return counts
 
 
-def _promotion_ready_reason(labeled_sample_count: int, ready_groups: Sequence[str]) -> str:
+def _promotion_ready_reason(
+    labeled_sample_count: int,
+    ready_groups: Sequence[str],
+    *,
+    raw_labeled_sample_count: int | None = None,
+) -> str:
+    raw_count = labeled_sample_count if raw_labeled_sample_count is None else raw_labeled_sample_count
     if ready_groups:
         return "one or more intent groups have enough labeled outcome evidence for promotion scoring"
     if labeled_sample_count:
         return "labeled outcome evidence exists, but no intent group has enough labels for promotion scoring"
+    if raw_count:
+        return "labeled outcome evidence exists, but no labels map to a low-risk intent group"
     return "runtime shadow records are unlabeled agreement evidence, not accuracy labels"
 
 

--- a/services/zoe-data/tests/test_pi_intent_shadow.py
+++ b/services/zoe-data/tests/test_pi_intent_shadow.py
@@ -121,6 +121,9 @@ def test_shadow_summary_empty_is_explicitly_not_accuracy_ready():
     assert report["sample_count"] == 0
     assert report["no_result_rate"] == 0.0
     assert report["accuracy_available"] is False
+    assert report["labeled_sample_count_by_group"]["weather"] == 0
+    assert report["sample_deficit_by_group"]["weather"] == PiPromotionPolicy().min_samples
+    assert report["promotion_ready_groups"] == []
 
 
 @pytest.mark.asyncio
@@ -340,7 +343,34 @@ def test_shadow_summary_needs_min_samples_for_promotion_ready():
 
     assert report["accuracy_available"] is True
     assert report["labeled_sample_count"] == 29
+    assert report["labeled_sample_count_by_group"]["weather"] == 29
+    assert report["sample_deficit_by_group"]["weather"] == 1
     assert report["promotion_ready"] is False
+    assert report["promotion_ready_groups"] == []
+
+
+def test_shadow_summary_requires_min_samples_in_one_group_for_promotion_ready():
+    records = [{"outcome_label": "weather"} for _ in range(15)]
+    records.extend({"outcome_label": "timer_create"} for _ in range(15))
+
+    report = summarize_pi_intent_shadow(records)
+
+    assert report["accuracy_available"] is True
+    assert report["labeled_sample_count"] == 30
+    assert report["labeled_sample_count_by_group"]["weather"] == 15
+    assert report["labeled_sample_count_by_group"]["timers"] == 15
+    assert report["sample_deficit_by_group"]["weather"] == 15
+    assert report["sample_deficit_by_group"]["timers"] == 15
+    assert report["promotion_ready"] is False
+    assert report["promotion_ready_groups"] == []
+
+
+def test_shadow_summary_names_groups_with_enough_labeled_evidence():
+    report = summarize_pi_intent_shadow([{"outcome_label": "weather"} for _ in range(PiPromotionPolicy().min_samples)])
+
+    assert report["promotion_ready"] is True
+    assert report["promotion_ready_groups"] == ["weather"]
+    assert report["sample_deficit_by_group"]["weather"] == 0
 
 
 def test_labeled_shadow_fallback_without_comparable_baseline_blocks_promotion(tmp_path):
@@ -414,6 +444,8 @@ def test_shadow_status_includes_promotion_report_for_labeled_records(tmp_path):
     assert status["report"]["accuracy_available"] is True
     assert status["report"]["labeled_sample_count"] == 30
     assert status["report"]["promotion_ready"] is True
+    assert status["report"]["promotion_ready_groups"] == ["weather"]
+    assert status["report"]["sample_deficit_by_group"]["weather"] == 0
     assert "weather" in status["promotion_report"]["promotable_groups"]
     assert status["promotion_report"]["promoted_groups"] == ["weather"]
     assert status["promotion_report"]["promotion_actions"]["next_promoted_groups"] == ["weather"]

--- a/services/zoe-data/tests/test_pi_intent_shadow.py
+++ b/services/zoe-data/tests/test_pi_intent_shadow.py
@@ -122,6 +122,7 @@ def test_shadow_summary_empty_is_explicitly_not_accuracy_ready():
     assert report["no_result_rate"] == 0.0
     assert report["accuracy_available"] is False
     assert report["labeled_sample_count_by_group"]["weather"] == 0
+    assert report["unmapped_labeled_sample_count"] == 0
     assert report["sample_deficit_by_group"]["weather"] == PiPromotionPolicy().min_samples
     assert report["promotion_ready_groups"] == []
 
@@ -363,6 +364,21 @@ def test_shadow_summary_requires_min_samples_in_one_group_for_promotion_ready():
     assert report["sample_deficit_by_group"]["timers"] == 15
     assert report["promotion_ready"] is False
     assert report["promotion_ready_groups"] == []
+    assert report["promotion_ready_reason"] == (
+        "labeled outcome evidence exists, but no intent group has enough labels for promotion scoring"
+    )
+
+
+def test_shadow_summary_reports_unmapped_labeled_evidence_separately():
+    report = summarize_pi_intent_shadow([{"outcome_label": "extend_capability"}])
+
+    assert report["accuracy_available"] is False
+    assert report["labeled_sample_count"] == 0
+    assert report["unmapped_labeled_sample_count"] == 1
+    assert report["promotion_ready"] is False
+    assert report["promotion_ready_reason"] == (
+        "labeled outcome evidence exists, but no labels map to a low-risk intent group"
+    )
 
 
 def test_shadow_summary_names_groups_with_enough_labeled_evidence():
@@ -370,6 +386,7 @@ def test_shadow_summary_names_groups_with_enough_labeled_evidence():
 
     assert report["promotion_ready"] is True
     assert report["promotion_ready_groups"] == ["weather"]
+    assert report["unmapped_labeled_sample_count"] == 0
     assert report["sample_deficit_by_group"]["weather"] == 0
 
 


### PR DESCRIPTION
## Summary
- add per-intent-group labeled sample counts to Pi shadow status
- report per-group sample deficits against the promotion policy minimum
- require one group, not arbitrary total labels, before shadow status marks promotion evidence ready

## Evidence
- python3 -m pytest -q services/zoe-data/tests/test_pi_intent_shadow.py services/zoe-data/tests/test_pi_intent_status_endpoint.py services/zoe-data/tests/test_zoe_pi_promotion.py services/zoe-data/tests/test_pi_promotion_eval_script.py services/zoe-data/tests/test_pi_eval_export.py
- python3 tools/audit/validate_structure.py
- python3 tools/audit/validate_critical_files.py
- git diff --check