### PR TITLE
[codex] Add speculative Pi safe fulfillment lab path

### DIFF
--- a/services/zoe-data/pi_intent_lab.py
+++ b/services/zoe-data/pi_intent_lab.py
@@ -78,6 +78,12 @@ async def compare_pi_intent_lab(
 
     zoe_router = await _run_zoe_router(stripped, user_id=user_id)
     processing_cue = _processing_cue(env)
+    speculative_safe_fulfillment = _start_speculative_safe_fulfillment(
+        zoe_router,
+        user_id=user_id,
+        enabled=include_safe_fulfillment,
+        timeout_seconds=safe_fulfillment_timeout_seconds,
+    )
     pi = await _run_pi(
         stripped,
         context_turns=context_turns,
@@ -99,6 +105,7 @@ async def compare_pi_intent_lab(
         user_id=user_id,
         enabled=include_safe_fulfillment,
         timeout_seconds=safe_fulfillment_timeout_seconds,
+        speculative=speculative_safe_fulfillment,
     )
 
     hybrid = None
@@ -315,6 +322,7 @@ async def _safe_fulfill_pi_intent(
     user_id: str,
     enabled: bool,
     timeout_seconds: float,
+    speculative: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     if not enabled:
         return {
@@ -327,29 +335,110 @@ async def _safe_fulfill_pi_intent(
             "would_execute": False,
         }
 
+    async def block(reason: str, *, intent: str | None = None, error: Any = None) -> dict[str, Any]:
+        return await _discard_speculative_safe_fulfillment(
+            speculative,
+            _blocked_fulfillment(reason, intent=intent, error=error),
+        )
+
     intent_name = str(pi.get("intent") or "")
     if not pi.get("ran"):
-        return _blocked_fulfillment("pi_not_run")
+        return await block("pi_not_run")
     if not intent_name:
-        return _blocked_fulfillment("pi_no_intent")
+        return await block("pi_no_intent")
     if pi.get("timed_out"):
-        return _blocked_fulfillment("pi_timed_out", intent=intent_name)
+        return await block("pi_timed_out", intent=intent_name)
     if pi.get("error"):
-        return _blocked_fulfillment("pi_error", intent=intent_name, error=pi.get("error"))
+        return await block("pi_error", intent=intent_name, error=pi.get("error"))
     if intent_name not in SAFE_FULFILLMENT_INTENTS:
-        return _blocked_fulfillment("side_effect_or_unsupported_intent", intent=intent_name)
+        return await block("side_effect_or_unsupported_intent", intent=intent_name)
     if not pi.get("low_risk_group"):
-        return _blocked_fulfillment("not_low_risk_group", intent=intent_name)
+        return await block("not_low_risk_group", intent=intent_name)
 
     from pi_intent_classifier import PI_INTENT_EXECUTE_THRESHOLD
 
     confidence = float(pi.get("confidence") or 0.0)
     if confidence < PI_INTENT_EXECUTE_THRESHOLD:
-        return _blocked_fulfillment("below_execute_threshold", intent=intent_name)
+        return await block("below_execute_threshold", intent=intent_name)
 
-    from intent_router import Intent, execute_intent
+    pi_slots = dict(pi.get("slots") or {})
+    discarded_speculative = None
+    if speculative is not None:
+        speculative_intent = str(speculative.get("intent") or "")
+        speculative_slots = dict(speculative.get("slots") or {})
+        speculative_task = speculative.get("task")
+        if (
+            speculative_intent == intent_name
+            and speculative_slots == pi_slots
+            and isinstance(speculative_task, asyncio.Task)
+        ):
+            return await _await_speculative_safe_fulfillment(speculative, timeout_seconds=timeout_seconds)
+        reason = "speculative_slots_mismatch" if speculative_intent == intent_name else "speculative_pi_disagreed"
+        discarded_speculative = await _discard_speculative_safe_fulfillment(
+            speculative,
+            _blocked_fulfillment(reason, intent=speculative_intent),
+        )
 
-    intent = Intent(intent_name, dict(pi.get("slots") or {}), confidence)
+    from intent_router import Intent
+
+    intent = Intent(intent_name, pi_slots, confidence)
+    result = await _execute_safe_fulfillment_intent(
+        intent,
+        user_id=user_id,
+        timeout_seconds=timeout_seconds,
+        started_before_pi=False,
+    )
+    if discarded_speculative is not None:
+        result["speculative_safe_fulfillment"] = "discarded"
+        result["speculative_intent"] = discarded_speculative.get("speculative_intent")
+        result["speculative_discard_reason"] = discarded_speculative.get("blocked_reason")
+    return result
+
+def _start_speculative_safe_fulfillment(
+    zoe_router: Mapping[str, Any],
+    *,
+    user_id: str,
+    enabled: bool,
+    timeout_seconds: float,
+) -> dict[str, Any] | None:
+    if not enabled:
+        return None
+    intent_name = str(zoe_router.get("intent") or "")
+    if not intent_name or intent_name not in SAFE_FULFILLMENT_INTENTS:
+        return None
+    if not zoe_router.get("baseline_comparable"):
+        return None
+
+    from intent_router import Intent
+
+    confidence = float(zoe_router.get("confidence") or 0.0)
+    intent = Intent(intent_name, dict(zoe_router.get("slots") or {}), confidence)
+    task = asyncio.create_task(
+        _execute_safe_fulfillment_intent(
+            intent,
+            user_id=user_id,
+            timeout_seconds=timeout_seconds,
+            started_before_pi=True,
+        )
+    )
+    return {
+        "intent": intent_name,
+        "slots": dict(zoe_router.get("slots") or {}),
+        "task": task,
+        "source": "zoe_router",
+    }
+
+
+async def _execute_safe_fulfillment_intent(
+    intent: Any,
+    *,
+    user_id: str,
+    timeout_seconds: float,
+    started_before_pi: bool,
+) -> dict[str, Any]:
+    from intent_router import execute_intent
+
+    intent_name = str(getattr(intent, "name", "") or "")
     started = time.perf_counter()
     try:
         response = await asyncio.wait_for(execute_intent(intent, user_id=user_id), timeout=timeout_seconds)
@@ -367,6 +456,8 @@ async def _safe_fulfill_pi_intent(
             "response_preview": _preview_response(response_text),
             "would_execute": True,
             "execution_scope": "read_only_allowlist",
+            "started_before_pi": started_before_pi,
+            "validated_by_pi": False,
         }
     except asyncio.TimeoutError:
         latency_ms = (time.perf_counter() - started) * 1000
@@ -382,6 +473,8 @@ async def _safe_fulfill_pi_intent(
             "response_preview": "",
             "would_execute": False,
             "execution_scope": "read_only_allowlist",
+            "started_before_pi": started_before_pi,
+            "validated_by_pi": False,
         }
     except Exception as exc:  # pragma: no cover - defensive operator surface
         latency_ms = (time.perf_counter() - started) * 1000
@@ -397,7 +490,59 @@ async def _safe_fulfill_pi_intent(
             "response_preview": "",
             "would_execute": False,
             "execution_scope": "read_only_allowlist",
+            "started_before_pi": started_before_pi,
+            "validated_by_pi": False,
         }
+
+
+async def _await_speculative_safe_fulfillment(speculative: Mapping[str, Any], *, timeout_seconds: float) -> dict[str, Any]:
+    task = speculative.get("task")
+    if not isinstance(task, asyncio.Task):
+        return _blocked_fulfillment("speculative_task_missing", intent=str(speculative.get("intent") or ""))
+    try:
+        result = await asyncio.wait_for(asyncio.shield(task), timeout=timeout_seconds)
+    except asyncio.TimeoutError:
+        return {
+            "requested": True,
+            "attempted": True,
+            "allowed": True,
+            "intent": str(speculative.get("intent") or ""),
+            "latency_ms": None,
+            "timed_out": True,
+            "error": None,
+            "response_chars": 0,
+            "response_preview": "",
+            "would_execute": False,
+            "execution_scope": "read_only_allowlist",
+            "started_before_pi": True,
+            "validated_by_pi": True,
+            "speculative_safe_fulfillment": "timed_out",
+        }
+    result = dict(result)
+    result["validated_by_pi"] = True
+    result["speculative_safe_fulfillment"] = "used"
+    return result
+
+
+async def _discard_speculative_safe_fulfillment(
+    speculative: Mapping[str, Any] | None,
+    fallback: dict[str, Any] | None,
+) -> dict[str, Any]:
+    if speculative is None:
+        return fallback or _blocked_fulfillment("speculative_not_available")
+    task = speculative.get("task")
+    if isinstance(task, asyncio.Task):
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        except Exception:
+            pass
+    result = fallback or _blocked_fulfillment("speculative_pi_disagreed", intent=str(speculative.get("intent") or ""))
+    result["speculative_safe_fulfillment"] = "discarded"
+    result["speculative_intent"] = str(speculative.get("intent") or "")
+    return result
 
 
 def _blocked_fulfillment(reason: str, *, intent: str | None = None, error: Any = None) -> dict[str, Any]:
@@ -458,7 +603,10 @@ def _simulated_hybrid_flow(
         and not safe_fulfillment.get("error")
     )
     if fulfilled and pi_latency is not None:
-        final_latency = pi_latency + (fulfillment_latency or 0.0)
+        if safe_fulfillment.get("started_before_pi"):
+            final_latency = max(pi_latency, fulfillment_latency or 0.0)
+        else:
+            final_latency = pi_latency + (fulfillment_latency or 0.0)
     else:
         final_latency = pi_latency if pi.get("ran") else agent_latency
     return {

--- a/services/zoe-data/pi_intent_lab.py
+++ b/services/zoe-data/pi_intent_lab.py
@@ -84,29 +84,33 @@ async def compare_pi_intent_lab(
         enabled=include_safe_fulfillment,
         timeout_seconds=safe_fulfillment_timeout_seconds,
     )
-    pi = await _run_pi(
-        stripped,
-        context_turns=context_turns,
-        run_pi=run_pi,
-        transport=pi_transport,
-        allow_pi_execution=allow_pi_execution,
-        local_model_configured=local_model_configured,
-        env=env,
-    )
-    zoe_agent = None
-    if measure_zoe_agent_baseline and zoe_router["intent"] is None:
-        zoe_agent = await _run_zoe_agent_baseline(
+    try:
+        pi = await _run_pi(
             stripped,
-            timeout_seconds=zoe_agent_timeout_seconds,
-            max_tokens=zoe_agent_max_tokens,
+            context_turns=context_turns,
+            run_pi=run_pi,
+            transport=pi_transport,
+            allow_pi_execution=allow_pi_execution,
+            local_model_configured=local_model_configured,
+            env=env,
         )
-    safe_fulfillment = await _safe_fulfill_pi_intent(
-        pi,
-        user_id=user_id,
-        enabled=include_safe_fulfillment,
-        timeout_seconds=safe_fulfillment_timeout_seconds,
-        speculative=speculative_safe_fulfillment,
-    )
+        zoe_agent = None
+        if measure_zoe_agent_baseline and zoe_router["intent"] is None:
+            zoe_agent = await _run_zoe_agent_baseline(
+                stripped,
+                timeout_seconds=zoe_agent_timeout_seconds,
+                max_tokens=zoe_agent_max_tokens,
+            )
+        safe_fulfillment = await _safe_fulfill_pi_intent(
+            pi,
+            user_id=user_id,
+            enabled=include_safe_fulfillment,
+            timeout_seconds=safe_fulfillment_timeout_seconds,
+            speculative=speculative_safe_fulfillment,
+        )
+    except BaseException:
+        await _discard_speculative_safe_fulfillment(speculative_safe_fulfillment, None)
+        raise
 
     hybrid = None
     if include_hybrid_status:

--- a/services/zoe-data/pi_intent_lab.py
+++ b/services/zoe-data/pi_intent_lab.py
@@ -506,6 +506,13 @@ async def _await_speculative_safe_fulfillment(speculative: Mapping[str, Any], *,
     try:
         result = await asyncio.wait_for(asyncio.shield(task), timeout=timeout_seconds)
     except asyncio.TimeoutError:
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        except Exception:
+            pass
         return {
             "requested": True,
             "attempted": True,

--- a/services/zoe-data/tests/test_pi_intent_lab.py
+++ b/services/zoe-data/tests/test_pi_intent_lab.py
@@ -430,6 +430,132 @@ async def test_lab_safe_fulfillment_error_is_reported(monkeypatch):
     assert result["safe_fulfillment"]["response_preview"] == ""
     assert result["simulated_hybrid_flow"]["safe_fulfillment_completion_latency_ms"] is None
 
+
+@pytest.mark.asyncio
+async def test_lab_reuses_speculative_safe_fulfillment_when_pi_agrees(monkeypatch):
+    calls = []
+    _install_fake_intent_router(
+        monkeypatch,
+        raw=_Intent("weather"),
+        extracted=_Intent("weather", {"forecast": False}),
+        execute_response="It's 18.5 C in Perth, light jacket weather.",
+        execute_calls=calls,
+        execute_delay_seconds=0.01,
+    )
+    _install_fake_pi_classifier(
+        monkeypatch,
+        result=types.SimpleNamespace(
+            intent="weather",
+            slots={"forecast": False},
+            confidence=0.93,
+            task_lane="fast_tool",
+            source="fake_pi",
+            latency_ms=123.0,
+            reason="weather signal",
+        ),
+    )
+    _install_fake_voice_presence(monkeypatch)
+
+    result = await compare_pi_intent_lab(
+        "need a jacket tonight",
+        include_hybrid_status=False,
+        include_safe_fulfillment=True,
+    )
+
+    assert len(calls) == 1
+    assert calls[0]["intent"].name == "weather"
+    assert calls[0]["intent"].slots == {"forecast": False}
+    assert result["safe_fulfillment"]["started_before_pi"] is True
+    assert result["safe_fulfillment"]["validated_by_pi"] is True
+    assert result["safe_fulfillment"]["speculative_safe_fulfillment"] == "used"
+    assert result["safe_fulfillment"]["response_preview"] == "It's 18.5 C in Perth, light jacket weather."
+    pi_latency = result["simulated_hybrid_flow"]["pi_completion_latency_ms"]
+    fulfillment_latency = result["simulated_hybrid_flow"]["safe_fulfillment_latency_ms"]
+    assert result["simulated_hybrid_flow"]["safe_fulfillment_completion_latency_ms"] == max(
+        pi_latency,
+        fulfillment_latency,
+    )
+
+
+@pytest.mark.asyncio
+async def test_lab_discards_speculative_safe_fulfillment_when_pi_slots_differ(monkeypatch):
+    calls = []
+
+    def response_for(intent):
+        return f"forecast={intent.slots.get('forecast')}"
+
+    _install_fake_intent_router(
+        monkeypatch,
+        raw=_Intent("weather"),
+        extracted=_Intent("weather", {"forecast": False}),
+        execute_response=response_for,
+        execute_calls=calls,
+    )
+    _install_fake_pi_classifier(
+        monkeypatch,
+        result=types.SimpleNamespace(
+            intent="weather",
+            slots={"forecast": True},
+            confidence=0.93,
+            task_lane="fast_tool",
+            source="fake_pi",
+            latency_ms=123.0,
+            reason="weather signal",
+        ),
+    )
+
+    result = await compare_pi_intent_lab(
+        "weather tomorrow",
+        include_hybrid_status=False,
+        include_safe_fulfillment=True,
+    )
+
+    assert [call["intent"].slots for call in calls] == [{"forecast": False}, {"forecast": True}]
+    assert result["safe_fulfillment"]["started_before_pi"] is False
+    assert result["safe_fulfillment"]["validated_by_pi"] is False
+    assert result["safe_fulfillment"]["speculative_safe_fulfillment"] == "discarded"
+    assert result["safe_fulfillment"]["speculative_intent"] == "weather"
+    assert result["safe_fulfillment"]["speculative_discard_reason"] == "speculative_slots_mismatch"
+    assert result["safe_fulfillment"]["response_preview"] == "forecast=True"
+
+
+@pytest.mark.asyncio
+async def test_lab_discards_speculative_safe_fulfillment_below_pi_threshold(monkeypatch):
+    calls = []
+    _install_fake_intent_router(
+        monkeypatch,
+        raw=_Intent("weather"),
+        extracted=_Intent("weather", {"forecast": False}),
+        execute_response="should not be exposed",
+        execute_calls=calls,
+        execute_delay_seconds=0.05,
+    )
+    _install_fake_pi_classifier(
+        monkeypatch,
+        result=types.SimpleNamespace(
+            intent="weather",
+            slots={"forecast": False},
+            confidence=0.2,
+            task_lane="fast_tool",
+            source="fake_pi",
+            latency_ms=123.0,
+            reason="weak weather signal",
+        ),
+    )
+
+    result = await compare_pi_intent_lab(
+        "weather maybe",
+        include_hybrid_status=False,
+        include_safe_fulfillment=True,
+    )
+
+    assert len(calls) == 1
+    assert result["safe_fulfillment"]["attempted"] is False
+    assert result["safe_fulfillment"]["blocked_reason"] == "below_execute_threshold"
+    assert result["safe_fulfillment"]["speculative_safe_fulfillment"] == "discarded"
+    assert result["safe_fulfillment"]["speculative_intent"] == "weather"
+    assert result["safe_fulfillment"]["response_preview"] == ""
+
 def _admin_app():
     app = FastAPI()
     app.include_router(pi_intent_lab_router)

--- a/services/zoe-data/tests/test_pi_intent_lab.py
+++ b/services/zoe-data/tests/test_pi_intent_lab.py
@@ -30,6 +30,8 @@ def _install_fake_intent_router(
     execute_calls=None,
     execute_delay_seconds=0.0,
     execute_exception=None,
+    execute_started_event=None,
+    execute_cancelled_event=None,
 ):
     module = types.ModuleType("intent_router")
 
@@ -48,8 +50,15 @@ def _install_fake_intent_router(
     async def execute_intent(intent, user_id="family-admin"):
         if execute_calls is not None:
             execute_calls.append({"intent": intent, "user_id": user_id})
-        if execute_delay_seconds:
-            await asyncio.sleep(execute_delay_seconds)
+        if execute_started_event is not None:
+            execute_started_event.set()
+        try:
+            if execute_delay_seconds:
+                await asyncio.sleep(execute_delay_seconds)
+        except asyncio.CancelledError:
+            if execute_cancelled_event is not None:
+                execute_cancelled_event.set()
+            raise
         if execute_exception is not None:
             raise execute_exception
         return execute_response(intent) if callable(execute_response) else execute_response
@@ -61,13 +70,15 @@ def _install_fake_intent_router(
     monkeypatch.setitem(sys.modules, "intent_router", module)
 
 
-def _install_fake_pi_classifier(monkeypatch, *, result=None, seen_env=None):
+def _install_fake_pi_classifier(monkeypatch, *, result=None, seen_env=None, delay_seconds=0.0):
     module = types.ModuleType("pi_intent_classifier")
     module.PI_INTENT_EXECUTE_THRESHOLD = 0.78
 
     async def classify_with_pi_intent_governor(text, *, context_turns="", env=None, config=None):
         if seen_env is not None:
             seen_env.append({"text": text, "context_turns": context_turns, "env": dict(env or os.environ)})
+        if delay_seconds:
+            await asyncio.sleep(delay_seconds)
         return result
 
     module.classify_with_pi_intent_governor = classify_with_pi_intent_governor
@@ -555,6 +566,60 @@ async def test_lab_discards_speculative_safe_fulfillment_below_pi_threshold(monk
     assert result["safe_fulfillment"]["speculative_safe_fulfillment"] == "discarded"
     assert result["safe_fulfillment"]["speculative_intent"] == "weather"
     assert result["safe_fulfillment"]["response_preview"] == ""
+
+
+@pytest.mark.asyncio
+async def test_lab_cancels_speculative_safe_fulfillment_when_comparison_is_cancelled(monkeypatch):
+    execute_started = asyncio.Event()
+    execute_cancelled = asyncio.Event()
+    calls = []
+    _install_fake_intent_router(
+        monkeypatch,
+        raw=_Intent("weather"),
+        extracted=_Intent("weather", {"forecast": False}),
+        execute_response="too late",
+        execute_calls=calls,
+        execute_delay_seconds=10.0,
+        execute_started_event=execute_started,
+        execute_cancelled_event=execute_cancelled,
+    )
+    _install_fake_pi_classifier(
+        monkeypatch,
+        result=types.SimpleNamespace(
+            intent="weather",
+            slots={"forecast": False},
+            confidence=0.93,
+            task_lane="fast_tool",
+            source="fake_pi",
+            latency_ms=123.0,
+            reason="weather signal",
+        ),
+        delay_seconds=10.0,
+    )
+
+    task = asyncio.create_task(
+        compare_pi_intent_lab(
+            "need a jacket tonight",
+            include_hybrid_status=False,
+            include_safe_fulfillment=True,
+        )
+    )
+    await asyncio.wait_for(execute_started.wait(), timeout=1.0)
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    await asyncio.wait_for(execute_cancelled.wait(), timeout=1.0)
+    pending_fulfillment_tasks = [
+        candidate
+        for candidate in asyncio.all_tasks()
+        if candidate is not asyncio.current_task()
+        and getattr(candidate.get_coro(), "__name__", "") == "_execute_safe_fulfillment_intent"
+        and not candidate.done()
+    ]
+    assert pending_fulfillment_tasks == []
+    assert len(calls) == 1
 
 def _admin_app():
     app = FastAPI()

--- a/services/zoe-data/tests/test_pi_intent_lab.py
+++ b/services/zoe-data/tests/test_pi_intent_lab.py
@@ -10,7 +10,7 @@ from fastapi.testclient import TestClient
 
 import auth
 from routers.pi_intent_lab import require_lab_operator
-from pi_intent_lab import compare_pi_intent_lab
+from pi_intent_lab import _await_speculative_safe_fulfillment, compare_pi_intent_lab
 from routers.pi_intent_lab import router as pi_intent_lab_router
 
 
@@ -620,6 +620,29 @@ async def test_lab_cancels_speculative_safe_fulfillment_when_comparison_is_cance
     ]
     assert pending_fulfillment_tasks == []
     assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_lab_await_speculative_timeout_cancels_shielded_task():
+    cancelled = asyncio.Event()
+
+    async def slow_fulfillment():
+        try:
+            await asyncio.sleep(10.0)
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+
+    task = asyncio.create_task(slow_fulfillment())
+    result = await _await_speculative_safe_fulfillment(
+        {"intent": "weather", "task": task},
+        timeout_seconds=0.01,
+    )
+
+    assert result["timed_out"] is True
+    assert result["speculative_safe_fulfillment"] == "timed_out"
+    await asyncio.wait_for(cancelled.wait(), timeout=1.0)
+    assert task.cancelled()
 
 def _admin_app():
     app = FastAPI()


### PR DESCRIPTION
## Summary
- Starts read-only safe fulfillment speculatively in the Pi intent lab when Zoe's deterministic router already extracted an allowlisted safe intent.
- Reuses the speculative result only after Pi validates the same intent and identical slots; otherwise discards it and falls back to normal Pi safe fulfillment or blocking.
- Updates simulated hybrid timing so prestarted fulfillment is measured as parallel with Pi instead of Pi latency plus fulfillment latency.

## Safety
- Lab-only path; no production routing or promotion change.
- Safe fulfillment remains limited to read-only allowlisted intents.
- Speculative results are not exposed unless Pi confidence passes the execute threshold and intent+slots match.
- Speculative tasks are cancelled/discarded on Pi timeout, errors, unsupported intent, low confidence, disagreement, or slot mismatch.

## Validation
- `python3 -m pytest -q services/zoe-data/tests/test_pi_intent_lab.py services/zoe-data/tests/test_pi_hybrid_stream_http_probe.py services/zoe-data/tests/test_pi_intent_classifier.py services/zoe-data/tests/test_pi_promotion_eval_script.py services/zoe-data/tests/test_zoe_pi_promotion.py` -> 134 passed
- `python3 tools/audit/validate_structure.py` -> passed
