### PR TITLE
[codex] Load Greploop wrapper env before PR lookup

### DIFF
--- a/scripts/maintenance/run_greploop_guard.sh
+++ b/scripts/maintenance/run_greploop_guard.sh
@@ -13,6 +13,7 @@ for env_file in "${ROOT}/services/zoe-data/.env" "${ROOT}/.env" "${HOME}/.hermes
     fi
 done
 
+# Use caller's ZOE_GITHUB_REPO if set, otherwise fall back to env file or default
 REPO="${ZOE_GITHUB_REPO:-${REPO}}"
 
 pr_number=""

--- a/scripts/maintenance/run_greploop_guard.sh
+++ b/scripts/maintenance/run_greploop_guard.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 REPO="${ZOE_GITHUB_REPO:-jason-easyazz/zoe-ai-assistant}"
+CALLER_ZOE_GITHUB_REPO="${ZOE_GITHUB_REPO:-}"
 
 for env_file in "${ROOT}/services/zoe-data/.env" "${ROOT}/.env" "${HOME}/.hermes/.env"; do
     if [[ -f "${env_file}" ]]; then
@@ -13,8 +14,7 @@ for env_file in "${ROOT}/services/zoe-data/.env" "${ROOT}/.env" "${HOME}/.hermes
     fi
 done
 
-# Use caller's ZOE_GITHUB_REPO if set, otherwise fall back to env file or default
-REPO="${ZOE_GITHUB_REPO:-${REPO}}"
+REPO="${CALLER_ZOE_GITHUB_REPO:-${ZOE_GITHUB_REPO:-${REPO}}}"
 
 pr_number=""
 repair_mode=0
@@ -50,7 +50,7 @@ EOF
         exit 2
     fi
     current_branch="$(git -C "${ROOT}" branch --show-current 2>/dev/null || true)"
-    if [[ -n "${head_branch}" && "${current_branch}" != "${head_branch}" ]]; then
+    if [[ "${current_branch}" != "${head_branch}" ]]; then
         worktree_path="$(git -C "${ROOT}" worktree list --porcelain 2>/dev/null | awk -v branch="branch refs/heads/${head_branch}" '
             /^worktree / { path = substr($0, 10) }
             $0 == branch && found == "" { found = path }

--- a/scripts/maintenance/run_greploop_guard.sh
+++ b/scripts/maintenance/run_greploop_guard.sh
@@ -4,6 +4,17 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 REPO="${ZOE_GITHUB_REPO:-jason-easyazz/zoe-ai-assistant}"
 
+for env_file in "${ROOT}/services/zoe-data/.env" "${ROOT}/.env" "${HOME}/.hermes/.env"; do
+    if [[ -f "${env_file}" ]]; then
+        set -a
+        # shellcheck disable=SC1090
+        source "${env_file}"
+        set +a
+    fi
+done
+
+REPO="${ZOE_GITHUB_REPO:-${REPO}}"
+
 pr_number=""
 repair_mode=0
 previous=""
@@ -28,6 +39,15 @@ done
 
 if [[ "${repair_mode}" == "1" && -n "${pr_number}" && "${ZOE_GREPLOOP_SKIP_WORKTREE_SWITCH:-0}" != "1" ]]; then
     head_branch="$(gh pr view "${pr_number}" --repo "${REPO}" --json headRefName --jq .headRefName 2>/dev/null || true)"
+    if [[ -z "${head_branch}" ]]; then
+        cat >&2 <<EOF
+Greploop repair mode could not determine the PR head branch.
+PR #${pr_number}
+Repository: ${REPO}
+Set ZOE_GREPLOOP_SKIP_WORKTREE_SWITCH=1 only for read-only debugging.
+EOF
+        exit 2
+    fi
     current_branch="$(git -C "${ROOT}" branch --show-current 2>/dev/null || true)"
     if [[ -n "${head_branch}" && "${current_branch}" != "${head_branch}" ]]; then
         worktree_path="$(git -C "${ROOT}" worktree list --porcelain 2>/dev/null | awk -v branch="branch refs/heads/${head_branch}" '
