### PR TITLE
[codex] Load Zoe env for Pi readiness reports

### DIFF
--- a/scripts/maintenance/pi_readiness_report.py
+++ b/scripts/maintenance/pi_readiness_report.py
@@ -5,15 +5,55 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
+import shlex
 import sys
 from pathlib import Path
+from typing import Iterable
 
 ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT / "services" / "zoe-data"))
 
 from pi_readiness_report import pi_readiness_report  # noqa: E402
 
+DEFAULT_ENV_FILES = (
+    ROOT / ".env",
+    ROOT / "services" / "zoe-data" / ".env",
+    Path("/home/zoe/assistant/.env"),
+    Path("/home/zoe/assistant/services/zoe-data/.env"),
+)
 _BLOCKED_STATES = {"configuration_blocked", "rollback_required"}
+
+
+def load_zoe_env(env_files: Iterable[str | Path] = DEFAULT_ENV_FILES) -> dict[str, str]:
+    """Load Zoe env files for operator reports without mutating os.environ."""
+    values: dict[str, str] = {}
+    for env_file in env_files:
+        path = Path(env_file).expanduser()
+        if path.exists():
+            values.update(_parse_env_file(path))
+    values.update(os.environ)
+    return values
+
+
+def _parse_env_file(path: Path) -> dict[str, str]:
+    parsed: dict[str, str] = {}
+    for raw_line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, raw_value = line.split("=", 1)
+        key = key.strip()
+        if key.startswith("export "):
+            key = key[len("export ") :].strip()
+        if not key or key.startswith("#"):
+            continue
+        try:
+            parts = shlex.split(raw_value, comments=True, posix=True)
+        except ValueError:
+            parts = [raw_value.strip().strip("\"").strip("'")]
+        parsed[key] = parts[0] if parts else ""
+    return parsed
 
 
 def _compact_summary(report: dict) -> dict:
@@ -35,9 +75,16 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Exit non-zero when the report says configuration is blocked or rollback is required",
     )
+    parser.add_argument(
+        "--env-file",
+        action="append",
+        default=None,
+        help="Additional env file to load after Zoe defaults; may be repeated",
+    )
     args = parser.parse_args(argv)
 
-    report = pi_readiness_report()
+    env_files = [*DEFAULT_ENV_FILES, *(args.env_file or [])]
+    report = pi_readiness_report(load_zoe_env(env_files))
     payload = _compact_summary(report) if args.summary else report
     text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
     if args.output:

--- a/services/zoe-data/tests/test_pi_readiness_report_cli.py
+++ b/services/zoe-data/tests/test_pi_readiness_report_cli.py
@@ -40,7 +40,7 @@ def _report(state="shadow_collecting"):
 
 def test_cli_prints_full_report_json(monkeypatch, capsys):
     module = _load_module()
-    monkeypatch.setattr(module, "pi_readiness_report", lambda: _report())
+    monkeypatch.setattr(module, "pi_readiness_report", lambda _env=None: _report())
 
     exit_code = module.main([])
 
@@ -54,7 +54,7 @@ def test_cli_prints_full_report_json(monkeypatch, capsys):
 def test_cli_can_write_compact_summary_to_file(monkeypatch, tmp_path, capsys):
     module = _load_module()
     output_path = tmp_path / "reports" / "pi-readiness.json"
-    monkeypatch.setattr(module, "pi_readiness_report", lambda: _report("promotion_apply_ready"))
+    monkeypatch.setattr(module, "pi_readiness_report", lambda _env=None: _report("promotion_apply_ready"))
 
     exit_code = module.main(["--summary", "--output", str(output_path)])
 
@@ -75,10 +75,54 @@ def test_cli_can_write_compact_summary_to_file(monkeypatch, tmp_path, capsys):
 
 def test_cli_fail_when_blocked_exits_nonzero_only_for_blocked_states(monkeypatch):
     module = _load_module()
-    monkeypatch.setattr(module, "pi_readiness_report", lambda: _report("configuration_blocked"))
+    monkeypatch.setattr(module, "pi_readiness_report", lambda _env=None: _report("configuration_blocked"))
     assert module.main(["--fail-when-blocked"]) == 2
 
-    monkeypatch.setattr(module, "pi_readiness_report", lambda: _report("rollback_required"))
+    monkeypatch.setattr(module, "pi_readiness_report", lambda _env=None: _report("rollback_required"))
     assert module.main(["--fail-when-blocked"]) == 2
 
