### PR TITLE
[codex] Add Pi promotion accuracy floor

### DIFF
--- a/services/zoe-data/tests/test_zoe_pi_promotion.py
+++ b/services/zoe-data/tests/test_zoe_pi_promotion.py
@@ -273,6 +273,28 @@ def test_promotion_blocks_when_accuracy_delta_is_too_small():
     assert "accuracy_delta_below_threshold" in decision.blockers
 
 
+def test_promotion_blocks_when_pi_absolute_accuracy_is_too_low():
+    samples = []
+    for index in range(30):
+        pi_intent = "weather" if index < 18 else "reminder_list"
+        zoe_intent = "weather" if index < 3 else "reminder_list"
+        samples.append(_sample(index, pi=pi_intent, zoe=zoe_intent))
+    policy = PiPromotionPolicy(min_samples=30, accuracy_win_margin=0.05, min_pi_accuracy=0.90)
+
+    decision = evaluate_pi_promotion(samples, intent_group="weather", policy=policy)
+
+    assert decision.state == "keep_shadow"
+    assert decision.pi_accuracy == 0.6
+    assert decision.zoe_accuracy == 0.1
+    assert decision.accuracy_delta == 0.5
+    assert "pi_accuracy_below_threshold" in decision.blockers
+    assert "accuracy_delta_below_threshold" not in decision.blockers
+
+    summary = build_pi_candidate_wins(samples, policy=policy)
+    assert summary["groups"] == []
+    assert summary["promotion_ready_groups"] == []
+
+
 def test_promotion_blocks_when_pi_is_not_faster_than_zoe():
     samples = [_sample(i, zoe_ms=250, pi_ms=450) for i in range(10)]
     policy = PiPromotionPolicy(min_samples=10, accuracy_win_margin=0.05)
@@ -298,6 +320,20 @@ def test_promoted_group_rolls_back_on_accuracy_regression():
 
     assert decision.state == "rollback"
     assert "accuracy_delta_below_threshold" in decision.blockers
+
+
+def test_promoted_group_rolls_back_when_pi_absolute_accuracy_regresses():
+    samples = []
+    for index in range(30):
+        pi_intent = "weather" if index < 18 else "reminder_list"
+        zoe_intent = "weather" if index < 3 else "reminder_list"
+        samples.append(_sample(index, pi=pi_intent, zoe=zoe_intent))
+    policy = PiPromotionPolicy(min_samples=30, accuracy_win_margin=0.05, min_pi_accuracy=0.90)
+
+    decision = evaluate_pi_promotion(samples, intent_group="weather", policy=policy, promoted=True)
+
+    assert decision.state == "rollback"
+    assert "pi_accuracy_below_threshold" in decision.blockers
 
 
 def test_promoted_group_rolls_back_when_evidence_stops():
@@ -488,6 +524,7 @@ def test_summary_lists_promotable_groups():
     assert report["unique_case_count"] == 10
     assert report["candidate_wins"]["promotion_ready_groups"] == ["weather"]
     assert report["policy"]["accuracy_win_margin"] == 0.05
+    assert report["policy"]["min_pi_accuracy"] == 0.90
     assert report["route_class_breakdown"]["fallback"]["sample_count"] == 10
     assert report["route_class_breakdown"]["fallback"]["latency_delta_ms"] > 0
     assert report["transport_breakdown"]["rpc"]["sample_count"] == 10

--- a/services/zoe-data/zoe_pi_promotion.py
+++ b/services/zoe-data/zoe_pi_promotion.py
@@ -176,6 +176,7 @@ class PiRouteSample:
 class PiPromotionPolicy:
     min_samples: int = 30
     accuracy_win_margin: float = 0.05
+    min_pi_accuracy: float = 0.90
     max_timeout_rate: float = 0.05
     max_correction_rate: float = 0.03
     require_latency_win: bool = True
@@ -184,7 +185,7 @@ class PiPromotionPolicy:
     def validate(self) -> None:
         if self.min_samples <= 0:
             raise ValueError("min_samples must be positive")
-        for field_name in ("accuracy_win_margin", "max_timeout_rate", "max_correction_rate"):
+        for field_name in ("accuracy_win_margin", "min_pi_accuracy", "max_timeout_rate", "max_correction_rate"):
             value = getattr(self, field_name)
             if not 0 <= value <= 1:
                 raise ValueError(f"{field_name} must be between 0 and 1")
@@ -281,6 +282,8 @@ def evaluate_pi_promotion(
         blockers.append("insufficient_samples")
     if accuracy_delta < active_policy.accuracy_win_margin:
         blockers.append("accuracy_delta_below_threshold")
+    if pi_accuracy < active_policy.min_pi_accuracy:
+        blockers.append("pi_accuracy_below_threshold")
     if active_policy.require_latency_win and (latency_delta is None or latency_delta <= 0):
         blockers.append("latency_not_faster_than_zoe")
     if timeout_rate > active_policy.max_timeout_rate:
@@ -301,6 +304,7 @@ def evaluate_pi_promotion(
         "timeout_rate_too_high",
         "correction_rate_too_high",
         "latency_not_faster_than_zoe",
+        "pi_accuracy_below_threshold",
     }
     # Non-comparable baseline evidence blocks promotion, but does not prove a promoted route regressed.
     if promoted and rollback_blockers.intersection(blockers):
@@ -349,6 +353,7 @@ def summarize_pi_promotion(
         "policy": {
             "min_samples": active_policy.min_samples,
             "accuracy_win_margin": active_policy.accuracy_win_margin,
+            "min_pi_accuracy": active_policy.min_pi_accuracy,
             "max_timeout_rate": active_policy.max_timeout_rate,
             "max_correction_rate": active_policy.max_correction_rate,
             "require_latency_win": active_policy.require_latency_win,


### PR DESCRIPTION
## Summary
- add `min_pi_accuracy` to the Pi promotion policy, defaulting to 0.90
- block promotion/candidate wins when Pi beats Zoe but remains below the absolute accuracy floor
- rollback already-promoted groups if fresh evidence drops below the Pi accuracy floor

## Why
The 90-case synthetic fleet exposed an unsafe gap: weather/timers could be faster than the fallback and beat Zoe by the 5pp delta gate while still only reaching roughly 53-60% Pi accuracy. Speed plus "better than bad" is not enough for Zoe core promotion.

## Validation
- `PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_zoe_pi_promotion.py services/zoe-data/tests/test_pi_promotion_eval_script.py services/zoe-data/tests/test_pi_readiness_report.py services/zoe-data/tests/test_pi_intent_shadow.py` -> 93 passed
- `python3 tools/audit/validate_structure.py` -> passed
- `git diff --check` -> passed
- 90-case Pi RPC synthetic fleet:
  - state: `keep_shadow`
  - weather: Pi accuracy 0.6333, blocked by `pi_accuracy_below_threshold`
  - timers: Pi accuracy 0.4667, blocked by `pi_accuracy_below_threshold`
  - daily_briefing: Pi accuracy 0.0, blocked by `accuracy_delta_below_threshold` and `pi_accuracy_below_threshold`
  - shadow evidence lines unchanged: 72 before, 72 after
