### PR TITLE
[codex] Keep unpromoted Pi shadow nonblocking

### DIFF
--- a/services/zoe-data/intent_router.py
+++ b/services/zoe-data/intent_router.py
@@ -23,6 +23,8 @@ from typing import TYPE_CHECKING, Optional
 
 from fastapi import HTTPException
 
+from zoe_pi_promotion import LOW_RISK_PI_INTENT_GROUPS
+
 if TYPE_CHECKING:
     from conversation_context import ConversationContext
 
@@ -1600,7 +1602,19 @@ async def detect_and_extract_intent(
         task = asyncio.create_task(_runner())
         task.add_done_callback(lambda done: done.exception() if not done.cancelled() else None)
 
+    def _pi_execution_has_promoted_groups() -> bool:
+        if not _env_enabled("ZOE_PI_INTENT_ENABLED"):
+            return False
+        requested = {
+            group.strip()
+            for group in str(os.environ.get("ZOE_PI_INTENT_PROMOTED_GROUPS") or "").split(",")
+            if group.strip()
+        }
+        return bool(requested.intersection(LOW_RISK_PI_INTENT_GROUPS))
+
     async def _try_pi_governor() -> tuple[Optional["Intent"], object | None]:
+        if not _pi_execution_has_promoted_groups():
+            return None, shadow_unset
         pi_classified = None
         try:
             from pi_intent_classifier import PI_INTENT_EXECUTE_THRESHOLD, classify_with_pi_intent_governor, pi_intent_is_promoted

--- a/services/zoe-data/tests/test_pi_intent_classifier.py
+++ b/services/zoe-data/tests/test_pi_intent_classifier.py
@@ -712,19 +712,52 @@ async def test_detect_and_extract_intent_does_not_execute_unpromoted_pi_result(t
             "reason": "reminder query phrased unusually",
         },
     )
+    record = tmp_path / "pi-record.json"
     monkeypatch.setenv("PATH", str(bindir))
     monkeypatch.setenv("ZOE_PI_INTENT_ENABLED", "true")
     monkeypatch.setenv("ZOE_PI_CWD", str(tmp_path))
     monkeypatch.setenv("ZOE_PI_ALLOW_EXECUTION", "true")
     monkeypatch.setenv("ZOE_PI_LOCAL_MODEL_CONFIGURED", "true")
     monkeypatch.setenv("ZOE_PI_INTENT_MODEL", "gemma-4-E2B-it-Q4_K_M.gguf")
+    monkeypatch.setenv("PI_TEST_RECORD", str(record))
     monkeypatch.delenv("ZOE_PI_INTENT_PROMOTED_GROUPS", raising=False)
+    monkeypatch.delenv("ZOE_PI_INTENT_SHADOW_ENABLED", raising=False)
 
     from intent_router import detect_and_extract_intent
 
     intent = await detect_and_extract_intent("anything I should remember right now")
 
     assert intent is None
+    assert not record.exists()
+
+
+@pytest.mark.asyncio
+async def test_detect_and_extract_intent_runs_unpromoted_pi_only_in_shadow(tmp_path, monkeypatch):
+    calls = 0
+    recorded = asyncio.Event()
+
+    async def fake_record(text, **kwargs):
+        nonlocal calls
+        await asyncio.sleep(0)
+        calls += 1
+        assert text == "anything I should remember right now"
+        assert "pi_result" not in kwargs
+        assert kwargs["route_class"] == "fallback"
+        recorded.set()
+        return {"recorded": True}
+
+    monkeypatch.setenv("ZOE_PI_INTENT_ENABLED", "true")
+    monkeypatch.setenv("ZOE_PI_INTENT_SHADOW_ENABLED", "true")
+    monkeypatch.delenv("ZOE_PI_INTENT_PROMOTED_GROUPS", raising=False)
+    monkeypatch.setattr("pi_intent_shadow.maybe_record_pi_intent_shadow", fake_record)
+
+    from intent_router import detect_and_extract_intent
+
+    intent = await detect_and_extract_intent("anything I should remember right now")
+    await asyncio.wait_for(recorded.wait(), timeout=1.0)
+
+    assert intent is None
+    assert calls == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- keep Pi intent classification out of the foreground unless at least one low-risk group is promoted
- preserve async Pi shadow evidence for unpromoted mode
- add tests proving unpromoted Pi is not executed synchronously and shadow mode still schedules evidence

## Why
The hybrid target is instant intent-buffer behavior while Pi spins beside Zoe. Before this change, `ZOE_PI_INTENT_ENABLED=true` could make missed/extraction-failed router paths wait on Pi even when no groups were promoted. That creates avoidable dead air in shadow/evidence mode.

## Validation
- `PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_pi_intent_classifier.py services/zoe-data/tests/test_pi_intent_shadow.py services/zoe-data/tests/test_pi_promotion_eval_script.py services/zoe-data/tests/test_pi_intent_fleet_benchmark.py services/zoe-data/tests/test_conversation_flow_probe.py` -> 85 passed
- `python3 tools/audit/validate_structure.py` -> passed
- `git diff --check` -> passed
- Fake slow Pi runtime smoke:
  - no promoted groups: ~69ms, `intent=null`, Pi invocations 0
  - `reminders` promoted: ~841ms, `intent=reminder_list`, Pi invocations 1
