### PR TITLE
[codex] Add Pi production evidence labels

### DIFF
--- a/services/zoe-data/pi_intent_evidence.py
+++ b/services/zoe-data/pi_intent_evidence.py
@@ -11,11 +11,15 @@ import json
 import os
 import re
 import time
+from collections import deque
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any, Mapping, Sequence
+
+from zoe_pi_promotion import intent_group_for_intent
 
 _DEFAULT_MISS_PATH = "~/.zoe/data/pi-intent-miss-evidence.jsonl"
 _DEFAULT_PRODUCTION_PATH = "~/.zoe/data/pi-hybrid-production-evidence.jsonl"
+_DEFAULT_PRODUCTION_LABELS_PATH = "~/.zoe/data/pi-hybrid-production-labels.jsonl"
 _EMAIL_RE = re.compile(r"[\w.+-]+@[\w-]+\.\w+")
 _URL_RE = re.compile(r"https?://\S+")
 _PHONE_RE = re.compile(r"\b\d[\d\s\-]{5,}\d\b")
@@ -24,6 +28,8 @@ _SPACE_RE = re.compile(r"\s+")
 _SECRET_KEY_RE = re.compile(r"(?i)(api[_-]?key|\btoken\b|\bsecret\b|password|authorization|\bbearer\b)")
 _SECRET_TEXT_RE = re.compile(r"(?i)(api[\s_-]?key|authorization|bearer\s+[a-z0-9._\-]+|password\s*(is|=)|secret\s*(is|=)|token\s*(is|=))")
 _ALLOWED_ROUTE_CLASSES = {"deterministic", "fallback", "extraction_failed"}
