### PR TITLE
[codex] Dedupe Greptile review triggers

### DIFF
--- a/services/zoe-data/greploop_guard.py
+++ b/services/zoe-data/greploop_guard.py
@@ -31,6 +31,7 @@ NO_PROGRESS_LIMIT = int(os.environ.get("ZOE_PR_GUARD_NO_PROGRESS_LIMIT", "3"))
 SAME_ERROR_LIMIT = int(os.environ.get("ZOE_PR_GUARD_SAME_ERROR_LIMIT", "3"))
 MAX_COST_USD = float(os.environ.get("ZOE_PR_GUARD_MAX_COST_USD", "0.25"))
 MAX_OUTPUT_CHARS = int(os.environ.get("ZOE_PR_GUARD_MAX_OUTPUT_CHARS", "12000"))
+TRIGGER_COOLDOWN_SECONDS = int(os.environ.get("ZOE_PR_GUARD_TRIGGER_COOLDOWN_SECONDS", "900"))
 
 # Cheap-model repair packets must never merge or bypass hooks; use merge_pr_when_ready().
 FORBIDDEN_ACTIONS = [
@@ -615,7 +616,7 @@ def _gh_pr_observation(pr_number: int, *, repo: str = DEFAULT_REPO) -> dict[str,
             "view",
             str(int(pr_number)),
             "--json",
-            "mergeable,mergeStateStatus,state,statusCheckRollup,mergedAt,mergeCommit,url",
+            "headRefOid,mergeable,mergeStateStatus,state,statusCheckRollup,mergedAt,mergeCommit,url",
         ],
         repo=repo,
     )
@@ -639,6 +640,161 @@ def _gh_greptile_check_success(observation: dict[str, Any]) -> bool:
         if status in {"COMPLETED", "SUCCESS"} and conclusion == "SUCCESS":
             return True
     return False
