### PR TITLE
fix(harness): poll-timeout sentinel no longer strands in-progress chains (+ poll-loop logging)

### DIFF
--- a/services/zoe-data/main.py
+++ b/services/zoe-data/main.py
@@ -128,6 +128,23 @@ async def _poll_chain_guarded(ref: str, *, issue: dict | None, timeout: float) -
         return {"found": False, "status": "poll_error", "error": str(exc)}
 
 
+async def _resolve_chain_for_dispatch(chain, *, ref, issue, poll_guarded, poll_timeout):
+    """Re-poll once with a longer timeout when the first poll failed.
+
+    ``_poll_chain_guarded`` returns a timeout/error sentinel on a slow/failed
+    poll. An *existing* multi-row chain's poll (worktree + git ops) is expensive
+    and can time out under event-loop load, while a fresh todo's poll is cheap —
+    so without a retry the sentinel made the backfill skip the chain forever
+    (stranding it past implement). If the chain isn't a sentinel, return it
+    unchanged (no extra poll).
+    """
+    from multica_poll_dispatch import chain_poll_failed  # type: ignore[import]
+
+    if not chain_poll_failed(chain):
+        return chain
+    return await poll_guarded(ref, issue=issue, timeout=max(float(poll_timeout) * 2, 60.0))
+
+
 async def _recover_stale_in_progress_issues(
     client,
     in_progress_issues: list[dict],
@@ -722,10 +739,9 @@ async def lifespan(app: FastAPI):
                 os.makedirs(os.path.dirname(_poll_log_path), exist_ok=True)
                 _fh = RotatingFileHandler(_poll_log_path, maxBytes=2_000_000, backupCount=3)
                 _fh.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(name)s %(message)s"))
+                _fh.setLevel(logging.INFO)  # handler-scoped; do NOT mutate the shared logger level
                 _fh._zoe_poll_log = True  # type: ignore[attr-defined]
                 logger.addHandler(_fh)
-                if logger.level > logging.INFO or logger.level == logging.NOTSET:
-                    logger.setLevel(logging.INFO)
                 logger.info("multica_poll: diagnostics logging to %s", _poll_log_path)
         except Exception as _log_exc:  # pragma: no cover - logging setup must never break the loop
             logger.warning("multica_poll: could not attach poll-loop file log: %s", _log_exc)
@@ -931,9 +947,22 @@ async def lifespan(app: FastAPI):
                                     _candidate.get("identifier") or _tid,
                                     _chain.get("status"),
                                 )
