### PR TITLE
[codex] Deduplicate Greptile triggers from GitHub state

### DIFF
--- a/services/zoe-data/greploop_guard.py
+++ b/services/zoe-data/greploop_guard.py
@@ -727,6 +727,60 @@ def _gh_greptile_check_success(observation: dict[str, Any]) -> bool:
     return False
 
 
+def _gh_greptile_check_running(observation: dict[str, Any]) -> bool:
+    for check in observation.get("statusCheckRollup") or []:
+        if not isinstance(check, dict):
+            continue
+        if str(check.get("name") or "") != "Greptile Review":
+            continue
+        status = str(check.get("status") or "").upper()
+        conclusion = str(check.get("conclusion") or "").upper()
+        if status in {"IN_PROGRESS", "QUEUED", "PENDING", "REQUESTED"} and not conclusion:
+            return True
+    return False
+
+
+def _github_greptile_trigger_skip(
+    *,
+    pr_number: int,
+    repo: str,
+    observation: dict[str, Any] | None,
+    status: dict[str, Any] | None,
+    head_sha: str | None,
+    target_confidence: int = 5,
+) -> dict[str, Any] | None:
+    if not observation or not observation.get("ok"):
+        return None
+    observed_head = _head_sha_for_trigger(None, observation)
+    if head_sha and observed_head and head_sha != observed_head:
+        return None
+    effective_head = head_sha or observed_head
+    if _gh_greptile_check_running(observation):
+        return {
+            "skipped": True,
+            "reason": "github_greptile_check_running",
+            "github_head_sha": observed_head,
+        }
+    if not _gh_greptile_check_success(observation):
+        return None
+    thread_counts = _gh_thread_counts(pr_number, repo=repo)
+    if not thread_counts.get("ok") or int(thread_counts.get("unresolved") or 0) != 0:
+        return None
+    confidence = int((status or {}).get("confidenceScore") or 0)
+    gh_confidence = _greptile_confidence_from_github_comments(pr_number, repo=repo)
+    if gh_confidence is not None:
+        confidence = max(confidence, gh_confidence)
+    if confidence < int(target_confidence):
+        return None
+    return {
+        "skipped": True,
+        "reason": "github_greptile_review_already_clear",
+        "confidence": confidence,
+        "github_head_sha": effective_head,
+        "unresolved_review_threads": int(thread_counts.get("unresolved") or 0),
+    }
+
+
 def _head_sha_for_trigger(status: dict[str, Any] | None, observation: dict[str, Any] | None) -> str | None:
     if status:
         value = status.get("headSha") or status.get("headRefOid")
@@ -790,19 +844,25 @@ async def trigger_review_safely(
     )
     head_sha = _head_sha_for_trigger(active_status, None)
     now = time.time()
