### PR TITLE
fix(harness): pass implement PR_URL into normal verify/review/closeout handoff

### DIFF
--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -457,11 +457,42 @@ def _issue_with_phase_handoff(issue: dict, phase: str, state: Any | None) -> dic
         for item in evidence
     )
     audit_profile = getattr(state, "evidence_profile", "") == "audit"
-    if not already_covered and not audit_profile:
-        return issue
     description = str(issue.get("description") or "")
     if "Zoe pipeline handoff (authoritative):" in description:
         return issue
+
+    # Authoritative PR URL from the implement phase's recorded evidence. This is
+    # written synchronously when implement completes, so it is available even
+    # before the poll loop's async write of pr_url onto the Multica ticket. The
+    # downstream verify/review/closeout worker must not have to race that write
+    # or hunt for the PR — without it, verify blocks "awaiting PR evidence" and
+    # the chain bounces back to implement.
+    pr_url = next(
+        (
+            str(getattr(item, "artifact", "") or "").strip()
+            for item in reversed(evidence)
+            if getattr(item, "kind", "") == "pr" and getattr(item, "artifact", None)
+        ),
+        "",
+    ) or _existing_pr_url(issue)
+
+    if not already_covered and not audit_profile:
+        # Normal (real-PR) path: inject only the authoritative PR_URL so the
+        # worker can act on the implement output directly. If there is no PR URL
+        # yet there is nothing to hand off, so preserve the prior behavior.
+        if not pr_url:
+            return issue
+        handoff = (
+            "Zoe pipeline handoff (authoritative):\n"
+            f"PR_URL={pr_url}\n"
+            "SUMMARY=Use this PR_URL as the implementation under review; it is the authoritative "
+            "PR for this ticket. Do not wait for, re-derive, or hunt for a different PR. Check out "
+            "the PR head from your workspace_path, run the focused checks/validators, then call "
+            "kanban_complete; call kanban_block only on a concrete failure (not for missing evidence).\n\n"
+        )
+        updated = dict(issue)
+        updated["description"] = handoff + description
+        return updated
 
     validator_summary = next(
         (getattr(item, "summary", "") for item in reversed(evidence) if getattr(item, "kind", "") == "validator"),

--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -467,14 +467,26 @@ def _issue_with_phase_handoff(issue: dict, phase: str, state: Any | None) -> dic
     # downstream verify/review/closeout worker must not have to race that write
     # or hunt for the PR — without it, verify blocks "awaiting PR evidence" and
     # the chain bounces back to implement.
-    pr_url = next(
-        (
-            str(getattr(item, "artifact", "") or "").strip()
-            for item in reversed(evidence)
-            if getattr(item, "kind", "") == "pr" and getattr(item, "artifact", None)
-        ),
-        "",
-    ) or _existing_pr_url(issue)
+    def _pr_artifact(item: Any) -> str:
+        if getattr(item, "kind", "") != "pr" or not getattr(item, "artifact", None):
+            return ""
+        return str(getattr(item, "artifact", "") or "").strip()
+
+    # Prefer the implement phase's recorded PR (the authoritative one this
+    # ticket is shipping); only fall back to any other recorded PR, then the
+    # ticket. A later phase that recorded its own pr item must not shadow it.
+    pr_url = (
+        next(
+            (
+                _pr_artifact(item)
+                for item in reversed(evidence)
+                if _pr_artifact(item) and (getattr(item, "metadata", {}) or {}).get("phase") == "implement"
+            ),
+            "",
+        )
+        or next((_pr_artifact(item) for item in reversed(evidence) if _pr_artifact(item)), "")
+        or _existing_pr_url(issue)
+    )
 
     if not already_covered and not audit_profile:
         # Normal (real-PR) path: inject only the authoritative PR_URL so the
@@ -482,13 +494,28 @@ def _issue_with_phase_handoff(issue: dict, phase: str, state: Any | None) -> dic
         # yet there is nothing to hand off, so preserve the prior behavior.
         if not pr_url:
             return issue
+        if phase == "verify":
+            role_summary = (
+                "Verify this PR: check out the PR head from your workspace_path, run the focused "
+                "tests/validators against the diff, then call kanban_complete with TESTS/VALIDATORS; "
+                "call kanban_block only on a concrete verification failure (not for missing evidence)."
+            )
+        elif phase == "review":
+            role_summary = (
+                "Review this PR: grade the diff and scope against the acceptance criteria and "
+                "verify-phase evidence, write the review marker, then call kanban_complete with "
+                "REVIEW=approved; call kanban_block only with a concrete review concern."
+            )
+        else:  # closeout / retro
+            role_summary = (
+                "This is the authoritative PR to close out: run the Greptile/merge closeout steps "
+                "against it, then call kanban_complete; call kanban_block only on a concrete blocker."
+            )
         handoff = (
             "Zoe pipeline handoff (authoritative):\n"
             f"PR_URL={pr_url}\n"
-            "SUMMARY=Use this PR_URL as the implementation under review; it is the authoritative "
-            "PR for this ticket. Do not wait for, re-derive, or hunt for a different PR. Check out "
-            "the PR head from your workspace_path, run the focused checks/validators, then call "
-            "kanban_complete; call kanban_block only on a concrete failure (not for missing evidence).\n\n"
+            "SUMMARY=Use this PR_URL as the authoritative PR for this ticket. Do not wait for, "
+            f"re-derive, or hunt for a different PR. {role_summary}\n\n"
         )
         updated = dict(issue)
         updated["description"] = handoff + description

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -297,6 +297,53 @@ async def test_dispatch_review_includes_audit_pipeline_handoff():
 
 
 @pytest.mark.asyncio
+async def test_dispatch_verify_injects_pr_url_from_implement_evidence():
+    """Normal (real-PR) verify handoff must carry the implement phase's PR_URL
+    from the authoritative pipeline evidence, so the verify worker does not race
+    the async Multica pr_url write, block 'awaiting PR evidence', and bounce the
+    chain back to implement."""
+    from pipeline_evidence import EvidenceItem, PipelineState
+    from pipeline_store import save_state
+
+    pr = "https://github.com/jason-easyazz/zoe-ai-assistant/pull/600"
+    state = PipelineState(
+        task_ref="multica:uuid-normal-verify",
+        phase="verify",
+        status="todo",
+        attempts={"implement": 1},
+        evidence=[
+            EvidenceItem(
+                kind="pr",
+                summary=pr,
+                artifact=pr,
+                passed=True,
+                metadata={"source": "handoff", "phase": "implement"},
+            )
+        ],
+    )
+    save_state(state, event="transition")
+    a = _FakeAdapter()
+
+    result = await a.dispatch(
+        {
+            "id": "uuid-normal-verify",
+            "identifier": "ZOE-NORMAL",
+            "title": "Add focused tests",
+            "description": "Original ticket body.",
+        }
+    )
+
+    assert result["ok"] is True
+    assert result["phase"] == "verify"
+    create = [c for c in a.calls if c[0] == "create"][0]
+    body = create[create.index("--body") + 1]
+    assert "Zoe pipeline handoff (authoritative):" in body
+    assert f"PR_URL={pr}" in body
+    assert "AUDIT_ONLY" not in body  # normal path, not the audit handoff
+    assert body.index(f"PR_URL={pr}") < body.index("Original ticket body")
+
+
+@pytest.mark.asyncio
 async def test_dispatch_does_not_parent_recovered_phase_to_blocked_prior_row():
     from pipeline_evidence import EvidenceItem, PipelineState
     from pipeline_store import save_state


### PR DESCRIPTION
## Problem (found in a live full-pipeline run)
A real ticket (ZOE-5812) auto-advanced scout→implement→verify, opened PR #600, then **verify bounced back to implement**. Root cause: the verify worker was dispatched with **no PR_URL**.

- `_issue_with_phase_handoff` only injected a `PR_URL` handoff block for the **audit / already-covered** paths. For a normal real-PR ticket it returned the issue unchanged.
- The Multica ticket's `pr_url` is written **asynchronously** by the poll loop (`_record_running_multica_chain_progress`) *after* the next phase has already been dispatched.
- So verify could start before `pr_url` landed, find nothing to verify, `kanban_block("awaiting PR evidence")`, and `infer_outcome` → `verification_failed` → reset to implement (evidence cleared).

## Fix
Inject the **authoritative PR_URL** — from the implement phase's recorded `pr` evidence `artifact` (written synchronously at implement completion), falling back to `_existing_pr_url(issue)` — into the normal `verify`/`review`/`closeout` handoff block. The worker now acts on the implement output directly instead of racing the async ticket write or hunting for a PR.

Additive and low-risk: if there is no PR URL yet, behavior is unchanged (early return preserved). Audit/already-covered blocks are untouched.

## Testing
- New `test_dispatch_verify_injects_pr_url_from_implement_evidence` (asserts PR_URL from implement evidence lands in the verify handoff, normal path, no AUDIT_ONLY).
- `pytest test_kanban_adapter.py -k "handoff or pr_url or ..."` → 11 passed.

Part of closing the last gaps to full idea→merged-PR autonomy (fix 1 of 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)