### PR TITLE
[codex] Require real evidence for Pi promotion

### DIFF
--- a/docs/architecture/zoe-pi-runtime-harness.md
+++ b/docs/architecture/zoe-pi-runtime-harness.md
@@ -109,11 +109,14 @@ Pi promotion scoring contract used by `pi_promotion_eval.py`, including
 `promotable_groups` and `rollback_groups`; non-comparable fallback evidence blocks
 promotion instead of being treated as a speed win. Reviewed records may also set
 `user_corrected=true` or `rollback_blocked=true`; those fields feed the same
-rollback gates as synthetic promotion samples. The promotion report includes
-`route_class_breakdown` for deterministic, fallback, and extraction_failed
-baselines, `transport_breakdown` for print vs RPC latency and accuracy, plus
-compact `failure_examples` with IDs, intents, latency, transport, and reason
-flags, but not raw text or text previews. Unlabeled
+rollback gates as promotion samples. Synthetic cases remain useful smoke and
+latency evidence, but cannot promote a group by themselves: promotion also
+requires enough real/log-derived or `pi_intent_shadow` labeled evidence. The
+promotion report includes `route_class_breakdown` for deterministic, fallback,
+and extraction_failed baselines, `transport_breakdown` for print vs RPC latency
+and accuracy, `source_breakdown` for real vs synthetic evidence, plus compact
+`failure_examples` with IDs, intents, latency, transport, and reason flags, but
+not raw text or text previews. Unlabeled
 records are never treated as accuracy evidence. Pi live execution remains
 separately gated by
 `ZOE_PI_INTENT_PROMOTED_GROUPS`, so enabling the classifier alone does not

