### PR TITLE
[codex] Use standalone Pi runtime discovery

### DIFF
--- a/services/zoe-data/pi_intent_classifier.py
+++ b/services/zoe-data/pi_intent_classifier.py
@@ -14,7 +14,6 @@ import logging
 import glob
 import os
 import re
-import shutil
 import time
 import uuid
 from dataclasses import dataclass
@@ -665,7 +664,9 @@ def _runtime_probe_env(env: Mapping[str, str] | None, config: PiIntentClassifier
     )
     values["ZOE_PI_ALLOW_EXECUTION"] = values.get("ZOE_PI_ALLOW_EXECUTION", "false")
     values["ZOE_PI_LOCAL_MODEL_CONFIGURED"] = values.get("ZOE_PI_LOCAL_MODEL_CONFIGURED", "false")
-    values["PATH"] = _path_with_node(values.get("PATH", ""))
+    values["PATH"] = _path_with_node(
+        values.get("PATH", ""), pi_command=config.command, discover_runtime_bins=env is None
+    )
     return values
 
 
@@ -678,19 +679,24 @@ def _pi_subprocess_env(env: Mapping[str, str]) -> dict[str, str]:
     return values
 
 
-def _path_with_node(path: str) -> str:
+def _path_with_node(path: str, *, pi_command: str, discover_runtime_bins: bool) -> str:
     parts = [part for part in path.split(os.pathsep) if part]
-    joined = os.pathsep.join(parts)
-    if shutil.which("node", path=joined) and shutil.which("npm", path=joined):
-        return joined
-    node_bin = os.environ.get("ZOE_NVM_NODE_BIN") or _discover_nvm_node_bin()
+    if not discover_runtime_bins:
+        return os.pathsep.join(parts)
+    configured_node_bin = os.environ.get("ZOE_NVM_NODE_BIN")
+    node_bin = configured_node_bin if _nvm_bin_has_runtime(configured_node_bin, pi_command=pi_command) else None
+    node_bin = node_bin or _discover_nvm_node_bin(pi_command=pi_command)
     if node_bin and node_bin not in parts:
         parts.append(node_bin)
     return os.pathsep.join(parts)
 
 
-def _discover_nvm_node_bin() -> str | None:
-    candidates = [path for path in glob.glob(os.path.expanduser("~/.nvm/versions/node/*/bin")) if os.path.isdir(path)]
+def _discover_nvm_node_bin(*, pi_command: str) -> str | None:
+    candidates = [
+        path
+        for path in glob.glob(os.path.expanduser("~/.nvm/versions/node/*/bin"))
+        if _nvm_bin_has_runtime(path, pi_command=pi_command)
+    ]
     if not candidates:
         return None
 
@@ -702,6 +708,16 @@ def _discover_nvm_node_bin() -> str | None:
             return (0,)
 
     return sorted(candidates, key=version_key)[-1]
+
+
+def _nvm_bin_has_runtime(path: str | None, *, pi_command: str) -> bool:
+    return bool(
+        path
+        and os.path.isdir(path)
+        and os.path.exists(os.path.join(path, "node"))
+        and os.path.exists(os.path.join(path, "npm"))
+        and os.path.exists(os.path.join(path, pi_command))
+    )
 
 
 def _sanitize_prompt_value(value: str) -> str:

--- a/services/zoe-data/pi_runtime_probe.py
+++ b/services/zoe-data/pi_runtime_probe.py
@@ -274,7 +274,7 @@ def _tool_snapshot(pi_command: str, env: Mapping[str, str] | None = None) -> dic
     values = env if env is not None else os.environ
     path = values.get("PATH")
     if env is None:
-        path = _path_with_nvm_node_bin(path or "", pi_command=pi_command)
+        path = _path_with_runtime_bins(path or "", pi_command=pi_command)
     return {
         "node": shutil.which("node", path=path),
         "npm": shutil.which("npm", path=path),
@@ -282,7 +282,7 @@ def _tool_snapshot(pi_command: str, env: Mapping[str, str] | None = None) -> dic
     }
 
 
-def _path_with_nvm_node_bin(path: str, *, pi_command: str) -> str:
+def _path_with_runtime_bins(path: str, *, pi_command: str) -> str:
     parts = [part for part in path.split(os.pathsep) if part]
     node_bin = _discover_nvm_node_bin(pi_command=pi_command)
     if node_bin:
@@ -295,11 +295,10 @@ def _discover_nvm_node_bin(*, pi_command: str) -> str | None:
     nvm_versions = Path.home() / ".nvm" / "versions" / "node"
     if not nvm_versions.is_dir():
         return None
-    candidates = [path / "bin" for path in nvm_versions.iterdir() if (path / "bin").is_dir()]
     candidates = [
-        path
-        for path in candidates
-        if (path / "node").exists() and (path / "npm").exists() and (path / pi_command).exists()
+        path / "bin"
+        for path in nvm_versions.iterdir()
+        if (path / "bin" / "node").exists() and (path / "bin" / "npm").exists()
     ]
     if not candidates:
         return None
