### PR TITLE
[codex] Add Pi production promotion evidence

### DIFF
--- a/services/zoe-data/pi_intent_evidence.py
+++ b/services/zoe-data/pi_intent_evidence.py
@@ -15,7 +15,7 @@ from collections import deque
 from pathlib import Path
 from typing import Any, Mapping, Sequence
 
-from zoe_pi_promotion import intent_group_for_intent
+from zoe_pi_promotion import PiRouteSample, intent_group_for_intent
 
 _DEFAULT_MISS_PATH = "~/.zoe/data/pi-intent-miss-evidence.jsonl"
 _DEFAULT_PRODUCTION_PATH = "~/.zoe/data/pi-hybrid-production-evidence.jsonl"
@@ -233,6 +233,72 @@ def append_pi_hybrid_production_label(
     }
 
 
+def production_records_to_route_samples(records: Sequence[Mapping[str, Any]]) -> list[PiRouteSample]:
+    """Convert reviewed production Pi hybrid evidence into promotion samples.
+
+    Only positive reviewed labels can become promotion samples. Negative labels
+    are useful review evidence, but PiRouteSample is scoped to allowlisted intent
+    groups rather than open chat/no-intent cases.
+    """
+    samples: list[PiRouteSample] = []
+    for index, record in enumerate(records):
+        expected_intent = _optional_str(record.get("outcome_label"))
+        intent_group = intent_group_for_intent(expected_intent)
+        if not expected_intent or not intent_group:
+            continue
+        zoe_latency_ms = _float_or_none(record.get("zoe_latency_ms"))
+        pi_latency_ms = _float_or_none(record.get("pi_latency_ms"))
+        if zoe_latency_ms is None or pi_latency_ms is None:
+            continue
+        route_class = _optional_str(record.get("route_class")) or "fallback"
+        baseline_kind, baseline_comparable = _production_baseline_metadata(record, route_class=route_class)
+        try:
+            samples.append(
+                PiRouteSample(
+                    case_id=_optional_str(record.get("text_hash")) or f"pi_hybrid_production_{index}",
+                    intent_group=intent_group,
+                    expected_intent=expected_intent,
+                    zoe_intent=_optional_str(record.get("zoe_intent")),
+                    pi_intent=_optional_str(record.get("pi_intent")),
+                    zoe_latency_ms=zoe_latency_ms,
+                    pi_latency_ms=pi_latency_ms,
+                    pi_confidence=_float_or_none(record.get("pi_confidence")) or 0.0,
+                    pi_transport=_optional_str(record.get("pi_transport")) or "rpc",
+                    route_class=route_class,
+                    timed_out=_bool_record_value(record.get("safe_fulfillment_timed_out"))
+                    or _optional_str(record.get("reason")) == "timeout",
+                    user_corrected=_bool_record_value(record.get("user_corrected")),
+                    rollback_blocked=_bool_record_value(record.get("rollback_blocked")),
+                    metadata={
+                        "source": "pi_hybrid_production",
+                        "text_hash": _optional_str(record.get("text_hash")) or "",
+                        "baseline_kind": baseline_kind,
+                        "baseline_comparable": baseline_comparable,
+                        "safe_fulfillment_latency_ms": _float_or_none(record.get("safe_fulfillment_latency_ms")),
+                        "production_route_change": _bool_record_value(record.get("production_route_change")),
+                        "accepted": _bool_record_value(record.get("accepted")),
+                        "outcome_label_source": _optional_str(record.get("outcome_label_source")),
+                    },
+                )
+            )
+        except (TypeError, ValueError):
+            continue
+    return samples
+
+
+def _production_baseline_metadata(record: Mapping[str, Any], *, route_class: str) -> tuple[str, bool]:
+    baseline_kind = _optional_str(record.get("baseline_kind"))
+    if not baseline_kind:
+        baseline_kind = "router" if route_class == "deterministic" else "router_only_not_comparable"
+    if record.get("baseline_comparable") is not None:
+        baseline_comparable = _bool_record_value(record.get("baseline_comparable"))
+    else:
+        baseline_comparable = baseline_kind not in {
+            "router_only_not_comparable",
+            "router_extraction_failed_not_comparable",
+        }
+    return baseline_kind, baseline_comparable
+
 def _production_label_from_row(row: Mapping[str, Any]) -> dict[str, Any]:
     label: dict[str, Any] = {}
     negative = _bool_record_value(row.get("negative"))
