### PR TITLE
Let Pi production labels carry baseline evidence

### DIFF
--- a/services/zoe-data/pi_intent_evidence.py
+++ b/services/zoe-data/pi_intent_evidence.py
@@ -28,6 +28,7 @@ _SPACE_RE = re.compile(r"\s+")
 _SECRET_KEY_RE = re.compile(r"(?i)(api[_-]?key|\btoken\b|\bsecret\b|password|authorization|\bbearer\b)")
 _SECRET_TEXT_RE = re.compile(r"(?i)(api[\s_-]?key|authorization|bearer\s+[a-z0-9._\-]+|password\s*(is|=)|secret\s*(is|=)|token\s*(is|=))")
 _ALLOWED_ROUTE_CLASSES = {"deterministic", "fallback", "extraction_failed"}
+_ALLOWED_BASELINE_KINDS = {"router", "router_only_not_comparable", "router_extraction_failed_not_comparable", "zoe_agent_fallback_baseline"}
 _ALLOWED_LABEL_SOURCES = {"admin_review", "operator_override"}
 _DEFAULT_PRODUCTION_RECORD_LIMIT = 1000
 
@@ -328,6 +329,8 @@ def _production_label_from_row(row: Mapping[str, Any]) -> dict[str, Any]:
         value = _optional_str(row.get(key))
         if value:
             if key == "route_class" and value not in _ALLOWED_ROUTE_CLASSES:
+                return {}
+            if key == "baseline_kind" and value not in _ALLOWED_BASELINE_KINDS:
                 return {}
             label[key] = value
     for key in ("baseline_comparable", "user_corrected", "rollback_blocked"):

--- a/services/zoe-data/pi_intent_evidence.py
+++ b/services/zoe-data/pi_intent_evidence.py
@@ -28,7 +28,19 @@ _SPACE_RE = re.compile(r"\s+")
 _SECRET_KEY_RE = re.compile(r"(?i)(api[_-]?key|\btoken\b|\bsecret\b|password|authorization|\bbearer\b)")
 _SECRET_TEXT_RE = re.compile(r"(?i)(api[\s_-]?key|authorization|bearer\s+[a-z0-9._\-]+|password\s*(is|=)|secret\s*(is|=)|token\s*(is|=))")
 _ALLOWED_ROUTE_CLASSES = {"deterministic", "fallback", "extraction_failed"}
-_ALLOWED_BASELINE_KINDS = {"router", "router_only_not_comparable", "router_extraction_failed_not_comparable", "zoe_agent_fallback_baseline"}
+_ALLOWED_BASELINE_KINDS = {
+    "operator_extraction_failed_override",
+    "operator_fallback_override",
+    "router",
+    "router_extraction_failed_not_comparable",
+    "router_only_not_comparable",
+    "zoe_agent_extraction_failed_baseline",
+    "zoe_agent_extraction_failed_error",
+    "zoe_agent_extraction_failed_timeout",
+    "zoe_agent_fallback_baseline",
+    "zoe_agent_fallback_error",
+    "zoe_agent_fallback_timeout",
+}
 _ALLOWED_LABEL_SOURCES = {"admin_review", "operator_override"}
 _DEFAULT_PRODUCTION_RECORD_LIMIT = 1000
 

