### PR TITLE
[codex] Target Greploop repairs to PR worktrees

### DIFF
--- a/scripts/maintenance/run_greploop_guard.sh
+++ b/scripts/maintenance/run_greploop_guard.sh
@@ -2,6 +2,53 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+REPO="${ZOE_GITHUB_REPO:-jason-easyazz/zoe-ai-assistant}"
+
+pr_number=""
+repair_mode=0
+previous=""
+for arg in "$@"; do
+    if [[ "${previous}" == "--pr" ]]; then
+        pr_number="${arg}"
+        previous=""
+        continue
+    fi
+    case "${arg}" in
+        --pr)
+            previous="--pr"
+            ;;
+        --pr=*)
+            pr_number="${arg#--pr=}"
+            ;;
+        --once|--packet-only)
+            repair_mode=1
+            ;;
+    esac
+done
+
+if [[ "${repair_mode}" == "1" && -n "${pr_number}" && "${ZOE_GREPLOOP_SKIP_WORKTREE_SWITCH:-0}" != "1" ]]; then
+    head_branch="$(gh pr view "${pr_number}" --repo "${REPO}" --json headRefName --jq .headRefName 2>/dev/null || true)"
+    current_branch="$(git -C "${ROOT}" branch --show-current 2>/dev/null || true)"
+    if [[ -n "${head_branch}" && "${current_branch}" != "${head_branch}" ]]; then
+        worktree_path="$(git -C "${ROOT}" worktree list --porcelain 2>/dev/null | awk -v branch="branch refs/heads/${head_branch}" '
+            /^worktree / { path = substr($0, 10) }
+            $0 == branch { print path; exit }
+        ')"
+        if [[ -n "${worktree_path}" && -x "${worktree_path}/scripts/maintenance/run_greploop_guard.sh" ]]; then
+            exec "${worktree_path}/scripts/maintenance/run_greploop_guard.sh" "$@"
+        fi
+        cat >&2 <<EOF
+Greploop repair mode must run from the PR branch worktree.
+PR #${pr_number} head branch: ${head_branch}
+Current root: ${ROOT}
+Current branch: ${current_branch:-<detached>}
+No matching worktree was found. Create/check out the PR worktree, then rerun this command.
+Set ZOE_GREPLOOP_SKIP_WORKTREE_SWITCH=1 only for read-only debugging.
+EOF
+        exit 2
+    fi
+fi
+
 USER_SITE="$(python3 -c 'import site; print(site.getusersitepackages())')"
 export PYTHONPATH="${USER_SITE}:${ROOT}/services/zoe-data${PYTHONPATH:+:${PYTHONPATH}}"
 

--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -1137,6 +1137,8 @@ class KanbanAdapter:
             "- Drive the Greptile grep loop with the pinned github-greptile-loop skill (guard REQUIRES --pr N;"
             " <=5 rounds, target confidence 5). Each round:\n"
             "    scripts/maintenance/run_greploop_guard.sh --pr N --once\n"
+            "  Repair-capable modes auto-switch to the matching PR branch worktree when it exists; if"
+            " no matching worktree is found, create/check out that PR worktree before rerunning.\n"
             "  Apply fixes yourself when the guard returns ESCALATE_HERMES or PACKET_READY; use --packet-only"
             " only to hand off to a cheap Cursor runner.\n"
             "  Re-trigger review when needed via"

--- a/services/zoe-data/tests/test_greploop_guard.py
+++ b/services/zoe-data/tests/test_greploop_guard.py
@@ -1,4 +1,7 @@
 import json
+import os
+import subprocess
+from pathlib import Path
 
 import pytest
 
@@ -49,6 +52,75 @@ def _packet(**overrides):
     }
     data.update(overrides)
     return greploop_guard.GuardPacket(**data)
