### PR TITLE
[codex] Add Pi readiness report CLI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Install / refresh Python deps
         run: |
           pip3 install --quiet --user \
-            "apscheduler==3.10.4" "sqlalchemy>=2.0,<3.0" \
+            "apscheduler==3.10.4" "tzlocal>=2,<3" "sqlalchemy>=2.0,<3.0" \
             alembic asyncpg psycopg2-binary pywebpush py-vapid
 
       - name: Apply database migrations

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -44,7 +44,7 @@ jobs:
         run: |
           pip install --quiet \
             aiosqlite asyncpg psycopg2-binary alembic \
-            fastapi "httpx>=0.27.0,<0.28" "apscheduler==3.10.4" "sqlalchemy>=2.0,<3.0" \
+            fastapi "httpx>=0.27.0,<0.28" "apscheduler==3.10.4" "tzlocal>=2,<3" "sqlalchemy>=2.0,<3.0" \
             pydantic pywebpush py-vapid cryptography \
             "ag-ui-protocol==0.1.14" websockets python-jose passlib \
             python-multipart uvicorn prometheus-client "python-json-logger>=4.1.0"

--- a/scripts/maintenance/pi_readiness_report.py
+++ b/scripts/maintenance/pi_readiness_report.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Print Zoe's current Pi hybrid promotion readiness report."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "services" / "zoe-data"))
+
+from pi_readiness_report import pi_readiness_report  # noqa: E402
+
+_BLOCKED_STATES = {"configuration_blocked", "rollback_required"}
+
+
+def _compact_summary(report: dict) -> dict:
+    summary = dict(report.get("summary") or {})
+    return {
+        "report_kind": report.get("report_kind"),
+        "state": report.get("state"),
+        "summary": summary,
+        "next_actions": list(report.get("next_actions") or []),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Print Zoe Pi readiness JSON without side effects")
+    parser.add_argument("--output", "-o", help="Optional JSON output path; defaults to stdout")
+    parser.add_argument("--summary", action="store_true", help="Print compact summary JSON instead of the full report")
+    parser.add_argument(
+        "--fail-when-blocked",
+        action="store_true",
+        help="Exit non-zero when the report says configuration is blocked or rollback is required",
+    )
+    args = parser.parse_args(argv)
+
+    report = pi_readiness_report()
+    payload = _compact_summary(report) if args.summary else report
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        target = Path(args.output)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(text, encoding="utf-8")
+    else:
+        sys.stdout.write(text)
+
+    if args.fail_when_blocked and str(report.get("state")) in _BLOCKED_STATES:
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/zoe-data/tests/test_pi_readiness_report_cli.py
+++ b/services/zoe-data/tests/test_pi_readiness_report_cli.py
@@ -1,0 +1,84 @@
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+
+def _load_module():
+    path = Path(__file__).resolve().parents[3] / "scripts" / "maintenance" / "pi_readiness_report.py"
+    spec = importlib.util.spec_from_file_location("pi_readiness_report_cli_test", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    old_path = list(sys.path)
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.path[:] = old_path
+    return module
+
+
+def _report(state="shadow_collecting"):
+    return {
+        "report_kind": "zoe_pi_readiness_report",
+        "state": state,
+        "summary": {
+            "state": state,
+            "ready": state != "configuration_blocked",
+            "promotion_ready_groups": [],
+        },
+        "hybrid": {"ready": state != "configuration_blocked"},
+        "evidence": {"labeled_sample_count": 4},
+        "next_actions": [
+            {
+                "kind": "continue_shadow_mode",
+                "priority": "p2",
+                "detail": "Keep Pi in shadow mode.",
+            }
+        ],
+    }
+
+
+def test_cli_prints_full_report_json(monkeypatch, capsys):
+    module = _load_module()
+    monkeypatch.setattr(module, "pi_readiness_report", lambda: _report())
+
+    exit_code = module.main([])
+
+    payload = json.loads(capsys.readouterr().out)
+    assert exit_code == 0
+    assert payload["report_kind"] == "zoe_pi_readiness_report"
+    assert payload["state"] == "shadow_collecting"
+    assert payload["evidence"] == {"labeled_sample_count": 4}
+
+
+def test_cli_can_write_compact_summary_to_file(monkeypatch, tmp_path, capsys):
+    module = _load_module()
+    output_path = tmp_path / "reports" / "pi-readiness.json"
+    monkeypatch.setattr(module, "pi_readiness_report", lambda: _report("promotion_apply_ready"))
+
+    exit_code = module.main(["--summary", "--output", str(output_path)])
+
+    assert exit_code == 0
+    assert capsys.readouterr().out == ""
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+    assert payload == {
+        "report_kind": "zoe_pi_readiness_report",
+        "state": "promotion_apply_ready",
+        "summary": {
+            "state": "promotion_apply_ready",
+            "ready": True,
+            "promotion_ready_groups": [],
+        },
+        "next_actions": _report("promotion_apply_ready")["next_actions"],
+    }
+
+
+def test_cli_fail_when_blocked_exits_nonzero_only_for_blocked_states(monkeypatch):
+    module = _load_module()
+    monkeypatch.setattr(module, "pi_readiness_report", lambda: _report("configuration_blocked"))
+    assert module.main(["--fail-when-blocked"]) == 2
+
+    monkeypatch.setattr(module, "pi_readiness_report", lambda: _report("rollback_required"))
+    assert module.main(["--fail-when-blocked"]) == 2
+
+    monkeypatch.setattr(module, "pi_readiness_report", lambda: _report("collect_more_evidence"))


### PR DESCRIPTION
## Summary

- Add `scripts/maintenance/pi_readiness_report.py` so operators can print or write Zoe's Pi hybrid promotion readiness report without side effects.
- Support compact `--summary`, `--output`, and `--fail-when-blocked` modes for repeatable local evidence and CI/operator gates.
- Add focused CLI tests with a stubbed report generator.
- Pin `tzlocal>=2,<3` in CI/deploy dependency installs so APScheduler-backed proactive imports work in Validate.

## Why

The Pi promotion work needs a repeatable command that answers the current state clearly: whether Pi is blocked, collecting evidence, ready for promotion, or needs rollback. This keeps the Pi-as-core evaluation grounded in speed/accuracy evidence instead of manual Python snippets.

The CI dependency pin closes an existing Validate failure where `test_multica_poll_dispatch` imported APScheduler and the runner did not have `tzlocal` available.

## Validation

- `python3 -m pytest -q services/zoe-data/tests/test_pi_readiness_report.py services/zoe-data/tests/test_pi_readiness_report_cli.py` -> 7 passed
- `python3 -m pytest -q services/zoe-data/tests/test_multica_poll_dispatch.py::test_resolve_chain_for_dispatch_repolls_only_on_sentinel services/zoe-data/tests/test_pi_readiness_report.py services/zoe-data/tests/test_pi_readiness_report_cli.py` -> 8 passed
- `python3 -m pytest -q services/zoe-data/tests/test_pi_intent_classifier.py services/zoe-data/tests/test_pi_intent_shadow.py services/zoe-data/tests/test_pi_readiness_report.py services/zoe-data/tests/test_pi_readiness_report_cli.py services/zoe-data/tests/test_pi_hybrid_flow_benchmark.py services/zoe-data/tests/test_pi_hybrid_stream_http_probe.py services/zoe-data/tests/test_voice_pi_flow_comparison.py services/zoe-data/tests/test_zoe_pi_promotion.py` -> 144 passed
- `python3 -m py_compile scripts/maintenance/pi_readiness_report.py services/zoe-data/pi_readiness_report.py`
- `python3 tools/audit/validate_structure.py`
- `python3 scripts/maintenance/pi_readiness_report.py --summary`
- `python3 scripts/maintenance/pi_readiness_report.py --fail-when-blocked` currently exits 2 because the live report is `configuration_blocked`.