### PR TITLE
[codex] Expand Pi intent eval cases

### DIFF
--- a/data/eval/pi_intent_eval_cases.jsonl
+++ b/data/eval/pi_intent_eval_cases.jsonl
@@ -6,3 +6,17 @@
 {"case_id":"eval_briefing_morning","text":"give me my morning briefing","expected_intent":"daily_briefing","intent_group":"daily_briefing","route_class":"fallback","source":"synthetic"}
 {"case_id":"eval_negative_breakfast_service","text":"I like the breakfast service here","expected_intent":null,"intent_group":"chat","route_class":"fallback","source":"known_failure","negative":true}
 {"case_id":"eval_negative_weather_movie","text":"the weather in that movie felt dramatic","expected_intent":null,"intent_group":"chat","route_class":"fallback","source":"known_failure","negative":true}
+{"case_id":"eval_reminder_stretch","text":"remind me to stretch after lunch","expected_intent":"reminder_create","intent_group":"reminders","route_class":"extraction_failed","source":"synthetic"}
+{"case_id":"eval_reminder_today","text":"what reminders do I have today","expected_intent":"reminder_list","intent_group":"reminders","route_class":"fallback","source":"synthetic"}
+{"case_id":"eval_list_show_packing","text":"show me my packing list","expected_intent":"list_show","intent_group":"lists","route_class":"deterministic","source":"synthetic"}
+{"case_id":"eval_list_add_tomatoes","text":"add tomatoes to the shopping list","expected_intent":"list_add","intent_group":"lists","route_class":"extraction_failed","source":"synthetic"}
+{"case_id":"eval_list_remove_milk","text":"remove milk from the grocery list","expected_intent":"list_remove","intent_group":"lists","route_class":"extraction_failed","source":"synthetic"}
+{"case_id":"eval_list_remove_done","text":"take batteries off my errands list","expected_intent":"list_remove","intent_group":"lists","route_class":"extraction_failed","source":"synthetic"}
+{"case_id":"eval_timer_tea","text":"start a tea timer for four minutes","expected_intent":"timer_create","intent_group":"timers","route_class":"fallback","source":"synthetic"}
+{"case_id":"eval_timer_laundry","text":"set a laundry timer for 45 minutes","expected_intent":"timer_create","intent_group":"timers","route_class":"fallback","source":"synthetic"}
+{"case_id":"eval_calc_percent","text":"what is 15 percent of eighty","expected_intent":"calculate","intent_group":"calculations","route_class":"fallback","source":"synthetic"}
+{"case_id":"eval_calc_addition","text":"add 38 and 47","expected_intent":"calculate","intent_group":"calculations","route_class":"fallback","source":"synthetic"}
+{"case_id":"eval_briefing_evening","text":"what is left on my day","expected_intent":"daily_briefing","intent_group":"daily_briefing","route_class":"fallback","source":"synthetic"}
+{"case_id":"eval_briefing_schedule","text":"tell me what is coming up today","expected_intent":"daily_briefing","intent_group":"daily_briefing","route_class":"fallback","source":"synthetic"}
+{"case_id":"eval_negative_timer_story","text":"that timer scene in the movie was tense","expected_intent":null,"intent_group":"chat","route_class":"fallback","source":"synthetic","negative":true}
+{"case_id":"eval_negative_shopping_memory","text":"I used to like shopping with grandma","expected_intent":null,"intent_group":"chat","route_class":"fallback","source":"synthetic","negative":true}