+
+
+def _write_executable(path: Path, body: str) -> None:
+    path.write_text(body)
+    path.chmod(0o755)
+
+
+def test_run_greploop_wrapper_switches_to_matching_pr_worktree(tmp_path):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    fake_worktree = tmp_path / "pr-worktree"
+    fake_worktree.mkdir()
+    target_script = fake_worktree / "scripts" / "maintenance" / "run_greploop_guard.sh"
+    target_script.parent.mkdir(parents=True)
+    _write_executable(target_script, "#!/usr/bin/env bash\necho switched-to-pr-worktree \"$@\"\nexit 43\n")
+    _write_executable(
+        bin_dir / "gh",
+        "#!/usr/bin/env bash\nprintf 'codex/pr-branch\n'\n",
+    )
+    _write_executable(
+        bin_dir / "git",
+        f"#!/usr/bin/env bash\n"
+        f"if [[ \"$*\" == *'branch --show-current'* ]]; then printf 'main\\n'; exit 0; fi\n"
+        f"if [[ \"$*\" == *'worktree list --porcelain'* ]]; then printf 'worktree {fake_worktree}\\nbranch refs/heads/codex/pr-branch\\n'; exit 0; fi\n"
+        f"exit 1\n",
+    )
+    env = {**os.environ, "PATH": f"{bin_dir}:{os.environ['PATH']}"}
+
+    proc = subprocess.run(
+        [str(greploop_guard.REPO_ROOT / "scripts/maintenance/run_greploop_guard.sh"), "--pr", "66", "--once"],
+        cwd=greploop_guard.REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert proc.returncode == 43
+    assert "switched-to-pr-worktree --pr 66 --once" in proc.stdout
+
+
+def test_run_greploop_wrapper_blocks_repair_without_pr_worktree(tmp_path):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_executable(
+        bin_dir / "gh",
+        "#!/usr/bin/env bash\nprintf 'codex/pr-branch\n'\n",
+    )
+    _write_executable(
+        bin_dir / "git",
+        "#!/usr/bin/env bash\n"
+        "if [[ \"$*\" == *'branch --show-current'* ]]; then printf 'main\\n'; exit 0; fi\n"
+        "if [[ \"$*\" == *'worktree list --porcelain'* ]]; then printf 'worktree /tmp/other\\nbranch refs/heads/other\\n'; exit 0; fi\n"
+        "exit 1\n",
+    )
+    env = {**os.environ, "PATH": f"{bin_dir}:{os.environ['PATH']}"}
+
+    proc = subprocess.run(
+        [str(greploop_guard.REPO_ROOT / "scripts/maintenance/run_greploop_guard.sh"), "--pr=66", "--packet-only"],
+        cwd=greploop_guard.REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert proc.returncode == 2
+    assert "Greploop repair mode must run from the PR branch worktree." in proc.stderr
+    assert "PR #66 head branch: codex/pr-branch" in proc.stderr
 
 
 def test_validate_packet_rejects_broad_missing_context():

--- a/services/zoe-data/tests/test_greploop_guard.py
+++ b/services/zoe-data/tests/test_greploop_guard.py
@@ -79,6 +79,7 @@ def test_run_greploop_wrapper_switches_to_matching_pr_worktree(tmp_path):
         f"exit 1\n",
     )
     env = {**os.environ, "PATH": f"{bin_dir}:{os.environ['PATH']}"}
+    env.pop("ZOE_GREPLOOP_SKIP_WORKTREE_SWITCH", None)
 
     proc = subprocess.run(
         [str(greploop_guard.REPO_ROOT / "scripts/maintenance/run_greploop_guard.sh"), "--pr", "66", "--once"],
@@ -108,6 +109,7 @@ def test_run_greploop_wrapper_blocks_repair_without_pr_worktree(tmp_path):
         "exit 1\n",
     )
     env = {**os.environ, "PATH": f"{bin_dir}:{os.environ['PATH']}"}
+    env.pop("ZOE_GREPLOOP_SKIP_WORKTREE_SWITCH", None)
 
     proc = subprocess.run(
         [str(greploop_guard.REPO_ROOT / "scripts/maintenance/run_greploop_guard.sh"), "--pr=66", "--packet-only"],


### PR DESCRIPTION
## Summary\n- auto-switch Greploop repair modes to the matching PR branch worktree when available\n- fail early with a clear message when --once/--packet-only is invoked from the wrong checkout without a matching worktree\n- update closeout instructions so agents know repair-capable modes need the PR worktree\n\n## Tests\n- python3 -m pytest -q services/zoe-data/tests/test_greploop_guard.py services/zoe-data/tests/test_greptile_client.py services/zoe-data/tests/test_panel_mcp_tools.py services/zoe-data/tests/test_kanban_adapter.py\n- bash -n scripts/maintenance/run_greploop_guard.sh\n- python3 tools/audit/validate_structure.py\n