--- a/services/zoe-data/pi_intent_evidence.py
+++ b/services/zoe-data/pi_intent_evidence.py
@@ -187,6 +187,10 @@ def append_pi_hybrid_production_label(
     negative: bool = False,
     source: str = "admin_review",
     reviewed_by: str | None = None,
+    route_class: str | None = None,
+    baseline_kind: str | None = None,
+    baseline_comparable: bool | None = None,
+    zoe_latency_ms: float | None = None,
     evidence_path: str = _DEFAULT_PRODUCTION_PATH,
     labels_path: str = _DEFAULT_PRODUCTION_LABELS_PATH,
     production_limit: int = _DEFAULT_PRODUCTION_RECORD_LIMIT,
@@ -218,6 +222,14 @@ def append_pi_hybrid_production_label(
         row["negative"] = True
     if reviewed_by:
         row["reviewed_by_hash"] = _hash_text(reviewed_by)
+    if route_class is not None:
+        row["route_class"] = route_class
+    if baseline_kind is not None:
+        row["baseline_kind"] = baseline_kind
+    if baseline_comparable is not None:
+        row["baseline_comparable"] = bool(baseline_comparable)
+    if zoe_latency_ms is not None:
+        row["zoe_latency_ms"] = zoe_latency_ms
 
     label = _production_label_from_row(row)
     if not label:
@@ -315,10 +327,17 @@ def _production_label_from_row(row: Mapping[str, Any]) -> dict[str, Any]:
     for key in ("route_class", "baseline_kind", "source"):
         value = _optional_str(row.get(key))
         if value:
+            if key == "route_class" and value not in _ALLOWED_ROUTE_CLASSES:
+                return {}
             label[key] = value
     for key in ("baseline_comparable", "user_corrected", "rollback_blocked"):
         if row.get(key) is not None:
             label[key] = _bool_record_value(row.get(key))
+    if row.get("zoe_latency_ms") is not None:
+        latency_ms = _float_or_none(row.get("zoe_latency_ms"))
+        if latency_ms is None or latency_ms < 0:
+            return {}
+        label["zoe_latency_ms"] = latency_ms
     return label
 
 

--- a/services/zoe-data/routers/system.py
+++ b/services/zoe-data/routers/system.py
@@ -290,6 +290,10 @@ class PiHybridProductionLabelRequest(BaseModel):
     outcome_label: Optional[str] = None
     negative: bool = False
     source: Literal["admin_review", "operator_override"] = "admin_review"
+    route_class: Optional[Literal["deterministic", "fallback", "extraction_failed"]] = None
+    baseline_kind: Optional[str] = None
+    baseline_comparable: Optional[bool] = None
+    zoe_latency_ms: Optional[float] = None
 
 
 @router.post("/pi-intent/production-labels")
@@ -307,6 +311,10 @@ async def post_pi_hybrid_production_label(
             negative=payload.negative,
             source=payload.source,
             reviewed_by=str(user.get("user_id") or "admin"),
+            route_class=payload.route_class,
+            baseline_kind=payload.baseline_kind,
+            baseline_comparable=payload.baseline_comparable,
+            zoe_latency_ms=payload.zoe_latency_ms,
             evidence_path=os.environ.get("ZOE_PI_HYBRID_PRODUCTION_EVIDENCE_PATH")
             or "~/.zoe/data/pi-hybrid-production-evidence.jsonl",
             labels_path=os.environ.get("ZOE_PI_HYBRID_PRODUCTION_LABELS_PATH")

--- a/services/zoe-data/routers/system.py
+++ b/services/zoe-data/routers/system.py
@@ -291,7 +291,21 @@ class PiHybridProductionLabelRequest(BaseModel):
     negative: bool = False
     source: Literal["admin_review", "operator_override"] = "admin_review"
     route_class: Optional[Literal["deterministic", "fallback", "extraction_failed"]] = None
-    baseline_kind: Optional[str] = None
+    baseline_kind: Optional[
+        Literal[
+            "operator_extraction_failed_override",
+            "operator_fallback_override",
+            "router",
+            "router_extraction_failed_not_comparable",
+            "router_only_not_comparable",
+            "zoe_agent_extraction_failed_baseline",
+            "zoe_agent_extraction_failed_error",
+            "zoe_agent_extraction_failed_timeout",
+            "zoe_agent_fallback_baseline",
+            "zoe_agent_fallback_error",
+            "zoe_agent_fallback_timeout",
+        ]
+    ] = None
     baseline_comparable: Optional[bool] = None
     zoe_latency_ms: Optional[float] = None
 

--- a/services/zoe-data/tests/test_pi_intent_evidence.py
+++ b/services/zoe-data/tests/test_pi_intent_evidence.py
@@ -226,6 +226,33 @@ def test_pi_hybrid_production_label_can_override_comparable_baseline(tmp_path):
     assert samples[0].metadata["baseline_comparable"] is True
 
 
+def test_pi_hybrid_production_label_rejects_unknown_route_class_and_baseline_kind(tmp_path):
+    evidence_path = tmp_path / "production.jsonl"
+    labels_path = tmp_path / "production-labels.jsonl"
+    evidence_path.write_text(
+        json.dumps({"text_hash": "briefing-hash", "source": "pi_hybrid_production"}) + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="low-risk"):
+        append_pi_hybrid_production_label(
+            text_hash="briefing-hash",
+            outcome_label="daily_briefing",
+            route_class="unknown_class",
+            evidence_path=str(evidence_path),
+            labels_path=str(labels_path),
+        )
+    with pytest.raises(ValueError, match="low-risk"):
+        append_pi_hybrid_production_label(
+            text_hash="briefing-hash",
+            outcome_label="daily_briefing",
+            baseline_kind="made_up_baseline",
+            evidence_path=str(evidence_path),
+            labels_path=str(labels_path),
+        )
+    assert not labels_path.exists()
+
+
 def test_pi_hybrid_production_label_rejects_missing_or_privileged_label(tmp_path):
     evidence_path = tmp_path / "production.jsonl"
     labels_path = tmp_path / "production-labels.jsonl"

--- a/services/zoe-data/tests/test_pi_intent_evidence.py
+++ b/services/zoe-data/tests/test_pi_intent_evidence.py
@@ -184,6 +184,48 @@ def test_pi_hybrid_production_label_sidecar_applies_latest_valid_label(tmp_path)
     assert "reviewed_by_hash" in labels_path.read_text(encoding="utf-8")
 
 
+def test_pi_hybrid_production_label_can_override_comparable_baseline(tmp_path):
+    evidence_path = tmp_path / "production.jsonl"
+    labels_path = tmp_path / "production-labels.jsonl"
+    record = {
+        "text_hash": "briefing-hash",
+        "source": "pi_hybrid_production",
+        "outcome_label": None,
+        "zoe_intent": None,
+        "pi_intent": "daily_briefing",
+        "pi_latency_ms": 2200.0,
+        "pi_confidence": 0.93,
+        "route_class": "fallback",
+        "baseline_kind": "router_only_not_comparable",
+        "baseline_comparable": False,
+        "zoe_latency_ms": 1.0,
+    }
+    evidence_path.write_text(json.dumps(record) + "\n", encoding="utf-8")
+
+    result = append_pi_hybrid_production_label(
+        text_hash="briefing-hash",
+        outcome_label="daily_briefing",
+        route_class="fallback",
+        baseline_kind="zoe_agent_fallback_baseline",
+        baseline_comparable=True,
+        zoe_latency_ms=4800.0,
+        evidence_path=str(evidence_path),
+        labels_path=str(labels_path),
+    )
+
+    labels = load_pi_hybrid_production_labels(str(labels_path))
+    labeled = apply_pi_hybrid_production_labels([record], labels)
+    samples = production_records_to_route_samples(labeled)
+
+    assert result["label"]["baseline_kind"] == "zoe_agent_fallback_baseline"
+    assert result["label"]["baseline_comparable"] is True
+    assert result["label"]["zoe_latency_ms"] == 4800.0
+    assert labeled[0]["zoe_latency_ms"] == 4800.0
+    assert samples[0].zoe_latency_ms == 4800.0
+    assert samples[0].metadata["baseline_kind"] == "zoe_agent_fallback_baseline"
+    assert samples[0].metadata["baseline_comparable"] is True
+
+
 def test_pi_hybrid_production_label_rejects_missing_or_privileged_label(tmp_path):
     evidence_path = tmp_path / "production.jsonl"
     labels_path = tmp_path / "production-labels.jsonl"

--- a/services/zoe-data/tests/test_pi_intent_status_endpoint.py
+++ b/services/zoe-data/tests/test_pi_intent_status_endpoint.py
@@ -454,17 +454,31 @@ def test_pi_hybrid_production_label_endpoint_appends_trusted_label(tmp_path, mon
 
     resp = TestClient(app).post(
         "/api/system/pi-intent/production-labels",
-        json={"text_hash": "weatherhash", "outcome_label": "weather"},
+        json={
+            "text_hash": "weatherhash",
+            "outcome_label": "weather",
+            "route_class": "fallback",
+            "baseline_kind": "zoe_agent_fallback_baseline",
+            "baseline_comparable": True,
+            "zoe_latency_ms": 4321.0,
+        },
     )
 
     assert resp.status_code == 200
     data = resp.json()
     assert data["ok"] is True
     assert data["label"]["outcome_label"] == "weather"
+    assert data["label"]["route_class"] == "fallback"
+    assert data["label"]["baseline_kind"] == "zoe_agent_fallback_baseline"
+    assert data["label"]["baseline_comparable"] is True
+    assert data["label"]["zoe_latency_ms"] == 4321.0
     assert data["matched_record"]["text_preview"] == "rain later"
     saved = json.loads(labels_path.read_text(encoding="utf-8"))
     assert saved["text_hash"] == "weatherhash"
     assert saved["outcome_label"] == "weather"
+    assert saved["baseline_kind"] == "zoe_agent_fallback_baseline"
+    assert saved["baseline_comparable"] is True
+    assert saved["zoe_latency_ms"] == 4321.0
     assert len(saved["reviewed_by_hash"]) == 64
     assert data["labels_store"] == "production_labels_sidecar"
 

--- a/services/zoe-data/tests/test_pi_readiness_report.py
+++ b/services/zoe-data/tests/test_pi_readiness_report.py
@@ -689,6 +689,70 @@ def test_readiness_report_scores_labeled_production_evidence_conservatively(tmp_
 
 
 
+def test_readiness_report_scores_labeled_production_baseline_override(tmp_path):
+    shadow_path = tmp_path / "shadow.jsonl"
+    shadow_path.write_text("", encoding="utf-8")
+    production_path = tmp_path / "production.jsonl"
+    labels_path = tmp_path / "production-labels.jsonl"
+    production_path.write_text(
+        json.dumps(
+            {
+                "ts": 1.0,
+                "source": "pi_hybrid_production",
+                "text_hash": "briefing-hash",
+                "accepted": True,
+                "reason": "accepted",
+                "intent": "daily_briefing",
+                "intent_group": "daily_briefing",
+                "pi_intent": "daily_briefing",
+                "route_class": "fallback",
+                "baseline_kind": "router_only_not_comparable",
+                "baseline_comparable": False,
+                "zoe_latency_ms": 1.0,
+                "pi_latency_ms": 2200.0,
+                "safe_fulfillment_latency_ms": 1100.0,
+                "production_route_change": True,
+                "text_preview": "give me my daily briefing",
+                "outcome_label": None,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    labels_path.write_text(
+        json.dumps(
+            {
+                "text_hash": "briefing-hash",
+                "outcome_label": "daily_briefing",
+                "source": "admin_review",
+                "route_class": "fallback",
+                "baseline_kind": "zoe_agent_fallback_baseline",
+                "baseline_comparable": True,
+                "zoe_latency_ms": 4800.0,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    env = _env(tmp_path, shadow_path)
+    env["ZOE_PI_HYBRID_PRODUCTION_EVIDENCE_ENABLED"] = "true"
+    env["ZOE_PI_HYBRID_PRODUCTION_EVIDENCE_PATH"] = str(production_path)
+    env["ZOE_PI_HYBRID_PRODUCTION_LABELS_PATH"] = str(labels_path)
+
+    report = pi_readiness_report(env)
+
+    decision = [
+        item
+        for item in report["production_evidence"]["promotion_report"]["decisions"]
+        if item["intent_group"] == "daily_briefing"
+    ][0]
+    assert "baseline_not_comparable" not in decision["blockers"]
+    assert "latency_not_faster_than_zoe" not in decision["blockers"]
+    assert decision["zoe_p95_latency_ms"] == 4800.0
+    assert decision["pi_p95_latency_ms"] == 2200.0
+    assert decision["baseline_lane_latency"]["fallback:zoe_agent_fallback_baseline"]["latency_delta_ms"] == 2600.0
+
+
 def test_readiness_report_surfaces_production_label_file_error(tmp_path):
     shadow_path = tmp_path / "shadow.jsonl"
     shadow_path.write_text("", encoding="utf-8")


### PR DESCRIPTION
## Summary
- let Pi hybrid production label sidecars carry comparable Zoe baseline evidence
- expose optional baseline fields on the admin production-label endpoint
- add helper, endpoint, and readiness tests proving fallback records can be rescored against measured Zoe Agent baselines

## Why
Production Pi evidence for fallback-style intents such as daily briefing currently records the near-zero router check as `router_only_not_comparable`. Operators can measure a real Zoe fallback baseline separately, but the production label path could not preserve that measured baseline into readiness scoring. This closes that last-mile evidence loop without changing live routing.

## Tests
- `python3 -m pytest services/zoe-data/tests/test_pi_intent_evidence.py services/zoe-data/tests/test_pi_readiness_report.py services/zoe-data/tests/test_pi_intent_status_endpoint.py -q`
- `python3 -m pytest services/zoe-data/tests/test_pi_hybrid_production.py services/zoe-data/tests/test_pi_touch_hybrid_production_probe.py services/zoe-data/tests/test_pi_hybrid_flow_benchmark.py services/zoe-data/tests/test_pi_promotion_eval_script.py services/zoe-data/tests/test_pi_readiness_report_cli.py services/zoe-data/tests/test_zoe_pi_promotion.py -q`
- `git diff --check`
- `python3 tools/audit/validate_structure.py`