@@ -311,7 +310,8 @@ def _discover_nvm_node_bin(*, pi_command: str) -> str | None:
         except ValueError:
             return (0,)
 
-    return str(sorted(candidates, key=version_key)[-1])
+    standalone_candidates = [path for path in candidates if (path / pi_command).exists()]
+    return str(sorted(standalone_candidates or candidates, key=version_key)[-1])
 
 
 def _tool_version_snapshot(

--- a/services/zoe-data/tests/test_pi_intent_classifier.py
+++ b/services/zoe-data/tests/test_pi_intent_classifier.py
@@ -209,10 +209,10 @@ def test_pi_intent_runtime_env_uses_standalone_nvm_pi_only(tmp_path, monkeypatch
     openclaw_bin.mkdir(parents=True)
     for command in ("node", "npm", "pi"):
         path = nvm_bin / command
-        path.write_text("#!/bin/sh" + chr(10) + "exit 0" + chr(10), encoding="utf-8")
+        path.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
         path.chmod(0o755)
     bundled_pi = openclaw_bin / "pi"
-    bundled_pi.write_text("#!/bin/sh" + chr(10) + "exit 0" + chr(10), encoding="utf-8")
+    bundled_pi.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
     bundled_pi.chmod(0o755)
     monkeypatch.setenv("HOME", str(home))
     monkeypatch.setenv("PATH", "")
@@ -223,6 +223,7 @@ def test_pi_intent_runtime_env_uses_standalone_nvm_pi_only(tmp_path, monkeypatch
     path_parts = runtime_env["PATH"].split(os.pathsep)
     assert str(nvm_bin) in path_parts
     assert str(openclaw_bin) not in path_parts
+
 
 def test_pi_intent_prefilter_allows_low_risk_tasks_and_rejects_casual_chat():
     assert pi_intent_prefilter_allows("rain later") is True

--- a/services/zoe-data/tests/test_pi_intent_classifier.py
+++ b/services/zoe-data/tests/test_pi_intent_classifier.py
@@ -12,6 +12,7 @@ from pi_intent_classifier import (
     _probe_pi_runtime_cached,
     _parse_pi_classification,
     _rpc_response_matches_request,
+    _runtime_probe_env,
     classify_with_pi_intent_governor,
     pi_intent_is_promoted,
     pi_intent_prefilter_allows,
@@ -198,6 +199,30 @@ def test_pi_intent_config_exposes_prefilter_default():
     assert config.prefilter_enabled is True
     assert config.to_dict()["prefilter_enabled"] is True
 
+
+
+def test_pi_intent_runtime_env_uses_standalone_nvm_pi_only(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    nvm_bin = home / ".nvm" / "versions" / "node" / "v22.22.0" / "bin"
+    openclaw_bin = home / ".openclaw" / "npm" / "node_modules" / ".bin"
+    nvm_bin.mkdir(parents=True)
+    openclaw_bin.mkdir(parents=True)
+    for command in ("node", "npm", "pi"):
+        path = nvm_bin / command
+        path.write_text("#!/bin/sh" + chr(10) + "exit 0" + chr(10), encoding="utf-8")
+        path.chmod(0o755)
+    bundled_pi = openclaw_bin / "pi"
+    bundled_pi.write_text("#!/bin/sh" + chr(10) + "exit 0" + chr(10), encoding="utf-8")
+    bundled_pi.chmod(0o755)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("PATH", "")
+    config = PiIntentClassifierConfig.from_env({"ZOE_PI_INTENT_ENABLED": "true"})
+
+    runtime_env = _runtime_probe_env(None, config)
+
+    path_parts = runtime_env["PATH"].split(os.pathsep)
+    assert str(nvm_bin) in path_parts
+    assert str(openclaw_bin) not in path_parts
 
 def test_pi_intent_prefilter_allows_low_risk_tasks_and_rejects_casual_chat():
     assert pi_intent_prefilter_allows("rain later") is True

--- a/services/zoe-data/tests/test_pi_intent_status_endpoint.py
+++ b/services/zoe-data/tests/test_pi_intent_status_endpoint.py
@@ -95,6 +95,7 @@ def test_pi_intent_status_endpoint_reports_available_execution_disabled_when_too
 
 def test_pi_intent_status_endpoint_reports_missing_pi_when_tools_absent(tmp_path, monkeypatch):
     bindir = _fake_node_runtime(tmp_path)
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
     monkeypatch.setenv("PATH", str(bindir))
     monkeypatch.setenv("ZOE_PI_INTENT_ENABLED", "true")
     monkeypatch.setenv("ZOE_PI_CWD", str(tmp_path))

--- a/services/zoe-data/tests/test_pi_runtime_probe.py
+++ b/services/zoe-data/tests/test_pi_runtime_probe.py
@@ -210,10 +210,10 @@ def test_default_probe_ignores_openclaw_pi_without_standalone_install(tmp_path, 
     versions = {"node": "v22.22.0", "npm": "10.9.4"}
     for command in ("node", "npm"):
         runtime = nvm_bin / command
-        runtime.write_text("#!/bin/sh" + chr(10) + f"echo {versions[command]}" + chr(10), encoding="utf-8")
+        runtime.write_text(f"#!/bin/sh\necho {versions[command]}\n", encoding="utf-8")
         runtime.chmod(0o755)
     bundled_pi = openclaw_bin / "pi"
-    bundled_pi.write_text("#!/bin/sh" + chr(10) + "echo 0.74.0" + chr(10), encoding="utf-8")
+    bundled_pi.write_text("#!/bin/sh\necho 0.74.0\n", encoding="utf-8")
     bundled_pi.chmod(0o755)
     monkeypatch.setenv("HOME", str(home))
     monkeypatch.setenv("PATH", "")
@@ -226,6 +226,7 @@ def test_default_probe_ignores_openclaw_pi_without_standalone_install(tmp_path, 
     assert result.tool_versions["node"] == "v22.22.0"
     assert result.to_dict()["requirements"]["node"]["status"] == "ok"
 
+
 def test_default_probe_prefers_standalone_nvm_pi_over_openclaw_bundle(tmp_path, monkeypatch):
     home = tmp_path / "home"
     nvm_bin = home / ".nvm" / "versions" / "node" / "v22.22.0" / "bin"
@@ -235,13 +236,13 @@ def test_default_probe_prefers_standalone_nvm_pi_over_openclaw_bundle(tmp_path, 
     versions = {"node": "v22.22.0", "npm": "10.9.4"}
     for command in ("node", "npm"):
         runtime = nvm_bin / command
-        runtime.write_text("#!/bin/sh" + chr(10) + f"echo {versions[command]}" + chr(10), encoding="utf-8")
+        runtime.write_text(f"#!/bin/sh\necho {versions[command]}\n", encoding="utf-8")
         runtime.chmod(0o755)
     standalone_pi = nvm_bin / "pi"
-    standalone_pi.write_text("#!/bin/sh" + chr(10) + "echo 0.79.3" + chr(10), encoding="utf-8")
+    standalone_pi.write_text("#!/bin/sh\necho 0.79.3\n", encoding="utf-8")
     standalone_pi.chmod(0o755)
     bundled_pi = openclaw_bin / "pi"
-    bundled_pi.write_text("#!/bin/sh" + chr(10) + "echo 0.74.0" + chr(10), encoding="utf-8")
+    bundled_pi.write_text("#!/bin/sh\necho 0.74.0\n", encoding="utf-8")
     bundled_pi.chmod(0o755)
     monkeypatch.setenv("HOME", str(home))
     monkeypatch.setenv("PATH", "")
@@ -254,6 +255,7 @@ def test_default_probe_prefers_standalone_nvm_pi_over_openclaw_bundle(tmp_path, 
     assert result.tools["npm"] == str(nvm_bin / "npm")
     assert result.tools["pi"] == str(standalone_pi)
     assert result.tool_versions["node"] == "v22.22.0"
+
 
 def test_default_probe_prefers_nvm_node_when_system_node_lacks_pi(tmp_path, monkeypatch):
     home = tmp_path / "home"

--- a/services/zoe-data/tests/test_pi_runtime_probe.py
+++ b/services/zoe-data/tests/test_pi_runtime_probe.py
@@ -200,6 +200,61 @@ def test_default_probe_discovers_nvm_pi_install(tmp_path, monkeypatch):
     assert result.to_dict()["requirements"]["node"]["status"] == "ok"
 
 
+
+def test_default_probe_ignores_openclaw_pi_without_standalone_install(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    nvm_bin = home / ".nvm" / "versions" / "node" / "v22.22.0" / "bin"
+    openclaw_bin = home / ".openclaw" / "npm" / "node_modules" / ".bin"
+    nvm_bin.mkdir(parents=True)
+    openclaw_bin.mkdir(parents=True)
+    versions = {"node": "v22.22.0", "npm": "10.9.4"}
+    for command in ("node", "npm"):
+        runtime = nvm_bin / command
+        runtime.write_text("#!/bin/sh" + chr(10) + f"echo {versions[command]}" + chr(10), encoding="utf-8")
+        runtime.chmod(0o755)
+    bundled_pi = openclaw_bin / "pi"
+    bundled_pi.write_text("#!/bin/sh" + chr(10) + "echo 0.74.0" + chr(10), encoding="utf-8")
+    bundled_pi.chmod(0o755)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("PATH", "")
+    monkeypatch.setenv("ZOE_PI_ENABLED", "true")
+
+    result = probe_pi_runtime()
+
+    assert result.status == "missing_pi"
+    assert result.tools == {"node": str(nvm_bin / "node"), "npm": str(nvm_bin / "npm"), "pi": None}
+    assert result.tool_versions["node"] == "v22.22.0"
+    assert result.to_dict()["requirements"]["node"]["status"] == "ok"
+
+def test_default_probe_prefers_standalone_nvm_pi_over_openclaw_bundle(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    nvm_bin = home / ".nvm" / "versions" / "node" / "v22.22.0" / "bin"
+    openclaw_bin = home / ".openclaw" / "npm" / "node_modules" / ".bin"
+    nvm_bin.mkdir(parents=True)
+    openclaw_bin.mkdir(parents=True)
+    versions = {"node": "v22.22.0", "npm": "10.9.4"}
+    for command in ("node", "npm"):
+        runtime = nvm_bin / command
+        runtime.write_text("#!/bin/sh" + chr(10) + f"echo {versions[command]}" + chr(10), encoding="utf-8")
+        runtime.chmod(0o755)
+    standalone_pi = nvm_bin / "pi"
+    standalone_pi.write_text("#!/bin/sh" + chr(10) + "echo 0.79.3" + chr(10), encoding="utf-8")
+    standalone_pi.chmod(0o755)
+    bundled_pi = openclaw_bin / "pi"
+    bundled_pi.write_text("#!/bin/sh" + chr(10) + "echo 0.74.0" + chr(10), encoding="utf-8")
+    bundled_pi.chmod(0o755)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("PATH", "")
+    monkeypatch.setenv("ZOE_PI_ENABLED", "true")
+
+    result = probe_pi_runtime()
+
+    assert result.status == "available_execution_disabled"
+    assert result.tools["node"] == str(nvm_bin / "node")
+    assert result.tools["npm"] == str(nvm_bin / "npm")
+    assert result.tools["pi"] == str(standalone_pi)
+    assert result.tool_versions["node"] == "v22.22.0"
+
 def test_default_probe_prefers_nvm_node_when_system_node_lacks_pi(tmp_path, monkeypatch):
     home = tmp_path / "home"
     nvm_bin = home / ".nvm" / "versions" / "node" / "v22.22.0" / "bin"


### PR DESCRIPTION
## Summary

Use Zoe standalone NVM Pi install for Pi runtime discovery instead of falling back to OpenClaw bundled Pi.

This keeps the Pi candidate path clean for speed/accuracy testing:
- standalone Pi is the Zoe runtime candidate;
- OpenClaw remains separate and is not auto-added to the Pi classifier/runtime PATH;
- Pi execution remains gated by Zoe policy and is not enabled by this PR.

## Why

The Zoe unit has two Pi installs:
- standalone: `/home/zoe/.nvm/versions/node/v22.22.0/bin/pi`, `@earendil-works/pi-coding-agent@0.79.3`
- OpenClaw bundled: `/home/zoe/.openclaw/npm/node_modules/.bin/pi`, `@earendil-works/pi-coding-agent@0.74.0`

For the hybrid Pi + intent-buffer work, evidence needs to come from the standalone Pi runtime only. Mixing in OpenClaw would make readiness and latency reports ambiguous.

## Changes

- Runtime probe now discovers NVM Node/npm and standalone NVM Pi only.
- Pi intent classifier runtime env now appends only an NVM bin containing `node`, `npm`, and the configured Pi command.
- Added regression tests proving:
  - OpenClaw-only Pi is ignored and reported as missing Pi.
  - Standalone NVM Pi wins even when an OpenClaw bundle exists.
  - Classifier runtime PATH excludes OpenClaw `.bin`.
  - Empty env/HOME isolation does not leak host Pi discovery into tests.

## Validation

- `PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_pi_runtime_probe.py services/zoe-data/tests/test_pi_intent_classifier.py services/zoe-data/tests/test_pi_intent_status_endpoint.py`
  - `75 passed in 2.68s`
- `python3 tools/audit/validate_structure.py`
  - passed
- `git diff --check`
  - passed
- `python3 -m compileall -q services/zoe-data/pi_runtime_probe.py services/zoe-data/pi_intent_classifier.py`
  - passed
- Live-style runtime probe with Zoe `.env` and execution disabled:
  - status: `available_execution_disabled`
  - node: `/home/zoe/.nvm/versions/node/v22.22.0/bin/node`
  - npm: `/home/zoe/.nvm/versions/node/v22.22.0/bin/npm`
  - pi: `/home/zoe/.nvm/versions/node/v22.22.0/bin/pi`
- Classifier runtime env probe:
  - `has_nvm_pi_bin=true`
  - `has_openclaw_pi_bin=false`
