### PR TITLE
[codex] Dedupe validate workflow triggers

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -2,6 +2,7 @@ name: Validate
 
 on:
   push:
+    branches: [main]
   pull_request:
 
 jobs:


### PR DESCRIPTION
## Summary
- Run the Validate workflow on pull requests and pushes to main only.
- Stop running duplicate validate jobs for every feature branch push before or alongside a PR.

## Validation
- python3 tools/audit/validate_structure.py
- python3 -c/PyYAML parse of .github/workflows/validate.yml
- Confirmed branch push produced no workflow runs for codex/ci-validate-dedupe before PR creation.

## Expected impact
PR updates should get one Validate run from the pull_request event instead of duplicate push + pull_request runs.