### PR TITLE
Guard Pi promotion by baseline lane

### DIFF
--- a/scripts/maintenance/pi_intent_fleet_benchmark.py
+++ b/scripts/maintenance/pi_intent_fleet_benchmark.py
@@ -149,11 +149,11 @@ def _breakdown(
     return {key: _stats(values) for key, values in sorted(grouped.items())}
 
 
-
 def _baseline_lane_key(item: Mapping[str, Any]) -> str:
     route_class = str(item.get("route_class") or "unknown")
     baseline_kind = str(item.get("zoe_baseline_kind") or "unknown")
     return f"{route_class}:{baseline_kind}"
+
 
 def _stats(observations: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
     if not observations:

--- a/scripts/maintenance/pi_intent_fleet_benchmark.py
+++ b/scripts/maintenance/pi_intent_fleet_benchmark.py
@@ -97,6 +97,7 @@ def build_report(
         "summary": {
             "overall": _stats(observations),
             "by_route_class": _breakdown(observations, lambda item: str(item.get("route_class") or "unknown")),
+            "by_baseline_lane": _breakdown(observations, _baseline_lane_key),
             "by_intent_group": _breakdown(observations, lambda item: str(item.get("intent_group") or "unknown")),
             "by_source": _breakdown(observations, lambda item: str(item.get("source") or "unknown")),
         },
@@ -147,6 +148,12 @@ def _breakdown(
         grouped[key_fn(item)].append(item)
     return {key: _stats(values) for key, values in sorted(grouped.items())}
 
+
+
+def _baseline_lane_key(item: Mapping[str, Any]) -> str:
+    route_class = str(item.get("route_class") or "unknown")
+    baseline_kind = str(item.get("zoe_baseline_kind") or "unknown")
+    return f"{route_class}:{baseline_kind}"
 
 def _stats(observations: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
     if not observations:

--- a/services/zoe-data/tests/test_pi_intent_fleet_benchmark.py
+++ b/services/zoe-data/tests/test_pi_intent_fleet_benchmark.py
@@ -110,6 +110,7 @@ def test_build_report_keeps_repeats_separate_from_unique_cases():
     assert report["summary"]["overall"]["unique_case_count"] == 2
     assert report["summary"]["overall"]["observation_count"] == 3
     assert report["summary"]["by_source"]["intent_miss"]["unique_case_count"] == 1
+    assert report["summary"]["by_baseline_lane"]["fallback:unknown"]["unique_case_count"] == 2
 
 
 def test_run_benchmark_repeats_without_pi(monkeypatch):

--- a/services/zoe-data/tests/test_zoe_pi_promotion.py
+++ b/services/zoe-data/tests/test_zoe_pi_promotion.py
@@ -336,6 +336,33 @@ def test_promotion_blocks_when_pi_loses_a_fast_baseline_lane():
     assert decision.baseline_lane_latency["fallback:router"]["latency_delta_ms"] < 0
 
 
+def test_promoted_group_rolls_back_when_pi_loses_a_fast_baseline_lane():
+    samples = [
+        _sample(
+            index,
+            zoe_ms=6000,
+            pi_ms=2500,
+            metadata={"baseline_comparable": True, "baseline_kind": "zoe_agent_fallback_baseline"},
+        )
+        for index in range(15)
+    ]
+    samples.extend(
+        _sample(
+            index + 100,
+            zoe_ms=10,
+            pi_ms=2500,
+            metadata={"baseline_comparable": True, "baseline_kind": "router"},
+        )
+        for index in range(15)
+    )
+    policy = PiPromotionPolicy(min_samples=30, accuracy_win_margin=0.05)
+
+    decision = evaluate_pi_promotion(samples, intent_group="weather", policy=policy, promoted=True)
+
+    assert decision.state == "rollback"
+    assert "baseline_lane_not_faster_than_zoe" in decision.blockers
+
+
 def test_policy_can_disable_baseline_lane_gate_for_smoke_data():
     samples = [
         _sample(

--- a/services/zoe-data/tests/test_zoe_pi_promotion.py
+++ b/services/zoe-data/tests/test_zoe_pi_promotion.py
@@ -305,6 +305,68 @@ def test_promotion_blocks_when_pi_is_not_faster_than_zoe():
     assert "latency_not_faster_than_zoe" in decision.blockers
 
 
+def test_promotion_blocks_when_pi_loses_a_fast_baseline_lane():
+    samples = [
+        _sample(
+            index,
+            zoe_ms=6000,
+            pi_ms=2500,
+            metadata={"baseline_comparable": True, "baseline_kind": "zoe_agent_fallback_baseline"},
+        )
+        for index in range(15)
+    ]
+    samples.extend(
+        _sample(
+            index + 100,
+            zoe_ms=10,
+            pi_ms=2500,
+            metadata={"baseline_comparable": True, "baseline_kind": "router"},
+        )
+        for index in range(15)
+    )
+    policy = PiPromotionPolicy(min_samples=30, accuracy_win_margin=0.05)
+
+    decision = evaluate_pi_promotion(samples, intent_group="weather", policy=policy)
+
+    assert decision.state == "keep_shadow"
+    assert decision.latency_delta_ms and decision.latency_delta_ms > 0
+    assert "latency_not_faster_than_zoe" not in decision.blockers
+    assert "baseline_lane_not_faster_than_zoe" in decision.blockers
+    assert decision.baseline_lane_latency["fallback:zoe_agent_fallback_baseline"]["latency_delta_ms"] > 0
+    assert decision.baseline_lane_latency["fallback:router"]["latency_delta_ms"] < 0
+
+
+def test_policy_can_disable_baseline_lane_gate_for_smoke_data():
+    samples = [
+        _sample(
+            index,
+            zoe_ms=6000,
+            pi_ms=2500,
+            metadata={"baseline_comparable": True, "baseline_kind": "zoe_agent_fallback_baseline"},
+        )
+        for index in range(15)
+    ]
+    samples.extend(
+        _sample(
+            index + 100,
+            zoe_ms=10,
+            pi_ms=2500,
+            metadata={"baseline_comparable": True, "baseline_kind": "router"},
+        )
+        for index in range(15)
+    )
+    policy = PiPromotionPolicy(
+        min_samples=30,
+        accuracy_win_margin=0.05,
+        require_baseline_lane_latency_win=False,
+    )
+
+    decision = evaluate_pi_promotion(samples, intent_group="weather", policy=policy)
+
+    assert decision.state == "promote"
+    assert "baseline_lane_not_faster_than_zoe" not in decision.blockers
+
+
 def test_promotion_blocks_non_allowlisted_groups():
     decision = evaluate_pi_promotion([], intent_group="device_control", policy=PiPromotionPolicy(min_samples=1))
 

--- a/services/zoe-data/zoe_pi_promotion.py
+++ b/services/zoe-data/zoe_pi_promotion.py
@@ -181,6 +181,7 @@ class PiPromotionPolicy:
     max_correction_rate: float = 0.03
     require_latency_win: bool = True
     require_comparable_baseline: bool = True
+    require_baseline_lane_latency_win: bool = True
 
     def validate(self) -> None:
         if self.min_samples <= 0:
@@ -205,6 +206,7 @@ class PiPromotionDecision:
     latency_delta_ms: float | None
     timeout_rate: float
     correction_rate: float
+    baseline_lane_latency: Mapping[str, Mapping[str, Any]] = field(default_factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         if self.state not in DECISION_STATES:
@@ -222,6 +224,9 @@ class PiPromotionDecision:
             "latency_delta_ms": self.latency_delta_ms,
             "timeout_rate": self.timeout_rate,
             "correction_rate": self.correction_rate,
+            "baseline_lane_latency": {
+                lane: dict(values) for lane, values in sorted(self.baseline_lane_latency.items())
+            },
         }
 
 
@@ -277,6 +282,7 @@ def evaluate_pi_promotion(
     latency_delta = None if zoe_p95 is None or pi_p95 is None else zoe_p95 - pi_p95
     timeout_rate = _rate(sample.timed_out for sample in decision_samples)
     correction_rate = _rate(sample.user_corrected for sample in decision_samples)
+    baseline_lane_latency = _baseline_lane_latency(decision_samples)
     blockers: list[str] = []
     if sample_count < active_policy.min_samples:
         blockers.append("insufficient_samples")
@@ -286,6 +292,13 @@ def evaluate_pi_promotion(
         blockers.append("pi_accuracy_below_threshold")
     if active_policy.require_latency_win and (latency_delta is None or latency_delta <= 0):
         blockers.append("latency_not_faster_than_zoe")
+    if active_policy.require_baseline_lane_latency_win and any(
+        lane.get("sample_count", 0) > 0
+        and lane.get("latency_delta_ms") is not None
+        and lane["latency_delta_ms"] <= 0
+        for lane in baseline_lane_latency.values()
+    ):
+        blockers.append("baseline_lane_not_faster_than_zoe")
     if timeout_rate > active_policy.max_timeout_rate:
         blockers.append("timeout_rate_too_high")
     if correction_rate > active_policy.max_correction_rate:
@@ -324,6 +337,7 @@ def evaluate_pi_promotion(
         latency_delta_ms=latency_delta,
         timeout_rate=timeout_rate,
         correction_rate=correction_rate,
+        baseline_lane_latency=baseline_lane_latency,
     )
 
 
@@ -358,6 +372,7 @@ def summarize_pi_promotion(
             "max_correction_rate": active_policy.max_correction_rate,
             "require_latency_win": active_policy.require_latency_win,
             "require_comparable_baseline": active_policy.require_comparable_baseline,
+            "require_baseline_lane_latency_win": active_policy.require_baseline_lane_latency_win,
         },
         "sample_count": len(samples),
         "unique_case_count": _unique_case_count(samples),
@@ -462,6 +477,27 @@ def build_pi_route_class_breakdown(samples: Sequence[PiRouteSample]) -> dict[str
         }
     return breakdown
 
+
+def _baseline_lane_latency(samples: Sequence[PiRouteSample]) -> dict[str, dict[str, Any]]:
+    lanes: dict[str, list[PiRouteSample]] = {}
+    for sample in samples:
+        if sample.metadata.get("baseline_comparable") is False:
+            continue
+        baseline_kind = _optional_str(sample.metadata.get("baseline_kind")) or "unknown"
+        lane = f"{sample.route_class}:{baseline_kind}"
+        lanes.setdefault(lane, []).append(sample)
+
+    breakdown: dict[str, dict[str, Any]] = {}
+    for lane, lane_samples in sorted(lanes.items()):
+        zoe_p95 = _percentile([sample.zoe_latency_ms for sample in lane_samples], 95)
+        pi_p95 = _percentile([sample.pi_latency_ms for sample in lane_samples], 95)
+        breakdown[lane] = {
+            "sample_count": len(lane_samples),
+            "zoe_p95_latency_ms": zoe_p95,
+            "pi_p95_latency_ms": pi_p95,
+            "latency_delta_ms": None if zoe_p95 is None or pi_p95 is None else zoe_p95 - pi_p95,
+        }
+    return breakdown
 
 def build_pi_transport_breakdown(samples: Sequence[PiRouteSample]) -> dict[str, dict[str, Any]]:
     """Summarize Pi print and RPC evidence separately.

--- a/services/zoe-data/zoe_pi_promotion.py
+++ b/services/zoe-data/zoe_pi_promotion.py
@@ -317,6 +317,7 @@ def evaluate_pi_promotion(
         "timeout_rate_too_high",
         "correction_rate_too_high",
         "latency_not_faster_than_zoe",
+        "baseline_lane_not_faster_than_zoe",
         "pi_accuracy_below_threshold",
     }
     # Non-comparable baseline evidence blocks promotion, but does not prove a promoted route regressed.


### PR DESCRIPTION
## Summary
- add a baseline-lane latency gate so Pi promotion cannot hide slow deterministic/router lanes behind faster fallback wins
- include per-lane latency evidence in promotion decisions
- add by_baseline_lane to the Pi fleet benchmark report

## Validation
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_zoe_pi_promotion.py services/zoe-data/tests/test_pi_promotion_eval_script.py services/zoe-data/tests/test_pi_intent_fleet_benchmark.py
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_pi_runtime_probe.py services/zoe-data/tests/test_pi_intent_classifier.py services/zoe-data/tests/test_pi_intent_status_endpoint.py services/zoe-data/tests/test_pi_readiness_report.py services/zoe-data/tests/test_pi_intent_fleet_benchmark.py services/zoe-data/tests/test_pi_promotion_eval_script.py services/zoe-data/tests/test_zoe_pi_promotion.py
- python3 tools/audit/validate_structure.py
- script smoke: pi_intent_fleet_benchmark emits summary.by_baseline_lane