+
+
+def _head_sha_for_trigger(status: dict[str, Any] | None, observation: dict[str, Any] | None) -> str | None:
+    if status:
+        value = status.get("headSha") or status.get("headRefOid")
+        if value:
+            return str(value)
+    if observation:
+        value = observation.get("headRefOid") or observation.get("headSha")
+        if value:
+            return str(value)
+    return None
+
+
+def _should_skip_greptile_trigger(
+    *,
+    state: dict[str, Any],
+    status: dict[str, Any] | None,
+    head_sha: str | None,
+    now: float,
+    force: bool = False,
+) -> dict[str, Any] | None:
+    if force:
+        return None
+    if status and status.get("reviewIsRunning"):
+        return {"skipped": True, "reason": "greptile_review_running"}
+    last_head = str(state.get("last_triggered_head_sha") or "")
+    try:
+        last_at = float(state.get("last_triggered_at") or 0)
+    except (TypeError, ValueError):
+        last_at = 0.0
+    if head_sha and last_head == head_sha and last_at and (now - last_at) < TRIGGER_COOLDOWN_SECONDS:
+        return {
+            "skipped": True,
+            "reason": "recently_triggered_for_head",
+            "cooldown_seconds": TRIGGER_COOLDOWN_SECONDS,
+            "retry_after_seconds": max(0, int(TRIGGER_COOLDOWN_SECONDS - (now - last_at))),
+        }
+    return None
+
+
+async def trigger_review_safely(
+    *,
+    pr_number: int,
+    repo: str = DEFAULT_REPO,
+    default_branch: str = DEFAULT_BASE_BRANCH,
+    branch: str | None = None,
+    status: dict[str, Any] | None = None,
+    state: dict[str, Any] | None = None,
+    force: bool = False,
+    source: str = "greploop_guard",
+    write_state: bool = True,
+) -> dict[str, Any]:
+    """Trigger Greptile once per PR/head within the cooldown window."""
+    from greptile_client import get_pr_status, trigger_review
+
+    pr_number = int(pr_number)
+    active_state = state if state is not None else _load_status(pr_number)
+    active_status = status if status is not None else await get_pr_status(
+        repo=repo,
+        pr_number=pr_number,
+        default_branch=default_branch,
+    )
+    head_sha = _head_sha_for_trigger(active_status, None)
+    now = time.time()
+    skipped = None
+    if not force and active_status and active_status.get("reviewIsRunning"):
+        skipped = _should_skip_greptile_trigger(
+            state=active_state,
+            status=active_status,
+            head_sha=head_sha,
+            now=now,
+            force=force,
+        )
+    if not skipped:
+        if not head_sha:
+            observation = _gh_pr_observation(pr_number, repo=repo)
+            head_sha = _head_sha_for_trigger(active_status, observation)
+        skipped = _should_skip_greptile_trigger(
+            state=active_state,
+            status=active_status,
+            head_sha=head_sha,
+            now=now,
+            force=force,
+        )
+    if skipped:
+        decision = {
+            "success": True,
+            "triggered": False,
+            "prNumber": pr_number,
+            "repo": repo,
+            "headSha": head_sha,
+            "source": source,
+            **skipped,
+        }
+        active_state["last_trigger_decision"] = decision
+        if write_state:
+            _write_json(pr_number, "status.json", active_state)
+        return decision
+
+    result = await trigger_review(
+        repo=repo,
+        pr_number=pr_number,
+        default_branch=default_branch,
+        branch=branch,
+    )
+    trigger_success = bool(result.get("success", True)) if isinstance(result, dict) else True
+    if trigger_success:
+        active_state["last_triggered_head_sha"] = head_sha
+        active_state["last_triggered_at"] = now
+        active_state["last_trigger_source"] = source
+    active_state["last_trigger_decision"] = {
+        "success": trigger_success,
+        "triggered": trigger_success,
+        "prNumber": pr_number,
+        "repo": repo,
+        "headSha": head_sha,
+        "source": source,
+        "response": result,
+    }
+    if write_state:
+        _write_json(pr_number, "status.json", active_state)
+    return result
+
+
+async def trigger_review_with_guard_lock(
+    *,
+    pr_number: int,
+    repo: str = DEFAULT_REPO,
+    default_branch: str = DEFAULT_BASE_BRANCH,
+    branch: str | None = None,
+    force: bool = False,
+    source: str = "mcp:greptile_trigger_review",
+) -> dict[str, Any]:
+    try:
+        with acquire_lock(int(pr_number)):
+            return await trigger_review_safely(
+                pr_number=int(pr_number),
+                repo=repo,
+                default_branch=default_branch,
+                branch=branch,
+                force=force,
+                source=source,
+            )
+    except GuardError as exc:
+        return {
+            "success": False,
+            "triggered": False,
+            "skipped": True,
+            "reason": "guard_already_running",
+            "detail": str(exc),
+            "prNumber": int(pr_number),
+            "repo": repo,
+            "source": source,
+        }
 
 
 def _greptile_confidence_from_github_comments(
@@ -866,7 +1022,7 @@ async def merge_pr_when_ready(
 async def run_guard_once(
     pr_number: int, *, packet_only: bool = False, target_confidence: int = 5
 ) -> dict[str, Any]:
-    from greptile_client import DEFAULT_REPO, get_pr_status, list_pr_comments, trigger_review
+    from greptile_client import DEFAULT_REPO, get_pr_status, list_pr_comments
 
     try:
         pr_number = int(pr_number)
@@ -934,7 +1090,15 @@ async def run_guard_once(
             _write_json(pr_number, "status.json", state)
             return {"ok": True, "state": "READY_TO_MERGE", "greptile": {**status, "confidenceScore": confidence}}
         if not actionable_findings:
-            triggered = await trigger_review(repo=DEFAULT_REPO, pr_number=pr_number, default_branch=DEFAULT_BASE_BRANCH)
+            triggered = await trigger_review_safely(
+                pr_number=pr_number,
+                repo=DEFAULT_REPO,
+                default_branch=DEFAULT_BASE_BRANCH,
+                status=status,
+                state=state,
+                source="greploop_guard:no_actionable_findings",
+                write_state=False,
+            )
             state["terminal_state"] = "WAITING_GREPTILE"
             _write_json(pr_number, "status.json", {**state, "triggered_review": triggered})
             return {"ok": True, "state": "WAITING_GREPTILE", "triggered_review": triggered}
@@ -959,7 +1123,15 @@ async def run_guard_once(
             state["terminal_state"] = analysis.get("classification") if runner_status == "OK" else runner_status
             _write_json(pr_number, "status.json", state)
             return {"ok": False, "state": state["terminal_state"], "result": result}
-        triggered = await trigger_review(repo=DEFAULT_REPO, pr_number=pr_number, default_branch=DEFAULT_BASE_BRANCH)
+        triggered = await trigger_review_safely(
+            pr_number=pr_number,
+            repo=DEFAULT_REPO,
+            default_branch=DEFAULT_BASE_BRANCH,
+            status=status,
+            state=state,
+            source="greploop_guard:cheap_agent_applied",
+            write_state=False,
+        )
         state["terminal_state"] = "WAITING_GREPTILE"
         _write_json(pr_number, "status.json", {**state, "triggered_review": triggered})
         return {"ok": True, "state": "WAITING_GREPTILE", "result": result, "triggered_review": triggered}

--- a/services/zoe-data/mcp_server.py
+++ b/services/zoe-data/mcp_server.py
@@ -479,6 +479,7 @@ TOOLS = [
                 "pr_number": {"type": "integer", "description": "Pull request number"},
                 "default_branch": {"type": "string", "default": "main"},
                 "branch": {"type": "string", "description": "Current PR branch"},
+                "force": {"type": "boolean", "default": False, "description": "Bypass same-head trigger cooldown."},
             },
             "required": ["pr_number"],
         },
@@ -1872,12 +1873,13 @@ async def _execute_tool(db, name: str, args: dict):
 
     elif name == "greptile_trigger_review":
         try:
-            from greptile_client import trigger_review  # type: ignore[import]
-            return await trigger_review(
+            from greploop_guard import trigger_review_with_guard_lock  # type: ignore[import]
+            return await trigger_review_with_guard_lock(
                 repo=args.get("repo") or "jason-easyazz/zoe-ai-assistant",
                 pr_number=args.get("pr_number"),
                 default_branch=args.get("default_branch") or "main",
                 branch=args.get("branch"),
+                force=bool(args.get("force", False)),
             )
         except Exception as exc:
             return {"error": f"Greptile trigger review failed: {exc}"}

--- a/services/zoe-data/tests/test_greploop_guard.py
+++ b/services/zoe-data/tests/test_greploop_guard.py
@@ -364,6 +364,185 @@ async def test_run_guard_once_ignores_pathless_greptile_summary_when_confident(t
 
 
 @pytest.mark.asyncio
+async def test_trigger_review_safely_skips_recent_same_head(tmp_path, monkeypatch):
+    async def fail_trigger(**_kwargs):
+        raise AssertionError("same-head trigger should be deduped")
+
+    monkeypatch.setattr(greploop_guard, "STATE_ROOT", tmp_path)
+    monkeypatch.setattr(greploop_guard, "TRIGGER_COOLDOWN_SECONDS", 900)
+    monkeypatch.setattr(greploop_guard.time, "time", lambda: 1_000.0)
+    monkeypatch.setattr("greptile_client.trigger_review", fail_trigger)
+    state = {
+        "pr": 66,
+        "last_triggered_head_sha": "abc",
+        "last_triggered_at": 500.0,
+    }
+
+    out = await greploop_guard.trigger_review_safely(
+        pr_number=66,
+        status={"headSha": "abc", "reviewIsRunning": False},
+        state=state,
+        source="test",
+    )
+
+    assert out["triggered"] is False
+    assert out["skipped"] is True
+    assert out["reason"] == "recently_triggered_for_head"
+    assert out["retry_after_seconds"] == 400
+    saved = greploop_guard.read_guard_state(66)
+    assert saved["last_trigger_decision"]["reason"] == "recently_triggered_for_head"
+
+
+@pytest.mark.asyncio
+async def test_trigger_review_safely_force_bypasses_same_head_cooldown(tmp_path, monkeypatch):
+    triggered = {}
+
+    async def fake_trigger(**kwargs):
+        triggered.update(kwargs)
+        return {"triggered": True, "ok": True}
+
+    monkeypatch.setattr(greploop_guard, "STATE_ROOT", tmp_path)
+    monkeypatch.setattr(greploop_guard.time, "time", lambda: 1_000.0)
+    monkeypatch.setattr("greptile_client.trigger_review", fake_trigger)
+    state = {
+        "pr": 66,
+        "last_triggered_head_sha": "abc",
+        "last_triggered_at": 999.0,
+    }
+
+    out = await greploop_guard.trigger_review_safely(
+        pr_number=66,
+        status={"headSha": "abc", "reviewIsRunning": False},
+        state=state,
+        force=True,
+        source="test-force",
+    )
+
+    assert out == {"triggered": True, "ok": True}
+    assert triggered["pr_number"] == 66
+    assert state["last_triggered_head_sha"] == "abc"
+    assert state["last_trigger_source"] == "test-force"
+
+
+@pytest.mark.asyncio
+async def test_trigger_review_safely_does_not_cooldown_failed_trigger(tmp_path, monkeypatch):
+    async def fake_trigger(**_kwargs):
+        return {"success": False, "error": "provider busy"}
+
+    monkeypatch.setattr(greploop_guard, "STATE_ROOT", tmp_path)
+    monkeypatch.setattr(greploop_guard.time, "time", lambda: 1_000.0)
+    monkeypatch.setattr("greptile_client.trigger_review", fake_trigger)
+    state = {"pr": 66}
+
+    out = await greploop_guard.trigger_review_safely(
+        pr_number=66,
+        status={"headSha": "abc", "reviewIsRunning": False},
+        state=state,
+        source="test-failed-trigger",
+    )
+
+    assert out == {"success": False, "error": "provider busy"}
+    assert "last_triggered_head_sha" not in state
+    assert "last_triggered_at" not in state
+    assert state["last_trigger_decision"]["success"] is False
+    assert state["last_trigger_decision"]["triggered"] is False
+    assert state["last_trigger_decision"]["response"] == out
+
+
+@pytest.mark.asyncio
+async def test_trigger_review_safely_skips_running_review(tmp_path, monkeypatch):
+    async def fail_trigger(**_kwargs):
+        raise AssertionError("running review should not be retriggered")
+
+    def fail_observation(*_args, **_kwargs):
+        raise AssertionError("running review should skip before gh pr view")
+
+    monkeypatch.setattr(greploop_guard, "STATE_ROOT", tmp_path)
+    monkeypatch.setattr("greptile_client.trigger_review", fail_trigger)
+    monkeypatch.setattr(greploop_guard, "_gh_pr_observation", fail_observation)
+
+    out = await greploop_guard.trigger_review_safely(
+        pr_number=66,
+        status={"headSha": "abc", "reviewIsRunning": True},
+        state={"pr": 66},
+        source="test-running",
+    )
+
+    assert out["triggered"] is False
+    assert out["reason"] == "greptile_review_running"
+
+
+@pytest.mark.asyncio
+async def test_trigger_review_with_guard_lock_reports_lock_contention(tmp_path, monkeypatch):
+    async def fail_trigger(**_kwargs):
+        raise AssertionError("locked trigger path should not call Greptile")
+
+    monkeypatch.setattr(greploop_guard, "STATE_ROOT", tmp_path)
+    monkeypatch.setattr("greptile_client.trigger_review", fail_trigger)
+
+    with greploop_guard.acquire_lock(66):
+        out = await greploop_guard.trigger_review_with_guard_lock(pr_number=66, source="test-lock")
+
+    assert out["success"] is False
+    assert out["triggered"] is False
+    assert out["skipped"] is True
+    assert out["reason"] == "guard_already_running"
+    assert out["source"] == "test-lock"
+
+
+@pytest.mark.asyncio
+async def test_run_guard_once_skips_recent_same_head_trigger(tmp_path, monkeypatch):
+    async def fake_status(**_kwargs):
+        return {
+            "confidenceScore": 4,
+            "reviewIsRunning": False,
+            "headSha": "abc",
+            "reviewCompleteness": "No Greptile review comments",
+        }
+
+    async def fake_comments(**_kwargs):
+        return {"findings": []}
+
+    async def fail_trigger(**_kwargs):
+        raise AssertionError("same-head trigger should be deduped")
+
+    monkeypatch.setattr(greploop_guard, "STATE_ROOT", tmp_path)
+    monkeypatch.setattr(greploop_guard, "TRIGGER_COOLDOWN_SECONDS", 900)
+    monkeypatch.setattr(greploop_guard.time, "time", lambda: 1_000.0)
+    monkeypatch.setattr("greptile_client.get_pr_status", fake_status)
+    monkeypatch.setattr("greptile_client.list_pr_comments", fake_comments)
+    monkeypatch.setattr("greptile_client.trigger_review", fail_trigger)
+    greploop_guard._write_json(
+        66,
+        "status.json",
+        {"pr": 66, "last_triggered_head_sha": "abc", "last_triggered_at": 500.0},
+    )
+    real_write_json = greploop_guard._write_json
+    status_writes = []
+
+    def tracked_write_json(pr_number, name, payload):
+        if name == "status.json":
+            status_writes.append(dict(payload))
+        return real_write_json(pr_number, name, payload)
+
+    monkeypatch.setattr(greploop_guard, "_write_json", tracked_write_json)
+
+    out = await greploop_guard.run_guard_once(66)
+
+    assert out["ok"] is True
+    assert out["state"] == "WAITING_GREPTILE"
+    assert out["triggered_review"]["triggered"] is False
+    assert out["triggered_review"]["reason"] == "recently_triggered_for_head"
+    state = greploop_guard.read_guard_state(66)
+    assert state["terminal_state"] == "WAITING_GREPTILE"
+    assert state["last_trigger_decision"]["reason"] == "recently_triggered_for_head"
+    trigger_decision_writes = [item for item in status_writes if "last_trigger_decision" in item]
+    assert len(trigger_decision_writes) == 1
+    assert trigger_decision_writes[0]["terminal_state"] == "WAITING_GREPTILE"
+    assert trigger_decision_writes[0]["triggered_review"]["reason"] == "recently_triggered_for_head"
+
+
+@pytest.mark.asyncio
 async def test_run_guard_once_retriggers_low_confidence_pathless_summary(tmp_path, monkeypatch):
     async def fake_status(**_kwargs):
         return {

--- a/services/zoe-data/tests/test_panel_mcp_tools.py
+++ b/services/zoe-data/tests/test_panel_mcp_tools.py
@@ -351,3 +351,44 @@ async def test_panel_ssh_exec_subprocess_error_returns_tool_error(monkeypatch):
         "error": "SSH exec failed: ssh unavailable",
         "panel_id": "zoe-touch-pi",
     }
+
+
+def test_greptile_trigger_review_schema_exposes_force_flag():
+    tool = _tool("greptile_trigger_review")
+
+    assert tool is not None
+    force = tool["inputSchema"]["properties"].get("force")
+    assert force == {
+        "type": "boolean",
+        "default": False,
+        "description": "Bypass same-head trigger cooldown.",
+    }
+
+
+@pytest.mark.asyncio
+async def test_greptile_trigger_review_uses_guard_dedupe(monkeypatch):
+    calls = []
+
+    async def fake_trigger_review_with_guard_lock(**kwargs):
+        calls.append(kwargs)
+        return {"success": True, "triggered": False, "skipped": True, "reason": "recently_triggered_for_head"}
+
+    monkeypatch.setattr("greploop_guard.trigger_review_with_guard_lock", fake_trigger_review_with_guard_lock)
+
+    result = await mcp_server._execute_tool(
+        db=None,
+        name="greptile_trigger_review",
+        args={"pr_number": 610, "branch": "codex/example", "force": True},
+    )
+
+    assert result["triggered"] is False
+    assert result["reason"] == "recently_triggered_for_head"
+    assert calls == [
+        {
+            "repo": "jason-easyazz/zoe-ai-assistant",
+            "pr_number": 610,
+            "default_branch": "main",
+            "branch": "codex/example",
+            "force": True,
+        }
+    ]


### PR DESCRIPTION
## Summary
- Add a guarded Greptile trigger path that skips duplicate same-head triggers inside a cooldown window.
- Skip manual retriggers while a Greptile review is already running.
- Route both Greploop guard-triggered reviews and the MCP greptile_trigger_review tool through the same guard path.
- Record trigger decisions in Greploop state for auditability.

## Validation
- python3 -m pytest -q services/zoe-data/tests/test_greploop_guard.py services/zoe-data/tests/test_greptile_client.py services/zoe-data/tests/test_panel_mcp_tools.py
- python3 tools/audit/validate_structure.py

## Notes
- Default cooldown is 900 seconds via ZOE_PR_GUARD_TRIGGER_COOLDOWN_SECONDS.
- force=true remains available for explicit operator retriggers.