### PR TITLE
[codex] Guard cheap repairs by PR checkout

### DIFF
--- a/services/zoe-data/greploop_guard.py
+++ b/services/zoe-data/greploop_guard.py
@@ -364,6 +364,78 @@ def _update_circuit_breakers(pr_number: int, state: dict[str, Any], progress_key
     return None
 
 
+def _current_branch() -> str | None:
+    proc = _run_git(["rev-parse", "--abbrev-ref", "HEAD"], check=False)
+    branch = (proc.stdout or "").strip()
+    return branch or None
+
+
+def _remote_tracking_branch() -> str | None:
+    proc = _run_git(["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"], check=False)
+    branch = (proc.stdout or "").strip()
+    return branch or None
+
+
+def _pr_checkout_observation(pr_number: int, *, repo: str = DEFAULT_REPO) -> dict[str, Any]:
+    proc = _run_gh(
+        [
+            "pr",
+            "view",
+            str(int(pr_number)),
+            "--json",
+            "headRefName,headRefOid,state",
+        ],
+        repo=repo,
+    )
+    if proc.returncode != 0:
+        return {"ok": False, "reason": "GH_PR_VIEW_FAILED", "detail": (proc.stderr or proc.stdout or "").strip()}
+    try:
+        data = _parse_gh_json(proc)
+    except GuardError as exc:
+        return {"ok": False, "reason": "GH_PR_VIEW_INVALID", "detail": str(exc)}
+    return {"ok": True, **data}
+
+
+def verify_pr_checkout_for_repair(packet: GuardPacket, *, repo: str = DEFAULT_REPO) -> dict[str, Any]:
+    branch = _current_branch()
+    local_head = _local_head_sha()
+    upstream = _remote_tracking_branch()
+    observation = _pr_checkout_observation(packet.pr, repo=repo)
+    if not observation.get("ok"):
+        return {**observation, "ok": False, "branch": branch, "local_head": local_head, "upstream": upstream}
+    expected_branch = str(observation.get("headRefName") or "")
+    expected_head = str(observation.get("headRefOid") or "")
+    state = str(observation.get("state") or "").upper()
+    if not expected_branch or not expected_head:
+        return {
+            "ok": False,
+            "reason": "GH_PR_VIEW_INCOMPLETE",
+            "detail": "headRefName or headRefOid missing from GitHub response",
+            "branch": branch,
+            "local_head": local_head,
+        }
+    if state != "OPEN":
+        return {"ok": False, "reason": "PR_NOT_OPEN", "state": state, "branch": branch, "local_head": local_head}
+    if not branch or branch in {"HEAD", DEFAULT_BASE_BRANCH, "main", "master"}:
+        return {"ok": False, "reason": "UNSAFE_BRANCH", "branch": branch, "expected_branch": expected_branch}
+    if expected_branch and branch != expected_branch:
+        return {"ok": False, "reason": "BRANCH_MISMATCH", "branch": branch, "expected_branch": expected_branch}
+    if upstream and expected_branch and upstream != f"origin/{expected_branch}":
+        return {"ok": False, "reason": "UPSTREAM_MISMATCH", "upstream": upstream, "expected_upstream": f"origin/{expected_branch}"}
+    if expected_head and local_head != expected_head:
+        return {"ok": False, "reason": "HEAD_MISMATCH", "local_head": local_head, "expected_head": expected_head}
+    if packet.head_sha and expected_head and packet.head_sha != expected_head:
+        return {"ok": False, "reason": "PACKET_HEAD_MISMATCH", "packet_head": packet.head_sha, "expected_head": expected_head}
+    return {
+        "ok": True,
+        "branch": branch,
+        "local_head": local_head,
+        "expected_branch": expected_branch,
+        "expected_head": expected_head,
+        "upstream": upstream,
+    }
+
+
 async def _record_cost_event(task_id: str | None, estimated_cost_usd: float) -> None:
     if estimated_cost_usd <= 0:
         return
@@ -391,6 +463,9 @@ async def _record_cost_event(task_id: str | None, estimated_cost_usd: float) -> 
 
 
 async def _run_cheap_agent(packet: GuardPacket, *, task_id: str | None = None) -> tuple[str, str]:
+    checkout = verify_pr_checkout_for_repair(packet)
+    if not checkout.get("ok"):
+        return "BLOCKED_WRONG_WORKTREE", json.dumps(redact(checkout), sort_keys=True)
     cmd = os.environ.get("ZOE_CHEAP_PR_AGENT_CMD")
     url = os.environ.get("ZOE_CHEAP_PR_AGENT_URL")
     if not cmd and not url:

--- a/services/zoe-data/tests/test_greploop_guard.py
+++ b/services/zoe-data/tests/test_greploop_guard.py
@@ -128,6 +128,7 @@ async def test_cheap_runner_blocks_before_budget_exceeded(monkeypatch):
     monkeypatch.setenv("ZOE_CHEAP_PR_AGENT_CMD", "false")
     monkeypatch.setenv("ZOE_CHEAP_PR_AGENT_ESTIMATED_COST_USD", "99")
     monkeypatch.setattr(greploop_guard, "MAX_COST_USD", 1.0)
+    monkeypatch.setattr(greploop_guard, "verify_pr_checkout_for_repair", lambda packet: {"ok": True})
 
     status, output = await greploop_guard._run_cheap_agent(_packet())
 
@@ -1125,10 +1126,186 @@ async def test_merge_pr_when_ready_merges_when_assessment_passes(tmp_path, monke
     assert ["pr", "merge", "66", "--squash"] in calls
 
 
+def test_verify_pr_checkout_for_repair_accepts_matching_branch_and_head(monkeypatch):
+    packet = _packet(pr=66, head_sha="head-sha")
+
+    monkeypatch.setattr(greploop_guard, "_current_branch", lambda: "codex/example")
+    monkeypatch.setattr(greploop_guard, "_local_head_sha", lambda: "head-sha")
+    monkeypatch.setattr(greploop_guard, "_remote_tracking_branch", lambda: "origin/codex/example")
+    monkeypatch.setattr(
+        greploop_guard,
+        "_pr_checkout_observation",
+        lambda pr, repo=greploop_guard.DEFAULT_REPO: {
+            "ok": True,
+            "state": "OPEN",
+            "headRefName": "codex/example",
+            "headRefOid": "head-sha",
+        },
+    )
+
+    out = greploop_guard.verify_pr_checkout_for_repair(packet)
+
+    assert out["ok"] is True
+    assert out["branch"] == "codex/example"
+    assert out["expected_head"] == "head-sha"
+
+
+def test_verify_pr_checkout_for_repair_blocks_branch_mismatch(monkeypatch):
+    packet = _packet(pr=66, head_sha="head-sha")
+
+    monkeypatch.setattr(greploop_guard, "_current_branch", lambda: "codex/other")
+    monkeypatch.setattr(greploop_guard, "_local_head_sha", lambda: "head-sha")
+    monkeypatch.setattr(greploop_guard, "_remote_tracking_branch", lambda: "origin/codex/other")
+    monkeypatch.setattr(
+        greploop_guard,
+        "_pr_checkout_observation",
+        lambda pr, repo=greploop_guard.DEFAULT_REPO: {
+            "ok": True,
+            "state": "OPEN",
+            "headRefName": "codex/example",
+            "headRefOid": "head-sha",
+        },
+    )
+
+    out = greploop_guard.verify_pr_checkout_for_repair(packet)
+
+    assert out["ok"] is False
+    assert out["reason"] == "BRANCH_MISMATCH"
+    assert out["branch"] == "codex/other"
+    assert out["expected_branch"] == "codex/example"
+
+
+@pytest.mark.parametrize(
+    "case,branch,local_head,upstream,observation,packet_head,expected",
+    [
+        (
+            "closed_pr",
+            "codex/example",
+            "head-sha",
+            "origin/codex/example",
+            {"ok": True, "state": "MERGED", "headRefName": "codex/example", "headRefOid": "head-sha"},
+            "head-sha",
+            "PR_NOT_OPEN",
+        ),
+        (
+            "unsafe_main",
+            "main",
+            "head-sha",
+            "origin/main",
+            {"ok": True, "state": "OPEN", "headRefName": "codex/example", "headRefOid": "head-sha"},
+            "head-sha",
+            "UNSAFE_BRANCH",
+        ),
+        (
+            "upstream_mismatch",
+            "codex/example",
+            "head-sha",
+            "origin/codex/other",
+            {"ok": True, "state": "OPEN", "headRefName": "codex/example", "headRefOid": "head-sha"},
+            "head-sha",
+            "UPSTREAM_MISMATCH",
+        ),
+        (
+            "gh_lookup_failed",
+            "codex/example",
+            "head-sha",
+            "origin/codex/example",
+            {"ok": False, "reason": "GH_PR_VIEW_FAILED", "detail": "network"},
+            "head-sha",
+            "GH_PR_VIEW_FAILED",
+        ),
+        (
+            "gh_incomplete",
+            "codex/example",
+            "head-sha",
+            "origin/codex/example",
+            {"ok": True, "state": "OPEN", "headRefName": "", "headRefOid": ""},
+            "head-sha",
+            "GH_PR_VIEW_INCOMPLETE",
+        ),
+        (
+            "packet_head_mismatch",
+            "codex/example",
+            "head-sha",
+            "origin/codex/example",
+            {"ok": True, "state": "OPEN", "headRefName": "codex/example", "headRefOid": "head-sha"},
+            "other-packet-sha",
+            "PACKET_HEAD_MISMATCH",
+        ),
+    ],
+)
+def test_verify_pr_checkout_for_repair_blocks_failure_modes(
+    monkeypatch,
+    case,
+    branch,
+    local_head,
+    upstream,
+    observation,
+    packet_head,
+    expected,
+):
+    packet = _packet(pr=66, head_sha=packet_head)
+
+    monkeypatch.setattr(greploop_guard, "_current_branch", lambda: branch)
+    monkeypatch.setattr(greploop_guard, "_local_head_sha", lambda: local_head)
+    monkeypatch.setattr(greploop_guard, "_remote_tracking_branch", lambda: upstream)
+    monkeypatch.setattr(
+        greploop_guard,
+        "_pr_checkout_observation",
+        lambda pr, repo=greploop_guard.DEFAULT_REPO: observation,
+    )
+
+    out = greploop_guard.verify_pr_checkout_for_repair(packet)
+
+    assert out["ok"] is False, case
+    assert out["reason"] == expected
+
+
+def test_verify_pr_checkout_for_repair_blocks_head_mismatch(monkeypatch):
+    packet = _packet(pr=66, head_sha="head-sha")
+
+    monkeypatch.setattr(greploop_guard, "_current_branch", lambda: "codex/example")
+    monkeypatch.setattr(greploop_guard, "_local_head_sha", lambda: "local-old-sha")
+    monkeypatch.setattr(greploop_guard, "_remote_tracking_branch", lambda: "origin/codex/example")
+    monkeypatch.setattr(
+        greploop_guard,
+        "_pr_checkout_observation",
+        lambda pr, repo=greploop_guard.DEFAULT_REPO: {
+            "ok": True,
+            "state": "OPEN",
+            "headRefName": "codex/example",
+            "headRefOid": "head-sha",
+        },
+    )
+
+    out = greploop_guard.verify_pr_checkout_for_repair(packet)
+
+    assert out["ok"] is False
+    assert out["reason"] == "HEAD_MISMATCH"
+    assert out["local_head"] == "local-old-sha"
+    assert out["expected_head"] == "head-sha"
+
+
+@pytest.mark.asyncio
+async def test_cheap_runner_blocks_wrong_worktree_before_command(monkeypatch):
+    monkeypatch.setenv("ZOE_CHEAP_PR_AGENT_CMD", "python3 -c 'raise SystemExit(99)'")
+    monkeypatch.setattr(
+        greploop_guard,
+        "verify_pr_checkout_for_repair",
+        lambda packet: {"ok": False, "reason": "BRANCH_MISMATCH", "branch": "codex/other"},
+    )
+
+    status, output = await greploop_guard._run_cheap_agent(_packet())
+
+    assert status == "BLOCKED_WRONG_WORKTREE"
+    assert "BRANCH_MISMATCH" in output
+
+
 @pytest.mark.asyncio
 async def test_cheap_runner_command_does_not_expand_shell_metacharacters(monkeypatch):
     monkeypatch.setenv("ZOE_CHEAP_PR_AGENT_CMD", "python3 -c 'import sys; sys.stdin.read(); print(\"$HOME\")'")
     monkeypatch.setenv("ZOE_CHEAP_PR_AGENT_ESTIMATED_COST_USD", "0")
+    monkeypatch.setattr(greploop_guard, "verify_pr_checkout_for_repair", lambda packet: {"ok": True})
 
     status, output = await greploop_guard._run_cheap_agent(_packet())
 


### PR DESCRIPTION
## Summary
- Verify the local checkout matches the PR branch before running cheap-agent repair.
- Block repair on unsafe branches, branch mismatch, upstream mismatch, local-head mismatch, packet-head mismatch, closed PRs, or GitHub lookup failure.
- Return BLOCKED_WRONG_WORKTREE before invoking command or URL repair runners.

## Validation
- python3 -m pytest -q services/zoe-data/tests/test_greploop_guard.py services/zoe-data/tests/test_greptile_client.py services/zoe-data/tests/test_panel_mcp_tools.py
- python3 tools/audit/validate_structure.py

## Why
Multiple agents can operate on Zoe at once. Cheap repair must never patch or push from a checkout that does not exactly match the PR it is meant to repair.