### PR TITLE
[codex] Surface persisted Pi eval evidence

### DIFF
--- a/scripts/maintenance/pi_promotion_eval.py
+++ b/scripts/maintenance/pi_promotion_eval.py
@@ -457,6 +457,7 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument("--no-default-cases", action="store_true", help="Use only --cases-file datasets")
     parser.add_argument("--env-file", action="append", default=[], help="Additional Zoe env file to load before measuring; shell env wins")
+    parser.add_argument("--output", "-o", help="Optional JSON output path; defaults to stdout")
     parser.add_argument(
         "--promoted-group",
         action="append",
@@ -499,7 +500,13 @@ def main(argv: list[str] | None = None) -> int:
         "promotion_report": promotion_report,
         "readiness": build_eval_readiness(promotion_report),
     }
-    print(json.dumps(payload, indent=2, sort_keys=True))
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        target = Path(args.output).expanduser()
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(text, encoding="utf-8")
+    else:
+        print(text, end="")
     return 0
 
 

--- a/services/zoe-data/pi_readiness_report.py
+++ b/services/zoe-data/pi_readiness_report.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+import json
 import os
+from pathlib import Path
 from typing import Any, Mapping
 
 from pi_hybrid_buffer import pi_hybrid_buffer_status
 from pi_intent_shadow import pi_intent_shadow_status
 from zoe_pi_promotion import LOW_RISK_PI_INTENT_GROUPS
+
+DEFAULT_EVAL_REPORT_PATH = "~/.zoe/data/pi-promotion-eval-report.json"
 
 
 def pi_readiness_report(env: Mapping[str, str] | None = None) -> dict[str, Any]:
@@ -16,14 +20,17 @@ def pi_readiness_report(env: Mapping[str, str] | None = None) -> dict[str, Any]:
     hybrid = pi_hybrid_buffer_status(values)
     shadow = pi_intent_shadow_status(values)
     promotion = shadow.get("promotion_report") or {}
+    eval_report = _load_eval_report(values)
+    benchmark = _benchmark_from_eval_report(eval_report)
+    benchmark_promotion = benchmark.get("promotion_report") or {}
     contract = hybrid.get("contract") or {}
     actions = promotion.get("promotion_actions") or {}
-    candidate_wins = promotion.get("candidate_wins") or {}
-    state = _readiness_state(contract, promotion, actions)
+    candidate_wins = _combined_candidate_wins(promotion, benchmark_promotion)
+    state = _readiness_state(contract, promotion, actions, benchmark_promotion=benchmark_promotion)
     return {
         "report_kind": "zoe_pi_readiness_report",
         "state": state,
-        "summary": _summary(state, contract, shadow, promotion, actions),
+        "summary": _summary(state, contract, shadow, promotion, actions, benchmark),
         "hybrid": {
             "mode": contract.get("mode"),
             "ready": bool(contract.get("ready")),
@@ -31,11 +38,12 @@ def pi_readiness_report(env: Mapping[str, str] | None = None) -> dict[str, Any]:
             "warnings": list(contract.get("warnings") or []),
             "promoted_groups": list(contract.get("promoted_groups") or []),
         },
-        "evidence": _evidence(shadow, promotion),
+        "evidence": _evidence(shadow, promotion, benchmark),
+        "benchmark": benchmark,
         "candidates": _candidate_details(candidate_wins),
         "blocked_decisions": _blocked_decisions(promotion),
         "promotion_actions": actions,
-        "next_actions": _next_actions(state, contract, shadow, promotion, actions),
+        "next_actions": _next_actions(state, contract, shadow, promotion, actions, benchmark_promotion=benchmark_promotion),
     }
 
 
@@ -43,6 +51,8 @@ def _readiness_state(
     contract: Mapping[str, Any],
     promotion: Mapping[str, Any],
     actions: Mapping[str, Any],
+    *,
+    benchmark_promotion: Mapping[str, Any] | None = None,
 ) -> str:
     rollback_groups = list(actions.get("rollback_groups") or promotion.get("rollback_groups") or [])
     promote_groups = list(actions.get("promote_groups") or promotion.get("promotable_groups") or [])
