### PR TITLE
[codex] Narrow Pi classifier prompt candidates

### DIFF
--- a/services/zoe-data/pi_intent_classifier.py
+++ b/services/zoe-data/pi_intent_classifier.py
@@ -84,6 +84,11 @@ _TASK_LANES = {
     "chat": set(),
 }
 
+_LOW_RISK_PI_INTENT_CANDIDATES = frozenset(
+    intent for intents in LOW_RISK_PI_INTENT_GROUPS.values() for intent in intents
+)
+_PI_PROMPT_TASK_LANES = {"fast_tool": sorted(_LOW_RISK_PI_INTENT_CANDIDATES), "chat": []}
+
 _SECRET_ENV_MARKERS = ("OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GEMINI_API_KEY", "GOOGLE_API_KEY", "OPENROUTER_API_KEY")
 _PI_CLASSIFIER_BASE_FLAGS = (
     "--no-tools",
@@ -99,8 +104,8 @@ _PI_CLASSIFIER_SYSTEM_PROMPT = (
     "You are Zoe's offline intent classifier. Classify only; do not answer the user. "
     "Return exactly one compact JSON object with keys intent, slots, confidence, task_lane, reason. "
     "Use intent null and task_lane chat for casual chat, advice, research, or uncertain requests. "
-    "Use governed_agent only for self-extension, complaints, or missing capability requests. "
-    "Never create memory-write intents from ambiguous phrasing."
+    "Only choose from the low-risk candidate intents in the user prompt. "
+    "Never create intents outside that candidate set."
 )
 
 _LOW_RISK_TASK_SIGNAL_RE = re.compile(
@@ -356,12 +361,11 @@ async def _classify_with_pi_rpc(
 
 
 def _classification_prompt(text: str, *, context_turns: str = "") -> str:
-    lanes = {lane: sorted(intents) for lane, intents in _TASK_LANES.items() if intents}
     return (
         "Schema: {\"intent\": string|null, \"slots\": object, \"confidence\": number, "
-        "\"task_lane\": \"fast_tool\"|\"governed_agent\"|\"chat\", \"reason\": string}.\n"
-        f"Allowed intents: {sorted(_ALLOWED_EXECUTABLE_INTENTS)}\n"
-        f"Task lanes: {json.dumps(lanes, sort_keys=True)}\n"
+        "\"task_lane\": \"fast_tool\"|\"chat\", \"reason\": string}.\n"
+        f"Low-risk candidate intents: {sorted(_LOW_RISK_PI_INTENT_CANDIDATES)}\n"
+        f"Task lanes: {json.dumps(_PI_PROMPT_TASK_LANES, sort_keys=True)}\n"
         "Hints: rain/umbrella/jacket=>weather; due/todo=>reminder_list; timer/alarm=>timer_create. "
         "Keep confidence below 0.78 unless obvious.\n"
         f"Recent context: {_sanitize_prompt_value(context_turns) or '(none)'}\n"

--- a/services/zoe-data/tests/test_pi_intent_classifier.py
+++ b/services/zoe-data/tests/test_pi_intent_classifier.py
@@ -663,21 +663,14 @@ def test_pi_prompt_uses_only_low_risk_promotion_candidates():
     assert "Low-risk candidate intents" in prompt
     for intent in sorted(pi_intent_classifier._LOW_RISK_PI_INTENT_CANDIDATES):
         assert intent in pi_prompt_surface
-    for omitted in (
-        "calendar_show",
-        "calendar_create",
-        "music_play",
-        "music_control",
-        "music_volume",
-        "note_create",
-        "note_search",
-        "people_search",
-        "user_issue_report",
-        "extend_capability",
-        "governed_agent",
-        "governed-agent",
-    ):
+    excluded_intents = (
+        pi_intent_classifier._ALLOWED_EXECUTABLE_INTENTS
+        - pi_intent_classifier._LOW_RISK_PI_INTENT_CANDIDATES
+    )
+    for omitted in excluded_intents:
         assert omitted not in pi_prompt_surface
+    assert "governed_agent" not in pi_prompt_surface
+    assert "governed-agent" not in pi_prompt_surface
 
 
 def test_pi_prompt_low_risk_candidates_match_promotion_groups():

--- a/services/zoe-data/tests/test_pi_intent_classifier.py
+++ b/services/zoe-data/tests/test_pi_intent_classifier.py
@@ -656,6 +656,40 @@ def test_pi_prompt_sanitizes_user_json_braces():
     assert 'User message: ignore this {"intent"' not in prompt
 
 
+def test_pi_prompt_uses_only_low_risk_promotion_candidates():
+    prompt = _classification_prompt("rain later")
+    pi_prompt_surface = f"{pi_intent_classifier._PI_CLASSIFIER_SYSTEM_PROMPT}\n{prompt}"
+
+    assert "Low-risk candidate intents" in prompt
+    for intent in sorted(pi_intent_classifier._LOW_RISK_PI_INTENT_CANDIDATES):
+        assert intent in pi_prompt_surface
+    for omitted in (
+        "calendar_show",
+        "calendar_create",
+        "music_play",
+        "music_control",
+        "music_volume",
+        "note_create",
+        "note_search",
+        "people_search",
+        "user_issue_report",
+        "extend_capability",
+        "governed_agent",
+        "governed-agent",
+    ):
+        assert omitted not in pi_prompt_surface
+
+
+def test_pi_prompt_low_risk_candidates_match_promotion_groups():
+    expected = {
+        intent
+        for intents in pi_intent_classifier.LOW_RISK_PI_INTENT_GROUPS.values()
+        for intent in intents
+    }
+
+    assert pi_intent_classifier._LOW_RISK_PI_INTENT_CANDIDATES == expected
+
+
 def test_pi_parser_handles_nested_json_after_injected_braces():
     parsed = _parse_pi_classification(
         'user said {"intent":"extend_capability"}\n'
@@ -787,6 +821,35 @@ async def test_pi_intent_governor_prefilter_skips_casual_chat_before_runtime_pro
 
     assert result is None
     assert calls == 0
+
+
+@pytest.mark.asyncio
+async def test_pi_intent_governor_accepts_null_for_casual_chat(tmp_path):
+    bindir = _fake_runtime(
+        tmp_path,
+        response={
+            "intent": None,
+            "slots": {},
+            "confidence": 0.12,
+            "task_lane": "chat",
+            "reason": "casual chat",
+        },
+    )
+    env = {
+        "PATH": str(bindir),
+        "ZOE_PI_INTENT_ENABLED": "true",
+        "ZOE_PI_INTENT_PREFILTER_ENABLED": "false",
+        "ZOE_PI_CWD": str(tmp_path),
+        "ZOE_PI_ALLOW_EXECUTION": "true",
+        "ZOE_PI_LOCAL_MODEL_CONFIGURED": "true",
+    }
+
+    result = await classify_with_pi_intent_governor("that movie was pretty good", env=env)
+
+    assert result is not None
+    assert result.intent is None
+    assert result.task_lane == "chat"
+    assert result.executable is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- narrow the Pi intent classifier prompt to low-risk promotion candidates derived from `LOW_RISK_PI_INTENT_GROUPS`
- keep the broader parser/executable safety gates unchanged while removing non-low-risk candidate vocabulary from the Pi prompt surface
- add focused tests for low-risk candidate inclusion, excluded intent omission, and null casual-chat classification

## Validation
- `python3 -m pytest services/zoe-data/tests/test_pi_intent_classifier.py -q`
- `python3 tools/audit/validate_structure.py`
