### PR TITLE
[codex] Guard Pi lab under resource pressure

### DIFF
--- a/services/zoe-data/routers/pi_intent_lab.py
+++ b/services/zoe-data/routers/pi_intent_lab.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import time
+from pathlib import Path
 from typing import Any, AsyncIterator, Literal, Mapping
 
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -49,6 +51,9 @@ class PiIntentLabCompareRequest(BaseModel):
 @router.post("/compare")
 async def compare_pi_intent(payload: PiIntentLabCompareRequest, user: dict = Depends(require_lab_operator)):
     """Compare Zoe router, optional Zoe Agent fallback, and standalone Pi without dispatching."""
+    pressure = _pi_lab_resource_pressure_blocker(payload)
+    if pressure:
+        raise HTTPException(status_code=503, detail=pressure)
     try:
         return await asyncio.wait_for(
             _run_compare(payload, user_id=str(user.get("user_id") or "admin")),
@@ -106,6 +111,15 @@ async def _hybrid_stream_events(payload: PiIntentLabCompareRequest, user: Mappin
             },
         }
     )
+    pressure = _pi_lab_resource_pressure_blocker(payload)
+    if pressure:
+        yield _stream_error(
+            started,
+            error=str(pressure.get("detail") or "Pi intent lab blocked by resource pressure"),
+            error_type="resource_pressure",
+            resource=pressure,
+        )
+        return
     try:
         result = await asyncio.wait_for(
             _run_compare(payload, user_id=str(user.get("user_id") or "admin")),
@@ -180,6 +194,7 @@ def _stream_error(
     error: str,
     error_type: str,
     exception_class: str | None = None,
+    resource: Mapping[str, Any] | None = None,
 ) -> str:
     payload: dict[str, Any] = {
         "event": "error",
@@ -191,7 +206,75 @@ def _stream_error(
     }
     if exception_class:
         payload["exception_class"] = exception_class
+    if resource:
+        payload["resource"] = dict(resource)
     return _json_line(payload)
+
+
+def _pi_lab_resource_pressure_blocker(payload: PiIntentLabCompareRequest) -> dict[str, Any] | None:
+    if not _env_bool("ZOE_PI_LAB_RESOURCE_GUARD_ENABLED", default=True):
+        return None
+    if not (payload.run_pi or payload.include_safe_fulfillment or payload.measure_zoe_agent_baseline):
+        return None
+    min_available_mb = _env_float("ZOE_PI_LAB_MIN_AVAILABLE_MB", 2048.0)
+    min_swap_free_mb = _env_float("ZOE_PI_LAB_MIN_SWAP_FREE_MB", 256.0)
+    if min_available_mb <= 0 and min_swap_free_mb <= 0:
+        return None
+    mem = _read_meminfo_mb()
+    if not mem:
+        return None
+    available_mb = mem.get("MemAvailable")
+    swap_free_mb = mem.get("SwapFree")
+    blockers: list[str] = []
+    if min_available_mb > 0 and available_mb is not None and available_mb < min_available_mb:
+        blockers.append("available_memory_below_threshold")
+    if min_swap_free_mb > 0 and swap_free_mb is not None and swap_free_mb < min_swap_free_mb:
+        blockers.append("swap_free_below_threshold")
+    if not blockers:
+        return None
+    return {
+        "error_type": "resource_pressure",
+        "detail": "Pi intent lab blocked to avoid zoe-data OOM restart",
+        "blockers": blockers,
+        "available_mb": available_mb,
+        "swap_free_mb": swap_free_mb,
+        "min_available_mb": int(min_available_mb),
+        "min_swap_free_mb": int(min_swap_free_mb),
+        "production_route_change": False,
+    }
+
+
+def _read_meminfo_mb(path: str = "/proc/meminfo") -> dict[str, int] | None:
+    try:
+        target = Path(path)
+        if not target.is_file():
+            return None
+        values: dict[str, int] = {}
+        for raw in target.read_text(encoding="utf-8", errors="ignore").splitlines():
+            parts = raw.split()
+            if len(parts) >= 2:
+                key = parts[0].rstrip(":")
+                if key in {"MemAvailable", "MemFree", "Buffers", "Cached", "SwapFree"}:
+                    values[key] = int(parts[1]) // 1024
+        if "MemAvailable" not in values and "MemFree" in values:
+            values["MemAvailable"] = values["MemFree"] + values.get("Buffers", 0) + values.get("Cached", 0)
+        return values
+    except (OSError, ValueError, IndexError):
+        return None
+
+
+def _env_bool(name: str, *, default: bool) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _env_float(name: str, default: float) -> float:
+    try:
+        return float(os.environ.get(name) or default)
+    except (TypeError, ValueError):
+        return default
 
 
 def _safe_error_message(exc: Exception, *, limit: int = 200) -> str:

--- a/services/zoe-data/routers/pi_intent_lab.py
+++ b/services/zoe-data/routers/pi_intent_lab.py
@@ -51,7 +51,7 @@ class PiIntentLabCompareRequest(BaseModel):
 @router.post("/compare")
 async def compare_pi_intent(payload: PiIntentLabCompareRequest, user: dict = Depends(require_lab_operator)):
     """Compare Zoe router, optional Zoe Agent fallback, and standalone Pi without dispatching."""
-    pressure = _pi_lab_resource_pressure_blocker(payload)
+    pressure = await _pi_lab_resource_pressure_blocker(payload)
     if pressure:
         raise HTTPException(status_code=503, detail=pressure)
     try:
@@ -111,7 +111,7 @@ async def _hybrid_stream_events(payload: PiIntentLabCompareRequest, user: Mappin
             },
         }
     )
