### PR TITLE
[codex] Report Pi promotion evidence sources

### DIFF
--- a/scripts/maintenance/pi_promotion_eval.py
+++ b/scripts/maintenance/pi_promotion_eval.py
@@ -68,6 +68,7 @@ def _demo_samples() -> list[PiRouteSample]:
                 pi_latency_ms=320,
                 pi_confidence=0.9,
                 pi_transport="rpc",
+                metadata={"source": "synthetic"},
             )
         )
     return samples
@@ -275,6 +276,7 @@ async def _run_cases(
                     route_class=case.route_class,
                     timed_out=bool(pi["timed_out"]),
                     metadata={
+                        "source": case.source,
                         "baseline_kind": zoe["baseline_kind"],
                         "baseline_comparable": zoe["baseline_comparable"],
                         "baseline_timed_out": zoe["baseline_timed_out"],

--- a/services/zoe-data/tests/test_pi_promotion_eval_script.py
+++ b/services/zoe-data/tests/test_pi_promotion_eval_script.py
@@ -216,6 +216,35 @@ def test_zoe_baseline_timeout_is_not_comparable(monkeypatch):
     assert result["baseline_timed_out"] is True
     assert result["baseline_response_chars"] == 0
 
+def test_run_cases_preserves_eval_case_source_in_sample_metadata(monkeypatch):
+    _install_fake_intent_router(monkeypatch, intent_name=None)
+    _install_fake_zoe_agent(monkeypatch, [], response="fallback answer")
+    _install_fake_pi_classifier(monkeypatch, result=types.SimpleNamespace(intent="weather", confidence=0.93))
+    module = _load_module()
+    case = module.PiIntentEvalCase(
+        "weather_miss",
+        "will it rain later",
+        "weather",
+        "weather",
+        "fallback",
+        source="intent_miss",
+    )
+
+    _comparisons, samples = asyncio.run(
+        module._run_cases(
+            [case],
+            transport="rpc",
+            enable_execution=True,
+            local_model_configured=True,
+            measure_zoe_agent_baseline=True,
+        )
+    )
+
+    assert len(samples) == 1
+    assert samples[0].metadata["source"] == "intent_miss"
+    assert samples[0].metadata["baseline_kind"] == "zoe_agent_fallback_baseline"
+
+
 def test_run_pi_fast_no_result_is_not_timeout(monkeypatch):
     _install_fake_pi_classifier(monkeypatch, result=None)
     monkeypatch.setenv("ZOE_PI_INTENT_PREFILTER_ENABLED", "false")

--- a/services/zoe-data/tests/test_zoe_pi_promotion.py
+++ b/services/zoe-data/tests/test_zoe_pi_promotion.py
@@ -7,6 +7,7 @@ from zoe_pi_promotion import (
     PiRouteSample,
     build_pi_failure_examples,
     build_pi_route_class_breakdown,
+    build_pi_source_breakdown,
     build_pi_transport_breakdown,
     build_pi_promotion_actions,
     eval_cases_to_dict,
@@ -360,6 +361,30 @@ def test_route_class_breakdown_compares_baselines_independently():
     assert breakdown["extraction_failed"]["zoe_p95_latency_ms"] is None
 
 
+def test_source_breakdown_counts_real_synthetic_and_unknown_sources():
+    samples = [
+        _sample(1, metadata={"source": "synthetic"}),
+        _sample(2, metadata={"source": "intent_miss"}),
+        _sample(3),
+        _sample(4, group="timers", expected="timer_create", zoe="weather", pi="timer_create", metadata={"source": "pi_intent_shadow"}),
+    ]
+
+    breakdown = build_pi_source_breakdown(samples, policy=PiPromotionPolicy(min_samples=2))
+
+    assert breakdown["sample_count"] == 4
+    assert breakdown["source_counts"] == {"intent_miss": 1, "pi_intent_shadow": 1, "synthetic": 1, "unknown": 1}
+    assert breakdown["real_source_sample_count"] == 2
+    assert breakdown["synthetic_sample_count"] == 1
+    assert breakdown["unknown_source_sample_count"] == 1
+    assert breakdown["source_counts_by_group"]["weather"] == {"intent_miss": 1, "synthetic": 1, "unknown": 1}
+    assert breakdown["source_counts_by_group"]["timers"] == {"pi_intent_shadow": 1}
+    assert breakdown["real_source_sample_count_by_group"]["weather"] == 1
+    assert breakdown["real_source_sample_count_by_group"]["timers"] == 1
+    assert breakdown["real_source_sample_deficit_by_group"]["weather"] == 1
+    assert breakdown["real_source_sample_deficit_by_group"]["timers"] == 1
+    assert breakdown["real_source_ready_groups"] == []
+
+
 def test_transport_breakdown_separates_print_and_rpc_latency():
     samples = [
         _sample(1, pi_transport="print", zoe_ms=900, pi_ms=700),
@@ -413,6 +438,8 @@ def test_summary_lists_promotable_groups():
     assert report["route_class_breakdown"]["fallback"]["latency_delta_ms"] > 0
     assert report["transport_breakdown"]["rpc"]["sample_count"] == 10
     assert report["transport_breakdown"]["rpc"]["latency_delta_ms"] > 0
+    assert report["source_breakdown"]["unknown_source_sample_count"] == 10
+    assert report["source_breakdown"]["real_source_sample_deficit_by_group"]["weather"] == 10
 
 
 def test_summary_lists_rollback_groups_for_active_promotions():

--- a/services/zoe-data/zoe_pi_promotion.py
+++ b/services/zoe-data/zoe_pi_promotion.py
@@ -700,6 +700,7 @@ __all__ = [
     "PiRouteSample",
     "build_pi_failure_examples",
     "build_pi_route_class_breakdown",
+    "build_pi_source_breakdown",
     "build_pi_transport_breakdown",
     "build_pi_promotion_actions",
     "eval_cases_to_dict",

--- a/services/zoe-data/zoe_pi_promotion.py
+++ b/services/zoe-data/zoe_pi_promotion.py
@@ -33,7 +33,11 @@ PRIVILEGED_INTENTS = {
     "install_runtime",
 }
 
+# Static eval-case labels. Runtime-only sources such as pi_intent_shadow are
+# intentionally excluded because they are produced after collection/labeling.
 EVAL_SOURCES = {"synthetic", "intent_miss", "chat_log", "voice_log", "known_failure"}
+# Sources counted as real/log-derived promotion evidence. Synthetic cases remain
+# useful smoke tests, but should be visible separately in promotion reports.
 REAL_PROMOTION_EVIDENCE_SOURCES = {"intent_miss", "chat_log", "voice_log", "known_failure", "pi_intent_shadow"}
 ROUTE_CLASSES = {"deterministic", "fallback", "extraction_failed"}
 PI_TRANSPORTS = {"print", "rpc"}

--- a/services/zoe-data/zoe_pi_promotion.py
+++ b/services/zoe-data/zoe_pi_promotion.py
@@ -34,6 +34,7 @@ PRIVILEGED_INTENTS = {
 }
 
 EVAL_SOURCES = {"synthetic", "intent_miss", "chat_log", "voice_log", "known_failure"}
+REAL_PROMOTION_EVIDENCE_SOURCES = {"intent_miss", "chat_log", "voice_log", "known_failure", "pi_intent_shadow"}
 ROUTE_CLASSES = {"deterministic", "fallback", "extraction_failed"}
 PI_TRANSPORTS = {"print", "rpc"}
 DECISION_STATES = {"promote", "keep_shadow", "rollback", "blocked"}
@@ -355,6 +356,7 @@ def summarize_pi_promotion(
         "rollback_groups": rollback_groups,
         "route_class_breakdown": build_pi_route_class_breakdown(samples),
         "transport_breakdown": build_pi_transport_breakdown(samples),
+        "source_breakdown": build_pi_source_breakdown(samples, policy=active_policy),
         "failure_examples": build_pi_failure_examples(samples),
         "promotion_actions": build_pi_promotion_actions(
             current_promoted_groups=sorted(active_promoted_groups),
@@ -415,6 +417,52 @@ def build_pi_transport_breakdown(samples: Sequence[PiRouteSample]) -> dict[str, 
             "correction_rate": _rate(sample.user_corrected for sample in transport_samples),
         }
     return breakdown
+
+
+def build_pi_source_breakdown(
+    samples: Sequence[PiRouteSample],
+    *,
+    policy: PiPromotionPolicy | None = None,
+) -> dict[str, Any]:
+    """Summarize where promotion samples came from.
+
+    This is reporting-only evidence. Promotion decisions still use the explicit
+    speed/accuracy gates, while operators can see whether the sample set is
+    synthetic-heavy or backed by runtime/log-derived labels.
+    """
+    active_policy = policy or PiPromotionPolicy()
+    source_counts: dict[str, int] = {}
+    source_counts_by_group: dict[str, dict[str, int]] = {
+        group: {} for group in sorted(LOW_RISK_PI_INTENT_GROUPS)
+    }
+    real_counts_by_group = {group: 0 for group in sorted(LOW_RISK_PI_INTENT_GROUPS)}
+    real_sample_count = 0
+    for sample in samples:
+        sample.validate()
+        source = _sample_source(sample)
+        source_counts[source] = source_counts.get(source, 0) + 1
+        group_counts = source_counts_by_group.setdefault(sample.intent_group, {})
+        group_counts[source] = group_counts.get(source, 0) + 1
+        if source in REAL_PROMOTION_EVIDENCE_SOURCES:
+            real_sample_count += 1
+            real_counts_by_group[sample.intent_group] = real_counts_by_group.get(sample.intent_group, 0) + 1
+    real_deficits = {
+        group: max(0, active_policy.min_samples - real_counts_by_group.get(group, 0))
+        for group in sorted(LOW_RISK_PI_INTENT_GROUPS)
+    }
+    return {
+        "sample_count": len(samples),
+        "source_counts": dict(sorted(source_counts.items())),
+        "source_counts_by_group": {
+            group: dict(sorted(counts.items())) for group, counts in sorted(source_counts_by_group.items())
+        },
+        "real_source_sample_count": real_sample_count,
+        "synthetic_sample_count": source_counts.get("synthetic", 0),
+        "unknown_source_sample_count": source_counts.get("unknown", 0),
+        "real_source_sample_count_by_group": real_counts_by_group,
+        "real_source_sample_deficit_by_group": real_deficits,
+        "real_source_ready_groups": [group for group in sorted(real_deficits) if real_deficits[group] == 0],
+    }
 
 
 def build_pi_failure_examples(samples: Sequence[PiRouteSample], *, limit: int = 5) -> list[dict[str, Any]]:
@@ -539,6 +587,14 @@ def summarize_eval_case_sources(cases: Sequence[PiIntentEvalCase]) -> dict[str, 
 
 def eval_cases_to_dict(cases: Sequence[PiIntentEvalCase] = DEFAULT_PI_INTENT_EVAL_CASES) -> list[dict[str, Any]]:
     return [case.to_dict() for case in cases]
+
+
+def _sample_source(sample: PiRouteSample) -> str:
+    if isinstance(sample.metadata, Mapping):
+        source = _optional_str(sample.metadata.get("source"))
+        if source:
+            return source
+    return "unknown"
 
 
 def _failure_reasons(sample: PiRouteSample) -> list[str]:


### PR DESCRIPTION
## Summary
- carry eval case source into Pi route sample metadata
- add source breakdown reporting to Pi promotion reports
- show real/log-derived sample counts and per-group deficits separately from synthetic and unknown samples

## Why
This keeps Pi speed/accuracy promotion evidence honest before we scale the eval fleet. Synthetic samples can still be useful for smoke tests, but operators can now see whether a group has enough real/log-derived labels to trust a promotion decision.

## Evidence
- python3 -m pytest -q services/zoe-data/tests/test_zoe_pi_promotion.py services/zoe-data/tests/test_pi_promotion_eval_script.py services/zoe-data/tests/test_pi_intent_shadow.py services/zoe-data/tests/test_pi_eval_export.py
- python3 tools/audit/validate_structure.py
- python3 tools/audit/validate_critical_files.py
- git diff --check