### PR TITLE
[codex] Add Pi shadow label sidecar

### DIFF
--- a/scripts/maintenance/pi_eval_export.py
+++ b/scripts/maintenance/pi_eval_export.py
@@ -20,6 +20,7 @@ ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT / "services" / "zoe-data"))
 
 from pi_intent_evidence import has_secret_evidence_text, sanitize_evidence_text  # noqa: E402
+from pi_intent_shadow import apply_pi_intent_shadow_labels, load_pi_intent_shadow_labels  # noqa: E402
 from zoe_pi_promotion import PiIntentEvalCase, intent_group_for_intent, merge_pi_intent_eval_cases  # noqa: E402
 
 _ALLOWED_SOURCES = {"intent_miss", "chat_log", "voice_log", "known_failure", "synthetic"}
@@ -177,12 +178,15 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--case-prefix", default="evidence")
     parser.add_argument("--route-class", choices=sorted(_ALLOWED_ROUTE_CLASSES), default="fallback")
     parser.add_argument("--max-words", type=int, default=32)
+    parser.add_argument("--labels-file", help="Optional JSONL sidecar mapping text_hash to trusted labels")
     parser.add_argument("--summary", action="store_true", help="Write summary JSON to stderr")
     args = parser.parse_args(argv)
 
     rows = load_jsonl(args.input)
+    labels = load_pi_intent_shadow_labels(args.labels_file) if args.labels_file else {}
+    labeled_rows = apply_pi_intent_shadow_labels(rows, labels) if labels else rows
     cases = export_eval_cases(
-        rows,
+        labeled_rows,
         source=args.source,
         case_prefix=args.case_prefix,
         default_route_class=args.route_class,
@@ -196,7 +200,7 @@ def main(argv: list[str] | None = None) -> int:
     else:
         sys.stdout.write(payload)
     if args.summary:
-        print(json.dumps({"input_rows": len(rows), "exported_cases": len(cases)}, sort_keys=True), file=sys.stderr)
+        print(json.dumps({"input_rows": len(rows), "label_count": len(labels), "exported_cases": len(cases)}, sort_keys=True), file=sys.stderr)
     return 0
 
 

--- a/services/zoe-data/pi_intent_shadow.py
+++ b/services/zoe-data/pi_intent_shadow.py
@@ -236,6 +236,8 @@ def _shadow_label_from_row(row: Mapping[str, Any]) -> dict[str, Any]:
     label: dict[str, Any] = {}
     negative = _bool_record_value(row.get("negative"))
     outcome_label = _optional_str(row.get("outcome_label") or row.get("expected_intent") or row.get("label"))
+    if negative and outcome_label and outcome_label not in {"chat", "none", "no_intent"}:
+        return {}
     if negative or outcome_label in {"chat", "none", "no_intent"}:
         label["negative"] = True
         label["outcome_label"] = None
@@ -251,6 +253,7 @@ def _shadow_label_from_row(row: Mapping[str, Any]) -> dict[str, Any]:
         if row.get(key) is not None:
             label[key] = _bool_record_value(row.get(key))
     return label
+
 
 def shadow_records_to_route_samples(records: Sequence[Mapping[str, Any]]) -> list[PiRouteSample]:
     samples: list[PiRouteSample] = []

--- a/services/zoe-data/pi_intent_shadow.py
+++ b/services/zoe-data/pi_intent_shadow.py
@@ -27,6 +27,7 @@ from zoe_pi_promotion import (
 )
 
 _DEFAULT_SHADOW_PATH = "~/.zoe/data/pi-intent-shadow.jsonl"
+_DEFAULT_LABELS_PATH = "~/.zoe/data/pi-intent-shadow-labels.jsonl"
 _UNSET = object()
 _DEFAULT_MAX_REPORT_RECORDS = 500
 _SECRET_KEY_RE = re.compile(r"(?i)(api[_-]?key|\btoken\b|\bsecret\b|password|authorization|\bbearer\b)")
@@ -44,6 +45,7 @@ class PiIntentShadowConfig:
     max_words: int = 32
     include_preview: bool = True
     force_classifier_enabled: bool = True
+    labels_path: str = _DEFAULT_LABELS_PATH
 
     @classmethod
     def from_env(cls, env: Mapping[str, str] | None = None) -> "PiIntentShadowConfig":
@@ -54,6 +56,9 @@ class PiIntentShadowConfig:
             max_words=_int_env(values.get("ZOE_PI_INTENT_SHADOW_MAX_WORDS"), default=32),
             include_preview=_env_bool(values.get("ZOE_PI_INTENT_SHADOW_INCLUDE_PREVIEW"), default=True),
             force_classifier_enabled=_env_bool(values.get("ZOE_PI_INTENT_SHADOW_FORCE_ENABLED"), default=True),
+            labels_path=(
+                values.get("ZOE_PI_INTENT_SHADOW_LABELS_PATH") or _DEFAULT_LABELS_PATH
+            ).strip() or _DEFAULT_LABELS_PATH,
         )
 
     def validate(self) -> None:
@@ -70,6 +75,7 @@ class PiIntentShadowConfig:
             "max_words": self.max_words,
             "include_preview": self.include_preview,
             "force_classifier_enabled": self.force_classifier_enabled,
+            "labels_path": self.labels_path,
         }
 
 
@@ -151,7 +157,9 @@ async def maybe_record_pi_intent_shadow(
 def pi_intent_shadow_status(env: Mapping[str, str] | None = None, *, limit: int = _DEFAULT_MAX_REPORT_RECORDS) -> dict[str, Any]:
     values = env if env is not None else os.environ
     config = PiIntentShadowConfig.from_env(values)
-    records = load_pi_intent_shadow_records(config.path, limit=limit)
+    raw_records = load_pi_intent_shadow_records(config.path, limit=limit)
+    labels = load_pi_intent_shadow_labels(config.labels_path)
+    records = apply_pi_intent_shadow_labels(raw_records, labels)
     samples = shadow_records_to_route_samples(records)
     requested_promoted_groups = _csv_env(values.get("ZOE_PI_INTENT_PROMOTED_GROUPS"))
     promoted_groups = [group for group in requested_promoted_groups if group in LOW_RISK_PI_INTENT_GROUPS]
@@ -159,6 +167,8 @@ def pi_intent_shadow_status(env: Mapping[str, str] | None = None, *, limit: int 
     return {
         "config": config.to_dict(),
         "record_count_window": len(records),
+        "raw_record_count_window": len(raw_records),
+        "label_count": len(labels),
         "report": summarize_pi_intent_shadow(records),
         "promotion_report": summarize_pi_route_promotion(samples, promoted_groups=promoted_groups),
         "ignored_promoted_groups": ignored_promoted_groups,
@@ -181,6 +191,66 @@ def load_pi_intent_shadow_records(path: str, *, limit: int = _DEFAULT_MAX_REPORT
             records.append(item)
     return records
 
+
+def load_pi_intent_shadow_labels(path: str) -> dict[str, dict[str, Any]]:
+    target = Path(path).expanduser()
+    if not target.exists():
+        return {}
+    labels: dict[str, dict[str, Any]] = {}
+    with target.open("r", encoding="utf-8", errors="replace") as handle:
+        for line in handle:
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            try:
+                row = json.loads(stripped)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(row, Mapping):
+                continue
+            text_hash = _optional_str(row.get("text_hash"))
+            if not text_hash:
+                continue
+            label = _shadow_label_from_row(row)
+            if label:
+                labels[text_hash] = label
+    return labels
+
+
+def apply_pi_intent_shadow_labels(
+    records: Sequence[Mapping[str, Any]], labels: Mapping[str, Mapping[str, Any]]
+) -> list[dict[str, Any]]:
+    output: list[dict[str, Any]] = []
+    for record in records:
+        item = dict(record)
+        text_hash = _optional_str(item.get("text_hash"))
+        label = labels.get(text_hash or "")
+        if label:
+            item.update(label)
+            item["outcome_label_source"] = "shadow_label_sidecar"
+        output.append(item)
+    return output
+
+
+def _shadow_label_from_row(row: Mapping[str, Any]) -> dict[str, Any]:
+    label: dict[str, Any] = {}
+    negative = _bool_record_value(row.get("negative"))
+    outcome_label = _optional_str(row.get("outcome_label") or row.get("expected_intent") or row.get("label"))
+    if negative or outcome_label in {"chat", "none", "no_intent"}:
+        label["negative"] = True
+        label["outcome_label"] = None
+    elif outcome_label and intent_group_for_intent(outcome_label):
+        label["outcome_label"] = outcome_label
+    else:
+        return {}
+    for key in ("route_class", "baseline_kind", "source"):
+        value = _optional_str(row.get(key))
+        if value:
+            label[key] = value
+    for key in ("baseline_comparable", "user_corrected", "rollback_blocked"):
+        if row.get(key) is not None:
+            label[key] = _bool_record_value(row.get(key))
+    return label
 
 def shadow_records_to_route_samples(records: Sequence[Mapping[str, Any]]) -> list[PiRouteSample]:
     samples: list[PiRouteSample] = []
@@ -475,6 +545,8 @@ def _env_bool(value: str | None, *, default: bool = False) -> bool:
 
 __all__ = [
     "PiIntentShadowConfig",
+    "apply_pi_intent_shadow_labels",
+    "load_pi_intent_shadow_labels",
     "load_pi_intent_shadow_records",
     "maybe_record_pi_intent_shadow",
     "pi_intent_shadow_status",

--- a/services/zoe-data/tests/test_pi_eval_export.py
+++ b/services/zoe-data/tests/test_pi_eval_export.py
@@ -133,6 +133,44 @@ def test_skips_privileged_intent_with_explicit_intent_group():
     assert len(cases) == 0
 
 
+
+def test_cli_applies_sidecar_labels_before_export(tmp_path, capsys):
+    module = _load_module()
+    source_path = tmp_path / "shadow.jsonl"
+    labels_path = tmp_path / "labels.jsonl"
+    output_path = tmp_path / "cases.jsonl"
+    source_path.write_text(
+        json.dumps({"text_preview": "rain later", "text_hash": "abc123", "route_class": "fallback"}) + "\n",
+        encoding="utf-8",
+    )
+    labels_path.write_text(
+        json.dumps({"text_hash": "abc123", "outcome_label": "weather"}) + "\n",
+        encoding="utf-8",
+    )
+
+    exit_code = module.main(
+        [
+            str(source_path),
+            "--labels-file",
+            str(labels_path),
+            "--output",
+            str(output_path),
+            "--source",
+            "intent_miss",
+            "--case-prefix",
+            "shadow",
+            "--summary",
+        ]
+    )
+
+    summary = json.loads(capsys.readouterr().err)
+    rows = [json.loads(line) for line in output_path.read_text().splitlines()]
+    assert exit_code == 0
+    assert summary == {"exported_cases": 1, "input_rows": 1, "label_count": 1}
+    assert rows[0]["case_id"] == "shadow_abc123"
+    assert rows[0]["expected_intent"] == "weather"
+    assert rows[0]["intent_group"] == "weather"
+
 def test_cli_output_feeds_pi_promotion_eval(tmp_path, capsys):
     export_module = _load_module()
     eval_module = _load_eval_module()

--- a/services/zoe-data/tests/test_pi_intent_shadow.py
+++ b/services/zoe-data/tests/test_pi_intent_shadow.py
@@ -6,6 +6,8 @@ import pytest
 from pi_intent_classifier import PiIntentClassification
 from pi_intent_shadow import (
     PiIntentShadowConfig,
+    apply_pi_intent_shadow_labels,
+    load_pi_intent_shadow_labels,
     load_pi_intent_shadow_records,
     maybe_record_pi_intent_shadow,
     pi_intent_shadow_status,
@@ -114,6 +116,87 @@ def test_shadow_status_summarizes_records(tmp_path):
     assert status["report"]["accuracy_available"] is False
     assert status["report"]["promotion_ready"] is False
 
+
+
+def test_shadow_status_applies_trusted_sidecar_labels(tmp_path):
+    shadow_path = tmp_path / "shadow.jsonl"
+    labels_path = tmp_path / "labels.jsonl"
+    text_hash = "weatherhash"
+    shadow_path.write_text(
+        json.dumps(
+            {
+                "text_hash": text_hash,
+                "text_preview": "rain later",
+                "route_class": "fallback",
+                "zoe_intent": None,
+                "zoe_latency_ms": 500,
+                "pi_intent": "weather",
+                "pi_latency_ms": 120,
+                "pi_confidence": 0.91,
+                "pi_transport": "rpc",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    labels_path.write_text(
+        json.dumps(
+            {
+                "text_hash": text_hash,
+                "outcome_label": "weather",
+                "baseline_kind": "operator_fallback_override",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    status = pi_intent_shadow_status(
+        {
+            "ZOE_PI_INTENT_SHADOW_ENABLED": "true",
+            "ZOE_PI_INTENT_SHADOW_PATH": str(shadow_path),
+            "ZOE_PI_INTENT_SHADOW_LABELS_PATH": str(labels_path),
+        }
+    )
+
+    assert status["label_count"] == 1
+    assert status["record_count_window"] == 1
+    assert status["report"]["accuracy_available"] is True
+    assert status["report"]["labeled_sample_count_by_group"]["weather"] == 1
+    decision = [
+        item for item in status["promotion_report"]["decisions"] if item["intent_group"] == "weather"
+    ][0]
+    assert decision["sample_count"] == 1
+    assert decision["pi_accuracy"] == 1.0
+    assert decision["zoe_accuracy"] == 0.0
+    assert "insufficient_samples" in decision["blockers"]
+
+
+def test_shadow_label_loader_ignores_unmapped_and_applies_negative_labels(tmp_path):
+    labels_path = tmp_path / "labels.jsonl"
+    labels_path.write_text(
+        "\n".join(
+            [
+                json.dumps({"text_hash": "weather", "expected_intent": "weather"}),
+                json.dumps({"text_hash": "casual", "negative": True}),
+                json.dumps({"text_hash": "bad", "expected_intent": "extend_capability"}),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    labels = load_pi_intent_shadow_labels(str(labels_path))
+    records = apply_pi_intent_shadow_labels(
+        [{"text_hash": "weather"}, {"text_hash": "casual"}, {"text_hash": "bad"}], labels
+    )
+
+    assert sorted(labels) == ["casual", "weather"]
+    assert records[0]["outcome_label"] == "weather"
+    assert records[0]["outcome_label_source"] == "shadow_label_sidecar"
+    assert records[1]["negative"] is True
+    assert records[1]["outcome_label"] is None
+    assert "outcome_label" not in records[2]
 
 def test_shadow_summary_empty_is_explicitly_not_accuracy_ready():
     report = summarize_pi_intent_shadow([])

--- a/services/zoe-data/tests/test_pi_intent_shadow.py
+++ b/services/zoe-data/tests/test_pi_intent_shadow.py
@@ -502,7 +502,12 @@ def test_labeled_shadow_fallback_without_comparable_baseline_blocks_promotion(tm
         )
     path.write_text("\n".join(rows) + "\n")
 
-    status = pi_intent_shadow_status({"ZOE_PI_INTENT_SHADOW_PATH": str(path)})
+    status = pi_intent_shadow_status(
+        {
+            "ZOE_PI_INTENT_SHADOW_PATH": str(path),
+            "ZOE_PI_INTENT_SHADOW_LABELS_PATH": str(tmp_path / "no-labels.jsonl"),
+        }
+    )
 
     weather = next(
         decision for decision in status["promotion_report"]["decisions"] if decision["intent_group"] == "weather"
@@ -543,6 +548,7 @@ def test_shadow_status_includes_promotion_report_for_labeled_records(tmp_path):
         {
             "ZOE_PI_INTENT_SHADOW_PATH": str(path),
             "ZOE_PI_INTENT_PROMOTED_GROUPS": "weather",
+            "ZOE_PI_INTENT_SHADOW_LABELS_PATH": str(tmp_path / "no-labels.jsonl"),
         }
     )
 
@@ -564,6 +570,7 @@ def test_shadow_status_ignores_unknown_promoted_groups(tmp_path):
         {
             "ZOE_PI_INTENT_SHADOW_PATH": str(path),
             "ZOE_PI_INTENT_PROMOTED_GROUPS": "weather,device_control",
+            "ZOE_PI_INTENT_SHADOW_LABELS_PATH": str(tmp_path / "no-labels.jsonl"),
         }
     )
 
@@ -599,6 +606,7 @@ def test_shadow_status_lists_rollback_groups_for_labeled_promoted_regression(tmp
         {
             "ZOE_PI_INTENT_SHADOW_PATH": str(path),
             "ZOE_PI_INTENT_PROMOTED_GROUPS": "weather",
+            "ZOE_PI_INTENT_SHADOW_LABELS_PATH": str(tmp_path / "no-labels.jsonl"),
         }
     )
 
@@ -637,6 +645,7 @@ def test_shadow_status_rolls_back_promoted_group_on_reviewed_corrections(tmp_pat
         {
             "ZOE_PI_INTENT_SHADOW_PATH": str(path),
             "ZOE_PI_INTENT_PROMOTED_GROUPS": "weather",
+            "ZOE_PI_INTENT_SHADOW_LABELS_PATH": str(tmp_path / "no-labels.jsonl"),
         }
     )
 
@@ -677,6 +686,7 @@ def test_shadow_status_blocks_promoted_group_on_reviewed_rollback_block(tmp_path
         {
             "ZOE_PI_INTENT_SHADOW_PATH": str(path),
             "ZOE_PI_INTENT_PROMOTED_GROUPS": "weather",
+            "ZOE_PI_INTENT_SHADOW_LABELS_PATH": str(tmp_path / "no-labels.jsonl"),
         }
     )
 
@@ -718,7 +728,12 @@ def test_shadow_status_includes_failure_examples_without_text(tmp_path):
         + "\n"
     )
 
-    status = pi_intent_shadow_status({"ZOE_PI_INTENT_SHADOW_PATH": str(path)})
+    status = pi_intent_shadow_status(
+        {
+            "ZOE_PI_INTENT_SHADOW_PATH": str(path),
+            "ZOE_PI_INTENT_SHADOW_LABELS_PATH": str(tmp_path / "no-labels.jsonl"),
+        }
+    )
 
     examples = status["promotion_report"]["failure_examples"]
     assert len(examples) == 1

--- a/services/zoe-data/tests/test_pi_intent_shadow.py
+++ b/services/zoe-data/tests/test_pi_intent_shadow.py
@@ -105,6 +105,7 @@ def test_shadow_status_summarizes_records(tmp_path):
         {
             "ZOE_PI_INTENT_SHADOW_ENABLED": "true",
             "ZOE_PI_INTENT_SHADOW_PATH": str(path),
+            "ZOE_PI_INTENT_SHADOW_LABELS_PATH": str(tmp_path / "no-labels.jsonl"),
         }
     )
 
@@ -180,6 +181,7 @@ def test_shadow_label_loader_ignores_unmapped_and_applies_negative_labels(tmp_pa
                 json.dumps({"text_hash": "weather", "expected_intent": "weather"}),
                 json.dumps({"text_hash": "casual", "negative": True}),
                 json.dumps({"text_hash": "bad", "expected_intent": "extend_capability"}),
+                json.dumps({"text_hash": "conflict", "negative": True, "outcome_label": "weather"}),
             ]
         )
         + "\n",
@@ -188,7 +190,8 @@ def test_shadow_label_loader_ignores_unmapped_and_applies_negative_labels(tmp_pa
 
     labels = load_pi_intent_shadow_labels(str(labels_path))
     records = apply_pi_intent_shadow_labels(
-        [{"text_hash": "weather"}, {"text_hash": "casual"}, {"text_hash": "bad"}], labels
+        [{"text_hash": "weather"}, {"text_hash": "casual"}, {"text_hash": "bad"}, {"text_hash": "conflict"}],
+        labels,
     )
 
     assert sorted(labels) == ["casual", "weather"]
@@ -197,6 +200,8 @@ def test_shadow_label_loader_ignores_unmapped_and_applies_negative_labels(tmp_pa
     assert records[1]["negative"] is True
     assert records[1]["outcome_label"] is None
     assert "outcome_label" not in records[2]
+    assert "outcome_label" not in records[3]
+
 
 def test_shadow_summary_empty_is_explicitly_not_accuracy_ready():
     report = summarize_pi_intent_shadow([])


### PR DESCRIPTION
## What changed

- Add a Pi shadow label sidecar path: `ZOE_PI_INTENT_SHADOW_LABELS_PATH`, defaulting to `~/.zoe/data/pi-intent-shadow-labels.jsonl`.
- Apply trusted sidecar labels inside `pi_intent_shadow_status()`, so shadow status can report labeled accuracy and promotion candidates without mutating raw shadow JSONL.
- Teach `scripts/maintenance/pi_eval_export.py --labels-file` to export labeled shadow records as sanitized Pi eval JSONL.
- Add regression tests for sidecar label loading, negative labels, status reporting, and eval export.

## Why

Hybrid Pi shadow mode is now live, but raw shadow records have `outcome_label=null`. Promotion needs trusted labels. This closes the loop from live shadow evidence to promotion scoring while keeping raw evidence append-only.

## Validation

- `PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_pi_intent_shadow.py services/zoe-data/tests/test_pi_eval_export.py services/zoe-data/tests/test_zoe_pi_promotion.py services/zoe-data/tests/test_pi_promotion_eval_script.py`
- `python3 tools/audit/validate_structure.py`
- Temp end-to-end smoke: shadow JSONL + labels JSONL -> status `label_count=1`, weather labeled sample count `1`, candidate group `weather`, and exported eval case `shadow_hashweather`.