--- a/services/zoe-data/tests/test_zoe_pi_promotion.py
+++ b/services/zoe-data/tests/test_zoe_pi_promotion.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 
 from zoe_pi_promotion import (
@@ -99,6 +101,45 @@ def test_load_pi_intent_eval_cases_from_json_object(tmp_path):
     assert len(cases) == 1
     assert cases[0].case_id == "timer_file"
     assert cases[0].source == "intent_miss"
+
+
+def test_committed_pi_intent_eval_cases_validate_requested_coverage():
+    repo_root = Path(__file__).resolve().parents[3]
+    path = repo_root / "data" / "eval" / "pi_intent_eval_cases.jsonl"
+
+    cases = load_pi_intent_eval_cases(path)
+    by_id = {case.case_id: case for case in cases}
+    new_synthetic_case_ids = {
+        "eval_reminder_stretch",
+        "eval_reminder_today",
+        "eval_list_show_packing",
+        "eval_list_add_tomatoes",
+        "eval_list_remove_milk",
+        "eval_list_remove_done",
+        "eval_timer_tea",
+        "eval_timer_laundry",
+        "eval_calc_percent",
+        "eval_calc_addition",
+        "eval_briefing_evening",
+        "eval_briefing_schedule",
+        "eval_negative_timer_story",
+        "eval_negative_shopping_memory",
+    }
+
+    assert new_synthetic_case_ids <= set(by_id)
+    assert all(by_id[case_id].source == "synthetic" for case_id in new_synthetic_case_ids)
+    assert {
+        "reminder_create",
+        "reminder_list",
+        "list_add",
+        "list_show",
+        "list_remove",
+        "timer_create",
+        "calculate",
+        "daily_briefing",
+    } <= {case.expected_intent for case in cases if case.expected_intent}
+    assert by_id["eval_negative_timer_story"].negative is True
+    assert by_id["eval_negative_shopping_memory"].intent_group == "chat"
 
 
 def test_load_pi_intent_eval_cases_rejects_duplicate_case_ids(tmp_path):

--- a/services/zoe-data/tests/test_zoe_pi_promotion.py
+++ b/services/zoe-data/tests/test_zoe_pi_promotion.py
@@ -139,6 +139,7 @@ def test_committed_pi_intent_eval_cases_validate_requested_coverage():
         "daily_briefing",
     } <= {case.expected_intent for case in cases if case.expected_intent}
     assert by_id["eval_negative_timer_story"].negative is True
+    assert by_id["eval_negative_timer_story"].intent_group == "chat"
     assert by_id["eval_negative_shopping_memory"].negative is True
     assert by_id["eval_negative_shopping_memory"].intent_group == "chat"
 

--- a/services/zoe-data/tests/test_zoe_pi_promotion.py
+++ b/services/zoe-data/tests/test_zoe_pi_promotion.py
@@ -139,6 +139,7 @@ def test_committed_pi_intent_eval_cases_validate_requested_coverage():
         "daily_briefing",
     } <= {case.expected_intent for case in cases if case.expected_intent}
     assert by_id["eval_negative_timer_story"].negative is True
+    assert by_id["eval_negative_shopping_memory"].negative is True
     assert by_id["eval_negative_shopping_memory"].intent_group == "chat"
 
 


### PR DESCRIPTION
## Summary

Adds expanded synthetic Pi intent eval coverage for the low-risk promotion corpus:

- reminders: create and list variants
- lists: show, add, and remove variants
- timers, calculations, and daily briefing variants
- negative casual chat examples that mention timer/shopping language without expecting an intent

Also adds a focused loader test for the committed `data/eval/pi_intent_eval_cases.jsonl` file so schema validation and requested coverage are exercised by the existing `PiIntentEvalCase` path.

## Validation

- `PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_pi_promotion_eval_script.py services/zoe-data/tests/test_zoe_pi_promotion.py` → 64 passed
- `PYTHONPATH=services/zoe-data python3 - <<'PY' ... load_pi_intent_eval_cases("data/eval/pi_intent_eval_cases.jsonl") ... PY` → loaded 22 cases; sources `{'intent_miss': 1, 'known_failure': 3, 'synthetic': 18}`; expected intents include `list_remove`
- `python3 tools/audit/validate_structure.py` → passed
- `git diff --check` → passed

## Notes

Kept the PR scoped to the eval corpus and its directly related loader test. No Pi stream probe files were modified.