### PR TITLE
[codex] Surface Pi production evidence in readiness report

### DIFF
--- a/services/zoe-data/pi_readiness_report.py
+++ b/services/zoe-data/pi_readiness_report.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import math
 import os
 from pathlib import Path
 from typing import Any, Mapping
@@ -346,6 +347,8 @@ def _load_production_evidence(env: Mapping[str, str]) -> dict[str, Any]:
     if not raw_path:
         return {"enabled": enabled, "loaded": False, "path": None, "record_count": 0}
     path = Path(raw_path).expanduser()
+    if not enabled:
+        return {"enabled": False, "loaded": False, "path": str(path), "record_count": 0, "disabled": True}
     if not path.exists():
         return {"enabled": enabled, "loaded": False, "path": str(path), "record_count": 0}
     records: list[dict[str, Any]] = []
@@ -456,9 +459,6 @@ def _append_number(values: list[float], value: Any) -> None:
     number = _float_or_none(value)
     if number is not None:
         values.append(number)
-
-
-import math
 
 
 def _p95(values: list[float]) -> float | None:

--- a/services/zoe-data/pi_readiness_report.py
+++ b/services/zoe-data/pi_readiness_report.py
@@ -458,11 +458,14 @@ def _append_number(values: list[float], value: Any) -> None:
         values.append(number)
 
 
+import math
+
+
 def _p95(values: list[float]) -> float | None:
     if not values:
         return None
     ordered = sorted(values)
-    index = max(0, min(len(ordered) - 1, int((len(ordered) * 0.95) + 0.999999) - 1))
+    index = max(0, min(len(ordered) - 1, math.ceil(len(ordered) * 0.95) - 1))
     return ordered[index]
 
 

--- a/services/zoe-data/pi_readiness_report.py
+++ b/services/zoe-data/pi_readiness_report.py
@@ -12,6 +12,7 @@ from pi_intent_shadow import pi_intent_shadow_status
 from zoe_pi_promotion import LOW_RISK_PI_INTENT_GROUPS
 
 DEFAULT_EVAL_REPORT_PATH = "~/.zoe/data/pi-promotion-eval-report.json"
+DEFAULT_PRODUCTION_EVIDENCE_PATH = "~/.zoe/data/pi-hybrid-production-evidence.jsonl"
 
 
 def pi_readiness_report(env: Mapping[str, str] | None = None) -> dict[str, Any]:
@@ -22,6 +23,7 @@ def pi_readiness_report(env: Mapping[str, str] | None = None) -> dict[str, Any]:
     promotion = shadow.get("promotion_report") or {}
     eval_report = _load_eval_report(values)
     benchmark = _benchmark_from_eval_report(eval_report)
+    production = _load_production_evidence(values)
     benchmark_promotion = benchmark.get("promotion_report") or {}
     contract = hybrid.get("contract") or {}
     actions = promotion.get("promotion_actions") or {}
@@ -30,7 +32,7 @@ def pi_readiness_report(env: Mapping[str, str] | None = None) -> dict[str, Any]:
     return {
         "report_kind": "zoe_pi_readiness_report",
         "state": state,
-        "summary": _summary(state, contract, shadow, promotion, actions, benchmark),
+        "summary": _summary(state, contract, shadow, promotion, actions, benchmark, production),
         "hybrid": {
             "mode": contract.get("mode"),
             "ready": bool(contract.get("ready")),
@@ -38,12 +40,21 @@ def pi_readiness_report(env: Mapping[str, str] | None = None) -> dict[str, Any]:
             "warnings": list(contract.get("warnings") or []),
             "promoted_groups": list(contract.get("promoted_groups") or []),
         },
-        "evidence": _evidence(shadow, promotion, benchmark),
+        "evidence": _evidence(shadow, promotion, benchmark, production),
         "benchmark": benchmark,
+        "production_evidence": production,
         "candidates": _candidate_details(candidate_wins),
         "blocked_decisions": _blocked_decisions(promotion),
         "promotion_actions": actions,
-        "next_actions": _next_actions(state, contract, shadow, promotion, actions, benchmark_promotion=benchmark_promotion),
+        "next_actions": _next_actions(
+            state,
+            contract,
+            shadow,
+            promotion,
+            actions,
+            benchmark_promotion=benchmark_promotion,
+            production=production,
+        ),
     }
 
 
