### PR TITLE
Add Pi intent lab comparison router

### DIFF
--- a/services/zoe-data/main.py
+++ b/services/zoe-data/main.py
@@ -31,6 +31,7 @@ from routers import (
     music_router,
     skybridge_router,
     autoresearch_router,
+    pi_intent_lab_router,
 )
 from routers.dashboard import router as dashboard_router
 from routers.stubs import router as stubs_router
@@ -1242,6 +1243,7 @@ app.include_router(capability_matrix_router)
 app.include_router(music_router)
 app.include_router(skybridge_router)
 app.include_router(autoresearch_router)
+app.include_router(pi_intent_lab_router)
 
 from routers.portrait import router as portrait_router
 app.include_router(portrait_router)

--- a/services/zoe-data/pi_intent_lab.py
+++ b/services/zoe-data/pi_intent_lab.py
@@ -18,6 +18,9 @@ from typing import Any, Mapping
 from zoe_pi_promotion import LOW_RISK_PI_INTENT_GROUPS, intent_group_for_intent
 
 
+_ENV_LOCK = asyncio.Lock()
+
+
 @contextmanager
 def _temporary_env(updates: Mapping[str, str | None]):
     old_values = {key: os.environ.get(key) for key in updates}
@@ -113,13 +116,14 @@ async def compare_pi_intent_lab(
 async def _run_zoe_router(text: str, *, user_id: str) -> dict[str, Any]:
     from intent_router import detect_and_extract_intent, detect_intent
 
-    with _temporary_env({"ZOE_PI_INTENT_ENABLED": "false", "ZOE_PI_INTENT_SHADOW_ENABLED": "false"}):
-        raw_started = time.perf_counter()
-        raw_intent = detect_intent(text, user_id=user_id)
-        raw_latency_ms = (time.perf_counter() - raw_started) * 1000
-        started = time.perf_counter()
-        extracted_intent = await detect_and_extract_intent(text, user_id=user_id)
-        latency_ms = (time.perf_counter() - started) * 1000
+    async with _ENV_LOCK:
+        with _temporary_env({"ZOE_PI_INTENT_ENABLED": "false", "ZOE_PI_INTENT_SHADOW_ENABLED": "false"}):
+            raw_started = time.perf_counter()
+            raw_intent = detect_intent(text, user_id=user_id)
+            raw_latency_ms = (time.perf_counter() - raw_started) * 1000
+            started = time.perf_counter()
+            extracted_intent = await detect_and_extract_intent(text, user_id=user_id)
+            latency_ms = (time.perf_counter() - started) * 1000
 
     if extracted_intent is not None:
         route_class = "deterministic"
@@ -182,13 +186,24 @@ async def _run_pi(
     started = time.perf_counter()
     error = None
     result = None
+    timed_out_by_guard = False
     try:
         if env is None:
             # Let the classifier perform standalone Pi runtime discovery, including NVM node/bin lookup.
-            with _temporary_env(updates):
-                result = await classify_with_pi_intent_governor(text, context_turns=context_turns)
+            # The env lock prevents concurrent lab requests from interleaving temporary os.environ changes.
+            async with _ENV_LOCK:
+                with _temporary_env(updates):
+                    result = await asyncio.wait_for(
+                        classify_with_pi_intent_governor(text, context_turns=context_turns),
+                        timeout=timeout_seconds,
+                    )
         else:
-            result = await classify_with_pi_intent_governor(text, context_turns=context_turns, env=runtime_env)
+            result = await asyncio.wait_for(
+                classify_with_pi_intent_governor(text, context_turns=context_turns, env=runtime_env),
+                timeout=timeout_seconds,
+            )
+    except asyncio.TimeoutError:
+        timed_out_by_guard = True
     except Exception as exc:  # pragma: no cover - defensive operator surface
         error = exc.__class__.__name__
     latency_ms = (time.perf_counter() - started) * 1000
@@ -196,7 +211,7 @@ async def _run_pi(
     confidence = float(result.confidence) if result else 0.0
     group = intent_group_for_intent(intent)
     executable = bool(intent) and confidence >= PI_INTENT_EXECUTE_THRESHOLD and group in LOW_RISK_PI_INTENT_GROUPS
-    timed_out = result is None and error is None and latency_ms >= (timeout_seconds * 1000 * 0.95)
+    timed_out = timed_out_by_guard or (result is None and error is None and latency_ms >= (timeout_seconds * 1000 * 0.95))
     return {
         "ran": True,
         "intent": intent,

--- a/services/zoe-data/pi_intent_lab.py
+++ b/services/zoe-data/pi_intent_lab.py
@@ -1,0 +1,338 @@
+"""Admin-only Pi intent lab comparisons.
+
+The lab compares Zoe's current intent path with standalone Pi classification
+without dispatching intents, writing memory, collecting shadow evidence, or
+promoting routes. It is a measurement surface for deciding whether Pi can earn
+specific Zoe intent lanes.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+import uuid
+from contextlib import contextmanager
+from typing import Any, Mapping
+
+from zoe_pi_promotion import LOW_RISK_PI_INTENT_GROUPS, intent_group_for_intent
+
+
+@contextmanager
+def _temporary_env(updates: Mapping[str, str | None]):
+    old_values = {key: os.environ.get(key) for key in updates}
+    try:
+        for key, value in updates.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+        yield
+    finally:
+        for key, value in old_values.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+
+async def compare_pi_intent_lab(
+    text: str,
+    *,
+    user_id: str = "pi-intent-lab",
+    context_turns: str = "",
+    run_pi: bool = True,
+    pi_transport: str | None = "rpc",
+    allow_pi_execution: bool | None = None,
+    local_model_configured: bool | None = None,
+    measure_zoe_agent_baseline: bool = False,
+    zoe_agent_timeout_seconds: float = 12.0,
+    zoe_agent_max_tokens: int = 64,
+    include_hybrid_status: bool = True,
+    env: Mapping[str, str] | None = None,
+) -> dict[str, Any]:
+    """Return an apples-to-apples intent comparison without side effects."""
+    stripped = (text or "").strip()
+    if not stripped:
+        raise ValueError("text is required")
+    if zoe_agent_timeout_seconds <= 0:
+        raise ValueError("zoe_agent_timeout_seconds must be positive")
+    if zoe_agent_max_tokens <= 0:
+        raise ValueError("zoe_agent_max_tokens must be positive")
+
+    zoe_router = await _run_zoe_router(stripped, user_id=user_id)
+    pi = await _run_pi(
+        stripped,
+        context_turns=context_turns,
+        run_pi=run_pi,
+        transport=pi_transport,
+        allow_pi_execution=allow_pi_execution,
+        local_model_configured=local_model_configured,
+        env=env,
+    )
+    zoe_agent = None
+    if measure_zoe_agent_baseline and zoe_router["intent"] is None:
+        zoe_agent = await _run_zoe_agent_baseline(
+            stripped,
+            timeout_seconds=zoe_agent_timeout_seconds,
+            max_tokens=zoe_agent_max_tokens,
+        )
+
+    hybrid = None
+    if include_hybrid_status:
+        from pi_hybrid_buffer import pi_hybrid_buffer_status
+
+        hybrid = pi_hybrid_buffer_status(env, repeat=3, include_shadow_status=False)
+
+    return {
+        "report_kind": "zoe_pi_intent_lab_comparison",
+        "contract": {
+            "admin_only": True,
+            "side_effects": "none",
+            "intent_dispatch_enabled": False,
+            "memory_writes_enabled": False,
+            "shadow_writes_enabled": False,
+            "promotion_enabled": False,
+            "pi_runtime": "standalone",
+        },
+        "input": {
+            "text_chars": len(stripped),
+            "context_turns_chars": len(context_turns or ""),
+            "user_id": user_id,
+        },
+        "zoe_router": zoe_router,
+        "pi": pi,
+        "zoe_agent_baseline": zoe_agent,
+        "hybrid_buffer": _compact_hybrid(hybrid),
+        "comparison": _comparison(zoe_router, pi, zoe_agent),
+    }
+
+
+async def _run_zoe_router(text: str, *, user_id: str) -> dict[str, Any]:
+    from intent_router import detect_and_extract_intent, detect_intent
+
+    with _temporary_env({"ZOE_PI_INTENT_ENABLED": "false", "ZOE_PI_INTENT_SHADOW_ENABLED": "false"}):
+        raw_started = time.perf_counter()
+        raw_intent = detect_intent(text, user_id=user_id)
+        raw_latency_ms = (time.perf_counter() - raw_started) * 1000
+        started = time.perf_counter()
+        extracted_intent = await detect_and_extract_intent(text, user_id=user_id)
+        latency_ms = (time.perf_counter() - started) * 1000
+
+    if extracted_intent is not None:
+        route_class = "deterministic"
+        baseline_kind = "router"
+        baseline_comparable = True
+    elif raw_intent is None:
+        route_class = "fallback"
+        baseline_kind = "router_only_not_comparable"
+        baseline_comparable = False
+    else:
+        route_class = "extraction_failed"
+        baseline_kind = "router_extraction_failed_not_comparable"
+        baseline_comparable = False
+
+    return {
+        "intent": _intent_name(extracted_intent),
+        "confidence": _intent_confidence(extracted_intent),
+        "slots": _intent_slots(extracted_intent),
+        "raw_intent": _intent_name(raw_intent),
+        "raw_confidence": _intent_confidence(raw_intent),
+        "route_class": route_class,
+        "baseline_kind": baseline_kind,
+        "baseline_lane": f"{route_class}:{baseline_kind}",
+        "baseline_comparable": baseline_comparable,
+        "latency_ms": latency_ms,
+        "raw_router_latency_ms": raw_latency_ms,
+        "would_execute": extracted_intent is not None,
+    }
+
+
+async def _run_pi(
+    text: str,
+    *,
+    context_turns: str,
+    run_pi: bool,
+    transport: str | None,
+    allow_pi_execution: bool | None,
+    local_model_configured: bool | None,
+    env: Mapping[str, str] | None,
+) -> dict[str, Any]:
+    if not run_pi:
+        return {"ran": False, "intent": None, "reason": "run_pi_false", "would_execute": False}
+
+    from pi_intent_classifier import PI_INTENT_EXECUTE_THRESHOLD, classify_with_pi_intent_governor
+
+    runtime_env = dict(env if env is not None else os.environ)
+    updates = {
+        "ZOE_PI_INTENT_ENABLED": "true",
+        "ZOE_PI_INTENT_SHADOW_ENABLED": "false",
+    }
+    if transport:
+        updates["ZOE_PI_INTENT_TRANSPORT"] = transport
+    if allow_pi_execution is not None:
+        updates["ZOE_PI_ALLOW_EXECUTION"] = "true" if allow_pi_execution else "false"
+    if local_model_configured is not None:
+        updates["ZOE_PI_LOCAL_MODEL_CONFIGURED"] = "true" if local_model_configured else "false"
+    runtime_env.update(updates)
+
+    timeout_seconds = float(runtime_env.get("ZOE_PI_INTENT_TIMEOUT_SECONDS") or 4.0)
+    started = time.perf_counter()
+    error = None
+    result = None
+    try:
+        if env is None:
+            # Let the classifier perform standalone Pi runtime discovery, including NVM node/bin lookup.
+            with _temporary_env(updates):
+                result = await classify_with_pi_intent_governor(text, context_turns=context_turns)
+        else:
+            result = await classify_with_pi_intent_governor(text, context_turns=context_turns, env=runtime_env)
+    except Exception as exc:  # pragma: no cover - defensive operator surface
+        error = exc.__class__.__name__
+    latency_ms = (time.perf_counter() - started) * 1000
+    intent = result.intent if result else None
+    confidence = float(result.confidence) if result else 0.0
+    group = intent_group_for_intent(intent)
+    executable = bool(intent) and confidence >= PI_INTENT_EXECUTE_THRESHOLD and group in LOW_RISK_PI_INTENT_GROUPS
+    timed_out = result is None and error is None and latency_ms >= (timeout_seconds * 1000 * 0.95)
+    return {
+        "ran": True,
+        "intent": intent,
+        "confidence": confidence,
+        "slots": dict(result.slots) if result else {},
+        "task_lane": result.task_lane if result else None,
+        "source": result.source if result else None,
+        "reason": result.reason if result else None,
+        "intent_group": group,
+        "low_risk_group": group in LOW_RISK_PI_INTENT_GROUPS if group else False,
+        "latency_ms": latency_ms,
+        "classifier_latency_ms": float(result.latency_ms) if result else None,
+        "timed_out": timed_out,
+        "error": error,
+        "transport": runtime_env.get("ZOE_PI_INTENT_TRANSPORT") or "print",
+        "would_execute": False,
+        "would_execute_reason": "lab_never_dispatches_intents" if executable else "not_executable_or_not_low_risk",
+    }
+
+
+async def _run_zoe_agent_baseline(text: str, *, timeout_seconds: float, max_tokens: int) -> dict[str, Any]:
+    from zoe_agent import run_zoe_agent
+
+    session_id = f"pi-intent-lab-{uuid.uuid4().hex[:8]}"
+    started = time.perf_counter()
+    try:
+        with _temporary_env({"ZOE_PI_INTENT_ENABLED": "false", "ZOE_PI_INTENT_SHADOW_ENABLED": "false"}):
+            response = await asyncio.wait_for(
+                run_zoe_agent(
+                    text,
+                    session_id,
+                    "pi-intent-lab",
+                    history=[],
+                    db_memory_context="",
+                    portrait="",
+                    max_tokens_override=max_tokens,
+                ),
+                timeout=timeout_seconds,
+            )
+        latency_ms = (time.perf_counter() - started) * 1000
+        return {
+            "measured": True,
+            "baseline_kind": "zoe_agent_fallback_baseline",
+            "baseline_comparable": True,
+            "latency_ms": latency_ms,
+            "timed_out": False,
+            "response_chars": len(response or ""),
+            "would_execute": False,
+        }
+    except asyncio.TimeoutError:
+        latency_ms = (time.perf_counter() - started) * 1000
+        return {
+            "measured": True,
+            "baseline_kind": "zoe_agent_fallback_timeout",
+            "baseline_comparable": False,
+            "latency_ms": latency_ms,
+            "timed_out": True,
+            "response_chars": 0,
+            "would_execute": False,
+        }
+    except Exception as exc:  # pragma: no cover - defensive operator surface
+        latency_ms = (time.perf_counter() - started) * 1000
+        return {
+            "measured": True,
+            "baseline_kind": "zoe_agent_fallback_error",
+            "baseline_comparable": False,
+            "latency_ms": latency_ms,
+            "timed_out": False,
+            "response_chars": 0,
+            "error": exc.__class__.__name__,
+            "would_execute": False,
+        }
+
+
+def _comparison(
+    zoe_router: Mapping[str, Any],
+    pi: Mapping[str, Any],
+    zoe_agent: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    pi_latency = _float_or_none(pi.get("latency_ms"))
+    router_latency = _float_or_none(zoe_router.get("latency_ms"))
+    agent_latency = _float_or_none((zoe_agent or {}).get("latency_ms"))
+    if zoe_agent and zoe_agent.get("baseline_comparable"):
+        comparable_latency = agent_latency
+    elif zoe_router.get("baseline_comparable"):
+        comparable_latency = router_latency
+    else:
+        comparable_latency = None
+    return {
+        "baseline_lane": zoe_router.get("baseline_lane"),
+        "zoe_router_intent": zoe_router.get("intent"),
+        "pi_intent": pi.get("intent"),
+        "agreement": zoe_router.get("intent") == pi.get("intent"),
+        "pi_vs_router_latency_delta_ms": None if pi_latency is None or router_latency is None else router_latency - pi_latency,
+        "pi_vs_comparable_latency_delta_ms": (
+            None if pi_latency is None or comparable_latency is None else comparable_latency - pi_latency
+        ),
+        "pi_candidate_for_lane": bool(
+            zoe_router.get("intent") is None
+            and pi.get("intent")
+            and pi.get("low_risk_group")
+            and not pi.get("timed_out")
+            and not pi.get("error")
+        ),
+        "production_route_change": False,
+    }
+
+
+def _compact_hybrid(hybrid: Mapping[str, Any] | None) -> dict[str, Any] | None:
+    if hybrid is None:
+        return None
+    contract = hybrid.get("contract") or {}
+    return {
+        "mode": contract.get("mode"),
+        "ready": contract.get("ready"),
+        "foreground_pi_execution_enabled": contract.get("foreground_pi_execution_enabled"),
+        "promoted_groups": list(contract.get("promoted_groups") or []),
+        "blockers": list(contract.get("blockers") or []),
+        "warnings": list(contract.get("warnings") or []),
+    }
+
+
+def _intent_name(intent: Any) -> str | None:
+    return getattr(intent, "name", None) if intent is not None else None
+
+
+def _intent_confidence(intent: Any) -> float | None:
+    value = getattr(intent, "confidence", None) if intent is not None else None
+    return float(value) if isinstance(value, (int, float)) else None
+
+
+def _intent_slots(intent: Any) -> dict[str, Any]:
+    slots = getattr(intent, "slots", None) if intent is not None else None
+    return dict(slots) if isinstance(slots, Mapping) else {}
+
+
+def _float_or_none(value: Any) -> float | None:
+    return float(value) if isinstance(value, (int, float)) else None
+
+
+__all__ = ["compare_pi_intent_lab"]

--- a/services/zoe-data/pi_intent_lab.py
+++ b/services/zoe-data/pi_intent_lab.py
@@ -61,6 +61,7 @@ async def compare_pi_intent_lab(
         raise ValueError("zoe_agent_max_tokens must be positive")
 
     zoe_router = await _run_zoe_router(stripped, user_id=user_id)
+    processing_cue = _processing_cue(env)
     pi = await _run_pi(
         stripped,
         context_turns=context_turns,
@@ -104,6 +105,7 @@ async def compare_pi_intent_lab(
         "pi": pi,
         "zoe_agent_baseline": zoe_agent,
         "hybrid_buffer": _compact_hybrid(hybrid),
+        "simulated_hybrid_flow": _simulated_hybrid_flow(processing_cue, pi, zoe_agent),
         "comparison": _comparison(zoe_router, pi, zoe_agent),
     }
 
@@ -268,6 +270,53 @@ async def _run_zoe_agent_baseline(text: str, *, timeout_seconds: float, max_toke
             "would_execute": False,
         }
 
+
+
+def _processing_cue(env: Mapping[str, str] | None) -> dict[str, Any]:
+    from voice_presence import processing_ack_event
+
+    started = time.perf_counter()
+    event = processing_ack_event(env, index=0)
+    latency_ms = (time.perf_counter() - started) * 1000
+    safe_event = _safe_voice_event(event) if event else None
+    return {
+        "available": safe_event is not None,
+        "latency_ms": latency_ms,
+        "event": safe_event,
+        "text": str((safe_event or {}).get("text") or ""),
+    }
+
+
+def _simulated_hybrid_flow(
+    processing_cue: Mapping[str, Any],
+    pi: Mapping[str, Any],
+    zoe_agent: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    pi_latency = _float_or_none(pi.get("latency_ms"))
+    agent_latency = _float_or_none((zoe_agent or {}).get("latency_ms"))
+    final_latency = pi_latency if pi.get("ran") else agent_latency
+    return {
+        "strategy": "processing_ack_then_pi_or_fallback",
+        "cue_available": bool(processing_cue.get("available")),
+        "cue_text": processing_cue.get("text") or "",
+        "cue_latency_ms": processing_cue.get("latency_ms"),
+        "cue_event": processing_cue.get("event"),
+        "pi_completion_latency_ms": pi_latency,
+        "fallback_completion_latency_ms": agent_latency,
+        "final_completion_latency_ms": final_latency,
+        "natural_flow_candidate": bool(processing_cue.get("available") and final_latency is not None),
+        "production_route_change": False,
+    }
+
+
+def _safe_voice_event(event: Mapping[str, Any] | None) -> dict[str, Any] | None:
+    if event is None:
+        return None
+    safe = dict(event)
+    audio = safe.pop("audio_base64", None)
+    if audio:
+        safe["audio_base64_chars"] = len(str(audio))
+    return safe
 
 def _comparison(
     zoe_router: Mapping[str, Any],

--- a/services/zoe-data/routers/__init__.py
+++ b/services/zoe-data/routers/__init__.py
@@ -19,6 +19,7 @@ from .capability_matrix import router as capability_matrix_router
 from .music import router as music_router
 from .skybridge import router as skybridge_router
 from .autoresearch import router as autoresearch_router
+from .pi_intent_lab import router as pi_intent_lab_router
 
 __all__ = [
     "people_router",
@@ -42,4 +43,5 @@ __all__ = [
     "music_router",
     "skybridge_router",
     "autoresearch_router",
+    "pi_intent_lab_router",
 ]

--- a/services/zoe-data/routers/pi_intent_lab.py
+++ b/services/zoe-data/routers/pi_intent_lab.py
@@ -1,0 +1,47 @@
+"""Admin-only Pi intent lab router."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+from auth import require_admin
+from pi_intent_lab import compare_pi_intent_lab
+
+router = APIRouter(prefix="/api/pi-intent-lab", tags=["pi-intent-lab"])
+
+
+class PiIntentLabCompareRequest(BaseModel):
+    text: str = Field(..., min_length=1, max_length=1000)
+    context_turns: str = Field(default="", max_length=2000)
+    run_pi: bool = True
+    pi_transport: Literal["rpc", "print"] | None = "rpc"
+    allow_pi_execution: bool | None = None
+    local_model_configured: bool | None = None
+    measure_zoe_agent_baseline: bool = False
+    zoe_agent_timeout_seconds: float = Field(default=12.0, gt=0, le=60)
+    zoe_agent_max_tokens: int = Field(default=64, gt=0, le=512)
+    include_hybrid_status: bool = True
+
+
+@router.post("/compare")
+async def compare_pi_intent(payload: PiIntentLabCompareRequest, user: dict = Depends(require_admin)):
+    """Compare Zoe router, optional Zoe Agent fallback, and standalone Pi without dispatching."""
+    try:
+        return await compare_pi_intent_lab(
+            payload.text,
+            user_id=str(user.get("user_id") or "admin"),
+            context_turns=payload.context_turns,
+            run_pi=payload.run_pi,
+            pi_transport=payload.pi_transport,
+            allow_pi_execution=payload.allow_pi_execution,
+            local_model_configured=payload.local_model_configured,
+            measure_zoe_agent_baseline=payload.measure_zoe_agent_baseline,
+            zoe_agent_timeout_seconds=payload.zoe_agent_timeout_seconds,
+            zoe_agent_max_tokens=payload.zoe_agent_max_tokens,
+            include_hybrid_status=payload.include_hybrid_status,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/services/zoe-data/tests/test_pi_intent_lab.py
+++ b/services/zoe-data/tests/test_pi_intent_lab.py
@@ -64,6 +64,16 @@ def _install_fake_hybrid(monkeypatch):
     monkeypatch.setitem(sys.modules, "pi_hybrid_buffer", module)
 
 
+
+def _install_fake_voice_presence(monkeypatch):
+    module = types.ModuleType("voice_presence")
+
+    def processing_ack_event(env=None, index=None):
+        return {"type": "voice:processing_ack", "text": "Let me check.", "source": "intent_buffer"}
+
+    module.processing_ack_event = processing_ack_event
+    monkeypatch.setitem(sys.modules, "voice_presence", module)
+
 def _install_fake_zoe_agent(monkeypatch, calls):
     module = types.ModuleType("zoe_agent")
 
@@ -93,6 +103,7 @@ async def test_lab_compares_router_pi_and_never_dispatches(monkeypatch):
         seen_env=seen_env,
     )
     _install_fake_hybrid(monkeypatch)
+    _install_fake_voice_presence(monkeypatch)
 
     result = await compare_pi_intent_lab(
         "rain later",
@@ -172,6 +183,29 @@ async def test_lab_skips_pi_when_requested(monkeypatch):
     assert result["comparison"]["pi_vs_comparable_latency_delta_ms"] is None
 
 
+
+@pytest.mark.asyncio
+async def test_lab_enforces_pi_timeout(monkeypatch):
+    _install_fake_intent_router(monkeypatch, raw=None, extracted=None)
+    module = types.ModuleType("pi_intent_classifier")
+    module.PI_INTENT_EXECUTE_THRESHOLD = 0.78
+
+    async def classify_with_pi_intent_governor(text, *, context_turns="", env=None, config=None):
+        import asyncio
+
+        await asyncio.sleep(1)
+        return None
+
+    module.classify_with_pi_intent_governor = classify_with_pi_intent_governor
+    monkeypatch.setitem(sys.modules, "pi_intent_classifier", module)
+    monkeypatch.setenv("ZOE_PI_INTENT_TIMEOUT_SECONDS", "0.01")
+
+    result = await compare_pi_intent_lab("rain later", include_hybrid_status=False)
+
+    assert result["pi"]["timed_out"] is True
+    assert result["pi"]["intent"] is None
+    assert result["comparison"]["pi_candidate_for_lane"] is False
+
 def _admin_app():
     app = FastAPI()
     app.include_router(pi_intent_lab_router)
@@ -212,6 +246,7 @@ def test_pi_intent_lab_endpoint_returns_comparison(monkeypatch):
         ),
     )
     _install_fake_hybrid(monkeypatch)
+    _install_fake_voice_presence(monkeypatch)
     app = _admin_app()
 
     resp = TestClient(app).post(

--- a/services/zoe-data/tests/test_pi_intent_lab.py
+++ b/services/zoe-data/tests/test_pi_intent_lab.py
@@ -119,6 +119,10 @@ async def test_lab_compares_router_pi_and_never_dispatches(monkeypatch):
     assert result["pi"]["would_execute_reason"] == "lab_never_dispatches_intents"
     assert result["comparison"]["agreement"] is True
     assert result["comparison"]["production_route_change"] is False
+    assert result["simulated_hybrid_flow"]["cue_available"] is True
+    assert result["simulated_hybrid_flow"]["cue_event"]["type"] == "voice:processing_ack"
+    assert result["simulated_hybrid_flow"]["pi_completion_latency_ms"] is not None
+    assert result["simulated_hybrid_flow"]["production_route_change"] is False
     assert result["hybrid_buffer"]["mode"] == "shadow_buffer"
     assert seen_env[0]["env"]["ZOE_PI_INTENT_ENABLED"] == "true"
     assert seen_env[0]["env"]["ZOE_PI_INTENT_SHADOW_ENABLED"] == "false"
@@ -221,3 +225,4 @@ def test_pi_intent_lab_endpoint_returns_comparison(monkeypatch):
     assert data["zoe_router"]["baseline_lane"] == "deterministic:router"
     assert data["pi"]["intent"] == "weather"
     assert data["contract"]["intent_dispatch_enabled"] is False
+    assert data["simulated_hybrid_flow"]["cue_available"] is True

--- a/services/zoe-data/tests/test_pi_intent_lab.py
+++ b/services/zoe-data/tests/test_pi_intent_lab.py
@@ -1,0 +1,223 @@
+import os
+import sys
+import types
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+from auth import require_admin
+from pi_intent_lab import compare_pi_intent_lab
+from routers.pi_intent_lab import router as pi_intent_lab_router
+
+
+class _Intent:
+    def __init__(self, name, slots=None, confidence=0.9):
+        self.name = name
+        self.slots = slots or {}
+        self.confidence = confidence
+
+
+def _install_fake_intent_router(monkeypatch, *, raw=None, extracted=None):
+    module = types.ModuleType("intent_router")
+
+    def detect_intent(text, user_id="family-admin", context=None):
+        return raw(text) if callable(raw) else raw
+
+    async def detect_and_extract_intent(text, user_id="family-admin", context=None):
+        return extracted(text) if callable(extracted) else extracted
+
+    module.detect_intent = detect_intent
+    module.detect_and_extract_intent = detect_and_extract_intent
+    monkeypatch.setitem(sys.modules, "intent_router", module)
+
+
+def _install_fake_pi_classifier(monkeypatch, *, result=None, seen_env=None):
+    module = types.ModuleType("pi_intent_classifier")
+    module.PI_INTENT_EXECUTE_THRESHOLD = 0.78
+
+    async def classify_with_pi_intent_governor(text, *, context_turns="", env=None, config=None):
+        if seen_env is not None:
+            seen_env.append({"text": text, "context_turns": context_turns, "env": dict(env or os.environ)})
+        return result
+
+    module.classify_with_pi_intent_governor = classify_with_pi_intent_governor
+    monkeypatch.setitem(sys.modules, "pi_intent_classifier", module)
+
+
+def _install_fake_hybrid(monkeypatch):
+    module = types.ModuleType("pi_hybrid_buffer")
+
+    def pi_hybrid_buffer_status(env=None, repeat=3, include_shadow_status=False):
+        return {
+            "contract": {
+                "mode": "shadow_buffer",
+                "ready": True,
+                "foreground_pi_execution_enabled": False,
+                "promoted_groups": [],
+                "blockers": [],
+                "warnings": [],
+            }
+        }
+
+    module.pi_hybrid_buffer_status = pi_hybrid_buffer_status
+    monkeypatch.setitem(sys.modules, "pi_hybrid_buffer", module)
+
+
+def _install_fake_zoe_agent(monkeypatch, calls):
+    module = types.ModuleType("zoe_agent")
+
+    async def run_zoe_agent(message, session_id, user_id="family-admin", **kwargs):
+        calls.append({"message": message, "session_id": session_id, "user_id": user_id, "kwargs": kwargs})
+        return "fallback answer"
+
+    module.run_zoe_agent = run_zoe_agent
+    monkeypatch.setitem(sys.modules, "zoe_agent", module)
+
+
+@pytest.mark.asyncio
+async def test_lab_compares_router_pi_and_never_dispatches(monkeypatch):
+    _install_fake_intent_router(monkeypatch, raw=_Intent("weather"), extracted=_Intent("weather", {"place": "home"}))
+    seen_env = []
+    _install_fake_pi_classifier(
+        monkeypatch,
+        result=types.SimpleNamespace(
+            intent="weather",
+            slots={"place": "home"},
+            confidence=0.91,
+            task_lane="fast_tool",
+            source="fake_pi",
+            latency_ms=123.0,
+            reason="weather signal",
+        ),
+        seen_env=seen_env,
+    )
+    _install_fake_hybrid(monkeypatch)
+
+    result = await compare_pi_intent_lab(
+        "rain later",
+        user_id="admin",
+        context_turns="previous='hello'",
+        allow_pi_execution=True,
+        local_model_configured=True,
+    )
+
+    assert result["contract"] == {
+        "admin_only": True,
+        "side_effects": "none",
+        "intent_dispatch_enabled": False,
+        "memory_writes_enabled": False,
+        "shadow_writes_enabled": False,
+        "promotion_enabled": False,
+        "pi_runtime": "standalone",
+    }
+    assert result["zoe_router"]["intent"] == "weather"
+    assert result["zoe_router"]["baseline_lane"] == "deterministic:router"
+    assert result["zoe_router"]["would_execute"] is True
+    assert result["pi"]["intent"] == "weather"
+    assert result["pi"]["would_execute"] is False
+    assert result["pi"]["would_execute_reason"] == "lab_never_dispatches_intents"
+    assert result["comparison"]["agreement"] is True
+    assert result["comparison"]["production_route_change"] is False
+    assert result["hybrid_buffer"]["mode"] == "shadow_buffer"
+    assert seen_env[0]["env"]["ZOE_PI_INTENT_ENABLED"] == "true"
+    assert seen_env[0]["env"]["ZOE_PI_INTENT_SHADOW_ENABLED"] == "false"
+    assert seen_env[0]["env"]["ZOE_PI_ALLOW_EXECUTION"] == "true"
+
+
+@pytest.mark.asyncio
+async def test_lab_measures_agent_baseline_only_for_fallback(monkeypatch):
+    _install_fake_intent_router(monkeypatch, raw=None, extracted=None)
+    _install_fake_pi_classifier(
+        monkeypatch,
+        result=types.SimpleNamespace(
+            intent="timer_create",
+            slots={"duration": "10 minutes"},
+            confidence=0.95,
+            task_lane="fast_tool",
+            source="fake_pi",
+            latency_ms=222.0,
+            reason=None,
+        ),
+    )
+    calls = []
+    _install_fake_zoe_agent(monkeypatch, calls)
+
+    result = await compare_pi_intent_lab(
+        "timer for ten minutes",
+        measure_zoe_agent_baseline=True,
+        include_hybrid_status=False,
+    )
+
+    assert result["zoe_router"]["route_class"] == "fallback"
+    assert result["zoe_agent_baseline"]["baseline_kind"] == "zoe_agent_fallback_baseline"
+    assert len(calls) == 1
+    assert calls[0]["user_id"] == "pi-intent-lab"
+    assert result["comparison"]["pi_candidate_for_lane"] is True
+    assert result["comparison"]["pi_vs_comparable_latency_delta_ms"] is not None
+
+
+@pytest.mark.asyncio
+async def test_lab_skips_pi_when_requested(monkeypatch):
+    _install_fake_intent_router(monkeypatch, raw=None, extracted=None)
+
+    result = await compare_pi_intent_lab("that movie was good", run_pi=False, include_hybrid_status=False)
+
+    assert result["pi"] == {"ran": False, "intent": None, "reason": "run_pi_false", "would_execute": False}
+    assert result["comparison"]["pi_candidate_for_lane"] is False
+    assert result["comparison"]["pi_vs_comparable_latency_delta_ms"] is None
+
+
+def _admin_app():
+    app = FastAPI()
+    app.include_router(pi_intent_lab_router)
+
+    async def fake_admin():
+        return {"user_id": "admin", "role": "family-admin"}
+
+    app.dependency_overrides[require_admin] = fake_admin
+    return app
+
+
+def test_pi_intent_lab_endpoint_is_admin_scoped(monkeypatch):
+    app = FastAPI()
+    app.include_router(pi_intent_lab_router)
+
+    async def fake_non_admin():
+        raise HTTPException(status_code=403, detail="Admin access required")
+
+    app.dependency_overrides[require_admin] = fake_non_admin
+
+    resp = TestClient(app).post("/api/pi-intent-lab/compare", json={"text": "rain later"})
+
+    assert resp.status_code == 403
+
+
+def test_pi_intent_lab_endpoint_returns_comparison(monkeypatch):
+    _install_fake_intent_router(monkeypatch, raw=_Intent("weather"), extracted=_Intent("weather"))
+    _install_fake_pi_classifier(
+        monkeypatch,
+        result=types.SimpleNamespace(
+            intent="weather",
+            slots={},
+            confidence=0.9,
+            task_lane="fast_tool",
+            source="fake_pi",
+            latency_ms=100.0,
+            reason=None,
+        ),
+    )
+    _install_fake_hybrid(monkeypatch)
+    app = _admin_app()
+
+    resp = TestClient(app).post(
+        "/api/pi-intent-lab/compare",
+        json={"text": "rain later", "allow_pi_execution": True, "local_model_configured": True},
+    )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["report_kind"] == "zoe_pi_intent_lab_comparison"
+    assert data["zoe_router"]["baseline_lane"] == "deterministic:router"
+    assert data["pi"]["intent"] == "weather"
+    assert data["contract"]["intent_dispatch_enabled"] is False


### PR DESCRIPTION
## Summary
- add an admin-only Pi Intent Lab compare endpoint at /api/pi-intent-lab/compare
- compare Zoe router/extraction, standalone Pi classification, optional Zoe Agent fallback, and hybrid-buffer status without dispatching intents
- keep the contract evidence-only: no memory writes, no shadow writes, no promotions, no production route changes

## Validation
- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_pi_intent_lab.py services/zoe-data/tests/test_pi_intent_status_endpoint.py services/zoe-data/tests/test_pi_runtime_probe.py services/zoe-data/tests/test_pi_intent_classifier.py services/zoe-data/tests/test_pi_readiness_report.py services/zoe-data/tests/test_pi_intent_fleet_benchmark.py services/zoe-data/tests/test_pi_promotion_eval_script.py services/zoe-data/tests/test_zoe_pi_promotion.py
- python3 tools/audit/validate_structure.py
- live standalone Pi lab smoke: rain later -> Pi weather in ~3.7s, Zoe router null, baseline fallback:router_only_not_comparable, side_effects=none
