### PR TITLE
Fix Pi lab list_show safe fulfillment

### DIFF
--- a/services/zoe-data/intent_router.py
+++ b/services/zoe-data/intent_router.py
@@ -1804,6 +1804,57 @@ async def _execute_reminder_create_direct(intent: Intent, user_id: str) -> Optio
         return None
 
 
+async def _execute_list_show_direct(intent: Intent, user_id: str) -> Optional[str]:
+    slots = intent.slots or {}
+    list_type = str(slots.get("list_type") or "shopping").strip() or "shopping"
+    list_name = str(slots.get("list_name") or "").strip()
+    try:
+        from database import get_db_ctx
+
+        async with get_db_ctx() as db:
+            if list_name:
+                cursor = await db.execute(
+                    "SELECT l.id, l.name, li.id as item_id, li.text, li.completed, li.quantity, li.category"
+                    " FROM lists l LEFT JOIN list_items li ON l.id = li.list_id AND li.deleted=0"
+                    " WHERE (l.user_id=? OR l.visibility='family') AND l.list_type=? AND l.name LIKE ? AND l.deleted=0"
+                    " ORDER BY li.sort_order",
+                    (user_id, list_type, f"%{list_name}%"),
+                )
+            else:
+                cursor = await db.execute(
+                    "SELECT l.id, l.name, li.id as item_id, li.text, li.completed, li.quantity, li.category"
+                    " FROM lists l LEFT JOIN list_items li ON l.id = li.list_id AND li.deleted=0"
+                    " WHERE (l.user_id=? OR l.visibility='family') AND l.list_type=? AND l.deleted=0"
+                    " ORDER BY l.name, li.sort_order",
+                    (user_id, list_type),
+                )
+            rows = await cursor.fetchall()
+
+        lists_map: dict[str, dict] = {}
+        for row in rows:
+            data = dict(row)
+            list_id = data.get("id")
+            if not list_id:
+                continue
+            if list_id not in lists_map:
+                lists_map[list_id] = {"id": list_id, "name": data.get("name"), "items": []}
+            if data.get("item_id") and data.get("text"):
+                lists_map[list_id]["items"].append(
+                    {
+                        "id": data.get("item_id"),
+                        "text": data.get("text"),
+                        "completed": bool(data.get("completed")),
+                        "quantity": data.get("quantity"),
+                        "category": data.get("category"),
+                    }
+                )
+
+        return _format_response(intent, json.dumps({"lists": list(lists_map.values())}))
+    except Exception as exc:
+        logger.warning("list_show direct execution unavailable; falling back to mcporter: %s", exc)
+        return None
+
+
 async def execute_intent(intent: Intent, user_id: str = "family-admin") -> Optional[str]:
     if intent.name == "lets_talk":
         # Navigation is handled by _broadcast_intent_nav via _INTENT_PANEL_NAV in chat.py.
@@ -2367,6 +2418,11 @@ async def execute_intent(intent: Intent, user_id: str = "family-admin") -> Optio
     # Route directly to the weather backend helpers for deterministic voice UX.
     if intent.name == "weather":
         return await _execute_weather_direct(user_id=user_id, forecast=bool(intent.slots.get("forecast")))
+
+    if intent.name == "list_show":
+        direct_result = await _execute_list_show_direct(intent, user_id)
+        if direct_result:
+            return direct_result
 
     if intent.name == "reminder_create":
         direct_result = await _execute_reminder_create_direct(intent, user_id)

--- a/services/zoe-data/intent_router.py
+++ b/services/zoe-data/intent_router.py
@@ -1804,6 +1804,10 @@ async def _execute_reminder_create_direct(intent: Intent, user_id: str) -> Optio
         return None
 
 
+def _escape_like_pattern(value: str) -> str:
+    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
 async def _execute_list_show_direct(intent: Intent, user_id: str) -> Optional[str]:
     slots = intent.slots or {}
     list_type = str(slots.get("list_type") or "shopping").strip() or "shopping"