-                                _chain = await _poll_chain_guarded(
-                                    f"multica:{_tid}", issue=_candidate, timeout=max(_poll_timeout * 2, 60.0)
+                                _chain = await _resolve_chain_for_dispatch(
+                                    _chain,
+                                    ref=f"multica:{_tid}",
+                                    issue=_candidate,
+                                    poll_guarded=_poll_chain_guarded,
+                                    poll_timeout=_poll_timeout,
                                 )
+                                # Keep the per-cycle cache consistent with the re-poll so the
+                                # later todo loop sees the resolved state, not the stale sentinel.
+                                _chain_cache[_tid] = _chain
+                                # If the re-poll revealed an active worker, the single lane is
+                                # genuinely occupied (the earlier running-count missed it via the
+                                # sentinel). Mark the lane full so the todo loop can't over-dispatch.
+                                if chain_is_running(_chain):
+                                    _wh_dispatched = _wh_limit
+                                    return
                             if not chain_needs_dispatch(_chain) and not chain_poll_failed(_chain):
                                 return
                             _phase = (_chain.get("pipeline") or {}).get("phase")

--- a/services/zoe-data/main.py
+++ b/services/zoe-data/main.py
@@ -710,6 +710,25 @@ async def lifespan(app: FastAPI):
     # Multica board polling loop (30s interval, no-op if ZOE_MULTICA=false)
     async def _multica_poll_loop():
         import time as _t
+        # Observability: the systemd unit doesn't capture app stdout (journalctl
+        # shows nothing for zoe-data), so persist poll-loop diagnostics to a
+        # dedicated rotating file. Isolated to this module logger — does not touch
+        # uvicorn's logging config. Without this, dispatch stalls are invisible.
+        try:
+            from logging.handlers import RotatingFileHandler
+
+            if not any(getattr(_h, "_zoe_poll_log", False) for _h in logger.handlers):
+                _poll_log_path = os.path.expanduser("~/.zoe/zoe-data-poll.log")
+                os.makedirs(os.path.dirname(_poll_log_path), exist_ok=True)
+                _fh = RotatingFileHandler(_poll_log_path, maxBytes=2_000_000, backupCount=3)
+                _fh.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(name)s %(message)s"))
+                _fh._zoe_poll_log = True  # type: ignore[attr-defined]
+                logger.addHandler(_fh)
+                if logger.level > logging.INFO or logger.level == logging.NOTSET:
+                    logger.setLevel(logging.INFO)
+                logger.info("multica_poll: diagnostics logging to %s", _poll_log_path)
+        except Exception as _log_exc:  # pragma: no cover - logging setup must never break the loop
+            logger.warning("multica_poll: could not attach poll-loop file log: %s", _log_exc)
         _last_worktree_prune = 0.0
         try:
             _prune_interval_s = float(os.environ.get("ZOE_WORKTREE_PRUNE_INTERVAL_S", "86400") or "86400")
@@ -785,7 +804,7 @@ async def lifespan(app: FastAPI):
                 try:
                     from multica_webhook_emitter import is_configured as _wh_ok
                     from multica_client import get_engineering_multica_agent_id  # type: ignore[import]
-                    from multica_poll_dispatch import chain_is_running, chain_needs_dispatch  # type: ignore[import]
+                    from multica_poll_dispatch import chain_is_running, chain_needs_dispatch, chain_poll_failed  # type: ignore[import]
                     from multica_dispatch_control import dispatch_is_paused, pause_reason
 
                     _dispatch_paused = dispatch_is_paused()
@@ -899,7 +918,23 @@ async def lifespan(app: FastAPI):
                             if not _tid:
                                 return
                             _chain = await _poll_chain(_candidate)
-                            if not chain_needs_dispatch(_chain):
+                            # A failed poll (timeout/error sentinel) on a known in-progress
+                            # chain must NOT silently skip it — that stranded chains past
+                            # implement forever (an existing multi-row chain's poll can time
+                            # out under load). Re-poll once fresh with a generous timeout; if
+                            # it still can't resolve, fall through to dispatch_issue anyway —
+                            # dispatch is idempotent + re-derives state from the journal, so it
+                            # safely creates the next ready phase or no-ops if a row exists.
+                            if chain_poll_failed(_chain) and not from_todo:
+                                logger.info(
+                                    "multica_poll: chain poll failed for %s (%s); re-polling before skip",
+                                    _candidate.get("identifier") or _tid,
+                                    _chain.get("status"),
+                                )
+                                _chain = await _poll_chain_guarded(
+                                    f"multica:{_tid}", issue=_candidate, timeout=max(_poll_timeout * 2, 60.0)
+                                )
+                            if not chain_needs_dispatch(_chain) and not chain_poll_failed(_chain):
                                 return
                             _phase = (_chain.get("pipeline") or {}).get("phase")
                             # Dispatch the next ready phase IN-PROCESS. The poll loop runs

--- a/services/zoe-data/multica_poll_dispatch.py
+++ b/services/zoe-data/multica_poll_dispatch.py
@@ -65,6 +65,23 @@ def chain_is_running(chain: dict) -> bool:
     return pipeline.get("status") == "running"
 
 
+def chain_poll_failed(chain: dict) -> bool:
+    """True when the chain poll could not determine state (timeout/error sentinel).
+
+    ``_poll_chain_guarded`` returns ``{"found": False, "status": "poll_timeout"|
+    "poll_error"}`` when ``poll_ref`` times out or raises. That sentinel makes
+    ``chain_needs_dispatch`` return False — which previously caused the poll loop
+    to silently SKIP an in-progress chain forever (it stranded past implement,
+    because an existing multi-row chain's poll is expensive and can time out under
+    event-loop load, while a fresh todo's poll is cheap). Callers should treat a
+    failed poll on a known in-progress chain as "state unknown — let the
+    idempotent dispatch re-derive it", not as "inactive, skip".
+    """
+    if not chain:
+        return True
+    return bool(chain.get("timed_out")) or chain.get("status") in ("poll_timeout", "poll_error")
+
+
 def _issue_age_hours(issue: dict, *, now: _dt.datetime) -> float | None:
     """Hours since the issue's last metadata update (falls back to created_at)."""
     raw = (issue or {}).get("updated_at") or (issue or {}).get("created_at") or ""

--- a/services/zoe-data/tests/test_main_multica_poll.py
+++ b/services/zoe-data/tests/test_main_multica_poll.py
@@ -794,6 +794,36 @@ async def test_poll_chain_guarded_passes_through_live_result(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_resolve_chain_for_dispatch_repolls_only_on_sentinel():
+    """A poll sentinel triggers ONE fresh re-poll (longer timeout); a real chain
+    is returned unchanged with no extra poll. This is the recovery that stops a
+    transient poll timeout/error from stranding an in-progress chain past implement."""
+    from main import _resolve_chain_for_dispatch
+
+    calls = []
+
+    async def _repoll(ref, *, issue=None, timeout=None):
+        calls.append({"ref": ref, "timeout": timeout})
+        return {"found": True, "status": "partial", "phases": {"implement": "done"}}
+
+    # Sentinel -> re-polls with a longer (>= 60s) timeout and returns the fresh result.
+    sentinel = {"found": False, "status": "poll_timeout", "timed_out": True}
+    out = await _resolve_chain_for_dispatch(
+        sentinel, ref="multica:x", issue={"id": "x"}, poll_guarded=_repoll, poll_timeout=20.0
+    )
+    assert out["status"] == "partial"
+    assert len(calls) == 1 and calls[0]["timeout"] >= 60.0
+
+    # Real (non-sentinel) chain -> returned as-is, no extra poll.
+    real = {"found": True, "status": "partial", "phases": {"implement": "done"}}
+    out2 = await _resolve_chain_for_dispatch(
+        real, ref="multica:y", issue={"id": "y"}, poll_guarded=_repoll, poll_timeout=20.0
+    )
+    assert out2 is real
+    assert len(calls) == 1  # not called again
+
+
+@pytest.mark.asyncio
 async def test_recover_stale_in_progress_resets_dead_chain_and_frees_lane():
     import datetime as dt
 

--- a/services/zoe-data/tests/test_multica_poll_dispatch.py
+++ b/services/zoe-data/tests/test_multica_poll_dispatch.py
@@ -5,6 +5,7 @@ from multica_poll_dispatch import (
     chain_is_active,
     chain_is_running,
     chain_needs_dispatch,
+    chain_poll_failed,
     is_stale_in_progress,
 )
 import executors.kanban_adapter as ka
@@ -15,6 +16,18 @@ _NOW = dt.datetime(2026, 6, 14, 12, 0, tzinfo=dt.timezone.utc)
 
 def _aged(hours):
     return (_NOW - dt.timedelta(hours=hours)).isoformat()
+
+
+def test_chain_poll_failed_detects_sentinels_but_not_real_status():
+    # The timeout/error sentinels from _poll_chain_guarded — a failed poll, NOT a
+    # real "inactive" state. Previously these silently stranded in-progress chains.
+    assert chain_poll_failed({"found": False, "status": "poll_timeout", "timed_out": True}) is True
+    assert chain_poll_failed({"found": False, "status": "poll_error", "error": "boom"}) is True
+    assert chain_poll_failed({}) is True
+    # Real statuses are NOT poll failures.
+    assert chain_poll_failed({"status": "partial", "phases": {"implement": "done"}}) is False
+    assert chain_poll_failed({"status": "running"}) is False
+    assert chain_poll_failed({"found": False, "status": "not_found"}) is False
 
 
 def test_chain_needs_dispatch_not_found():

--- a/services/zoe-data/tests/test_multica_poll_dispatch.py
+++ b/services/zoe-data/tests/test_multica_poll_dispatch.py
@@ -30,6 +30,40 @@ def test_chain_poll_failed_detects_sentinels_but_not_real_status():
     assert chain_poll_failed({"found": False, "status": "not_found"}) is False
 
 
+def test_resolve_chain_for_dispatch_repolls_only_on_sentinel():
+    """The re-poll recovery (main._resolve_chain_for_dispatch) that stops a poll
+    timeout/error sentinel from stranding an in-progress chain: a sentinel triggers
+    ONE fresh re-poll with a longer (>=60s) timeout, then the backfill decides on
+    the resolved chain; a real chain is returned unchanged with no extra poll."""
+    import asyncio
+
+    from main import _resolve_chain_for_dispatch
+
+    calls = []
+
+    async def _repoll(ref, *, issue=None, timeout=None):
+        calls.append(timeout)
+        return {"found": True, "status": "partial", "phases": {"implement": "done"}}
+
+    sentinel = {"found": False, "status": "poll_timeout", "timed_out": True}
+    out = asyncio.run(
+        _resolve_chain_for_dispatch(
+            sentinel, ref="multica:x", issue={"id": "x"}, poll_guarded=_repoll, poll_timeout=20.0
+        )
+    )
+    assert out["status"] == "partial"
+    assert len(calls) == 1 and calls[0] >= 60.0
+
+    real = {"found": True, "status": "partial", "phases": {"implement": "done"}}
+    out2 = asyncio.run(
+        _resolve_chain_for_dispatch(
+            real, ref="multica:y", issue={"id": "y"}, poll_guarded=_repoll, poll_timeout=20.0
+        )
+    )
+    assert out2 is real
+    assert len(calls) == 1  # no second poll for a real chain
+
+
 def test_chain_needs_dispatch_not_found():
     assert chain_needs_dispatch({"found": False, "status": "not_found"}) is True
 


### PR DESCRIPTION
## The real phase-advance bug (corrects #565)
#565's loopback hypothesis was wrong. The actual bug: `_poll_chain_guarded` returns a sentinel `{found:False, status:poll_timeout|poll_error}` on timeout(20s)/error; `chain_needs_dispatch(sentinel)` is **False**, so the in-progress backfill **silently skips the chain every cycle** — stranding it past implement (verify never dispatched). Implement dispatches because a fresh `todo`'s poll is cheap; an existing multi-row chain's poll (worktree+git) is expensive and times out under load.

**Confirmed, not guessed:** `chain_needs_dispatch(sentinel)=False`, and calling `dispatch_issue()` directly on the stranded chain returns `ok=True, created=['verify']` and the gateway runs it — so dispatch + execution are fine; only the poll-loop's *decision* was poisoned by the sentinel.

## Fix
- `chain_poll_failed()` helper (pure, tested).
- Backfill: on a failed poll for an in-progress chain, **re-poll once fresh** (2×/60s), then fall through to `dispatch_issue` instead of skipping. `dispatch_issue` is idempotent and re-derives state from the journal, so it safely creates the next ready phase or no-ops if a row already exists.
- **Observability:** dedicated `RotatingFileHandler` → `~/.zoe/zoe-data-poll.log` (the systemd unit captures no app stdout — `journalctl` showed nothing, which is why #565 shipped blind).

Tests: `chain_poll_failed` unit test; poll/dispatch/adapter suites green (290).

## Deploy
Runtime poll-loop change → restart zoe-data after merge, then a controlled ticket should run implement→verify→…→closeout fully autonomously (verifiable now via the new log).

🤖 Generated with [Claude Code](https://claude.com/claude-code)