### PR TITLE
[codex] Strengthen Greploop resolved finding matching

### DIFF
--- a/services/zoe-data/greploop_guard.py
+++ b/services/zoe-data/greploop_guard.py
@@ -624,11 +624,35 @@ def _actionable_greptile_findings(findings: list[dict[str, Any]]) -> list[dict[s
     return [f for f in findings if (f.get("file_path") or "").strip()]
 
 
+def _comment_title(body: Any) -> str:
+    return " ".join(str(body or "").split())[:120]
+
+
+def _comment_identity_keys(comment: dict[str, Any], *, file_path_key: str = "path") -> list[tuple[str, str]]:
+    path = str(comment.get(file_path_key) or "")
+    title = _comment_title(comment.get("body"))
+    keys: list[tuple[str, str]] = []
+    for key_name in ("url", "id"):
+        value = str(comment.get(key_name) or "")
+        if value:
+            keys.append((key_name, value))
+    line = comment.get("line")
+    if path and line not in (None, ""):
+        keys.append(("path_line_title", f"{path}:{line}:{title}"))
+    if path:
+        keys.append(("path_title", f"{path}:{title}"))
+    return keys
+
+
+def _finding_thread_keys(finding: dict[str, Any]) -> list[tuple[str, str]]:
+    return _comment_identity_keys(finding, file_path_key="file_path")
+
+
 def _finding_thread_key(finding: dict[str, Any]) -> tuple[str, str]:
+    """Compatibility key for older tests/callers; prefer _finding_thread_keys()."""
     path = str(finding.get("file_path") or "")
-    body = str(finding.get("body") or "")
-    title = " ".join(body.split())[:120]
-    return (path, title)
+    title = _comment_title(finding.get("body"))
+    return ("path_title", f"{path}:{title}")
 
 
 def _gh_pr_review_threads(pr_number: int, *, repo: str = DEFAULT_REPO) -> list[dict[str, Any]] | None:
@@ -641,14 +665,14 @@ def _gh_pr_review_threads(pr_number: int, *, repo: str = DEFAULT_REPO) -> list[d
         "repository(owner:$owner,name:$repo){pullRequest(number:$pr){"
         "reviewThreads(first:100){"
         "pageInfo{hasNextPage endCursor}"
-        "nodes{isResolved comments(first:20){nodes{author{login} path line body url}}}}}}}"
+        "nodes{isResolved comments(first:20){nodes{id author{login} path line body url}}}}}}}"
     )
     query_next = (
         "query($owner:String!,$repo:String!,$pr:Int!,$after:String!){"
         "repository(owner:$owner,name:$repo){pullRequest(number:$pr){"
         "reviewThreads(first:100,after:$after){"
         "pageInfo{hasNextPage endCursor}"
-        "nodes{isResolved comments(first:20){nodes{author{login} path line body url}}}}}}}"
+        "nodes{isResolved comments(first:20){nodes{id author{login} path line body url}}}}}}}"
     )
     threads: list[dict[str, Any]] = []
     after: str | None = None
@@ -712,9 +736,7 @@ def _gh_thread_counts(pr_number: int, *, repo: str = DEFAULT_REPO) -> dict[str, 
             unresolved += 1
             continue
         for comment in greptile_comments:
-            body = str(comment.get("body") or "")
-            title = " ".join(body.split())[:120]
-            resolved_greptile_keys.append((str(comment.get("path") or ""), title))
+            resolved_greptile_keys.extend(_comment_identity_keys(comment, file_path_key="path"))
     return {
         "ok": True,
         "unresolved": unresolved,
@@ -741,7 +763,17 @@ def _filter_actionable_findings(
     resolved_keys = set(counts.get("resolved_greptile_keys") or [])
     if not resolved_keys:
         return actionable
-    return [finding for finding in actionable if _finding_thread_key(finding) not in resolved_keys]
+    allow_legacy_match = int(counts.get("unresolved") or 0) == 0
+    filtered: list[dict[str, Any]] = []
+    for finding in actionable:
+        keys = _finding_thread_keys(finding)
+        strong_keys = [key for key in keys if key[0] != "path_title"]
+        if any(key in resolved_keys for key in strong_keys):
+            continue
+        if allow_legacy_match and any(key in resolved_keys for key in keys):
+            continue
+        filtered.append(finding)
+    return filtered
 
 
 def _effective_greptile_confidence(

--- a/services/zoe-data/greploop_guard.py
+++ b/services/zoe-data/greploop_guard.py
@@ -722,6 +722,7 @@ def _gh_thread_counts(pr_number: int, *, repo: str = DEFAULT_REPO) -> dict[str, 
         return {"ok": False, "unresolved": -1, "resolved_greptile_keys": []}
     resolved_greptile_keys: list[tuple[str, str]] = []
     unresolved = 0
+    unresolved_greptile_threads = 0
     greptile_thread_count = 0
     for thread in threads:
         comments = ((thread.get("comments") or {}).get("nodes") or [])
@@ -734,12 +735,15 @@ def _gh_thread_counts(pr_number: int, *, repo: str = DEFAULT_REPO) -> dict[str, 
             greptile_thread_count += 1
         if not thread.get("isResolved"):
             unresolved += 1
+            if greptile_comments:
+                unresolved_greptile_threads += 1
             continue
         for comment in greptile_comments:
             resolved_greptile_keys.extend(_comment_identity_keys(comment, file_path_key="path"))
     return {
         "ok": True,
         "unresolved": unresolved,
+        "unresolved_greptile_threads": unresolved_greptile_threads,
         "thread_count": len(threads),
         "greptile_thread_count": greptile_thread_count,
         "resolved_greptile_keys": resolved_greptile_keys,
@@ -763,7 +767,8 @@ def _filter_actionable_findings(
     resolved_keys = set(counts.get("resolved_greptile_keys") or [])
     if not resolved_keys:
         return actionable
-    allow_legacy_match = int(counts.get("unresolved") or 0) == 0
+    unresolved_greptile_threads = counts.get("unresolved_greptile_threads", counts.get("unresolved"))
+    allow_legacy_match = int(unresolved_greptile_threads or 0) == 0
     filtered: list[dict[str, Any]] = []
     for finding in actionable:
         keys = _finding_thread_keys(finding)

--- a/services/zoe-data/tests/test_greploop_guard.py
+++ b/services/zoe-data/tests/test_greploop_guard.py
@@ -1174,7 +1174,7 @@ def test_filter_actionable_findings_requires_completed_check_for_zero_unresolved
     assert cleared == []
 
 
-def test_filter_actionable_findings_ignores_line_for_resolved_thread_match():
+def test_filter_actionable_findings_allows_legacy_match_when_no_unresolved_threads():
     body = "Resolved multi-line Greptile body"
     findings = [
         {
@@ -1191,8 +1191,61 @@ def test_filter_actionable_findings_ignores_line_for_resolved_thread_match():
         pr_number=66,
         thread_counts={
             "ok": True,
+            "unresolved": 0,
+            "resolved_greptile_keys": [("path_title", f"services/zoe-data/example.py:{body}")],
+        },
+    )
+
+    assert out == []
+
+
+def test_filter_actionable_findings_keeps_new_line_when_unresolved_threads_exist():
+    body = "Resolved multi-line Greptile body"
+    findings = [
+        {
+            "id": "comment-new",
+            "file_path": "services/zoe-data/example.py",
+            "line": 99,
+            "body": body,
+            "addressed": False,
+        }
+    ]
+
+    out = greploop_guard._filter_actionable_findings(
+        findings,
+        pr_number=66,
+        thread_counts={
+            "ok": True,
             "unresolved": 1,
-            "resolved_greptile_keys": [("services/zoe-data/example.py", body)],
+            "resolved_greptile_keys": [
+                ("path_line_title", f"services/zoe-data/example.py:10:{body}"),
+                ("path_title", f"services/zoe-data/example.py:{body}"),
+            ],
+        },
+    )
+
+    assert out == findings
+
+
+def test_filter_actionable_findings_matches_resolved_comment_url():
+    findings = [
+        {
+            "id": "comment-new",
+            "url": "https://github.example/review/comment/1",
+            "file_path": "services/zoe-data/example.py",
+            "line": 99,
+            "body": "Resolved via exact URL",
+            "addressed": False,
+        }
+    ]
+
+    out = greploop_guard._filter_actionable_findings(
+        findings,
+        pr_number=66,
+        thread_counts={
+            "ok": True,
+            "unresolved": 1,
+            "resolved_greptile_keys": [("url", "https://github.example/review/comment/1")],
         },
     )
 

--- a/services/zoe-data/tests/test_greploop_guard.py
+++ b/services/zoe-data/tests/test_greploop_guard.py
@@ -1252,6 +1252,31 @@ def test_filter_actionable_findings_matches_resolved_comment_url():
     assert out == []
 
 
+def test_filter_actionable_findings_matches_resolved_comment_id():
+    findings = [
+        {
+            "id": "PRRC_abc123",
+            "url": "https://github.example/review/comment/2",
+            "file_path": "services/zoe-data/example.py",
+            "line": 99,
+            "body": "Resolved via exact ID",
+            "addressed": False,
+        }
+    ]
+
+    out = greploop_guard._filter_actionable_findings(
+        findings,
+        pr_number=66,
+        thread_counts={
+            "ok": True,
+            "unresolved": 1,
+            "resolved_greptile_keys": [("id", "PRRC_abc123")],
+        },
+    )
+
+    assert out == []
+
+
 @pytest.mark.asyncio
 async def test_run_guard_once_uses_github_summary_confidence_without_retrigger(tmp_path, monkeypatch):
     async def fake_status(**_kwargs):

--- a/services/zoe-data/tests/test_greploop_guard.py
+++ b/services/zoe-data/tests/test_greploop_guard.py
@@ -1556,7 +1556,7 @@ async def test_run_guard_once_suppresses_stale_resolved_github_thread(tmp_path, 
         lambda pr, repo=greploop_guard.DEFAULT_REPO: {
             "ok": True,
             "unresolved": 0,
-            "resolved_greptile_keys": [("services/zoe-data/example.py", body)],
+            "resolved_greptile_keys": [("path_title", f"services/zoe-data/example.py:{body}")],
         },
     )
     monkeypatch.setattr(
@@ -1612,7 +1612,7 @@ async def test_assess_merge_readiness_ignores_mcp_comment_when_thread_resolved(m
         lambda pr, repo=greploop_guard.DEFAULT_REPO: {
             "ok": True,
             "unresolved": 0,
-            "resolved_greptile_keys": [("services/zoe-data/example.py", body)],
+            "resolved_greptile_keys": [("path_title", f"services/zoe-data/example.py:{body}")],
         },
     )
     monkeypatch.setattr(

--- a/services/zoe-data/tests/test_greploop_guard.py
+++ b/services/zoe-data/tests/test_greploop_guard.py
@@ -8,6 +8,8 @@ import pytest
 
 import greploop_guard
 
+_ORIGINAL_GH_THREAD_COUNTS = greploop_guard._gh_thread_counts
+
 
 @pytest.fixture(autouse=True)
 def _default_github_helpers(monkeypatch):
@@ -418,6 +420,54 @@ def test_gh_mergeable_state_blocks_conflicting_mergeable(monkeypatch):
 
     assert out["ok"] is False
     assert out["reason"] == "GH_NOT_MERGEABLE"
+
+
+def test_gh_thread_counts_tracks_unresolved_greptile_threads_separately(monkeypatch):
+    monkeypatch.setattr(
+        greploop_guard,
+        "_gh_pr_review_threads",
+        lambda pr, repo=greploop_guard.DEFAULT_REPO: [
+            {
+                "isResolved": False,
+                "comments": {
+                    "nodes": [
+                        {"author": {"login": "human-reviewer"}, "path": "a.py", "body": "human thread"}
+                    ]
+                },
+            },
+            {
+                "isResolved": False,
+                "comments": {
+                    "nodes": [
+                        {"author": {"login": "greptile-apps"}, "path": "b.py", "body": "greptile thread"}
+                    ]
+                },
+            },
+            {
+                "isResolved": True,
+                "comments": {
+                    "nodes": [
+                        {
+                            "id": "PRRC_resolved",
+                            "author": {"login": "greptile-apps"},
+                            "path": "c.py",
+                            "line": 12,
+                            "body": "resolved greptile thread",
+                            "url": "https://github.example/comment/3",
+                        }
+                    ]
+                },
+            },
+        ],
+    )
+
+    out = _ORIGINAL_GH_THREAD_COUNTS(66)
+
+    assert out["unresolved"] == 2
+    assert out["unresolved_greptile_threads"] == 1
+    assert out["greptile_thread_count"] == 2
+    assert ("id", "PRRC_resolved") in out["resolved_greptile_keys"]
+    assert ("url", "https://github.example/comment/3") in out["resolved_greptile_keys"]
 
 
 @pytest.mark.asyncio
@@ -1199,6 +1249,32 @@ def test_filter_actionable_findings_allows_legacy_match_when_no_unresolved_threa
     assert out == []
 
 
+def test_filter_actionable_findings_allows_legacy_match_with_only_human_threads_open():
+    body = "Resolved Greptile body while human thread remains open"
+    findings = [
+        {
+            "id": "comment-1",
+            "file_path": "services/zoe-data/example.py",
+            "line": 10,
+            "body": body,
+            "addressed": False,
+        }
+    ]
+
+    out = greploop_guard._filter_actionable_findings(
+        findings,
+        pr_number=66,
+        thread_counts={
+            "ok": True,
+            "unresolved": 1,
+            "unresolved_greptile_threads": 0,
+            "resolved_greptile_keys": [("path_title", f"services/zoe-data/example.py:{body}")],
+        },
+    )
+
+    assert out == []
+
+
 def test_filter_actionable_findings_keeps_new_line_when_unresolved_threads_exist():
     body = "Resolved multi-line Greptile body"
     findings = [
@@ -1217,6 +1293,7 @@ def test_filter_actionable_findings_keeps_new_line_when_unresolved_threads_exist
         thread_counts={
             "ok": True,
             "unresolved": 1,
+            "unresolved_greptile_threads": 1,
             "resolved_greptile_keys": [
                 ("path_line_title", f"services/zoe-data/example.py:10:{body}"),
                 ("path_title", f"services/zoe-data/example.py:{body}"),


### PR DESCRIPTION
## Summary

- strengthen resolved Greptile comment matching with URL, ID, and path+line+title keys
- keep legacy path+title fallback only when GitHub reports zero unresolved review threads
- request review comment IDs from GitHub GraphQL
- add regressions for safe legacy matching, same-body/new-line protection, and exact URL matching

## Why

The previous matching used only `(path, first 120 body chars)`. That could suppress a new Greptile finding when an older resolved thread had the same file and leading text. This keeps the useful resolved-thread suppression while avoiding accidental hiding when unresolved threads still exist.

## Validation

- `python3 -m py_compile services/zoe-data/greploop_guard.py services/zoe-data/tests/test_greploop_guard.py`
- `python3 -m pytest -q services/zoe-data/tests/test_greploop_guard.py`
- `python3 -m pytest -q services/zoe-data/tests/test_greptile_client.py services/zoe-data/tests/test_greploop_guard.py`
- `python3 tools/audit/validate_structure.py`
- `git diff --check`
