### PR TITLE
[codex] Use PR head fallback in Greploop state

### DIFF
--- a/services/zoe-data/greploop_guard.py
+++ b/services/zoe-data/greploop_guard.py
@@ -272,14 +272,24 @@ def _finding_hash(finding: dict[str, Any]) -> str:
     return hashlib.sha256(raw.encode()).hexdigest()[:16]
 
 
-def _packet_for_finding(pr_number: int, status: dict[str, Any], finding: dict[str, Any]) -> GuardPacket:
+def _effective_pr_head_sha(status: dict[str, Any] | None, observation: dict[str, Any] | None = None) -> str | None:
+    return _head_sha_for_trigger(status, observation) or _local_head_sha()
+
+
+def _packet_for_finding(
+    pr_number: int,
+    status: dict[str, Any],
+    finding: dict[str, Any],
+    *,
+    head_sha: str | None = None,
+) -> GuardPacket:
     allowed_file = finding.get("file_path") or ""
     if not allowed_file:
         raise GuardError("BLOCKED_MISSING_CONTEXT: finding has no file path")
     packet = GuardPacket(
         task_type="FIX_GREPTILE_FINDING",
         pr=int(pr_number),
-        head_sha=status.get("headSha") or _local_head_sha(),
+        head_sha=head_sha or _effective_pr_head_sha(status),
         base_branch=DEFAULT_BASE_BRANCH,
         allowed_files=[allowed_file],
         max_files=1,
@@ -1038,6 +1048,7 @@ async def run_guard_once(
         thread_counts = _gh_thread_counts(pr_number, repo=DEFAULT_REPO)
         confidence = _effective_greptile_confidence(pr_number, status, findings, repo=DEFAULT_REPO)
         gh_observation = _gh_pr_observation(pr_number, repo=DEFAULT_REPO)
+        pr_head_sha = _effective_pr_head_sha(status, gh_observation)
         greptile_check_success = _gh_greptile_check_success(gh_observation)
         actionable_findings = _filter_actionable_findings(
             findings,
@@ -1071,7 +1082,7 @@ async def run_guard_once(
             _write_json(pr_number, "status.json", state)
             return {"ok": True, "state": "WAITING_GREPTILE", "greptile": status}
         state["waiting_greptile_count"] = 0
-        progress_key = f"{status.get('headSha')}:{confidence}:{len(actionable_findings)}:{len(findings)}"
+        progress_key = f"{pr_head_sha}:{confidence}:{len(actionable_findings)}:{len(findings)}"
         blocked = _update_circuit_breakers(pr_number, state, progress_key)
         if blocked:
             state["terminal_state"] = blocked
@@ -1107,7 +1118,7 @@ async def run_guard_once(
             state["terminal_state"] = "ESCALATE_HERMES"
             _write_json(pr_number, "status.json", state)
             return {"ok": False, "state": "ESCALATE_HERMES", "finding": finding}
-        packet = _packet_for_finding(pr_number, status, finding)
+        packet = _packet_for_finding(pr_number, status, finding, head_sha=pr_head_sha)
         _write_json(pr_number, "last_packet.json", packet.to_dict())
         _append_progress(pr_number, f"packet {_finding_hash(finding)} for {finding.get('file_path')}")
         if packet_only:

--- a/services/zoe-data/tests/test_greploop_guard.py
+++ b/services/zoe-data/tests/test_greploop_guard.py
@@ -135,6 +135,12 @@ async def test_cheap_runner_blocks_before_budget_exceeded(monkeypatch):
     assert "max_cost_usd=1.0" in output
 
 
+def test_effective_pr_head_sha_returns_none_when_all_sources_missing(monkeypatch):
+    monkeypatch.setattr(greploop_guard, "_local_head_sha", lambda: None)
+
+    assert greploop_guard._effective_pr_head_sha({"headSha": None}, {"ok": False}) is None
+
+
 def test_ci_status_from_rollup_flags_pending_and_failed():
     rollup = [
         {"name": "validate", "status": "IN_PROGRESS", "conclusion": ""},
@@ -747,6 +753,58 @@ async def test_run_guard_once_waits_when_historical_confidence_has_no_completed_
     assert out["state"] == "WAITING_GREPTILE"
     assert out["triggered_review"] == {"triggered": True}
     assert triggered["pr_number"] == 66
+
+@pytest.mark.asyncio
+async def test_run_guard_once_uses_github_head_ref_for_progress_and_packet(tmp_path, monkeypatch):
+    async def fake_status(**_kwargs):
+        return {
+            "confidenceScore": 4,
+            "reviewIsRunning": False,
+            "headSha": None,
+            "reviewCompleteness": "0/1 Greptile comments addressed",
+        }
+
+    async def fake_comments(**_kwargs):
+        return {
+            "findings": [
+                {
+                    "id": "comment-1",
+                    "file_path": "services/zoe-data/example.py",
+                    "line": 42,
+                    "body": "Fix the narrow issue",
+                    "addressed": False,
+                }
+            ]
+        }
+
+    def fail_local_head():
+        raise AssertionError("GitHub headRefOid should be used before local HEAD")
+
+    monkeypatch.setattr(greploop_guard, "STATE_ROOT", tmp_path)
+    monkeypatch.setattr("greptile_client.get_pr_status", fake_status)
+    monkeypatch.setattr("greptile_client.list_pr_comments", fake_comments)
+    monkeypatch.setattr(greploop_guard, "_local_head_sha", fail_local_head)
+    monkeypatch.setattr(
+        greploop_guard,
+        "_gh_pr_observation",
+        lambda pr, repo=greploop_guard.DEFAULT_REPO: {
+            "ok": True,
+            "headRefOid": "github-head-sha",
+            "state": "OPEN",
+            "statusCheckRollup": [],
+        },
+    )
+
+    out = await greploop_guard.run_guard_once(66, packet_only=True)
+
+    assert out["ok"] is True
+    assert out["state"] == "PACKET_READY"
+    assert out["packet"]["head_sha"] == "github-head-sha"
+    state = greploop_guard.read_guard_state(66)
+    assert state["last_progress_key"] == "github-head-sha:4:1:1"
+    packet = json.loads((tmp_path / "pr-66" / "last_packet.json").read_text())
+    assert packet["head_sha"] == "github-head-sha"
+
 
 @pytest.mark.asyncio
 async def test_run_guard_once_suppresses_stale_resolved_github_thread(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- Resolve an effective PR head SHA from Greptile status first, then GitHub headRefOid, before falling back to local HEAD.
- Use that effective PR head in Greploop circuit-breaker progress keys.
- Use that same PR head in cheap-agent repair packets.

## Validation
- python3 -m pytest -q services/zoe-data/tests/test_greploop_guard.py services/zoe-data/tests/test_greptile_client.py services/zoe-data/tests/test_panel_mcp_tools.py
- python3 tools/audit/validate_structure.py

## Why
Greptile often omits headSha. Without the GitHub fallback, Greploop state can record progress keys like None:... and repair packets can fall back to the local checkout SHA instead of the PR head.