### PR TITLE
[codex] Count unique Pi shadow labels in status

### DIFF
--- a/services/zoe-data/pi_intent_shadow.py
+++ b/services/zoe-data/pi_intent_shadow.py
@@ -423,8 +423,9 @@ def summarize_pi_intent_shadow(records: Sequence[Mapping[str, Any]]) -> dict[str
         if isinstance(record.get("pi_latency_ms"), (int, float)):
             pi_latencies.append(float(record["pi_latency_ms"]))
     policy = PiPromotionPolicy()
-    labeled_counts = _labeled_counts_by_group(records)
-    raw_labeled_sample_count = sum(1 for record in records if record.get("outcome_label"))
+    unique_labeled_records = _unique_labeled_records(records)
+    labeled_counts = _labeled_counts_by_group(unique_labeled_records)
+    raw_labeled_sample_count = sum(1 for record in unique_labeled_records if record.get("outcome_label"))
     labeled_sample_count = sum(labeled_counts.values())
     unmapped_labeled_sample_count = max(0, raw_labeled_sample_count - labeled_sample_count)
     sample_deficits = {
@@ -455,6 +456,24 @@ def summarize_pi_intent_shadow(records: Sequence[Mapping[str, Any]]) -> dict[str
             raw_labeled_sample_count=raw_labeled_sample_count,
         ),
     }
+
+
+def _unique_labeled_records(records: Sequence[Mapping[str, Any]]) -> list[Mapping[str, Any]]:
+    unique_by_hash: dict[str, Mapping[str, Any]] = {}
+    ordered_keys: list[str] = []
+    output: list[Mapping[str, Any]] = []
+    for record in records:
+        if not record.get("outcome_label"):
+            continue
+        text_hash = _optional_str(record.get("text_hash"))
+        if not text_hash:
+            output.append(record)
+            continue
+        if text_hash not in unique_by_hash:
+            ordered_keys.append(text_hash)
+        unique_by_hash[text_hash] = record
+    output.extend(unique_by_hash[text_hash] for text_hash in ordered_keys)
+    return output
 
 
 def _labeled_counts_by_group(records: Sequence[Mapping[str, Any]]) -> dict[str, int]:

--- a/services/zoe-data/tests/test_pi_intent_shadow.py
+++ b/services/zoe-data/tests/test_pi_intent_shadow.py
@@ -500,6 +500,37 @@ def test_labeled_shadow_records_skip_missing_latency():
     assert samples == []
 
 
+def test_shadow_summary_counts_duplicate_text_hash_labels_once():
+    records = [
+        {"text_hash": "same", "outcome_label": "weather"},
+        {"text_hash": "same", "outcome_label": "weather"},
+        {"text_hash": "other", "outcome_label": "weather"},
+        {"outcome_label": "weather"},
+        {"outcome_label": "weather"},
+    ]
+
+    report = summarize_pi_intent_shadow(records)
+
+    assert report["sample_count"] == 5
+    assert report["labeled_sample_count"] == 4
+    assert report["labeled_sample_count_by_group"]["weather"] == 4
+    assert report["sample_deficit_by_group"]["weather"] == PiPromotionPolicy().min_samples - 4
+
+
+def test_shadow_summary_uses_last_label_for_duplicate_text_hash():
+    records = [
+        {"text_hash": "same", "outcome_label": "weather"},
+        {"text_hash": "same", "outcome_label": "timer_create"},
+    ]
+
+    report = summarize_pi_intent_shadow(records)
+
+    assert report["sample_count"] == 2
+    assert report["labeled_sample_count"] == 1
+    assert report["labeled_sample_count_by_group"]["weather"] == 0
+    assert report["labeled_sample_count_by_group"]["timers"] == 1
+
+
 def test_shadow_summary_needs_min_samples_for_promotion_ready():
     report = summarize_pi_intent_shadow([{"outcome_label": "weather"} for _ in range(29)])
 


### PR DESCRIPTION
## Summary
- make Pi shadow status count durable labeled evidence by unique text_hash
- keep raw shadow sample_count unchanged
- preserve in-memory synthetic records without text_hash as distinct samples
- add regression coverage for repeated shadow rows sharing a text_hash

## Validation
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_pi_intent_shadow.py services/zoe-data/tests/test_pi_intent_status_endpoint.py services/zoe-data/tests/test_pi_eval_export.py services/zoe-data/tests/test_zoe_pi_promotion.py services/zoe-data/tests/test_pi_promotion_eval_script.py services/zoe-data/tests/test_conversation_flow_probe.py
- python3 tools/audit/validate_structure.py
- git diff --check
- python3 -m py_compile services/zoe-data/pi_intent_shadow.py

## Live-style smoke
- Against live shadow/label files: label_count=10, positive unique labeled_sample_count=8, weather=3, negatives excluded from promotion counts.