### PR TITLE
[codex] Expose Pi hybrid production status

### DIFF
--- a/services/zoe-data/routers/system.py
+++ b/services/zoe-data/routers/system.py
@@ -34,6 +34,17 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/system", tags=["system"])
 
 
+def _pi_hybrid_production_public_status() -> dict[str, Any]:
+    """Minimal non-admin summary for the live Pi hybrid production lane."""
+    status = _pi_hybrid_production_status()
+    return {
+        "report_kind": "zoe_pi_hybrid_production_summary",
+        "ok": bool(status.get("ok")),
+        "status": status.get("status") or "unknown",
+        "details_endpoint": "/api/system/pi-intent/production-status",
+    }
+
+
 def _pi_hybrid_production_status() -> dict[str, Any]:
     """Read-only status for the live Pi hybrid production lane."""
     try:
@@ -199,7 +210,7 @@ async def get_system_status(
             "pending_actions": ui_actions_pending,
             "online_panels_30s": panels_online,
         },
-        "pi_hybrid_production": _pi_hybrid_production_status(),
+        "pi_hybrid_production": _pi_hybrid_production_public_status(),
     }
 
 

--- a/services/zoe-data/routers/system.py
+++ b/services/zoe-data/routers/system.py
@@ -60,7 +60,7 @@ def _pi_hybrid_production_status() -> dict[str, Any]:
     return {
         "report_kind": "zoe_pi_hybrid_production_status",
         "ok": bool(config.enabled and enabled_groups),
-        "status": "enabled" if config.enabled else "disabled",
+        "status": "enabled_no_groups" if config.enabled and not enabled_groups else "enabled" if config.enabled else "disabled",
         "route": "pi_intent_buffer_plus_zoe_safe_fulfillment",
         "surfaces": ["chat_non_stream", "chat_stream", "voice_non_stream"],
         "config": config_dict,

--- a/services/zoe-data/routers/system.py
+++ b/services/zoe-data/routers/system.py
@@ -34,6 +34,43 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/system", tags=["system"])
 
 
+def _pi_hybrid_production_status() -> dict[str, Any]:
+    """Read-only status for the live Pi hybrid production lane."""
+    try:
+        from pi_hybrid_production import PiHybridProductionConfig
+
+        config = PiHybridProductionConfig.from_env()
+        config_dict = config.to_dict()
+    except ValueError as exc:
+        return {
+            "report_kind": "zoe_pi_hybrid_production_status",
+            "ok": False,
+            "status": "invalid_config",
+            "error": str(exc),
+        }
+    except Exception as exc:
+        return {
+            "report_kind": "zoe_pi_hybrid_production_status",
+            "ok": False,
+            "status": "unavailable",
+            "error": exc.__class__.__name__,
+        }
+
+    enabled_groups = config_dict.get("groups") or []
+    return {
+        "report_kind": "zoe_pi_hybrid_production_status",
+        "ok": bool(config.enabled and enabled_groups),
+        "status": "enabled" if config.enabled else "disabled",
+        "route": "pi_intent_buffer_plus_zoe_safe_fulfillment",
+        "surfaces": ["chat_non_stream", "chat_stream", "voice_non_stream"],
+        "config": config_dict,
+        "notes": [
+            "Production Pi hybrid is separate from shadow/promotion evidence status.",
+            "Only allowlisted low-risk groups can be enabled here.",
+        ],
+    }
+
+
 @router.get("/platform")
 async def get_platform():
     return {
@@ -162,6 +199,7 @@ async def get_system_status(
             "pending_actions": ui_actions_pending,
             "online_panels_30s": panels_online,
         },
+        "pi_hybrid_production": _pi_hybrid_production_status(),
     }
 
 
@@ -195,6 +233,13 @@ async def get_pi_hybrid_buffer_status(user: dict = Depends(require_admin)):
     from pi_hybrid_buffer import pi_hybrid_buffer_status
 
     return pi_hybrid_buffer_status()
+
+
+@router.get("/pi-intent/production-status")
+async def get_pi_hybrid_production_status(user: dict = Depends(require_admin)):
+    """Read-only status for Zoe's live Pi hybrid production lane."""
+
+    return _pi_hybrid_production_status()
 
 
 @router.get("/pi-intent/readiness-report")

--- a/services/zoe-data/tests/test_pi_intent_status_endpoint.py
+++ b/services/zoe-data/tests/test_pi_intent_status_endpoint.py
@@ -3,7 +3,7 @@ from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
 
 from auth import require_admin
-from routers.system import router as system_router
+from routers.system import _pi_hybrid_production_public_status, router as system_router
 
 
 def _write_exe(path, body):
@@ -285,6 +285,22 @@ def test_pi_hybrid_production_status_endpoint_reports_invalid_config(monkeypatch
     assert data["ok"] is False
     assert data["status"] == "invalid_config"
     assert "device_control" in data["error"]
+
+
+def test_pi_hybrid_production_public_status_hides_admin_details(monkeypatch):
+    monkeypatch.setenv("ZOE_PI_HYBRID_PRODUCTION_ENABLED", "true")
+    monkeypatch.setenv("ZOE_PI_HYBRID_PRODUCTION_GROUPS", "weather,device_control")
+
+    data = _pi_hybrid_production_public_status()
+
+    assert data == {
+        "report_kind": "zoe_pi_hybrid_production_summary",
+        "ok": False,
+        "status": "invalid_config",
+        "details_endpoint": "/api/system/pi-intent/production-status",
+    }
+    assert "config" not in data
+    assert "error" not in data
 
 
 def test_pi_hybrid_production_status_endpoint_rejects_non_admin():

--- a/services/zoe-data/tests/test_pi_intent_status_endpoint.py
+++ b/services/zoe-data/tests/test_pi_intent_status_endpoint.py
@@ -247,6 +247,60 @@ def test_pi_hybrid_buffer_status_blocks_promoted_groups_when_classifier_disabled
     assert "promoted_groups_without_pi_classifier_enabled" in data["contract"]["blockers"]
 
 
+def test_pi_hybrid_production_status_endpoint_reports_live_config(monkeypatch):
+    monkeypatch.setenv("ZOE_PI_HYBRID_PRODUCTION_ENABLED", "true")
+    monkeypatch.setenv("ZOE_PI_HYBRID_PRODUCTION_GROUPS", "weather,daily_briefing")
+    monkeypatch.setenv("ZOE_PI_HYBRID_PRODUCTION_TRANSPORT", "rpc")
+    monkeypatch.setenv("ZOE_PI_HYBRID_RESOURCE_GUARD_ENABLED", "true")
+    monkeypatch.setenv("ZOE_PI_HYBRID_MIN_AVAILABLE_MB", "1024")
+    monkeypatch.setenv("ZOE_PI_HYBRID_MIN_SWAP_FREE_MB", "128")
+    app = _admin_app()
+
+    resp = TestClient(app).get("/api/system/pi-intent/production-status")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["report_kind"] == "zoe_pi_hybrid_production_status"
+    assert data["ok"] is True
+    assert data["status"] == "enabled"
+    assert data["route"] == "pi_intent_buffer_plus_zoe_safe_fulfillment"
+    assert "voice_non_stream" in data["surfaces"]
+    assert data["config"]["enabled"] is True
+    assert set(data["config"]["groups"]) == {"weather", "daily_briefing"}
+    assert data["config"]["transport"] == "rpc"
+    assert data["config"]["resource_guard_enabled"] is True
+    assert data["config"]["min_available_mb"] == 1024
+    assert data["config"]["min_swap_free_mb"] == 128
+
+
+def test_pi_hybrid_production_status_endpoint_reports_invalid_config(monkeypatch):
+    monkeypatch.setenv("ZOE_PI_HYBRID_PRODUCTION_ENABLED", "true")
+    monkeypatch.setenv("ZOE_PI_HYBRID_PRODUCTION_GROUPS", "weather,device_control")
+    app = _admin_app()
+
+    resp = TestClient(app).get("/api/system/pi-intent/production-status")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["ok"] is False
+    assert data["status"] == "invalid_config"
+    assert "device_control" in data["error"]
+
+
+def test_pi_hybrid_production_status_endpoint_rejects_non_admin():
+    app = FastAPI()
+    app.include_router(system_router)
+
+    async def fake_non_admin():
+        raise HTTPException(status_code=403, detail="Admin access required")
+
+    app.dependency_overrides[require_admin] = fake_non_admin
+
+    resp = TestClient(app).get("/api/system/pi-intent/production-status")
+
+    assert resp.status_code == 403
+
+
 def test_pi_readiness_report_endpoint_is_admin_scoped(tmp_path, monkeypatch):
     path = tmp_path / "shadow.jsonl"
     labels_path = tmp_path / "labels.jsonl"


### PR DESCRIPTION
## Summary
- adds a read-only `/api/system/pi-intent/production-status` admin endpoint for the live Pi hybrid production lane
- includes compact Pi hybrid production status in `/api/system/status`
- covers enabled, invalid-config, and non-admin endpoint behavior

## Why
The existing hybrid-buffer status describes shadow/evidence readiness, not the live production lane now enabled for weather and daily briefing. Operators need a clear status surface for the production groups, guard settings, and route mode.

## Validation
- `PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_pi_intent_status_endpoint.py`
- `python3 tools/audit/validate_structure.py`
