### PR TITLE
[codex] Use direct daily briefing fulfillment

### DIFF
--- a/services/zoe-data/intent_router.py
+++ b/services/zoe-data/intent_router.py
@@ -2453,26 +2453,19 @@ async def execute_intent(intent: Intent, user_id: str = "family-admin") -> Optio
 
 async def _execute_daily_briefing(user_id: str) -> Optional[str]:
     """Composite intent: weather + calendar + reminders."""
-    base = f"{MCPORTER} call"
-    cmds = {
-        "weather": f"{base} zoe-data.weather_current",
-        "calendar": f"{base} zoe-data.calendar_today",
-        "reminders": f"{base} zoe-data.reminder_list today_only=true",
-    }
-
-    results = {}
-    task_keys = list(cmds)
+    task_keys = ["weather", "calendar", "reminders"]
     task_results = await asyncio.gather(
-        *(_run_mcporter(cmds[key]) for key in task_keys),
+        _daily_briefing_weather(user_id),
+        _daily_briefing_calendar(user_id),
+        _daily_briefing_reminders(user_id),
         return_exceptions=True,
     )
 
-    for key, raw in zip(task_keys, task_results):
-        if raw and not isinstance(raw, BaseException):
-            try:
-                results[key] = json.loads(raw)
-            except json.JSONDecodeError:
-                pass
+    results = {
+        key: raw
+        for key, raw in zip(task_keys, task_results)
+        if raw and not isinstance(raw, BaseException)
+    }
 
     lines = ["Here's your day:"]
 
@@ -2498,6 +2491,69 @@ async def _execute_daily_briefing(user_id: str) -> Optional[str]:
             lines.append(f"  - {r.get('title', '?')}{suffix}")
 
     return "\n".join(lines)
+
+
+async def _daily_briefing_weather(user_id: str) -> Optional[dict]:
+    try:
+        from database import get_db
+        from routers.weather import _get_current, _resolve_location, _row_to_prefs
+
+        async for db in get_db():
+            cursor = await db.execute(
+                "SELECT * FROM weather_preferences WHERE user_id = ?",
+                [user_id],
+            )
+            prefs = _row_to_prefs(await cursor.fetchone())
+            lat, lon, city, country = _resolve_location(prefs)
+            current = await _get_current(lat, lon, city, country)
+            return {
+                "temp": current.get("temp"),
+                "city": current.get("city") or city or "your area",
+                "description": current.get("description", ""),
+            }
+    except Exception as exc:
+        logger.warning("daily briefing weather direct execution unavailable: %s", exc)
+    return None
+
+
+async def _daily_briefing_calendar(user_id: str) -> Optional[dict]:
+    try:
+        from datetime import date
+        from database import get_db_ctx
+
+        today = date.today().isoformat()
+        async with get_db_ctx() as db:
+            cursor = await db.execute(
+                "SELECT id, title, start_time, end_time, category, location FROM events"
+                " WHERE start_date = ? AND (visibility = 'family' OR user_id = ?) AND deleted = 0"
+                " ORDER BY start_time",
+                (today, user_id),
+            )
+            rows = await cursor.fetchall()
+        return {"date": today, "events": [dict(r) for r in rows]}
+    except Exception as exc:
+        logger.warning("daily briefing calendar direct execution unavailable: %s", exc)
+    return None
+
+
+async def _daily_briefing_reminders(user_id: str) -> Optional[dict]:
+    try:
+        from datetime import date
+        from database import get_db_ctx
+
+        today = date.today().isoformat()
+        async with get_db_ctx() as db:
+            cursor = await db.execute(
+                "SELECT id, title, due_date, due_time, priority, category FROM reminders"
+                " WHERE due_date = ? AND (visibility = 'family' OR user_id = ?)"
+                " AND is_active = 1 AND deleted = 0 ORDER BY due_time",
+                (today, user_id),
+            )
+            rows = await cursor.fetchall()
+        return {"reminders": [dict(r) for r in rows]}
+    except Exception as exc:
+        logger.warning("daily briefing reminder direct execution unavailable: %s", exc)
+    return None
 
 
 async def _execute_weather_direct(user_id: str, forecast: bool = False) -> Optional[str]:

--- a/services/zoe-data/tests/test_daily_briefing_concurrency.py
+++ b/services/zoe-data/tests/test_daily_briefing_concurrency.py
@@ -1,30 +1,34 @@
 import asyncio
-import json
 import pytest
 
 from intent_router import _execute_daily_briefing
 
 
 @pytest.mark.asyncio
-async def test_daily_briefing_runs_mcporter_calls_concurrently(monkeypatch):
+async def test_daily_briefing_runs_direct_calls_concurrently(monkeypatch):
     calls = []
     all_started = asyncio.Event()
     release = asyncio.Event()
 
-    async def fake_run_mcporter(cmd):
-        calls.append(cmd)
+    async def fake_direct(key, payload):
+        calls.append(key)
         if len(calls) == 3:
             all_started.set()
         await release.wait()
