### PR TITLE
[codex] Allow internal Pi intent lab probes

### DIFF
--- a/services/zoe-data/routers/pi_intent_lab.py
+++ b/services/zoe-data/routers/pi_intent_lab.py
@@ -5,13 +5,26 @@ from __future__ import annotations
 import asyncio
 from typing import Literal
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, Field
 
-from auth import require_admin
+import auth
 from pi_intent_lab import compare_pi_intent_lab
 
 router = APIRouter(prefix="/api/pi-intent-lab", tags=["pi-intent-lab"])
+
+
+async def require_lab_operator(request: Request) -> dict:
+    """Allow admin users or Zoe internal loopback/token callers to use the lab."""
+    try:
+        await auth.require_internal_token(request)
+        return {"user_id": "internal-pi-intent-lab", "role": "admin", "auth_path": "internal"}
+    except HTTPException as internal_exc:
+        if request.headers.get("X-Internal-Token") and getattr(auth, "_ZOE_INTERNAL_TOKEN", ""):
+            raise internal_exc
+
+    user = await auth.get_current_user(request)
+    return await auth.require_admin(user)
 
 
 class PiIntentLabCompareRequest(BaseModel):
@@ -31,7 +44,7 @@ class PiIntentLabCompareRequest(BaseModel):
 
 
 @router.post("/compare")
-async def compare_pi_intent(payload: PiIntentLabCompareRequest, user: dict = Depends(require_admin)):
+async def compare_pi_intent(payload: PiIntentLabCompareRequest, user: dict = Depends(require_lab_operator)):
     """Compare Zoe router, optional Zoe Agent fallback, and standalone Pi without dispatching."""
     try:
         return await asyncio.wait_for(

--- a/services/zoe-data/tests/test_pi_intent_lab.py
+++ b/services/zoe-data/tests/test_pi_intent_lab.py
@@ -7,7 +7,8 @@ import pytest
 from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
 
-from auth import require_admin
+import auth
+from routers.pi_intent_lab import require_lab_operator
 from pi_intent_lab import compare_pi_intent_lab
 from routers.pi_intent_lab import router as pi_intent_lab_router
 
@@ -435,7 +436,7 @@ def _admin_app():
     async def fake_admin():
         return {"user_id": "admin", "role": "family-admin"}
 
-    app.dependency_overrides[require_admin] = fake_admin
+    app.dependency_overrides[require_lab_operator] = fake_admin
     return app
 
 
@@ -446,11 +447,102 @@ def test_pi_intent_lab_endpoint_is_admin_scoped(monkeypatch):
     async def fake_non_admin():
         raise HTTPException(status_code=403, detail="Admin access required")
 
-    app.dependency_overrides[require_admin] = fake_non_admin
+    app.dependency_overrides[require_lab_operator] = fake_non_admin
 
     resp = TestClient(app).post("/api/pi-intent-lab/compare", json={"text": "rain later"})
 
     assert resp.status_code == 403
+
+
+def test_pi_intent_lab_endpoint_allows_internal_token(monkeypatch):
+    _install_fake_intent_router(monkeypatch, raw=_Intent("weather"), extracted=_Intent("weather"))
+    _install_fake_pi_classifier(
+        monkeypatch,
+        result=types.SimpleNamespace(
+            intent="weather",
+            slots={},
+            confidence=0.9,
+            task_lane="fast_tool",
+            source="fake_pi",
+            latency_ms=100.0,
+            reason=None,
+        ),
+    )
+    _install_fake_hybrid(monkeypatch)
+    _install_fake_voice_presence(monkeypatch)
+    monkeypatch.setattr(auth, "_ZOE_INTERNAL_TOKEN", "pi-lab-token")
+    app = FastAPI()
+    app.include_router(pi_intent_lab_router)
+
+    resp = TestClient(app).post(
+        "/api/pi-intent-lab/compare",
+        json={"text": "rain later", "run_pi": True},
+        headers={"X-Internal-Token": "pi-lab-token"},
+    )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["input"]["user_id"] == "internal-pi-intent-lab"
+    assert data["pi"]["intent"] == "weather"
+
+
+def test_pi_intent_lab_endpoint_rejects_wrong_internal_token(monkeypatch):
+    monkeypatch.setattr(auth, "_ZOE_INTERNAL_TOKEN", "pi-lab-token")
+    app = FastAPI()
+    app.include_router(pi_intent_lab_router)
+
+    resp = TestClient(app).post(
+        "/api/pi-intent-lab/compare",
+        json={"text": "rain later", "run_pi": False},
+        headers={"X-Internal-Token": "wrong-token"},
+    )
+
+    assert resp.status_code == 403
+    assert "X-Internal-Token" in resp.json()["detail"]
+
+
+def test_pi_intent_lab_endpoint_falls_back_to_admin_session_when_internal_token_unconfigured(monkeypatch):
+    _install_fake_intent_router(monkeypatch, raw=_Intent("weather"), extracted=_Intent("weather"))
+    _install_fake_pi_classifier(
+        monkeypatch,
+        result=types.SimpleNamespace(
+            intent="weather",
+            slots={},
+            confidence=0.9,
+            task_lane="fast_tool",
+            source="fake_pi",
+            latency_ms=100.0,
+            reason=None,
+        ),
+    )
+    _install_fake_hybrid(monkeypatch)
+    _install_fake_voice_presence(monkeypatch)
+    monkeypatch.setattr(auth, "_ZOE_INTERNAL_TOKEN", "")
+    calls = []
+
+    async def fake_current_user(request):
+        calls.append("get_current_user")
+        return {"user_id": "session-admin", "role": "family-admin"}
+
+    async def fake_require_admin(user):
+        calls.append(("require_admin", user["user_id"]))
+        return user
+
+    monkeypatch.setattr(auth, "get_current_user", fake_current_user)
+    monkeypatch.setattr(auth, "require_admin", fake_require_admin)
+    app = FastAPI()
+    app.include_router(pi_intent_lab_router)
+
+    resp = TestClient(app).post(
+        "/api/pi-intent-lab/compare",
+        json={"text": "rain later", "run_pi": True},
+        headers={"X-Internal-Token": "proxy-added-but-feature-disabled"},
+    )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["input"]["user_id"] == "session-admin"
+    assert calls == ["get_current_user", ("require_admin", "session-admin")]
 
 
 def test_pi_intent_lab_endpoint_returns_comparison(monkeypatch):


### PR DESCRIPTION
## Summary\n- allow Zoe internal loopback/token callers to use the admin Pi intent lab endpoint\n- keep normal admin auth fallback for UI/session callers\n- add regression tests for valid/wrong internal token paths\n\n## Verification\n- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_pi_intent_lab.py services/zoe-data/tests/test_pi_intent_lab_http_probe.py services/zoe-data/tests/test_metrics_auth_regression.py\n- PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_pi_intent_lab.py services/zoe-data/tests/test_pi_intent_lab_http_probe.py services/zoe-data/tests/test_pi_hybrid_flow_benchmark.py services/zoe-data/tests/test_conversation_flow_probe.py services/zoe-data/tests/test_pi_intent_fleet_benchmark.py services/zoe-data/tests/test_metrics_auth_regression.py\n- python3 tools/audit/validate_structure.py\n