@@ -1816,9 +1820,10 @@ async def _execute_list_show_direct(intent: Intent, user_id: str) -> Optional[st
                 cursor = await db.execute(
                     "SELECT l.id, l.name, li.id as item_id, li.text, li.completed, li.quantity, li.category"
                     " FROM lists l LEFT JOIN list_items li ON l.id = li.list_id AND li.deleted=0"
-                    " WHERE (l.user_id=? OR l.visibility='family') AND l.list_type=? AND l.name LIKE ? AND l.deleted=0"
+                    " WHERE (l.user_id=? OR l.visibility='family') AND l.list_type=?"
+                    " AND l.name LIKE ? ESCAPE '\\' AND l.deleted=0"
                     " ORDER BY li.sort_order",
-                    (user_id, list_type, f"%{list_name}%"),
+                    (user_id, list_type, f"%{_escape_like_pattern(list_name)}%"),
                 )
             else:
                 cursor = await db.execute(
@@ -3033,16 +3038,26 @@ def _format_response(intent: Intent, raw_output: str) -> str:
         lt = s.get("list_type", "shopping")
         friendly = "shopping list" if lt == "shopping" else f"{lt.replace('_', ' ')} list"
         lists = data.get("lists", [])
-        if not lists or not lists[0].get("items"):
+        active_lists = []
+        for list_data in lists:
+            items = list_data.get("items") or []
+            active = [i["text"] for i in items if i.get("text") and not i.get("completed")]
+            if active:
+                active_lists.append((list_data.get("name") or friendly, active))
+        if not active_lists:
             return f"Your {friendly} is empty."
-        items = lists[0]["items"]
-        active = [i["text"] for i in items if not i.get("completed")]
-        if not active:
-            return f"Your {friendly} is empty."
-        lines = [f"Your {friendly}:"]
-        for item in active:
-            lines.append(f"  - {item}")
+        if len(active_lists) == 1:
+            lines = [f"Your {friendly}:"]
+            for item in active_lists[0][1]:
+                lines.append(f"  - {item}")
+            return "\n".join(lines)
+        lines = [f"Your {friendly}s:"]
+        for list_name, active in active_lists:
+            lines.append(f"{list_name}:")
+            for item in active:
+                lines.append(f"  - {item}")
         return "\n".join(lines)
+
 
     if intent.name == "list_remove":
         item = s.get("item", "item")

--- a/services/zoe-data/tests/test_list_show_direct_execution.py
+++ b/services/zoe-data/tests/test_list_show_direct_execution.py
@@ -123,6 +123,56 @@ async def test_list_show_direct_ignores_completed_items(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_list_show_direct_escapes_list_name_like_wildcards(monkeypatch):
+    db = _FakeDB([])
+    _install_fake_db(monkeypatch, db)
+
+    result = await _execute_list_show_direct(
+        Intent("list_show", {"list_type": "shopping", "list_name": "50%_off\\sale"}),
+        "pi-intent-lab",
+    )
+
+    assert result == "Your shopping list is empty."
+    sql, params = db.calls[0]
+    assert "ESCAPE" in sql
+    assert params == ("pi-intent-lab", "shopping", "%50\\%\\_off\\\\sale%")
+
+
+@pytest.mark.asyncio
+async def test_list_show_direct_renders_multiple_lists(monkeypatch):
+    db = _FakeDB(
+        [
+            {
+                "id": "pantry",
+                "name": "Pantry",
+                "item_id": "item-1",
+                "text": "rice",
+                "completed": False,
+                "quantity": None,
+                "category": None,
+            },
+            {
+                "id": "shopping",
+                "name": "Shopping",
+                "item_id": "item-2",
+                "text": "milk",
+                "completed": False,
+                "quantity": None,
+                "category": None,
+            },
+        ]
+    )
+    _install_fake_db(monkeypatch, db)
+
+    result = await _execute_list_show_direct(
+        Intent("list_show", {"list_type": "shopping"}),
+        "pi-intent-lab",
+    )
+
+    assert result == "Your shopping lists:\nPantry:\n  - rice\nShopping:\n  - milk"
+
+
+@pytest.mark.asyncio
 async def test_mutating_list_intents_still_use_mcporter(monkeypatch):
     calls = []
 

--- a/services/zoe-data/tests/test_list_show_direct_execution.py
+++ b/services/zoe-data/tests/test_list_show_direct_execution.py
@@ -1,0 +1,144 @@
+from contextlib import asynccontextmanager
+
+import pytest
+
+from intent_router import Intent, _execute_list_show_direct, execute_intent
+
+
+class _Cursor:
+    def __init__(self, rows=None):
+        self._rows = rows or []
+
+    async def fetchall(self):
+        return self._rows
+
+
+class _FakeDB:
+    def __init__(self, rows=None):
+        self.rows = rows or []
+        self.calls = []
+
+    async def execute(self, sql, params=()):
+        self.calls.append((sql, tuple(params)))
+        return _Cursor(self.rows)
+
+
+def _install_fake_db(monkeypatch, db):
+    @asynccontextmanager
+    async def fake_get_db_ctx():
+        yield db
+
+    monkeypatch.setattr("database.get_db_ctx", fake_get_db_ctx)
+
+
+@pytest.mark.asyncio
+async def test_list_show_direct_returns_empty_text_when_no_lists(monkeypatch):
+    db = _FakeDB([])
+    _install_fake_db(monkeypatch, db)
+
+    result = await _execute_list_show_direct(
+        Intent("list_show", {"list_type": "shopping"}),
+        "pi-intent-lab",
+    )
+
+    assert result == "Your shopping list is empty."
+    assert len(db.calls) == 1
+    assert db.calls[0][1] == ("pi-intent-lab", "shopping")
+
+
+@pytest.mark.asyncio
+async def test_execute_list_show_returns_empty_text_for_pi_lab_when_no_lists(monkeypatch):
+    db = _FakeDB([])
+    _install_fake_db(monkeypatch, db)
+
+    async def fail_mcporter(_cmd):
+        raise AssertionError("list_show should use the read-only direct path")
+
+    monkeypatch.setattr("intent_router._run_mcporter", fail_mcporter)
+
+    result = await execute_intent(
+        Intent("list_show", {"list_type": "shopping"}),
+        "pi-intent-lab",
+    )
+
+    assert result == "Your shopping list is empty."
+    assert len(db.calls) == 1
+    assert db.calls[0][1] == ("pi-intent-lab", "shopping")
+
+
+@pytest.mark.asyncio
+async def test_execute_list_show_uses_read_only_direct_path_before_mcporter(monkeypatch):
+    db = _FakeDB(
+        [
+            {
+                "id": "shopping-1",
+                "name": "Shopping",
+                "item_id": "item-1",
+                "text": "milk",
+                "completed": False,
+                "quantity": None,
+                "category": None,
+            }
+        ]
+    )
+    _install_fake_db(monkeypatch, db)
+
+    async def fail_mcporter(_cmd):
+        raise AssertionError("list_show should use the read-only direct path")
+
+    monkeypatch.setattr("intent_router._run_mcporter", fail_mcporter)
+
+    result = await execute_intent(
+        Intent("list_show", {"list_type": "shopping"}),
+        "pi-intent-lab",
+    )
+
+    assert result == "Your shopping list:\n  - milk"
+    assert len(db.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_list_show_direct_ignores_completed_items(monkeypatch):
+    db = _FakeDB(
+        [
+            {
+                "id": "shopping-1",
+                "name": "Shopping",
+                "item_id": "item-1",
+                "text": "milk",
+                "completed": True,
+                "quantity": None,
+                "category": None,
+            }
+        ]
+    )
+    _install_fake_db(monkeypatch, db)
+
+    result = await _execute_list_show_direct(
+        Intent("list_show", {"list_type": "shopping"}),
+        "pi-intent-lab",
+    )
+
+    assert result == "Your shopping list is empty."
+
+
+@pytest.mark.asyncio
+async def test_mutating_list_intents_still_use_mcporter(monkeypatch):
+    calls = []
+
+    async def fake_mcporter(cmd):
+        calls.append(cmd)
+        return "{}"
+
+    monkeypatch.setattr("intent_router._run_mcporter", fake_mcporter)
+
+    result = await execute_intent(
+        Intent("list_add", {"list_type": "shopping", "item": "milk"}),
+        "pi-intent-lab",
+    )
+
+    assert result == "Added milk to your shopping list."
+    assert len(calls) == 1
+    assert "zoe-data.list_add_item" in calls[0]
+    assert 'text="milk"' in calls[0]
+    assert "user_id=pi-intent-lab" in calls[0]


### PR DESCRIPTION
## Summary
- add a read-only direct list_show execution path that reuses the existing list response formatter
- return empty-list text for pi-intent-lab when no shopping list/items are available
- cover the Pi lab empty direct result and preserve mcporter behavior for mutating list intents

## Tests
- python3 -m pytest services/zoe-data/tests/test_list_show_direct_execution.py
- python3 -m pytest services/zoe-data/tests/test_pi_intent_lab.py -q
- python3 tools/audit/validate_structure.py