-    pressure = _pi_lab_resource_pressure_blocker(payload)
+    pressure = await _pi_lab_resource_pressure_blocker(payload)
     if pressure:
         yield _stream_error(
             started,
@@ -211,7 +211,7 @@ def _stream_error(
     return _json_line(payload)
 
 
-def _pi_lab_resource_pressure_blocker(payload: PiIntentLabCompareRequest) -> dict[str, Any] | None:
+async def _pi_lab_resource_pressure_blocker(payload: PiIntentLabCompareRequest) -> dict[str, Any] | None:
     if not _env_bool("ZOE_PI_LAB_RESOURCE_GUARD_ENABLED", default=True):
         return None
     if not (payload.run_pi or payload.include_safe_fulfillment or payload.measure_zoe_agent_baseline):
@@ -220,7 +220,7 @@ def _pi_lab_resource_pressure_blocker(payload: PiIntentLabCompareRequest) -> dic
     min_swap_free_mb = _env_float("ZOE_PI_LAB_MIN_SWAP_FREE_MB", 256.0)
     if min_available_mb <= 0 and min_swap_free_mb <= 0:
         return None
-    mem = _read_meminfo_mb()
+    mem = await asyncio.to_thread(_read_meminfo_mb)
     if not mem:
         return None
     available_mb = mem.get("MemAvailable")

--- a/services/zoe-data/tests/test_pi_intent_lab.py
+++ b/services/zoe-data/tests/test_pi_intent_lab.py
@@ -957,20 +957,83 @@ def test_pi_intent_lab_endpoint_returns_comparison(monkeypatch):
 
 
 
+
+@pytest.mark.asyncio
+async def test_pi_lab_resource_pressure_guard_thresholds(monkeypatch):
+    import routers.pi_intent_lab as route_module
+
+    payload = route_module.PiIntentLabCompareRequest(text="rain later", run_pi=True)
+    monkeypatch.setenv("ZOE_PI_LAB_MIN_AVAILABLE_MB", "2048")
+    monkeypatch.setenv("ZOE_PI_LAB_MIN_SWAP_FREE_MB", "256")
+    monkeypatch.setattr(
+        route_module,
+        "_read_meminfo_mb",
+        lambda: {"MemAvailable": 1024, "SwapFree": 128},
+    )
+
+    pressure = await route_module._pi_lab_resource_pressure_blocker(payload)
+
+    assert pressure is not None
+    assert pressure["error_type"] == "resource_pressure"
+    assert pressure["blockers"] == ["available_memory_below_threshold", "swap_free_below_threshold"]
+    assert pressure["available_mb"] == 1024
+    assert pressure["swap_free_mb"] == 128
+
+
+@pytest.mark.asyncio
+async def test_pi_lab_resource_pressure_guard_passes_when_healthy(monkeypatch):
+    import routers.pi_intent_lab as route_module
+
+    payload = route_module.PiIntentLabCompareRequest(text="rain later", run_pi=True)
+    monkeypatch.setenv("ZOE_PI_LAB_MIN_AVAILABLE_MB", "2048")
+    monkeypatch.setenv("ZOE_PI_LAB_MIN_SWAP_FREE_MB", "256")
+    monkeypatch.setattr(
+        route_module,
+        "_read_meminfo_mb",
+        lambda: {"MemAvailable": 4096, "SwapFree": 1024},
+    )
+
+    assert await route_module._pi_lab_resource_pressure_blocker(payload) is None
+
+
+@pytest.mark.asyncio
+async def test_pi_lab_resource_pressure_guard_can_be_disabled(monkeypatch):
+    import routers.pi_intent_lab as route_module
+
+    payload = route_module.PiIntentLabCompareRequest(text="rain later", run_pi=True)
+    monkeypatch.setenv("ZOE_PI_LAB_RESOURCE_GUARD_ENABLED", "0")
+    monkeypatch.setattr(route_module, "_read_meminfo_mb", lambda: {"MemAvailable": 1, "SwapFree": 1})
+
+    assert await route_module._pi_lab_resource_pressure_blocker(payload) is None
+
+
+def test_pi_lab_resource_pressure_meminfo_fallback(tmp_path):
+    import routers.pi_intent_lab as route_module
+
+    meminfo = tmp_path / "meminfo"
+    meminfo.write_text(
+        "MemFree:        1048576 kB\nBuffers:         262144 kB\nCached:          524288 kB\nSwapFree:        131072 kB\n",
+        encoding="utf-8",
+    )
+
+    values = route_module._read_meminfo_mb(str(meminfo))
+
+    assert values["MemAvailable"] == 1792
+    assert values["SwapFree"] == 128
+
 def test_pi_intent_lab_compare_blocks_under_resource_pressure(monkeypatch):
     import routers.pi_intent_lab as route_module
 
-    monkeypatch.setattr(
-        route_module,
-        "_pi_lab_resource_pressure_blocker",
-        lambda payload: {
+    async def fake_pressure(payload):
+        return {
             "error_type": "resource_pressure",
             "detail": "Pi intent lab blocked to avoid zoe-data OOM restart",
             "available_mb": 512,
             "min_available_mb": 2048,
             "production_route_change": False,
-        },
-    )
+        }
+
+    monkeypatch.setattr(route_module, "_pi_lab_resource_pressure_blocker", fake_pressure)
     app = _admin_app()
 
     resp = TestClient(app).post(
@@ -988,17 +1051,16 @@ def test_pi_intent_lab_compare_blocks_under_resource_pressure(monkeypatch):
 def test_pi_intent_lab_hybrid_stream_emits_resource_pressure_after_cue(monkeypatch):
     import routers.pi_intent_lab as route_module
 
-    monkeypatch.setattr(
-        route_module,
-        "_pi_lab_resource_pressure_blocker",
-        lambda payload: {
+    async def fake_pressure(payload):
+        return {
             "error_type": "resource_pressure",
             "detail": "Pi intent lab blocked to avoid zoe-data OOM restart",
             "available_mb": 512,
             "min_available_mb": 2048,
             "production_route_change": False,
-        },
-    )
+        }
+
+    monkeypatch.setattr(route_module, "_pi_lab_resource_pressure_blocker", fake_pressure)
     monkeypatch.setattr(
         route_module,
         "_processing_cue",

--- a/services/zoe-data/tests/test_pi_intent_lab.py
+++ b/services/zoe-data/tests/test_pi_intent_lab.py
@@ -956,6 +956,70 @@ def test_pi_intent_lab_endpoint_returns_comparison(monkeypatch):
     assert data["simulated_hybrid_flow"]["cue_available"] is True
 
 
+
+def test_pi_intent_lab_compare_blocks_under_resource_pressure(monkeypatch):
+    import routers.pi_intent_lab as route_module
+
+    monkeypatch.setattr(
+        route_module,
+        "_pi_lab_resource_pressure_blocker",
+        lambda payload: {
+            "error_type": "resource_pressure",
+            "detail": "Pi intent lab blocked to avoid zoe-data OOM restart",
+            "available_mb": 512,
+            "min_available_mb": 2048,
+            "production_route_change": False,
+        },
+    )
+    app = _admin_app()
+
+    resp = TestClient(app).post(
+        "/api/pi-intent-lab/compare",
+        json={"text": "rain later", "run_pi": True},
+    )
+
+    assert resp.status_code == 503
+    detail = resp.json()["detail"]
+    assert detail["error_type"] == "resource_pressure"
+    assert detail["production_route_change"] is False
+    assert detail["available_mb"] == 512
+
+
+def test_pi_intent_lab_hybrid_stream_emits_resource_pressure_after_cue(monkeypatch):
+    import routers.pi_intent_lab as route_module
+
+    monkeypatch.setattr(
+        route_module,
+        "_pi_lab_resource_pressure_blocker",
+        lambda payload: {
+            "error_type": "resource_pressure",
+            "detail": "Pi intent lab blocked to avoid zoe-data OOM restart",
+            "available_mb": 512,
+            "min_available_mb": 2048,
+            "production_route_change": False,
+        },
+    )
+    monkeypatch.setattr(
+        route_module,
+        "_processing_cue",
+        lambda: {"available": True, "latency_ms": 0.05, "event": None, "text": "Let me check."},
+    )
+    app = _admin_app()
+
+    with TestClient(app).stream(
+        "POST",
+        "/api/pi-intent-lab/hybrid-stream",
+        json={"text": "rain later", "run_pi": True},
+    ) as resp:
+        assert resp.status_code == 200
+        events = [json.loads(line) for line in resp.iter_lines() if line]
+
+    assert [event["event"] for event in events] == ["processing_cue", "error"]
+    assert events[1]["error_type"] == "resource_pressure"
+    assert events[1]["phase"] == "final"
+    assert events[1]["resource"]["available_mb"] == 512
+    assert events[1]["production_route_change"] is False
+
 def test_pi_intent_lab_endpoint_times_out_stuck_comparison(monkeypatch):
     import routers.pi_intent_lab as route_module
 


### PR DESCRIPTION
## Summary
- add a configurable /proc/meminfo resource-pressure guard before Pi lab comparisons
- return HTTP 503 for /compare when memory/swap is below threshold
- keep /hybrid-stream cue-first, then emit a structured resource_pressure error instead of risking an OOM restart

## Validation
- python3 -m pytest -q services/zoe-data/tests/test_pi_intent_lab.py services/zoe-data/tests/test_pi_hybrid_stream_http_probe.py services/zoe-data/tests/test_pi_intent_lab_http_probe.py services/zoe-data/tests/test_conversation_flow_probe.py
- python3 -m py_compile services/zoe-data/routers/pi_intent_lab.py scripts/maintenance/pi_hybrid_stream_http_probe.py scripts/maintenance/conversation_flow_probe.py
- python3 tools/audit/validate_structure.py
- git diff --check