@@ -345,6 +411,7 @@ __all__ = [
     "has_secret_evidence_text",
     "load_pi_hybrid_production_labels",
     "load_pi_hybrid_production_records",
+    "production_records_to_route_samples",
     "record_intent_miss_evidence",
     "record_pi_hybrid_production_evidence",
     "sanitize_evidence_text",

--- a/services/zoe-data/pi_readiness_report.py
+++ b/services/zoe-data/pi_readiness_report.py
@@ -9,9 +9,13 @@ from pathlib import Path
 from typing import Any, Mapping
 
 from pi_hybrid_buffer import pi_hybrid_buffer_status
-from pi_intent_evidence import apply_pi_hybrid_production_labels, load_pi_hybrid_production_labels
+from pi_intent_evidence import (
+    apply_pi_hybrid_production_labels,
+    load_pi_hybrid_production_labels,
+    production_records_to_route_samples,
+)
 from pi_intent_shadow import pi_intent_shadow_status
-from zoe_pi_promotion import LOW_RISK_PI_INTENT_GROUPS
+from zoe_pi_promotion import LOW_RISK_PI_INTENT_GROUPS, summarize_pi_promotion
 
 DEFAULT_EVAL_REPORT_PATH = "~/.zoe/data/pi-promotion-eval-report.json"
 DEFAULT_PRODUCTION_EVIDENCE_PATH = "~/.zoe/data/pi-hybrid-production-evidence.jsonl"
@@ -30,8 +34,18 @@ def pi_readiness_report(env: Mapping[str, str] | None = None) -> dict[str, Any]:
     benchmark_promotion = benchmark.get("promotion_report") or {}
     contract = hybrid.get("contract") or {}
     actions = promotion.get("promotion_actions") or {}
-    candidate_wins = _combined_candidate_wins(promotion, benchmark_promotion)
-    state = _readiness_state(contract, promotion, actions, benchmark_promotion=benchmark_promotion)
+    production_promotion = production.get("promotion_report") if isinstance(production.get("promotion_report"), Mapping) else {}
+    candidate_wins = _combined_candidate_wins(
+        promotion,
+        _combined_promotion_reports(benchmark_promotion, production_promotion),
+    )
+    state = _readiness_state(
+        contract,
+        promotion,
+        actions,
+        benchmark_promotion=benchmark_promotion,
+        production_promotion=production_promotion,
+    )
     return {
         "report_kind": "zoe_pi_readiness_report",
         "state": state,
@@ -67,6 +81,7 @@ def _readiness_state(
     actions: Mapping[str, Any],
     *,
     benchmark_promotion: Mapping[str, Any] | None = None,
+    production_promotion: Mapping[str, Any] | None = None,
 ) -> str:
     rollback_groups = list(actions.get("rollback_groups") or promotion.get("rollback_groups") or [])
     promote_groups = list(actions.get("promote_groups") or promotion.get("promotable_groups") or [])
@@ -78,7 +93,8 @@ def _readiness_state(
         return "promotion_apply_ready"
     candidate_groups = list(((promotion.get("candidate_wins") or {}).get("groups")) or [])
     benchmark_candidate_groups = list((((benchmark_promotion or {}).get("candidate_wins") or {}).get("groups")) or [])
-    if candidate_groups or benchmark_candidate_groups:
+    production_candidate_groups = list((((production_promotion or {}).get("candidate_wins") or {}).get("groups")) or [])
+    if candidate_groups or benchmark_candidate_groups or production_candidate_groups:
         return "collect_more_evidence"
     if _groups_with_blocker(promotion, "baseline_not_comparable"):
         return "measure_comparable_baseline"
@@ -99,6 +115,7 @@ def _summary(
     evidence = shadow.get("report") or {}
     benchmark = benchmark or {}
     production = production or {}
+    production_promotion = production.get("promotion_report") if isinstance(production.get("promotion_report"), Mapping) else {}
     return {
         "state": state,
         "mode": contract.get("mode"),
@@ -107,6 +124,7 @@ def _summary(
         "labeled_sample_count": int(evidence.get("labeled_sample_count") or 0),
         "candidate_win_groups": list(((promotion.get("candidate_wins") or {}).get("groups")) or []),
         "benchmark_candidate_win_groups": list(((benchmark.get("candidate_wins") or {}).get("groups")) or []),
+        "production_candidate_win_groups": list(((production_promotion.get("candidate_wins") or {}).get("groups")) or []),
         "promotion_ready_groups": list(promotion.get("promotable_groups") or []),
         "rollback_groups": list(actions.get("rollback_groups") or promotion.get("rollback_groups") or []),
         "requires_operator_apply": bool(actions.get("requires_operator_apply")),
@@ -128,6 +146,7 @@ def _evidence(
     source = promotion.get("source_breakdown") or {}
     benchmark = benchmark or {}
     production = production or {}
+    production_promotion = production.get("promotion_report") if isinstance(production.get("promotion_report"), Mapping) else {}
     return {
         "record_count_window": shadow.get("record_count_window"),
         "raw_record_count_window": shadow.get("raw_record_count_window"),
@@ -145,6 +164,10 @@ def _evidence(
         "production_accepted_count": int(production.get("accepted_count") or 0),
         "production_label_count": int(production.get("label_count") or 0),
         "production_unlabeled_count": int(production.get("unlabeled_count") or 0),
+        "production_sample_count": int((production_promotion or {}).get("sample_count") or 0),
+        "production_real_source_sample_count_by_group": dict(
+            ((production_promotion.get("source_breakdown") or {}).get("real_source_sample_count_by_group") or {})
+        ),
         "production_record_count_by_group": {
             group: int(stats.get("record_count") or 0)
             for group, stats in (production.get("by_group") or {}).items()
@@ -244,10 +267,20 @@ def _next_actions(
     shadow_action_groups = {
         str(action.get("intent_group")) for action in shadow_evidence_actions if action.get("intent_group")
     }
-    next_actions.extend(
+    benchmark_evidence_actions = [
         action
         for action in _evidence_collection_actions(benchmark_promotion or {}, source="benchmark")
         if str(action.get("intent_group")) not in shadow_action_groups
+    ]
+    next_actions.extend(benchmark_evidence_actions)
+    evidence_action_groups = shadow_action_groups | {
+        str(action.get("intent_group")) for action in benchmark_evidence_actions if action.get("intent_group")
+    }
+    production_promotion = (production or {}).get("promotion_report") if isinstance((production or {}).get("promotion_report"), Mapping) else {}
+    next_actions.extend(
+        action
+        for action in _evidence_collection_actions(production_promotion or {}, source="production")
+        if str(action.get("intent_group")) not in evidence_action_groups
     )
     baseline_groups = _groups_with_blocker(promotion, "baseline_not_comparable")
     benchmark_groups = _benchmark_candidate_groups(benchmark_promotion)
@@ -404,7 +437,9 @@ def _load_production_evidence(env: Mapping[str, str]) -> dict[str, Any]:
         labels = {}
         label_error = exc.__class__.__name__
     labeled_records = apply_pi_hybrid_production_labels(records, labels)
+    samples = production_records_to_route_samples(labeled_records)
     summary = _summarize_production_records(labeled_records)
+    promotion_report = summarize_pi_promotion(samples)
     result = {
         "enabled": enabled,
         "loaded": True,
@@ -412,6 +447,7 @@ def _load_production_evidence(env: Mapping[str, str]) -> dict[str, Any]:
         "labels_path": str(labels_path) if labels_path else None,
         "label_count": len(labels),
         "invalid_lines": invalid_lines,
+        "promotion_report": promotion_report,
         **summary,
     }
     if label_error:
@@ -579,6 +615,25 @@ def _combined_candidate_wins(
     groups = sorted({str(item.get("intent_group")) for item in details if isinstance(item, Mapping) and item.get("intent_group")})
     return {**primary, "details": details, "groups": groups}
 
+
+def _combined_promotion_reports(
+    primary: Mapping[str, Any] | None, secondary: Mapping[str, Any] | None
+) -> dict[str, Any]:
+    primary = primary or {}
+    secondary = secondary or {}
+    if not primary:
+        return dict(secondary)
+    if not secondary:
+        return dict(primary)
+    primary_candidate = primary.get("candidate_wins") if isinstance(primary.get("candidate_wins"), Mapping) else {}
+    secondary_candidate = secondary.get("candidate_wins") if isinstance(secondary.get("candidate_wins"), Mapping) else {}
+    return {
+        **primary,
+        "candidate_wins": _combined_candidate_wins(
+            {"candidate_wins": primary_candidate},
+            {"candidate_wins": secondary_candidate},
+        ),
+    }
 
 def _benchmark_candidate_groups(benchmark_promotion: Mapping[str, Any] | None) -> list[str]:
     return list((((benchmark_promotion or {}).get("candidate_wins") or {}).get("groups")) or [])

--- a/services/zoe-data/tests/test_pi_intent_evidence.py
+++ b/services/zoe-data/tests/test_pi_intent_evidence.py
@@ -9,6 +9,7 @@ from pi_intent_evidence import (
     append_pi_hybrid_production_label,
     apply_pi_hybrid_production_labels,
     load_pi_hybrid_production_labels,
+    production_records_to_route_samples,
     record_intent_miss_evidence,
     record_pi_hybrid_production_evidence,
     sanitize_evidence_text,
@@ -219,6 +220,59 @@ def test_pi_hybrid_production_label_rejects_missing_or_privileged_label(tmp_path
             evidence_path=str(evidence_path),
             labels_path=str(labels_path),
         )
+
+
+def test_production_records_to_route_samples_uses_reviewed_positive_labels_only():
+    records = [
+        {
+            "text_hash": "weather-hash",
+            "outcome_label": "weather",
+            "zoe_intent": "weather",
+            "pi_intent": "weather",
+            "zoe_latency_ms": 1.0,
+            "pi_latency_ms": 4200.0,
+            "pi_confidence": 0.92,
+            "pi_transport": "rpc",
+            "route_class": "deterministic",
+            "baseline_kind": "router",
+            "safe_fulfillment_latency_ms": 900.0,
+            "production_route_change": True,
+            "accepted": True,
+            "outcome_label_source": "production_label_sidecar",
+        },
+        {
+            "text_hash": "chat-hash",
+            "outcome_label": None,
+            "negative": True,
+            "zoe_latency_ms": 1.0,
+            "pi_latency_ms": 2000.0,
+            "route_class": "fallback",
+        },
+        {
+            "text_hash": "missing-latency",
+            "outcome_label": "weather",
+            "pi_intent": "weather",
+            "pi_latency_ms": 2000.0,
+            "route_class": "fallback",
+        },
+    ]
+
+    samples = production_records_to_route_samples(records)
+
+    assert len(samples) == 1
+    sample = samples[0]
+    assert sample.case_id == "weather-hash"
+    assert sample.intent_group == "weather"
+    assert sample.expected_intent == "weather"
+    assert sample.zoe_intent == "weather"
+    assert sample.pi_intent == "weather"
+    assert sample.zoe_latency_ms == 1.0
+    assert sample.pi_latency_ms == 4200.0
+    assert sample.metadata["source"] == "pi_hybrid_production"
+    assert sample.metadata["baseline_kind"] == "router"
+    assert sample.metadata["baseline_comparable"] is True
+    assert sample.metadata["safe_fulfillment_latency_ms"] == 900.0
+
 
 
 def test_record_pi_hybrid_production_evidence_skips_secret_like_text(tmp_path):

--- a/services/zoe-data/tests/test_pi_readiness_report.py
+++ b/services/zoe-data/tests/test_pi_readiness_report.py
@@ -419,7 +419,11 @@ def test_readiness_report_surfaces_production_evidence_summary(tmp_path):
     assert report["summary"]["production_unlabeled_count"] == 2
     assert report["summary"]["production_groups"] == ["daily_briefing", "weather"]
     assert report["evidence"]["production_record_count_by_group"] == {"daily_briefing": 1, "weather": 2}
-    assert report["production_evidence"] == {
+    assert report["evidence"]["production_sample_count"] == 0
+    assert report["production_evidence"]["promotion_report"]["sample_count"] == 0
+    production_evidence = dict(report["production_evidence"])
+    production_evidence.pop("promotion_report")
+    assert production_evidence == {
         "enabled": True,
         "loaded": True,
         "path": str(production_path),
@@ -596,6 +600,93 @@ def test_readiness_report_applies_production_label_sidecar(tmp_path):
         "production_label_sidecar"
     }
     assert not [action for action in report["next_actions"] if action.get("kind") == "label_production_evidence"]
+
+
+def test_readiness_report_scores_labeled_production_evidence_conservatively(tmp_path):
+    shadow_path = tmp_path / "shadow.jsonl"
+    shadow_path.write_text("", encoding="utf-8")
+    production_path = tmp_path / "production.jsonl"
+    labels_path = tmp_path / "production-labels.jsonl"
+    production_path.write_text(
+        "".join(
+            json.dumps(row) + "\n"
+            for row in [
+                {
+                    "ts": 1.0,
+                    "source": "pi_hybrid_production",
+                    "text_hash": "weather-hash",
+                    "accepted": True,
+                    "reason": "accepted",
+                    "intent": "weather",
+                    "intent_group": "weather",
+                    "pi_intent": "weather",
+                    "zoe_intent": "weather",
+                    "route_class": "deterministic",
+                    "baseline_kind": "router",
+                    "zoe_latency_ms": 1.0,
+                    "pi_latency_ms": 4100.0,
+                    "safe_fulfillment_latency_ms": 900.0,
+                    "production_route_change": True,
+                    "text_preview": "will it rain later",
+                    "outcome_label": None,
+                },
+                {
+                    "ts": 2.0,
+                    "source": "pi_hybrid_production",
+                    "text_hash": "briefing-hash",
+                    "accepted": True,
+                    "reason": "accepted",
+                    "intent": "daily_briefing",
+                    "intent_group": "daily_briefing",
+                    "pi_intent": "daily_briefing",
+                    "route_class": "fallback",
+                    "baseline_kind": "router_only_not_comparable",
+                    "zoe_latency_ms": 1.0,
+                    "pi_latency_ms": 2200.0,
+                    "safe_fulfillment_latency_ms": 1100.0,
+                    "production_route_change": True,
+                    "text_preview": "give me my daily briefing",
+                    "outcome_label": None,
+                },
+            ]
+        ),
+        encoding="utf-8",
+    )
+    labels_path.write_text(
+        "".join(
+            json.dumps(row) + "\n"
+            for row in [
+                {"text_hash": "weather-hash", "outcome_label": "weather", "source": "admin_review"},
+                {"text_hash": "briefing-hash", "outcome_label": "daily_briefing", "source": "admin_review"},
+            ]
+        ),
+        encoding="utf-8",
+    )
+    env = _env(tmp_path, shadow_path)
+    env["ZOE_PI_HYBRID_PRODUCTION_EVIDENCE_ENABLED"] = "true"
+    env["ZOE_PI_HYBRID_PRODUCTION_EVIDENCE_PATH"] = str(production_path)
+    env["ZOE_PI_HYBRID_PRODUCTION_LABELS_PATH"] = str(labels_path)
+
+    report = pi_readiness_report(env)
+
+    production_report = report["production_evidence"]["promotion_report"]
+    assert production_report["sample_count"] == 2
+    assert report["evidence"]["production_sample_count"] == 2
+    assert report["evidence"]["production_real_source_sample_count_by_group"]["weather"] == 1
+    assert report["evidence"]["production_real_source_sample_count_by_group"]["daily_briefing"] == 1
+    weather_decision = [
+        item for item in production_report["decisions"] if item["intent_group"] == "weather"
+    ][0]
+    assert weather_decision["sample_count"] == 1
+    assert weather_decision["zoe_accuracy"] == 1.0
+    assert weather_decision["pi_accuracy"] == 1.0
+    assert "latency_not_faster_than_zoe" in weather_decision["blockers"]
+    briefing_decision = [
+        item for item in production_report["decisions"] if item["intent_group"] == "daily_briefing"
+    ][0]
+    assert "baseline_not_comparable" in briefing_decision["blockers"]
+    assert report["summary"]["production_candidate_win_groups"] == []
+
 
 
 def test_readiness_report_surfaces_production_label_file_error(tmp_path):

--- a/services/zoe-data/zoe_pi_promotion.py
+++ b/services/zoe-data/zoe_pi_promotion.py
@@ -38,7 +38,7 @@ PRIVILEGED_INTENTS = {
 EVAL_SOURCES = {"synthetic", "intent_miss", "chat_log", "voice_log", "known_failure"}
 # Sources counted as real/log-derived promotion evidence. Synthetic cases remain
 # useful smoke tests, but should be visible separately in promotion reports.
-REAL_PROMOTION_EVIDENCE_SOURCES = {"intent_miss", "chat_log", "voice_log", "known_failure", "pi_intent_shadow"}
+REAL_PROMOTION_EVIDENCE_SOURCES = {"intent_miss", "chat_log", "voice_log", "known_failure", "pi_intent_shadow", "pi_hybrid_production"}
 ROUTE_CLASSES = {"deterministic", "fallback", "extraction_failed"}
 PI_TRANSPORTS = {"print", "rpc"}
 DECISION_STATES = {"promote", "keep_shadow", "rollback", "blocked"}


### PR DESCRIPTION
## What changed
- Converts reviewed Pi hybrid production evidence into `PiRouteSample` promotion samples.
- Counts `pi_hybrid_production` as a real/log-derived promotion evidence source.
- Adds a production `promotion_report` to the readiness report, including source counts and conservative production candidate wins.
- Keeps promotion honest: production records only become positive promotion samples when they have reviewed labels and usable Pi/Zoe latencies; negative chat/no-intent labels remain review evidence but do not become promotable intent samples.

## Why
The touch-panel Pi hybrid path was collecting and labeling live production evidence, but readiness only summarized it. This closes the next contract loop: reviewed production outcomes now influence the promotion evidence view, while still blocking promotion when Pi is slower than Zoe's comparable route or when the baseline is not comparable.

## Validation
- `python3 -m py_compile services/zoe-data/zoe_pi_promotion.py services/zoe-data/pi_intent_evidence.py services/zoe-data/pi_readiness_report.py`
- `python3 -m pytest services/zoe-data/tests/test_pi_intent_evidence.py services/zoe-data/tests/test_pi_readiness_report.py -q` (26 passed)
- `python3 -m pytest services/zoe-data/tests/test_pi*.py -q` (432 passed)
- `python3 tools/audit/validate_structure.py`
- `git diff --check`
- Live readiness against current production evidence: 6 labeled production records, 0 unlabeled, production promotion samples present, no production candidate wins because weather Pi is slower than deterministic router and daily briefing lacks comparable baseline.
