### PR TITLE
[codex] Harden Greploop state persistence

### DIFF
--- a/services/zoe-data/greploop_guard.py
+++ b/services/zoe-data/greploop_guard.py
@@ -136,7 +136,7 @@ def _write_json(pr_number: int, name: str, payload: dict[str, Any]) -> None:
 
 def _fsync_dir(path: Path) -> None:
     try:
-        dir_fd = os.open(path, os.O_RDONLY)
+        dir_fd = os.open(path, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
     except OSError:
         return
     try:

--- a/services/zoe-data/greploop_guard.py
+++ b/services/zoe-data/greploop_guard.py
@@ -371,7 +371,7 @@ def analyze_result(packet: GuardPacket, result_text: str, *, pre_run_sha: str | 
 
 def _load_status(pr_number: int) -> dict[str, Any]:
     state = read_guard_state(pr_number)
-    if state.get("state") == "MISSING":
+    if state.get("state") in ("MISSING", "STALE_READ_RETRY"):
         return {
             "pr": int(pr_number),
             "iteration": 0,

--- a/services/zoe-data/greploop_guard.py
+++ b/services/zoe-data/greploop_guard.py
@@ -118,14 +118,55 @@ def _json_path(pr_number: int, name: str) -> Path:
 def _write_json(pr_number: int, name: str, payload: dict[str, Any]) -> None:
     path = _json_path(pr_number, name)
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(redact(payload), indent=2, sort_keys=True) + "\n")
+    data = json.dumps(redact(payload), indent=2, sort_keys=True) + "\n"
+    tmp_path = path.with_name(f".{path.name}.{os.getpid()}.{uuid.uuid4().hex}.tmp")
+    try:
+        with tmp_path.open("w", encoding="utf-8") as handle:
+            handle.write(data)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_path, path)
+        _fsync_dir(path.parent)
+    finally:
+        try:
+            tmp_path.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def _fsync_dir(path: Path) -> None:
+    try:
+        dir_fd = os.open(path, os.O_RDONLY)
+    except OSError:
+        return
+    try:
+        os.fsync(dir_fd)
+    except OSError:
+        pass
+    finally:
+        os.close(dir_fd)
 
 
 def read_guard_state(pr_number: int) -> dict[str, Any]:
     path = _json_path(pr_number, "status.json")
     if not path.exists():
         return {"pr": int(pr_number), "state": "MISSING"}
-    return json.loads(path.read_text())
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return {
+            "pr": int(pr_number),
+            "state": "STALE_READ_RETRY",
+            "terminal_state": "STALE_READ_RETRY",
+            "error": "invalid_json_state",
+        }
+    except OSError as exc:
+        return {
+            "pr": int(pr_number),
+            "state": "STALE_READ_RETRY",
+            "terminal_state": "STALE_READ_RETRY",
+            "error": exc.__class__.__name__,
+        }
 
 
 def read_observed_guard_state(pr_number: int, *, repo: str = DEFAULT_REPO) -> dict[str, Any]:

--- a/services/zoe-data/tests/test_greploop_guard.py
+++ b/services/zoe-data/tests/test_greploop_guard.py
@@ -341,6 +341,22 @@ def test_write_json_uses_atomic_replace(tmp_path, monkeypatch):
     assert json.loads(status_path.read_text())["terminal_state"] == "READY_TO_MERGE"
 
 
+def test_fsync_dir_uses_directory_open_flag(tmp_path, monkeypatch):
+    calls = []
+
+    def fake_open(path, flags):
+        calls.append((Path(path), flags))
+        return 123
+
+    monkeypatch.setattr(greploop_guard.os, "open", fake_open)
+    monkeypatch.setattr(greploop_guard.os, "fsync", lambda fd: None)
+    monkeypatch.setattr(greploop_guard.os, "close", lambda fd: None)
+
+    greploop_guard._fsync_dir(tmp_path)
+
+    assert calls == [(tmp_path, greploop_guard.os.O_RDONLY | getattr(greploop_guard.os, "O_DIRECTORY", 0))]
+
+
 def test_read_guard_state_returns_retry_for_partial_json(tmp_path, monkeypatch):
     monkeypatch.setattr(greploop_guard, "STATE_ROOT", tmp_path)
     state_dir = tmp_path / "pr-66"

--- a/services/zoe-data/tests/test_greploop_guard.py
+++ b/services/zoe-data/tests/test_greploop_guard.py
@@ -371,6 +371,30 @@ def test_read_guard_state_returns_retry_for_partial_json(tmp_path, monkeypatch):
     assert state["error"] == "invalid_json_state"
 
 
+def test_load_status_resets_stale_retry_state(monkeypatch):
+    monkeypatch.setattr(
+        greploop_guard,
+        "read_guard_state",
+        lambda pr: {
+            "pr": int(pr),
+            "state": "STALE_READ_RETRY",
+            "terminal_state": "STALE_READ_RETRY",
+            "error": "invalid_json_state",
+        },
+    )
+
+    state = greploop_guard._load_status(66)
+
+    assert state == {
+        "pr": 66,
+        "iteration": 0,
+        "no_progress_count": 0,
+        "same_error_count": 0,
+        "last_progress_key": "",
+        "last_error_hash": "",
+    }
+
+
 @pytest.mark.asyncio
 async def test_cheap_runner_blocks_before_budget_exceeded(monkeypatch):
     monkeypatch.setenv("ZOE_CHEAP_PR_AGENT_CMD", "false")

--- a/services/zoe-data/tests/test_greploop_guard.py
+++ b/services/zoe-data/tests/test_greploop_guard.py
@@ -318,6 +318,43 @@ def test_write_json_redacts_state(tmp_path, monkeypatch):
     assert "abc123" not in (tmp_path / "pr-66" / "status.json").read_text()
 
 
+def test_write_json_uses_atomic_replace(tmp_path, monkeypatch):
+    monkeypatch.setattr(greploop_guard, "STATE_ROOT", tmp_path)
+    real_replace = greploop_guard.os.replace
+    calls = []
+
+    def tracked_replace(src, dst):
+        calls.append((Path(src), Path(dst)))
+        return real_replace(src, dst)
+
+    monkeypatch.setattr(greploop_guard.os, "replace", tracked_replace)
+
+    greploop_guard._write_json(66, "status.json", {"terminal_state": "READY_TO_MERGE"})
+
+    status_path = tmp_path / "pr-66" / "status.json"
+    assert calls
+    tmp_path_used, final_path = calls[0]
+    assert tmp_path_used.parent == status_path.parent
+    assert tmp_path_used.name.startswith(".status.json.")
+    assert final_path == status_path
+    assert not tmp_path_used.exists()
+    assert json.loads(status_path.read_text())["terminal_state"] == "READY_TO_MERGE"
+
+
+def test_read_guard_state_returns_retry_for_partial_json(tmp_path, monkeypatch):
+    monkeypatch.setattr(greploop_guard, "STATE_ROOT", tmp_path)
+    state_dir = tmp_path / "pr-66"
+    state_dir.mkdir()
+    (state_dir / "status.json").write_text('{"terminal_state": "WAITING_GREPTILE"')
+
+    state = greploop_guard.read_guard_state(66)
+
+    assert state["pr"] == 66
+    assert state["state"] == "STALE_READ_RETRY"
+    assert state["terminal_state"] == "STALE_READ_RETRY"
+    assert state["error"] == "invalid_json_state"
+
+
 @pytest.mark.asyncio
 async def test_cheap_runner_blocks_before_budget_exceeded(monkeypatch):
     monkeypatch.setenv("ZOE_CHEAP_PR_AGENT_CMD", "false")


### PR DESCRIPTION
## What changed

Hardens Greploop guard state persistence for multi-agent use:

- writes guard JSON via same-directory temp files and `os.replace`;
- fsyncs the temp file and best-effort fsyncs the state directory after replace;
- makes `read_guard_state()` tolerate transient malformed/partial `status.json` by returning `STALE_READ_RETRY` instead of raising;
- adds focused tests for atomic replace behavior and partial JSON reads.

## Why

The Greploop audit found no current same-repo/same-PR P0 collision bug, but identified non-atomic state writes plus non-tolerant reads as the most important reliability gap before heavier multi-agent use.

## Validation

- `python3 -m pytest -q services/zoe-data/tests/test_greploop_guard.py services/zoe-data/tests/test_greptile_client.py` -> `76 passed`
- `python3 -m py_compile services/zoe-data/greploop_guard.py`
- `python3 tools/audit/validate_structure.py`

## Scope

This is intentionally narrow. It does not change repo-scoped state layout, Greptile trigger routing, polling policy, or merge policy.