### PR TITLE
[codex] Fix stale Greptile guard state

### DIFF
--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -1,11 +1,12 @@
 {
   "strictness": 2,
-  "commentTypes": ["logic", "style"],
+  "commentTypes": ["logic", "syntax"],
   "excludeBranches": ["draft", "wip"],
   "triggerOnDrafts": false,
   "triggerOnUpdates": true,
   "statusCheck": true,
   "statusCommentsEnabled": true,
+  "updateExistingSummaryComment": true,
   "summarySection": {
     "included": true,
     "collapsible": true,

--- a/scripts/maintenance/greploop_guard.py
+++ b/scripts/maintenance/greploop_guard.py
@@ -15,7 +15,7 @@ sys.path.insert(0, str(ROOT / "services" / "zoe-data"))
 from greploop_guard import (  # noqa: E402
     GuardError,
     merge_pr_when_ready,
-    read_guard_state,
+    read_observed_guard_state,
     run_guard_once,
 )
 
@@ -53,7 +53,7 @@ def main() -> int:
         if not args.pr:
             parser.error("--pr is required")
         if args.state:
-            print(json.dumps(read_guard_state(args.pr), indent=2, sort_keys=True))
+            print(json.dumps(read_observed_guard_state(args.pr), indent=2, sort_keys=True))
             return 0
         if args.packet_only and args.merge_when_ready:
             parser.error("--merge-when-ready is incompatible with --packet-only")

--- a/services/zoe-data/greploop_guard.py
+++ b/services/zoe-data/greploop_guard.py
@@ -124,6 +124,24 @@ def read_guard_state(pr_number: int) -> dict[str, Any]:
     return json.loads(path.read_text())
 
 
+def read_observed_guard_state(pr_number: int, *, repo: str = DEFAULT_REPO) -> dict[str, Any]:
+    """Return local guard state plus a live GitHub observation when available."""
+    state = read_guard_state(pr_number)
+    observed = _gh_pr_observation(pr_number, repo=repo)
+    if observed.get("ok"):
+        state = {**state, "observed": observed}
+        if observed.get("state") == "MERGED" and state.get("terminal_state") != "MERGED":
+            state["historical_terminal_state"] = state.get("terminal_state")
+            state["terminal_state"] = "MERGED"
+        elif _gh_greptile_check_success(observed) and state.get("terminal_state") in {
+            "WAITING_GREPTILE",
+            "BLOCKED_GREPTILE_STUCK",
+        }:
+            state["historical_terminal_state"] = state.get("terminal_state")
+            state["terminal_state"] = "GITHUB_GREPTILE_COMPLETE"
+    return state
+
+
 def _append_progress(pr_number: int, line: str) -> None:
     path = _json_path(pr_number, "progress.md")
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -417,6 +435,179 @@ def _actionable_greptile_findings(findings: list[dict[str, Any]]) -> list[dict[s
     return [f for f in findings if (f.get("file_path") or "").strip()]
 
 
+def _finding_thread_key(finding: dict[str, Any]) -> tuple[str, str]:
+    path = str(finding.get("file_path") or "")
+    body = str(finding.get("body") or "")
+    title = " ".join(body.split())[:120]
+    return (path, title)
+
+
+def _gh_pr_review_threads(pr_number: int, *, repo: str = DEFAULT_REPO) -> list[dict[str, Any]] | None:
+    try:
+        owner, name = repo.split("/", 1)
+    except ValueError:
+        return None
+    query_first = (
+        "query($owner:String!,$repo:String!,$pr:Int!){"
+        "repository(owner:$owner,name:$repo){pullRequest(number:$pr){"
+        "reviewThreads(first:100){"
+        "pageInfo{hasNextPage endCursor}"
+        "nodes{isResolved comments(first:20){nodes{author{login} path line body url}}}}}}}"
+    )
+    query_next = (
+        "query($owner:String!,$repo:String!,$pr:Int!,$after:String!){"
+        "repository(owner:$owner,name:$repo){pullRequest(number:$pr){"
+        "reviewThreads(first:100,after:$after){"
+        "pageInfo{hasNextPage endCursor}"
+        "nodes{isResolved comments(first:20){nodes{author{login} path line body url}}}}}}}"
+    )
+    threads: list[dict[str, Any]] = []
+    after: str | None = None
+    for _ in range(50):
+        cmd = [
+            "gh",
+            "api",
+            "graphql",
+            "-f",
+            f"query={query_next if after else query_first}",
+            "-f",
+            f"owner={owner}",
+            "-f",
+            f"repo={name}",
+            "-F",
+            f"pr={int(pr_number)}",
+        ]
+        if after:
+            cmd.extend(["-f", f"after={after}"])
+        proc = subprocess.run(cmd, cwd=REPO_ROOT, text=True, capture_output=True)
+        if proc.returncode != 0:
+            return None
+        try:
+            data = json.loads(proc.stdout or "{}")
+            page = (
+                data.get("data", {})
+                .get("repository", {})
+                .get("pullRequest", {})
+                .get("reviewThreads", {})
+            )
+        except (AttributeError, TypeError, ValueError, json.JSONDecodeError):
+            return None
+        nodes = page.get("nodes") or []
+        threads.extend(node for node in nodes if isinstance(node, dict))
+        page_info = page.get("pageInfo") or {}
+        if not page_info.get("hasNextPage"):
+            break
+        after = page_info.get("endCursor")
+        if not after:
+            break
+    return threads
+
+
+def _gh_thread_counts(pr_number: int, *, repo: str = DEFAULT_REPO) -> dict[str, Any]:
+    threads = _gh_pr_review_threads(pr_number, repo=repo)
+    if threads is None:
+        return {"ok": False, "unresolved": -1, "resolved_greptile_keys": []}
+    resolved_greptile_keys: list[tuple[str, str]] = []
+    unresolved = 0
+    greptile_thread_count = 0
+    for thread in threads:
+        comments = ((thread.get("comments") or {}).get("nodes") or [])
+        greptile_comments = [
+            comment
+            for comment in comments
+            if "greptile" in str(((comment.get("author") or {}).get("login") or "")).lower()
+        ]
+        if greptile_comments:
+            greptile_thread_count += 1
+        if not thread.get("isResolved"):
+            unresolved += 1
+            continue
+        for comment in greptile_comments:
+            body = str(comment.get("body") or "")
+            title = " ".join(body.split())[:120]
+            resolved_greptile_keys.append((str(comment.get("path") or ""), title))
+    return {
+        "ok": True,
+        "unresolved": unresolved,
+        "thread_count": len(threads),
+        "greptile_thread_count": greptile_thread_count,
+        "resolved_greptile_keys": resolved_greptile_keys,
+    }
+
+
+def _filter_actionable_findings(
+    findings: list[dict[str, Any]],
+    *,
+    pr_number: int,
+    repo: str = DEFAULT_REPO,
+    thread_counts: dict[str, Any] | None = None,
+    clear_when_no_unresolved: bool = False,
+) -> list[dict[str, Any]]:
+    actionable = [f for f in _actionable_greptile_findings(findings) if not f.get("addressed")]
+    counts = thread_counts if thread_counts is not None else _gh_thread_counts(pr_number, repo=repo)
+    if not counts.get("ok"):
+        return actionable
+    if clear_when_no_unresolved and int(counts.get("unresolved") or 0) == 0:
+        return []
+    resolved_keys = set(counts.get("resolved_greptile_keys") or [])
+    if not resolved_keys:
+        return actionable
+    return [finding for finding in actionable if _finding_thread_key(finding) not in resolved_keys]
+
+
+def _effective_greptile_confidence(
+    pr_number: int,
+    status: dict[str, Any],
+    findings: list[dict[str, Any]],
+    *,
+    repo: str = DEFAULT_REPO,
+) -> int:
+    from greptile_client import parse_confidence_score
+
+    confidence = int(status.get("confidenceScore") or 0)
+    for row in findings:
+        score = parse_confidence_score(row.get("body"))
+        if score is not None:
+            confidence = max(confidence, score)
+    gh_confidence = _greptile_confidence_from_github_comments(pr_number, repo=repo)
+    if gh_confidence is not None:
+        confidence = max(confidence, gh_confidence)
+    return confidence
+
+
+def _gh_pr_observation(pr_number: int, *, repo: str = DEFAULT_REPO) -> dict[str, Any]:
+    proc = _run_gh(
+        [
+            "pr",
+            "view",
+            str(int(pr_number)),
+            "--json",
+            "mergeable,mergeStateStatus,state,statusCheckRollup,mergedAt,mergeCommit,url",
+        ],
+        repo=repo,
+    )
+    if proc.returncode != 0:
+        return {"ok": False, "reason": "GH_PR_VIEW_FAILED", "detail": (proc.stderr or proc.stdout or "").strip()}
+    try:
+        data = _parse_gh_json(proc)
+    except GuardError as exc:
+        return {"ok": False, "reason": "GH_PR_VIEW_FAILED", "detail": str(exc)}
+    return {"ok": True, **data}
+
+
+def _gh_greptile_check_success(observation: dict[str, Any]) -> bool:
+    for check in observation.get("statusCheckRollup") or []:
+        if not isinstance(check, dict):
+            continue
+        if str(check.get("name") or "") != "Greptile Review":
+            continue
+        status = str(check.get("status") or "").upper()
+        conclusion = str(check.get("conclusion") or "").upper()
+        if status in {"COMPLETED", "SUCCESS"} and conclusion == "SUCCESS":
+            return True
+    return False
+
+
 def _greptile_confidence_from_github_comments(
     pr_number: int, *, repo: str = DEFAULT_REPO
 ) -> int | None:
@@ -454,82 +645,34 @@ def _gh_unresolved_review_thread_count(
 
     Returns ``None`` when the GitHub API check fails (caller must block merge).
     """
-    try:
-        owner, name = repo.split("/", 1)
-    except ValueError:
+    counts = _gh_thread_counts(pr_number, repo=repo)
+    if not counts.get("ok"):
         return None
-    query_first = (
-        "query($owner:String!,$repo:String!,$pr:Int!){"
-        "repository(owner:$owner,name:$repo){pullRequest(number:$pr){"
-        "reviewThreads(first:100){"
-        "pageInfo{hasNextPage endCursor}"
-        "nodes{isResolved}}}}}"
-    )
-    query_next = (
-        "query($owner:String!,$repo:String!,$pr:Int!,$after:String!){"
-        "repository(owner:$owner,name:$repo){pullRequest(number:$pr){"
-        "reviewThreads(first:100,after:$after){"
-        "pageInfo{hasNextPage endCursor}"
-        "nodes{isResolved}}}}}"
-    )
-    unresolved = 0
-    after: str | None = None
-    for _ in range(50):  # up to 5000 threads
-        cmd = [
-            "gh",
-            "api",
-            "graphql",
-            "-f",
-            f"query={query_next if after else query_first}",
-            "-f",
-            f"owner={owner}",
-            "-f",
-            f"repo={name}",
-            "-F",
-            f"pr={int(pr_number)}",
-        ]
-        if after:
-            cmd.extend(["-f", f"after={after}"])
-        proc = subprocess.run(cmd, cwd=REPO_ROOT, text=True, capture_output=True)
-        if proc.returncode != 0:
-            return None
-        try:
-            data = json.loads(proc.stdout or "{}")
-            threads = (
-                data.get("data", {})
-                .get("repository", {})
-                .get("pullRequest", {})
-                .get("reviewThreads", {})
-            )
-        except (AttributeError, TypeError, ValueError, json.JSONDecodeError):
-            return None
-        nodes = threads.get("nodes") or []
-        unresolved += sum(
-            1 for node in nodes if isinstance(node, dict) and not node.get("isResolved")
+    return int(counts.get("unresolved") or 0)
+
+
+def _gh_mergeable_state(
+    pr_number: int,
+    *,
+    repo: str = DEFAULT_REPO,
+    observation: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    if observation and observation.get("ok"):
+        data = observation
+    else:
+        proc = _run_gh(
+            [
+                "pr",
+                "view",
+                str(int(pr_number)),
+                "--json",
+                "mergeable,mergeStateStatus,state,statusCheckRollup",
+            ],
+            repo=repo,
         )
-        page_info = threads.get("pageInfo") or {}
-        if not page_info.get("hasNextPage"):
-            break
-        after = page_info.get("endCursor")
-        if not after:
-            break
-    return unresolved
-
-
-def _gh_mergeable_state(pr_number: int, *, repo: str = DEFAULT_REPO) -> dict[str, Any]:
-    proc = _run_gh(
-        [
-            "pr",
-            "view",
-            str(int(pr_number)),
-            "--json",
-            "mergeable,mergeStateStatus,state,statusCheckRollup",
-        ],
-        repo=repo,
-    )
-    if proc.returncode != 0:
-        return {"ok": False, "reason": "GH_PR_VIEW_FAILED", "detail": (proc.stderr or proc.stdout or "").strip()}
-    data = _parse_gh_json(proc)
+        if proc.returncode != 0:
+            return {"ok": False, "reason": "GH_PR_VIEW_FAILED", "detail": (proc.stderr or proc.stdout or "").strip()}
+        data = _parse_gh_json(proc)
     if str(data.get("state") or "").upper() == "MERGED":
         return {"ok": True, "already_merged": True, "mergeStateStatus": data.get("mergeStateStatus")}
     mergeable = str(data.get("mergeable") or "").upper()
@@ -555,7 +698,7 @@ async def assess_merge_readiness(
     default_branch: str = DEFAULT_BASE_BRANCH,
 ) -> dict[str, Any]:
     """Return whether a PR is safe to squash-merge via normal gh (no admin/force)."""
-    from greptile_client import get_pr_status, list_pr_comments, parse_confidence_score
+    from greptile_client import get_pr_status, list_pr_comments
 
     pr_number = int(pr_number)
     status = await get_pr_status(repo=repo, pr_number=pr_number, default_branch=default_branch)
@@ -566,30 +709,35 @@ async def assess_merge_readiness(
         unaddressed_only=False,
     )
     findings = comments.get("findings") or []
-    actionable = [
-        f
-        for f in _actionable_greptile_findings(findings)
-        if not f.get("addressed")
-    ]
-    unresolved_threads = _gh_unresolved_review_thread_count(pr_number, repo=repo)
+    thread_counts = _gh_thread_counts(pr_number, repo=repo)
+    confidence = _effective_greptile_confidence(pr_number, status, findings, repo=repo)
+    gh_observation = _gh_pr_observation(pr_number, repo=repo)
+    greptile_check_success = _gh_greptile_check_success(gh_observation)
+    actionable = _filter_actionable_findings(
+        findings,
+        pr_number=pr_number,
+        repo=repo,
+        thread_counts=thread_counts,
+        clear_when_no_unresolved=greptile_check_success,
+    )
+    unresolved_threads = int(thread_counts.get("unresolved") or 0) if thread_counts.get("ok") else None
+    stale_running_review = (
+        status.get("reviewIsRunning")
+        and greptile_check_success
+        and thread_counts.get("ok")
+        and int(thread_counts.get("unresolved") or 0) == 0
+        and confidence >= int(target_confidence)
+    )
     blockers: list[str] = []
-    if status.get("reviewIsRunning"):
+    if status.get("reviewIsRunning") and not stale_running_review:
         blockers.append("GREPTILE_REVIEW_RUNNING")
     if unresolved_threads is None:
         blockers.append("GREPTILE_THREAD_CHECK_FAILED")
     elif unresolved_threads:
         blockers.append(f"GREPTILE_UNRESOLVED_THREADS:{unresolved_threads}")
-    confidence = int(status.get("confidenceScore") or 0)
-    for row in findings:
-        score = parse_confidence_score(row.get("body"))
-        if score is not None:
-            confidence = max(confidence, score)
-    gh_confidence = _greptile_confidence_from_github_comments(pr_number, repo=repo)
-    if gh_confidence is not None:
-        confidence = max(confidence, gh_confidence)
     if confidence < int(target_confidence):
         blockers.append(f"GREPTILE_CONFIDENCE:{confidence}<{target_confidence}")
-    gh_state = _gh_mergeable_state(pr_number, repo=repo)
+    gh_state = _gh_mergeable_state(pr_number, repo=repo, observation=gh_observation)
     if not gh_state.get("ok"):
         blockers.append(str(gh_state.get("reason") or "GH_NOT_READY"))
     return {
@@ -696,13 +844,30 @@ async def run_guard_once(
         status = await get_pr_status(repo=DEFAULT_REPO, pr_number=pr_number, default_branch=DEFAULT_BASE_BRANCH)
         comments = await list_pr_comments(repo=DEFAULT_REPO, pr_number=pr_number, default_branch=DEFAULT_BASE_BRANCH)
         findings = comments.get("findings") or []
-        actionable_findings = _actionable_greptile_findings(findings)
-        if status.get("reviewIsRunning"):
+        thread_counts = _gh_thread_counts(pr_number, repo=DEFAULT_REPO)
+        confidence = _effective_greptile_confidence(pr_number, status, findings, repo=DEFAULT_REPO)
+        gh_observation = _gh_pr_observation(pr_number, repo=DEFAULT_REPO)
+        greptile_check_success = _gh_greptile_check_success(gh_observation)
+        actionable_findings = _filter_actionable_findings(
+            findings,
+            pr_number=pr_number,
+            repo=DEFAULT_REPO,
+            thread_counts=thread_counts,
+            clear_when_no_unresolved=greptile_check_success,
+        )
+        stale_running_review = (
+            status.get("reviewIsRunning")
+            and greptile_check_success
+            and thread_counts.get("ok")
+            and int(thread_counts.get("unresolved") or 0) == 0
+            and confidence >= int(task.get("target_confidence") or 5)
+        )
+        if status.get("reviewIsRunning") and not stale_running_review:
             wait_count = int(state.get("waiting_greptile_count") or 0) + 1
             state["waiting_greptile_count"] = wait_count
             state["greptile"] = {
                 "status": status.get("reviewCompleteness") or "review_running",
-                "confidence": status.get("confidenceScore"),
+                "confidence": confidence,
                 "unaddressed_count": len(actionable_findings),
                 "summary_count": max(0, len(findings) - len(actionable_findings)),
             }
@@ -715,7 +880,7 @@ async def run_guard_once(
             _write_json(pr_number, "status.json", state)
             return {"ok": True, "state": "WAITING_GREPTILE", "greptile": status}
         state["waiting_greptile_count"] = 0
-        progress_key = f"{status.get('headSha')}:{status.get('confidenceScore')}:{len(actionable_findings)}:{len(findings)}"
+        progress_key = f"{status.get('headSha')}:{confidence}:{len(actionable_findings)}:{len(findings)}"
         blocked = _update_circuit_breakers(pr_number, state, progress_key)
         if blocked:
             state["terminal_state"] = blocked
@@ -724,15 +889,15 @@ async def run_guard_once(
             return {"ok": False, "state": blocked, "status": state}
         state["greptile"] = {
             "status": status.get("reviewCompleteness") or "reviewed",
-            "confidence": status.get("confidenceScore"),
+            "confidence": confidence,
             "unaddressed_count": len(actionable_findings),
             "summary_count": max(0, len(findings) - len(actionable_findings)),
         }
         _write_json(pr_number, "status.json", state)
-        if (status.get("confidenceScore") or 0) >= int(task.get("target_confidence") or 5) and not actionable_findings:
+        if greptile_check_success and confidence >= int(task.get("target_confidence") or 5) and not actionable_findings:
             state["terminal_state"] = "READY_TO_MERGE"
             _write_json(pr_number, "status.json", state)
-            return {"ok": True, "state": "READY_TO_MERGE", "greptile": status}
+            return {"ok": True, "state": "READY_TO_MERGE", "greptile": {**status, "confidenceScore": confidence}}
         if not actionable_findings:
             triggered = await trigger_review(repo=DEFAULT_REPO, pr_number=pr_number, default_branch=DEFAULT_BASE_BRANCH)
             state["terminal_state"] = "WAITING_GREPTILE"

--- a/services/zoe-data/greptile_client.py
+++ b/services/zoe-data/greptile_client.py
@@ -51,15 +51,22 @@ def normalize_pr_comment(comment: dict[str, Any]) -> dict[str, Any]:
     """Normalize Greptile/GitHub comment fields for guard packets."""
     body = comment.get("body") or comment.get("text") or comment.get("content") or ""
     path = comment.get("filePath") or comment.get("path") or comment.get("file") or ""
-    line = comment.get("line") or comment.get("startLine") or comment.get("originalLine")
+    line = (
+        comment.get("line")
+        or comment.get("lineStart")
+        or comment.get("startLine")
+        or comment.get("originalLine")
+    )
     return {
         "id": str(comment.get("id") or comment.get("commentId") or comment.get("nodeId") or ""),
         "file_path": path,
         "line": line,
+        "line_end": comment.get("lineEnd") or comment.get("endLine") or comment.get("originalEndLine"),
         "body": body,
         "suggested_code": comment.get("suggestedCode") or comment.get("suggestion"),
         "has_suggestion": bool(comment.get("hasSuggestion") or comment.get("suggestedCode")),
         "addressed": bool(comment.get("addressed", False)),
+        "url": comment.get("url") or comment.get("htmlUrl") or comment.get("html_url"),
         "raw": comment,
     }
 

--- a/services/zoe-data/routers/system.py
+++ b/services/zoe-data/routers/system.py
@@ -1087,9 +1087,9 @@ async def list_engineering_workflow_tasks(
 @_agent_card_router.get("/engineering/guard/{pr_number}")
 async def get_engineering_guard(pr_number: int, user: dict = Depends(require_admin)):
     """PR-keyed Greptile grep-loop guard state."""
-    from greploop_guard import read_guard_state
+    from greploop_guard import read_observed_guard_state
 
-    return {"ok": True, "pr_number": pr_number, "state": read_guard_state(pr_number)}
+    return {"ok": True, "pr_number": pr_number, "state": read_observed_guard_state(pr_number)}
 
 
 @_agent_card_router.post("/engineering/guard/{pr_number}/once")

--- a/services/zoe-data/tests/test_greploop_guard.py
+++ b/services/zoe-data/tests/test_greploop_guard.py
@@ -5,6 +5,19 @@ import pytest
 import greploop_guard
 
 
+@pytest.fixture(autouse=True)
+def _default_gh_pr_observation(monkeypatch):
+    monkeypatch.setattr(
+        greploop_guard,
+        "_gh_pr_observation",
+        lambda pr, repo=greploop_guard.DEFAULT_REPO: {
+            "ok": True,
+            "state": "OPEN",
+            "statusCheckRollup": [],
+        },
+    )
+
+
 def _packet(**overrides):
     data = {
         "task_type": "FIX_GREPTILE_FINDING",
@@ -206,7 +219,7 @@ async def test_assess_merge_readiness_blocks_low_confidence(monkeypatch):
     monkeypatch.setattr(
         greploop_guard,
         "_gh_mergeable_state",
-        lambda pr, repo=greploop_guard.DEFAULT_REPO: {"ok": True},
+        lambda pr, repo=greploop_guard.DEFAULT_REPO, observation=None: {"ok": True},
     )
 
     out = await greploop_guard.assess_merge_readiness(66, target_confidence=5)
@@ -308,6 +321,17 @@ async def test_run_guard_once_ignores_pathless_greptile_summary_when_confident(t
     monkeypatch.setattr("greptile_client.list_pr_comments", fake_comments)
     monkeypatch.setattr("greptile_client.trigger_review", fail_trigger)
     monkeypatch.setattr(greploop_guard, "_run_cheap_agent", fail_runner)
+    monkeypatch.setattr(
+        greploop_guard,
+        "_gh_pr_observation",
+        lambda pr, repo=greploop_guard.DEFAULT_REPO: {
+            "ok": True,
+            "state": "OPEN",
+            "statusCheckRollup": [
+                {"name": "Greptile Review", "status": "COMPLETED", "conclusion": "SUCCESS"},
+            ],
+        },
+    )
 
     out = await greploop_guard.run_guard_once(66)
 
@@ -366,6 +390,414 @@ async def test_run_guard_once_retriggers_low_confidence_pathless_summary(tmp_pat
     assert state["terminal_state"] == "WAITING_GREPTILE"
     assert state["greptile"]["unaddressed_count"] == 0
     assert state["greptile"]["summary_count"] == 1
+
+
+def test_filter_actionable_findings_requires_completed_check_for_zero_unresolved_shortcut():
+    findings = [
+        {
+            "id": "comment-1",
+            "file_path": "services/zoe-data/example.py",
+            "line": 99,
+            "body": "MCP stale body that no longer matches GitHub exactly",
+            "addressed": False,
+        }
+    ]
+    thread_counts = {"ok": True, "unresolved": 0, "resolved_greptile_keys": []}
+
+    blocked = greploop_guard._filter_actionable_findings(
+        findings,
+        pr_number=66,
+        thread_counts=thread_counts,
+        clear_when_no_unresolved=False,
+    )
+    cleared = greploop_guard._filter_actionable_findings(
+        findings,
+        pr_number=66,
+        thread_counts=thread_counts,
+        clear_when_no_unresolved=True,
+    )
+
+    assert blocked == findings
+    assert cleared == []
+
+
+def test_filter_actionable_findings_ignores_line_for_resolved_thread_match():
+    body = "Resolved multi-line Greptile body"
+    findings = [
+        {
+            "id": "comment-1",
+            "file_path": "services/zoe-data/example.py",
+            "line": 10,
+            "body": body,
+            "addressed": False,
+        }
+    ]
+
+    out = greploop_guard._filter_actionable_findings(
+        findings,
+        pr_number=66,
+        thread_counts={
+            "ok": True,
+            "unresolved": 1,
+            "resolved_greptile_keys": [("services/zoe-data/example.py", body)],
+        },
+    )
+
+    assert out == []
+
+
+@pytest.mark.asyncio
+async def test_run_guard_once_uses_github_summary_confidence_without_retrigger(tmp_path, monkeypatch):
+    async def fake_status(**_kwargs):
+        return {
+            "confidenceScore": None,
+            "reviewIsRunning": False,
+            "headSha": "abc",
+            "reviewCompleteness": "No Greptile review comments",
+        }
+
+    async def fake_comments(**_kwargs):
+        return {"findings": []}
+
+    async def fail_trigger(**_kwargs):
+        raise AssertionError("GitHub 5/5 summary should prevent Greptile retrigger")
+
+    monkeypatch.setattr(greploop_guard, "STATE_ROOT", tmp_path)
+    monkeypatch.setattr("greptile_client.get_pr_status", fake_status)
+    monkeypatch.setattr("greptile_client.list_pr_comments", fake_comments)
+    monkeypatch.setattr("greptile_client.trigger_review", fail_trigger)
+    monkeypatch.setattr(
+        greploop_guard,
+        "_greptile_confidence_from_github_comments",
+        lambda pr, repo=greploop_guard.DEFAULT_REPO: 5,
+    )
+    monkeypatch.setattr(
+        greploop_guard,
+        "_gh_thread_counts",
+        lambda pr, repo=greploop_guard.DEFAULT_REPO: {
+            "ok": True,
+            "unresolved": 0,
+            "resolved_greptile_keys": [],
+        },
+    )
+    monkeypatch.setattr(
+        greploop_guard,
+        "_gh_pr_observation",
+        lambda pr, repo=greploop_guard.DEFAULT_REPO: {
+            "ok": True,
+            "state": "OPEN",
+            "statusCheckRollup": [
+                {"name": "Greptile Review", "status": "COMPLETED", "conclusion": "SUCCESS"},
+            ],
+        },
+    )
+
+    out = await greploop_guard.run_guard_once(66)
+
+    assert out["ok"] is True
+    assert out["state"] == "READY_TO_MERGE"
+    assert out["greptile"]["confidenceScore"] == 5
+
+
+@pytest.mark.asyncio
+async def test_run_guard_once_waits_when_historical_confidence_has_no_completed_check(tmp_path, monkeypatch):
+    async def fake_status(**_kwargs):
+        return {
+            "confidenceScore": None,
+            "reviewIsRunning": False,
+            "headSha": "abc",
+            "reviewCompleteness": "No Greptile review comments",
+        }
+
+    async def fake_comments(**_kwargs):
+        return {"findings": []}
+
+    triggered = {}
+
+    async def fake_trigger(**kwargs):
+        triggered.update(kwargs)
+        return {"triggered": True}
+
+    monkeypatch.setattr(greploop_guard, "STATE_ROOT", tmp_path)
+    monkeypatch.setattr("greptile_client.get_pr_status", fake_status)
+    monkeypatch.setattr("greptile_client.list_pr_comments", fake_comments)
+    monkeypatch.setattr("greptile_client.trigger_review", fake_trigger)
+    monkeypatch.setattr(
+        greploop_guard,
+        "_greptile_confidence_from_github_comments",
+        lambda pr, repo=greploop_guard.DEFAULT_REPO: 5,
+    )
+    monkeypatch.setattr(
+        greploop_guard,
+        "_gh_thread_counts",
+        lambda pr, repo=greploop_guard.DEFAULT_REPO: {
+            "ok": True,
+            "unresolved": 0,
+            "resolved_greptile_keys": [],
+        },
+    )
+    monkeypatch.setattr(
+        greploop_guard,
+        "_gh_pr_observation",
+        lambda pr, repo=greploop_guard.DEFAULT_REPO: {"ok": True, "state": "OPEN", "statusCheckRollup": []},
+    )
+
+    out = await greploop_guard.run_guard_once(66)
+
+    assert out["ok"] is True
+    assert out["state"] == "WAITING_GREPTILE"
+    assert out["triggered_review"] == {"triggered": True}
+    assert triggered["pr_number"] == 66
+
+@pytest.mark.asyncio
+async def test_run_guard_once_suppresses_stale_resolved_github_thread(tmp_path, monkeypatch):
+    body = "P2 stale comment body"
+
+    async def fake_status(**_kwargs):
+        return {
+            "confidenceScore": None,
+            "reviewIsRunning": False,
+            "headSha": "abc",
+            "reviewCompleteness": "0/1 Greptile comments addressed",
+        }
+
+    async def fake_comments(**_kwargs):
+        return {
+            "findings": [
+                {
+                    "id": "comment-1",
+                    "file_path": "services/zoe-data/example.py",
+                    "line": 42,
+                    "body": body,
+                    "addressed": False,
+                }
+            ]
+        }
+
+    async def fail_trigger(**_kwargs):
+        raise AssertionError("resolved GitHub thread should not retrigger Greptile")
+
+    async def fail_runner(*_args, **_kwargs):
+        raise AssertionError("resolved GitHub thread should not become a repair packet")
+
+    monkeypatch.setattr(greploop_guard, "STATE_ROOT", tmp_path)
+    monkeypatch.setattr("greptile_client.get_pr_status", fake_status)
+    monkeypatch.setattr("greptile_client.list_pr_comments", fake_comments)
+    monkeypatch.setattr("greptile_client.trigger_review", fail_trigger)
+    monkeypatch.setattr(greploop_guard, "_run_cheap_agent", fail_runner)
+    monkeypatch.setattr(
+        greploop_guard,
+        "_greptile_confidence_from_github_comments",
+        lambda pr, repo=greploop_guard.DEFAULT_REPO: 5,
+    )
+    monkeypatch.setattr(
+        greploop_guard,
+        "_gh_thread_counts",
+        lambda pr, repo=greploop_guard.DEFAULT_REPO: {
+            "ok": True,
+            "unresolved": 0,
+            "resolved_greptile_keys": [("services/zoe-data/example.py", body)],
+        },
+    )
+    monkeypatch.setattr(
+        greploop_guard,
+        "_gh_pr_observation",
+        lambda pr, repo=greploop_guard.DEFAULT_REPO: {
+            "ok": True,
+            "state": "OPEN",
+            "statusCheckRollup": [
+                {"name": "Greptile Review", "status": "COMPLETED", "conclusion": "SUCCESS"},
+            ],
+        },
+    )
+
+    out = await greploop_guard.run_guard_once(66)
+
+    assert out["ok"] is True
+    assert out["state"] == "READY_TO_MERGE"
+    state = greploop_guard.read_guard_state(66)
+    assert state["greptile"]["unaddressed_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_assess_merge_readiness_ignores_mcp_comment_when_thread_resolved(monkeypatch):
+    body = "Resolved stale Greptile body"
+
+    async def fake_status(**_kwargs):
+        return {"confidenceScore": None, "reviewIsRunning": False, "headSha": "abc"}
+
+    async def fake_comments(**_kwargs):
+        return {
+            "findings": [
+                {
+                    "id": "comment-1",
+                    "file_path": "services/zoe-data/example.py",
+                    "line": 7,
+                    "body": body,
+                    "addressed": False,
+                }
+            ]
+        }
+
+    monkeypatch.setattr("greptile_client.get_pr_status", fake_status)
+    monkeypatch.setattr("greptile_client.list_pr_comments", fake_comments)
+    monkeypatch.setattr(
+        greploop_guard,
+        "_greptile_confidence_from_github_comments",
+        lambda pr, repo=greploop_guard.DEFAULT_REPO: 5,
+    )
+    monkeypatch.setattr(
+        greploop_guard,
+        "_gh_thread_counts",
+        lambda pr, repo=greploop_guard.DEFAULT_REPO: {
+            "ok": True,
+            "unresolved": 0,
+            "resolved_greptile_keys": [("services/zoe-data/example.py", body)],
+        },
+    )
+    monkeypatch.setattr(
+        greploop_guard,
+        "_gh_pr_observation",
+        lambda pr, repo=greploop_guard.DEFAULT_REPO: {
+            "ok": True,
+            "state": "OPEN",
+            "statusCheckRollup": [
+                {"name": "Greptile Review", "status": "COMPLETED", "conclusion": "SUCCESS"},
+            ],
+        },
+    )
+    monkeypatch.setattr(
+        greploop_guard,
+        "_gh_mergeable_state",
+        lambda pr, repo=greploop_guard.DEFAULT_REPO, observation=None: {"ok": True},
+    )
+
+    out = await greploop_guard.assess_merge_readiness(66)
+
+    assert out["ready"] is True
+    assert out["unaddressed_count"] == 0
+    assert out["unresolved_review_threads"] == 0
+
+
+@pytest.mark.asyncio
+async def test_assess_merge_readiness_treats_completed_github_check_as_not_running(monkeypatch):
+    async def fake_status(**_kwargs):
+        return {"confidenceScore": None, "reviewIsRunning": True, "headSha": "abc"}
+
+    async def fake_comments(**_kwargs):
+        return {"findings": []}
+
+    monkeypatch.setattr("greptile_client.get_pr_status", fake_status)
+    monkeypatch.setattr("greptile_client.list_pr_comments", fake_comments)
+    monkeypatch.setattr(
+        greploop_guard,
+        "_greptile_confidence_from_github_comments",
+        lambda pr, repo=greploop_guard.DEFAULT_REPO: 5,
+    )
+    monkeypatch.setattr(
+        greploop_guard,
+        "_gh_thread_counts",
+        lambda pr, repo=greploop_guard.DEFAULT_REPO: {
+            "ok": True,
+            "unresolved": 0,
+            "resolved_greptile_keys": [],
+        },
+    )
+    monkeypatch.setattr(
+        greploop_guard,
+        "_gh_pr_observation",
+        lambda pr, repo=greploop_guard.DEFAULT_REPO: {
+            "ok": True,
+            "state": "OPEN",
+            "statusCheckRollup": [
+                {"name": "Greptile Review", "status": "COMPLETED", "conclusion": "SUCCESS"},
+            ],
+        },
+    )
+    monkeypatch.setattr(
+        greploop_guard,
+        "_gh_mergeable_state",
+        lambda pr, repo=greploop_guard.DEFAULT_REPO, observation=None: {"ok": True},
+    )
+
+    out = await greploop_guard.assess_merge_readiness(66)
+
+    assert out["ready"] is True
+    assert "GREPTILE_REVIEW_RUNNING" not in out["blockers"]
+
+def test_read_observed_guard_state_marks_stale_waiting_as_merged(tmp_path, monkeypatch):
+    monkeypatch.setattr(greploop_guard, "STATE_ROOT", tmp_path)
+    greploop_guard._write_json(
+        66,
+        "status.json",
+        {"pr": 66, "terminal_state": "WAITING_GREPTILE", "waiting_greptile_count": 3},
+    )
+    monkeypatch.setattr(
+        greploop_guard,
+        "_gh_pr_observation",
+        lambda pr, repo=greploop_guard.DEFAULT_REPO: {
+            "ok": True,
+            "state": "MERGED",
+            "url": "https://github.com/o/r/pull/66",
+            "statusCheckRollup": [],
+        },
+    )
+
+    state = greploop_guard.read_observed_guard_state(66)
+
+    assert state["terminal_state"] == "MERGED"
+    assert state["historical_terminal_state"] == "WAITING_GREPTILE"
+    assert state["observed"]["state"] == "MERGED"
+
+
+@pytest.mark.asyncio
+async def test_run_guard_once_treats_completed_github_check_as_not_running(tmp_path, monkeypatch):
+    async def fake_status(**_kwargs):
+        return {
+            "confidenceScore": None,
+            "reviewIsRunning": True,
+            "headSha": "abc",
+            "reviewCompleteness": "REVIEWING_FILES",
+            "codeReviews": [{"status": "REVIEWING_FILES"}],
+        }
+
+    async def fake_comments(**_kwargs):
+        return {"findings": []}
+
+    monkeypatch.setattr(greploop_guard, "STATE_ROOT", tmp_path)
+    monkeypatch.setattr("greptile_client.get_pr_status", fake_status)
+    monkeypatch.setattr("greptile_client.list_pr_comments", fake_comments)
+    monkeypatch.setattr(
+        greploop_guard,
+        "_greptile_confidence_from_github_comments",
+        lambda pr, repo=greploop_guard.DEFAULT_REPO: 5,
+    )
+    monkeypatch.setattr(
+        greploop_guard,
+        "_gh_thread_counts",
+        lambda pr, repo=greploop_guard.DEFAULT_REPO: {
+            "ok": True,
+            "unresolved": 0,
+            "resolved_greptile_keys": [],
+        },
+    )
+    monkeypatch.setattr(
+        greploop_guard,
+        "_gh_pr_observation",
+        lambda pr, repo=greploop_guard.DEFAULT_REPO: {
+            "ok": True,
+            "state": "OPEN",
+            "statusCheckRollup": [
+                {"name": "Greptile Review", "status": "COMPLETED", "conclusion": "SUCCESS"},
+            ],
+        },
+    )
+
+    out = await greploop_guard.run_guard_once(66)
+
+    assert out["ok"] is True
+    assert out["state"] == "READY_TO_MERGE"
+    assert greploop_guard.read_guard_state(66)["waiting_greptile_count"] == 0
 
 
 @pytest.mark.asyncio

--- a/services/zoe-data/tests/test_greploop_guard.py
+++ b/services/zoe-data/tests/test_greploop_guard.py
@@ -6,7 +6,7 @@ import greploop_guard
 
 
 @pytest.fixture(autouse=True)
-def _default_gh_pr_observation(monkeypatch):
+def _default_github_helpers(monkeypatch):
     monkeypatch.setattr(
         greploop_guard,
         "_gh_pr_observation",
@@ -15,6 +15,20 @@ def _default_gh_pr_observation(monkeypatch):
             "state": "OPEN",
             "statusCheckRollup": [],
         },
+    )
+    monkeypatch.setattr(
+        greploop_guard,
+        "_gh_thread_counts",
+        lambda pr, repo=greploop_guard.DEFAULT_REPO: {
+            "ok": True,
+            "unresolved": 0,
+            "resolved_greptile_keys": [],
+        },
+    )
+    monkeypatch.setattr(
+        greploop_guard,
+        "_greptile_confidence_from_github_comments",
+        lambda pr, repo=greploop_guard.DEFAULT_REPO: None,
     )
 
 

--- a/services/zoe-data/tests/test_greptile_client.py
+++ b/services/zoe-data/tests/test_greptile_client.py
@@ -18,9 +18,11 @@ def test_normalize_pr_comment_maps_common_fields():
     comment = {
         "id": 123,
         "filePath": "services/zoe-data/example.py",
-        "line": 42,
+        "lineStart": 42,
+        "lineEnd": 43,
         "body": "Fix this",
         "suggestedCode": "pass",
+        "url": "https://github.example/comment",
     }
 
     normalized = greptile_client.normalize_pr_comment(comment)
@@ -28,6 +30,8 @@ def test_normalize_pr_comment_maps_common_fields():
     assert normalized["id"] == "123"
     assert normalized["file_path"] == "services/zoe-data/example.py"
     assert normalized["line"] == 42
+    assert normalized["line_end"] == 43
+    assert normalized["url"] == "https://github.example/comment"
     assert normalized["has_suggestion"] is True
 
 


### PR DESCRIPTION
## Summary
- reconcile Greploop readiness with GitHub review threads, Greptile check state, and GitHub summary confidence when Greptile MCP state is stale
- prevent stale MCP comments/resolved GitHub threads from generating repair packets or false unaddressed counts
- surface observed GitHub state in guard status/CLI output and reduce Greptile style noise

## Verification
- `PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_zoe_pr_maintenance.py services/zoe-data/tests/test_greptile_client.py services/zoe-data/tests/test_greploop_guard.py` -> 36 passed
- `git diff --check`
- `python3 tools/audit/validate_structure.py`
- `python3 tools/audit/validate_critical_files.py`
- live read-only probes: PR #599 and #602 both ready=true, blockers=[], confidence=5, unaddressed_count=0, unresolved_review_threads=0
- `scripts/maintenance/run_greploop_guard.sh --pr 599 --state` and `--pr 602 --state` report terminal_state=MERGED with historical stale states preserved

## Operator note
`/home/zoe/bin/greptile-mcp.py` was also patched on the Zoe host to omit `branch` on manual retriggers unless `--head-branch` is explicitly provided. That tool is outside this repository.