+_ALLOWED_LABEL_SOURCES = {"admin_review", "operator_override"}
+_DEFAULT_PRODUCTION_RECORD_LIMIT = 1000
 
 
 def record_intent_miss_evidence(
@@ -110,6 +116,164 @@ def record_pi_hybrid_production_evidence(
     return record
 
 
+def load_pi_hybrid_production_records(
+    path: str = _DEFAULT_PRODUCTION_PATH,
+    *,
+    limit: int = _DEFAULT_PRODUCTION_RECORD_LIMIT,
+) -> list[dict[str, Any]]:
+    """Load recent production Pi hybrid evidence records from JSONL."""
+    target = Path(path or _DEFAULT_PRODUCTION_PATH).expanduser()
+    if not target.exists():
+        return []
+    with target.open("r", encoding="utf-8", errors="replace") as handle:
+        rows = deque(handle, maxlen=max(1, int(limit)))
+    records: list[dict[str, Any]] = []
+    for line in rows:
+        try:
+            item = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(item, dict):
+            records.append(item)
+    return records
+
+
+def load_pi_hybrid_production_labels(path: str = _DEFAULT_PRODUCTION_LABELS_PATH) -> dict[str, dict[str, Any]]:
+    """Load latest valid append-only labels keyed by production evidence text_hash."""
+    target = Path(path or _DEFAULT_PRODUCTION_LABELS_PATH).expanduser()
+    if not target.exists():
+        return {}
+    labels: dict[str, dict[str, Any]] = {}
+    with target.open("r", encoding="utf-8", errors="replace") as handle:
+        for line in handle:
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            try:
+                row = json.loads(stripped)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(row, Mapping):
+                continue
+            text_hash = _optional_str(row.get("text_hash"))
+            if not text_hash:
+                continue
+            label = _production_label_from_row(row)
+            if label:
+                labels[text_hash] = label
+    return labels
+
+
+def apply_pi_hybrid_production_labels(
+    records: Sequence[Mapping[str, Any]], labels: Mapping[str, Mapping[str, Any]]
+) -> list[dict[str, Any]]:
+    """Return production records with label sidecar values applied."""
+    output: list[dict[str, Any]] = []
+    for record in records:
+        item = dict(record)
+        text_hash = _optional_str(item.get("text_hash"))
+        label = labels.get(text_hash or "")
+        if label:
+            item.update(label)
+            item["outcome_label_source"] = "production_label_sidecar"
+        output.append(item)
+    return output
+
+
+def append_pi_hybrid_production_label(
+    *,
+    text_hash: str,
+    outcome_label: str | None = None,
+    negative: bool = False,
+    source: str = "admin_review",
+    reviewed_by: str | None = None,
+    evidence_path: str = _DEFAULT_PRODUCTION_PATH,
+    labels_path: str = _DEFAULT_PRODUCTION_LABELS_PATH,
+    production_limit: int = _DEFAULT_PRODUCTION_RECORD_LIMIT,
+) -> dict[str, Any]:
+    """Append one trusted admin label for an existing production evidence record."""
+    normalized_hash = str(text_hash or "").strip()
+    if not normalized_hash:
+        raise ValueError("text_hash is required")
+    records = load_pi_hybrid_production_records(evidence_path, limit=production_limit)
+    matching_record = next(
+        (record for record in records if str(record.get("text_hash") or "").strip() == normalized_hash),
+        None,
+    )
+    if matching_record is None:
+        raise ValueError(f"text_hash not found in the most-recent {production_limit} Pi hybrid production records")
+
+    source_value = str(source or "admin_review").strip() or "admin_review"
+    if source_value not in _ALLOWED_LABEL_SOURCES:
+        raise ValueError("source must be one of: admin_review, operator_override")
+
+    row: dict[str, Any] = {
+        "text_hash": normalized_hash,
+        "source": source_value,
+        "labeled_at": time.time(),
+    }
+    if outcome_label is not None:
+        row["outcome_label"] = str(outcome_label).strip()
+    if negative:
+        row["negative"] = True
+    if reviewed_by:
+        row["reviewed_by_hash"] = _hash_text(reviewed_by)
+
+    label = _production_label_from_row(row)
+    if not label:
+        raise ValueError("label must be a low-risk Pi intent or a negative chat/none label")
+
+    _append_jsonl(labels_path, row)
+    return {
+        "ok": True,
+        "text_hash": normalized_hash,
+        "labels_store": "production_labels_sidecar",
+        "label": label,
+        "matched_record": _compact_production_record_for_label_response(matching_record),
+    }
+
+
+def _production_label_from_row(row: Mapping[str, Any]) -> dict[str, Any]:
+    label: dict[str, Any] = {}
+    negative = _bool_record_value(row.get("negative"))
+    outcome_label = _optional_str(row.get("outcome_label") or row.get("expected_intent") or row.get("label"))
+    if negative and outcome_label and outcome_label not in {"chat", "none", "no_intent"}:
+        return {}
+    if negative or outcome_label in {"chat", "none", "no_intent"}:
+        label["negative"] = True
+        label["outcome_label"] = None
+    elif outcome_label and intent_group_for_intent(outcome_label):
+        label["outcome_label"] = outcome_label
+    else:
+        return {}
+    for key in ("route_class", "baseline_kind", "source"):
+        value = _optional_str(row.get(key))
+        if value:
+            label[key] = value
+    for key in ("baseline_comparable", "user_corrected", "rollback_blocked"):
+        if row.get(key) is not None:
+            label[key] = _bool_record_value(row.get(key))
+    return label
+
+
+def _compact_production_record_for_label_response(record: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "text_hash": _optional_str(record.get("text_hash")),
+        "text_preview": _optional_str(record.get("text_preview")),
+        "accepted": bool(record.get("accepted")),
+        "reason": _optional_str(record.get("reason")),
+        "intent": _optional_str(record.get("intent")),
+        "pi_intent": _optional_str(record.get("pi_intent")),
+        "intent_group": _optional_str(record.get("intent_group")),
+    }
+
+
+def _bool_record_value(value: Any) -> bool:
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)
+
+
 def sanitize_evidence_text(text: str) -> str:
     clean = _EMAIL_RE.sub("[EMAIL]", str(text or ""))
     clean = _URL_RE.sub("[URL]", clean)
@@ -175,4 +339,13 @@ def _env_bool(value: str | None, *, default: bool = False) -> bool:
     return str(value).strip().lower() in {"1", "true", "yes", "on"}
 
 
-__all__ = ["has_secret_evidence_text", "record_intent_miss_evidence", "record_pi_hybrid_production_evidence", "sanitize_evidence_text"]
+__all__ = [
+    "append_pi_hybrid_production_label",
+    "apply_pi_hybrid_production_labels",
+    "has_secret_evidence_text",
+    "load_pi_hybrid_production_labels",
+    "load_pi_hybrid_production_records",
+    "record_intent_miss_evidence",
+    "record_pi_hybrid_production_evidence",
+    "sanitize_evidence_text",
+]

--- a/services/zoe-data/pi_readiness_report.py
+++ b/services/zoe-data/pi_readiness_report.py
@@ -14,6 +14,7 @@ from zoe_pi_promotion import LOW_RISK_PI_INTENT_GROUPS
 
 DEFAULT_EVAL_REPORT_PATH = "~/.zoe/data/pi-promotion-eval-report.json"
 DEFAULT_PRODUCTION_EVIDENCE_PATH = "~/.zoe/data/pi-hybrid-production-evidence.jsonl"
+DEFAULT_PRODUCTION_LABELS_PATH = "~/.zoe/data/pi-hybrid-production-labels.jsonl"
 
 
 def pi_readiness_report(env: Mapping[str, str] | None = None) -> dict[str, Any]:
@@ -110,6 +111,7 @@ def _summary(
         "requires_operator_apply": bool(actions.get("requires_operator_apply")),
         "production_record_count": int(production.get("record_count") or 0),
         "production_accepted_count": int(production.get("accepted_count") or 0),
+        "production_label_count": int(production.get("label_count") or 0),
         "production_unlabeled_count": int(production.get("unlabeled_count") or 0),
         "production_groups": list((production.get("by_group") or {}).keys()),
     }
@@ -140,6 +142,7 @@ def _evidence(
         "benchmark_candidate_win_groups": list((benchmark.get("candidate_wins") or {}).get("groups") or []),
         "production_record_count": int(production.get("record_count") or 0),
         "production_accepted_count": int(production.get("accepted_count") or 0),
+        "production_label_count": int(production.get("label_count") or 0),
         "production_unlabeled_count": int(production.get("unlabeled_count") or 0),
         "production_record_count_by_group": {
             group: int(stats.get("record_count") or 0)
@@ -336,6 +339,7 @@ def _production_evidence_actions(production: Mapping[str, Any]) -> list[dict[str
             "priority": "p1",
             "detail": f"Label {unlabeled} Pi hybrid production evidence records before promotion scoring.",
             "path": production.get("path"),
+            "labels_path": production.get("labels_path"),
             "groups": groups,
         }
     ]
@@ -343,14 +347,29 @@ def _production_evidence_actions(production: Mapping[str, Any]) -> list[dict[str
 
 def _load_production_evidence(env: Mapping[str, str]) -> dict[str, Any]:
     raw_path = (env.get("ZOE_PI_HYBRID_PRODUCTION_EVIDENCE_PATH") or DEFAULT_PRODUCTION_EVIDENCE_PATH).strip()
+    raw_labels_path = (env.get("ZOE_PI_HYBRID_PRODUCTION_LABELS_PATH") or DEFAULT_PRODUCTION_LABELS_PATH).strip()
     enabled = _env_bool(env.get("ZOE_PI_HYBRID_PRODUCTION_EVIDENCE_ENABLED"), default=False)
     if not raw_path:
-        return {"enabled": enabled, "loaded": False, "path": None, "record_count": 0}
+        return {"enabled": enabled, "loaded": False, "path": None, "labels_path": None, "record_count": 0}
     path = Path(raw_path).expanduser()
+    labels_path = Path(raw_labels_path).expanduser() if raw_labels_path else None
     if not enabled:
-        return {"enabled": False, "loaded": False, "path": str(path), "record_count": 0, "disabled": True}
+        return {
+            "enabled": False,
+            "loaded": False,
+            "path": str(path),
+            "labels_path": str(labels_path) if labels_path else None,
+            "record_count": 0,
+            "disabled": True,
+        }
     if not path.exists():
-        return {"enabled": enabled, "loaded": False, "path": str(path), "record_count": 0}
+        return {
+            "enabled": enabled,
+            "loaded": False,
+            "path": str(path),
+            "labels_path": str(labels_path) if labels_path else None,
+            "record_count": 0,
+        }
     records: list[dict[str, Any]] = []
     invalid_lines = 0
     try:
@@ -369,9 +388,46 @@ def _load_production_evidence(env: Mapping[str, str]) -> dict[str, Any]:
                 else:
                     invalid_lines += 1
     except OSError as exc:
-        return {"enabled": enabled, "loaded": False, "path": str(path), "record_count": 0, "error": exc.__class__.__name__}
-    summary = _summarize_production_records(records)
-    return {"enabled": enabled, "loaded": True, "path": str(path), "invalid_lines": invalid_lines, **summary}
+        return {
+            "enabled": enabled,
+            "loaded": False,
+            "path": str(path),
+            "labels_path": str(labels_path) if labels_path else None,
+            "record_count": 0,
+            "error": exc.__class__.__name__,
+        }
+    labels = _load_production_labels(str(labels_path)) if labels_path else {}
+    labeled_records = _apply_production_labels(records, labels)
+    summary = _summarize_production_records(labeled_records)
+    return {
+        "enabled": enabled,
+        "loaded": True,
+        "path": str(path),
+        "labels_path": str(labels_path) if labels_path else None,
+        "label_count": len(labels),
+        "invalid_lines": invalid_lines,
+        **summary,
+    }
+
+
+def _load_production_labels(path: str) -> dict[str, dict[str, Any]]:
+    try:
+        from pi_intent_evidence import load_pi_hybrid_production_labels
+
+        return load_pi_hybrid_production_labels(path)
+    except Exception:
+        return {}
+
+
+def _apply_production_labels(
+    records: list[Mapping[str, Any]], labels: Mapping[str, Mapping[str, Any]]
+) -> list[dict[str, Any]]:
+    try:
+        from pi_intent_evidence import apply_pi_hybrid_production_labels
+
+        return apply_pi_hybrid_production_labels(records, labels)
+    except Exception:
+        return [dict(record) for record in records]
 
 
 def _summarize_production_records(records: list[Mapping[str, Any]]) -> dict[str, Any]:
@@ -442,6 +498,7 @@ def _production_group(record: Mapping[str, Any]) -> str:
 def _compact_production_record(record: Mapping[str, Any], group: str) -> dict[str, Any]:
     return {
         "ts": record.get("ts"),
+        "text_hash": record.get("text_hash"),
         "intent_group": group,
         "accepted": bool(record.get("accepted")),
         "reason": record.get("reason"),
@@ -451,6 +508,7 @@ def _compact_production_record(record: Mapping[str, Any], group: str) -> dict[st
         "safe_fulfillment_latency_ms": _float_or_none(record.get("safe_fulfillment_latency_ms")),
         "production_route_change": bool(record.get("production_route_change")),
         "outcome_label": record.get("outcome_label"),
+        "outcome_label_source": record.get("outcome_label_source"),
         "text_preview": record.get("text_preview"),
     }
 
@@ -550,4 +608,4 @@ def _groups_with_blocker(promotion: Mapping[str, Any], blocker: str) -> list[str
     return sorted(set(groups))
 
 
-__all__ = ["pi_readiness_report", "DEFAULT_EVAL_REPORT_PATH", "DEFAULT_PRODUCTION_EVIDENCE_PATH"]
+__all__ = ["pi_readiness_report", "DEFAULT_EVAL_REPORT_PATH", "DEFAULT_PRODUCTION_EVIDENCE_PATH", "DEFAULT_PRODUCTION_LABELS_PATH"]

--- a/services/zoe-data/pi_readiness_report.py
+++ b/services/zoe-data/pi_readiness_report.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any, Mapping
 
 from pi_hybrid_buffer import pi_hybrid_buffer_status
+from pi_intent_evidence import apply_pi_hybrid_production_labels, load_pi_hybrid_production_labels
 from pi_intent_shadow import pi_intent_shadow_status
 from zoe_pi_promotion import LOW_RISK_PI_INTENT_GROUPS
 
@@ -396,10 +397,15 @@ def _load_production_evidence(env: Mapping[str, str]) -> dict[str, Any]:
             "record_count": 0,
             "error": exc.__class__.__name__,
         }
-    labels = _load_production_labels(str(labels_path)) if labels_path else {}
-    labeled_records = _apply_production_labels(records, labels)
+    label_error = None
+    try:
+        labels = load_pi_hybrid_production_labels(str(labels_path)) if labels_path else {}
+    except OSError as exc:
+        labels = {}
+        label_error = exc.__class__.__name__
+    labeled_records = apply_pi_hybrid_production_labels(records, labels)
     summary = _summarize_production_records(labeled_records)
-    return {
+    result = {
         "enabled": enabled,
         "loaded": True,
         "path": str(path),
@@ -408,26 +414,9 @@ def _load_production_evidence(env: Mapping[str, str]) -> dict[str, Any]:
         "invalid_lines": invalid_lines,
         **summary,
     }
-
-
-def _load_production_labels(path: str) -> dict[str, dict[str, Any]]:
-    try:
-        from pi_intent_evidence import load_pi_hybrid_production_labels
-
-        return load_pi_hybrid_production_labels(path)
-    except Exception:
-        return {}
-
-
-def _apply_production_labels(
-    records: list[Mapping[str, Any]], labels: Mapping[str, Mapping[str, Any]]
-) -> list[dict[str, Any]]:
-    try:
-        from pi_intent_evidence import apply_pi_hybrid_production_labels
-
-        return apply_pi_hybrid_production_labels(records, labels)
-    except Exception:
-        return [dict(record) for record in records]
+    if label_error:
+        result["label_error"] = label_error
+    return result
 
 
 def _summarize_production_records(records: list[Mapping[str, Any]]) -> dict[str, Any]:

--- a/services/zoe-data/pi_readiness_report.py
+++ b/services/zoe-data/pi_readiness_report.py
@@ -459,7 +459,7 @@ def _summarize_production_records(records: list[Mapping[str, Any]]) -> dict[str,
         if record.get("production_route_change"):
             route_change_count += 1
             stats["route_change_count"] += 1
-        if not record.get("outcome_label"):
+        if not record.get("outcome_label") and not record.get("negative"):
             unlabeled_count += 1
             stats["unlabeled_count"] += 1
         _append_number(stats["pi_latency_ms"], record.get("pi_latency_ms"))

--- a/services/zoe-data/routers/system.py
+++ b/services/zoe-data/routers/system.py
@@ -285,6 +285,37 @@ async def post_pi_intent_shadow_label(payload: PiIntentShadowLabelRequest, user:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
+class PiHybridProductionLabelRequest(BaseModel):
+    text_hash: str
+    outcome_label: Optional[str] = None
+    negative: bool = False
+    source: Literal["admin_review", "operator_override"] = "admin_review"
+
+
+@router.post("/pi-intent/production-labels")
+async def post_pi_hybrid_production_label(
+    payload: PiHybridProductionLabelRequest,
+    user: dict = Depends(require_admin),
+):
+    """Append one trusted admin label for an existing Pi hybrid production record."""
+    from pi_intent_evidence import append_pi_hybrid_production_label
+
+    try:
+        return append_pi_hybrid_production_label(
+            text_hash=payload.text_hash,
+            outcome_label=payload.outcome_label,
+            negative=payload.negative,
+            source=payload.source,
+            reviewed_by=str(user.get("user_id") or "admin"),
+            evidence_path=os.environ.get("ZOE_PI_HYBRID_PRODUCTION_EVIDENCE_PATH")
+            or "~/.zoe/data/pi-hybrid-production-evidence.jsonl",
+            labels_path=os.environ.get("ZOE_PI_HYBRID_PRODUCTION_LABELS_PATH")
+            or "~/.zoe/data/pi-hybrid-production-labels.jsonl",
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
 def _load_skills_and_cron():
     skills = []
     skills_dir = os.path.expanduser("~/.openclaw/workspace/skills")

--- a/services/zoe-data/tests/test_pi_intent_evidence.py
+++ b/services/zoe-data/tests/test_pi_intent_evidence.py
@@ -2,8 +2,17 @@ import hashlib
 import json
 from pathlib import Path
 
+import pytest
+
 from intent_router import detect_intent
-from pi_intent_evidence import record_intent_miss_evidence, record_pi_hybrid_production_evidence, sanitize_evidence_text
+from pi_intent_evidence import (
+    append_pi_hybrid_production_label,
+    apply_pi_hybrid_production_labels,
+    load_pi_hybrid_production_labels,
+    record_intent_miss_evidence,
+    record_pi_hybrid_production_evidence,
+    sanitize_evidence_text,
+)
 
 
 def test_record_intent_miss_evidence_disabled_does_not_write(tmp_path):
@@ -138,6 +147,78 @@ def test_record_pi_hybrid_production_evidence_writes_compact_sanitized_jsonl(tmp
     assert saved["enabled_groups"] == ["weather"]
     assert saved["outcome_label"] is None
     assert "Jason Smith" not in path.read_text(encoding="utf-8")
+
+
+def test_pi_hybrid_production_label_sidecar_applies_latest_valid_label(tmp_path):
+    evidence_path = tmp_path / "production.jsonl"
+    labels_path = tmp_path / "production-labels.jsonl"
+    record = record_pi_hybrid_production_evidence(
+        "will it rain later",
+        user_id="jason",
+        decision=_production_decision(),
+        env={
+            "ZOE_PI_HYBRID_PRODUCTION_EVIDENCE_ENABLED": "true",
+            "ZOE_PI_HYBRID_PRODUCTION_EVIDENCE_PATH": str(evidence_path),
+        },
+    )
+    assert record is not None
+
+    result = append_pi_hybrid_production_label(
+        text_hash=record["text_hash"],
+        outcome_label="weather",
+        reviewed_by="jason",
+        evidence_path=str(evidence_path),
+        labels_path=str(labels_path),
+    )
+
+    labels = load_pi_hybrid_production_labels(str(labels_path))
+    labeled = apply_pi_hybrid_production_labels([record], labels)
+
+    assert result["ok"] is True
+    assert result["labels_store"] == "production_labels_sidecar"
+    assert result["matched_record"]["text_preview"] == "will it rain later"
+    assert labels[record["text_hash"]]["outcome_label"] == "weather"
+    assert labeled[0]["outcome_label"] == "weather"
+    assert labeled[0]["outcome_label_source"] == "production_label_sidecar"
+    assert "reviewed_by_hash" in labels_path.read_text(encoding="utf-8")
+
+
+def test_pi_hybrid_production_label_rejects_missing_or_privileged_label(tmp_path):
+    evidence_path = tmp_path / "production.jsonl"
+    labels_path = tmp_path / "production-labels.jsonl"
+    record = record_pi_hybrid_production_evidence(
+        "will it rain later",
+        user_id="jason",
+        decision=_production_decision(),
+        env={
+            "ZOE_PI_HYBRID_PRODUCTION_EVIDENCE_ENABLED": "true",
+            "ZOE_PI_HYBRID_PRODUCTION_EVIDENCE_PATH": str(evidence_path),
+        },
+    )
+    assert record is not None
+
+    with pytest.raises(ValueError, match="text_hash not found"):
+        append_pi_hybrid_production_label(
+            text_hash="missing",
+            outcome_label="weather",
+            evidence_path=str(evidence_path),
+            labels_path=str(labels_path),
+        )
+    with pytest.raises(ValueError, match="low-risk"):
+        append_pi_hybrid_production_label(
+            text_hash=record["text_hash"],
+            outcome_label="extend_capability",
+            evidence_path=str(evidence_path),
+            labels_path=str(labels_path),
+        )
+    with pytest.raises(ValueError, match="low-risk"):
+        append_pi_hybrid_production_label(
+            text_hash=record["text_hash"],
+            outcome_label="weather",
+            negative=True,
+            evidence_path=str(evidence_path),
+            labels_path=str(labels_path),
+        )
 
 
 def test_record_pi_hybrid_production_evidence_skips_secret_like_text(tmp_path):

--- a/services/zoe-data/tests/test_pi_intent_status_endpoint.py
+++ b/services/zoe-data/tests/test_pi_intent_status_endpoint.py
@@ -441,6 +441,51 @@ def test_pi_intent_shadow_label_endpoint_rejects_non_admin():
     assert resp.status_code == 403
 
 
+def test_pi_hybrid_production_label_endpoint_appends_trusted_label(tmp_path, monkeypatch):
+    production_path = tmp_path / "production.jsonl"
+    labels_path = tmp_path / "production-labels.jsonl"
+    production_path.write_text(
+        '{"text_hash":"weatherhash","text_preview":"rain later","accepted":true,"reason":"accepted","intent":"weather","intent_group":"weather","pi_intent":"weather"}\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("ZOE_PI_HYBRID_PRODUCTION_EVIDENCE_PATH", str(production_path))
+    monkeypatch.setenv("ZOE_PI_HYBRID_PRODUCTION_LABELS_PATH", str(labels_path))
+    app = _admin_app()
+
+    resp = TestClient(app).post(
+        "/api/system/pi-intent/production-labels",
+        json={"text_hash": "weatherhash", "outcome_label": "weather"},
+    )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["ok"] is True
+    assert data["label"]["outcome_label"] == "weather"
+    assert data["matched_record"]["text_preview"] == "rain later"
+    saved = json.loads(labels_path.read_text(encoding="utf-8"))
+    assert saved["text_hash"] == "weatherhash"
+    assert saved["outcome_label"] == "weather"
+    assert len(saved["reviewed_by_hash"]) == 64
+    assert data["labels_store"] == "production_labels_sidecar"
+
+
+def test_pi_hybrid_production_label_endpoint_rejects_non_admin():
+    app = FastAPI()
+    app.include_router(system_router)
+
+    async def fake_non_admin():
+        raise HTTPException(status_code=403, detail="Admin access required")
+
+    app.dependency_overrides[require_admin] = fake_non_admin
+
+    resp = TestClient(app).post(
+        "/api/system/pi-intent/production-labels",
+        json={"text_hash": "known", "outcome_label": "weather"},
+    )
+
+    assert resp.status_code == 403
+
+
 def test_pi_intent_shadow_status_endpoint_rejects_non_admin():
     app = FastAPI()
     app.include_router(system_router)

--- a/services/zoe-data/tests/test_pi_readiness_report.py
+++ b/services/zoe-data/tests/test_pi_readiness_report.py
@@ -13,6 +13,7 @@ def _env(tmp_path, shadow_path):
         "ZOE_PI_INTENT_SHADOW_PATH": str(shadow_path),
         "ZOE_PI_INTENT_SHADOW_LABELS_PATH": str(tmp_path / "labels.jsonl"),
         "ZOE_PI_HYBRID_PRODUCTION_EVIDENCE_PATH": str(tmp_path / "production.jsonl"),
+        "ZOE_PI_HYBRID_PRODUCTION_LABELS_PATH": str(tmp_path / "production-labels.jsonl"),
         "ZOE_PI_PROMOTION_EVAL_REPORT_PATH": str(tmp_path / "missing-eval-report.json"),
     }
 
@@ -361,6 +362,7 @@ def test_readiness_report_surfaces_production_evidence_summary(tmp_path):
             for row in [
                 {
                     "ts": 1.0,
+                    "text_hash": None,
                     "source": "pi_hybrid_production",
                     "accepted": True,
                     "reason": "accepted",
@@ -375,6 +377,7 @@ def test_readiness_report_surfaces_production_evidence_summary(tmp_path):
                 },
                 {
                     "ts": 2.0,
+                    "text_hash": None,
                     "source": "pi_hybrid_production",
                     "accepted": False,
                     "reason": "timeout",
@@ -387,6 +390,7 @@ def test_readiness_report_surfaces_production_evidence_summary(tmp_path):
                 },
                 {
                     "ts": 3.0,
+                    "text_hash": None,
                     "source": "pi_hybrid_production",
                     "accepted": True,
                     "reason": "accepted",
@@ -419,6 +423,8 @@ def test_readiness_report_surfaces_production_evidence_summary(tmp_path):
         "enabled": True,
         "loaded": True,
         "path": str(production_path),
+        "labels_path": str(tmp_path / "production-labels.jsonl"),
+        "label_count": 0,
         "invalid_lines": 1,
         "record_count": 3,
         "accepted_count": 2,
@@ -448,6 +454,7 @@ def test_readiness_report_surfaces_production_evidence_summary(tmp_path):
         "recent": [
             {
                 "ts": 1.0,
+                "text_hash": None,
                 "intent_group": "weather",
                 "accepted": True,
                 "reason": "accepted",
@@ -457,10 +464,12 @@ def test_readiness_report_surfaces_production_evidence_summary(tmp_path):
                 "safe_fulfillment_latency_ms": 900.0,
                 "production_route_change": True,
                 "outcome_label": None,
+                "outcome_label_source": None,
                 "text_preview": "will it rain later",
             },
             {
                 "ts": 2.0,
+                "text_hash": None,
                 "intent_group": "weather",
                 "accepted": False,
                 "reason": "timeout",
@@ -470,10 +479,12 @@ def test_readiness_report_surfaces_production_evidence_summary(tmp_path):
                 "safe_fulfillment_latency_ms": None,
                 "production_route_change": False,
                 "outcome_label": "weather_timeout",
+                "outcome_label_source": None,
                 "text_preview": "weather tomorrow",
             },
             {
                 "ts": 3.0,
+                "text_hash": None,
                 "intent_group": "daily_briefing",
                 "accepted": True,
                 "reason": "accepted",
@@ -483,6 +494,7 @@ def test_readiness_report_surfaces_production_evidence_summary(tmp_path):
                 "safe_fulfillment_latency_ms": 1100.0,
                 "production_route_change": True,
                 "outcome_label": None,
+                "outcome_label_source": None,
                 "text_preview": "give me my daily briefing",
             },
         ],
@@ -492,8 +504,80 @@ def test_readiness_report_surfaces_production_evidence_summary(tmp_path):
         "priority": "p1",
         "detail": "Label 2 Pi hybrid production evidence records before promotion scoring.",
         "path": str(production_path),
+        "labels_path": str(tmp_path / "production-labels.jsonl"),
         "groups": ["daily_briefing", "weather"],
     } in report["next_actions"]
+
+
+def test_readiness_report_applies_production_label_sidecar(tmp_path):
+    shadow_path = tmp_path / "shadow.jsonl"
+    shadow_path.write_text("", encoding="utf-8")
+    production_path = tmp_path / "production.jsonl"
+    labels_path = tmp_path / "production-labels.jsonl"
+    production_path.write_text(
+        "".join(
+            json.dumps(row) + "\n"
+            for row in [
+                {
+                    "ts": 1.0,
+                    "source": "pi_hybrid_production",
+                    "text_hash": "weather-hash",
+                    "accepted": True,
+                    "reason": "accepted",
+                    "intent": "weather",
+                    "intent_group": "weather",
+                    "pi_intent": "weather",
+                    "pi_latency_ms": 4100.0,
+                    "safe_fulfillment_latency_ms": 900.0,
+                    "production_route_change": True,
+                    "text_preview": "will it rain later",
+                    "outcome_label": None,
+                },
+                {
+                    "ts": 2.0,
+                    "source": "pi_hybrid_production",
+                    "text_hash": "briefing-hash",
+                    "accepted": True,
+                    "reason": "accepted",
+                    "intent": "daily_briefing",
+                    "intent_group": "daily_briefing",
+                    "pi_intent": "daily_briefing",
+                    "pi_latency_ms": 2200.0,
+                    "safe_fulfillment_latency_ms": 1100.0,
+                    "production_route_change": True,
+                    "text_preview": "give me my daily briefing",
+                    "outcome_label": None,
+                },
+            ]
+        ),
+        encoding="utf-8",
+    )
+    labels_path.write_text(
+        "".join(
+            json.dumps(row) + "\n"
+            for row in [
+                {"text_hash": "weather-hash", "outcome_label": "weather", "source": "admin_review"},
+                {"text_hash": "briefing-hash", "outcome_label": "daily_briefing", "source": "admin_review"},
+            ]
+        ),
+        encoding="utf-8",
+    )
+    env = _env(tmp_path, shadow_path)
+    env["ZOE_PI_HYBRID_PRODUCTION_EVIDENCE_ENABLED"] = "true"
+    env["ZOE_PI_HYBRID_PRODUCTION_EVIDENCE_PATH"] = str(production_path)
+    env["ZOE_PI_HYBRID_PRODUCTION_LABELS_PATH"] = str(labels_path)
+
+    report = pi_readiness_report(env)
+
+    assert report["summary"]["production_label_count"] == 2
+    assert report["summary"]["production_unlabeled_count"] == 0
+    assert report["production_evidence"]["label_count"] == 2
+    assert report["production_evidence"]["unlabeled_count"] == 0
+    assert {row["outcome_label"] for row in report["production_evidence"]["recent"]} == {"weather", "daily_briefing"}
+    assert {row["outcome_label_source"] for row in report["production_evidence"]["recent"]} == {
+        "production_label_sidecar"
+    }
+    assert not [action for action in report["next_actions"] if action.get("kind") == "label_production_evidence"]
 
 
 def test_readiness_report_missing_production_evidence_is_nonblocking(tmp_path):
@@ -508,6 +592,7 @@ def test_readiness_report_missing_production_evidence_is_nonblocking(tmp_path):
         "enabled": True,
         "loaded": False,
         "path": str(tmp_path / "production.jsonl"),
+        "labels_path": str(tmp_path / "production-labels.jsonl"),
         "record_count": 0,
     }
     assert report["state"] == "shadow_collecting"
@@ -539,6 +624,7 @@ def test_readiness_report_disabled_production_evidence_does_not_load_existing_fi
         "enabled": False,
         "loaded": False,
         "path": str(production_path),
+        "labels_path": str(tmp_path / "production-labels.jsonl"),
         "record_count": 0,
         "disabled": True,
     }

--- a/services/zoe-data/tests/test_pi_readiness_report.py
+++ b/services/zoe-data/tests/test_pi_readiness_report.py
@@ -548,6 +548,19 @@ def test_readiness_report_applies_production_label_sidecar(tmp_path):
                     "text_preview": "give me my daily briefing",
                     "outcome_label": None,
                 },
+                {
+                    "ts": 3.0,
+                    "source": "pi_hybrid_production",
+                    "text_hash": "chat-hash",
+                    "accepted": False,
+                    "reason": "pi_disagreed",
+                    "intent_group": "weather",
+                    "pi_latency_ms": 1800.0,
+                    "safe_fulfillment_latency_ms": None,
+                    "production_route_change": False,
+                    "text_preview": "just chatting",
+                    "outcome_label": None,
+                },
             ]
         ),
         encoding="utf-8",
@@ -558,6 +571,7 @@ def test_readiness_report_applies_production_label_sidecar(tmp_path):
             for row in [
                 {"text_hash": "weather-hash", "outcome_label": "weather", "source": "admin_review"},
                 {"text_hash": "briefing-hash", "outcome_label": "daily_briefing", "source": "admin_review"},
+                {"text_hash": "chat-hash", "outcome_label": "chat", "source": "admin_review"},
             ]
         ),
         encoding="utf-8",
@@ -569,15 +583,50 @@ def test_readiness_report_applies_production_label_sidecar(tmp_path):
 
     report = pi_readiness_report(env)
 
-    assert report["summary"]["production_label_count"] == 2
+    assert report["summary"]["production_label_count"] == 3
     assert report["summary"]["production_unlabeled_count"] == 0
-    assert report["production_evidence"]["label_count"] == 2
+    assert report["production_evidence"]["label_count"] == 3
     assert report["production_evidence"]["unlabeled_count"] == 0
-    assert {row["outcome_label"] for row in report["production_evidence"]["recent"]} == {"weather", "daily_briefing"}
+    assert {row["outcome_label"] for row in report["production_evidence"]["recent"]} == {
+        None,
+        "weather",
+        "daily_briefing",
+    }
     assert {row["outcome_label_source"] for row in report["production_evidence"]["recent"]} == {
         "production_label_sidecar"
     }
     assert not [action for action in report["next_actions"] if action.get("kind") == "label_production_evidence"]
+
+
+def test_readiness_report_surfaces_production_label_file_error(tmp_path):
+    shadow_path = tmp_path / "shadow.jsonl"
+    shadow_path.write_text("", encoding="utf-8")
+    production_path = tmp_path / "production.jsonl"
+    labels_path = tmp_path / "production-labels.jsonl"
+    labels_path.mkdir()
+    production_path.write_text(
+        json.dumps(
+            {
+                "source": "pi_hybrid_production",
+                "text_hash": "weather-hash",
+                "accepted": True,
+                "intent_group": "weather",
+                "outcome_label": None,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    env = _env(tmp_path, shadow_path)
+    env["ZOE_PI_HYBRID_PRODUCTION_EVIDENCE_ENABLED"] = "true"
+    env["ZOE_PI_HYBRID_PRODUCTION_EVIDENCE_PATH"] = str(production_path)
+    env["ZOE_PI_HYBRID_PRODUCTION_LABELS_PATH"] = str(labels_path)
+
+    report = pi_readiness_report(env)
+
+    assert report["production_evidence"]["label_count"] == 0
+    assert report["production_evidence"]["label_error"] == "IsADirectoryError"
+    assert report["summary"]["production_unlabeled_count"] == 1
 
 
 def test_readiness_report_missing_production_evidence_is_nonblocking(tmp_path):


### PR DESCRIPTION
## What changed
- Added an append-only Pi hybrid production label sidecar keyed by production evidence `text_hash`.
- Applied production labels in the Pi readiness report so reviewed evidence clears the `label_production_evidence` action.
- Added an admin endpoint at `/api/system/pi-intent/production-labels` that writes to the configured production evidence/label paths.
- Added focused helper, readiness, and endpoint regressions for trusted labels, bad labels, non-admin rejection, and blocker clearance.

## Why
The live touch-panel Pi hybrid path was collecting production evidence, but the records were unlabeled. That meant the promotion/readiness loop could not distinguish reviewed evidence from unreviewed evidence, and operators had no wired path to close the contract.

## Validation
- `python3 -m py_compile services/zoe-data/pi_intent_evidence.py services/zoe-data/pi_readiness_report.py services/zoe-data/routers/system.py`
- `python3 -m pytest services/zoe-data/tests/test_pi_intent_evidence.py services/zoe-data/tests/test_pi_readiness_report.py -q`
- `python3 -m pytest services/zoe-data/tests/test_pi_intent_status_endpoint.py -q`
- `python3 -m pytest services/zoe-data/tests/test_pi_intent_evidence.py services/zoe-data/tests/test_pi_readiness_report.py services/zoe-data/tests/test_pi_intent_shadow.py services/zoe-data/tests/test_pi_touch_hybrid_production_probe.py -q`
- `python3 tools/audit/validate_structure.py`
- `git diff --check`
- `python3 -m pytest services/zoe-data/tests/test_pi*.py -q` (429 passed)
