### PR TITLE
[codex] Use elapsed Greptile wait backoff

### DIFF
--- a/services/zoe-data/greploop_guard.py
+++ b/services/zoe-data/greploop_guard.py
@@ -32,6 +32,8 @@ SAME_ERROR_LIMIT = int(os.environ.get("ZOE_PR_GUARD_SAME_ERROR_LIMIT", "3"))
 MAX_COST_USD = float(os.environ.get("ZOE_PR_GUARD_MAX_COST_USD", "0.25"))
 MAX_OUTPUT_CHARS = int(os.environ.get("ZOE_PR_GUARD_MAX_OUTPUT_CHARS", "12000"))
 TRIGGER_COOLDOWN_SECONDS = int(os.environ.get("ZOE_PR_GUARD_TRIGGER_COOLDOWN_SECONDS", "900"))
+GREPTILE_WAIT_TIMEOUT_SECONDS = int(os.environ.get("ZOE_PR_GUARD_GREPTILE_WAIT_TIMEOUT_SECONDS", "1800"))
+GREPTILE_WAIT_POLL_SECONDS = int(os.environ.get("ZOE_PR_GUARD_GREPTILE_WAIT_POLL_SECONDS", "120"))
 
 # Cheap-model repair packets must never merge or bypass hooks; use merge_pr_when_ready().
 FORBIDDEN_ACTIONS = [
@@ -499,6 +501,67 @@ async def _run_cheap_agent(packet: GuardPacket, *, task_id: str | None = None) -
     elapsed = time.time() - start
     await _record_cost_event(task_id, estimated_cost)
     return status, f"elapsed={elapsed:.1f}s estimated_cost_usd={estimated_cost}\n{output}"
+
+
+def _float_state(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _update_greptile_wait_state(
+    state: dict[str, Any],
+    *,
+    now: float,
+    status: dict[str, Any],
+    confidence: int,
+    actionable_count: int,
+    summary_count: int,
+) -> dict[str, Any]:
+    started_at = _float_state(state.get("greptile_wait_started_at"))
+    if started_at <= 0:
+        started_at = now
+        poll_due = True
+    else:
+        poll_due = now >= _float_state(state.get("greptile_next_poll_after"))
+    wait_count = int(state.get("waiting_greptile_count") or 0)
+    if poll_due:
+        wait_count += 1
+        state["greptile_next_poll_after"] = now + max(1, GREPTILE_WAIT_POLL_SECONDS)
+    elif not state.get("greptile_next_poll_after"):
+        state["greptile_next_poll_after"] = now + max(1, GREPTILE_WAIT_POLL_SECONDS)
+    elapsed_seconds = max(0.0, now - started_at)
+    state["greptile_wait_started_at"] = started_at
+    state["greptile_wait_last_seen_at"] = now
+    state["greptile_wait_elapsed_seconds"] = int(elapsed_seconds)
+    state["waiting_greptile_count"] = wait_count
+    state["greptile"] = {
+        "status": status.get("reviewCompleteness") or "review_running",
+        "confidence": confidence,
+        "unaddressed_count": actionable_count,
+        "summary_count": summary_count,
+        "wait_count": wait_count,
+        "wait_elapsed_seconds": int(elapsed_seconds),
+        "next_poll_after": int(_float_state(state.get("greptile_next_poll_after"))),
+    }
+    return {
+        "wait_count": wait_count,
+        "elapsed_seconds": int(elapsed_seconds),
+        "poll_due": poll_due,
+        "stuck": elapsed_seconds >= GREPTILE_WAIT_TIMEOUT_SECONDS,
+    }
+
+
+def _clear_greptile_wait_state(state: dict[str, Any]) -> None:
+    state["waiting_greptile_count"] = 0
+    for key in (
+        "greptile_wait_started_at",
+        "greptile_wait_last_seen_at",
+        "greptile_wait_elapsed_seconds",
+        "greptile_next_poll_after",
+    ):
+        state.pop(key, None)
 
 
 def _run_gh(args: list[str], *, repo: str = DEFAULT_REPO, check: bool = False) -> subprocess.CompletedProcess[str]:
@@ -1200,23 +1263,26 @@ async def run_guard_once(
             and confidence >= int(task.get("target_confidence") or 5)
         )
         if status.get("reviewIsRunning") and not stale_running_review:
-            wait_count = int(state.get("waiting_greptile_count") or 0) + 1
-            state["waiting_greptile_count"] = wait_count
-            state["greptile"] = {
-                "status": status.get("reviewCompleteness") or "review_running",
-                "confidence": confidence,
-                "unaddressed_count": len(actionable_findings),
-                "summary_count": max(0, len(findings) - len(actionable_findings)),
-            }
-            if wait_count > MAX_ITERATIONS:
+            wait = _update_greptile_wait_state(
+                state,
+                now=time.time(),
+                status=status,
+                confidence=confidence,
+                actionable_count=len(actionable_findings),
+                summary_count=max(0, len(findings) - len(actionable_findings)),
+            )
+            if wait["stuck"]:
                 state["terminal_state"] = "BLOCKED_GREPTILE_STUCK"
                 _write_json(pr_number, "status.json", state)
-                _record_guardrail(pr_number, "Greptile review stayed active past wait limit")
-                return {"ok": False, "state": "BLOCKED_GREPTILE_STUCK", "greptile": status}
+                _record_guardrail(
+                    pr_number,
+                    f"Greptile review stayed active for {wait['elapsed_seconds']}s past wait limit",
+                )
+                return {"ok": False, "state": "BLOCKED_GREPTILE_STUCK", "greptile": status, "wait": wait}
             state["terminal_state"] = "WAITING_GREPTILE"
             _write_json(pr_number, "status.json", state)
-            return {"ok": True, "state": "WAITING_GREPTILE", "greptile": status}
-        state["waiting_greptile_count"] = 0
+            return {"ok": True, "state": "WAITING_GREPTILE", "greptile": status, "wait": wait}
+        _clear_greptile_wait_state(state)
         progress_key = f"{pr_head_sha}:{confidence}:{len(actionable_findings)}:{len(findings)}"
         blocked = _update_circuit_breakers(pr_number, state, progress_key)
         if blocked:

--- a/services/zoe-data/greploop_guard.py
+++ b/services/zoe-data/greploop_guard.py
@@ -529,8 +529,6 @@ def _update_greptile_wait_state(
     if poll_due:
         wait_count += 1
         state["greptile_next_poll_after"] = now + max(1, GREPTILE_WAIT_POLL_SECONDS)
-    elif not state.get("greptile_next_poll_after"):
-        state["greptile_next_poll_after"] = now + max(1, GREPTILE_WAIT_POLL_SECONDS)
     elapsed_seconds = max(0.0, now - started_at)
     state["greptile_wait_started_at"] = started_at
     state["greptile_wait_last_seen_at"] = now
@@ -562,6 +560,7 @@ def _clear_greptile_wait_state(state: dict[str, Any]) -> None:
         "greptile_next_poll_after",
     ):
         state.pop(key, None)
+    state.pop("greptile", None)
 
 
 def _run_gh(args: list[str], *, repo: str = DEFAULT_REPO, check: bool = False) -> subprocess.CompletedProcess[str]:

--- a/services/zoe-data/tests/test_greploop_guard.py
+++ b/services/zoe-data/tests/test_greploop_guard.py
@@ -316,6 +316,48 @@ async def test_run_guard_once_active_review_does_not_trip_no_progress(tmp_path, 
 
 
 @pytest.mark.asyncio
+async def test_run_guard_once_active_review_uses_elapsed_poll_windows(tmp_path, monkeypatch):
+    async def fake_status(**_kwargs):
+        return {
+            "confidenceScore": None,
+            "reviewIsRunning": True,
+            "headSha": None,
+            "reviewCompleteness": "No Greptile review comments",
+            "codeReviews": [{"status": "REVIEWING_FILES"}],
+        }
+
+    async def fake_comments(**_kwargs):
+        return {"findings": []}
+
+    now = {"value": 1_000.0}
+    monkeypatch.setattr(greploop_guard, "STATE_ROOT", tmp_path)
+    monkeypatch.setattr(greploop_guard, "GREPTILE_WAIT_TIMEOUT_SECONDS", 600)
+    monkeypatch.setattr(greploop_guard, "GREPTILE_WAIT_POLL_SECONDS", 120)
+    monkeypatch.setattr(greploop_guard.time, "time", lambda: now["value"])
+    monkeypatch.setattr("greptile_client.get_pr_status", fake_status)
+    monkeypatch.setattr("greptile_client.list_pr_comments", fake_comments)
+
+    for timestamp in (1_000.0, 1_001.0, 1_050.0):
+        now["value"] = timestamp
+        out = await greploop_guard.run_guard_once(66)
+        assert out["ok"] is True
+        assert out["state"] == "WAITING_GREPTILE"
+
+    state = greploop_guard.read_guard_state(66)
+    assert state["waiting_greptile_count"] == 1
+    assert state["greptile_wait_started_at"] == 1_000.0
+    assert state["greptile"]["wait_elapsed_seconds"] == 50
+
+    now["value"] = 1_121.0
+    out = await greploop_guard.run_guard_once(66)
+
+    assert out["ok"] is True
+    assert out["wait"]["poll_due"] is True
+    state = greploop_guard.read_guard_state(66)
+    assert state["waiting_greptile_count"] == 2
+
+
+@pytest.mark.asyncio
 async def test_run_guard_once_ignores_pathless_greptile_summary_when_confident(tmp_path, monkeypatch):
     async def fake_status(**_kwargs):
         return {
@@ -1184,16 +1226,24 @@ async def test_run_guard_once_blocks_permanently_active_review(tmp_path, monkeyp
     async def fake_comments(**_kwargs):
         return {"findings": []}
 
+    now = {"value": 1_000.0}
     monkeypatch.setattr(greploop_guard, "STATE_ROOT", tmp_path)
+    monkeypatch.setattr(greploop_guard, "GREPTILE_WAIT_TIMEOUT_SECONDS", 60)
+    monkeypatch.setattr(greploop_guard, "GREPTILE_WAIT_POLL_SECONDS", 10)
+    monkeypatch.setattr(greploop_guard.time, "time", lambda: now["value"])
     monkeypatch.setattr("greptile_client.get_pr_status", fake_status)
     monkeypatch.setattr("greptile_client.list_pr_comments", fake_comments)
 
-    out = {}
-    for _ in range(greploop_guard.MAX_ITERATIONS + 1):
-        out = await greploop_guard.run_guard_once(66)
+    first = await greploop_guard.run_guard_once(66)
+    assert first["ok"] is True
+    assert first["state"] == "WAITING_GREPTILE"
+
+    now["value"] = 1_061.0
+    out = await greploop_guard.run_guard_once(66)
 
     assert out["ok"] is False
     assert out["state"] == "BLOCKED_GREPTILE_STUCK"
+    assert out["wait"]["elapsed_seconds"] == 61
     state = greploop_guard.read_guard_state(66)
     assert state["terminal_state"] == "BLOCKED_GREPTILE_STUCK"
     assert state["no_progress_count"] == 0

--- a/services/zoe-data/tests/test_greploop_guard.py
+++ b/services/zoe-data/tests/test_greploop_guard.py
@@ -255,6 +255,21 @@ async def test_assess_merge_readiness_blocks_low_confidence(monkeypatch):
     assert any("GREPTILE_CONFIDENCE" in b for b in out["blockers"])
 
 
+def test_clear_greptile_wait_state_removes_wait_diagnostics():
+    state = {
+        "waiting_greptile_count": 3,
+        "greptile_wait_started_at": 1_000.0,
+        "greptile_wait_last_seen_at": 1_050.0,
+        "greptile_wait_elapsed_seconds": 50,
+        "greptile_next_poll_after": 1_120.0,
+        "greptile": {"wait_count": 3, "wait_elapsed_seconds": 50},
+    }
+
+    greploop_guard._clear_greptile_wait_state(state)
+
+    assert state == {"waiting_greptile_count": 0}
+
+
 @pytest.mark.asyncio
 async def test_run_guard_once_does_not_retrigger_active_reviewing_files(tmp_path, monkeypatch):
     async def fake_status(**_kwargs):


### PR DESCRIPTION
## Summary\n- track active Greptile review waits by elapsed time and poll windows instead of raw guard invocation count\n- keep wait diagnostics in guard state: started_at, last_seen_at, elapsed seconds, next poll, wait count\n- block stuck reviews only after the configured elapsed timeout\n\n## Tests\n- python3 -m pytest -q services/zoe-data/tests/test_greploop_guard.py services/zoe-data/tests/test_greptile_client.py services/zoe-data/tests/test_panel_mcp_tools.py\n- python3 tools/audit/validate_structure.py\n