### PR TITLE
[codex] Quote voice ack env examples

### DIFF
--- a/docs/guides/OPERATOR_RUNBOOK.md
+++ b/docs/guides/OPERATOR_RUNBOOK.md
@@ -46,8 +46,9 @@ systemctl --user restart openclaw-gateway # After openclaw.json changes
 | `HA_ACCESS_TOKEN` | .env | — | Home Assistant long-lived token (named `zoe-data`) |
 | `ZOE_WAKE_ACK_PHRASE` | zoe-data + Pi daemon | — | Instant websocket wake transcript and optional TTS phrase after wake word |
 | `ZOE_WAKE_ACK_AUDIO_PATH` | zoe-data + Pi daemon | — | Pre-generated wake ack audio file served from cache before live TTS |
-| `ZOE_WAKE_ACK_PHRASES` / `ZOE_WAKE_ACK_AUDIO_PATHS` | zoe-data + Pi daemon | — | Pipe-separated cached wake response bank; phrase/audio entries are index-aligned |
-| `ZOE_WAKE_ACK_VARIANT_LABELS` | zoe-data + Pi daemon | — | Optional pipe-aligned labels (`default`, `morning`, `afternoon`, `evening`, `night`) for deterministic time-aware wake acks |
+| `ZOE_WAKE_ACK_PHRASES` / `ZOE_WAKE_ACK_AUDIO_PATHS` | zoe-data + Pi daemon | — | Pipe-separated cached wake response bank; phrase/audio entries are index-aligned. Quote pipe-separated values in `.env`, e.g. `ZOE_WAKE_ACK_PHRASES="Yes Jason.|Hi Jason."` |
+| `ZOE_WAKE_ACK_VARIANT_LABELS` | zoe-data + Pi daemon | — | Optional pipe-aligned labels (`default`, `morning`, `afternoon`, `evening`, `night`) for deterministic time-aware wake acks; quote when using pipes, e.g. `"default|morning|evening"` |
+| `ZOE_PROCESSING_ACK_PHRASES` | zoe-data | `"Let me check.|One moment.|I will check that."` | Pipe-separated transition phrases for slow voice turns; quote in `.env` so maintenance probes can shell-source the file safely |
 | `ZOE_DEVICE_TOKEN_SECRET` | zoe-data | — | Secret for device token HMAC (optional extra layer) |
 | `ZOE_PIN_MAX_ATTEMPTS` | zoe-data | 5 | PIN lockout attempts |
 | `ZOE_PIN_CHALLENGE_TTL_S` | zoe-data | 120 | PIN challenge expiry in seconds |

--- a/scripts/setup/pi_voice_daemon_install.sh
+++ b/scripts/setup/pi_voice_daemon_install.sh
@@ -115,6 +115,8 @@ WAKEWORD_DEBUG=0
 VERIFY_SSL=true
 # Optional TTS ack phrase when wake word fires ("" to disable)
 ZOE_WAKE_ACK_PHRASE=
+# Optional phrase bank. Quote pipe-separated values if enabled.
+# ZOE_WAKE_ACK_PHRASES="Yes Jason.|Hi Jason.|Good morning Jason."
 EOF
     echo "    IMPORTANT: Edit $ENV_FILE and set DEVICE_TOKEN before starting."
 else

--- a/services/zoe-data/.env.example
+++ b/services/zoe-data/.env.example
@@ -46,8 +46,10 @@
 # Leave empty to use only the wake beep. Set AUDIO_PATH to a pre-generated
 # wav/mp3 file for instant websocket/Pi wake acknowledgement without live TTS.
 # Use pipe-separated PHRASES/PATHS for a small cached response bank; entries are
-# index-aligned, e.g. Yes Jason?|Good morning Jason.|Good evening Jason.
+# index-aligned and quote values when copying into .env, e.g.
+# ZOE_WAKE_ACK_PHRASES="Yes Jason?|Good morning Jason.|Good evening Jason."
 # Optional labels prefer time-aware variants: default|morning|evening
+# ZOE_WAKE_ACK_VARIANT_LABELS="default|morning|evening"
 # ZOE_WAKE_ACK_PHRASE=
 # ZOE_WAKE_ACK_AUDIO_PATH=
 # ZOE_WAKE_ACK_PHRASES=
@@ -61,7 +63,7 @@
 # ZOE_PROCESSING_ACK_DEFAULT_ENABLED=true
 # ZOE_PROCESSING_ACK_PHRASE=
 # ZOE_PROCESSING_ACK_AUDIO_PATH=
-# ZOE_PROCESSING_ACK_PHRASES=Let me check.|One moment.|I will check that.
+# ZOE_PROCESSING_ACK_PHRASES="Let me check.|One moment.|I will check that."
 # ZOE_PROCESSING_ACK_AUDIO_PATHS=
 #
 # ── Voice: barge-in ──────────────────────────────────────────────────────

--- a/services/zoe-data/tests/test_voice_ack_env_examples.py
+++ b/services/zoe-data/tests/test_voice_ack_env_examples.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[3]
+
+
+def _comment_value(path: Path, key: str) -> str:
+    prefix = f"# {key}="
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if line.startswith(prefix):
+            return line.removeprefix(prefix).strip()
+    raise AssertionError(f"missing {key} in {path}")
+
+
+def test_pipe_separated_ack_examples_are_shell_safe_when_copied_to_env():
+    example = ROOT / "services" / "zoe-data" / ".env.example"
+
+    for key in ("ZOE_PROCESSING_ACK_PHRASES",):
+        value = _comment_value(example, key)
+        assert "|" in value
+        assert value.startswith('"') and value.endswith('"')
+
+    text = example.read_text(encoding="utf-8")
+    assert 'ZOE_WAKE_ACK_PHRASES="Yes Jason?|Good morning Jason.|Good evening Jason."' in text
+    assert 'ZOE_WAKE_ACK_VARIANT_LABELS="default|morning|evening"' in text
+
+
+def test_pi_voice_daemon_template_warns_to_quote_phrase_bank():
+    text = (ROOT / "scripts" / "setup" / "pi_voice_daemon_install.sh").read_text(encoding="utf-8")
+
+    assert 'ZOE_WAKE_ACK_PHRASES="Yes Jason.|Hi Jason.|Good morning Jason."' in text
+    assert "Quote pipe-separated values" in text

--- a/services/zoe-data/tests/test_voice_ack_env_examples.py
+++ b/services/zoe-data/tests/test_voice_ack_env_examples.py
@@ -5,6 +5,12 @@ ROOT = Path(__file__).resolve().parents[3]
 
 
 def _comment_value(path: Path, key: str) -> str:
+    """Return the value from the first commented '# KEY=value' line.
+
+    Only reliable for keys with a single entry, such as
+    ZOE_PROCESSING_ACK_PHRASES. Keys that appear twice as example plus empty
+    placeholder should be checked with raw text substring matching instead.
+    """
     prefix = f"# {key}="
     for line in path.read_text(encoding="utf-8").splitlines():
         if line.startswith(prefix):


### PR DESCRIPTION
## Summary

Makes the wake/processing acknowledgement env examples shell-safe by quoting pipe-separated phrase banks.

This follows the deployment issue we hit when maintenance probes shell-sourced `.env`: unquoted `|` values are valid-looking examples, but they break in shell contexts.

## Validation

- `python3 -m pytest -q services/zoe-data/tests/test_voice_ack_env_examples.py services/zoe-data/tests/test_voice_presence.py`
- `python3 tools/audit/validate_structure.py`
