### PR TITLE
[codex] Align Pi hybrid reports with nonblocking shadow

### DIFF
--- a/services/zoe-data/pi_hybrid_buffer.py
+++ b/services/zoe-data/pi_hybrid_buffer.py
@@ -85,6 +85,7 @@ def _hybrid_contract(
     ignored_groups = list(promotion.get("ignored_groups") or [])
     pi_enabled = bool(pi_config.get("enabled"))
     shadow_enabled = bool(shadow_config.get("enabled"))
+    foreground_pi_execution_enabled = pi_enabled and bool(active_groups)
     processing_ready = bool(presence_gate.get("processing_ack_ready"))
     wake_ready = bool(presence_gate.get("wake_ack_ready"))
 
@@ -94,8 +95,10 @@ def _hybrid_contract(
     warnings.extend(str(item) for item in presence_gate.get("warnings") or [])
     if ignored_groups:
         blockers.append("non_allowlisted_pi_groups_requested")
-    if pi_enabled and not active_groups:
-        blockers.append("pi_execution_enabled_without_promoted_groups")
+    if active_groups and not pi_enabled:
+        blockers.append("promoted_groups_without_pi_classifier_enabled")
+    if pi_enabled and shadow_enabled and not active_groups:
+        warnings.append("pi_classifier_enabled_without_promoted_groups_runs_shadow_only")
     if not shadow_enabled and not active_groups:
         blockers.append("pi_shadow_disabled_without_promoted_groups")
     if str(pi_config.get("transport") or "print") != "rpc":
@@ -107,12 +110,10 @@ def _hybrid_contract(
         if label_count == 0:
             warnings.append("pi_shadow_has_no_outcome_labels_yet")
 
-    if pi_enabled and active_groups:
+    if foreground_pi_execution_enabled:
         mode = "promoted_buffer"
-    elif shadow_enabled and not pi_enabled:
-        mode = "shadow_buffer"
     elif shadow_enabled:
-        mode = "shadow_with_execution_misconfigured"
+        mode = "shadow_buffer"
     else:
         mode = "buffer_only"
 
@@ -123,7 +124,9 @@ def _hybrid_contract(
         "wake_ack_ready": wake_ready,
         "processing_ack_ready": processing_ready,
         "pi_shadow_enabled": shadow_enabled,
+        "pi_classifier_enabled": pi_enabled,
         "pi_execution_enabled": pi_enabled,
+        "foreground_pi_execution_enabled": foreground_pi_execution_enabled,
         "promoted_groups": active_groups,
         "blockers": _dedupe(blockers),
         "warnings": _dedupe(warnings),

--- a/services/zoe-data/tests/test_pi_intent_status_endpoint.py
+++ b/services/zoe-data/tests/test_pi_intent_status_endpoint.py
@@ -193,7 +193,7 @@ def test_pi_hybrid_buffer_status_endpoint_reports_shadow_buffer_ready(tmp_path, 
     assert data["pi"]["shadow"]["record_count_window"] == 1
 
 
-def test_pi_hybrid_buffer_status_blocks_execution_without_promoted_groups(tmp_path, monkeypatch):
+def test_pi_hybrid_buffer_status_reports_enabled_pi_without_promotions_as_nonblocking_shadow(tmp_path, monkeypatch):
     path = tmp_path / "shadow.jsonl"
     labels_path = tmp_path / "labels.jsonl"
     path.write_text("", encoding="utf-8")
@@ -211,9 +211,39 @@ def test_pi_hybrid_buffer_status_blocks_execution_without_promoted_groups(tmp_pa
 
     assert resp.status_code == 200
     data = resp.json()
-    assert data["contract"]["mode"] == "shadow_with_execution_misconfigured"
+    assert data["contract"]["mode"] == "shadow_buffer"
+    assert data["contract"]["ready"] is True
+    assert data["contract"]["pi_classifier_enabled"] is True
+    assert data["contract"]["pi_execution_enabled"] is True
+    assert data["contract"]["foreground_pi_execution_enabled"] is False
+    assert "pi_execution_enabled_without_promoted_groups" not in data["contract"]["blockers"]
+    assert "pi_classifier_enabled_without_promoted_groups_runs_shadow_only" in data["contract"]["warnings"]
+
+
+def test_pi_hybrid_buffer_status_blocks_promoted_groups_when_classifier_disabled(tmp_path, monkeypatch):
+    path = tmp_path / "shadow.jsonl"
+    labels_path = tmp_path / "labels.jsonl"
+    path.write_text("", encoding="utf-8")
+    labels_path.write_text("", encoding="utf-8")
+    monkeypatch.setenv("ZOE_WAKE_ACK_PHRASES", "Yes Jason.")
+    monkeypatch.setenv("ZOE_PROCESSING_ACK_PHRASES", "Let me check.")
+    monkeypatch.setenv("ZOE_PI_INTENT_ENABLED", "false")
+    monkeypatch.setenv("ZOE_PI_INTENT_SHADOW_ENABLED", "true")
+    monkeypatch.setenv("ZOE_PI_INTENT_PROMOTED_GROUPS", "weather")
+    monkeypatch.setenv("ZOE_PI_INTENT_SHADOW_PATH", str(path))
+    monkeypatch.setenv("ZOE_PI_INTENT_SHADOW_LABELS_PATH", str(labels_path))
+    app = _admin_app()
+
+    resp = TestClient(app).get("/api/system/pi-intent/hybrid-buffer-status")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["contract"]["mode"] == "shadow_buffer"
     assert data["contract"]["ready"] is False
-    assert "pi_execution_enabled_without_promoted_groups" in data["contract"]["blockers"]
+    assert data["contract"]["pi_classifier_enabled"] is False
+    assert data["contract"]["foreground_pi_execution_enabled"] is False
+    assert data["contract"]["promoted_groups"] == ["weather"]
+    assert "promoted_groups_without_pi_classifier_enabled" in data["contract"]["blockers"]
 
 
 def test_pi_readiness_report_endpoint_is_admin_scoped(tmp_path, monkeypatch):

--- a/services/zoe-data/tests/test_pi_readiness_report.py
+++ b/services/zoe-data/tests/test_pi_readiness_report.py
@@ -97,7 +97,7 @@ def test_readiness_report_surfaces_operator_apply_when_promotion_ready(tmp_path)
     }
 
 
-def test_readiness_report_prioritizes_configuration_blockers_over_promotable_evidence(tmp_path):
+def test_readiness_report_treats_enabled_pi_without_promotions_as_shadow_mode(tmp_path):
     shadow_path = tmp_path / "shadow.jsonl"
     shadow_path.write_text(
         "".join(json.dumps(_winning_weather_row(index)) + "\n" for index in range(30)),
@@ -109,9 +109,12 @@ def test_readiness_report_prioritizes_configuration_blockers_over_promotable_evi
 
     report = pi_readiness_report(env)
 
-    assert report["state"] == "configuration_blocked"
-    assert "pi_execution_enabled_without_promoted_groups" in report["hybrid"]["blockers"]
-    assert report["next_actions"][0]["kind"] == "fix_configuration"
+    assert report["state"] == "promotion_apply_ready"
+    assert report["hybrid"]["mode"] == "shadow_buffer"
+    assert report["hybrid"]["ready"] is True
+    assert "pi_execution_enabled_without_promoted_groups" not in report["hybrid"]["blockers"]
+    assert "pi_classifier_enabled_without_promoted_groups_runs_shadow_only" in report["hybrid"]["warnings"]
+    assert report["promotion_actions"]["promote_groups"] == ["weather"]
 
 
 def test_readiness_report_requests_comparable_baseline_for_router_only_shadow_data(tmp_path):


### PR DESCRIPTION
## Summary
- align Pi hybrid/readiness reports with the nonblocking shadow behavior merged in #577
- separate `pi_classifier_enabled` from foreground `pi_execution_enabled`
- report `ZOE_PI_INTENT_ENABLED=true` with no promoted groups as safe shadow mode, not misconfiguration

## Why
After #577, enabling Pi without promoted groups no longer runs Pi in the foreground. The operator status still called that state `shadow_with_execution_misconfigured`, which made the report contradict runtime behavior and could send us chasing a fake blocker.

## Validation
- `PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_pi_intent_status_endpoint.py services/zoe-data/tests/test_pi_readiness_report.py services/zoe-data/tests/test_conversation_flow_probe.py services/zoe-data/tests/test_pi_intent_classifier.py` -> 56 passed
- `python3 tools/audit/validate_structure.py` -> passed
- `git diff --check` -> passed
- direct report smoke now returns `mode=shadow_buffer`, `ready=True`, `pi_classifier_enabled=True`, `foreground_pi_execution_enabled=False`, and no `pi_execution_enabled_without_promoted_groups` blocker
