### PR TITLE
[codex] Guard Pi intent lab HTTP probes

### DIFF
--- a/scripts/maintenance/pi_intent_lab_http_probe.py
+++ b/scripts/maintenance/pi_intent_lab_http_probe.py
@@ -46,12 +46,25 @@ def run_probe(
     allow_pi_execution: bool,
     local_model_configured: bool,
     timeout_seconds: float,
+    request_timeout_seconds: float | None = None,
+    session_id: str | None = None,
+    device_token: str | None = None,
     post_json: Callable[[str, Mapping[str, Any], float], Mapping[str, Any]] | None = None,
 ) -> list[dict[str, Any]]:
     observations: list[dict[str, Any]] = []
     active_repeat = max(1, repeat)
     endpoint = _endpoint_url(base_url)
-    sender = post_json or _post_json
+    auth_headers = _auth_headers(session_id=session_id, device_token=device_token)
+    if post_json is not None and auth_headers:
+        raise ValueError("session_id/device_token require the default HTTP sender")
+    if request_timeout_seconds is not None and request_timeout_seconds >= timeout_seconds:
+        raise ValueError("request_timeout_seconds must be less than timeout_seconds")
+
+    def send(url: str, payload: Mapping[str, Any], timeout: float) -> Mapping[str, Any]:
+        if post_json is not None:
+            return post_json(url, payload, timeout)
+        return _post_json(url, payload, timeout, headers=auth_headers)
+
     for repeat_index in range(1, active_repeat + 1):
         for raw_case in cases:
             case = _normalise_case(raw_case)
@@ -63,11 +76,13 @@ def run_probe(
                 "include_hybrid_status": False,
                 "include_safe_fulfillment": include_safe_fulfillment,
             }
+            if request_timeout_seconds is not None:
+                payload["request_timeout_seconds"] = request_timeout_seconds
             started = time.perf_counter()
             error = None
             result: Mapping[str, Any] | None = None
             try:
-                result = sender(endpoint, payload, timeout_seconds)
+                result = send(endpoint, payload, timeout_seconds)
             except Exception as exc:
                 error = f"{type(exc).__name__}: {exc}"
             http_latency_ms = (time.perf_counter() - started) * 1000
