### PR TITLE
[codex] Dedupe implicit Pi shadow eval exports

### DIFF
--- a/scripts/maintenance/pi_eval_export.py
+++ b/scripts/maintenance/pi_eval_export.py
@@ -56,7 +56,9 @@ def export_eval_cases(
     if source not in _ALLOWED_SOURCES:
         raise ValueError(f"unsupported source {source!r}")
     cases: list[PiIntentEvalCase] = []
+    implicit_cases: dict[str, dict[str, Any]] = {}
     for index, row in enumerate(rows, start=1):
+        explicit_case_id = bool(_optional_str(row.get("case_id")))
         case = _case_from_row(
             row,
             index=index,
@@ -65,8 +67,17 @@ def export_eval_cases(
             default_route_class=default_route_class,
             max_words=max_words,
         )
-        if case is not None:
-            cases.append(case)
+        if case is None:
+            continue
+        if not explicit_case_id:
+            payload = case.to_dict()
+            previous = implicit_cases.get(case.case_id)
+            if previous is not None:
+                if previous == payload:
+                    continue
+                raise ValueError(f"conflicting duplicate implicit eval case_id: {case.case_id}")
+            implicit_cases[case.case_id] = payload
+        cases.append(case)
     return merge_pi_intent_eval_cases(cases)
 
 

--- a/services/zoe-data/tests/test_pi_eval_export.py
+++ b/services/zoe-data/tests/test_pi_eval_export.py
@@ -108,6 +108,30 @@ def test_invalid_route_class_falls_back_to_default():
     assert cases[0].route_class == "fallback"
 
 
+def test_skips_duplicate_implicit_shadow_case_ids():
+    module = _load_module()
+    rows = [
+        {"text_hash": "samehash", "text_preview": "rain later", "outcome_label": "weather"},
+        {"text_hash": "samehash", "text_preview": "rain later", "outcome_label": "weather"},
+    ]
+
+    cases = module.export_eval_cases(rows, source="intent_miss", case_prefix="shadow")
+
+    assert len(cases) == 1
+    assert cases[0].case_id == "shadow_samehash"
+
+
+def test_rejects_conflicting_duplicate_implicit_case_ids():
+    module = _load_module()
+    rows = [
+        {"text_hash": "samehash", "text_preview": "rain later", "outcome_label": "weather"},
+        {"text_hash": "samehash", "text_preview": "will it snow", "outcome_label": "weather"},
+    ]
+
+    with pytest.raises(ValueError, match="conflicting duplicate implicit"):
+        module.export_eval_cases(rows, source="intent_miss", case_prefix="shadow")
+
+
 def test_rejects_duplicate_exported_case_ids():
     module = _load_module()
     rows = [


### PR DESCRIPTION
## Summary
- dedupe repeated implicit Pi shadow export cases when rows share the same generated case_id and payload
- keep explicit duplicate case_id validation unchanged
- add regression coverage for duplicate and conflicting implicit shadow rows

## Validation
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_pi_eval_export.py services/zoe-data/tests/test_zoe_pi_promotion.py services/zoe-data/tests/test_pi_promotion_eval_script.py
- python3 tools/audit/validate_structure.py
- git diff --check
- python3 -m py_compile scripts/maintenance/pi_eval_export.py

## Live smoke
- Exported live shadow + sidecar labels successfully: 18 input rows, 10 labels, 10 exported eval cases.