--- a/scripts/maintenance/pi_promotion_eval.py
+++ b/scripts/maintenance/pi_promotion_eval.py
@@ -345,19 +345,22 @@ def _eval_next_actions(
         if not isinstance(item, dict) or item.get("status") != "needs_more_evidence":
             continue
         blockers = set(str(blocker) for blocker in item.get("promotion_blockers") or [])
-        if blockers and blockers != {"insufficient_samples"}:
+        evidence_blockers = {"insufficient_samples", "insufficient_real_source_samples"}
+        if blockers and not blockers <= evidence_blockers:
             continue
-        deficit = int(item.get("unique_case_deficit") or item.get("sample_deficit") or 0)
-        if deficit <= 0:
+        unique_deficit = int(item.get("unique_case_deficit") or item.get("sample_deficit") or 0)
+        real_source_deficit = int(item.get("real_source_sample_deficit") or 0)
+        if unique_deficit <= 0 and real_source_deficit <= 0:
             continue
-        next_actions.append(
-            {
-                "kind": "collect_labeled_evidence",
-                "priority": "p1",
-                "intent_group": item.get("intent_group"),
-                "needed_unique_cases": deficit,
-            }
-        )
+        action = {
+            "kind": "collect_labeled_evidence",
+            "priority": "p1",
+            "intent_group": item.get("intent_group"),
+            "needed_unique_cases": unique_deficit,
+        }
+        if real_source_deficit > 0:
+            action["needed_real_source_cases"] = real_source_deficit
+        next_actions.append(action)
     if not next_actions and state == "collect_more_evidence":
         next_actions.append(
             {

--- a/services/zoe-data/pi_readiness_report.py
+++ b/services/zoe-data/pi_readiness_report.py
@@ -111,6 +111,7 @@ def _candidate_details(candidate_wins: Mapping[str, Any]) -> list[dict[str, Any]
                 "unique_case_count": item.get("unique_case_count"),
                 "unique_case_deficit": item.get("unique_case_deficit"),
                 "sample_deficit": item.get("sample_deficit"),
+                "real_source_sample_deficit": item.get("real_source_sample_deficit"),
                 "accuracy_delta": item.get("accuracy_delta"),
                 "latency_delta_ms": item.get("latency_delta_ms"),
                 "pi_p95_latency_ms": item.get("pi_p95_latency_ms"),
@@ -220,20 +221,23 @@ def _evidence_collection_actions(promotion: Mapping[str, Any]) -> list[dict[str,
         if group not in LOW_RISK_PI_INTENT_GROUPS:
             continue
         blockers = set(str(blocker) for blocker in item.get("promotion_blockers") or [])
-        if blockers and blockers != {"insufficient_samples"}:
+        evidence_blockers = {"insufficient_samples", "insufficient_real_source_samples"}
+        if blockers and not blockers <= evidence_blockers:
             continue
-        deficit = int(item.get("unique_case_deficit") or item.get("sample_deficit") or 0)
-        if deficit <= 0:
+        unique_deficit = int(item.get("unique_case_deficit") or item.get("sample_deficit") or 0)
+        real_source_deficit = int(item.get("real_source_sample_deficit") or 0)
+        if unique_deficit <= 0 and real_source_deficit <= 0:
             continue
-        actions.append(
-            {
-                "kind": "collect_labeled_evidence",
-                "priority": "p1",
-                "intent_group": group,
-                "needed_unique_cases": deficit,
-                "detail": f"Collect and label {deficit} more unique {group} cases before promotion.",
-            }
-        )
+        action = {
+            "kind": "collect_labeled_evidence",
+            "priority": "p1",
+            "intent_group": group,
+            "needed_unique_cases": unique_deficit,
+            "detail": f"Collect and label {unique_deficit} more unique {group} cases before promotion.",
+        }
+        if real_source_deficit > 0:
+            action["needed_real_source_cases"] = real_source_deficit
+        actions.append(action)
     return actions
 
 

--- a/services/zoe-data/pi_readiness_report.py
+++ b/services/zoe-data/pi_readiness_report.py
@@ -228,12 +228,24 @@ def _evidence_collection_actions(promotion: Mapping[str, Any]) -> list[dict[str,
         real_source_deficit = int(item.get("real_source_sample_deficit") or 0)
         if unique_deficit <= 0 and real_source_deficit <= 0:
             continue
+        if unique_deficit > 0 and real_source_deficit > 0:
+            detail = (
+                f"Collect and label {unique_deficit} more unique {group} cases "
+                f"({real_source_deficit} must be real/log-derived) before promotion."
+            )
+        elif real_source_deficit > 0:
+            detail = (
+                f"Collect {real_source_deficit} real/log-derived {group} samples "
+                f"(pi_intent_shadow, intent_miss, chat_log, etc.) before promotion."
+            )
+        else:
+            detail = f"Collect and label {unique_deficit} more unique {group} cases before promotion."
         action = {
             "kind": "collect_labeled_evidence",
             "priority": "p1",
             "intent_group": group,
             "needed_unique_cases": unique_deficit,
-            "detail": f"Collect and label {unique_deficit} more unique {group} cases before promotion.",
+            "detail": detail,
         }
         if real_source_deficit > 0:
             action["needed_real_source_cases"] = real_source_deficit

--- a/services/zoe-data/tests/test_pi_promotion_eval_script.py
+++ b/services/zoe-data/tests/test_pi_promotion_eval_script.py
@@ -372,6 +372,43 @@ def test_cli_combines_default_and_cases_file(tmp_path, capsys):
     assert len(case_ids) > 1
 
 
+def test_build_eval_readiness_collects_real_source_evidence_for_candidate_wins():
+    module = _load_module()
+    report = {
+        "promotable_groups": [],
+        "rollback_groups": [],
+        "promotion_actions": {"requires_operator_apply": False, "promote_groups": [], "rollback_groups": []},
+        "candidate_wins": {
+            "groups": ["weather"],
+            "blocked_groups": ["weather"],
+            "promotion_ready_groups": [],
+            "details": [
+                {
+                    "intent_group": "weather",
+                    "status": "needs_more_evidence",
+                    "unique_case_deficit": 0,
+                    "sample_deficit": 0,
+                    "real_source_sample_deficit": 30,
+                    "promotion_blockers": ["insufficient_real_source_samples"],
+                }
+            ],
+        },
+    }
+
+    readiness = module.build_eval_readiness(report)
+
+    assert readiness["state"] == "collect_more_evidence"
+    assert readiness["next_actions"] == [
+        {
+            "kind": "collect_labeled_evidence",
+            "priority": "p1",
+            "intent_group": "weather",
+            "needed_unique_cases": 0,
+            "needed_real_source_cases": 30,
+        }
+    ]
+
+
 def test_build_eval_readiness_collects_more_evidence_for_candidate_wins():
     module = _load_module()
     report = {

--- a/services/zoe-data/tests/test_pi_readiness_report.py
+++ b/services/zoe-data/tests/test_pi_readiness_report.py
@@ -72,7 +72,7 @@ def test_readiness_report_collects_more_evidence_for_candidate_wins(tmp_path):
         "intent_group": "weather",
         "needed_unique_cases": 27,
         "needed_real_source_cases": 27,
-        "detail": "Collect and label 27 more unique weather cases before promotion.",
+        "detail": "Collect and label 27 more unique weather cases (27 must be real/log-derived) before promotion.",
     } in report["next_actions"]
 
 
@@ -117,6 +117,38 @@ def test_readiness_report_treats_enabled_pi_without_promotions_as_shadow_mode(tm
     assert "pi_execution_enabled_without_promoted_groups" not in report["hybrid"]["blockers"]
     assert "pi_classifier_enabled_without_promoted_groups_runs_shadow_only" in report["hybrid"]["warnings"]
     assert report["promotion_actions"]["promote_groups"] == ["weather"]
+
+
+def test_readiness_real_source_only_deficit_has_clear_detail():
+    from pi_readiness_report import _evidence_collection_actions
+
+    actions = _evidence_collection_actions(
+        {
+            "candidate_wins": {
+                "details": [
+                    {
+                        "intent_group": "weather",
+                        "status": "needs_more_evidence",
+                        "unique_case_deficit": 0,
+                        "sample_deficit": 0,
+                        "real_source_sample_deficit": 5,
+                        "promotion_blockers": ["insufficient_real_source_samples"],
+                    }
+                ]
+            }
+        }
+    )
+
+    assert actions == [
+        {
+            "kind": "collect_labeled_evidence",
+            "priority": "p1",
+            "intent_group": "weather",
+            "needed_unique_cases": 0,
+            "detail": "Collect 5 real/log-derived weather samples (pi_intent_shadow, intent_miss, chat_log, etc.) before promotion.",
+            "needed_real_source_cases": 5,
+        }
+    ]
 
 
 def test_readiness_report_requests_comparable_baseline_for_router_only_shadow_data(tmp_path):

--- a/services/zoe-data/tests/test_pi_readiness_report.py
+++ b/services/zoe-data/tests/test_pi_readiness_report.py
@@ -62,7 +62,8 @@ def test_readiness_report_collects_more_evidence_for_candidate_wins(tmp_path):
             "latency_delta_ms": 9000.0,
             "pi_p95_latency_ms": 3000.0,
             "zoe_p95_latency_ms": 12000.0,
-            "promotion_blockers": ["insufficient_samples"],
+            "promotion_blockers": ["insufficient_samples", "insufficient_real_source_samples"],
+            "real_source_sample_deficit": 27,
         }
     ]
     assert {
@@ -70,6 +71,7 @@ def test_readiness_report_collects_more_evidence_for_candidate_wins(tmp_path):
         "priority": "p1",
         "intent_group": "weather",
         "needed_unique_cases": 27,
+        "needed_real_source_cases": 27,
         "detail": "Collect and label 27 more unique weather cases before promotion.",
     } in report["next_actions"]
 
@@ -132,7 +134,12 @@ def test_readiness_report_requests_comparable_baseline_for_router_only_shadow_da
         {
             "intent_group": "weather",
             "sample_count": 1,
-            "blockers": ["insufficient_samples", "latency_not_faster_than_zoe", "baseline_not_comparable"],
+            "blockers": [
+                "insufficient_samples",
+                "latency_not_faster_than_zoe",
+                "baseline_not_comparable",
+                "insufficient_real_source_samples",
+            ],
             "accuracy_delta": 1.0,
             "latency_delta_ms": -2990.0,
         }

--- a/services/zoe-data/tests/test_zoe_pi_promotion.py
+++ b/services/zoe-data/tests/test_zoe_pi_promotion.py
@@ -24,6 +24,8 @@ from zoe_pi_promotion import (
 
 
 def _sample(index, *, group="weather", zoe="reminder_list", pi="weather", expected="weather", zoe_ms=900, pi_ms=300, **kwargs):
+    metadata = dict(kwargs.pop("metadata", {}) or {})
+    metadata.setdefault("source", "intent_miss")
     return PiRouteSample(
         case_id=f"case_{index}",
         intent_group=group,
@@ -33,6 +35,7 @@ def _sample(index, *, group="weather", zoe="reminder_list", pi="weather", expect
         zoe_latency_ms=zoe_ms,
         pi_latency_ms=pi_ms,
         pi_confidence=0.91,
+        metadata=metadata,
         **kwargs,
     )
 
@@ -255,6 +258,27 @@ def test_promotion_requires_five_percent_accuracy_win_and_latency_win():
     assert decision.blockers == ()
 
 
+def test_synthetic_only_evidence_blocks_promotion_until_real_sources_exist():
+    samples = [_sample(i, metadata={"source": "synthetic"}) for i in range(10)]
+    policy = PiPromotionPolicy(min_samples=10, accuracy_win_margin=0.05)
+
+    decision = evaluate_pi_promotion(samples, intent_group="weather", policy=policy)
+
+    assert decision.state == "keep_shadow"
+    assert "insufficient_real_source_samples" in decision.blockers
+    assert "insufficient_samples" not in decision.blockers
+
+
+def test_policy_can_disable_real_source_gate_for_smoke_data():
+    samples = [_sample(i, metadata={"source": "synthetic"}) for i in range(10)]
+    policy = PiPromotionPolicy(min_samples=10, require_real_source_evidence=False)
+
+    decision = evaluate_pi_promotion(samples, intent_group="weather", policy=policy)
+
+    assert decision.state == "promote"
+    assert "insufficient_real_source_samples" not in decision.blockers
+
+
 def test_promotion_counts_unique_cases_not_repeated_observations():
     samples = [_sample(1) for _ in range(10)]
     policy = PiPromotionPolicy(min_samples=2, accuracy_win_margin=0.05)
@@ -303,7 +327,8 @@ def test_candidate_wins_separate_speed_accuracy_evidence_from_promotion_readines
     assert "sample_count" not in detail
     assert detail["sample_deficit"] == 1
     assert detail["unique_case_deficit"] == 1
-    assert detail["promotion_blockers"] == ["insufficient_samples"]
+    assert detail["promotion_blockers"] == ["insufficient_samples", "insufficient_real_source_samples"]
+    assert detail["real_source_sample_deficit"] == 1
 
 
 def test_promotion_blocks_when_accuracy_delta_is_too_small():
@@ -585,7 +610,7 @@ def test_source_breakdown_counts_real_synthetic_and_unknown_sources():
     samples = [
         _sample(1, metadata={"source": "synthetic"}),
         _sample(2, metadata={"source": "intent_miss"}),
-        _sample(3),
+        _sample(3, metadata={"source": "unknown"}),
         _sample(4, group="timers", expected="timer_create", zoe="weather", pi="timer_create", metadata={"source": "pi_intent_shadow"}),
     ]
 
@@ -661,8 +686,8 @@ def test_summary_lists_promotable_groups():
     assert report["route_class_breakdown"]["fallback"]["latency_delta_ms"] > 0
     assert report["transport_breakdown"]["rpc"]["sample_count"] == 10
     assert report["transport_breakdown"]["rpc"]["latency_delta_ms"] > 0
-    assert report["source_breakdown"]["unknown_source_sample_count"] == 10
-    assert report["source_breakdown"]["real_source_sample_deficit_by_group"]["weather"] == 10
+    assert report["source_breakdown"]["unknown_source_sample_count"] == 0
+    assert report["source_breakdown"]["real_source_sample_deficit_by_group"]["weather"] == 0
 
 
 def test_summary_lists_rollback_groups_for_active_promotions():
@@ -684,6 +709,7 @@ def test_summary_includes_operator_promotion_actions():
             zoe_latency_ms=500,
             pi_latency_ms=100,
             pi_confidence=0.9,
+            metadata={"source": "intent_miss"},
         )
         for index in range(30)
     ] + [
@@ -696,6 +722,7 @@ def test_summary_includes_operator_promotion_actions():
             zoe_latency_ms=450,
             pi_latency_ms=90,
             pi_confidence=0.9,
+            metadata={"source": "intent_miss"},
         )
         for index in range(30)
     ]

--- a/services/zoe-data/tests/test_zoe_pi_promotion.py
+++ b/services/zoe-data/tests/test_zoe_pi_promotion.py
@@ -258,6 +258,21 @@ def test_promotion_requires_five_percent_accuracy_win_and_latency_win():
     assert decision.blockers == ()
 
 
+def test_collapsed_mixed_source_case_counts_real_evidence():
+    samples = [
+        _sample(1, metadata={"source": "synthetic"}),
+        _sample(1, metadata={"source": "intent_miss"}),
+    ]
+    policy = PiPromotionPolicy(min_samples=1, accuracy_win_margin=0.05)
+
+    decision = evaluate_pi_promotion(samples, intent_group="weather", policy=policy)
+    summary = build_pi_candidate_wins(samples, policy=policy)
+
+    assert decision.state == "promote"
+    assert "insufficient_real_source_samples" not in decision.blockers
+    assert summary["details"][0]["real_source_sample_deficit"] == 0
+
+
 def test_synthetic_only_evidence_blocks_promotion_until_real_sources_exist():
     samples = [_sample(i, metadata={"source": "synthetic"}) for i in range(10)]
     policy = PiPromotionPolicy(min_samples=10, accuracy_win_margin=0.05)

--- a/services/zoe-data/zoe_pi_promotion.py
+++ b/services/zoe-data/zoe_pi_promotion.py
@@ -182,6 +182,7 @@ class PiPromotionPolicy:
     require_latency_win: bool = True
     require_comparable_baseline: bool = True
     require_baseline_lane_latency_win: bool = True
+    require_real_source_evidence: bool = True
 
     def validate(self) -> None:
         if self.min_samples <= 0:
@@ -307,6 +308,12 @@ def evaluate_pi_promotion(
         sample.metadata.get("baseline_comparable") is False for sample in group_samples
     ):
         blockers.append("baseline_not_comparable")
+    if active_policy.require_real_source_evidence:
+        real_source_sample_count = sum(
+            1 for sample in decision_samples if _sample_source(sample) in REAL_PROMOTION_EVIDENCE_SOURCES
+        )
+        if real_source_sample_count < active_policy.min_samples:
+            blockers.append("insufficient_real_source_samples")
     if any(sample.rollback_blocked for sample in group_samples):
         blockers.append("rollback_blocked")
 
@@ -374,6 +381,7 @@ def summarize_pi_promotion(
             "require_latency_win": active_policy.require_latency_win,
             "require_comparable_baseline": active_policy.require_comparable_baseline,
             "require_baseline_lane_latency_win": active_policy.require_baseline_lane_latency_win,
+            "require_real_source_evidence": active_policy.require_real_source_evidence,
         },
         "sample_count": len(samples),
         "unique_case_count": _unique_case_count(samples),
@@ -421,7 +429,7 @@ def build_pi_candidate_wins(
         for sample in group_samples:
             sample.validate()
         blockers = list(decision.get("blockers") or [])
-        non_evidence_blockers = sorted(set(blockers) - {"insufficient_samples"})
+        non_evidence_blockers = sorted(set(blockers) - {"insufficient_samples", "insufficient_real_source_samples"})
         if decision.get("sample_count", 0) <= 0 or non_evidence_blockers:
             continue
         unique_case_count = _unique_case_count(group_samples)
@@ -435,6 +443,15 @@ def build_pi_candidate_wins(
                 "promotion_blockers": blockers,
                 "sample_deficit": max(0, active_policy.min_samples - int(decision.get("sample_count", 0) or 0)),
                 "unique_case_deficit": max(0, active_policy.min_samples - unique_case_count),
+                "real_source_sample_deficit": max(
+                    0,
+                    active_policy.min_samples
+                    - sum(
+                        1
+                        for sample in _collapse_samples_by_case(group_samples)
+                        if _sample_source(sample) in REAL_PROMOTION_EVIDENCE_SOURCES
+                    ),
+                ),
                 "zoe_accuracy": decision.get("zoe_accuracy"),
                 "pi_accuracy": decision.get("pi_accuracy"),
                 "accuracy_delta": decision.get("accuracy_delta"),

--- a/services/zoe-data/zoe_pi_promotion.py
+++ b/services/zoe-data/zoe_pi_promotion.py
@@ -775,6 +775,11 @@ def _first_non_expected_zoe_intent(samples: Sequence[PiRouteSample]) -> str | No
 
 def _collapse_sample_metadata(samples: Sequence[PiRouteSample]) -> dict[str, Any]:
     merged = dict(samples[0].metadata)
+    sources = [_sample_source(sample) for sample in samples]
+    merged["sources"] = sorted(set(sources))
+    real_sources = [source for source in sources if source in REAL_PROMOTION_EVIDENCE_SOURCES]
+    if real_sources:
+        merged["source"] = sorted(set(real_sources))[0]
     if any(sample.metadata.get("baseline_comparable") is False for sample in samples):
         merged["baseline_comparable"] = False
     return merged


### PR DESCRIPTION
## What changed

Closes the Pi promotion source-evidence contract:

- adds `require_real_source_evidence=True` to `PiPromotionPolicy`;
- blocks promotion with `insufficient_real_source_samples` unless each group has enough real/log-derived or `pi_intent_shadow` labeled samples;
- keeps synthetic cases useful for smoke and speed/accuracy candidate evidence, but not sufficient for live route promotion;
- carries `real_source_sample_deficit` through candidate and readiness reports;
- updates next actions to ask for real-source labels when speed/accuracy wins exist but evidence source is weak;
- documents the rule in the Pi runtime harness doc.

## Why

The system already tracked `REAL_PROMOTION_EVIDENCE_SOURCES`, but promotion decisions only reported source mix instead of enforcing it. That meant a large synthetic-only eval set could accidentally make a group promotion-ready. This keeps promotion aligned with the self-evolution safety goal: evidence must come from real/shadow/log-derived outcomes before Pi can win live routing.

## Validation

- `python3 -m pytest -q services/zoe-data/tests/test_pi_*.py services/zoe-data/tests/test_zoe_pi_promotion.py` -> `270 passed`
- `python3 -m py_compile services/zoe-data/zoe_pi_promotion.py services/zoe-data/pi_readiness_report.py scripts/maintenance/pi_promotion_eval.py scripts/maintenance/pi_readiness_report.py`
- `python3 tools/audit/validate_structure.py`

## Scope

No route is promoted and no runtime behavior changes. This only tightens promotion/readiness reporting and policy gates.