@@ -80,9 +91,11 @@ def _summary(
     promotion: Mapping[str, Any],
     actions: Mapping[str, Any],
     benchmark: Mapping[str, Any] | None = None,
+    production: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     evidence = shadow.get("report") or {}
     benchmark = benchmark or {}
+    production = production or {}
     return {
         "state": state,
         "mode": contract.get("mode"),
@@ -94,15 +107,23 @@ def _summary(
         "promotion_ready_groups": list(promotion.get("promotable_groups") or []),
         "rollback_groups": list(actions.get("rollback_groups") or promotion.get("rollback_groups") or []),
         "requires_operator_apply": bool(actions.get("requires_operator_apply")),
+        "production_record_count": int(production.get("record_count") or 0),
+        "production_accepted_count": int(production.get("accepted_count") or 0),
+        "production_unlabeled_count": int(production.get("unlabeled_count") or 0),
+        "production_groups": list((production.get("by_group") or {}).keys()),
     }
 
 
 def _evidence(
-    shadow: Mapping[str, Any], promotion: Mapping[str, Any], benchmark: Mapping[str, Any] | None = None
+    shadow: Mapping[str, Any],
+    promotion: Mapping[str, Any],
+    benchmark: Mapping[str, Any] | None = None,
+    production: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     report = shadow.get("report") or {}
     source = promotion.get("source_breakdown") or {}
     benchmark = benchmark or {}
+    production = production or {}
     return {
         "record_count_window": shadow.get("record_count_window"),
         "raw_record_count_window": shadow.get("raw_record_count_window"),
@@ -116,6 +137,14 @@ def _evidence(
         "benchmark_report_path": benchmark.get("path"),
         "benchmark_loaded": bool(benchmark.get("loaded")),
         "benchmark_candidate_win_groups": list((benchmark.get("candidate_wins") or {}).get("groups") or []),
+        "production_record_count": int(production.get("record_count") or 0),
+        "production_accepted_count": int(production.get("accepted_count") or 0),
+        "production_unlabeled_count": int(production.get("unlabeled_count") or 0),
+        "production_record_count_by_group": {
+            group: int(stats.get("record_count") or 0)
+            for group, stats in (production.get("by_group") or {}).items()
+            if isinstance(stats, Mapping)
+        },
     }
 
 
@@ -170,6 +199,7 @@ def _next_actions(
     actions: Mapping[str, Any],
     *,
     benchmark_promotion: Mapping[str, Any] | None = None,
+    production: Mapping[str, Any] | None = None,
 ) -> list[dict[str, Any]]:
     next_actions: list[dict[str, Any]] = []
     blockers = list(contract.get("blockers") or [])
@@ -227,6 +257,7 @@ def _next_actions(
                 "groups": baseline_groups,
             }
         )
+    next_actions.extend(_production_evidence_actions(production or {}))
     if not next_actions and int(shadow.get("label_count") or 0) == 0:
         next_actions.append(
             {
@@ -287,6 +318,167 @@ def _evidence_collection_actions(promotion: Mapping[str, Any], *, source: str = 
             action["needed_real_source_cases"] = real_source_deficit
         actions.append(action)
     return actions
+
+
+def _production_evidence_actions(production: Mapping[str, Any]) -> list[dict[str, Any]]:
+    unlabeled = int(production.get("unlabeled_count") or 0)
+    if unlabeled <= 0:
+        return []
+    groups = sorted(
+        group
+        for group, stats in (production.get("by_group") or {}).items()
+        if isinstance(stats, Mapping) and int(stats.get("unlabeled_count") or 0) > 0
+    )
+    return [
+        {
+            "kind": "label_production_evidence",
+            "priority": "p1",
+            "detail": f"Label {unlabeled} Pi hybrid production evidence records before promotion scoring.",
+            "path": production.get("path"),
+            "groups": groups,
+        }
+    ]
+
+
+def _load_production_evidence(env: Mapping[str, str]) -> dict[str, Any]:
+    raw_path = (env.get("ZOE_PI_HYBRID_PRODUCTION_EVIDENCE_PATH") or DEFAULT_PRODUCTION_EVIDENCE_PATH).strip()
+    enabled = _env_bool(env.get("ZOE_PI_HYBRID_PRODUCTION_EVIDENCE_ENABLED"), default=False)
+    if not raw_path:
+        return {"enabled": enabled, "loaded": False, "path": None, "record_count": 0}
+    path = Path(raw_path).expanduser()
+    if not path.exists():
+        return {"enabled": enabled, "loaded": False, "path": str(path), "record_count": 0}
+    records: list[dict[str, Any]] = []
+    invalid_lines = 0
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    payload = json.loads(line)
+                except json.JSONDecodeError:
+                    invalid_lines += 1
+                    continue
+                if isinstance(payload, Mapping):
+                    records.append(dict(payload))
+                else:
+                    invalid_lines += 1
+    except OSError as exc:
+        return {"enabled": enabled, "loaded": False, "path": str(path), "record_count": 0, "error": exc.__class__.__name__}
+    summary = _summarize_production_records(records)
+    return {"enabled": enabled, "loaded": True, "path": str(path), "invalid_lines": invalid_lines, **summary}
+
+
+def _summarize_production_records(records: list[Mapping[str, Any]]) -> dict[str, Any]:
+    by_group: dict[str, dict[str, Any]] = {}
+    accepted_count = 0
+    route_change_count = 0
+    unlabeled_count = 0
+    recent: list[dict[str, Any]] = []
+    for record in records:
+        group = _production_group(record)
+        stats = by_group.setdefault(
+            group,
+            {
+                "record_count": 0,
+                "accepted_count": 0,
+                "rejected_count": 0,
+                "route_change_count": 0,
+                "unlabeled_count": 0,
+                "pi_latency_ms": [],
+                "safe_fulfillment_latency_ms": [],
+            },
+        )
+        stats["record_count"] += 1
+        if record.get("accepted"):
+            accepted_count += 1
+            stats["accepted_count"] += 1
+        else:
+            stats["rejected_count"] += 1
+        if record.get("production_route_change"):
+            route_change_count += 1
+            stats["route_change_count"] += 1
+        if not record.get("outcome_label"):
+            unlabeled_count += 1
+            stats["unlabeled_count"] += 1
+        _append_number(stats["pi_latency_ms"], record.get("pi_latency_ms"))
+        _append_number(stats["safe_fulfillment_latency_ms"], record.get("safe_fulfillment_latency_ms"))
+        recent.append(_compact_production_record(record, group))
+    compact_groups: dict[str, dict[str, Any]] = {}
+    for group, stats in sorted(by_group.items()):
+        compact_groups[group] = {
+            "record_count": stats["record_count"],
+            "accepted_count": stats["accepted_count"],
+            "rejected_count": stats["rejected_count"],
+            "route_change_count": stats["route_change_count"],
+            "unlabeled_count": stats["unlabeled_count"],
+            "pi_p95_latency_ms": _p95(stats["pi_latency_ms"]),
+            "safe_fulfillment_p95_latency_ms": _p95(stats["safe_fulfillment_latency_ms"]),
+        }
+    return {
+        "record_count": len(records),
+        "accepted_count": accepted_count,
+        "rejected_count": len(records) - accepted_count,
+        "route_change_count": route_change_count,
+        "unlabeled_count": unlabeled_count,
+        "by_group": compact_groups,
+        "recent": recent[-5:],
+    }
+
+
+def _production_group(record: Mapping[str, Any]) -> str:
+    for key in ("intent_group", "pi_intent_group", "intent", "pi_intent"):
+        value = str(record.get(key) or "").strip()
+        if value:
+            return value
+    return "unknown"
+
+
+def _compact_production_record(record: Mapping[str, Any], group: str) -> dict[str, Any]:
+    return {
+        "ts": record.get("ts"),
+        "intent_group": group,
+        "accepted": bool(record.get("accepted")),
+        "reason": record.get("reason"),
+        "intent": record.get("intent"),
+        "pi_intent": record.get("pi_intent"),
+        "pi_latency_ms": _float_or_none(record.get("pi_latency_ms")),
+        "safe_fulfillment_latency_ms": _float_or_none(record.get("safe_fulfillment_latency_ms")),
+        "production_route_change": bool(record.get("production_route_change")),
+        "outcome_label": record.get("outcome_label"),
+        "text_preview": record.get("text_preview"),
+    }
+
+
+def _append_number(values: list[float], value: Any) -> None:
+    number = _float_or_none(value)
+    if number is not None:
+        values.append(number)
+
+
+def _p95(values: list[float]) -> float | None:
+    if not values:
+        return None
+    ordered = sorted(values)
+    index = max(0, min(len(ordered) - 1, int((len(ordered) * 0.95) + 0.999999) - 1))
+    return ordered[index]
+
+
+def _float_or_none(value: Any) -> float | None:
+    try:
+        if value is None or value == "":
+            return None
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _env_bool(value: str | None, *, default: bool = False) -> bool:
+    if value is None:
+        return default
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}
 
 
 def _load_eval_report(env: Mapping[str, str]) -> dict[str, Any]:
@@ -355,4 +547,4 @@ def _groups_with_blocker(promotion: Mapping[str, Any], blocker: str) -> list[str
     return sorted(set(groups))
 
 
-__all__ = ["pi_readiness_report", "DEFAULT_EVAL_REPORT_PATH"]
+__all__ = ["pi_readiness_report", "DEFAULT_EVAL_REPORT_PATH", "DEFAULT_PRODUCTION_EVIDENCE_PATH"]

--- a/services/zoe-data/tests/test_pi_readiness_report.py
+++ b/services/zoe-data/tests/test_pi_readiness_report.py
@@ -511,3 +511,35 @@ def test_readiness_report_missing_production_evidence_is_nonblocking(tmp_path):
         "record_count": 0,
     }
     assert report["state"] == "shadow_collecting"
+
+
+def test_readiness_report_disabled_production_evidence_does_not_load_existing_file(tmp_path):
+    shadow_path = tmp_path / "shadow.jsonl"
+    shadow_path.write_text("", encoding="utf-8")
+    production_path = tmp_path / "production.jsonl"
+    production_path.write_text(
+        json.dumps(
+            {
+                "source": "pi_hybrid_production",
+                "accepted": True,
+                "intent_group": "weather",
+                "outcome_label": None,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    env = _env(tmp_path, shadow_path)
+    env["ZOE_PI_HYBRID_PRODUCTION_EVIDENCE_ENABLED"] = "false"
+    env["ZOE_PI_HYBRID_PRODUCTION_EVIDENCE_PATH"] = str(production_path)
+
+    report = pi_readiness_report(env)
+
+    assert report["production_evidence"] == {
+        "enabled": False,
+        "loaded": False,
+        "path": str(production_path),
+        "record_count": 0,
+        "disabled": True,
+    }
+    assert not [action for action in report["next_actions"] if action.get("kind") == "label_production_evidence"]

--- a/services/zoe-data/tests/test_pi_readiness_report.py
+++ b/services/zoe-data/tests/test_pi_readiness_report.py
@@ -12,6 +12,8 @@ def _env(tmp_path, shadow_path):
         "ZOE_PI_INTENT_TRANSPORT": "rpc",
         "ZOE_PI_INTENT_SHADOW_PATH": str(shadow_path),
         "ZOE_PI_INTENT_SHADOW_LABELS_PATH": str(tmp_path / "labels.jsonl"),
+        "ZOE_PI_HYBRID_PRODUCTION_EVIDENCE_PATH": str(tmp_path / "production.jsonl"),
+        "ZOE_PI_PROMOTION_EVAL_REPORT_PATH": str(tmp_path / "missing-eval-report.json"),
     }
 
 
@@ -341,10 +343,171 @@ def test_readiness_report_missing_eval_benchmark_is_nonblocking(tmp_path):
     shadow_path = tmp_path / "shadow.jsonl"
     shadow_path.write_text("", encoding="utf-8")
     env = _env(tmp_path, shadow_path)
-    env["ZOE_PI_PROMOTION_EVAL_REPORT_PATH"] = str(tmp_path / "missing.json")
 
     report = pi_readiness_report(env)
 
     assert report["benchmark"]["loaded"] is False
     assert report["evidence"]["benchmark_loaded"] is False
+    assert report["state"] == "shadow_collecting"
+
+
+def test_readiness_report_surfaces_production_evidence_summary(tmp_path):
+    shadow_path = tmp_path / "shadow.jsonl"
+    shadow_path.write_text("", encoding="utf-8")
+    production_path = tmp_path / "production.jsonl"
+    production_path.write_text(
+        "\n".join(
+            json.dumps(row)
+            for row in [
+                {
+                    "ts": 1.0,
+                    "source": "pi_hybrid_production",
+                    "accepted": True,
+                    "reason": "accepted",
+                    "intent": "weather",
+                    "intent_group": "weather",
+                    "pi_intent": "weather",
+                    "pi_latency_ms": 4100.0,
+                    "safe_fulfillment_latency_ms": 900.0,
+                    "production_route_change": True,
+                    "text_preview": "will it rain later",
+                    "outcome_label": None,
+                },
+                {
+                    "ts": 2.0,
+                    "source": "pi_hybrid_production",
+                    "accepted": False,
+                    "reason": "timeout",
+                    "intent_group": "weather",
+                    "pi_latency_ms": 8000.0,
+                    "safe_fulfillment_latency_ms": None,
+                    "production_route_change": False,
+                    "text_preview": "weather tomorrow",
+                    "outcome_label": "weather_timeout",
+                },
+                {
+                    "ts": 3.0,
+                    "source": "pi_hybrid_production",
+                    "accepted": True,
+                    "reason": "accepted",
+                    "intent": "daily_briefing",
+                    "intent_group": "daily_briefing",
+                    "pi_intent": "daily_briefing",
+                    "pi_latency_ms": 2200.0,
+                    "safe_fulfillment_latency_ms": 1100.0,
+                    "production_route_change": True,
+                    "text_preview": "give me my daily briefing",
+                    "outcome_label": None,
+                },
+            ]
+        )
+        + "\nnot-json\n",
+        encoding="utf-8",
+    )
+    env = _env(tmp_path, shadow_path)
+    env["ZOE_PI_HYBRID_PRODUCTION_EVIDENCE_ENABLED"] = "true"
+    env["ZOE_PI_HYBRID_PRODUCTION_EVIDENCE_PATH"] = str(production_path)
+
+    report = pi_readiness_report(env)
+
+    assert report["summary"]["production_record_count"] == 3
+    assert report["summary"]["production_accepted_count"] == 2
+    assert report["summary"]["production_unlabeled_count"] == 2
+    assert report["summary"]["production_groups"] == ["daily_briefing", "weather"]
+    assert report["evidence"]["production_record_count_by_group"] == {"daily_briefing": 1, "weather": 2}
+    assert report["production_evidence"] == {
+        "enabled": True,
+        "loaded": True,
+        "path": str(production_path),
+        "invalid_lines": 1,
+        "record_count": 3,
+        "accepted_count": 2,
+        "rejected_count": 1,
+        "route_change_count": 2,
+        "unlabeled_count": 2,
+        "by_group": {
+            "daily_briefing": {
+                "record_count": 1,
+                "accepted_count": 1,
+                "rejected_count": 0,
+                "route_change_count": 1,
+                "unlabeled_count": 1,
+                "pi_p95_latency_ms": 2200.0,
+                "safe_fulfillment_p95_latency_ms": 1100.0,
+            },
+            "weather": {
+                "record_count": 2,
+                "accepted_count": 1,
+                "rejected_count": 1,
+                "route_change_count": 1,
+                "unlabeled_count": 1,
+                "pi_p95_latency_ms": 8000.0,
+                "safe_fulfillment_p95_latency_ms": 900.0,
+            },
+        },
+        "recent": [
+            {
+                "ts": 1.0,
+                "intent_group": "weather",
+                "accepted": True,
+                "reason": "accepted",
+                "intent": "weather",
+                "pi_intent": "weather",
+                "pi_latency_ms": 4100.0,
+                "safe_fulfillment_latency_ms": 900.0,
+                "production_route_change": True,
+                "outcome_label": None,
+                "text_preview": "will it rain later",
+            },
+            {
+                "ts": 2.0,
+                "intent_group": "weather",
+                "accepted": False,
+                "reason": "timeout",
+                "intent": None,
+                "pi_intent": None,
+                "pi_latency_ms": 8000.0,
+                "safe_fulfillment_latency_ms": None,
+                "production_route_change": False,
+                "outcome_label": "weather_timeout",
+                "text_preview": "weather tomorrow",
+            },
+            {
+                "ts": 3.0,
+                "intent_group": "daily_briefing",
+                "accepted": True,
+                "reason": "accepted",
+                "intent": "daily_briefing",
+                "pi_intent": "daily_briefing",
+                "pi_latency_ms": 2200.0,
+                "safe_fulfillment_latency_ms": 1100.0,
+                "production_route_change": True,
+                "outcome_label": None,
+                "text_preview": "give me my daily briefing",
+            },
+        ],
+    }
+    assert {
+        "kind": "label_production_evidence",
+        "priority": "p1",
+        "detail": "Label 2 Pi hybrid production evidence records before promotion scoring.",
+        "path": str(production_path),
+        "groups": ["daily_briefing", "weather"],
+    } in report["next_actions"]
+
+
+def test_readiness_report_missing_production_evidence_is_nonblocking(tmp_path):
+    shadow_path = tmp_path / "shadow.jsonl"
+    shadow_path.write_text("", encoding="utf-8")
+    env = _env(tmp_path, shadow_path)
+    env["ZOE_PI_HYBRID_PRODUCTION_EVIDENCE_ENABLED"] = "true"
+
+    report = pi_readiness_report(env)
+
+    assert report["production_evidence"] == {
+        "enabled": True,
+        "loaded": False,
+        "path": str(tmp_path / "production.jsonl"),
+        "record_count": 0,
+    }
     assert report["state"] == "shadow_collecting"


### PR DESCRIPTION
## Summary

- surfaces Pi hybrid production JSONL evidence in the Pi readiness report
- adds accepted/rejected/unlabeled counts, group breakdowns, p95 Pi/safe-fulfillment latency, and recent sanitized records
- adds a next action to label production evidence before promotion scoring
- isolates readiness tests from live operator evidence files

## Validation

- `PYTHONPATH=services/zoe-data python3 -m pytest -q services/zoe-data/tests/test_pi_readiness_report.py services/zoe-data/tests/test_pi_readiness_report_cli.py services/zoe-data/tests/test_pi_intent_status_endpoint.py services/zoe-data/tests/test_pi_intent_evidence.py services/zoe-data/tests/test_pi_hybrid_production.py`
- `python3 tools/audit/validate_structure.py`
- `git diff --check`
- live branch report loaded `/home/zoe/.zoe/data/pi-hybrid-production-evidence.jsonl` and surfaced 2 production records across weather/daily_briefing
