### PR TITLE
[codex] Add Pi shadow label admission

### DIFF
--- a/services/zoe-data/pi_intent_shadow.py
+++ b/services/zoe-data/pi_intent_shadow.py
@@ -30,6 +30,7 @@ _DEFAULT_SHADOW_PATH = "~/.zoe/data/pi-intent-shadow.jsonl"
 _DEFAULT_LABELS_PATH = "~/.zoe/data/pi-intent-shadow-labels.jsonl"
 _UNSET = object()
 _DEFAULT_MAX_REPORT_RECORDS = 500
+_ALLOWED_LABEL_SOURCES = {"admin_review", "operator_override"}
 _SECRET_KEY_RE = re.compile(r"(?i)(api[_-]?key|\btoken\b|\bsecret\b|password|authorization|\bbearer\b)")
 _EMAIL_RE = re.compile(r"[\w.+-]+@[\w-]+\.\w+")
 _URL_RE = re.compile(r"https?://\S+")
@@ -230,6 +231,77 @@ def apply_pi_intent_shadow_labels(
             item["outcome_label_source"] = "shadow_label_sidecar"
         output.append(item)
     return output
+
+
+def append_pi_intent_shadow_label(
+    *,
+    text_hash: str,
+    outcome_label: str | None = None,
+    negative: bool = False,
+    source: str = "admin_review",
+    reviewed_by: str | None = None,
+    env: Mapping[str, str] | None = None,
+    config: PiIntentShadowConfig | None = None,
+    shadow_limit: int = _DEFAULT_MAX_REPORT_RECORDS,
+) -> dict[str, Any]:
+    """Append one trusted label for an existing Pi shadow record.
+
+    The sidecar is append-only. If a record is re-labeled later, normal label
+    loading keeps the newest valid row for the same text_hash.
+    """
+    active_config = config or PiIntentShadowConfig.from_env(env)
+    active_config.validate()
+    normalized_hash = str(text_hash or "").strip()
+    if not normalized_hash:
+        raise ValueError("text_hash is required")
+
+    records = load_pi_intent_shadow_records(active_config.path, limit=shadow_limit)
+    matching_record = next(
+        (record for record in records if str(record.get("text_hash") or "").strip() == normalized_hash),
+        None,
+    )
+    if matching_record is None:
+        raise ValueError(f"text_hash not found in the most-recent {shadow_limit} Pi shadow records")
+
+    source_value = str(source or "admin_review").strip() or "admin_review"
+    if source_value not in _ALLOWED_LABEL_SOURCES:
+        raise ValueError("source must be one of: admin_review, operator_override")
+
+    row: dict[str, Any] = {
+        "text_hash": normalized_hash,
+        "source": source_value,
+        "labeled_at": time.time(),
+    }
+    if outcome_label is not None:
+        row["outcome_label"] = str(outcome_label).strip()
+    if negative:
+        row["negative"] = True
+    if reviewed_by:
+        row["reviewed_by_hash"] = _hash_text(reviewed_by)
+
+    label = _shadow_label_from_row(row)
+    if not label:
+        raise ValueError("label must be a low-risk Pi intent or a negative chat/none label")
+
+    _append_jsonl(active_config.labels_path, row)
+    return {
+        "ok": True,
+        "text_hash": normalized_hash,
+        "labels_store": "shadow_labels_sidecar",
+        "label": label,
+        "matched_record": _compact_shadow_record_for_label_response(matching_record),
+    }
+
+
+def _compact_shadow_record_for_label_response(record: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "text_hash": _optional_str(record.get("text_hash")),
+        "text_preview": _optional_str(record.get("text_preview")),
+        "route_class": _optional_str(record.get("route_class")),
+        "zoe_intent": _optional_str(record.get("zoe_intent")),
+        "pi_intent": _optional_str(record.get("pi_intent")),
+        "agreement": _bool_record_value(record.get("agreement")),
+    }
 
 
 def _shadow_label_from_row(row: Mapping[str, Any]) -> dict[str, Any]:
@@ -548,6 +620,7 @@ def _env_bool(value: str | None, *, default: bool = False) -> bool:
 
 __all__ = [
     "PiIntentShadowConfig",
+    "append_pi_intent_shadow_label",
     "apply_pi_intent_shadow_labels",
     "load_pi_intent_shadow_labels",
     "load_pi_intent_shadow_records",

--- a/services/zoe-data/routers/system.py
+++ b/services/zoe-data/routers/system.py
@@ -197,6 +197,30 @@ async def get_pi_hybrid_buffer_status(user: dict = Depends(require_admin)):
     return pi_hybrid_buffer_status()
 
 
+class PiIntentShadowLabelRequest(BaseModel):
+    text_hash: str
+    outcome_label: Optional[str] = None
+    negative: bool = False
+    source: Literal["admin_review", "operator_override"] = "admin_review"
+
+
+@router.post("/pi-intent/shadow-labels")
+async def post_pi_intent_shadow_label(payload: PiIntentShadowLabelRequest, user: dict = Depends(require_admin)):
+    """Append one trusted admin label for an existing Pi shadow record."""
+    from pi_intent_shadow import append_pi_intent_shadow_label
+
+    try:
+        return append_pi_intent_shadow_label(
+            text_hash=payload.text_hash,
+            outcome_label=payload.outcome_label,
+            negative=payload.negative,
+            source=payload.source,
+            reviewed_by=str(user.get("user_id") or "admin"),
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
 def _load_skills_and_cron():
     skills = []
     skills_dir = os.path.expanduser("~/.openclaw/workspace/skills")

--- a/services/zoe-data/tests/test_pi_intent_shadow.py
+++ b/services/zoe-data/tests/test_pi_intent_shadow.py
@@ -6,6 +6,7 @@ import pytest
 from pi_intent_classifier import PiIntentClassification
 from pi_intent_shadow import (
     PiIntentShadowConfig,
+    append_pi_intent_shadow_label,
     apply_pi_intent_shadow_labels,
     load_pi_intent_shadow_labels,
     load_pi_intent_shadow_records,
@@ -171,6 +172,78 @@ def test_shadow_status_applies_trusted_sidecar_labels(tmp_path):
     assert decision["pi_accuracy"] == 1.0
     assert decision["zoe_accuracy"] == 0.0
     assert "insufficient_samples" in decision["blockers"]
+
+
+def test_append_shadow_label_requires_existing_record_and_persists_sidecar(tmp_path):
+    shadow_path = tmp_path / "shadow.jsonl"
+    labels_path = tmp_path / "labels.jsonl"
+    shadow_path.write_text(
+        json.dumps(
+            {
+                "text_hash": "weatherhash",
+                "text_preview": "rain later",
+                "route_class": "fallback",
+                "zoe_intent": None,
+                "zoe_latency_ms": 500,
+                "pi_intent": "weather",
+                "pi_latency_ms": 120,
+                "pi_confidence": 0.91,
+                "pi_transport": "rpc",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    result = append_pi_intent_shadow_label(
+        text_hash="weatherhash",
+        outcome_label="weather",
+        reviewed_by="admin@example.test",
+        config=PiIntentShadowConfig(enabled=True, path=str(shadow_path), labels_path=str(labels_path)),
+    )
+
+    saved = json.loads(labels_path.read_text(encoding="utf-8"))
+    assert result["ok"] is True
+    assert result["label"]["outcome_label"] == "weather"
+    assert result["matched_record"]["text_preview"] == "rain later"
+    assert result["labels_store"] == "shadow_labels_sidecar"
+    assert "labels_path" not in result
+    assert saved["text_hash"] == "weatherhash"
+    assert saved["outcome_label"] == "weather"
+    assert len(saved["reviewed_by_hash"]) == 64
+    assert "admin@example.test" not in labels_path.read_text(encoding="utf-8")
+
+    status = pi_intent_shadow_status(
+        {
+            "ZOE_PI_INTENT_SHADOW_ENABLED": "true",
+            "ZOE_PI_INTENT_SHADOW_PATH": str(shadow_path),
+            "ZOE_PI_INTENT_SHADOW_LABELS_PATH": str(labels_path),
+        }
+    )
+    assert status["label_count"] == 1
+    assert status["report"]["labeled_sample_count_by_group"]["weather"] == 1
+
+
+def test_append_shadow_label_rejects_unknown_or_privileged_labels(tmp_path):
+    shadow_path = tmp_path / "shadow.jsonl"
+    labels_path = tmp_path / "labels.jsonl"
+    shadow_path.write_text(json.dumps({"text_hash": "known", "text_preview": "upgrade yourself"}) + "\n")
+    config = PiIntentShadowConfig(enabled=True, path=str(shadow_path), labels_path=str(labels_path))
+
+    with pytest.raises(ValueError, match="most-recent"):
+        append_pi_intent_shadow_label(text_hash="missing", outcome_label="weather", config=config)
+    with pytest.raises(ValueError, match="source must be one of"):
+        append_pi_intent_shadow_label(
+            text_hash="known",
+            outcome_label="weather",
+            source="freeform",
+            config=config,
+        )
+    with pytest.raises(ValueError, match="low-risk"):
+        append_pi_intent_shadow_label(text_hash="known", outcome_label="extend_capability", config=config)
+    with pytest.raises(ValueError, match="low-risk"):
+        append_pi_intent_shadow_label(text_hash="known", outcome_label="weather", negative=True, config=config)
+    assert not labels_path.exists()
 
 
 def test_shadow_label_loader_ignores_unmapped_and_applies_negative_labels(tmp_path):

--- a/services/zoe-data/tests/test_pi_intent_status_endpoint.py
+++ b/services/zoe-data/tests/test_pi_intent_status_endpoint.py
@@ -1,3 +1,4 @@
+import json
 from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
 
@@ -213,6 +214,94 @@ def test_pi_hybrid_buffer_status_blocks_execution_without_promoted_groups(tmp_pa
     assert data["contract"]["mode"] == "shadow_with_execution_misconfigured"
     assert data["contract"]["ready"] is False
     assert "pi_execution_enabled_without_promoted_groups" in data["contract"]["blockers"]
+
+
+def test_pi_intent_shadow_label_endpoint_appends_trusted_label(tmp_path, monkeypatch):
+    shadow_path = tmp_path / "shadow.jsonl"
+    labels_path = tmp_path / "labels.jsonl"
+    shadow_path.write_text(
+        '{"text_hash":"weatherhash","text_preview":"rain later","route_class":"fallback","zoe_latency_ms":500,"pi_intent":"weather","pi_latency_ms":120,"pi_confidence":0.91}\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("ZOE_PI_INTENT_SHADOW_ENABLED", "true")
+    monkeypatch.setenv("ZOE_PI_INTENT_SHADOW_PATH", str(shadow_path))
+    monkeypatch.setenv("ZOE_PI_INTENT_SHADOW_LABELS_PATH", str(labels_path))
+    app = _admin_app()
+
+    resp = TestClient(app).post(
+        "/api/system/pi-intent/shadow-labels",
+        json={"text_hash": "weatherhash", "outcome_label": "weather"},
+    )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["ok"] is True
+    assert data["label"]["outcome_label"] == "weather"
+    assert data["matched_record"]["text_preview"] == "rain later"
+    saved = json.loads(labels_path.read_text(encoding="utf-8"))
+    assert saved["text_hash"] == "weatherhash"
+    assert saved["outcome_label"] == "weather"
+    assert len(saved["reviewed_by_hash"]) == 64
+    assert "labels_path" not in data
+    assert data["labels_store"] == "shadow_labels_sidecar"
+
+    status = TestClient(app).get("/api/system/pi-intent/shadow-status").json()
+    assert status["label_count"] == 1
+    assert status["report"]["accuracy_available"] is True
+
+
+def test_pi_intent_shadow_label_endpoint_rejects_unlisted_source(tmp_path, monkeypatch):
+    shadow_path = tmp_path / "shadow.jsonl"
+    labels_path = tmp_path / "labels.jsonl"
+    shadow_path.write_text('{"text_hash":"known","text_preview":"rain later"}\n', encoding="utf-8")
+    monkeypatch.setenv("ZOE_PI_INTENT_SHADOW_ENABLED", "true")
+    monkeypatch.setenv("ZOE_PI_INTENT_SHADOW_PATH", str(shadow_path))
+    monkeypatch.setenv("ZOE_PI_INTENT_SHADOW_LABELS_PATH", str(labels_path))
+    app = _admin_app()
+
+    resp = TestClient(app).post(
+        "/api/system/pi-intent/shadow-labels",
+        json={"text_hash": "known", "outcome_label": "weather", "source": "freeform"},
+    )
+
+    assert resp.status_code == 422
+    assert not labels_path.exists()
+
+
+def test_pi_intent_shadow_label_endpoint_rejects_bad_label(tmp_path, monkeypatch):
+    shadow_path = tmp_path / "shadow.jsonl"
+    labels_path = tmp_path / "labels.jsonl"
+    shadow_path.write_text('{"text_hash":"known","text_preview":"upgrade yourself"}\n', encoding="utf-8")
+    monkeypatch.setenv("ZOE_PI_INTENT_SHADOW_ENABLED", "true")
+    monkeypatch.setenv("ZOE_PI_INTENT_SHADOW_PATH", str(shadow_path))
+    monkeypatch.setenv("ZOE_PI_INTENT_SHADOW_LABELS_PATH", str(labels_path))
+    app = _admin_app()
+
+    resp = TestClient(app).post(
+        "/api/system/pi-intent/shadow-labels",
+        json={"text_hash": "known", "outcome_label": "extend_capability"},
+    )
+
+    assert resp.status_code == 400
+    assert "low-risk" in resp.json()["detail"]
+    assert not labels_path.exists()
+
+
+def test_pi_intent_shadow_label_endpoint_rejects_non_admin():
+    app = FastAPI()
+    app.include_router(system_router)
+
+    async def fake_non_admin():
+        raise HTTPException(status_code=403, detail="Admin access required")
+
+    app.dependency_overrides[require_admin] = fake_non_admin
+
+    resp = TestClient(app).post(
+        "/api/system/pi-intent/shadow-labels",
+        json={"text_hash": "known", "outcome_label": "weather"},
+    )
+
+    assert resp.status_code == 403
 
 
 def test_pi_intent_shadow_status_endpoint_rejects_non_admin():


### PR DESCRIPTION
## Summary
- add an append-only admin label admission helper for existing Pi shadow records
- expose POST /api/system/pi-intent/shadow-labels behind require_admin
- validate labels against known shadow records and low-risk/negative label rules
- hash reviewer identity before writing sidecar rows

## Validation
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_pi_intent_shadow.py services/zoe-data/tests/test_pi_intent_status_endpoint.py services/zoe-data/tests/test_pi_eval_export.py services/zoe-data/tests/test_zoe_pi_promotion.py services/zoe-data/tests/test_pi_promotion_eval_script.py services/zoe-data/tests/test_conversation_flow_probe.py
- python3 tools/audit/validate_structure.py
- git diff --check
- python3 -m py_compile services/zoe-data/pi_intent_shadow.py services/zoe-data/routers/system.py

## Smoke
- Temp shadow + POST-style append produced label_count=1 and accuracy_available=true; hybrid warning pi_shadow_has_no_outcome_labels_yet disappeared after label admission.