### PR TITLE
[codex] Add voice processing intent buffer

### DIFF
--- a/services/zoe-data/.env.example
+++ b/services/zoe-data/.env.example
@@ -54,6 +54,16 @@
 # ZOE_WAKE_ACK_AUDIO_PATHS=
 # ZOE_WAKE_ACK_VARIANT_LABELS=
 #
+# ── Voice: processing acknowledgement phrase (perceived latency) ─────────
+# Short transition phrases for slow streamed/LiveKit turns. Use pre-generated
+# audio paths for truly instant spoken feedback; live TTS is not used here.
+# Defaults are enabled for text/data-channel acknowledgement only.
+# ZOE_PROCESSING_ACK_DEFAULT_ENABLED=true
+# ZOE_PROCESSING_ACK_PHRASE=
+# ZOE_PROCESSING_ACK_AUDIO_PATH=
+# ZOE_PROCESSING_ACK_PHRASES=Let me check.|One moment.|I will check that.
+# ZOE_PROCESSING_ACK_AUDIO_PATHS=
+#
 # ── Voice: barge-in ──────────────────────────────────────────────────────
 # BARGE_IN_ENABLED=true
 # BARGE_IN_THRESHOLD=0.5

--- a/services/zoe-data/routers/voice_livekit.py
+++ b/services/zoe-data/routers/voice_livekit.py
@@ -224,6 +224,19 @@ async def _run_pipeline(local_participant, frames: list[bytes], user_id: str, se
 
     await _send_data(local_participant, {"type": "transcript", "role": "user", "text": transcript})
 
+    try:
+        from voice_presence import processing_ack_event
+
+        ack_event = processing_ack_event()
+        if ack_event:
+            ack_text = str(ack_event.get("text") or "").strip()
+            if ack_text:
+                await _send_data(local_participant, {"type": "transcript", "role": "zoe", "text": ack_text})
+            if ack_event.get("audio_base64"):
+                await _send_data(local_participant, ack_event)
+    except Exception as exc:
+        logger.debug("LiveKit processing acknowledgement failed: %s", exc)
+
     # ── LLM ──────────────────────────────────────────────────────────────────
     response = "Sorry, I had trouble with that."
     llm_ok = True

--- a/services/zoe-data/routers/voice_tts.py
+++ b/services/zoe-data/routers/voice_tts.py
@@ -3551,6 +3551,8 @@ async def voice_command(
                 from push import broadcaster as _bc_stream
                 import json as _json
 
+                nonlocal _t_first_token
+
                 chunk_index = 0
                 token_buf = ""
                 full_reply_parts: list[str] = []
@@ -3630,6 +3632,34 @@ async def voice_command(
 
                     async def _emit_line(line: dict):
                         yield (_json.dumps(line) + "\n").encode()
+
+                    try:
+                        from voice_presence import processing_ack_event
+
+                        ack_event = processing_ack_event()
+                        if ack_event:
+                            ack_text = str(ack_event.get("text") or "").strip()
+                            if ack_text:
+                                await _bc_stream.broadcast("all", "voice:responding", {
+                                    "panel_id": panel_id,
+                                    "text": ack_text,
+                                    "processing_ack": True,
+                                })
+                            if ack_event.get("audio_base64"):
+                                header = _json.dumps({
+                                    "chunk": chunk_index,
+                                    "text": ack_text[:80],
+                                    "provider": str(ack_event.get("audio_source") or "cached-processing-ack"),
+                                    "processing_ack": True,
+                                })
+                                yield (header + "\n").encode()
+                                yield str(ack_event["audio_base64"]).encode() + b"\n"
+                                chunk_index += 1
+                            else:
+                                async for out_line in _emit_line({"processing_ack": True, "text": ack_text, "panel_id": panel_id}):
+                                    yield out_line
+                    except Exception as ack_exc:
+                        logger.debug("voice/command stream processing acknowledgement failed: %s", ack_exc)
 
                     _voice_history = await _load_voice_history(session_id, limit=3)
                     async for delta in run_zoe_agent_streaming(

--- a/services/zoe-data/tests/test_voice_livekit_health.py
+++ b/services/zoe-data/tests/test_voice_livekit_health.py
@@ -12,11 +12,15 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
+import voice_presence
 from routers import voice_livekit
 
 
 @pytest.fixture(autouse=True)
-def _reset_health():
+def _reset_health(monkeypatch):
+    monkeypatch.setattr(voice_presence, "_AUDIO_CACHE", {})
+    monkeypatch.setattr(voice_presence, "_VARIANT_CURSOR", 0)
+    monkeypatch.setattr(voice_presence, "_PROCESSING_ACK_CURSOR", 0)
     voice_livekit.reset_voice_health_for_tests()
     yield
     voice_livekit.reset_voice_health_for_tests()

--- a/services/zoe-data/tests/test_voice_livekit_health.py
+++ b/services/zoe-data/tests/test_voice_livekit_health.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import sys
+import types
 from pathlib import Path
 
 import pytest
@@ -88,6 +89,42 @@ async def test_pipeline_failure_updates_health(monkeypatch):
     assert health["last_stage"] == "stt_failed"
     assert "stt unavailable" in health["last_error"]
     assert local.messages[-1] == {"type": "state", "state": "ambient"}
+
+
+@pytest.mark.asyncio
+async def test_pipeline_emits_processing_ack_before_slow_response(monkeypatch):
+    from routers import voice_tts
+
+    async def _fake_transcribe(_path: str) -> str:
+        return "will I need an umbrella later"
+
+    async def _fake_agent(message, session_id, user_id, voice_mode=False):
+        await asyncio.sleep(0)
+        assert message == "will I need an umbrella later"
+        assert session_id == "s1"
+        assert user_id == "u1"
+        assert voice_mode is True
+        return "It looks like rain later. Take a jacket."
+
+    class Audio:
+        body = b"RIFF-final"
+        media_type = "audio/wav"
+
+    async def _fake_synthesize(_payload, caller=None):
+        return Audio()
+
+    monkeypatch.setattr(voice_tts, "_transcribe_audio", _fake_transcribe)
+    monkeypatch.setattr(voice_tts, "synthesize", _fake_synthesize)
+    monkeypatch.setitem(sys.modules, "zoe_agent", types.SimpleNamespace(run_zoe_agent=_fake_agent))
+    monkeypatch.setenv("ZOE_PROCESSING_ACK_PHRASE", "Let me check.")
+    local = _LocalParticipant()
+
+    await voice_livekit._run_pipeline(local, [b"\x00\x00" * 160], "u1", "s1")
+
+    transcript_messages = [item for item in local.messages if item.get("type") == "transcript"]
+    assert transcript_messages[0] == {"type": "transcript", "role": "user", "text": "will I need an umbrella later"}
+    assert transcript_messages[1] == {"type": "transcript", "role": "zoe", "text": "Let me check."}
+    assert transcript_messages[2] == {"type": "transcript", "role": "zoe", "text": "It looks like rain later. Take a jacket."}
 
 
 @pytest.mark.asyncio

--- a/services/zoe-data/tests/test_voice_presence.py
+++ b/services/zoe-data/tests/test_voice_presence.py
@@ -12,6 +12,10 @@ import voice_presence
 from voice_presence import (
     is_wake_payload,
     is_wake_text,
+    processing_ack_audio_payload,
+    processing_ack_event,
+    processing_ack_phrases,
+    processing_ack_variant,
     wake_ack_audio_payload,
     wake_ack_events,
     wake_ack_phrase,
@@ -228,6 +232,44 @@ def test_presence_event_builder_is_sub_millisecond_for_hot_path():
     elapsed_ms = (time.perf_counter() - started) * 1000
 
     assert elapsed_ms < 5.0
+
+
+def test_processing_ack_phrases_default_and_override():
+    assert processing_ack_phrases({}) == ["Let me check.", "One moment.", "I will check that."]
+    assert processing_ack_phrases({"ZOE_PROCESSING_ACK_DEFAULT_ENABLED": "false"}) == []
+    assert processing_ack_phrases({"ZOE_PROCESSING_ACK_PHRASE": "  Checking now. "}) == ["Checking now."]
+    assert processing_ack_phrases({"ZOE_PROCESSING_ACK_PHRASES": "Checking.|On it."}) == [
+        "Checking.",
+        "On it.",
+    ]
+
+
+def test_processing_ack_variant_rotates_without_reasoning():
+    env = {"ZOE_PROCESSING_ACK_PHRASES": "Checking.|On it."}
+
+    assert processing_ack_variant(env)["phrase"] == "Checking."
+    assert processing_ack_variant(env)["phrase"] == "On it."
+    assert processing_ack_variant(env)["phrase"] == "Checking."
+
+
+def test_processing_ack_event_can_include_cached_audio(tmp_path):
+    audio_path = tmp_path / "processing.wav"
+    audio_path.write_bytes(b"RIFFprocessing")
+
+    event = processing_ack_event(
+        {
+            "ZOE_PROCESSING_ACK_PHRASE": "Let me check.",
+            "ZOE_PROCESSING_ACK_AUDIO_PATH": str(audio_path),
+        }
+    )
+
+    assert event is not None
+    assert event["type"] == "voice:processing_ack"
+    assert event["text"] == "Let me check."
+    assert event["source"] == "intent_buffer"
+    assert event["audio_base64"] == "UklGRnByb2Nlc3Npbmc="
+    assert event["audio_source"] == "cached_processing_ack"
+    assert processing_ack_audio_payload(audio_path=str(audio_path))["source"] == "cached_processing_ack"
 
 
 def test_websocket_wake_returns_presence_events_without_reasoning(monkeypatch):

--- a/services/zoe-data/tests/test_voice_presence.py
+++ b/services/zoe-data/tests/test_voice_presence.py
@@ -29,6 +29,7 @@ from voice_presence import (
 def _reset_voice_presence_state(monkeypatch):
     monkeypatch.setattr(voice_presence, "_AUDIO_CACHE", {})
     monkeypatch.setattr(voice_presence, "_VARIANT_CURSOR", 0)
+    monkeypatch.setattr(voice_presence, "_PROCESSING_ACK_CURSOR", 0)
 
 
 def test_is_wake_text_matches_only_wake_phrase():
@@ -250,6 +251,17 @@ def test_processing_ack_variant_rotates_without_reasoning():
     assert processing_ack_variant(env)["phrase"] == "Checking."
     assert processing_ack_variant(env)["phrase"] == "On it."
     assert processing_ack_variant(env)["phrase"] == "Checking."
+
+
+def test_processing_ack_rotation_is_independent_from_wake_rotation():
+    wake_env = {"ZOE_WAKE_ACK_PHRASES": "Yes.|Morning.|Evening."}
+    processing_env = {"ZOE_PROCESSING_ACK_PHRASES": "Let me check.|One moment."}
+
+    assert wake_ack_variant(wake_env)["phrase"] == "Yes."
+    assert wake_ack_variant(wake_env)["phrase"] == "Morning."
+    assert wake_ack_variant(wake_env)["phrase"] == "Evening."
+
+    assert processing_ack_variant(processing_env)["phrase"] == "Let me check."
 
 
 def test_processing_ack_event_can_include_cached_audio(tmp_path):

--- a/services/zoe-data/tests/test_voice_weather_queue.py
+++ b/services/zoe-data/tests/test_voice_weather_queue.py
@@ -665,3 +665,64 @@ async def test_voice_identity_challenge_survives_tts_failure(monkeypatch) -> Non
     assert calls["challenge"]["panel_id"] == "panel-auth"
     assert calls["request_auth"]["challenge_id"] == "challenge-1"
     assert voice_tts._PENDING_VOICE_IDENT["panel-auth"]["transcript"] == "show my calendar"
+
+
+@pytest.mark.asyncio
+async def test_voice_command_stream_emits_processing_ack_before_slow_response(monkeypatch) -> None:
+    calls: dict[str, object] = {"broadcast": []}
+
+    async def no_user(*_args, **_kwargs):
+        return None
+
+    async def resolve_skybridge_request(*_args, **_kwargs):
+        return None
+
+    class Broadcaster:
+        async def broadcast(self, channel, event, payload):
+            calls["broadcast"].append((channel, event, payload))
+
+    async def load_voice_history(*_args, **_kwargs):
+        return []
+
+    async def run_zoe_agent_streaming(*_args, **_kwargs):
+        yield "The answer is ready."
+
+    async def synthesize_sentence(*_args, **_kwargs):
+        return b"RIFF-final"
+
+    monkeypatch.setenv("ZOE_PROCESSING_ACK_PHRASE", "Let me check.")
+    monkeypatch.setattr(voice_tts, "_resolve_recent_panel_session_user", no_user)
+    monkeypatch.setattr(voice_tts, "_resolve_panel_default_user", no_user)
+    monkeypatch.setattr(voice_tts, "_load_voice_history", load_voice_history)
+    monkeypatch.setattr(voice_tts, "_synthesize_kokoro_sidecar", synthesize_sentence)
+    monkeypatch.setattr(voice_tts, "_VOICE_SESSIONS", {})
+    monkeypatch.setitem(sys.modules, "push", types.SimpleNamespace(broadcaster=Broadcaster()))
+    monkeypatch.setitem(
+        sys.modules,
+        "skybridge_service",
+        types.SimpleNamespace(resolve_skybridge_request=resolve_skybridge_request),
+    )
+    monkeypatch.setitem(sys.modules, "zoe_agent", types.SimpleNamespace(run_zoe_agent_streaming=run_zoe_agent_streaming))
+    monkeypatch.setattr(skybridge_service, "resolve_skybridge_request", resolve_skybridge_request)
+
+    response = await voice_command(
+        {"text": "could you think about this for me", "panel_id": "panel-stream", "session_id": "session-stream"},
+        caller={"user_id": "guest", "panel_id": "panel-stream"},
+        stream=True,
+        db=object(),
+    )
+
+    chunks = [chunk async for chunk in response.body_iterator]
+    first_line = json.loads(chunks[0].decode())
+    final_header = json.loads(chunks[1].decode())
+    done = json.loads(chunks[-1].decode())
+
+    assert first_line == {"processing_ack": True, "text": "Let me check.", "panel_id": "panel-stream"}
+    assert (
+        "all",
+        "voice:responding",
+        {"panel_id": "panel-stream", "text": "Let me check.", "processing_ack": True},
+    ) in calls["broadcast"]
+    assert final_header["text"] == "The answer is ready."
+    assert done["done"] is True
+    assert done["reply"] == "The answer is ready."

--- a/services/zoe-data/tests/test_voice_weather_queue.py
+++ b/services/zoe-data/tests/test_voice_weather_queue.py
@@ -4,6 +4,7 @@ import types
 
 import pytest
 
+import voice_presence
 import skybridge_service
 import routers.voice_tts as voice_tts
 from routers.voice_tts import (
@@ -12,6 +13,13 @@ from routers.voice_tts import (
     _should_supersede_voice_weather_action,
     voice_command,
 )
+
+
+@pytest.fixture(autouse=True)
+def _reset_voice_presence_state(monkeypatch):
+    monkeypatch.setattr(voice_presence, "_AUDIO_CACHE", {})
+    monkeypatch.setattr(voice_presence, "_VARIANT_CURSOR", 0)
+    monkeypatch.setattr(voice_presence, "_PROCESSING_ACK_CURSOR", 0)
 
 
 def _row(action_type: str, payload: dict, key: str = "old-key") -> dict:

--- a/services/zoe-data/voice_presence.py
+++ b/services/zoe-data/voice_presence.py
@@ -20,6 +20,7 @@ _DEFAULT_PROCESSING_ACK_PHRASES = "Let me check.|One moment.|I will check that."
 _WAKE_TEXT_RE = re.compile(r"^\s*(?:hey|hi|hello)\s+zoe[.!?\s]*$", re.I)
 _AUDIO_CACHE: dict[str, Any] = {}
 _VARIANT_CURSOR = 0
+_PROCESSING_ACK_CURSOR = 0
 _VARIANT_LOCK = threading.Lock()
 
 
@@ -163,7 +164,7 @@ def processing_ack_variant(
     These phrases are for perceived latency only. They do not imply completion,
     memory writes, tool success, or authority to execute anything.
     """
-    global _VARIANT_CURSOR
+    global _PROCESSING_ACK_CURSOR
     values = env if env is not None else os.environ
     phrases = processing_ack_phrases(values)
     audio_paths = _split_variants(values.get("ZOE_PROCESSING_ACK_AUDIO_PATHS"))
@@ -173,8 +174,8 @@ def processing_ack_variant(
     variant_count = max(len(phrases), len(audio_paths), 1)
     if index is None:
         with _VARIANT_LOCK:
-            selected = _VARIANT_CURSOR % variant_count
-            _VARIANT_CURSOR += 1
+            selected = _PROCESSING_ACK_CURSOR % variant_count
+            _PROCESSING_ACK_CURSOR += 1
     else:
         selected = index % variant_count
     phrase = phrases[selected] if selected < len(phrases) else ""

--- a/services/zoe-data/voice_presence.py
+++ b/services/zoe-data/voice_presence.py
@@ -16,6 +16,7 @@ import threading
 from pathlib import Path
 from typing import Any, Mapping
 
+_DEFAULT_PROCESSING_ACK_PHRASES = "Let me check.|One moment.|I will check that."
 _WAKE_TEXT_RE = re.compile(r"^\s*(?:hey|hi|hello)\s+zoe[.!?\s]*$", re.I)
 _AUDIO_CACHE: dict[str, Any] = {}
 _VARIANT_CURSOR = 0
@@ -43,6 +44,11 @@ def _split_variants(value: str | None) -> list[str]:
     return [item.strip() for item in str(value or "").split("|") if item.strip()]
 
 
+def _env_bool(value: str | None, *, default: bool = False) -> bool:
+    if value is None:
+        return default
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
 def wake_ack_phrases(env: Mapping[str, str] | None = None) -> list[str]:
     """Resolve configured wake phrases, preserving single-phrase compatibility."""
     values = env if env is not None else os.environ
@@ -67,6 +73,20 @@ def wake_ack_variant_labels(env: Mapping[str, str] | None = None) -> list[str]:
     """Resolve optional pipe-aligned labels for time-aware wake variants."""
     values = env if env is not None else os.environ
     return [label.lower() for label in _split_variants(values.get("ZOE_WAKE_ACK_VARIANT_LABELS"))]
+
+
+def processing_ack_phrases(env: Mapping[str, str] | None = None) -> list[str]:
+    """Resolve short transition phrases for slow voice turns."""
+    values = env if env is not None else os.environ
+    phrases = _split_variants(values.get("ZOE_PROCESSING_ACK_PHRASES"))
+    if phrases:
+        return phrases
+    phrase = str(values.get("ZOE_PROCESSING_ACK_PHRASE") or "").strip()
+    if phrase:
+        return [phrase]
+    if _env_bool(values.get("ZOE_PROCESSING_ACK_DEFAULT_ENABLED"), default=True):
+        return _split_variants(_DEFAULT_PROCESSING_ACK_PHRASES)
+    return []
 
 
 def wake_ack_time_period(now: datetime | None = None) -> str:
@@ -133,6 +153,35 @@ def wake_ack_variant(
     return {"phrase": phrase, "audio_path": audio_path, "index": selected, "label": label}
 
 
+def processing_ack_variant(
+    env: Mapping[str, str] | None = None,
+    *,
+    index: int | None = None,
+) -> dict[str, Any]:
+    """Pick a short acknowledgement for slow voice processing.
+
+    These phrases are for perceived latency only. They do not imply completion,
+    memory writes, tool success, or authority to execute anything.
+    """
+    global _VARIANT_CURSOR
+    values = env if env is not None else os.environ
+    phrases = processing_ack_phrases(values)
+    audio_paths = _split_variants(values.get("ZOE_PROCESSING_ACK_AUDIO_PATHS"))
+    if not audio_paths:
+        audio_path = str(values.get("ZOE_PROCESSING_ACK_AUDIO_PATH") or "").strip()
+        audio_paths = [audio_path] if audio_path else []
+    variant_count = max(len(phrases), len(audio_paths), 1)
+    if index is None:
+        with _VARIANT_LOCK:
+            selected = _VARIANT_CURSOR % variant_count
+            _VARIANT_CURSOR += 1
+    else:
+        selected = index % variant_count
+    phrase = phrases[selected] if selected < len(phrases) else ""
+    audio_path = audio_paths[selected] if selected < len(audio_paths) else ""
+    return {"phrase": phrase, "audio_path": audio_path, "index": selected}
+
+
 def wake_ack_audio_payload(env: Mapping[str, str] | None = None, *, audio_path: str | None = None) -> dict[str, Any] | None:
     """Return cached wake acknowledgement audio from a pre-generated file.
 
@@ -174,6 +223,18 @@ def wake_ack_audio_payload(env: Mapping[str, str] | None = None, *, audio_path: 
     return dict(payload)
 
 
+def processing_ack_audio_payload(
+    env: Mapping[str, str] | None = None,
+    *,
+    audio_path: str | None = None,
+) -> dict[str, Any] | None:
+    """Return cached processing acknowledgement audio from a file only."""
+    payload = wake_ack_audio_payload(env, audio_path=audio_path)
+    if payload:
+        payload["source"] = "cached_processing_ack"
+    return payload
+
+
 def wake_presence_events(*, ack_phrase: str = "", ack_audio: Mapping[str, Any] | None = None) -> list[dict[str, Any]]:
     """Build the instant websocket events for a wake turn.
 
@@ -210,3 +271,18 @@ def wake_ack_events(env: Mapping[str, str] | None = None, *, now: datetime | Non
     variant = wake_ack_variant(env, now=now)
     audio = wake_ack_audio_payload(env, audio_path=variant.get("audio_path"))
     return wake_presence_events(ack_phrase=str(variant.get("phrase") or ""), ack_audio=audio)
+
+
+def processing_ack_event(env: Mapping[str, str] | None = None, *, index: int | None = None) -> dict[str, Any] | None:
+    """Build one data-channel event for the slow-turn intent buffer."""
+    variant = processing_ack_variant(env, index=index)
+    phrase = str(variant.get("phrase") or "").strip()
+    audio = processing_ack_audio_payload(env, audio_path=str(variant.get("audio_path") or ""))
+    if not phrase and not audio:
+        return None
+    event: dict[str, Any] = {"type": "voice:processing_ack", "text": phrase, "source": "intent_buffer"}
+    if audio and audio.get("audio_base64"):
+        event["audio_base64"] = audio["audio_base64"]
+        event["content_type"] = str(audio.get("content_type") or "audio/wav")
+        event["audio_source"] = str(audio.get("source") or "cached_processing_ack")
+    return event


### PR DESCRIPTION
## Summary

Adds a small voice processing acknowledgement buffer for slow Pi/Gemma-style turns.

The intent system still handles deterministic/quick routes first. When a turn falls through to the slower streamed/LiveKit voice path, Zoe can now emit a short natural acknowledgement like "Let me check." before the model/tool response completes.

## Why

Pi RPC is currently close enough for fallback use, but still too slow to sit silently in front of every turn. This creates the best-of-both-worlds shape:

- fast intent paths remain instant;
- slow ambiguous turns get immediate perceived feedback;
- Pi/Gemma can finish in the background without dead air;
- cached audio can be configured for truly instant spoken acknowledgement without live TTS.

## Notes

This does not claim the legacy non-stream HTTP voice command can play audio before its response returns. The implementation is wired only into transports that can emit before the final answer: streaming voice command and LiveKit data-channel voice.

## Validation

- `python3 -m py_compile services/zoe-data/voice_presence.py services/zoe-data/routers/voice_tts.py services/zoe-data/routers/voice_livekit.py services/zoe-data/tests/test_voice_weather_queue.py services/zoe-data/tests/test_voice_livekit_health.py services/zoe-data/tests/test_voice_presence.py`
- `python3 -m pytest -q services/zoe-data/tests/test_voice_presence.py services/zoe-data/tests/test_voice_livekit_health.py services/zoe-data/tests/test_voice_weather_queue.py`
- `python3 tools/audit/validate_structure.py`