@@ -53,7 +63,8 @@ def _readiness_state(
     if promote_groups:
         return "promotion_apply_ready"
     candidate_groups = list(((promotion.get("candidate_wins") or {}).get("groups")) or [])
-    if candidate_groups:
+    benchmark_candidate_groups = list((((benchmark_promotion or {}).get("candidate_wins") or {}).get("groups")) or [])
+    if candidate_groups or benchmark_candidate_groups:
         return "collect_more_evidence"
     if _groups_with_blocker(promotion, "baseline_not_comparable"):
         return "measure_comparable_baseline"
@@ -68,8 +79,10 @@ def _summary(
     shadow: Mapping[str, Any],
     promotion: Mapping[str, Any],
     actions: Mapping[str, Any],
+    benchmark: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     evidence = shadow.get("report") or {}
+    benchmark = benchmark or {}
     return {
         "state": state,
         "mode": contract.get("mode"),
@@ -77,15 +90,19 @@ def _summary(
         "label_count": int(shadow.get("label_count") or 0),
         "labeled_sample_count": int(evidence.get("labeled_sample_count") or 0),
         "candidate_win_groups": list(((promotion.get("candidate_wins") or {}).get("groups")) or []),
+        "benchmark_candidate_win_groups": list(((benchmark.get("candidate_wins") or {}).get("groups")) or []),
         "promotion_ready_groups": list(promotion.get("promotable_groups") or []),
         "rollback_groups": list(actions.get("rollback_groups") or promotion.get("rollback_groups") or []),
         "requires_operator_apply": bool(actions.get("requires_operator_apply")),
     }
 
 
-def _evidence(shadow: Mapping[str, Any], promotion: Mapping[str, Any]) -> dict[str, Any]:
+def _evidence(
+    shadow: Mapping[str, Any], promotion: Mapping[str, Any], benchmark: Mapping[str, Any] | None = None
+) -> dict[str, Any]:
     report = shadow.get("report") or {}
     source = promotion.get("source_breakdown") or {}
+    benchmark = benchmark or {}
     return {
         "record_count_window": shadow.get("record_count_window"),
         "raw_record_count_window": shadow.get("raw_record_count_window"),
@@ -96,6 +113,9 @@ def _evidence(shadow: Mapping[str, Any], promotion: Mapping[str, Any]) -> dict[s
         "sample_deficit_by_group": dict(report.get("sample_deficit_by_group") or {}),
         "real_source_sample_count_by_group": dict(source.get("real_source_sample_count_by_group") or {}),
         "real_source_sample_deficit_by_group": dict(source.get("real_source_sample_deficit_by_group") or {}),
+        "benchmark_report_path": benchmark.get("path"),
+        "benchmark_loaded": bool(benchmark.get("loaded")),
+        "benchmark_candidate_win_groups": list((benchmark.get("candidate_wins") or {}).get("groups") or []),
     }
 
 
@@ -148,6 +168,8 @@ def _next_actions(
     shadow: Mapping[str, Any],
     promotion: Mapping[str, Any],
     actions: Mapping[str, Any],
+    *,
+    benchmark_promotion: Mapping[str, Any] | None = None,
 ) -> list[dict[str, Any]]:
     next_actions: list[dict[str, Any]] = []
     blockers = list(contract.get("blockers") or [])
@@ -183,7 +205,10 @@ def _next_actions(
             }
         )
     next_actions.extend(_evidence_collection_actions(promotion))
+    next_actions.extend(_evidence_collection_actions(benchmark_promotion or {}, source="benchmark"))
     baseline_groups = _groups_with_blocker(promotion, "baseline_not_comparable")
+    if baseline_groups and _benchmark_candidate_groups(benchmark_promotion):
+        baseline_groups = []
     if baseline_groups:
         next_actions.append(
             {
@@ -212,7 +237,7 @@ def _next_actions(
     return next_actions
 
 
-def _evidence_collection_actions(promotion: Mapping[str, Any]) -> list[dict[str, Any]]:
+def _evidence_collection_actions(promotion: Mapping[str, Any], *, source: str = "shadow") -> list[dict[str, Any]]:
     actions: list[dict[str, Any]] = []
     for item in ((promotion.get("candidate_wins") or {}).get("details") or []):
         if not isinstance(item, Mapping):
@@ -247,10 +272,65 @@ def _evidence_collection_actions(promotion: Mapping[str, Any]) -> list[dict[str,
             "needed_unique_cases": unique_deficit,
             "detail": detail,
         }
+        if source != "shadow":
+            action["evidence_source"] = source
         if real_source_deficit > 0:
             action["needed_real_source_cases"] = real_source_deficit
         actions.append(action)
     return actions
+
+
+def _load_eval_report(env: Mapping[str, str]) -> dict[str, Any]:
+    raw_path = (env.get("ZOE_PI_PROMOTION_EVAL_REPORT_PATH") or DEFAULT_EVAL_REPORT_PATH).strip()
+    if not raw_path:
+        return {"loaded": False, "path": None}
+    path = Path(raw_path).expanduser()
+    if not path.exists():
+        return {"loaded": False, "path": str(path)}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return {"loaded": False, "path": str(path), "error": exc.__class__.__name__}
+    if not isinstance(payload, Mapping):
+        return {"loaded": False, "path": str(path), "error": "invalid_report"}
+    return {"loaded": True, "path": str(path), "payload": payload}
+
+
+def _benchmark_from_eval_report(eval_report: Mapping[str, Any]) -> dict[str, Any]:
+    payload = eval_report.get("payload") if isinstance(eval_report, Mapping) else None
+    if not isinstance(payload, Mapping):
+        return {"loaded": bool(eval_report.get("loaded")), "path": eval_report.get("path"), "error": eval_report.get("error")}
+    promotion = payload.get("promotion_report") if isinstance(payload.get("promotion_report"), Mapping) else {}
+    return {
+        "loaded": True,
+        "path": eval_report.get("path"),
+        "readiness": payload.get("readiness") if isinstance(payload.get("readiness"), Mapping) else {},
+        "promotion_report": promotion,
+        "candidate_wins": promotion.get("candidate_wins") or {},
+        "source_breakdown": promotion.get("source_breakdown") or {},
+    }
+
+
+def _combined_candidate_wins(
+    promotion: Mapping[str, Any], benchmark_promotion: Mapping[str, Any] | None
+) -> dict[str, Any]:
+    primary = promotion.get("candidate_wins") if isinstance(promotion.get("candidate_wins"), Mapping) else {}
+    benchmark = (benchmark_promotion or {}).get("candidate_wins")
+    if not isinstance(benchmark, Mapping) or not benchmark.get("details"):
+        return dict(primary)
+    if not primary.get("details"):
+        return {**benchmark, "source": "benchmark"}
+    details = list(primary.get("details") or [])
+    seen = {str(item.get("intent_group")) for item in details if isinstance(item, Mapping)}
+    for item in benchmark.get("details") or []:
+        if isinstance(item, Mapping) and str(item.get("intent_group")) not in seen:
+            details.append({**item, "source": "benchmark"})
+    groups = sorted({str(item.get("intent_group")) for item in details if isinstance(item, Mapping) and item.get("intent_group")})
+    return {**primary, "details": details, "groups": groups}
+
+
+def _benchmark_candidate_groups(benchmark_promotion: Mapping[str, Any] | None) -> list[str]:
+    return list((((benchmark_promotion or {}).get("candidate_wins") or {}).get("groups")) or [])
 
 
 def _groups_with_blocker(promotion: Mapping[str, Any], blocker: str) -> list[str]:
@@ -266,4 +346,4 @@ def _groups_with_blocker(promotion: Mapping[str, Any], blocker: str) -> list[str
     return sorted(set(groups))
 
 
-__all__ = ["pi_readiness_report"]
+__all__ = ["pi_readiness_report", "DEFAULT_EVAL_REPORT_PATH"]

--- a/services/zoe-data/pi_readiness_report.py
+++ b/services/zoe-data/pi_readiness_report.py
@@ -209,7 +209,7 @@ def _next_actions(
     baseline_groups = _groups_with_blocker(promotion, "baseline_not_comparable")
     benchmark_groups = _benchmark_candidate_groups(benchmark_promotion)
     if baseline_groups and benchmark_groups:
-        baseline_groups = [g for g in baseline_groups if g in benchmark_groups]
+        baseline_groups = [g for g in baseline_groups if g not in benchmark_groups]
     if baseline_groups:
         next_actions.append(
             {

--- a/services/zoe-data/pi_readiness_report.py
+++ b/services/zoe-data/pi_readiness_report.py
@@ -204,8 +204,16 @@ def _next_actions(
                 "env": dict(actions.get("env") or {}),
             }
         )
-    next_actions.extend(_evidence_collection_actions(promotion))
-    next_actions.extend(_evidence_collection_actions(benchmark_promotion or {}, source="benchmark"))
+    shadow_evidence_actions = _evidence_collection_actions(promotion)
+    next_actions.extend(shadow_evidence_actions)
+    shadow_action_groups = {
+        str(action.get("intent_group")) for action in shadow_evidence_actions if action.get("intent_group")
+    }
+    next_actions.extend(
+        action
+        for action in _evidence_collection_actions(benchmark_promotion or {}, source="benchmark")
+        if str(action.get("intent_group")) not in shadow_action_groups
+    )
     baseline_groups = _groups_with_blocker(promotion, "baseline_not_comparable")
     benchmark_groups = _benchmark_candidate_groups(benchmark_promotion)
     if baseline_groups and benchmark_groups:

--- a/services/zoe-data/pi_readiness_report.py
+++ b/services/zoe-data/pi_readiness_report.py
@@ -207,8 +207,9 @@ def _next_actions(
     next_actions.extend(_evidence_collection_actions(promotion))
     next_actions.extend(_evidence_collection_actions(benchmark_promotion or {}, source="benchmark"))
     baseline_groups = _groups_with_blocker(promotion, "baseline_not_comparable")
-    if baseline_groups and _benchmark_candidate_groups(benchmark_promotion):
-        baseline_groups = []
+    benchmark_groups = _benchmark_candidate_groups(benchmark_promotion)
+    if baseline_groups and benchmark_groups:
+        baseline_groups = [g for g in baseline_groups if g in benchmark_groups]
     if baseline_groups:
         next_actions.append(
             {

--- a/services/zoe-data/tests/test_pi_promotion_eval_script.py
+++ b/services/zoe-data/tests/test_pi_promotion_eval_script.py
@@ -542,3 +542,16 @@ def test_build_eval_readiness_reviews_sparse_candidate_evidence():
     assert readiness["next_actions"] == [
         {"kind": "review_candidate_evidence", "priority": "p1", "groups": ["weather"]}
     ]
+
+
+def test_cli_writes_output_file(tmp_path, capsys):
+    module = _load_module()
+    output_path = tmp_path / "report.json"
+
+    exit_code = module.main(["--no-default-cases", "--output", str(output_path)])
+
+    assert exit_code == 0
+    assert capsys.readouterr().out == ""
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+    assert payload["eval_cases"] == []
+    assert payload["promotion_report"]["sample_count"] == 0

--- a/services/zoe-data/tests/test_pi_readiness_report.py
+++ b/services/zoe-data/tests/test_pi_readiness_report.py
@@ -182,3 +182,71 @@ def test_readiness_report_requests_comparable_baseline_for_router_only_shadow_da
         "detail": "Measure Pi against Zoe Agent or operator fallback latency before judging promotion.",
         "groups": ["weather"],
     } in report["next_actions"]
+
+
+def test_readiness_report_uses_persisted_eval_benchmark_for_candidate_wins(tmp_path):
+    shadow_path = tmp_path / "shadow.jsonl"
+    shadow_path.write_text(json.dumps(_winning_weather_row(1)) + "\n", encoding="utf-8")
+    eval_report_path = tmp_path / "pi-eval.json"
+    eval_report_path.write_text(
+        json.dumps(
+            {
+                "promotion_report": {
+                    "candidate_wins": {
+                        "groups": ["weather"],
+                        "details": [
+                            {
+                                "intent_group": "weather",
+                                "status": "needs_more_evidence",
+                                "unique_case_count": 3,
+                                "unique_case_deficit": 27,
+                                "sample_deficit": 27,
+                                "real_source_sample_deficit": 27,
+                                "accuracy_delta": 1.0,
+                                "latency_delta_ms": 5000.0,
+                                "pi_p95_latency_ms": 3000.0,
+                                "zoe_p95_latency_ms": 8000.0,
+                                "promotion_blockers": ["insufficient_samples", "insufficient_real_source_samples"],
+                            }
+                        ],
+                    },
+                    "decisions": [],
+                    "promotion_actions": {},
+                },
+                "readiness": {"state": "collect_more_evidence"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    env = _env(tmp_path, shadow_path)
+    env["ZOE_PI_PROMOTION_EVAL_REPORT_PATH"] = str(eval_report_path)
+
+    report = pi_readiness_report(env)
+
+    assert report["state"] == "collect_more_evidence"
+    assert report["benchmark"]["loaded"] is True
+    assert report["summary"]["benchmark_candidate_win_groups"] == ["weather"]
+    assert report["evidence"]["benchmark_loaded"] is True
+    assert report["candidates"][0]["intent_group"] == "weather"
+    assert {
+        "kind": "collect_labeled_evidence",
+        "priority": "p1",
+        "intent_group": "weather",
+        "needed_unique_cases": 27,
+        "needed_real_source_cases": 27,
+        "detail": "Collect and label 27 more unique weather cases (27 must be real/log-derived) before promotion.",
+        "evidence_source": "benchmark",
+    } in report["next_actions"]
+
+
+def test_readiness_report_missing_eval_benchmark_is_nonblocking(tmp_path):
+    shadow_path = tmp_path / "shadow.jsonl"
+    shadow_path.write_text("", encoding="utf-8")
+    env = _env(tmp_path, shadow_path)
+    env["ZOE_PI_PROMOTION_EVAL_REPORT_PATH"] = str(tmp_path / "missing.json")
+
+    report = pi_readiness_report(env)
+
+    assert report["benchmark"]["loaded"] is False
+    assert report["evidence"]["benchmark_loaded"] is False
+    assert report["state"] == "shadow_collecting"

--- a/services/zoe-data/tests/test_pi_readiness_report.py
+++ b/services/zoe-data/tests/test_pi_readiness_report.py
@@ -186,7 +186,7 @@ def test_readiness_report_requests_comparable_baseline_for_router_only_shadow_da
 
 def test_readiness_report_uses_persisted_eval_benchmark_for_candidate_wins(tmp_path):
     shadow_path = tmp_path / "shadow.jsonl"
-    shadow_path.write_text(json.dumps(_winning_weather_row(1)) + "\n", encoding="utf-8")
+    shadow_path.write_text("", encoding="utf-8")
     eval_report_path = tmp_path / "pi-eval.json"
     eval_report_path.write_text(
         json.dumps(
@@ -238,6 +238,53 @@ def test_readiness_report_uses_persisted_eval_benchmark_for_candidate_wins(tmp_p
         "evidence_source": "benchmark",
     } in report["next_actions"]
 
+
+
+
+def test_readiness_report_deduplicates_shadow_and_benchmark_collection_actions(tmp_path):
+    shadow_path = tmp_path / "shadow.jsonl"
+    shadow_path.write_text(json.dumps(_winning_weather_row(1)) + "\n", encoding="utf-8")
+    eval_report_path = tmp_path / "pi-eval.json"
+    eval_report_path.write_text(
+        json.dumps(
+            {
+                "promotion_report": {
+                    "candidate_wins": {
+                        "groups": ["weather"],
+                        "details": [
+                            {
+                                "intent_group": "weather",
+                                "status": "needs_more_evidence",
+                                "unique_case_deficit": 28,
+                                "sample_deficit": 28,
+                                "real_source_sample_deficit": 30,
+                                "accuracy_delta": 1.0,
+                                "latency_delta_ms": 2500.0,
+                                "pi_p95_latency_ms": 3000.0,
+                                "zoe_p95_latency_ms": 5500.0,
+                                "promotion_blockers": ["insufficient_samples", "insufficient_real_source_samples"],
+                            }
+                        ],
+                    },
+                    "decisions": [],
+                    "promotion_actions": {},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    env = _env(tmp_path, shadow_path)
+    env["ZOE_PI_PROMOTION_EVAL_REPORT_PATH"] = str(eval_report_path)
+
+    report = pi_readiness_report(env)
+
+    weather_actions = [
+        action
+        for action in report["next_actions"]
+        if action.get("kind") == "collect_labeled_evidence" and action.get("intent_group") == "weather"
+    ]
+    assert len(weather_actions) == 1
+    assert "evidence_source" not in weather_actions[0]
 
 
 def test_readiness_report_keeps_baseline_action_for_groups_not_covered_by_benchmark(tmp_path):

--- a/services/zoe-data/tests/test_pi_readiness_report.py
+++ b/services/zoe-data/tests/test_pi_readiness_report.py
@@ -239,6 +239,57 @@ def test_readiness_report_uses_persisted_eval_benchmark_for_candidate_wins(tmp_p
     } in report["next_actions"]
 
 
+
+def test_readiness_report_keeps_baseline_action_for_groups_not_covered_by_benchmark(tmp_path):
+    shadow_path = tmp_path / "shadow.jsonl"
+    row = _winning_weather_row(1)
+    row["zoe_latency_ms"] = 10
+    row["baseline_kind"] = "router_only_not_comparable"
+    row["baseline_comparable"] = False
+    shadow_path.write_text(json.dumps(row) + "\n", encoding="utf-8")
+    eval_report_path = tmp_path / "pi-eval.json"
+    eval_report_path.write_text(
+        json.dumps(
+            {
+                "promotion_report": {
+                    "candidate_wins": {
+                        "groups": ["timers"],
+                        "details": [
+                            {
+                                "intent_group": "timers",
+                                "status": "needs_more_evidence",
+                                "unique_case_deficit": 29,
+                                "sample_deficit": 29,
+                                "real_source_sample_deficit": 30,
+                                "accuracy_delta": 1.0,
+                                "latency_delta_ms": 1800.0,
+                                "pi_p95_latency_ms": 2400.0,
+                                "zoe_p95_latency_ms": 4200.0,
+                                "promotion_blockers": ["insufficient_samples", "insufficient_real_source_samples"],
+                            }
+                        ],
+                    },
+                    "decisions": [],
+                    "promotion_actions": {},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    env = _env(tmp_path, shadow_path)
+    env["ZOE_PI_PROMOTION_EVAL_REPORT_PATH"] = str(eval_report_path)
+
+    report = pi_readiness_report(env)
+
+    assert report["state"] == "collect_more_evidence"
+    assert {
+        "kind": "measure_comparable_baseline",
+        "priority": "p1",
+        "detail": "Measure Pi against Zoe Agent or operator fallback latency before judging promotion.",
+        "groups": ["weather"],
+    } in report["next_actions"]
+
+
 def test_readiness_report_missing_eval_benchmark_is_nonblocking(tmp_path):
     shadow_path = tmp_path / "shadow.jsonl"
     shadow_path.write_text("", encoding="utf-8")


### PR DESCRIPTION
## Summary
- add --output support to pi_promotion_eval so real benchmark reports can be persisted
- teach pi_readiness_report to load the persisted eval report and surface benchmark candidate wins
- move readiness from baseline-measurement to evidence-collection when benchmark candidates exist

## Validation
- python3 -m pytest -q services/zoe-data/tests/test_pi_readiness_report.py services/zoe-data/tests/test_pi_promotion_eval_script.py
- python3 -m pytest -q services/zoe-data/tests/test_pi_*.py services/zoe-data/tests/test_zoe_pi_promotion.py
- python3 -m py_compile scripts/maintenance/pi_promotion_eval.py services/zoe-data/pi_readiness_report.py
- python3 tools/audit/validate_structure.py