### PR TITLE
[codex] Expose Pi speculative probe evidence

### DIFF
--- a/scripts/maintenance/pi_hybrid_stream_http_probe.py
+++ b/scripts/maintenance/pi_hybrid_stream_http_probe.py
@@ -256,6 +256,11 @@ def _observation(
         "safe_fulfillment_latency_ms": _float_or_none(safe.get("latency_ms")),
         "safe_fulfillment_error": safe.get("error"),
         "safe_fulfillment_timed_out": bool(safe.get("timed_out")),
+        "safe_fulfillment_started_before_pi": bool(safe.get("started_before_pi")),
+        "safe_fulfillment_validated_by_pi": bool(safe.get("validated_by_pi")),
+        "speculative_safe_fulfillment": safe.get("speculative_safe_fulfillment"),
+        "speculative_intent": safe.get("speculative_intent"),
+        "speculative_discard_reason": safe.get("speculative_discard_reason"),
         "simulated_final_completion_latency_ms": _float_or_none(flow.get("final_completion_latency_ms")),
         "response_preview": response_preview,
         "cue_within_budget": cue_within_budget,
@@ -284,8 +289,14 @@ def _stats(observations: Sequence[Mapping[str, Any]], *, pi_ran: bool) -> dict[s
             "stream_natural_rate": None,
             "conversation_natural_rate": None,
             "safe_fulfillment_success_rate": None,
+            "speculative_used_rate": None,
+            "speculative_discard_rate": None,
+            "speculative_timeout_rate": None,
+            "started_before_pi_rate": None,
+            "validated_by_pi_rate": None,
             "cue_client_latency_ms": _latency_stats([]),
             "final_client_latency_ms": _latency_stats([]),
+            "simulated_final_completion_latency_ms": _latency_stats([]),
             "pi_latency_ms": _latency_stats([]),
             "safe_fulfillment_latency_ms": _latency_stats([]),
         }
@@ -308,8 +319,26 @@ def _stats(observations: Sequence[Mapping[str, Any]], *, pi_ran: bool) -> dict[s
         "safe_fulfillment_success_rate": (
             _rate(bool(item.get("safe_fulfillment_success")) for item in safe_requested) if safe_requested else None
         ),
+        "speculative_used_rate": (
+            _rate(item.get("speculative_safe_fulfillment") == "used" for item in safe_requested) if safe_requested else None
+        ),
+        "speculative_discard_rate": (
+            _rate(item.get("speculative_safe_fulfillment") == "discarded" for item in safe_requested) if safe_requested else None
+        ),
+        "speculative_timeout_rate": (
+            _rate(item.get("speculative_safe_fulfillment") == "timed_out" for item in safe_requested) if safe_requested else None
+        ),
+        "started_before_pi_rate": (
+            _rate(bool(item.get("safe_fulfillment_started_before_pi")) for item in safe_requested) if safe_requested else None
+        ),
+        "validated_by_pi_rate": (
+            _rate(bool(item.get("safe_fulfillment_validated_by_pi")) for item in safe_requested) if safe_requested else None
+        ),
         "cue_client_latency_ms": _latency_stats(_floats(item.get("cue_client_latency_ms") for item in observations)),
         "final_client_latency_ms": _latency_stats(_floats(item.get("final_client_latency_ms") for item in observations)),
+        "simulated_final_completion_latency_ms": _latency_stats(
+            _floats(item.get("simulated_final_completion_latency_ms") for item in observations)
+        ),
         "pi_latency_ms": _latency_stats(_floats(item.get("pi_latency_ms") for item in observations)),
         "safe_fulfillment_latency_ms": _latency_stats(
             _floats(item.get("safe_fulfillment_latency_ms") for item in observations)

--- a/services/zoe-data/tests/test_pi_hybrid_stream_http_probe.py
+++ b/services/zoe-data/tests/test_pi_hybrid_stream_http_probe.py
@@ -62,6 +62,9 @@ def _events(*, intent="weather", response_preview="It is 18.5 C."):
                     "latency_ms": 300.0,
                     "response_chars": len(response_preview),
                     "response_preview": response_preview,
+                    "started_before_pi": True,
+                    "validated_by_pi": True,
+                    "speculative_safe_fulfillment": "used",
                 },
                 "simulated_hybrid_flow": {"final_completion_latency_ms": 2800.0},
             },
@@ -112,11 +115,70 @@ def test_stream_probe_summarises_cue_final_and_fulfillment():
     assert report["summary"]["overall"]["stream_natural_rate"] == 1.0
     assert report["summary"]["overall"]["conversation_natural_rate"] == 1.0
     assert report["summary"]["overall"]["safe_fulfillment_success_rate"] == 1.0
+    assert report["summary"]["overall"]["speculative_used_rate"] == 1.0
+    assert report["summary"]["overall"]["speculative_discard_rate"] == 0.0
+    assert report["summary"]["overall"]["speculative_timeout_rate"] == 0.0
+    assert report["summary"]["overall"]["started_before_pi_rate"] == 1.0
+    assert report["summary"]["overall"]["validated_by_pi_rate"] == 1.0
+    assert report["summary"]["overall"]["simulated_final_completion_latency_ms"]["p95"] == 2800.0
     assert report["observations"][0]["cue_client_latency_ms"] == 4.0
     assert report["observations"][0]["final_client_latency_ms"] == 2810.0
+    assert report["observations"][0]["safe_fulfillment_started_before_pi"] is True
+    assert report["observations"][0]["safe_fulfillment_validated_by_pi"] is True
+    assert report["observations"][0]["speculative_safe_fulfillment"] == "used"
     assert report["observations"][0]["response_preview"] == "It is 18.5 C."
 
 
+
+
+def test_stream_probe_summarises_speculative_discard_and_timeout():
+    module = _load_module()
+    cases = [
+        _case(module, case_id="discard", text="show list", expected="list_show", group="lists"),
+        _case(module, case_id="timeout", text="rain later", expected="weather", group="weather"),
+    ]
+    events = []
+    for state in ("discarded", "timed_out"):
+        item = _events(intent="list_show" if state == "discarded" else "weather", response_preview="ok")
+        safe = item[1]["result"]["safe_fulfillment"]
+        safe["speculative_safe_fulfillment"] = state
+        safe["started_before_pi"] = state == "timed_out"
+        safe["validated_by_pi"] = state == "timed_out"
+        if state == "discarded":
+            safe["speculative_intent"] = "weather"
+            safe["speculative_discard_reason"] = "speculative_pi_disagreed"
+        events.append(item)
+
+    observations = module.run_probe(
+        cases,
+        base_url="http://127.0.0.1:8000",
+        repeat=1,
+        run_pi=True,
+        include_safe_fulfillment=True,
+        allow_pi_execution=True,
+        local_model_configured=True,
+        timeout_seconds=20.0,
+        stream_post=lambda url, payload, timeout: events.pop(0),
+    )
+    report = module.build_report(
+        cases,
+        observations,
+        base_url="http://127.0.0.1:8000",
+        repeat=1,
+        run_pi=True,
+        include_safe_fulfillment=True,
+        include_observations=True,
+    )
+
+    assert report["summary"]["overall"]["speculative_used_rate"] == 0.0
+    assert report["summary"]["overall"]["speculative_discard_rate"] == 0.5
+    assert report["summary"]["overall"]["speculative_timeout_rate"] == 0.5
+    assert report["summary"]["overall"]["started_before_pi_rate"] == 0.5
+    assert report["summary"]["overall"]["validated_by_pi_rate"] == 0.5
+    assert report["observations"][0]["speculative_safe_fulfillment"] == "discarded"
+    assert report["observations"][0]["speculative_intent"] == "weather"
+    assert report["observations"][0]["speculative_discard_reason"] == "speculative_pi_disagreed"
+    assert report["observations"][1]["speculative_safe_fulfillment"] == "timed_out"
 def test_stream_error_packet_is_reported_without_final_packet():
     module = _load_module()
 

--- a/services/zoe-data/tests/test_pi_hybrid_stream_http_probe.py
+++ b/services/zoe-data/tests/test_pi_hybrid_stream_http_probe.py
@@ -129,8 +129,6 @@ def test_stream_probe_summarises_cue_final_and_fulfillment():
     assert report["observations"][0]["response_preview"] == "It is 18.5 C."
 
 
-
-
 def test_stream_probe_summarises_speculative_discard_and_timeout():
     module = _load_module()
     cases = [
@@ -179,6 +177,8 @@ def test_stream_probe_summarises_speculative_discard_and_timeout():
     assert report["observations"][0]["speculative_intent"] == "weather"
     assert report["observations"][0]["speculative_discard_reason"] == "speculative_pi_disagreed"
     assert report["observations"][1]["speculative_safe_fulfillment"] == "timed_out"
+
+
 def test_stream_error_packet_is_reported_without_final_packet():
     module = _load_module()
 


### PR DESCRIPTION
## Summary
- Adds speculative safe-fulfillment evidence fields to the Pi hybrid HTTP probe observations.
- Adds aggregate rates for speculative used/discarded/timed-out, started-before-Pi, validated-by-Pi, and simulated final completion latency.
- Covers the new probe contract with focused tests.

## Why
After the speculative safe-fulfillment lab path landed, live fleet reports could show final latency but not whether the speculative path actually engaged. This closes that evidence gap so the next optimization can be judged with real fleet data.

## Validation
- `python3 -m pytest -q services/zoe-data/tests/test_pi_hybrid_stream_http_probe.py services/zoe-data/tests/test_pi_intent_lab.py services/zoe-data/tests/test_pi_intent_classifier.py services/zoe-data/tests/test_pi_promotion_eval_script.py services/zoe-data/tests/test_zoe_pi_promotion.py` -> 137 passed
- `python3 tools/audit/validate_structure.py` -> passed