-        if "weather_current" in cmd:
-            return json.dumps({"temp": 18.5, "city": "Perth", "description": "clear"})
-        if "calendar_today" in cmd:
-            return json.dumps({"events": [{"title": "Standup", "start_time": "09:00"}]})
-        if "reminder_list" in cmd:
-            return json.dumps({"reminders": [{"title": "pay invoice", "due_time": "17:00"}]})
-        return None
+        return payload
 
-    monkeypatch.setattr("intent_router._run_mcporter", fake_run_mcporter)
+    monkeypatch.setattr(
+        "intent_router._daily_briefing_weather",
+        lambda user_id: fake_direct("weather", {"temp": 18.5, "city": "Perth", "description": "clear"}),
+    )
+    monkeypatch.setattr(
+        "intent_router._daily_briefing_calendar",
+        lambda user_id: fake_direct("calendar", {"events": [{"title": "Standup", "start_time": "09:00"}]}),
+    )
+    monkeypatch.setattr(
+        "intent_router._daily_briefing_reminders",
+        lambda user_id: fake_direct("reminders", {"reminders": [{"title": "pay invoice", "due_time": "17:00"}]}),
+    )
 
     task = asyncio.create_task(_execute_daily_briefing("family-admin"))
     await asyncio.wait_for(all_started.wait(), timeout=1.0)
@@ -37,24 +41,44 @@ async def test_daily_briefing_runs_mcporter_calls_concurrently(monkeypatch):
     assert "Weather: 18.5" in result
     assert "Standup at 09:00" in result
     assert "pay invoice at 17:00" in result
+    assert set(calls) == {"weather", "calendar", "reminders"}
 
 
 @pytest.mark.asyncio
 async def test_daily_briefing_preserves_partial_results_when_one_call_fails(monkeypatch):
-    async def fake_run_mcporter(cmd):
+    async def fake_weather(user_id):
         await asyncio.sleep(0)
-        if "weather_current" in cmd:
-            return json.dumps({"temp": 19, "city": "Perth", "description": "cloudy"})
-        if "calendar_today" in cmd:
-            raise RuntimeError("calendar unavailable")
-        if "reminder_list" in cmd:
-            return json.dumps({"reminders": [{"title": "check oven"}]})
-        return None
+        return {"temp": 19, "city": "Perth", "description": "cloudy"}
 
-    monkeypatch.setattr("intent_router._run_mcporter", fake_run_mcporter)
+    async def fake_calendar(user_id):
+        await asyncio.sleep(0)
+        raise RuntimeError("calendar unavailable")
+
+    async def fake_reminders(user_id):
+        await asyncio.sleep(0)
+        return {"reminders": [{"title": "check oven"}]}
+
+    monkeypatch.setattr("intent_router._daily_briefing_weather", fake_weather)
+    monkeypatch.setattr("intent_router._daily_briefing_calendar", fake_calendar)
+    monkeypatch.setattr("intent_router._daily_briefing_reminders", fake_reminders)
 
     result = await _execute_daily_briefing("family-admin")
 
     assert "Weather: 19" in result
     assert "No events on the calendar today." in result
     assert "check oven" in result
+
+
+@pytest.mark.asyncio
+async def test_daily_briefing_does_not_use_mcporter(monkeypatch):
+    async def fail_mcporter(_cmd):
+        raise AssertionError("daily briefing should use direct in-process fulfillment")
+
+    monkeypatch.setattr("intent_router._run_mcporter", fail_mcporter)
+    monkeypatch.setattr("intent_router._daily_briefing_weather", lambda user_id: asyncio.sleep(0, result=None))
+    monkeypatch.setattr("intent_router._daily_briefing_calendar", lambda user_id: asyncio.sleep(0, result={"events": []}))
+    monkeypatch.setattr("intent_router._daily_briefing_reminders", lambda user_id: asyncio.sleep(0, result={"reminders": []}))
+
+    result = await _execute_daily_briefing("family-admin")
+
+    assert result == "Here\'s your day:\n\nNo events on the calendar today."


### PR DESCRIPTION
## Summary
- replaces daily briefing's mcporter subprocess fan-out with direct in-process weather, calendar, and reminder reads
- keeps partial-result behavior for daily briefing when one data source fails
- adds regression coverage proving daily briefing no longer calls mcporter

## Why
Pi hybrid daily briefing was producing a usable answer, but the fulfillment path emitted mcporter connection errors before falling back. This closes the production contract so the touch-panel voice path can promote daily briefing cleanly after merge.

## Validation
- `PYTHONPATH=. python3 -m pytest -q tests/test_daily_briefing_concurrency.py tests/test_pi_hybrid_production.py`
- `PYTHONPATH=. python3 -m pytest -q tests/test_voice_weather_queue.py tests/test_pi_hybrid_production.py tests/test_daily_briefing_concurrency.py`
- `python3 tools/audit/validate_structure.py`
- live branch probe: Pi hybrid daily briefing accepted with direct weather/calendar/reminder fulfillment and no mcporter errors
