### PR TITLE
[codex] Reset Pi RPC worker after unparsable output

### DIFF
--- a/services/zoe-data/pi_intent_classifier.py
+++ b/services/zoe-data/pi_intent_classifier.py
@@ -346,7 +346,13 @@ async def _classify_with_pi_rpc(
         logger.debug("Pi RPC intent governor failed: %s", exc)
         return None
     latency_ms = (time.perf_counter() - start) * 1000
-    return _parse_pi_classification(raw, latency_ms=latency_ms)
+    parsed = _parse_pi_classification(raw, latency_ms=latency_ms)
+    if parsed is None:
+        text = raw.strip().lstrip("` \n").rstrip("` \n")
+        if _extract_first_json_object(text) is None:
+            await worker.reset()
+            logger.debug("Pi RPC intent governor returned unparsable output; worker reset")
+    return parsed
 
 
 def _classification_prompt(text: str, *, context_turns: str = "") -> str:

--- a/services/zoe-data/tests/test_pi_intent_classifier.py
+++ b/services/zoe-data/tests/test_pi_intent_classifier.py
@@ -386,6 +386,87 @@ for line in sys.stdin:
 
 
 @pytest.mark.asyncio
+async def test_pi_rpc_unparsable_output_resets_process(tmp_path, monkeypatch):
+    bindir = tmp_path / "rpc-empty-output-bin"
+    bindir.mkdir()
+    _write_exe(bindir / "node", "#!/bin/sh\nexit 0\n")
+    _write_exe(bindir / "npm", "#!/bin/sh\nexit 0\n")
+    _write_exe(
+        bindir / "pi",
+        "#!/usr/bin/python3\n"
+        "import json, sys, time\n"
+        "for line in sys.stdin:\n"
+        "    request = json.loads(line)\n"
+        "    print(json.dumps({'id': request['id'], 'type': 'response', 'command': 'prompt', 'success': True}), flush=True)\n"
+        "    print(json.dumps({'id': request['id'], 'type': 'agent_end', 'messages': []}), flush=True)\n"
+        "    time.sleep(10)\n",
+    )
+    workers = {}
+    monkeypatch.setattr(pi_intent_classifier, "_RPC_WORKERS", workers)
+    env = {
+        "PATH": str(bindir),
+        "ZOE_PI_INTENT_ENABLED": "true",
+        "ZOE_PI_INTENT_TRANSPORT": "rpc",
+        "ZOE_PI_COMMAND": "pi",
+        "ZOE_PI_CWD": str(tmp_path),
+        "ZOE_PI_ALLOW_EXECUTION": "true",
+        "ZOE_PI_LOCAL_MODEL_CONFIGURED": "true",
+        "ZOE_PI_INTENT_TIMEOUT_SECONDS": "2",
+    }
+
+    result = await classify_with_pi_intent_governor("rain later", env=env)
+
+    assert result is None
+    assert len(workers) == 1
+    worker = next(iter(workers.values()))
+    assert worker.proc is None
+
+
+@pytest.mark.asyncio
+async def test_pi_rpc_valid_json_unknown_intent_keeps_warm_process(tmp_path, monkeypatch):
+    bindir = tmp_path / "rpc-unknown-intent-bin"
+    bindir.mkdir()
+    _write_exe(bindir / "node", "#!/bin/sh\nexit 0\n")
+    _write_exe(bindir / "npm", "#!/bin/sh\nexit 0\n")
+    payload = json.dumps({"intent": "delete_everything", "slots": {}, "confidence": 0.99, "task_lane": "fast_tool"})
+    _write_exe(
+        bindir / "pi",
+        "#!/usr/bin/python3\n"
+        "import json, sys, time\n"
+        f"payload = {payload!r}\n"
+        "for line in sys.stdin:\n"
+        "    request = json.loads(line)\n"
+        "    print(json.dumps({'id': request['id'], 'type': 'response', 'command': 'prompt', 'success': True}), flush=True)\n"
+        "    print(json.dumps({'id': request['id'], 'type': 'agent_end', 'messages': [{'role': 'assistant', 'content': [{'type': 'text', 'text': payload}]}]}), flush=True)\n"
+        "    time.sleep(10)\n",
+    )
+    workers = {}
+    monkeypatch.setattr(pi_intent_classifier, "_RPC_WORKERS", workers)
+    env = {
+        "PATH": str(bindir),
+        "ZOE_PI_INTENT_ENABLED": "true",
+        "ZOE_PI_INTENT_TRANSPORT": "rpc",
+        "ZOE_PI_COMMAND": "pi",
+        "ZOE_PI_CWD": str(tmp_path),
+        "ZOE_PI_ALLOW_EXECUTION": "true",
+        "ZOE_PI_LOCAL_MODEL_CONFIGURED": "true",
+        "ZOE_PI_INTENT_TIMEOUT_SECONDS": "2",
+        "ZOE_PI_INTENT_PREFILTER_ENABLED": "false",
+    }
+
+    try:
+        result = await classify_with_pi_intent_governor("please do something weird", env=env)
+        assert result is None
+        assert len(workers) == 1
+        worker = next(iter(workers.values()))
+        assert worker.proc is not None
+        assert worker.proc.returncode is None
+    finally:
+        for worker in list(workers.values()):
+            await worker.reset()
+
+
+@pytest.mark.asyncio
 async def test_pi_rpc_timeout_resets_process_under_worker_lock(tmp_path, monkeypatch):
     bindir = tmp_path / "rpc-timeout-bin"
     bindir.mkdir()


### PR DESCRIPTION
## What changed

- Reset the warm Pi RPC worker when a prompt returns output that cannot be parsed into Zoe intent-classification JSON.
- Added a regression test for an accepted RPC prompt that ends with empty/unparsable output.

## Why

The live Pi lab showed a stale service state where RPC returned fast intent=None results until zoe-data was restarted. After restart, standalone Pi classified the weather cases correctly and safe fulfillment executed. This fix prevents one empty/unparsable RPC turn from poisoning the next turn.

## Live evidence

- Before restart: live RPC returned intent=null quickly for weather cases.
- After controlled zoe-data restart: RPC returned weather with confidence 0.95 and safe fulfillment executed.
- Refreshed hybrid benchmark: Pi accuracy 1.0, safe fulfillment 1.0, cue p95 about 0.036 ms; per-case final latencies about 3.87 s and 3.34 s.

## Validation

- python3 -m py_compile services/zoe-data/pi_intent_classifier.py
- /home/zoe/.local/bin/pytest -q services/zoe-data/tests/test_pi_intent_classifier.py
- /home/zoe/.local/bin/pytest -q services/zoe-data/tests/test_pi_intent_classifier.py services/zoe-data/tests/test_pi_runtime_probe.py services/zoe-data/tests/test_pi_intent_lab.py services/zoe-data/tests/test_pi_intent_lab_http_probe.py services/zoe-data/tests/test_pi_promotion_eval_script.py
- python3 tools/audit/validate_structure.py
