### PR TITLE
fix(harness): dispatch next phase in-process so chains auto-advance past implement

### DIFF
--- a/services/zoe-data/main.py
+++ b/services/zoe-data/main.py
@@ -782,7 +782,7 @@ async def lifespan(app: FastAPI):
 
                 # Webhook bridge: Hermes-assigned todos / in_progress (no chain) → issue.assigned.
                 try:
-                    from multica_webhook_emitter import emit_issue_assigned, is_configured as _wh_ok
+                    from multica_webhook_emitter import is_configured as _wh_ok
                     from multica_client import get_engineering_multica_agent_id  # type: ignore[import]
                     from multica_poll_dispatch import chain_is_running, chain_needs_dispatch  # type: ignore[import]
                     from multica_dispatch_control import dispatch_is_paused, pause_reason
@@ -900,41 +900,68 @@ async def lifespan(app: FastAPI):
                             _chain = await _poll_chain(_candidate)
                             if not chain_needs_dispatch(_chain):
                                 return
-                            _emit = await emit_issue_assigned(_candidate)
-                            _body = _emit.get("body") or {}
-                            if _emit.get("ok") and isinstance(_body, dict) and _body.get("dispatched"):
-                                if from_todo:
-                                    try:
-                                        await client.update_issue(_tid, status="in_progress")
-                                    except Exception as _ip_exc:
-                                        logger.debug(
-                                            "multica_poll: set in_progress failed for %s: %s",
-                                            _tid,
-                                            _ip_exc,
-                                        )
-                                elif (_candidate.get("status") or "") == "blocked":
-                                    try:
-                                        _phase = (_chain.get("pipeline") or {}).get("phase")
-                                        await client.record_progress(
-                                            _tid,
-                                            phase=_phase,
-                                            evidence="Engineering run resumed",
-                                            status="in_progress",
-                                            clear_blocker=True,
-                                        )
-                                    except Exception as _resume_exc:
-                                        logger.debug(
-                                            "multica_poll: clear stale blocked status failed for %s: %s",
-                                            _tid,
-                                            _resume_exc,
-                                        )
-                                _wh_dispatched += 1
-                                _wh_dispatched_ids.add(_tid)
-                                logger.info(
-                                    "multica_poll: webhook dispatched %s (%s)",
+                            _phase = (_chain.get("pipeline") or {}).get("phase")
+                            # Dispatch the next ready phase IN-PROCESS. The poll loop runs
+                            # inside zoe-data, so it calls dispatch_issue() directly rather
+                            # than POSTing issue.assigned to its own :8000 webhook receiver.
+                            # That loopback hop (a self-HTTP call with a 10s timeout against a
+                            # busy event loop) could silently no-op and strand a chain at its
+                            # next phase — e.g. implement done but verify never dispatched,
+                            # which blocked autonomous verify→review→closeout advancement.
+                            try:
+                                from executor_registry import dispatch_issue  # type: ignore[import]
+
+                                _result = await dispatch_issue(_candidate)
+                            except Exception as _disp_exc:
+                                logger.warning(
+                                    "multica_poll: dispatch_issue failed for %s (phase=%s): %s",
                                     _candidate.get("identifier") or _tid,
-                                    "todo" if from_todo else "in_progress-backfill",
+                                    _phase,
+                                    _disp_exc,
                                 )
+                                return
+                            if not (isinstance(_result, dict) and _result.get("ok")):
+                                logger.info(
+                                    "multica_poll: dispatch_issue(%s) phase=%s not dispatched: %s",
+                                    _candidate.get("identifier") or _tid,
+                                    _phase,
+                                    (_result or {}).get("reason")
+                                    if isinstance(_result, dict)
+                                    else _result,
+                                )
+                                return
+                            if from_todo:
+                                try:
+                                    await client.update_issue(_tid, status="in_progress")
+                                except Exception as _ip_exc:
+                                    logger.debug(
+                                        "multica_poll: set in_progress failed for %s: %s",
+                                        _tid,
+                                        _ip_exc,
+                                    )
+                            elif (_candidate.get("status") or "") == "blocked":
+                                try:
+                                    await client.record_progress(
+                                        _tid,
+                                        phase=_phase,
+                                        evidence="Engineering run resumed",
+                                        status="in_progress",
+                                        clear_blocker=True,
+                                    )
+                                except Exception as _resume_exc:
+                                    logger.debug(
+                                        "multica_poll: clear stale blocked status failed for %s: %s",
+                                        _tid,
+                                        _resume_exc,
+                                    )
+                            _wh_dispatched += 1
+                            _wh_dispatched_ids.add(_tid)
+                            logger.info(
+                                "multica_poll: dispatched %s phase=%s (%s)",
+                                _candidate.get("identifier") or _tid,
+                                _phase,
+                                "todo" if from_todo else "in_progress-backfill",
+                            )
 
                         # Backfill existing in-progress runs before starting fresh todo work.
                         # A partial chain owns the one active ticket lane but still needs this

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -509,6 +509,9 @@ async def test_dispatch_after_implement_evidence_creates_verify():
         creates[0][creates[0].index("--idempotency-key") + 1]
         == "multica:uuid-impl-verify:verify"
     )
