### PR TITLE
[codex] Avoid Greploop worktree discovery SIGPIPE

### DIFF
--- a/scripts/maintenance/run_greploop_guard.sh
+++ b/scripts/maintenance/run_greploop_guard.sh
@@ -32,7 +32,8 @@ if [[ "${repair_mode}" == "1" && -n "${pr_number}" && "${ZOE_GREPLOOP_SKIP_WORKT
     if [[ -n "${head_branch}" && "${current_branch}" != "${head_branch}" ]]; then
         worktree_path="$(git -C "${ROOT}" worktree list --porcelain 2>/dev/null | awk -v branch="branch refs/heads/${head_branch}" '
             /^worktree / { path = substr($0, 10) }
-            $0 == branch { print path; exit }
+            $0 == branch && found == "" { found = path }
+            END { if (found != "") print found }
         ')"
         if [[ -n "${worktree_path}" && -x "${worktree_path}/scripts/maintenance/run_greploop_guard.sh" ]]; then
             exec "${worktree_path}/scripts/maintenance/run_greploop_guard.sh" "$@"

--- a/services/zoe-data/tests/test_greploop_guard.py
+++ b/services/zoe-data/tests/test_greploop_guard.py
@@ -74,8 +74,13 @@ def test_run_greploop_wrapper_switches_to_matching_pr_worktree(tmp_path):
     _write_executable(
         bin_dir / "git",
         f"#!/usr/bin/env bash\n"
+        f"set -euo pipefail\n"
         f"if [[ \"$*\" == *'branch --show-current'* ]]; then printf 'main\\n'; exit 0; fi\n"
-        f"if [[ \"$*\" == *'worktree list --porcelain'* ]]; then printf 'worktree {fake_worktree}\\nbranch refs/heads/codex/pr-branch\\n'; exit 0; fi\n"
+        f"if [[ \"$*\" == *'worktree list --porcelain'* ]]; then\n"
+        f"  printf 'worktree {fake_worktree}\\nbranch refs/heads/codex/pr-branch\\n'\n"
+        f"  for i in $(seq 1 500); do printf 'worktree /tmp/other-%s\\nbranch refs/heads/other-%s\\n' \"$i\" \"$i\"; done\n"
+        f"  exit 0\n"
+        f"fi\n"
         f"exit 1\n",
     )
     env = {**os.environ, "PATH": f"{bin_dir}:{os.environ['PATH']}"}


### PR DESCRIPTION
## Summary\n- avoid early-exit awk in Greploop worktree discovery under set -o pipefail\n- strengthen the wrapper regression so a long worktree list still auto-switches safely\n\n## Tests\n- ZOE_GREPLOOP_SKIP_WORKTREE_SWITCH=1 python3 -m pytest -q services/zoe-data/tests/test_greploop_guard.py services/zoe-data/tests/test_greptile_client.py services/zoe-data/tests/test_panel_mcp_tools.py services/zoe-data/tests/test_kanban_adapter.py\n- bash -n scripts/maintenance/run_greploop_guard.sh\n- python3 tools/audit/validate_structure.py\n