### PR TITLE
[codex] Add Pi hybrid stream lab endpoint

### DIFF
--- a/services/zoe-data/routers/pi_intent_lab.py
+++ b/services/zoe-data/routers/pi_intent_lab.py
@@ -139,7 +139,7 @@ async def _hybrid_stream_events(payload: PiIntentLabCompareRequest, user: Mappin
                 "event": "error",
                 "phase": "final",
                 "elapsed_ms": _elapsed_ms(started),
-                "error": str(exc),
+                "error": str(exc)[:200],
                 "error_type": "validation",
                 "production_route_change": False,
             }

--- a/services/zoe-data/routers/pi_intent_lab.py
+++ b/services/zoe-data/routers/pi_intent_lab.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Literal
+import json
+import time
+from typing import Any, AsyncIterator, Literal, Mapping
 
 from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
 
 import auth
@@ -69,3 +72,117 @@ async def compare_pi_intent(payload: PiIntentLabCompareRequest, user: dict = Dep
         raise HTTPException(status_code=504, detail="Pi intent lab comparison timed out") from exc
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.post("/hybrid-stream")
+async def stream_pi_hybrid_flow(payload: PiIntentLabCompareRequest, user: dict = Depends(require_lab_operator)):
+    """Stream the lab hybrid flow as cue-first NDJSON, then Pi/final evidence."""
+    return StreamingResponse(
+        _hybrid_stream_events(payload, user),
+        media_type="application/x-ndjson",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )
+
+
+async def _hybrid_stream_events(payload: PiIntentLabCompareRequest, user: Mapping[str, Any]) -> AsyncIterator[str]:
+    started = time.perf_counter()
+    cue = _processing_cue()
+    yield _json_line(
+        {
+            "event": "processing_cue",
+            "phase": "cue",
+            "elapsed_ms": _elapsed_ms(started),
+            "cue": cue,
+            "contract": {
+                "admin_only": True,
+                "production_route_change": False,
+                "memory_writes_enabled": False,
+                "shadow_writes_enabled": False,
+                "promotion_enabled": False,
+            },
+        }
+    )
+    try:
+        result = await asyncio.wait_for(
+            compare_pi_intent_lab(
+                payload.text,
+                user_id=str(user.get("user_id") or "admin"),
+                context_turns=payload.context_turns,
+                run_pi=payload.run_pi,
+                pi_transport=payload.pi_transport,
+                allow_pi_execution=payload.allow_pi_execution,
+                local_model_configured=payload.local_model_configured,
+                measure_zoe_agent_baseline=payload.measure_zoe_agent_baseline,
+                zoe_agent_timeout_seconds=payload.zoe_agent_timeout_seconds,
+                zoe_agent_max_tokens=payload.zoe_agent_max_tokens,
+                include_hybrid_status=payload.include_hybrid_status,
+                include_safe_fulfillment=payload.include_safe_fulfillment,
+                safe_fulfillment_timeout_seconds=payload.safe_fulfillment_timeout_seconds,
+            ),
+            timeout=payload.request_timeout_seconds,
+        )
+    except asyncio.TimeoutError:
+        yield _json_line(
+            {
+                "event": "error",
+                "phase": "final",
+                "elapsed_ms": _elapsed_ms(started),
+                "error": "Pi intent lab comparison timed out",
+                "error_type": "timeout",
+                "production_route_change": False,
+            }
+        )
+        return
+    except ValueError as exc:
+        yield _json_line(
+            {
+                "event": "error",
+                "phase": "final",
+                "elapsed_ms": _elapsed_ms(started),
+                "error": str(exc),
+                "error_type": "validation",
+                "production_route_change": False,
+            }
+        )
+        return
+
+    yield _json_line(
+        {
+            "event": "final",
+            "phase": "final",
+            "elapsed_ms": _elapsed_ms(started),
+            "result": result,
+            "production_route_change": False,
+        }
+    )
+
+
+def _processing_cue() -> dict[str, Any]:
+    from voice_presence import processing_ack_event
+
+    started = time.perf_counter()
+    event = processing_ack_event(index=0)
+    return {
+        "available": event is not None,
+        "latency_ms": _elapsed_ms(started),
+        "event": _safe_voice_event(event),
+        "text": str((event or {}).get("text") or ""),
+    }
+
+
+def _safe_voice_event(event: Mapping[str, Any] | None) -> dict[str, Any] | None:
+    if event is None:
+        return None
+    safe = dict(event)
+    audio = safe.pop("audio_base64", None)
+    if audio:
+        safe["audio_base64_chars"] = len(str(audio))
+    return safe
+
+
+def _elapsed_ms(started: float) -> float:
+    return (time.perf_counter() - started) * 1000
+
+
+def _json_line(payload: Mapping[str, Any]) -> str:
+    return json.dumps(payload, separators=(",", ":"), sort_keys=True) + "\n"

--- a/services/zoe-data/routers/pi_intent_lab.py
+++ b/services/zoe-data/routers/pi_intent_lab.py
@@ -51,21 +51,7 @@ async def compare_pi_intent(payload: PiIntentLabCompareRequest, user: dict = Dep
     """Compare Zoe router, optional Zoe Agent fallback, and standalone Pi without dispatching."""
     try:
         return await asyncio.wait_for(
-            compare_pi_intent_lab(
-                payload.text,
-                user_id=str(user.get("user_id") or "admin"),
-                context_turns=payload.context_turns,
-                run_pi=payload.run_pi,
-                pi_transport=payload.pi_transport,
-                allow_pi_execution=payload.allow_pi_execution,
-                local_model_configured=payload.local_model_configured,
-                measure_zoe_agent_baseline=payload.measure_zoe_agent_baseline,
-                zoe_agent_timeout_seconds=payload.zoe_agent_timeout_seconds,
-                zoe_agent_max_tokens=payload.zoe_agent_max_tokens,
-                include_hybrid_status=payload.include_hybrid_status,
-                include_safe_fulfillment=payload.include_safe_fulfillment,
-                safe_fulfillment_timeout_seconds=payload.safe_fulfillment_timeout_seconds,
-            ),
+            _run_compare(payload, user_id=str(user.get("user_id") or "admin")),
             timeout=payload.request_timeout_seconds,
         )
     except asyncio.TimeoutError as exc:
@@ -84,9 +70,27 @@ async def stream_pi_hybrid_flow(payload: PiIntentLabCompareRequest, user: dict =
     )
 
 
+async def _run_compare(payload: PiIntentLabCompareRequest, *, user_id: str) -> dict[str, Any]:
+    return await compare_pi_intent_lab(
+        payload.text,
+        user_id=user_id,
+        context_turns=payload.context_turns,
+        run_pi=payload.run_pi,
+        pi_transport=payload.pi_transport,
+        allow_pi_execution=payload.allow_pi_execution,
+        local_model_configured=payload.local_model_configured,
+        measure_zoe_agent_baseline=payload.measure_zoe_agent_baseline,
+        zoe_agent_timeout_seconds=payload.zoe_agent_timeout_seconds,
+        zoe_agent_max_tokens=payload.zoe_agent_max_tokens,
+        include_hybrid_status=payload.include_hybrid_status,
+        include_safe_fulfillment=payload.include_safe_fulfillment,
+        safe_fulfillment_timeout_seconds=payload.safe_fulfillment_timeout_seconds,
+    )
+
+
 async def _hybrid_stream_events(payload: PiIntentLabCompareRequest, user: Mapping[str, Any]) -> AsyncIterator[str]:
     started = time.perf_counter()
-    cue = _processing_cue()
+    cue = _safe_processing_cue()
     yield _json_line(
         {
             "event": "processing_cue",
@@ -104,45 +108,21 @@ async def _hybrid_stream_events(payload: PiIntentLabCompareRequest, user: Mappin
     )
     try:
         result = await asyncio.wait_for(
-            compare_pi_intent_lab(
-                payload.text,
-                user_id=str(user.get("user_id") or "admin"),
-                context_turns=payload.context_turns,
-                run_pi=payload.run_pi,
-                pi_transport=payload.pi_transport,
-                allow_pi_execution=payload.allow_pi_execution,
-                local_model_configured=payload.local_model_configured,
-                measure_zoe_agent_baseline=payload.measure_zoe_agent_baseline,
-                zoe_agent_timeout_seconds=payload.zoe_agent_timeout_seconds,
-                zoe_agent_max_tokens=payload.zoe_agent_max_tokens,
-                include_hybrid_status=payload.include_hybrid_status,
-                include_safe_fulfillment=payload.include_safe_fulfillment,
-                safe_fulfillment_timeout_seconds=payload.safe_fulfillment_timeout_seconds,
-            ),
+            _run_compare(payload, user_id=str(user.get("user_id") or "admin")),
             timeout=payload.request_timeout_seconds,
         )
     except asyncio.TimeoutError:
-        yield _json_line(
-            {
-                "event": "error",
-                "phase": "final",
-                "elapsed_ms": _elapsed_ms(started),
-                "error": "Pi intent lab comparison timed out",
-                "error_type": "timeout",
-                "production_route_change": False,
-            }
-        )
+        yield _stream_error(started, error="Pi intent lab comparison timed out", error_type="timeout")
         return
     except ValueError as exc:
-        yield _json_line(
-            {
-                "event": "error",
-                "phase": "final",
-                "elapsed_ms": _elapsed_ms(started),
-                "error": str(exc)[:200],
-                "error_type": "validation",
-                "production_route_change": False,
-            }
+        yield _stream_error(started, error=_safe_error_message(exc), error_type="validation")
+        return
+    except Exception as exc:  # pragma: no cover - defensive streaming guard
+        yield _stream_error(
+            started,
+            error=_safe_error_message(exc),
+            error_type="exception",
+            exception_class=exc.__class__.__name__,
         )
         return
 
@@ -155,6 +135,20 @@ async def _hybrid_stream_events(payload: PiIntentLabCompareRequest, user: Mappin
             "production_route_change": False,
         }
     )
+
+
+def _safe_processing_cue() -> dict[str, Any]:
+    try:
+        return _processing_cue()
+    except Exception as exc:  # pragma: no cover - defensive streaming guard
+        return {
+            "available": False,
+            "latency_ms": None,
+            "event": None,
+            "text": "",
+            "error": _safe_error_message(exc),
+            "error_type": exc.__class__.__name__,
+        }
 
 
 def _processing_cue() -> dict[str, Any]:
@@ -178,6 +172,30 @@ def _safe_voice_event(event: Mapping[str, Any] | None) -> dict[str, Any] | None:
     if audio:
         safe["audio_base64_chars"] = len(str(audio))
     return safe
+
+
+def _stream_error(
+    started: float,
+    *,
+    error: str,
+    error_type: str,
+    exception_class: str | None = None,
+) -> str:
+    payload: dict[str, Any] = {
+        "event": "error",
+        "phase": "final",
+        "elapsed_ms": _elapsed_ms(started),
+        "error": error,
+        "error_type": error_type,
+        "production_route_change": False,
+    }
+    if exception_class:
+        payload["exception_class"] = exception_class
+    return _json_line(payload)
+
+
+def _safe_error_message(exc: Exception, *, limit: int = 200) -> str:
+    return str(exc)[:limit]
 
 
 def _elapsed_ms(started: float) -> float:

--- a/services/zoe-data/tests/test_pi_intent_lab.py
+++ b/services/zoe-data/tests/test_pi_intent_lab.py
@@ -689,3 +689,65 @@ def test_pi_intent_lab_hybrid_stream_is_admin_scoped(monkeypatch):
     resp = TestClient(app).post("/api/pi-intent-lab/hybrid-stream", json={"text": "rain later"})
 
     assert resp.status_code == 403
+
+
+def test_pi_intent_lab_hybrid_stream_emits_packet_when_cue_builder_fails(monkeypatch):
+    import routers.pi_intent_lab as route_module
+
+    async def fake_compare(text, **kwargs):
+        return {
+            "report_kind": "zoe_pi_intent_lab_comparison",
+            "input": {"user_id": kwargs["user_id"]},
+            "pi": {"intent": "weather"},
+        }
+
+    def broken_cue():
+        raise RuntimeError("cue builder exploded with a long but non-sensitive lab message")
+
+    monkeypatch.setattr(route_module, "compare_pi_intent_lab", fake_compare)
+    monkeypatch.setattr(route_module, "_processing_cue", broken_cue)
+    app = _admin_app()
+
+    with TestClient(app).stream(
+        "POST",
+        "/api/pi-intent-lab/hybrid-stream",
+        json={"text": "rain later"},
+    ) as resp:
+        assert resp.status_code == 200
+        events = [json.loads(line) for line in resp.iter_lines() if line]
+
+    assert [event["event"] for event in events] == ["processing_cue", "final"]
+    assert events[0]["cue"]["available"] is False
+    assert events[0]["cue"]["error_type"] == "RuntimeError"
+    assert "cue builder exploded" in events[0]["cue"]["error"]
+    assert events[1]["result"]["pi"]["intent"] == "weather"
+
+
+def test_pi_intent_lab_hybrid_stream_unexpected_compare_error_terminates_cleanly(monkeypatch):
+    import routers.pi_intent_lab as route_module
+
+    async def broken_compare(*args, **kwargs):
+        raise RuntimeError("backend vanished " + "x" * 300)
+
+    monkeypatch.setattr(route_module, "compare_pi_intent_lab", broken_compare)
+    monkeypatch.setattr(
+        route_module,
+        "_processing_cue",
+        lambda: {"available": True, "latency_ms": 0.05, "event": None, "text": "Let me check."},
+    )
+    app = _admin_app()
+
+    with TestClient(app).stream(
+        "POST",
+        "/api/pi-intent-lab/hybrid-stream",
+        json={"text": "rain later"},
+    ) as resp:
+        assert resp.status_code == 200
+        events = [json.loads(line) for line in resp.iter_lines() if line]
+
+    assert [event["event"] for event in events] == ["processing_cue", "error"]
+    assert events[1]["error_type"] == "exception"
+    assert events[1]["exception_class"] == "RuntimeError"
+    assert events[1]["phase"] == "final"
+    assert len(events[1]["error"]) == 200
+    assert events[1]["production_route_change"] is False

--- a/services/zoe-data/tests/test_pi_intent_lab.py
+++ b/services/zoe-data/tests/test_pi_intent_lab.py
@@ -1,3 +1,4 @@
+import json
 import os
 import sys
 import types
@@ -594,3 +595,97 @@ def test_pi_intent_lab_endpoint_times_out_stuck_comparison(monkeypatch):
 
     assert resp.status_code == 504
     assert resp.json()["detail"] == "Pi intent lab comparison timed out"
+
+
+def test_pi_intent_lab_hybrid_stream_emits_cue_then_final(monkeypatch):
+    import routers.pi_intent_lab as route_module
+
+    async def fake_compare(text, **kwargs):
+        await asyncio.sleep(0.01)
+        return {
+            "report_kind": "zoe_pi_intent_lab_comparison",
+            "input": {"user_id": kwargs["user_id"]},
+            "contract": {"production_route_change": False},
+            "pi": {"intent": "weather", "confidence": 0.95},
+            "safe_fulfillment": {"response_preview": "It is 18.5 C."},
+            "simulated_hybrid_flow": {
+                "cue_available": True,
+                "final_completion_latency_ms": 2600.0,
+                "production_route_change": False,
+            },
+        }
+
+    monkeypatch.setattr(route_module, "compare_pi_intent_lab", fake_compare)
+    monkeypatch.setattr(
+        route_module,
+        "_processing_cue",
+        lambda: {
+            "available": True,
+            "latency_ms": 0.05,
+            "event": {"type": "voice:processing_ack", "text": "Let me check."},
+            "text": "Let me check.",
+        },
+    )
+    app = _admin_app()
+
+    with TestClient(app).stream(
+        "POST",
+        "/api/pi-intent-lab/hybrid-stream",
+        json={"text": "rain later", "include_safe_fulfillment": True},
+    ) as resp:
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith("application/x-ndjson")
+        events = [json.loads(line) for line in resp.iter_lines() if line]
+
+    assert [event["event"] for event in events] == ["processing_cue", "final"]
+    assert events[0]["phase"] == "cue"
+    assert events[0]["cue"]["text"] == "Let me check."
+    assert events[0]["contract"]["production_route_change"] is False
+    assert events[1]["phase"] == "final"
+    assert events[1]["result"]["input"]["user_id"] == "admin"
+    assert events[1]["result"]["pi"]["intent"] == "weather"
+    assert events[1]["production_route_change"] is False
+    assert events[1]["elapsed_ms"] >= events[0]["elapsed_ms"]
+
+
+def test_pi_intent_lab_hybrid_stream_times_out_as_final_error(monkeypatch):
+    import routers.pi_intent_lab as route_module
+
+    async def stuck_compare(*args, **kwargs):
+        await asyncio.sleep(1)
+        return {"unexpected": True}
+
+    monkeypatch.setattr(route_module, "compare_pi_intent_lab", stuck_compare)
+    monkeypatch.setattr(
+        route_module,
+        "_processing_cue",
+        lambda: {"available": True, "latency_ms": 0.05, "event": None, "text": "Let me check."},
+    )
+    app = _admin_app()
+
+    with TestClient(app).stream(
+        "POST",
+        "/api/pi-intent-lab/hybrid-stream",
+        json={"text": "rain later", "request_timeout_seconds": 0.01},
+    ) as resp:
+        assert resp.status_code == 200
+        events = [json.loads(line) for line in resp.iter_lines() if line]
+
+    assert [event["event"] for event in events] == ["processing_cue", "error"]
+    assert events[1]["error_type"] == "timeout"
+    assert events[1]["phase"] == "final"
+    assert events[1]["production_route_change"] is False
+
+
+def test_pi_intent_lab_hybrid_stream_is_admin_scoped(monkeypatch):
+    app = FastAPI()
+    app.include_router(pi_intent_lab_router)
+
+    async def fake_non_admin():
+        raise HTTPException(status_code=403, detail="Admin access required")
+
+    app.dependency_overrides[require_lab_operator] = fake_non_admin
+
+    resp = TestClient(app).post("/api/pi-intent-lab/hybrid-stream", json={"text": "rain later"})
+
+    assert resp.status_code == 403


### PR DESCRIPTION
## Summary

Adds an admin/internal-only Pi intent lab streaming endpoint for the hybrid conversation test:

- `/api/pi-intent-lab/hybrid-stream` emits a `processing_cue` NDJSON packet immediately.
- The same request then streams a `final` packet with the existing Pi lab comparison result.
- Timeout/validation failures are returned as final stream error packets instead of hanging the client.
- No production chat/voice routing is changed.
- No memory, shadow, or promotion writes are enabled by this endpoint.

## Why

The existing lab comparison measured the right components, but clients only saw a completed HTTP response. This closes the test contract for the user-visible hybrid idea: "instant cue, then Pi/Gemma final answer".

## Live Branch Evidence

Ran the branch server on `127.0.0.1:8019` and called `/api/pi-intent-lab/hybrid-stream` over loopback:

- `need a jacket tonight`: cue client received ~25ms, final client received ~5398ms, Pi intent `weather`, confidence 0.90.
- `rain later`: cue client received ~4ms, final client received ~3578ms, Pi intent `weather`, confidence 0.90.

This confirms the first packet is effectively instant while the final answer follows after Pi + safe weather fulfillment.

## Validation

- `python3 -m py_compile services/zoe-data/routers/pi_intent_lab.py services/zoe-data/tests/test_pi_intent_lab.py`
- `/home/zoe/.local/bin/pytest -q services/zoe-data/tests/test_pi_intent_lab.py services/zoe-data/tests/test_pi_intent_lab_http_probe.py services/zoe-data/tests/test_pi_hybrid_flow_benchmark.py services/zoe-data/tests/test_pi_intent_classifier.py services/zoe-data/tests/test_pi_runtime_probe.py`
- `python3 tools/audit/validate_structure.py`