-    monkeypatch.setattr(module, "pi_readiness_report", lambda: _report("collect_more_evidence"))
+    monkeypatch.setattr(module, "pi_readiness_report", lambda _env=None: _report("collect_more_evidence"))
+    assert module.main(["--fail-when-blocked"]) == 0
+
+
+def test_cli_loads_zoe_env_files_without_mutating_process_env(monkeypatch, tmp_path):
+    module = _load_module()
+    for key in ("ZOE_WAKE_ACK_PHRASES", "ZOE_PI_INTENT_SHADOW_ENABLED", "ZOE_PI_INTENT_TRANSPORT"):
+        monkeypatch.delenv(key, raising=False)
+    root_env = tmp_path / "root.env"
+    data_env = tmp_path / "data.env"
+    override_env = tmp_path / "override.env"
+    root_env.write_text(
+        'ZOE_WAKE_ACK_PHRASES="Yes Jason.|Hi Jason."\nZOE_PI_INTENT_SHADOW_ENABLED=false\n',
+        encoding="utf-8",
+    )
+    data_env.write_text("ZOE_PI_INTENT_SHADOW_ENABLED=true\n", encoding="utf-8")
+    override_env.write_text("export ZOE_PI_INTENT_TRANSPORT=rpc # keep comments out\n", encoding="utf-8")
+    monkeypatch.setenv("ZOE_WAKE_ACK_PHRASES", "Shell wins.")
+
+    env = module.load_zoe_env([root_env, data_env, override_env])
+
+    assert env["ZOE_WAKE_ACK_PHRASES"] == "Shell wins."
+    assert env["ZOE_PI_INTENT_SHADOW_ENABLED"] == "true"
+    assert env["ZOE_PI_INTENT_TRANSPORT"] == "rpc"
+    assert module.os.environ["ZOE_WAKE_ACK_PHRASES"] == "Shell wins."
+
+
+def test_cli_passes_loaded_env_to_readiness_report(monkeypatch, tmp_path, capsys):
+    module = _load_module()
+    for key in ("ZOE_WAKE_ACK_PHRASES", "ZOE_PI_INTENT_SHADOW_ENABLED", "ZOE_PI_INTENT_TRANSPORT"):
+        monkeypatch.delenv(key, raising=False)
+    env_path = tmp_path / "zoe.env"
+    env_path.write_text('ZOE_WAKE_ACK_PHRASES="Yes Jason."\n', encoding="utf-8")
+    seen_env = {}
+
+    def fake_report(env):
+        seen_env.update(env)
+        return _report("shadow_collecting")
+
+    monkeypatch.setattr(module, "DEFAULT_ENV_FILES", ())
+    monkeypatch.setattr(module, "pi_readiness_report", fake_report)
+
+    assert module.main(["--env-file", str(env_path), "--summary"]) == 0
+    assert json.loads(capsys.readouterr().out)["state"] == "shadow_collecting"
+    assert seen_env["ZOE_WAKE_ACK_PHRASES"] == "Yes Jason."


### PR DESCRIPTION
## Summary

- Load Zoe `.env` files in `scripts/maintenance/pi_readiness_report.py` before building the Pi readiness report.
- Include canonical `/home/zoe/assistant` env paths so worktree/operator runs report the live Zoe configuration.
- Keep shell environment values highest precedence and avoid mutating `os.environ`.
- Restore the missing non-blocked assertion for `--fail-when-blocked` and add hermetic env-loading tests.
- Handle `export KEY=value` lines in env files.

## Why

The merged readiness CLI was technically correct but incomplete end to end: the live Zoe config already had wake/processing ack phrases and Pi shadow mode enabled, yet the command reported `configuration_blocked` because it only read the process environment. Loading Zoe env files closes that last-mile contract and makes the operator evidence reflect the actual runtime configuration.

With the live env loaded, the report moves from `configuration_blocked` to `measure_comparable_baseline`, mode `shadow_buffer`, ready `true`, with no hybrid blockers.

## Validation

- `python3 -m pytest -q services/zoe-data/tests/test_pi_readiness_report.py services/zoe-data/tests/test_pi_readiness_report_cli.py` -> 9 passed
- `python3 -m pytest -q services/zoe-data/tests/test_pi_readiness_report.py services/zoe-data/tests/test_pi_readiness_report_cli.py services/zoe-data/tests/test_pi_intent_status_endpoint.py services/zoe-data/tests/test_conversation_flow_probe.py services/zoe-data/tests/test_voice_presence.py services/zoe-data/tests/test_voice_ack_env_examples.py` -> 66 passed
- `python3 -m py_compile scripts/maintenance/pi_readiness_report.py services/zoe-data/pi_readiness_report.py services/zoe-data/pi_hybrid_buffer.py`
- `python3 tools/audit/validate_structure.py`
- `python3 scripts/maintenance/pi_readiness_report.py --summary` -> `measure_comparable_baseline`, `shadow_buffer`, ready `true`
- `python3 scripts/maintenance/pi_readiness_report.py --fail-when-blocked` -> exit 0

## Greptile fixes

- Added `monkeypatch.delenv(...)` guards around env-loading tests.
- Added `export ` prefix handling in `_parse_env_file`.