@@ -52,14 +72,5 @@ fi
 
 USER_SITE="$(python3 -c 'import site; print(site.getusersitepackages())')"
 export PYTHONPATH="${USER_SITE}:${ROOT}/services/zoe-data${PYTHONPATH:+:${PYTHONPATH}}"
-
-for env_file in "${ROOT}/services/zoe-data/.env" "${ROOT}/.env" "${HOME}/.hermes/.env"; do
-    if [[ -f "${env_file}" ]]; then
-        set -a
-        # shellcheck disable=SC1090
-        source "${env_file}"
-        set +a
-    fi
-done
 
 exec python3 "${ROOT}/scripts/maintenance/greploop_guard.py" "$@"

--- a/services/zoe-data/tests/test_greploop_guard.py
+++ b/services/zoe-data/tests/test_greploop_guard.py
@@ -100,6 +100,49 @@ def test_run_greploop_wrapper_switches_to_matching_pr_worktree(tmp_path):
     assert "switched-to-pr-worktree --pr 66 --once" in proc.stdout
 
 
+def test_run_greploop_wrapper_loads_env_before_pr_head_lookup(tmp_path):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    fake_worktree = tmp_path / "pr-worktree"
+    fake_worktree.mkdir()
+    target_script = fake_worktree / "scripts" / "maintenance" / "run_greploop_guard.sh"
+    target_script.parent.mkdir(parents=True)
+    _write_executable(target_script, "#!/usr/bin/env bash\necho env-loaded\nexit 0\n")
+    hermes_env = fake_home / ".hermes" / ".env"
+    hermes_env.parent.mkdir()
+    hermes_env.write_text("ZOE_GITHUB_REPO=example/env-repo\n")
+    _write_executable(
+        bin_dir / "gh",
+        "#!/usr/bin/env bash\n"
+        "if [[ \"$*\" != *'--repo example/env-repo'* ]]; then echo \"$*\" >&2; exit 9; fi\n"
+        "printf 'main\\n'\n",
+    )
+    _write_executable(
+        bin_dir / "git",
+        "#!/usr/bin/env bash\n"
+        "if [[ \"$*\" == *'branch --show-current'* ]]; then printf 'other\\n'; exit 0; fi\n"
+        f"if [[ \"$*\" == *'worktree list --porcelain'* ]]; then printf 'worktree {fake_worktree}\\nbranch refs/heads/main\\n'; exit 0; fi\n"
+        "exit 1\n",
+    )
+    env = {**os.environ, "HOME": str(fake_home), "PATH": f"{bin_dir}:{os.environ['PATH']}"}
+    env.pop("ZOE_GREPLOOP_SKIP_WORKTREE_SWITCH", None)
+    env.pop("ZOE_GITHUB_REPO", None)
+
+    proc = subprocess.run(
+        [str(greploop_guard.REPO_ROOT / "scripts/maintenance/run_greploop_guard.sh"), "--pr", "66", "--packet-only"],
+        cwd=greploop_guard.REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert proc.returncode == 0
+    assert "env-loaded" in proc.stdout
+
+
 def test_run_greploop_wrapper_blocks_repair_without_pr_worktree(tmp_path):
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
@@ -129,6 +172,29 @@ def test_run_greploop_wrapper_blocks_repair_without_pr_worktree(tmp_path):
     assert proc.returncode == 2
     assert "Greploop repair mode must run from the PR branch worktree." in proc.stderr
     assert "PR #66 head branch: codex/pr-branch" in proc.stderr
+
+
+def test_run_greploop_wrapper_blocks_repair_when_pr_head_unknown(tmp_path):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_executable(
+        bin_dir / "gh",
+        "#!/usr/bin/env bash\nexit 1\n",
+    )
+    env = {**os.environ, "PATH": f"{bin_dir}:{os.environ['PATH']}"}
+    env.pop("ZOE_GREPLOOP_SKIP_WORKTREE_SWITCH", None)
+
+    proc = subprocess.run(
+        [str(greploop_guard.REPO_ROOT / "scripts/maintenance/run_greploop_guard.sh"), "--pr", "66", "--once"],
+        cwd=greploop_guard.REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert proc.returncode == 2
+    assert "could not determine the PR head branch" in proc.stderr
 
 
 def test_validate_packet_rejects_broad_missing_context():

--- a/services/zoe-data/tests/test_greploop_guard.py
+++ b/services/zoe-data/tests/test_greploop_guard.py
@@ -143,6 +143,53 @@ def test_run_greploop_wrapper_loads_env_before_pr_head_lookup(tmp_path):
     assert "env-loaded" in proc.stdout
 
 
+def test_run_greploop_wrapper_preserves_caller_repo_over_env_file(tmp_path):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    fake_worktree = tmp_path / "pr-worktree"
+    fake_worktree.mkdir()
+    target_script = fake_worktree / "scripts" / "maintenance" / "run_greploop_guard.sh"
+    target_script.parent.mkdir(parents=True)
+    _write_executable(target_script, "#!/usr/bin/env bash\necho caller-repo-kept\nexit 0\n")
+    hermes_env = fake_home / ".hermes" / ".env"
+    hermes_env.parent.mkdir()
+    hermes_env.write_text("ZOE_GITHUB_REPO=example/env-repo\n")
+    _write_executable(
+        bin_dir / "gh",
+        "#!/usr/bin/env bash\n"
+        "if [[ \"$*\" != *'--repo example/caller-repo'* ]]; then echo \"$*\" >&2; exit 9; fi\n"
+        "printf 'main\\n'\n",
+    )
+    _write_executable(
+        bin_dir / "git",
+        "#!/usr/bin/env bash\n"
+        "if [[ \"$*\" == *'branch --show-current'* ]]; then printf 'other\\n'; exit 0; fi\n"
+        f"if [[ \"$*\" == *'worktree list --porcelain'* ]]; then printf 'worktree {fake_worktree}\\nbranch refs/heads/main\\n'; exit 0; fi\n"
+        "exit 1\n",
+    )
+    env = {
+        **os.environ,
+        "HOME": str(fake_home),
+        "PATH": f"{bin_dir}:{os.environ['PATH']}",
+        "ZOE_GITHUB_REPO": "example/caller-repo",
+    }
+    env.pop("ZOE_GREPLOOP_SKIP_WORKTREE_SWITCH", None)
+
+    proc = subprocess.run(
+        [str(greploop_guard.REPO_ROOT / "scripts/maintenance/run_greploop_guard.sh"), "--pr", "66", "--packet-only"],
+        cwd=greploop_guard.REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert proc.returncode == 0
+    assert "caller-repo-kept" in proc.stdout
+
+
 def test_run_greploop_wrapper_blocks_repair_without_pr_worktree(tmp_path):
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()


### PR DESCRIPTION
## Summary

- load Greploop wrapper env files before `gh pr view` resolves the PR head branch
- fail closed in repair mode when the PR head branch cannot be determined
- add wrapper regressions for env-backed repo lookup and unknown PR head failures

## Why

Multiple agents now rely on `run_greploop_guard.sh --once` / `--packet-only` to target PR worktrees. If the wrapper cannot load GitHub/repo env before the PR lookup, it can skip the switch and fall through into the wrong checkout. Repair mode should stop instead of guessing.

## Validation

- `python3 -m pytest -q services/zoe-data/tests/test_greploop_guard.py`
- `python3 -m pytest -q services/zoe-data/tests/test_greptile_client.py services/zoe-data/tests/test_greploop_guard.py`
- `bash -n scripts/maintenance/run_greploop_guard.sh`
- `python3 -m py_compile services/zoe-data/tests/test_greploop_guard.py`
- `git diff --check`
- `python3 tools/audit/validate_structure.py`
