### PR TITLE
[codex] Add lab speculative fulfillment hints

### DIFF
--- a/services/zoe-data/pi_intent_lab.py
+++ b/services/zoe-data/pi_intent_lab.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import re
 import time
 import uuid
 from contextlib import contextmanager
@@ -28,6 +29,15 @@ SAFE_FULFILLMENT_INTENTS = frozenset(
         "weather",
     }
 )
+_SPECULATIVE_WEATHER_RE = re.compile(
+    r"\b(rain|umbrella|forecast|weather|jacket|temperature|temp|storm|windy|humid|hot|cold)\b",
+    re.I,
+)
+_SPECULATIVE_DAILY_BRIEFING_RE = re.compile(
+    r"(\bwhat(?:'s| is) my day\b|\bmy day looking\b|\bleft on my day\b|\bcoming up today\b|\bbriefing\b|\bagenda\b)",
+    re.I,
+)
+_SPECULATIVE_HINT_CONFIDENCE = 0.8
 
 
 @contextmanager
@@ -80,6 +90,7 @@ async def compare_pi_intent_lab(
     processing_cue = _processing_cue(env)
     speculative_safe_fulfillment = _start_speculative_safe_fulfillment(
         zoe_router,
+        text=stripped,
         user_id=user_id,
         enabled=include_safe_fulfillment,
         timeout_seconds=safe_fulfillment_timeout_seconds,
@@ -401,22 +412,20 @@ async def _safe_fulfill_pi_intent(
 def _start_speculative_safe_fulfillment(
     zoe_router: Mapping[str, Any],
     *,
+    text: str,
     user_id: str,
     enabled: bool,
     timeout_seconds: float,
 ) -> dict[str, Any] | None:
     if not enabled:
         return None
-    intent_name = str(zoe_router.get("intent") or "")
-    if not intent_name or intent_name not in SAFE_FULFILLMENT_INTENTS:
-        return None
-    if not zoe_router.get("baseline_comparable"):
+    candidate = _speculative_safe_fulfillment_candidate(zoe_router, text=text)
+    if candidate is None:
         return None
 
     from intent_router import Intent
 
-    confidence = float(zoe_router.get("confidence") or 0.0)
-    intent = Intent(intent_name, dict(zoe_router.get("slots") or {}), confidence)
+    intent = Intent(candidate["intent"], dict(candidate.get("slots") or {}), float(candidate["confidence"]))
     task = asyncio.create_task(
         _execute_safe_fulfillment_intent(
             intent,
@@ -426,11 +435,42 @@ def _start_speculative_safe_fulfillment(
         )
     )
     return {
-        "intent": intent_name,
-        "slots": dict(zoe_router.get("slots") or {}),
+        "intent": candidate["intent"],
+        "slots": dict(candidate.get("slots") or {}),
         "task": task,
-        "source": "zoe_router",
+        "source": candidate["source"],
     }
+
+
+def _speculative_safe_fulfillment_candidate(zoe_router: Mapping[str, Any], *, text: str) -> dict[str, Any] | None:
+    intent_name = str(zoe_router.get("intent") or "")
+    if intent_name and intent_name in SAFE_FULFILLMENT_INTENTS and zoe_router.get("baseline_comparable"):
+        return {
+            "intent": intent_name,
+            "slots": dict(zoe_router.get("slots") or {}),
+            "confidence": float(zoe_router.get("confidence") or 0.0),
+            "source": "zoe_router",
+        }
+    if str(zoe_router.get("route_class") or "") != "fallback":
+        return None
+    stripped = (text or "").strip()
+    if not stripped:
+        return None
+    if _SPECULATIVE_DAILY_BRIEFING_RE.search(stripped):
+        return {
+            "intent": "daily_briefing",
+            "slots": {},
+            "confidence": _SPECULATIVE_HINT_CONFIDENCE,
+            "source": "intent_buffer_hint",
+        }
+    if _SPECULATIVE_WEATHER_RE.search(stripped):
+        return {
+            "intent": "weather",
+            "slots": {},
+            "confidence": _SPECULATIVE_HINT_CONFIDENCE,
+            "source": "intent_buffer_hint",
+        }
+    return None
 
 
 async def _execute_safe_fulfillment_intent(

--- a/services/zoe-data/pi_intent_lab.py
+++ b/services/zoe-data/pi_intent_lab.py
@@ -29,8 +29,13 @@ SAFE_FULFILLMENT_INTENTS = frozenset(
         "weather",
     }
 )
-_SPECULATIVE_WEATHER_RE = re.compile(
-    r"\b(rain|umbrella|forecast|weather|jacket|temperature|temp|storm|windy|humid|hot|cold)\b",
+_SPECULATIVE_WEATHER_STRONG_RE = re.compile(
+    r"\b(rain|forecast|weather|temperature|storm|windy|humid)\b",
+    re.I,
+)
+_SPECULATIVE_WEATHER_CONTEXT_RE = re.compile(
+    r"\b(umbrella|jacket|temp|hot|cold)\b.*\b(today|tonight|tomorrow|later|outside|forecast|weather|rain|degrees|celsius)\b"
+    r"|\b(today|tonight|tomorrow|later|outside|forecast|weather|rain|degrees|celsius)\b.*\b(umbrella|jacket|temp|hot|cold)\b",
     re.I,
 )
 _SPECULATIVE_DAILY_BRIEFING_RE = re.compile(
@@ -463,7 +468,7 @@ def _speculative_safe_fulfillment_candidate(zoe_router: Mapping[str, Any], *, te
             "confidence": _SPECULATIVE_HINT_CONFIDENCE,
             "source": "intent_buffer_hint",
         }
-    if _SPECULATIVE_WEATHER_RE.search(stripped):
+    if _has_speculative_weather_signal(stripped):
         return {
             "intent": "weather",
             "slots": {},
@@ -471,6 +476,10 @@ def _speculative_safe_fulfillment_candidate(zoe_router: Mapping[str, Any], *, te
             "source": "intent_buffer_hint",
         }
     return None
+
+
+def _has_speculative_weather_signal(text: str) -> bool:
+    return bool(_SPECULATIVE_WEATHER_STRONG_RE.search(text) or _SPECULATIVE_WEATHER_CONTEXT_RE.search(text))
 
 
 async def _execute_safe_fulfillment_intent(

--- a/services/zoe-data/tests/test_pi_intent_lab.py
+++ b/services/zoe-data/tests/test_pi_intent_lab.py
@@ -277,7 +277,7 @@ async def test_lab_can_fulfill_safe_read_only_pi_result(monkeypatch):
     _install_fake_voice_presence(monkeypatch)
 
     result = await compare_pi_intent_lab(
-        "need a jacket tonight",
+        "conditions outside",
         include_hybrid_status=False,
         include_safe_fulfillment=True,
     )
@@ -486,6 +486,125 @@ async def test_lab_reuses_speculative_safe_fulfillment_when_pi_agrees(monkeypatc
         pi_latency,
         fulfillment_latency,
     )
+
+
+@pytest.mark.asyncio
+async def test_lab_reuses_fallback_hint_speculative_weather_when_pi_agrees(monkeypatch):
+    calls = []
+    _install_fake_intent_router(
+        monkeypatch,
+        raw=None,
+        extracted=None,
+        execute_response="It's 18.5 C in Perth, light jacket weather.",
+        execute_calls=calls,
+        execute_delay_seconds=0.01,
+    )
+    _install_fake_pi_classifier(
+        monkeypatch,
+        result=types.SimpleNamespace(
+            intent="weather",
+            slots={},
+            confidence=0.93,
+            task_lane="fast_tool",
+            source="fake_pi",
+            latency_ms=123.0,
+            reason="weather signal",
+        ),
+        delay_seconds=0.03,
+    )
+    _install_fake_voice_presence(monkeypatch)
+
+    result = await compare_pi_intent_lab(
+        "need a jacket tonight",
+        include_hybrid_status=False,
+        include_safe_fulfillment=True,
+    )
+
+    assert result["zoe_router"]["route_class"] == "fallback"
+    assert len(calls) == 1
+    assert calls[0]["intent"].name == "weather"
+    assert calls[0]["intent"].slots == {}
+    assert result["safe_fulfillment"]["started_before_pi"] is True
+    assert result["safe_fulfillment"]["validated_by_pi"] is True
+    assert result["safe_fulfillment"]["speculative_safe_fulfillment"] == "used"
+    assert result["safe_fulfillment"]["response_preview"] == "It's 18.5 C in Perth, light jacket weather."
+
+
+@pytest.mark.asyncio
+async def test_lab_reuses_fallback_hint_speculative_daily_briefing_when_pi_agrees(monkeypatch):
+    calls = []
+    _install_fake_intent_router(
+        monkeypatch,
+        raw=None,
+        extracted=None,
+        execute_response="Here's your day: No events on the calendar today.",
+        execute_calls=calls,
+        execute_delay_seconds=0.01,
+    )
+    _install_fake_pi_classifier(
+        monkeypatch,
+        result=types.SimpleNamespace(
+            intent="daily_briefing",
+            slots={},
+            confidence=0.93,
+            task_lane="fast_tool",
+            source="fake_pi",
+            latency_ms=123.0,
+            reason="daily briefing signal",
+        ),
+        delay_seconds=0.03,
+    )
+    _install_fake_voice_presence(monkeypatch)
+
+    result = await compare_pi_intent_lab(
+        "what is my day looking like",
+        include_hybrid_status=False,
+        include_safe_fulfillment=True,
+    )
+
+    assert result["zoe_router"]["route_class"] == "fallback"
+    assert len(calls) == 1
+    assert calls[0]["intent"].name == "daily_briefing"
+    assert calls[0]["intent"].slots == {}
+    assert result["safe_fulfillment"]["started_before_pi"] is True
+    assert result["safe_fulfillment"]["validated_by_pi"] is True
+    assert result["safe_fulfillment"]["speculative_safe_fulfillment"] == "used"
+    assert result["safe_fulfillment"]["response_preview"] == "Here's your day: No events on the calendar today."
+
+
+@pytest.mark.asyncio
+async def test_lab_does_not_speculate_casual_fallback_text(monkeypatch):
+    calls = []
+    _install_fake_intent_router(
+        monkeypatch,
+        raw=None,
+        extracted=None,
+        execute_response="should not run",
+        execute_calls=calls,
+    )
+    _install_fake_pi_classifier(
+        monkeypatch,
+        result=types.SimpleNamespace(
+            intent=None,
+            slots={},
+            confidence=0.0,
+            task_lane="chat",
+            source="fake_pi",
+            latency_ms=10.0,
+            reason="casual chat",
+        ),
+    )
+
+    result = await compare_pi_intent_lab(
+        "I like the breakfast service",
+        include_hybrid_status=False,
+        include_safe_fulfillment=True,
+    )
+
+    assert result["zoe_router"]["route_class"] == "fallback"
+    assert calls == []
+    assert result["safe_fulfillment"]["blocked_reason"] == "pi_no_intent"
+    assert "speculative_safe_fulfillment" not in result["safe_fulfillment"]
 
 
 @pytest.mark.asyncio

--- a/services/zoe-data/tests/test_pi_intent_lab.py
+++ b/services/zoe-data/tests/test_pi_intent_lab.py
@@ -607,6 +607,51 @@ async def test_lab_does_not_speculate_casual_fallback_text(monkeypatch):
     assert "speculative_safe_fulfillment" not in result["safe_fulfillment"]
 
 
+@pytest.mark.parametrize(
+    "text",
+    [
+        "that cold case documentary was great",
+        "can you open the temp file",
+        "I had a hot dog for lunch",
+        "jacket potato sounds good",
+        "that umbrella clause is confusing",
+    ],
+)
+@pytest.mark.asyncio
+async def test_lab_does_not_speculate_ambiguous_weather_words(monkeypatch, text):
+    calls = []
+    _install_fake_intent_router(
+        monkeypatch,
+        raw=None,
+        extracted=None,
+        execute_response="should not run",
+        execute_calls=calls,
+    )
+    _install_fake_pi_classifier(
+        monkeypatch,
+        result=types.SimpleNamespace(
+            intent=None,
+            slots={},
+            confidence=0.0,
+            task_lane="chat",
+            source="fake_pi",
+            latency_ms=10.0,
+            reason="casual chat",
+        ),
+    )
+
+    result = await compare_pi_intent_lab(
+        text,
+        include_hybrid_status=False,
+        include_safe_fulfillment=True,
+    )
+
+    assert result["zoe_router"]["route_class"] == "fallback"
+    assert calls == []
+    assert result["safe_fulfillment"]["blocked_reason"] == "pi_no_intent"
+    assert "speculative_safe_fulfillment" not in result["safe_fulfillment"]
+
+
 @pytest.mark.asyncio
 async def test_lab_discards_speculative_safe_fulfillment_when_pi_slots_differ(monkeypatch):
     calls = []


### PR DESCRIPTION
## What changed

Adds lab-only speculative safe-fulfillment hints for Pi intent comparison:

- fallback weather and daily briefing hints can start read-only safe fulfillment while Pi is still running;
- speculative results are withheld unless Pi later agrees on both intent and slots;
- casual fallback text remains unspeculated;
- this does not change production chat routing, memory writes, shadow mode, promotion, or privileged execution.

## Why

The hybrid Pi path already delivers near-instant cue packets, but safe read-only fulfillment was still mostly Pi-bound. This gives the lab harness a controlled way to test whether intent-buffer hints can reduce perceived/final latency without trusting the hint blindly.

## Safety

- Lab harness only.
- Read-only supported intents only.
- Exact Pi intent+slot validation required before using speculative output.
- Weather hints intentionally discard if Pi extracts extra temporal/item slots, preserving correctness over speed.

## Validation

- `python3 -m py_compile services/zoe-data/pi_intent_lab.py services/zoe-data/routers/pi_intent_lab.py`
- `python3 tools/audit/validate_structure.py`
- `python3 -m pytest -q services/zoe-data/tests/test_pi_intent_lab.py services/zoe-data/tests/test_pi_hybrid_stream_http_probe.py services/zoe-data/tests/test_pi_intent_lab_http_probe.py services/zoe-data/tests/test_pi_hybrid_flow_benchmark.py` -> `54 passed`

In-process spot check: fallback daily briefing can start safe fulfillment before Pi and reuse it once Pi validates the same empty-slot intent.