-    skipped = None
-    if not force and active_status and active_status.get("reviewIsRunning"):
-        skipped = _should_skip_greptile_trigger(
-            state=active_state,
+    skipped = _should_skip_greptile_trigger(
+        state=active_state,
+        status=active_status,
+        head_sha=head_sha,
+        now=now,
+        force=force,
+    )
+    observation = None
+    if not skipped and not force:
+        observation = _gh_pr_observation(pr_number, repo=repo)
+        head_sha = _head_sha_for_trigger(active_status, observation)
+        skipped = _github_greptile_trigger_skip(
+            pr_number=pr_number,
+            repo=repo,
+            observation=observation,
             status=active_status,
             head_sha=head_sha,
-            now=now,
-            force=force,
         )
     if not skipped:
-        if not head_sha:
-            observation = _gh_pr_observation(pr_number, repo=repo)
-            head_sha = _head_sha_for_trigger(active_status, observation)
         skipped = _should_skip_greptile_trigger(
             state=active_state,
             status=active_status,

--- a/services/zoe-data/tests/test_greploop_guard.py
+++ b/services/zoe-data/tests/test_greploop_guard.py
@@ -512,6 +512,43 @@ async def test_trigger_review_safely_skips_github_running_same_head(tmp_path, mo
 
 
 @pytest.mark.asyncio
+async def test_trigger_review_safely_triggers_on_github_head_mismatch(tmp_path, monkeypatch):
+    triggered = {}
+
+    async def fake_trigger(**kwargs):
+        triggered.update(kwargs)
+        return {"success": True, "triggered": True}
+
+    monkeypatch.setattr(greploop_guard, "STATE_ROOT", tmp_path)
+    monkeypatch.setattr(greploop_guard.time, "time", lambda: 1_000.0)
+    monkeypatch.setattr("greptile_client.trigger_review", fake_trigger)
+    monkeypatch.setattr(
+        greploop_guard,
+        "_gh_pr_observation",
+        lambda pr, repo=greploop_guard.DEFAULT_REPO: {
+            "ok": True,
+            "headRefOid": "old-sha",
+            "statusCheckRollup": [
+                {"name": "Greptile Review", "status": "IN_PROGRESS", "conclusion": ""},
+            ],
+        },
+    )
+
+    out = await greploop_guard.trigger_review_safely(
+        pr_number=66,
+        status={"headSha": "new-sha", "reviewIsRunning": False},
+        state={"pr": 66},
+        source="test-gh-head-mismatch",
+    )
+
+    assert out == {"success": True, "triggered": True}
+    assert triggered["pr_number"] == 66
+    saved = greploop_guard.read_guard_state(66)
+    assert saved["last_triggered_head_sha"] == "new-sha"
+    assert saved["last_trigger_decision"]["triggered"] is True
+
+
+@pytest.mark.asyncio
 async def test_trigger_review_safely_skips_github_clear_same_head(tmp_path, monkeypatch):
     async def fail_trigger(**_kwargs):
         raise AssertionError("same-head clear GitHub review should not retrigger Greptile")

--- a/services/zoe-data/tests/test_greploop_guard.py
+++ b/services/zoe-data/tests/test_greploop_guard.py
@@ -480,6 +480,81 @@ async def test_trigger_review_safely_skips_running_review(tmp_path, monkeypatch)
 
 
 @pytest.mark.asyncio
+async def test_trigger_review_safely_skips_github_running_same_head(tmp_path, monkeypatch):
+    async def fail_trigger(**_kwargs):
+        raise AssertionError("same-head GitHub running check should not retrigger Greptile")
+
+    monkeypatch.setattr(greploop_guard, "STATE_ROOT", tmp_path)
+    monkeypatch.setattr("greptile_client.trigger_review", fail_trigger)
+    monkeypatch.setattr(
+        greploop_guard,
+        "_gh_pr_observation",
+        lambda pr, repo=greploop_guard.DEFAULT_REPO: {
+            "ok": True,
+            "headRefOid": "abc",
+            "statusCheckRollup": [
+                {"name": "Greptile Review", "status": "IN_PROGRESS", "conclusion": ""},
+            ],
+        },
+    )
+
+    out = await greploop_guard.trigger_review_safely(
+        pr_number=66,
+        status={"headSha": "abc", "reviewIsRunning": False},
+        state={"pr": 66},
+        source="test-gh-running",
+    )
+
+    assert out["triggered"] is False
+    assert out["reason"] == "github_greptile_check_running"
+    saved = greploop_guard.read_guard_state(66)
+    assert saved["last_trigger_decision"]["reason"] == "github_greptile_check_running"
+
+
+@pytest.mark.asyncio
+async def test_trigger_review_safely_skips_github_clear_same_head(tmp_path, monkeypatch):
+    async def fail_trigger(**_kwargs):
+        raise AssertionError("same-head clear GitHub review should not retrigger Greptile")
+
+    monkeypatch.setattr(greploop_guard, "STATE_ROOT", tmp_path)
+    monkeypatch.setattr("greptile_client.trigger_review", fail_trigger)
+    monkeypatch.setattr(
+        greploop_guard,
+        "_gh_pr_observation",
+        lambda pr, repo=greploop_guard.DEFAULT_REPO: {
+            "ok": True,
+            "headRefOid": "abc",
+            "statusCheckRollup": [
+                {"name": "Greptile Review", "status": "COMPLETED", "conclusion": "SUCCESS"},
+            ],
+        },
+    )
+    monkeypatch.setattr(
+        greploop_guard,
+        "_gh_thread_counts",
+        lambda pr, repo=greploop_guard.DEFAULT_REPO: {"ok": True, "unresolved": 0},
+    )
+    monkeypatch.setattr(
+        greploop_guard,
+        "_greptile_confidence_from_github_comments",
+        lambda pr, repo=greploop_guard.DEFAULT_REPO: 5,
+    )
+
+    out = await greploop_guard.trigger_review_safely(
+        pr_number=66,
+        status={"headSha": "abc", "reviewIsRunning": False, "confidenceScore": 0},
+        state={"pr": 66},
+        source="test-gh-clear",
+    )
+
+    assert out["triggered"] is False
+    assert out["reason"] == "github_greptile_review_already_clear"
+    assert out["confidence"] == 5
+    saved = greploop_guard.read_guard_state(66)
+    assert saved["last_trigger_decision"]["reason"] == "github_greptile_review_already_clear"
+
+
+@pytest.mark.asyncio
 async def test_trigger_review_with_guard_lock_reports_lock_contention(tmp_path, monkeypatch):
     async def fail_trigger(**_kwargs):
         raise AssertionError("locked trigger path should not call Greptile")


### PR DESCRIPTION
## Summary\n- skip Greptile trigger when GitHub already shows a same-head Greptile check running\n- skip Greptile trigger when GitHub already shows a same-head successful Greptile review, 5/5 confidence, and no unresolved review threads\n- record skip decisions in the existing guard state path\n\n## Tests\n- python3 -m pytest -q services/zoe-data/tests/test_greploop_guard.py services/zoe-data/tests/test_greptile_client.py services/zoe-data/tests/test_panel_mcp_tools.py\n- python3 tools/audit/validate_structure.py\n