### PR TITLE
ci(validate): run test_kanban_phase_budget in CI allowlist (ZOE-5804)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -97,6 +97,7 @@ jobs:
             services/zoe-data/tests/test_pipeline_evidence.py \
             services/zoe-data/tests/test_multica_poll_dispatch.py \
             services/zoe-data/tests/test_main_multica_poll.py \
+            services/zoe-data/tests/test_kanban_phase_budget.py \
             -x -q \
             --override-ini="asyncio_mode=auto"
           PYTHONPATH="${{ github.workspace }}/services/zoe-auth:${{ github.workspace }}/services/zoe-auth/tests" pytest \


### PR DESCRIPTION
Adds `services/zoe-data/tests/test_kanban_phase_budget.py` to the existing zoe-data pytest allowlist in `.github/workflows/validate.yml`, so the harness detectors merged in ZOE-5800 actually run in CI.

### Why
The test file was merged but never added to the allowlist (only the slim dep list is used in CI by design), so it provided zero regression protection.

### What
One-line addition to the zoe-data pytest block. No other CI behavior changes (still an allowlist, not the full suite).

### Deps
None. The test imports only `pytest` and the stdlib-only `services/zoe-data/kanban_phase_budget.py` module, which is already importable via the existing `PYTHONPATH=services/zoe-data`.

### Verification
```
PYTHONPATH=services/zoe-data python3 -m pytest services/zoe-data/tests/test_kanban_phase_budget.py
# 19 passed in 0.14s
```

### Refs
- ZOE-5804 (Multica `cdcbc5bd`)
- ZOE-5800 (merge that added the test file)