### PR TITLE
[codex] Fetch Greploop review inputs concurrently

### DIFF
--- a/services/zoe-data/greploop_guard.py
+++ b/services/zoe-data/greploop_guard.py
@@ -1097,12 +1097,14 @@ async def assess_merge_readiness(
     from greptile_client import get_pr_status, list_pr_comments
 
     pr_number = int(pr_number)
-    status = await get_pr_status(repo=repo, pr_number=pr_number, default_branch=default_branch)
-    comments = await list_pr_comments(
-        repo=repo,
-        pr_number=pr_number,
-        default_branch=default_branch,
-        unaddressed_only=False,
+    status, comments = await asyncio.gather(
+        get_pr_status(repo=repo, pr_number=pr_number, default_branch=default_branch),
+        list_pr_comments(
+            repo=repo,
+            pr_number=pr_number,
+            default_branch=default_branch,
+            unaddressed_only=False,
+        ),
     )
     findings = comments.get("findings") or []
     thread_counts = _gh_thread_counts(pr_number, repo=repo)
@@ -1239,8 +1241,10 @@ async def run_guard_once(
     task_id = f"pr-{pr_number}"
     with acquire_lock(pr_number):
         state = _load_status(pr_number)
-        status = await get_pr_status(repo=DEFAULT_REPO, pr_number=pr_number, default_branch=DEFAULT_BASE_BRANCH)
-        comments = await list_pr_comments(repo=DEFAULT_REPO, pr_number=pr_number, default_branch=DEFAULT_BASE_BRANCH)
+        status, comments = await asyncio.gather(
+            get_pr_status(repo=DEFAULT_REPO, pr_number=pr_number, default_branch=DEFAULT_BASE_BRANCH),
+            list_pr_comments(repo=DEFAULT_REPO, pr_number=pr_number, default_branch=DEFAULT_BASE_BRANCH),
+        )
         findings = comments.get("findings") or []
         thread_counts = _gh_thread_counts(pr_number, repo=DEFAULT_REPO)
         confidence = _effective_greptile_confidence(pr_number, status, findings, repo=DEFAULT_REPO)

--- a/services/zoe-data/greploop_guard.py
+++ b/services/zoe-data/greploop_guard.py
@@ -1244,7 +1244,12 @@ async def run_guard_once(
         status, comments = await asyncio.gather(
             get_pr_status(repo=DEFAULT_REPO, pr_number=pr_number, default_branch=DEFAULT_BASE_BRANCH),
             list_pr_comments(repo=DEFAULT_REPO, pr_number=pr_number, default_branch=DEFAULT_BASE_BRANCH),
+            return_exceptions=True,
         )
+        if isinstance(status, BaseException):
+            raise status
+        if isinstance(comments, BaseException):
+            raise comments
         findings = comments.get("findings") or []
         thread_counts = _gh_thread_counts(pr_number, repo=DEFAULT_REPO)
         confidence = _effective_greptile_confidence(pr_number, status, findings, repo=DEFAULT_REPO)

--- a/services/zoe-data/greploop_guard.py
+++ b/services/zoe-data/greploop_guard.py
@@ -582,6 +582,14 @@ def _parse_gh_json(proc: subprocess.CompletedProcess[str]) -> dict[str, Any]:
         raise GuardError(f"gh returned non-JSON: {exc}") from exc
 
 
+async def _gather_or_raise(*aws: Any) -> list[Any]:
+    results = await asyncio.gather(*aws, return_exceptions=True)
+    for result in results:
+        if isinstance(result, BaseException):
+            raise result
+    return results
+
+
 _BLOCKED_MERGE_STATE_STATUSES = frozenset({"DIRTY", "UNSTABLE", "BEHIND", "BLOCKED", "UNKNOWN"})
 
 
@@ -1097,7 +1105,7 @@ async def assess_merge_readiness(
     from greptile_client import get_pr_status, list_pr_comments
 
     pr_number = int(pr_number)
-    status, comments = await asyncio.gather(
+    status, comments = await _gather_or_raise(
         get_pr_status(repo=repo, pr_number=pr_number, default_branch=default_branch),
         list_pr_comments(
             repo=repo,
@@ -1241,15 +1249,10 @@ async def run_guard_once(
     task_id = f"pr-{pr_number}"
     with acquire_lock(pr_number):
         state = _load_status(pr_number)
-        status, comments = await asyncio.gather(
+        status, comments = await _gather_or_raise(
             get_pr_status(repo=DEFAULT_REPO, pr_number=pr_number, default_branch=DEFAULT_BASE_BRANCH),
             list_pr_comments(repo=DEFAULT_REPO, pr_number=pr_number, default_branch=DEFAULT_BASE_BRANCH),
-            return_exceptions=True,
         )
-        if isinstance(status, BaseException):
-            raise status
-        if isinstance(comments, BaseException):
-            raise comments
         findings = comments.get("findings") or []
         thread_counts = _gh_thread_counts(pr_number, repo=DEFAULT_REPO)
         confidence = _effective_greptile_confidence(pr_number, status, findings, repo=DEFAULT_REPO)

--- a/services/zoe-data/tests/test_greploop_guard.py
+++ b/services/zoe-data/tests/test_greploop_guard.py
@@ -398,6 +398,24 @@ def test_clear_greptile_wait_state_removes_wait_diagnostics():
 
 
 @pytest.mark.asyncio
+async def test_gather_or_raise_waits_for_all_tasks_before_raising():
+    completed = asyncio.Event()
+
+    async def fail():
+        raise RuntimeError("status failed")
+
+    async def finish():
+        await asyncio.sleep(0)
+        completed.set()
+        return {"findings": []}
+
+    with pytest.raises(RuntimeError, match="status failed"):
+        await greploop_guard._gather_or_raise(fail(), finish())
+
+    assert completed.is_set()
+
+
+@pytest.mark.asyncio
 async def test_run_guard_once_does_not_retrigger_active_reviewing_files(tmp_path, monkeypatch):
     async def fake_status(**_kwargs):
         return {

--- a/services/zoe-data/tests/test_greploop_guard.py
+++ b/services/zoe-data/tests/test_greploop_guard.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import os
 import subprocess
@@ -334,6 +335,53 @@ async def test_assess_merge_readiness_blocks_low_confidence(monkeypatch):
     assert any("GREPTILE_CONFIDENCE" in b for b in out["blockers"])
 
 
+@pytest.mark.asyncio
+async def test_assess_merge_readiness_fetches_greptile_status_and_comments_concurrently(monkeypatch):
+    comments_started = asyncio.Event()
+
+    async def fake_status(**_kwargs):
+        await asyncio.wait_for(comments_started.wait(), timeout=0.5)
+        return {
+            "confidenceScore": 5,
+            "reviewIsRunning": False,
+            "headSha": "abc",
+            "reviewCompleteness": "No Greptile review comments",
+        }
+
+    async def fake_comments(**_kwargs):
+        comments_started.set()
+        await asyncio.sleep(0)
+        return {"findings": []}
+
+    monkeypatch.setattr("greptile_client.get_pr_status", fake_status)
+    monkeypatch.setattr("greptile_client.list_pr_comments", fake_comments)
+    monkeypatch.setattr(
+        greploop_guard,
+        "_gh_pr_observation",
+        lambda *args, **kwargs: {
+            "ok": True,
+            "state": "OPEN",
+            "statusCheckRollup": [
+                {"name": "Greptile Review", "status": "COMPLETED", "conclusion": "SUCCESS"}
+            ],
+        },
+    )
+    monkeypatch.setattr(
+        greploop_guard,
+        "_gh_mergeable_state",
+        lambda pr, repo=greploop_guard.DEFAULT_REPO, observation=None: {
+            "ok": True,
+            "mergeStateStatus": "CLEAN",
+            "ci": {"ok": True, "pending": [], "failures": []},
+        },
+    )
+
+    out = await greploop_guard.assess_merge_readiness(66, target_confidence=5)
+
+    assert out["ready"] is True
+    assert out["blockers"] == []
+
+
 def test_clear_greptile_wait_state_removes_wait_diagnostics():
     state = {
         "waiting_greptile_count": 3,
@@ -378,6 +426,46 @@ async def test_run_guard_once_does_not_retrigger_active_reviewing_files(tmp_path
     state = greploop_guard.read_guard_state(66)
     assert state["terminal_state"] == "WAITING_GREPTILE"
     assert state["iteration"] == 0
+
+
+@pytest.mark.asyncio
+async def test_run_guard_once_fetches_greptile_status_and_comments_concurrently(tmp_path, monkeypatch):
+    comments_started = asyncio.Event()
+
+    async def fake_status(**_kwargs):
+        await asyncio.wait_for(comments_started.wait(), timeout=0.5)
+        return {
+            "confidenceScore": 5,
+            "reviewIsRunning": False,
+            "headSha": "abc",
+            "reviewCompleteness": "No Greptile review comments",
+        }
+
+    async def fake_comments(**_kwargs):
+        comments_started.set()
+        await asyncio.sleep(0)
+        return {"findings": []}
+
+    monkeypatch.setattr(greploop_guard, "STATE_ROOT", tmp_path)
+    monkeypatch.setattr("greptile_client.get_pr_status", fake_status)
+    monkeypatch.setattr("greptile_client.list_pr_comments", fake_comments)
+    monkeypatch.setattr(
+        greploop_guard,
+        "_gh_pr_observation",
+        lambda pr, repo=greploop_guard.DEFAULT_REPO: {
+            "ok": True,
+            "state": "OPEN",
+            "headRefOid": "abc",
+            "statusCheckRollup": [
+                {"name": "Greptile Review", "status": "COMPLETED", "conclusion": "SUCCESS"}
+            ],
+        },
+    )
+
+    out = await greploop_guard.run_guard_once(66)
+
+    assert out["ok"] is True
+    assert out["state"] == "READY_TO_MERGE"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- fetch Greptile PR status and Greptile comments concurrently in `run_guard_once()`
- fetch the same independent inputs concurrently in `assess_merge_readiness()`
- add focused async regressions that fail if those calls become serial again

## Why

Greploop spends time waiting on remote Greptile/GitHub-backed data before it can decide whether to repair, wait, or merge. Status and comment retrieval are independent, so running them serially adds avoidable latency to every guard/readiness cycle.

## Validation

- `python3 -m py_compile services/zoe-data/greploop_guard.py services/zoe-data/tests/test_greploop_guard.py`
- `python3 -m pytest -q services/zoe-data/tests/test_greploop_guard.py`
- `python3 -m pytest -q services/zoe-data/tests/test_greptile_client.py services/zoe-data/tests/test_greploop_guard.py`
- `python3 tools/audit/validate_structure.py`
- `git diff --check`
