### PR TITLE
[codex] Record Pi hybrid production evidence

### DIFF
--- a/services/zoe-data/pi_hybrid_production.py
+++ b/services/zoe-data/pi_hybrid_production.py
@@ -109,6 +109,10 @@ async def try_pi_hybrid_production(
     active_config = config or PiHybridProductionConfig.from_env(env)
     active_config.validate()
     stripped = (text or "").strip()
+    def _with_evidence(decision: dict[str, Any]) -> dict[str, Any]:
+        _record_production_evidence(stripped, user_id=user_id, decision=decision, env=env)
+        return decision
+
     base = {
         "report_kind": "zoe_pi_hybrid_production_decision",
         "config": active_config.to_dict(),
@@ -122,13 +126,13 @@ async def try_pi_hybrid_production(
     eligible, reason = pi_hybrid_production_eligible(stripped, config=active_config)
     if not eligible:
         base["reason"] = reason
-        return base
+        return _with_evidence(base)
 
     pressure = await _resource_pressure(active_config)
     if pressure:
         base["reason"] = "resource_pressure"
         base["resource"] = pressure
-        return base
+        return _with_evidence(base)
 
     try:
         result = await asyncio.wait_for(
@@ -150,25 +154,25 @@ async def try_pi_hybrid_production(
         )
     except asyncio.TimeoutError:
         base["reason"] = "timeout"
-        return base
+        return _with_evidence(base)
     except ValueError as exc:
         base["reason"] = "validation_error"
         base["error"] = str(exc)
-        return base
+        return _with_evidence(base)
     except Exception as exc:  # pragma: no cover - production guard must fall back closed
         base["reason"] = "exception"
         base["error"] = exc.__class__.__name__
-        return base
+        return _with_evidence(base)
 
     decision = _acceptance_decision(result, active_config)
     response_text = str(decision.get("response_text") or "")
-    return {
+    return _with_evidence({
         **base,
         **decision,
         "response_text": response_text,
         "production_route_change": bool(decision.get("accepted")),
         "lab_result": _compact_lab_result(result),
-    }
+    })
 
 
 def pi_hybrid_production_eligible(text: str, *, config: PiHybridProductionConfig | None = None) -> tuple[bool, str]:
@@ -397,3 +401,18 @@ __all__ = [
     "processing_cue_packet",
     "try_pi_hybrid_production",
 ]
+
+
+def _record_production_evidence(
+    text: str,
+    *,
+    user_id: str,
+    decision: Mapping[str, Any],
+    env: Mapping[str, str] | None,
+) -> None:
+    try:
+        from pi_intent_evidence import record_pi_hybrid_production_evidence
+
+        record_pi_hybrid_production_evidence(text, user_id=user_id, decision=decision, env=env)
+    except Exception:
+        return

--- a/services/zoe-data/pi_hybrid_production.py
+++ b/services/zoe-data/pi_hybrid_production.py
@@ -109,6 +109,7 @@ async def try_pi_hybrid_production(
     active_config = config or PiHybridProductionConfig.from_env(env)
     active_config.validate()
     stripped = (text or "").strip()
+
     def _with_evidence(decision: dict[str, Any]) -> dict[str, Any]:
         _record_production_evidence(stripped, user_id=user_id, decision=decision, env=env)
         return decision
@@ -395,14 +396,6 @@ def _optional_str(value: Any) -> str | None:
     return text or None
 
 
-__all__ = [
-    "PiHybridProductionConfig",
-    "pi_hybrid_production_eligible",
-    "processing_cue_packet",
-    "try_pi_hybrid_production",
-]
-
-
 def _record_production_evidence(
     text: str,
     *,
@@ -416,3 +409,11 @@ def _record_production_evidence(
         record_pi_hybrid_production_evidence(text, user_id=user_id, decision=decision, env=env)
     except Exception:
         return
+
+
+__all__ = [
+    "PiHybridProductionConfig",
+    "pi_hybrid_production_eligible",
+    "processing_cue_packet",
+    "try_pi_hybrid_production",
+]

--- a/services/zoe-data/pi_intent_evidence.py
+++ b/services/zoe-data/pi_intent_evidence.py
@@ -66,7 +66,8 @@ def record_pi_hybrid_production_evidence(
     values = env if env is not None else os.environ
     if not _env_bool(values.get("ZOE_PI_HYBRID_PRODUCTION_EVIDENCE_ENABLED"), default=False):
         return None
-    if has_secret_evidence_text(text):
+    preview = sanitize_evidence_text(text)
+    if not preview or has_secret_evidence_text(text) or _SECRET_TEXT_RE.search(preview):
         return None
 
     lab = decision.get("lab_result") if isinstance(decision.get("lab_result"), Mapping) else {}

--- a/services/zoe-data/pi_intent_evidence.py
+++ b/services/zoe-data/pi_intent_evidence.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import Any, Mapping
 
 _DEFAULT_MISS_PATH = "~/.zoe/data/pi-intent-miss-evidence.jsonl"
+_DEFAULT_PRODUCTION_PATH = "~/.zoe/data/pi-hybrid-production-evidence.jsonl"
 _EMAIL_RE = re.compile(r"[\w.+-]+@[\w-]+\.\w+")
 _URL_RE = re.compile(r"https?://\S+")
 _PHONE_RE = re.compile(r"\b\d[\d\s\-]{5,}\d\b")
@@ -54,6 +55,60 @@ def record_intent_miss_evidence(
     return record
 
 
+def record_pi_hybrid_production_evidence(
+    text: str,
+    *,
+    user_id: str,
+    decision: Mapping[str, Any],
+    env: Mapping[str, str] | None = None,
+) -> dict[str, Any] | None:
+    """Record one sanitized production Pi hybrid decision for later scoring."""
+    values = env if env is not None else os.environ
+    if not _env_bool(values.get("ZOE_PI_HYBRID_PRODUCTION_EVIDENCE_ENABLED"), default=False):
+        return None
+    if has_secret_evidence_text(text):
+        return None
+
+    lab = decision.get("lab_result") if isinstance(decision.get("lab_result"), Mapping) else {}
+    pi = lab.get("pi") if isinstance(lab.get("pi"), Mapping) else {}
+    router = lab.get("zoe_router") if isinstance(lab.get("zoe_router"), Mapping) else {}
+    safe = lab.get("safe_fulfillment") if isinstance(lab.get("safe_fulfillment"), Mapping) else {}
+    config = decision.get("config") if isinstance(decision.get("config"), Mapping) else {}
+    include_preview = _env_bool(values.get("ZOE_PI_HYBRID_PRODUCTION_EVIDENCE_INCLUDE_PREVIEW"), default=True)
+
+    record = {
+        "ts": time.time(),
+        "source": "pi_hybrid_production",
+        "text_hash": _hash_text(text),
+        "text_preview": sanitize_evidence_text(text) if include_preview else None,
+        "user_hash": _hash_text(user_id or "unknown")[:16],
+        "accepted": bool(decision.get("accepted")),
+        "reason": _optional_str(decision.get("reason")),
+        "production_route_change": bool(decision.get("production_route_change")),
+        "intent": _optional_str(decision.get("intent")),
+        "intent_group": _optional_str(decision.get("intent_group")),
+        "agreement_kind": _optional_str(decision.get("agreement_kind")),
+        "pi_intent": _optional_str(pi.get("intent")),
+        "pi_intent_group": _optional_str(pi.get("intent_group")),
+        "pi_confidence": _float_or_none(pi.get("confidence")),
+        "pi_latency_ms": _float_or_none(pi.get("latency_ms")),
+        "pi_transport": _optional_str(pi.get("transport")) or _optional_str(config.get("transport")),
+        "zoe_intent": _optional_str(router.get("intent")),
+        "route_class": _optional_str(router.get("route_class")),
+        "baseline_kind": _optional_str(router.get("baseline_kind")),
+        "zoe_latency_ms": _float_or_none(router.get("latency_ms")),
+        "safe_fulfillment_intent": _optional_str(safe.get("intent")),
+        "safe_fulfillment_latency_ms": _float_or_none(safe.get("latency_ms")),
+        "safe_fulfillment_timed_out": bool(safe.get("timed_out")),
+        "safe_fulfillment_error": _optional_str(safe.get("error")),
+        "response_chars": _int_or_none(safe.get("response_chars")),
+        "enabled_groups": list(config.get("groups") or ()),
+        "outcome_label": None,
+    }
+    _append_jsonl(values.get("ZOE_PI_HYBRID_PRODUCTION_EVIDENCE_PATH") or _DEFAULT_PRODUCTION_PATH, record)
+    return record
+
+
 def sanitize_evidence_text(text: str) -> str:
     clean = _EMAIL_RE.sub("[EMAIL]", str(text or ""))
     clean = _URL_RE.sub("[URL]", clean)
@@ -65,6 +120,31 @@ def sanitize_evidence_text(text: str) -> str:
 
 def has_secret_evidence_text(text: str) -> bool:
     return bool(_SECRET_TEXT_RE.search(str(text or "")))
+
+
+def _optional_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _float_or_none(value: Any) -> float | None:
+    try:
+        if value is None or value == "":
+            return None
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _int_or_none(value: Any) -> int | None:
+    try:
+        if value is None or value == "":
+            return None
+        return int(value)
+    except (TypeError, ValueError):
+        return None
 
 
 def _append_jsonl(path: str, record: Mapping[str, Any]) -> None:
@@ -94,4 +174,4 @@ def _env_bool(value: str | None, *, default: bool = False) -> bool:
     return str(value).strip().lower() in {"1", "true", "yes", "on"}
 
 
-__all__ = ["has_secret_evidence_text", "record_intent_miss_evidence", "sanitize_evidence_text"]
+__all__ = ["has_secret_evidence_text", "record_intent_miss_evidence", "record_pi_hybrid_production_evidence", "sanitize_evidence_text"]

--- a/services/zoe-data/tests/test_pi_hybrid_production.py
+++ b/services/zoe-data/tests/test_pi_hybrid_production.py
@@ -121,6 +121,30 @@ async def test_try_pi_hybrid_records_production_evidence_when_enabled(tmp_path, 
 
 
 @pytest.mark.asyncio
+async def test_try_pi_hybrid_records_rejected_production_evidence_when_enabled(tmp_path, monkeypatch):
+    _install_prefilter(monkeypatch)
+    evidence_path = tmp_path / "production-rejected.jsonl"
+
+    decision = await try_pi_hybrid_production(
+        "will it rain later",
+        user_id="jason",
+        config=PiHybridProductionConfig(enabled=False),
+        env={
+            "ZOE_PI_HYBRID_PRODUCTION_EVIDENCE_ENABLED": "true",
+            "ZOE_PI_HYBRID_PRODUCTION_EVIDENCE_PATH": str(evidence_path),
+        },
+    )
+
+    assert decision["accepted"] is False
+    assert decision["reason"] == "disabled"
+    saved = json.loads(evidence_path.read_text(encoding="utf-8"))
+    assert saved["source"] == "pi_hybrid_production"
+    assert saved["accepted"] is False
+    assert saved["reason"] == "disabled"
+    assert saved["production_route_change"] is False
+
+
+@pytest.mark.asyncio
 async def test_try_pi_hybrid_rejects_side_effect_intent(monkeypatch):
     _install_prefilter(monkeypatch)
 

--- a/services/zoe-data/tests/test_pi_hybrid_production.py
+++ b/services/zoe-data/tests/test_pi_hybrid_production.py
@@ -1,3 +1,4 @@
+import json
 import sys
 import types
 
@@ -87,6 +88,36 @@ async def test_try_pi_hybrid_accepts_safe_agreed_weather(monkeypatch):
     assert decision["agreement_kind"] == "zoe_router"
     assert decision["response_text"] == "It is 18.5 C."
     assert decision["production_route_change"] is True
+
+
+@pytest.mark.asyncio
+async def test_try_pi_hybrid_records_production_evidence_when_enabled(tmp_path, monkeypatch):
+    _install_prefilter(monkeypatch)
+    evidence_path = tmp_path / "production.jsonl"
+
+    async def fake_compare(text, **kwargs):
+        return _accepted_lab_result()
+
+    monkeypatch.setattr(pi_hybrid_production, "compare_pi_intent_lab", fake_compare)
+    monkeypatch.setattr(pi_hybrid_production, "_read_meminfo_mb", lambda: {"MemAvailable": 99999, "SwapFree": 99999})
+
+    decision = await try_pi_hybrid_production(
+        "will it rain later",
+        user_id="jason",
+        config=PiHybridProductionConfig(enabled=True, resource_guard_enabled=True),
+        env={
+            "ZOE_PI_HYBRID_PRODUCTION_EVIDENCE_ENABLED": "true",
+            "ZOE_PI_HYBRID_PRODUCTION_EVIDENCE_PATH": str(evidence_path),
+        },
+    )
+
+    assert decision["accepted"] is True
+    saved = json.loads(evidence_path.read_text(encoding="utf-8"))
+    assert saved["source"] == "pi_hybrid_production"
+    assert saved["accepted"] is True
+    assert saved["intent"] == "weather"
+    assert saved["pi_intent"] == "weather"
+    assert saved["production_route_change"] is True
 
 
 @pytest.mark.asyncio

--- a/services/zoe-data/tests/test_pi_intent_evidence.py
+++ b/services/zoe-data/tests/test_pi_intent_evidence.py
@@ -3,7 +3,7 @@ import json
 from pathlib import Path
 
 from intent_router import detect_intent
-from pi_intent_evidence import record_intent_miss_evidence, sanitize_evidence_text
+from pi_intent_evidence import record_intent_miss_evidence, record_pi_hybrid_production_evidence, sanitize_evidence_text
 
 
 def test_record_intent_miss_evidence_disabled_does_not_write(tmp_path):
@@ -52,6 +52,104 @@ def test_record_intent_miss_evidence_skips_secret_like_text(tmp_path):
         env={
             "ZOE_PI_INTENT_MISS_EVIDENCE_ENABLED": "true",
             "ZOE_PI_INTENT_MISS_EVIDENCE_PATH": str(path),
+        },
+    )
+
+    assert result is None
+    assert not path.exists()
+
+
+def _production_decision():
+    return {
+        "config": {"groups": ["weather"], "transport": "rpc"},
+        "accepted": True,
+        "reason": "accepted",
+        "production_route_change": True,
+        "intent": "weather",
+        "intent_group": "weather",
+        "agreement_kind": "zoe_router",
+        "lab_result": {
+            "zoe_router": {
+                "intent": "weather",
+                "route_class": "deterministic",
+                "baseline_kind": "router",
+                "latency_ms": 12.0,
+            },
+            "pi": {
+                "intent": "weather",
+                "intent_group": "weather",
+                "confidence": 0.94,
+                "latency_ms": 123.0,
+                "transport": "rpc",
+            },
+            "safe_fulfillment": {
+                "intent": "weather",
+                "latency_ms": 45.0,
+                "timed_out": False,
+                "error": None,
+                "response_chars": 25,
+            },
+        },
+    }
+
+
+def test_record_pi_hybrid_production_evidence_disabled_does_not_write(tmp_path):
+    path = tmp_path / "production.jsonl"
+
+    result = record_pi_hybrid_production_evidence(
+        "will it rain later",
+        user_id="jason",
+        decision=_production_decision(),
+        env={"ZOE_PI_HYBRID_PRODUCTION_EVIDENCE_PATH": str(path)},
+    )
+
+    assert result is None
+    assert not path.exists()
+
+
+def test_record_pi_hybrid_production_evidence_writes_compact_sanitized_jsonl(tmp_path):
+    path = tmp_path / "production.jsonl"
+
+    result = record_pi_hybrid_production_evidence(
+        "will it rain later for Jason Smith",
+        user_id="jason",
+        decision=_production_decision(),
+        env={
+            "ZOE_PI_HYBRID_PRODUCTION_EVIDENCE_ENABLED": "true",
+            "ZOE_PI_HYBRID_PRODUCTION_EVIDENCE_PATH": str(path),
+        },
+    )
+
+    assert result is not None
+    saved = json.loads(path.read_text(encoding="utf-8"))
+    expected_user_hash = hashlib.sha256(b"jason").hexdigest()[:16]
+    assert saved["source"] == "pi_hybrid_production"
+    assert saved["user_hash"] == expected_user_hash
+    assert saved["text_preview"] == "will it rain later for [NAME]"
+    assert saved["accepted"] is True
+    assert saved["reason"] == "accepted"
+    assert saved["intent"] == "weather"
+    assert saved["pi_intent"] == "weather"
+    assert saved["pi_confidence"] == 0.94
+    assert saved["pi_latency_ms"] == 123.0
+    assert saved["zoe_latency_ms"] == 12.0
+    assert saved["safe_fulfillment_latency_ms"] == 45.0
+    assert saved["response_chars"] == 25
+    assert saved["enabled_groups"] == ["weather"]
+    assert saved["outcome_label"] is None
+    assert "Jason Smith" not in path.read_text(encoding="utf-8")
+
+
+def test_record_pi_hybrid_production_evidence_skips_secret_like_text(tmp_path):
+    path = tmp_path / "production.jsonl"
+
+    result = record_pi_hybrid_production_evidence(
+        "my bearer token is abc123",
+        user_id="jason",
+        decision=_production_decision(),
+        env={
+            "ZOE_PI_HYBRID_PRODUCTION_EVIDENCE_ENABLED": "true",
+            "ZOE_PI_HYBRID_PRODUCTION_EVIDENCE_PATH": str(path),
         },
     )
 


### PR DESCRIPTION
## Summary

- records sanitized Pi hybrid production decisions to JSONL when explicitly enabled
- wires the recorder into `try_pi_hybrid_production()` so accepted and rejected production decisions can become speed/accuracy promotion evidence
- keeps the feature disabled by default and skips secret-like prompts instead of persisting them

## Why

The Pi hybrid path is now serving production-eligible voice intents. We need durable evidence for speed, agreement, accepted/rejected decisions, and fallback behavior before promoting more intent groups.

## Validation

- `PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_pi_intent_evidence.py services/zoe-data/tests/test_pi_hybrid_production.py`
- `python3 tools/audit/validate_structure.py`
