### PR TITLE
[codex] Add Pi hybrid fulfillment lab

### DIFF
--- a/services/zoe-data/pi_intent_lab.py
+++ b/services/zoe-data/pi_intent_lab.py
@@ -111,7 +111,7 @@ async def compare_pi_intent_lab(
         "report_kind": "zoe_pi_intent_lab_comparison",
         "contract": {
             "admin_only": True,
-            "side_effects": "none",
+            "side_effects": "read_only_external_only" if include_safe_fulfillment else "none",
             "intent_dispatch_enabled": bool(include_safe_fulfillment),
             "intent_dispatch_scope": "read_only_allowlist_only" if include_safe_fulfillment else "none",
             "safe_read_only_fulfillment_enabled": bool(include_safe_fulfillment),

--- a/services/zoe-data/pi_intent_lab.py
+++ b/services/zoe-data/pi_intent_lab.py
@@ -19,6 +19,15 @@ from zoe_pi_promotion import LOW_RISK_PI_INTENT_GROUPS, intent_group_for_intent
 
 
 _ENV_LOCK = asyncio.Lock()
+SAFE_FULFILLMENT_INTENTS = frozenset(
+    {
+        "daily_briefing",
+        "date_query",
+        "list_show",
+        "time_query",
+        "weather",
+    }
+)
 
 
 @contextmanager
@@ -52,6 +61,8 @@ async def compare_pi_intent_lab(
     zoe_agent_timeout_seconds: float = 12.0,
     zoe_agent_max_tokens: int = 64,
     include_hybrid_status: bool = True,
+    include_safe_fulfillment: bool = False,
+    safe_fulfillment_timeout_seconds: float = 8.0,
     env: Mapping[str, str] | None = None,
 ) -> dict[str, Any]:
     """Return an apples-to-apples intent comparison without side effects."""
@@ -62,6 +73,8 @@ async def compare_pi_intent_lab(
         raise ValueError("zoe_agent_timeout_seconds must be positive")
     if zoe_agent_max_tokens <= 0:
         raise ValueError("zoe_agent_max_tokens must be positive")
+    if safe_fulfillment_timeout_seconds <= 0:
+        raise ValueError("safe_fulfillment_timeout_seconds must be positive")
 
     zoe_router = await _run_zoe_router(stripped, user_id=user_id)
     processing_cue = _processing_cue(env)
@@ -81,6 +94,12 @@ async def compare_pi_intent_lab(
             timeout_seconds=zoe_agent_timeout_seconds,
             max_tokens=zoe_agent_max_tokens,
         )
+    safe_fulfillment = await _safe_fulfill_pi_intent(
+        pi,
+        user_id=user_id,
+        enabled=include_safe_fulfillment,
+        timeout_seconds=safe_fulfillment_timeout_seconds,
+    )
 
     hybrid = None
     if include_hybrid_status:
@@ -93,7 +112,10 @@ async def compare_pi_intent_lab(
         "contract": {
             "admin_only": True,
             "side_effects": "none",
-            "intent_dispatch_enabled": False,
+            "intent_dispatch_enabled": bool(include_safe_fulfillment),
+            "intent_dispatch_scope": "read_only_allowlist_only" if include_safe_fulfillment else "none",
+            "safe_read_only_fulfillment_enabled": bool(include_safe_fulfillment),
+            "safe_read_only_fulfillment_intents": sorted(SAFE_FULFILLMENT_INTENTS),
             "memory_writes_enabled": False,
             "shadow_writes_enabled": False,
             "promotion_enabled": False,
@@ -107,8 +129,9 @@ async def compare_pi_intent_lab(
         "zoe_router": zoe_router,
         "pi": pi,
         "zoe_agent_baseline": zoe_agent,
+        "safe_fulfillment": safe_fulfillment,
         "hybrid_buffer": _compact_hybrid(hybrid),
-        "simulated_hybrid_flow": _simulated_hybrid_flow(processing_cue, pi, zoe_agent),
+        "simulated_hybrid_flow": _simulated_hybrid_flow(processing_cue, pi, zoe_agent, safe_fulfillment),
         "comparison": _comparison(zoe_router, pi, zoe_agent),
     }
 
@@ -286,6 +309,115 @@ async def _run_zoe_agent_baseline(text: str, *, timeout_seconds: float, max_toke
         }
 
 
+async def _safe_fulfill_pi_intent(
+    pi: Mapping[str, Any],
+    *,
+    user_id: str,
+    enabled: bool,
+    timeout_seconds: float,
+) -> dict[str, Any]:
+    if not enabled:
+        return {
+            "requested": False,
+            "attempted": False,
+            "allowed": False,
+            "blocked_reason": "not_requested",
+            "would_execute": False,
+        }
+
+    intent_name = str(pi.get("intent") or "")
+    if not pi.get("ran"):
+        return _blocked_fulfillment("pi_not_run")
+    if not intent_name:
+        return _blocked_fulfillment("pi_no_intent")
+    if pi.get("timed_out"):
+        return _blocked_fulfillment("pi_timed_out", intent=intent_name)
+    if pi.get("error"):
+        return _blocked_fulfillment("pi_error", intent=intent_name, error=pi.get("error"))
+    if intent_name not in SAFE_FULFILLMENT_INTENTS:
+        return _blocked_fulfillment("side_effect_or_unsupported_intent", intent=intent_name)
+    if not pi.get("low_risk_group"):
+        return _blocked_fulfillment("not_low_risk_group", intent=intent_name)
+
+    from pi_intent_classifier import PI_INTENT_EXECUTE_THRESHOLD
+
+    confidence = float(pi.get("confidence") or 0.0)
+    if confidence < PI_INTENT_EXECUTE_THRESHOLD:
+        return _blocked_fulfillment("below_execute_threshold", intent=intent_name)
+
+    from intent_router import Intent, execute_intent
+
+    intent = Intent(intent_name, dict(pi.get("slots") or {}), confidence)
+    started = time.perf_counter()
+    try:
+        response = await asyncio.wait_for(execute_intent(intent, user_id=user_id), timeout=timeout_seconds)
+        latency_ms = (time.perf_counter() - started) * 1000
+        return {
+            "requested": True,
+            "attempted": True,
+            "allowed": True,
+            "intent": intent_name,
+            "latency_ms": latency_ms,
+            "timed_out": False,
+            "error": None,
+            "response_chars": len(response or ""),
+            "response_preview": _preview_response(response),
+            "would_execute": True,
+            "execution_scope": "read_only_allowlist",
+        }
+    except asyncio.TimeoutError:
+        latency_ms = (time.perf_counter() - started) * 1000
+        return {
+            "requested": True,
+            "attempted": True,
+            "allowed": True,
+            "intent": intent_name,
+            "latency_ms": latency_ms,
+            "timed_out": True,
+            "error": None,
+            "response_chars": 0,
+            "response_preview": "",
+            "would_execute": False,
+            "execution_scope": "read_only_allowlist",
+        }
+    except Exception as exc:  # pragma: no cover - defensive operator surface
+        latency_ms = (time.perf_counter() - started) * 1000
+        return {
+            "requested": True,
+            "attempted": True,
+            "allowed": True,
+            "intent": intent_name,
+            "latency_ms": latency_ms,
+            "timed_out": False,
+            "error": exc.__class__.__name__,
+            "response_chars": 0,
+            "response_preview": "",
+            "would_execute": False,
+            "execution_scope": "read_only_allowlist",
+        }
+
+
+def _blocked_fulfillment(reason: str, *, intent: str | None = None, error: Any = None) -> dict[str, Any]:
+    result = {
+        "requested": True,
+        "attempted": False,
+        "allowed": False,
+        "blocked_reason": reason,
+        "intent": intent,
+        "would_execute": False,
+    }
+    if error is not None:
+        result["error"] = error
+    return result
+
+
+def _preview_response(response: str | None, *, limit: int = 240) -> str:
+    text = " ".join(str(response or "").split())
+    if len(text) <= limit:
+        return text
+    return text[: limit - 1].rstrip() + "..."
+
+
 
 def _processing_cue(env: Mapping[str, str] | None) -> dict[str, Any]:
     from voice_presence import processing_ack_event
@@ -306,10 +438,20 @@ def _simulated_hybrid_flow(
     processing_cue: Mapping[str, Any],
     pi: Mapping[str, Any],
     zoe_agent: Mapping[str, Any] | None,
+    safe_fulfillment: Mapping[str, Any],
 ) -> dict[str, Any]:
     pi_latency = _float_or_none(pi.get("latency_ms"))
     agent_latency = _float_or_none((zoe_agent or {}).get("latency_ms"))
-    final_latency = pi_latency if pi.get("ran") else agent_latency
+    fulfillment_latency = _float_or_none(safe_fulfillment.get("latency_ms"))
+    fulfilled = bool(
+        safe_fulfillment.get("attempted")
+        and not safe_fulfillment.get("timed_out")
+        and not safe_fulfillment.get("error")
+    )
+    if fulfilled and pi_latency is not None:
+        final_latency = pi_latency + (fulfillment_latency or 0.0)
+    else:
+        final_latency = pi_latency if pi.get("ran") else agent_latency
     return {
         "strategy": "processing_ack_then_pi_or_fallback",
         "cue_available": bool(processing_cue.get("available")),
@@ -318,6 +460,9 @@ def _simulated_hybrid_flow(
         "cue_event": processing_cue.get("event"),
         "pi_completion_latency_ms": pi_latency,
         "fallback_completion_latency_ms": agent_latency,
+        "safe_fulfillment_latency_ms": fulfillment_latency,
+        "safe_fulfillment_completion_latency_ms": final_latency if fulfilled else None,
+        "safe_fulfillment_response_preview": safe_fulfillment.get("response_preview") or "",
         "final_completion_latency_ms": final_latency,
         "natural_flow_candidate": bool(processing_cue.get("available") and final_latency is not None),
         "production_route_change": False,

--- a/services/zoe-data/pi_intent_lab.py
+++ b/services/zoe-data/pi_intent_lab.py
@@ -322,6 +322,8 @@ async def _safe_fulfill_pi_intent(
             "attempted": False,
             "allowed": False,
             "blocked_reason": "not_requested",
+            "response_chars": 0,
+            "response_preview": "",
             "would_execute": False,
         }
 
@@ -351,6 +353,7 @@ async def _safe_fulfill_pi_intent(
     started = time.perf_counter()
     try:
         response = await asyncio.wait_for(execute_intent(intent, user_id=user_id), timeout=timeout_seconds)
+        response_text = _response_text(response)
         latency_ms = (time.perf_counter() - started) * 1000
         return {
             "requested": True,
@@ -360,8 +363,8 @@ async def _safe_fulfill_pi_intent(
             "latency_ms": latency_ms,
             "timed_out": False,
             "error": None,
-            "response_chars": len(response or ""),
-            "response_preview": _preview_response(response),
+            "response_chars": len(response_text),
+            "response_preview": _preview_response(response_text),
             "would_execute": True,
             "execution_scope": "read_only_allowlist",
         }
@@ -404,6 +407,8 @@ def _blocked_fulfillment(reason: str, *, intent: str | None = None, error: Any =
         "allowed": False,
         "blocked_reason": reason,
         "intent": intent,
+        "response_chars": 0,
+        "response_preview": "",
         "would_execute": False,
     }
     if error is not None:
@@ -411,8 +416,12 @@ def _blocked_fulfillment(reason: str, *, intent: str | None = None, error: Any =
     return result
 
 
-def _preview_response(response: str | None, *, limit: int = 240) -> str:
-    text = " ".join(str(response or "").split())
+def _response_text(response: Any) -> str:
+    return "" if response is None else str(response)
+
+
+def _preview_response(response: Any, *, limit: int = 240) -> str:
+    text = " ".join(_response_text(response).split())
     if len(text) <= limit:
         return text
     return text[: limit - 1].rstrip() + "..."

--- a/services/zoe-data/routers/pi_intent_lab.py
+++ b/services/zoe-data/routers/pi_intent_lab.py
@@ -24,6 +24,8 @@ class PiIntentLabCompareRequest(BaseModel):
     zoe_agent_timeout_seconds: float = Field(default=12.0, gt=0, le=60)
     zoe_agent_max_tokens: int = Field(default=64, gt=0, le=512)
     include_hybrid_status: bool = True
+    include_safe_fulfillment: bool = False
+    safe_fulfillment_timeout_seconds: float = Field(default=8.0, gt=0, le=30)
 
 
 @router.post("/compare")
@@ -42,6 +44,8 @@ async def compare_pi_intent(payload: PiIntentLabCompareRequest, user: dict = Dep
             zoe_agent_timeout_seconds=payload.zoe_agent_timeout_seconds,
             zoe_agent_max_tokens=payload.zoe_agent_max_tokens,
             include_hybrid_status=payload.include_hybrid_status,
+            include_safe_fulfillment=payload.include_safe_fulfillment,
+            safe_fulfillment_timeout_seconds=payload.safe_fulfillment_timeout_seconds,
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/services/zoe-data/tests/test_pi_intent_lab.py
+++ b/services/zoe-data/tests/test_pi_intent_lab.py
@@ -18,8 +18,14 @@ class _Intent:
         self.confidence = confidence
 
 
-def _install_fake_intent_router(monkeypatch, *, raw=None, extracted=None):
+def _install_fake_intent_router(monkeypatch, *, raw=None, extracted=None, execute_response=None, execute_calls=None):
     module = types.ModuleType("intent_router")
+
+    class Intent:
+        def __init__(self, name, slots=None, confidence=0.9):
+            self.name = name
+            self.slots = slots or {}
+            self.confidence = confidence
 
     def detect_intent(text, user_id="family-admin", context=None):
         return raw(text) if callable(raw) else raw
@@ -27,8 +33,15 @@ def _install_fake_intent_router(monkeypatch, *, raw=None, extracted=None):
     async def detect_and_extract_intent(text, user_id="family-admin", context=None):
         return extracted(text) if callable(extracted) else extracted
 
+    async def execute_intent(intent, user_id="family-admin"):
+        if execute_calls is not None:
+            execute_calls.append({"intent": intent, "user_id": user_id})
+        return execute_response(intent) if callable(execute_response) else execute_response
+
+    module.Intent = Intent
     module.detect_intent = detect_intent
     module.detect_and_extract_intent = detect_and_extract_intent
+    module.execute_intent = execute_intent
     monkeypatch.setitem(sys.modules, "intent_router", module)
 
 
@@ -113,15 +126,16 @@ async def test_lab_compares_router_pi_and_never_dispatches(monkeypatch):
         local_model_configured=True,
     )
 
-    assert result["contract"] == {
-        "admin_only": True,
-        "side_effects": "none",
-        "intent_dispatch_enabled": False,
-        "memory_writes_enabled": False,
-        "shadow_writes_enabled": False,
-        "promotion_enabled": False,
-        "pi_runtime": "standalone",
-    }
+    assert result["contract"]["admin_only"] is True
+    assert result["contract"]["side_effects"] == "none"
+    assert result["contract"]["intent_dispatch_enabled"] is False
+    assert result["contract"]["intent_dispatch_scope"] == "none"
+    assert result["contract"]["safe_read_only_fulfillment_enabled"] is False
+    assert "weather" in result["contract"]["safe_read_only_fulfillment_intents"]
+    assert result["contract"]["memory_writes_enabled"] is False
+    assert result["contract"]["shadow_writes_enabled"] is False
+    assert result["contract"]["promotion_enabled"] is False
+    assert result["contract"]["pi_runtime"] == "standalone"
     assert result["zoe_router"]["intent"] == "weather"
     assert result["zoe_router"]["baseline_lane"] == "deterministic:router"
     assert result["zoe_router"]["would_execute"] is True
@@ -133,6 +147,8 @@ async def test_lab_compares_router_pi_and_never_dispatches(monkeypatch):
     assert result["simulated_hybrid_flow"]["cue_available"] is True
     assert result["simulated_hybrid_flow"]["cue_event"]["type"] == "voice:processing_ack"
     assert result["simulated_hybrid_flow"]["pi_completion_latency_ms"] is not None
+    assert result["safe_fulfillment"]["blocked_reason"] == "not_requested"
+    assert result["safe_fulfillment"]["attempted"] is False
     assert result["simulated_hybrid_flow"]["production_route_change"] is False
     assert result["hybrid_buffer"]["mode"] == "shadow_buffer"
     assert seen_env[0]["env"]["ZOE_PI_INTENT_ENABLED"] == "true"
@@ -205,6 +221,82 @@ async def test_lab_enforces_pi_timeout(monkeypatch):
     assert result["pi"]["timed_out"] is True
     assert result["pi"]["intent"] is None
     assert result["comparison"]["pi_candidate_for_lane"] is False
+
+
+@pytest.mark.asyncio
+async def test_lab_can_fulfill_safe_read_only_pi_result(monkeypatch):
+    calls = []
+    _install_fake_intent_router(
+        monkeypatch,
+        raw=None,
+        extracted=None,
+        execute_response="It's 18.5 C in Perth, light jacket weather.",
+        execute_calls=calls,
+    )
+    _install_fake_pi_classifier(
+        monkeypatch,
+        result=types.SimpleNamespace(
+            intent="weather",
+            slots={"forecast": False},
+            confidence=0.93,
+            task_lane="fast_tool",
+            source="fake_pi",
+            latency_ms=123.0,
+            reason="weather signal",
+        ),
+    )
+    _install_fake_voice_presence(monkeypatch)
+
+    result = await compare_pi_intent_lab(
+        "need a jacket tonight",
+        include_hybrid_status=False,
+        include_safe_fulfillment=True,
+    )
+
+    assert len(calls) == 1
+    assert calls[0]["intent"].name == "weather"
+    assert calls[0]["intent"].slots == {"forecast": False}
+    assert calls[0]["user_id"] == "pi-intent-lab"
+    assert result["contract"]["intent_dispatch_enabled"] is True
+    assert result["contract"]["intent_dispatch_scope"] == "read_only_allowlist_only"
+    assert result["safe_fulfillment"]["attempted"] is True
+    assert result["safe_fulfillment"]["allowed"] is True
+    assert result["safe_fulfillment"]["would_execute"] is True
+    assert result["safe_fulfillment"]["response_preview"] == "It's 18.5 C in Perth, light jacket weather."
+    assert result["simulated_hybrid_flow"]["safe_fulfillment_completion_latency_ms"] is not None
+    assert "18.5 C" in result["simulated_hybrid_flow"]["safe_fulfillment_response_preview"]
+    assert result["simulated_hybrid_flow"]["production_route_change"] is False
+
+
+@pytest.mark.asyncio
+async def test_lab_blocks_side_effect_pi_fulfillment(monkeypatch):
+    calls = []
+    _install_fake_intent_router(monkeypatch, raw=None, extracted=None, execute_response="timer started", execute_calls=calls)
+    _install_fake_pi_classifier(
+        monkeypatch,
+        result=types.SimpleNamespace(
+            intent="timer_create",
+            slots={"minutes": 10},
+            confidence=0.95,
+            task_lane="fast_tool",
+            source="fake_pi",
+            latency_ms=90.0,
+            reason="timer signal",
+        ),
+    )
+
+    result = await compare_pi_intent_lab(
+        "timer for ten minutes",
+        include_hybrid_status=False,
+        include_safe_fulfillment=True,
+    )
+
+    assert calls == []
+    assert result["safe_fulfillment"]["attempted"] is False
+    assert result["safe_fulfillment"]["allowed"] is False
+    assert result["safe_fulfillment"]["blocked_reason"] == "side_effect_or_unsupported_intent"
+    assert result["safe_fulfillment"]["intent"] == "timer_create"
+    assert result["safe_fulfillment"]["would_execute"] is False
 
 def _admin_app():
     app = FastAPI()

--- a/services/zoe-data/tests/test_pi_intent_lab.py
+++ b/services/zoe-data/tests/test_pi_intent_lab.py
@@ -274,6 +274,7 @@ async def test_lab_can_fulfill_safe_read_only_pi_result(monkeypatch):
     assert calls[0]["intent"].slots == {"forecast": False}
     assert calls[0]["user_id"] == "pi-intent-lab"
     assert result["contract"]["intent_dispatch_enabled"] is True
+    assert result["contract"]["side_effects"] == "read_only_external_only"
     assert result["contract"]["intent_dispatch_scope"] == "read_only_allowlist_only"
     assert result["safe_fulfillment"]["attempted"] is True
     assert result["safe_fulfillment"]["allowed"] is True

--- a/services/zoe-data/tests/test_pi_intent_lab.py
+++ b/services/zoe-data/tests/test_pi_intent_lab.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import types
+import asyncio
 
 import pytest
 from fastapi import FastAPI, HTTPException
@@ -18,7 +19,16 @@ class _Intent:
         self.confidence = confidence
 
 
-def _install_fake_intent_router(monkeypatch, *, raw=None, extracted=None, execute_response=None, execute_calls=None):
+def _install_fake_intent_router(
+    monkeypatch,
+    *,
+    raw=None,
+    extracted=None,
+    execute_response=None,
+    execute_calls=None,
+    execute_delay_seconds=0.0,
+    execute_exception=None,
+):
     module = types.ModuleType("intent_router")
 
     class Intent:
@@ -36,6 +46,10 @@ def _install_fake_intent_router(monkeypatch, *, raw=None, extracted=None, execut
     async def execute_intent(intent, user_id="family-admin"):
         if execute_calls is not None:
             execute_calls.append({"intent": intent, "user_id": user_id})
+        if execute_delay_seconds:
+            await asyncio.sleep(execute_delay_seconds)
+        if execute_exception is not None:
+            raise execute_exception
         return execute_response(intent) if callable(execute_response) else execute_response
 
     module.Intent = Intent
@@ -149,6 +163,8 @@ async def test_lab_compares_router_pi_and_never_dispatches(monkeypatch):
     assert result["simulated_hybrid_flow"]["pi_completion_latency_ms"] is not None
     assert result["safe_fulfillment"]["blocked_reason"] == "not_requested"
     assert result["safe_fulfillment"]["attempted"] is False
+    assert result["safe_fulfillment"]["response_chars"] == 0
+    assert result["safe_fulfillment"]["response_preview"] == ""
     assert result["simulated_hybrid_flow"]["production_route_change"] is False
     assert result["hybrid_buffer"]["mode"] == "shadow_buffer"
     assert seen_env[0]["env"]["ZOE_PI_INTENT_ENABLED"] == "true"
@@ -269,6 +285,37 @@ async def test_lab_can_fulfill_safe_read_only_pi_result(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_lab_counts_non_string_safe_fulfillment_response_chars(monkeypatch):
+    _install_fake_intent_router(
+        monkeypatch,
+        raw=None,
+        extracted=None,
+        execute_response={"answer": "18.5 C"},
+    )
+    _install_fake_pi_classifier(
+        monkeypatch,
+        result=types.SimpleNamespace(
+            intent="weather",
+            slots={},
+            confidence=0.93,
+            task_lane="fast_tool",
+            source="fake_pi",
+            latency_ms=123.0,
+            reason="weather signal",
+        ),
+    )
+
+    result = await compare_pi_intent_lab(
+        "need a jacket tonight",
+        include_hybrid_status=False,
+        include_safe_fulfillment=True,
+    )
+
+    assert result["safe_fulfillment"]["response_preview"] == "{'answer': '18.5 C'}"
+    assert result["safe_fulfillment"]["response_chars"] == len("{'answer': '18.5 C'}")
+
+
+@pytest.mark.asyncio
 async def test_lab_blocks_side_effect_pi_fulfillment(monkeypatch):
     calls = []
     _install_fake_intent_router(monkeypatch, raw=None, extracted=None, execute_response="timer started", execute_calls=calls)
@@ -296,7 +343,89 @@ async def test_lab_blocks_side_effect_pi_fulfillment(monkeypatch):
     assert result["safe_fulfillment"]["allowed"] is False
     assert result["safe_fulfillment"]["blocked_reason"] == "side_effect_or_unsupported_intent"
     assert result["safe_fulfillment"]["intent"] == "timer_create"
+    assert result["safe_fulfillment"]["response_chars"] == 0
+    assert result["safe_fulfillment"]["response_preview"] == ""
     assert result["safe_fulfillment"]["would_execute"] is False
+
+
+@pytest.mark.asyncio
+async def test_lab_safe_fulfillment_timeout_is_reported(monkeypatch):
+    calls = []
+    _install_fake_intent_router(
+        monkeypatch,
+        raw=None,
+        extracted=None,
+        execute_response="too late",
+        execute_calls=calls,
+        execute_delay_seconds=0.05,
+    )
+    _install_fake_pi_classifier(
+        monkeypatch,
+        result=types.SimpleNamespace(
+            intent="weather",
+            slots={},
+            confidence=0.95,
+            task_lane="fast_tool",
+            source="fake_pi",
+            latency_ms=90.0,
+            reason="weather signal",
+        ),
+    )
+
+    result = await compare_pi_intent_lab(
+        "rain later",
+        include_hybrid_status=False,
+        include_safe_fulfillment=True,
+        safe_fulfillment_timeout_seconds=0.01,
+    )
+
+    assert len(calls) == 1
+    assert result["safe_fulfillment"]["attempted"] is True
+    assert result["safe_fulfillment"]["allowed"] is True
+    assert result["safe_fulfillment"]["timed_out"] is True
+    assert result["safe_fulfillment"]["would_execute"] is False
+    assert result["safe_fulfillment"]["response_chars"] == 0
+    assert result["safe_fulfillment"]["response_preview"] == ""
+    assert result["simulated_hybrid_flow"]["safe_fulfillment_completion_latency_ms"] is None
+
+
+@pytest.mark.asyncio
+async def test_lab_safe_fulfillment_error_is_reported(monkeypatch):
+    calls = []
+    _install_fake_intent_router(
+        monkeypatch,
+        raw=None,
+        extracted=None,
+        execute_calls=calls,
+        execute_exception=RuntimeError("weather backend failed"),
+    )
+    _install_fake_pi_classifier(
+        monkeypatch,
+        result=types.SimpleNamespace(
+            intent="weather",
+            slots={},
+            confidence=0.95,
+            task_lane="fast_tool",
+            source="fake_pi",
+            latency_ms=90.0,
+            reason="weather signal",
+        ),
+    )
+
+    result = await compare_pi_intent_lab(
+        "rain later",
+        include_hybrid_status=False,
+        include_safe_fulfillment=True,
+    )
+
+    assert len(calls) == 1
+    assert result["safe_fulfillment"]["attempted"] is True
+    assert result["safe_fulfillment"]["allowed"] is True
+    assert result["safe_fulfillment"]["error"] == "RuntimeError"
+    assert result["safe_fulfillment"]["would_execute"] is False
+    assert result["safe_fulfillment"]["response_chars"] == 0
+    assert result["safe_fulfillment"]["response_preview"] == ""
+    assert result["simulated_hybrid_flow"]["safe_fulfillment_completion_latency_ms"] is None
 
 def _admin_app():
     app = FastAPI()


### PR DESCRIPTION
## Summary

- adds optional lab-only safe fulfillment after Pi intent classification
- keeps default Pi intent lab behavior evidence-only with no dispatch
- restricts fulfillment to read-only intents: weather, daily_briefing, list_show, time_query, date_query
- reports cue latency, Pi latency, safe fulfillment latency, final completion latency, and answer preview

## Validation

- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_pi_intent_lab.py services/zoe-data/tests/test_pi_intent_status_endpoint.py services/zoe-data/tests/test_pi_runtime_probe.py services/zoe-data/tests/test_pi_intent_classifier.py services/zoe-data/tests/test_pi_readiness_report.py services/zoe-data/tests/test_pi_intent_fleet_benchmark.py services/zoe-data/tests/test_pi_promotion_eval_script.py services/zoe-data/tests/test_zoe_pi_promotion.py
- python3 tools/audit/validate_structure.py
- real standalone Pi smoke with fake read-only weather fulfillment: cue ~0.03ms, Pi weather, final ~4.38s