@@ -117,12 +132,20 @@ def build_report(
     return payload
 
 
-def _post_json(url: str, payload: Mapping[str, Any], timeout_seconds: float) -> Mapping[str, Any]:
+def _post_json(
+    url: str,
+    payload: Mapping[str, Any],
+    timeout_seconds: float,
+    *,
+    headers: Mapping[str, str] | None = None,
+) -> Mapping[str, Any]:
     data = json.dumps(payload).encode("utf-8")
+    request_headers = {"Content-Type": "application/json"}
+    request_headers.update(headers or {})
     request = urllib.request.Request(
         url,
         data=data,
-        headers={"Content-Type": "application/json"},
+        headers=request_headers,
         method="POST",
     )
     try:
@@ -132,6 +155,15 @@ def _post_json(url: str, payload: Mapping[str, Any], timeout_seconds: float) -> 
         body = exc.read().decode("utf-8", errors="replace")
         raise RuntimeError(f"HTTP {exc.code}: {body[:300]}") from exc
     return json.loads(raw)
+
+
+def _auth_headers(*, session_id: str | None, device_token: str | None) -> dict[str, str]:
+    headers: dict[str, str] = {}
+    if session_id:
+        headers["X-Session-ID"] = session_id
+    if device_token:
+        headers["X-Device-Token"] = device_token
+    return headers
 
 
 def _observation(
@@ -312,6 +344,14 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--local-model-configured", action="store_true")
     parser.add_argument("--include-safe-fulfillment", action="store_true")
     parser.add_argument("--timeout-seconds", type=float, default=12.0)
+    parser.add_argument(
+        "--request-timeout-seconds",
+        type=float,
+        default=10.0,
+        help="Server-side lab timeout; must be lower than --timeout-seconds so 504s are observable.",
+    )
+    parser.add_argument("--session-id")
+    parser.add_argument("--device-token")
     parser.add_argument("--include-observations", action="store_true")
     args = parser.parse_args(argv)
 
@@ -325,6 +365,9 @@ def main(argv: list[str] | None = None) -> int:
         allow_pi_execution=args.allow_pi_execution,
         local_model_configured=args.local_model_configured,
         timeout_seconds=args.timeout_seconds,
+        request_timeout_seconds=args.request_timeout_seconds,
+        session_id=args.session_id,
+        device_token=args.device_token,
     )
     print(
         json.dumps(

--- a/services/zoe-data/routers/pi_intent_lab.py
+++ b/services/zoe-data/routers/pi_intent_lab.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from typing import Literal
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -26,26 +27,32 @@ class PiIntentLabCompareRequest(BaseModel):
     include_hybrid_status: bool = True
     include_safe_fulfillment: bool = False
     safe_fulfillment_timeout_seconds: float = Field(default=8.0, gt=0, le=30)
+    request_timeout_seconds: float = Field(default=20.0, gt=0, le=90)
 
 
 @router.post("/compare")
 async def compare_pi_intent(payload: PiIntentLabCompareRequest, user: dict = Depends(require_admin)):
     """Compare Zoe router, optional Zoe Agent fallback, and standalone Pi without dispatching."""
     try:
-        return await compare_pi_intent_lab(
-            payload.text,
-            user_id=str(user.get("user_id") or "admin"),
-            context_turns=payload.context_turns,
-            run_pi=payload.run_pi,
-            pi_transport=payload.pi_transport,
-            allow_pi_execution=payload.allow_pi_execution,
-            local_model_configured=payload.local_model_configured,
-            measure_zoe_agent_baseline=payload.measure_zoe_agent_baseline,
-            zoe_agent_timeout_seconds=payload.zoe_agent_timeout_seconds,
-            zoe_agent_max_tokens=payload.zoe_agent_max_tokens,
-            include_hybrid_status=payload.include_hybrid_status,
-            include_safe_fulfillment=payload.include_safe_fulfillment,
-            safe_fulfillment_timeout_seconds=payload.safe_fulfillment_timeout_seconds,
+        return await asyncio.wait_for(
+            compare_pi_intent_lab(
+                payload.text,
+                user_id=str(user.get("user_id") or "admin"),
+                context_turns=payload.context_turns,
+                run_pi=payload.run_pi,
+                pi_transport=payload.pi_transport,
+                allow_pi_execution=payload.allow_pi_execution,
+                local_model_configured=payload.local_model_configured,
+                measure_zoe_agent_baseline=payload.measure_zoe_agent_baseline,
+                zoe_agent_timeout_seconds=payload.zoe_agent_timeout_seconds,
+                zoe_agent_max_tokens=payload.zoe_agent_max_tokens,
+                include_hybrid_status=payload.include_hybrid_status,
+                include_safe_fulfillment=payload.include_safe_fulfillment,
+                safe_fulfillment_timeout_seconds=payload.safe_fulfillment_timeout_seconds,
+            ),
+            timeout=payload.request_timeout_seconds,
         )
+    except asyncio.TimeoutError as exc:
+        raise HTTPException(status_code=504, detail="Pi intent lab comparison timed out") from exc
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/services/zoe-data/tests/test_pi_intent_lab.py
+++ b/services/zoe-data/tests/test_pi_intent_lab.py
@@ -483,3 +483,22 @@ def test_pi_intent_lab_endpoint_returns_comparison(monkeypatch):
     assert data["pi"]["intent"] == "weather"
     assert data["contract"]["intent_dispatch_enabled"] is False
     assert data["simulated_hybrid_flow"]["cue_available"] is True
+
+
+def test_pi_intent_lab_endpoint_times_out_stuck_comparison(monkeypatch):
+    import routers.pi_intent_lab as route_module
+
+    async def stuck_comparison(*args, **kwargs):
+        await asyncio.sleep(1)
+        return {"unexpected": True}
+
+    monkeypatch.setattr(route_module, "compare_pi_intent_lab", stuck_comparison)
+    app = _admin_app()
+
+    resp = TestClient(app).post(
+        "/api/pi-intent-lab/compare",
+        json={"text": "rain later", "request_timeout_seconds": 0.01},
+    )
+
+    assert resp.status_code == 504
+    assert resp.json()["detail"] == "Pi intent lab comparison timed out"

--- a/services/zoe-data/tests/test_pi_intent_lab_http_probe.py
+++ b/services/zoe-data/tests/test_pi_intent_lab_http_probe.py
@@ -74,6 +74,7 @@ def test_http_probe_summarises_endpoint_results():
         allow_pi_execution=True,
         local_model_configured=True,
         timeout_seconds=12.0,
+        request_timeout_seconds=9.0,
         post_json=fake_post,
     )
     report = module.build_report(
@@ -90,6 +91,7 @@ def test_http_probe_summarises_endpoint_results():
     assert calls[0]["url"] == "http://127.0.0.1:8013/api/pi-intent-lab/compare"
     assert calls[0]["payload"]["include_safe_fulfillment"] is True
     assert calls[0]["payload"]["include_hybrid_status"] is False
+    assert calls[0]["payload"]["request_timeout_seconds"] == 9.0
     assert report["safe_fulfillment_side_effects"] == "read_only_external_only"
     assert report["summary"]["overall"]["pi_accuracy"] == 1.0
     assert report["summary"]["overall"]["natural_flow_rate"] == 1.0
@@ -125,6 +127,86 @@ def test_empty_endpoint_response_is_not_success():
 
     assert observations[0]["safe_fulfillment_success"] is False
     assert report["summary"]["overall"]["safe_fulfillment_success_rate"] == 0.0
+
+
+def test_auth_headers_are_attached_to_real_http_sender(monkeypatch):
+    module = _load_module()
+    seen = {}
+
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self):
+            return json.dumps(_endpoint_result()).encode("utf-8")
+
+    def fake_urlopen(request, timeout):
+        seen["timeout"] = timeout
+        seen["headers"] = dict(request.header_items())
+        return FakeResponse()
+
+    monkeypatch.setattr(module.urllib.request, "urlopen", fake_urlopen)
+
+    result = module._post_json(
+        "http://127.0.0.1:8013/api/pi-intent-lab/compare",
+        {"text": "rain later"},
+        12.0,
+        headers=module._auth_headers(session_id="session-secret", device_token="device-secret"),
+    )
+
+    assert result["pi"]["intent"] == "weather"
+    assert seen["timeout"] == 12.0
+    assert seen["headers"]["X-session-id"] == "session-secret"
+    assert seen["headers"]["X-device-token"] == "device-secret"
+
+
+def test_custom_transport_rejects_auth_headers():
+    module = _load_module()
+
+    def fake_post(url, payload, timeout_seconds):
+        return _endpoint_result()
+
+    try:
+        module.run_probe(
+            [{"case_id": "weather", "text": "rain later", "expected_intent": "weather"}],
+            base_url="http://127.0.0.1:8013",
+            repeat=1,
+            run_pi=True,
+            include_safe_fulfillment=False,
+            allow_pi_execution=True,
+            local_model_configured=True,
+            timeout_seconds=12.0,
+            session_id="session-secret",
+            post_json=fake_post,
+        )
+    except ValueError as exc:
+        assert "default HTTP sender" in str(exc)
+    else:
+        raise AssertionError("expected ValueError")
+
+
+def test_request_timeout_must_be_below_http_timeout():
+    module = _load_module()
+
+    try:
+        module.run_probe(
+            [{"case_id": "weather", "text": "rain later", "expected_intent": "weather"}],
+            base_url="http://127.0.0.1:8013",
+            repeat=1,
+            run_pi=True,
+            include_safe_fulfillment=False,
+            allow_pi_execution=True,
+            local_model_configured=True,
+            timeout_seconds=12.0,
+            request_timeout_seconds=12.0,
+        )
+    except ValueError as exc:
+        assert "less than timeout_seconds" in str(exc)
+    else:
+        raise AssertionError("expected ValueError")
 
 
 def test_http_errors_are_reported():
@@ -204,6 +286,9 @@ def test_cli_runs_cases_file(tmp_path, capsys, monkeypatch):
     def fake_run_probe(cases_arg, **kwargs):
         assert len(cases_arg) == 1
         assert kwargs["base_url"] == "http://testserver"
+        assert kwargs["request_timeout_seconds"] == 9.0
+        assert kwargs["session_id"] == "session-secret"
+        assert kwargs["device_token"] == "device-secret"
         return [
             {
                 "case_id": "weather",
@@ -228,6 +313,12 @@ def test_cli_runs_cases_file(tmp_path, capsys, monkeypatch):
             "--no-default-cases",
             "--run-pi",
             "--include-safe-fulfillment",
+            "--request-timeout-seconds",
+            "9",
+            "--session-id",
+            "session-secret",
+            "--device-token",
+            "device-secret",
         ]
     )
 


### PR DESCRIPTION
## Summary\n- add an overall timeout guard to the admin Pi intent lab comparison endpoint\n- let the HTTP probe send admin session/device headers and request-timeout budgets\n- add focused timeout/header/CLI regression coverage\n\n## Verification\n- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_pi_intent_lab.py services/zoe-data/tests/test_pi_intent_lab_http_probe.py\n- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_pi_intent_lab.py services/zoe-data/tests/test_pi_intent_lab_http_probe.py services/zoe-data/tests/test_pi_hybrid_flow_benchmark.py services/zoe-data/tests/test_conversation_flow_probe.py services/zoe-data/tests/test_pi_intent_fleet_benchmark.py\n- python3 tools/audit/validate_structure.py\n- live temp HTTP probe on 127.0.0.1:8016 with Pi RPC + safe fulfillment + request_timeout_seconds=12: request_error_rate=0, pi_accuracy=1.0, natural_flow_rate=1.0, safe_fulfillment_success_rate=1.0, final p95 ~= 3.9s\n