### PR TITLE
[codex] Load Zoe env for Pi eval scripts

### DIFF
--- a/scripts/maintenance/pi_intent_fleet_benchmark.py
+++ b/scripts/maintenance/pi_intent_fleet_benchmark.py
@@ -22,7 +22,7 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(ROOT / "services" / "zoe-data"))
 sys.path.insert(0, str(SCRIPT_DIR))
 
-from pi_promotion_eval import _run_pi, _run_zoe_baseline  # noqa: E402
+from pi_promotion_eval import _run_pi, _run_zoe_baseline, _temporary_env, load_zoe_env  # noqa: E402
 from zoe_pi_promotion import (  # noqa: E402
     DEFAULT_PI_INTENT_EVAL_CASES,
     LOW_RISK_PI_INTENT_GROUPS,
@@ -226,6 +226,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--repeat", type=int, default=3, help="Repeat each case this many times for latency stability")
     parser.add_argument("--cases-file", action="append", default=[], help="JSON or JSONL eval cases file. Repeat to combine datasets.")
     parser.add_argument("--no-default-cases", action="store_true", help="Use only --cases-file datasets")
+    parser.add_argument("--env-file", action="append", default=[], help="Additional Zoe env file to load before measuring; shell env wins")
     parser.add_argument("--include-observations", action="store_true", help="Include every observation row in JSON output")
     parser.add_argument("--fallback-baseline-latency-ms", type=float, default=None)
     parser.add_argument("--extraction-failed-baseline-latency-ms", type=float, default=None)
@@ -237,21 +238,22 @@ def main(argv: list[str] | None = None) -> int:
     loaded_case_groups = [load_pi_intent_eval_cases(path) for path in args.cases_file]
     base_cases = [] if args.no_default_cases else list(DEFAULT_PI_INTENT_EVAL_CASES)
     cases = merge_pi_intent_eval_cases(base_cases, *loaded_case_groups)
-    observations = asyncio.run(
-        run_benchmark(
-            cases,
-            repeat=args.repeat,
-            run_pi=args.run_pi,
-            transport=args.transport,
-            enable_execution=args.allow_execution,
-            local_model_configured=args.local_model_configured,
-            fallback_baseline_latency_ms=args.fallback_baseline_latency_ms,
-            extraction_failed_baseline_latency_ms=args.extraction_failed_baseline_latency_ms,
-            measure_zoe_agent_baseline=args.measure_zoe_agent_baseline,
-            zoe_agent_baseline_timeout_seconds=args.zoe_agent_baseline_timeout_seconds,
-            zoe_agent_baseline_max_tokens=args.zoe_agent_baseline_max_tokens,
+    with _temporary_env(load_zoe_env(args.env_file)):
+        observations = asyncio.run(
+            run_benchmark(
+                cases,
+                repeat=args.repeat,
+                run_pi=args.run_pi,
+                transport=args.transport,
+                enable_execution=args.allow_execution,
+                local_model_configured=args.local_model_configured,
+                fallback_baseline_latency_ms=args.fallback_baseline_latency_ms,
+                extraction_failed_baseline_latency_ms=args.extraction_failed_baseline_latency_ms,
+                measure_zoe_agent_baseline=args.measure_zoe_agent_baseline,
+                zoe_agent_baseline_timeout_seconds=args.zoe_agent_baseline_timeout_seconds,
+                zoe_agent_baseline_max_tokens=args.zoe_agent_baseline_max_tokens,
+            )
         )
-    )
     print(
         json.dumps(
             build_report(

--- a/scripts/maintenance/pi_promotion_eval.py
+++ b/scripts/maintenance/pi_promotion_eval.py
@@ -12,6 +12,7 @@ import argparse
 import asyncio
 import json
 import os
+import shlex
 import sys
 import time
 import uuid
@@ -21,6 +22,13 @@ from typing import Any
 
 ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT / "services" / "zoe-data"))
+
+DEFAULT_ENV_FILES = (
+    ROOT / ".env",
+    ROOT / "services" / "zoe-data" / ".env",
+    Path("/home/zoe/assistant/.env"),
+    Path("/home/zoe/assistant/services/zoe-data/.env"),
+)
 
 from zoe_pi_promotion import (  # noqa: E402
     DEFAULT_PI_INTENT_EVAL_CASES,
@@ -52,6 +60,36 @@ def _temporary_env(updates: dict[str, str | None]):
                 os.environ.pop(key, None)
             else:
                 os.environ[key] = value
+
+
+def load_zoe_env(env_files: list[str] | None = None) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for env_file in [*DEFAULT_ENV_FILES, *(env_files or [])]:
+        path = Path(env_file).expanduser()
+        if path.exists():
+            values.update(_parse_env_file(path))
+    values.update(os.environ)
+    return values
+
+
+def _parse_env_file(path: Path) -> dict[str, str]:
+    parsed: dict[str, str] = {}
+    for raw_line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, raw_value = line.split("=", 1)
+        key = key.strip()
+        if key.startswith("export "):
+            key = key[len("export ") :].strip()
+        if not key or key.startswith("#"):
+            continue
+        try:
+            parts = shlex.split(raw_value, comments=True, posix=True)
+        except ValueError:
+            parts = [raw_value.strip().strip('"').strip("'")]
+        parsed[key] = parts[0] if parts else ""
+    return parsed
 
 
 def _demo_samples() -> list[PiRouteSample]:
@@ -418,6 +456,7 @@ def main(argv: list[str] | None = None) -> int:
         help="JSON or JSONL eval cases file. Repeat to combine datasets.",
     )
     parser.add_argument("--no-default-cases", action="store_true", help="Use only --cases-file datasets")
+    parser.add_argument("--env-file", action="append", default=[], help="Additional Zoe env file to load before measuring; shell env wins")
     parser.add_argument(
         "--promoted-group",
         action="append",
@@ -436,19 +475,20 @@ def main(argv: list[str] | None = None) -> int:
     if args.demo:
         samples.extend(_demo_samples())
     if args.run_pi:
-        comparisons, measured_samples = asyncio.run(
-            _run_cases(
-                eval_cases,
-                transport=args.transport,
-                enable_execution=args.allow_execution,
-                local_model_configured=args.local_model_configured,
-                fallback_baseline_latency_ms=args.fallback_baseline_latency_ms,
-                extraction_failed_baseline_latency_ms=args.extraction_failed_baseline_latency_ms,
-                measure_zoe_agent_baseline=args.measure_zoe_agent_baseline,
-                zoe_agent_baseline_timeout_seconds=args.zoe_agent_baseline_timeout_seconds,
-                zoe_agent_baseline_max_tokens=args.zoe_agent_baseline_max_tokens,
+        with _temporary_env(load_zoe_env(args.env_file)):
+            comparisons, measured_samples = asyncio.run(
+                _run_cases(
+                    eval_cases,
+                    transport=args.transport,
+                    enable_execution=args.allow_execution,
+                    local_model_configured=args.local_model_configured,
+                    fallback_baseline_latency_ms=args.fallback_baseline_latency_ms,
+                    extraction_failed_baseline_latency_ms=args.extraction_failed_baseline_latency_ms,
+                    measure_zoe_agent_baseline=args.measure_zoe_agent_baseline,
+                    zoe_agent_baseline_timeout_seconds=args.zoe_agent_baseline_timeout_seconds,
+                    zoe_agent_baseline_max_tokens=args.zoe_agent_baseline_max_tokens,
+                )
             )
-        )
         samples.extend(measured_samples)
     promotion_report = summarize_pi_promotion(samples, policy=policy, promoted_groups=args.promoted_group)
     payload = {

--- a/services/zoe-data/tests/test_pi_promotion_eval_script.py
+++ b/services/zoe-data/tests/test_pi_promotion_eval_script.py
@@ -61,6 +61,8 @@ def _install_fake_pi_classifier(monkeypatch, *, result=None, sleep_seconds=0):
 
 def test_load_zoe_env_loads_env_files_and_shell_env_wins(tmp_path, monkeypatch):
     module = _load_module()
+    monkeypatch.setattr(module, "DEFAULT_ENV_FILES", ())
+    monkeypatch.delenv("ZOE_PI_INTENT_TIMEOUT_SECONDS", raising=False)
     env_file = tmp_path / "zoe.env"
     env_file.write_text(
         "export ZOE_PI_INTENT_TIMEOUT_SECONDS=8\n"

--- a/services/zoe-data/tests/test_pi_promotion_eval_script.py
+++ b/services/zoe-data/tests/test_pi_promotion_eval_script.py
@@ -59,6 +59,22 @@ def _install_fake_pi_classifier(monkeypatch, *, result=None, sleep_seconds=0):
     monkeypatch.setitem(sys.modules, "pi_intent_classifier", module)
 
 
+def test_load_zoe_env_loads_env_files_and_shell_env_wins(tmp_path, monkeypatch):
+    module = _load_module()
+    env_file = tmp_path / "zoe.env"
+    env_file.write_text(
+        "export ZOE_PI_INTENT_TIMEOUT_SECONDS=8\n"
+        "ZOE_PI_LOCAL_MODEL_CONFIGURED=from-file\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("ZOE_PI_LOCAL_MODEL_CONFIGURED", "from-shell")
+
+    env = module.load_zoe_env([str(env_file)])
+
+    assert env["ZOE_PI_INTENT_TIMEOUT_SECONDS"] == "8"
+    assert env["ZOE_PI_LOCAL_MODEL_CONFIGURED"] == "from-shell"
+
+
 def test_cli_loads_cases_file_without_default_cases(tmp_path, capsys):
     module = _load_module()
     cases_path = tmp_path / "cases.jsonl"
@@ -297,6 +313,19 @@ def test_run_cases_preserves_eval_case_source_in_sample_metadata(monkeypatch):
     assert len(samples) == 1
     assert samples[0].metadata["source"] == "intent_miss"
     assert samples[0].metadata["baseline_kind"] == "zoe_agent_fallback_baseline"
+
+
+def test_run_pi_uses_loaded_timeout_env(monkeypatch):
+    _install_fake_pi_classifier(monkeypatch, result=None, sleep_seconds=0.02)
+    monkeypatch.setenv("ZOE_PI_INTENT_TIMEOUT_SECONDS", "1")
+    module = _load_module()
+    case = module.PiIntentEvalCase("casual", "that movie was good", None, "chat", "fallback", negative=True)
+
+    result = asyncio.run(
+        module._run_pi(case, transport="rpc", enable_execution=True, local_model_configured=True)
+    )
+
+    assert result["timed_out"] is False
 
 
 def test_run_pi_fast_no_result_is_not_timeout(monkeypatch):


### PR DESCRIPTION
## What changed

Makes Pi evaluation scripts load Zoe env files before measuring runtime behavior:

- `pi_promotion_eval.py` now loads Zoe `.env` files, plus optional `--env-file`, with shell env winning;
- `pi_intent_fleet_benchmark.py` uses the same loader;
- both scripts now measure with configured runtime values such as `ZOE_PI_INTENT_TIMEOUT_SECONDS=8` instead of silently falling back to the classifier default;
- added tests for env-file parsing, `export KEY=value`, and shell-env precedence.

## Why

The latest promotion eval run timed out weather at ~4.2s because the CLI did not load Zoe's configured 8s Pi intent timeout. That made promotion evidence disagree with live hybrid probes. The eval harness should measure Zoe's configured runtime, not an unconfigured shell default.

## Validation

- `python3 -m pytest -q services/zoe-data/tests/test_pi_promotion_eval_script.py services/zoe-data/tests/test_pi_intent_fleet_benchmark.py` -> `24 passed`
- `python3 -m pytest -q services/zoe-data/tests/test_pi_*.py services/zoe-data/tests/test_zoe_pi_promotion.py` -> `274 passed`
- `python3 -m py_compile scripts/maintenance/pi_promotion_eval.py scripts/maintenance/pi_intent_fleet_benchmark.py`
- `python3 tools/audit/validate_structure.py`

## Scope

No runtime route changes or promotions. This only fixes operator/eval measurement fidelity.