### PR TITLE
[codex] Run daily briefing tool calls concurrently

### DIFF
--- a/services/zoe-data/intent_router.py
+++ b/services/zoe-data/intent_router.py
@@ -2462,10 +2462,13 @@ async def _execute_daily_briefing(user_id: str) -> Optional[str]:
 
     results = {}
     task_keys = list(cmds)
-    task_results = await asyncio.gather(*(_run_mcporter(cmds[key]) for key in task_keys))
+    task_results = await asyncio.gather(
+        *(_run_mcporter(cmds[key]) for key in task_keys),
+        return_exceptions=True,
+    )
 
     for key, raw in zip(task_keys, task_results):
-        if raw:
+        if raw and not isinstance(raw, BaseException):
             try:
                 results[key] = json.loads(raw)
             except json.JSONDecodeError:

--- a/services/zoe-data/intent_router.py
+++ b/services/zoe-data/intent_router.py
@@ -2461,12 +2461,10 @@ async def _execute_daily_briefing(user_id: str) -> Optional[str]:
     }
 
     results = {}
-    tasks = []
-    for key, cmd in cmds.items():
-        tasks.append((key, _run_mcporter(cmd)))
+    task_keys = list(cmds)
+    task_results = await asyncio.gather(*(_run_mcporter(cmds[key]) for key in task_keys))
 
-    for key, coro in tasks:
-        raw = await coro
+    for key, raw in zip(task_keys, task_results):
         if raw:
             try:
                 results[key] = json.loads(raw)

--- a/services/zoe-data/tests/test_daily_briefing_concurrency.py
+++ b/services/zoe-data/tests/test_daily_briefing_concurrency.py
@@ -1,0 +1,56 @@
+import asyncio
+import json
+import time
+
+import pytest
+
+from intent_router import _execute_daily_briefing
+
+
+@pytest.mark.asyncio
+async def test_daily_briefing_runs_mcporter_calls_concurrently(monkeypatch):
+    calls = []
+
+    async def fake_run_mcporter(cmd):
+        calls.append(cmd)
+        await asyncio.sleep(0.05)
+        if "weather_current" in cmd:
+            return json.dumps({"temp": 18.5, "city": "Perth", "description": "clear"})
+        if "calendar_today" in cmd:
+            return json.dumps({"events": [{"title": "Standup", "start_time": "09:00"}]})
+        if "reminder_list" in cmd:
+            return json.dumps({"reminders": [{"title": "pay invoice", "due_time": "17:00"}]})
+        return None
+
+    monkeypatch.setattr("intent_router._run_mcporter", fake_run_mcporter)
+
+    started = time.perf_counter()
+    result = await _execute_daily_briefing("family-admin")
+    elapsed = time.perf_counter() - started
+
+    assert len(calls) == 3
+    assert elapsed < 0.12
+    assert "Weather: 18.5" in result
+    assert "Standup at 09:00" in result
+    assert "pay invoice at 17:00" in result
+
+
+@pytest.mark.asyncio
+async def test_daily_briefing_preserves_partial_results_when_one_call_fails(monkeypatch):
+    async def fake_run_mcporter(cmd):
+        await asyncio.sleep(0)
+        if "weather_current" in cmd:
+            return json.dumps({"temp": 19, "city": "Perth", "description": "cloudy"})
+        if "calendar_today" in cmd:
+            return None
+        if "reminder_list" in cmd:
+            return json.dumps({"reminders": [{"title": "check oven"}]})
+        return None
+
+    monkeypatch.setattr("intent_router._run_mcporter", fake_run_mcporter)
+
+    result = await _execute_daily_briefing("family-admin")
+
+    assert "Weather: 19" in result
+    assert "No events on the calendar today." in result
+    assert "check oven" in result

--- a/services/zoe-data/tests/test_daily_briefing_concurrency.py
+++ b/services/zoe-data/tests/test_daily_briefing_concurrency.py
@@ -1,7 +1,5 @@
 import asyncio
 import json
-import time
-
 import pytest
 
 from intent_router import _execute_daily_briefing
@@ -10,10 +8,14 @@ from intent_router import _execute_daily_briefing
 @pytest.mark.asyncio
 async def test_daily_briefing_runs_mcporter_calls_concurrently(monkeypatch):
     calls = []
+    all_started = asyncio.Event()
+    release = asyncio.Event()
 
     async def fake_run_mcporter(cmd):
         calls.append(cmd)
-        await asyncio.sleep(0.05)
+        if len(calls) == 3:
+            all_started.set()
+        await release.wait()
         if "weather_current" in cmd:
             return json.dumps({"temp": 18.5, "city": "Perth", "description": "clear"})
         if "calendar_today" in cmd:
@@ -24,12 +26,14 @@ async def test_daily_briefing_runs_mcporter_calls_concurrently(monkeypatch):
 
     monkeypatch.setattr("intent_router._run_mcporter", fake_run_mcporter)
 
-    started = time.perf_counter()
-    result = await _execute_daily_briefing("family-admin")
-    elapsed = time.perf_counter() - started
-
+    task = asyncio.create_task(_execute_daily_briefing("family-admin"))
+    await asyncio.wait_for(all_started.wait(), timeout=1.0)
     assert len(calls) == 3
-    assert elapsed < 0.12
+    assert not task.done()
+
+    release.set()
+    result = await asyncio.wait_for(task, timeout=1.0)
+
     assert "Weather: 18.5" in result
     assert "Standup at 09:00" in result
     assert "pay invoice at 17:00" in result
@@ -42,7 +46,7 @@ async def test_daily_briefing_preserves_partial_results_when_one_call_fails(monk
         if "weather_current" in cmd:
             return json.dumps({"temp": 19, "city": "Perth", "description": "cloudy"})
         if "calendar_today" in cmd:
-            return None
+            raise RuntimeError("calendar unavailable")
         if "reminder_list" in cmd:
             return json.dumps({"reminders": [{"title": "check oven"}]})
         return None


### PR DESCRIPTION
## Summary
- Runs the daily briefing weather/calendar/reminder mcporter calls concurrently instead of awaiting them serially.
- Keeps the same output formatting and partial-result behavior.
- Adds focused async tests proving concurrency and partial failure handling.

## Why
Pi safe-eligible probes showed daily briefing fulfillment as the largest additive tail: Pi latency plus roughly 3s of daily briefing safe fulfillment. The three daily briefing tool calls were already independent, so this reduces the safe fulfillment tail without changing production routing or Pi promotion policy.

## Validation
- `python3 -m pytest -q services/zoe-data/tests/test_daily_briefing_concurrency.py services/zoe-data/tests/test_pi_intent_lab.py services/zoe-data/tests/test_pi_hybrid_stream_http_probe.py services/zoe-data/tests/test_pi_intent_classifier.py services/zoe-data/tests/test_pi_promotion_eval_script.py services/zoe-data/tests/test_zoe_pi_promotion.py` -> 139 passed
- `python3 tools/audit/validate_structure.py` -> passed