+    # verify must be parented to the completed implement row for chain ordering.
+    assert "--parent" in creates[0]
+    assert creates[0][creates[0].index("--parent") + 1] == "t_implement"
 
 
 @pytest.mark.asyncio

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -473,6 +473,45 @@ async def test_dispatch_after_scout_evidence_creates_next_phase():
 
 
 @pytest.mark.asyncio
+async def test_dispatch_after_implement_evidence_creates_verify():
+    """Regression: when implement is done the chain must auto-advance — dispatch
+    creates the verify phase. This is the autonomous implement→verify→…→closeout
+    path; if it regresses, chains strand at implement and never self-close-out.
+    """
+    from pipeline_store import bootstrap_state, save_state
+    from pipeline_evidence import EvidenceItem, transition, with_evidence
+
+    state = await bootstrap_state("multica:uuid-impl-verify", start_phase="implement")
+    state = with_evidence(state, EvidenceItem(kind="tool", summary="graphify", passed=True))
+    state = with_evidence(
+        state,
+        EvidenceItem(
+            kind="pr",
+            summary="https://github.com/o/r/pull/1",
+            artifact="https://github.com/o/r/pull/1",
+            passed=True,
+        ),
+    )
+    state = with_evidence(state, EvidenceItem(kind="test", summary="pytest passed", passed=True))
+    state = transition(state, "complete")
+    assert state.phase == "verify"
+    save_state(state, event="transition", extra={"row_phase": "implement"})
+
+    rows = [_row("implement", "done", chain_version="v4", issue_id="uuid-impl-verify")]
+    a = _FakeAdapter(list_rows=rows)
+    result = await a.dispatch({"id": "uuid-impl-verify", "identifier": "ZOE-IV", "title": "Fix thing"})
+
+    creates = [c for c in a.calls if c[0] == "create"]
+    assert result["phase"] == "verify"
+    assert set(result["chain"]) == {"verify"}
+    assert len(creates) == 1
+    assert (
+        creates[0][creates[0].index("--idempotency-key") + 1]
+        == "multica:uuid-impl-verify:verify"
+    )
+
+
+@pytest.mark.asyncio
 async def test_dispatch_overnight_mode_extends_runtime(monkeypatch):
     monkeypatch.setenv("ZOE_KANBAN_OVERNIGHT_MAX_RUNTIME", "8h")
     a = _FakeAdapter()


### PR DESCRIPTION
## The keystone autonomy bug
The harness produces clean PRs autonomously but **never auto-advanced past implement** — verify→review→closeout never dispatched on their own, so every PR needed a manual merge.

## Root cause
The poll loop (running *inside* zoe-data) advanced a chain by **POSTing `issue.assigned` to zoe-data's own `:8000` webhook receiver** — a loopback self-HTTP call (10s timeout) that then calls `dispatch_issue`. Against a busy event loop that hop could silently no-op, stranding a `partial` chain (implement done, verify ready) with no verify task. Observed on **ZOE-5803**: implement done + `chain_needs_dispatch=True`, but no verify task for 13+ min.

`dispatch()` itself is correct (proven by repro + the new test) — the bug was purely the **invocation hop**.

## Fix
- Poll loop calls `executor_registry.dispatch_issue()` **directly in-process** (the exact call the receiver made) instead of the loopback webhook. The webhook receiver stays for genuine external Multica callers; `emit_issue_assigned` was used **only** by this loop.
- **Logging** of every dispatch outcome (success+phase / not-dispatched+reason / failure) so future no-ops are visible (zoe-data logs don't reach journald).
- Regression test: `test_dispatch_after_implement_evidence_creates_verify` (full `test_kanban_adapter.py` green, 236 passed; poll/dispatch suites green).

## Deploy note
Runtime change to the poll loop → needs a zoe-data restart after merge, then a controlled ticket should run implement→verify→…→closeout fully autonomously.

🤖 Generated with [Claude Code](https://claude.com/claude-code)