### PR TITLE
[codex] Report Pi hybrid production as operational

### DIFF
--- a/services/zoe-data/pi_readiness_report.py
+++ b/services/zoe-data/pi_readiness_report.py
@@ -101,6 +101,8 @@ def _readiness_state(
     promote_groups = list(actions.get("promote_groups") or promotion.get("promotable_groups") or [])
     if contract.get("blockers"):
         return "configuration_blocked"
+    if (production_config or {}).get("ignored_groups"):
+        return "configuration_blocked"
     if rollback_groups:
         return "rollback_required"
     if promote_groups:
@@ -251,6 +253,8 @@ def _next_actions(
     production_config: Mapping[str, Any] | None = None,
 ) -> list[dict[str, Any]]:
     next_actions: list[dict[str, Any]] = []
+    production_config = production_config or {}
+    ignored_production_groups = list(production_config.get("ignored_groups") or [])
     blockers = list(contract.get("blockers") or [])
     if blockers:
         next_actions.append(
@@ -259,6 +263,18 @@ def _next_actions(
                 "priority": "p0",
                 "detail": "Resolve hybrid buffer blockers before promoting Pi routes.",
                 "blockers": blockers,
+            }
+        )
+    if ignored_production_groups:
+        next_actions.append(
+            {
+                "kind": "fix_configuration",
+                "priority": "p0",
+                "detail": "Remove unsupported Pi hybrid production groups from ZOE_PI_HYBRID_PRODUCTION_GROUPS.",
+                "groups": ignored_production_groups,
+                "env": {
+                    "ZOE_PI_HYBRID_PRODUCTION_GROUPS": ",".join(production_config.get("groups") or []),
+                },
             }
         )
     rollback_groups = list(actions.get("rollback_groups") or promotion.get("rollback_groups") or [])
@@ -272,8 +288,7 @@ def _next_actions(
                 "env": dict(actions.get("env") or {}),
             }
         )
-    production_config = production_config or {}
-    if state == "production_hybrid_operational" and _production_hybrid_operational(production_config):
+    if state == "production_hybrid_operational":
         next_actions.append(
             {
                 "kind": "monitor_production_hybrid",
@@ -461,6 +476,7 @@ def _formal_promotion_actions(actions: list[dict[str, Any]], *, operational: boo
             item["detail"] = detail.replace(" before promotion.", " before formal default-route promotion.")
         adjusted.append(item)
     return adjusted
+
 
 def _load_production_evidence(env: Mapping[str, str]) -> dict[str, Any]:
     raw_path = (env.get("ZOE_PI_HYBRID_PRODUCTION_EVIDENCE_PATH") or DEFAULT_PRODUCTION_EVIDENCE_PATH).strip()

--- a/services/zoe-data/pi_readiness_report.py
+++ b/services/zoe-data/pi_readiness_report.py
@@ -101,7 +101,7 @@ def _readiness_state(
     promote_groups = list(actions.get("promote_groups") or promotion.get("promotable_groups") or [])
     if contract.get("blockers"):
         return "configuration_blocked"
-    if (production_config or {}).get("ignored_groups"):
+    if (production_config or {}).get("enabled") and (production_config or {}).get("ignored_groups"):
         return "configuration_blocked"
     if rollback_groups:
         return "rollback_required"
@@ -265,7 +265,7 @@ def _next_actions(
                 "blockers": blockers,
             }
         )
-    if ignored_production_groups:
+    if production_config.get("enabled") and ignored_production_groups:
         next_actions.append(
             {
                 "kind": "fix_configuration",

--- a/services/zoe-data/pi_readiness_report.py
+++ b/services/zoe-data/pi_readiness_report.py
@@ -31,6 +31,7 @@ def pi_readiness_report(env: Mapping[str, str] | None = None) -> dict[str, Any]:
     eval_report = _load_eval_report(values)
     benchmark = _benchmark_from_eval_report(eval_report)
     production = _load_production_evidence(values)
+    production_config = _production_hybrid_config(values)
     benchmark_promotion = benchmark.get("promotion_report") or {}
     contract = hybrid.get("contract") or {}
     actions = promotion.get("promotion_actions") or {}
@@ -45,11 +46,21 @@ def pi_readiness_report(env: Mapping[str, str] | None = None) -> dict[str, Any]:
         actions,
         benchmark_promotion=benchmark_promotion,
         production_promotion=production_promotion,
+        production_config=production_config,
     )
     return {
         "report_kind": "zoe_pi_readiness_report",
         "state": state,
-        "summary": _summary(state, contract, shadow, promotion, actions, benchmark, production),
+        "summary": _summary(
+            state,
+            contract,
+            shadow,
+            promotion,
+            actions,
+            benchmark,
+            production,
+            production_config,
+        ),
         "hybrid": {
             "mode": contract.get("mode"),
             "ready": bool(contract.get("ready")),
@@ -59,6 +70,7 @@ def pi_readiness_report(env: Mapping[str, str] | None = None) -> dict[str, Any]:
         },
         "evidence": _evidence(shadow, promotion, benchmark, production),
         "benchmark": benchmark,
+        "production_hybrid": production_config,
         "production_evidence": production,
         "candidates": _candidate_details(candidate_wins),
         "blocked_decisions": _blocked_decisions(promotion),
@@ -71,6 +83,7 @@ def pi_readiness_report(env: Mapping[str, str] | None = None) -> dict[str, Any]:
             actions,
             benchmark_promotion=benchmark_promotion,
             production=production,
+            production_config=production_config,
         ),
     }
 
@@ -82,6 +95,7 @@ def _readiness_state(
     *,
     benchmark_promotion: Mapping[str, Any] | None = None,
     production_promotion: Mapping[str, Any] | None = None,
+    production_config: Mapping[str, Any] | None = None,
 ) -> str:
     rollback_groups = list(actions.get("rollback_groups") or promotion.get("rollback_groups") or [])
     promote_groups = list(actions.get("promote_groups") or promotion.get("promotable_groups") or [])
@@ -94,6 +108,8 @@ def _readiness_state(
     candidate_groups = list(((promotion.get("candidate_wins") or {}).get("groups")) or [])
     benchmark_candidate_groups = list((((benchmark_promotion or {}).get("candidate_wins") or {}).get("groups")) or [])
     production_candidate_groups = list((((production_promotion or {}).get("candidate_wins") or {}).get("groups")) or [])
+    if _production_hybrid_operational(production_config or {}):
+        return "production_hybrid_operational"
     if candidate_groups or benchmark_candidate_groups or production_candidate_groups:
         return "collect_more_evidence"
     if _groups_with_blocker(promotion, "baseline_not_comparable"):
@@ -111,10 +127,12 @@ def _summary(
     actions: Mapping[str, Any],
     benchmark: Mapping[str, Any] | None = None,
     production: Mapping[str, Any] | None = None,
+    production_config: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     evidence = shadow.get("report") or {}
     benchmark = benchmark or {}
     production = production or {}
+    production_config = production_config or {}
     production_promotion = production.get("promotion_report") if isinstance(production.get("promotion_report"), Mapping) else {}
     return {
         "state": state,
@@ -128,6 +146,8 @@ def _summary(
         "promotion_ready_groups": list(promotion.get("promotable_groups") or []),
         "rollback_groups": list(actions.get("rollback_groups") or promotion.get("rollback_groups") or []),
         "requires_operator_apply": bool(actions.get("requires_operator_apply")),
+        "production_hybrid_operational": _production_hybrid_operational(production_config),
+        "production_hybrid_groups": list(production_config.get("groups") or []),
         "production_record_count": int(production.get("record_count") or 0),
         "production_accepted_count": int(production.get("accepted_count") or 0),
         "production_label_count": int(production.get("label_count") or 0),
@@ -228,6 +248,7 @@ def _next_actions(
     *,
     benchmark_promotion: Mapping[str, Any] | None = None,
     production: Mapping[str, Any] | None = None,
+    production_config: Mapping[str, Any] | None = None,
 ) -> list[dict[str, Any]]:
     next_actions: list[dict[str, Any]] = []
     blockers = list(contract.get("blockers") or [])
@@ -251,6 +272,16 @@ def _next_actions(
                 "env": dict(actions.get("env") or {}),
             }
         )
+    production_config = production_config or {}
+    if state == "production_hybrid_operational" and _production_hybrid_operational(production_config):
+        next_actions.append(
+            {
+                "kind": "monitor_production_hybrid",
+                "priority": "p1",
+                "detail": "Production Pi hybrid is live for operator-approved groups; keep formal default-route promotion evidence separate.",
+                "groups": list(production_config.get("groups") or []),
+            }
+        )
     promote_groups = list(actions.get("promote_groups") or promotion.get("promotable_groups") or [])
     if promote_groups:
         next_actions.append(
@@ -262,14 +293,20 @@ def _next_actions(
                 "env": dict(actions.get("env") or {}),
             }
         )
-    shadow_evidence_actions = _evidence_collection_actions(promotion)
+    shadow_evidence_actions = _formal_promotion_actions(
+        _evidence_collection_actions(promotion),
+        operational=state == "production_hybrid_operational",
+    )
     next_actions.extend(shadow_evidence_actions)
     shadow_action_groups = {
         str(action.get("intent_group")) for action in shadow_evidence_actions if action.get("intent_group")
     }
     benchmark_evidence_actions = [
         action
-        for action in _evidence_collection_actions(benchmark_promotion or {}, source="benchmark")
+        for action in _formal_promotion_actions(
+            _evidence_collection_actions(benchmark_promotion or {}, source="benchmark"),
+            operational=state == "production_hybrid_operational",
+        )
         if str(action.get("intent_group")) not in shadow_action_groups
     ]
     next_actions.extend(benchmark_evidence_actions)
@@ -279,7 +316,10 @@ def _next_actions(
     production_promotion = (production or {}).get("promotion_report") if isinstance((production or {}).get("promotion_report"), Mapping) else {}
     next_actions.extend(
         action
-        for action in _evidence_collection_actions(production_promotion or {}, source="production")
+        for action in _formal_promotion_actions(
+            _evidence_collection_actions(production_promotion or {}, source="production"),
+            operational=state == "production_hybrid_operational",
+        )
         if str(action.get("intent_group")) not in evidence_action_groups
     )
     baseline_groups = _groups_with_blocker(promotion, "baseline_not_comparable")
@@ -378,6 +418,49 @@ def _production_evidence_actions(production: Mapping[str, Any]) -> list[dict[str
         }
     ]
 
+
+def _production_hybrid_config(env: Mapping[str, str]) -> dict[str, Any]:
+    requested_groups = _csv_groups(env.get("ZOE_PI_HYBRID_PRODUCTION_GROUPS") or "")
+    groups = [group for group in requested_groups if group in LOW_RISK_PI_INTENT_GROUPS]
+    ignored_groups = [group for group in requested_groups if group not in LOW_RISK_PI_INTENT_GROUPS]
+    enabled = _env_bool(env.get("ZOE_PI_HYBRID_PRODUCTION_ENABLED"), default=False)
+    return {
+        "enabled": enabled,
+        "groups": groups,
+        "ignored_groups": ignored_groups,
+        "operational": bool(enabled and groups and not ignored_groups),
+        "route": "pi_intent_buffer_plus_zoe_safe_fulfillment",
+    }
+
+
+def _production_hybrid_operational(config: Mapping[str, Any]) -> bool:
+    return bool(config.get("operational"))
+
+
+def _csv_groups(value: str) -> list[str]:
+    seen: set[str] = set()
+    groups: list[str] = []
+    for item in str(value or "").split(","):
+        group = item.strip()
+        if not group or group in seen:
+            continue
+        seen.add(group)
+        groups.append(group)
+    return groups
+
+
+def _formal_promotion_actions(actions: list[dict[str, Any]], *, operational: bool) -> list[dict[str, Any]]:
+    if not operational:
+        return actions
+    adjusted: list[dict[str, Any]] = []
+    for action in actions:
+        item = dict(action)
+        if item.get("kind") == "collect_labeled_evidence":
+            item["priority"] = "p2"
+            detail = str(item.get("detail") or "")
+            item["detail"] = detail.replace(" before promotion.", " before formal default-route promotion.")
+        adjusted.append(item)
+    return adjusted
 
 def _load_production_evidence(env: Mapping[str, str]) -> dict[str, Any]:
     raw_path = (env.get("ZOE_PI_HYBRID_PRODUCTION_EVIDENCE_PATH") or DEFAULT_PRODUCTION_EVIDENCE_PATH).strip()

--- a/services/zoe-data/tests/test_pi_readiness_report.py
+++ b/services/zoe-data/tests/test_pi_readiness_report.py
@@ -244,6 +244,72 @@ def test_readiness_report_uses_persisted_eval_benchmark_for_candidate_wins(tmp_p
 
 
 
+def test_readiness_report_reports_operator_hybrid_as_operational(tmp_path):
+    shadow_path = tmp_path / "shadow.jsonl"
+    shadow_path.write_text("", encoding="utf-8")
+    eval_report_path = tmp_path / "pi-eval.json"
+    eval_report_path.write_text(
+        json.dumps(
+            {
+                "promotion_report": {
+                    "candidate_wins": {
+                        "groups": ["weather"],
+                        "details": [
+                            {
+                                "intent_group": "weather",
+                                "status": "needs_more_evidence",
+                                "unique_case_deficit": 27,
+                                "sample_deficit": 27,
+                                "real_source_sample_deficit": 27,
+                                "accuracy_delta": 1.0,
+                                "latency_delta_ms": 5000.0,
+                                "pi_p95_latency_ms": 3000.0,
+                                "zoe_p95_latency_ms": 8000.0,
+                                "promotion_blockers": ["insufficient_samples", "insufficient_real_source_samples"],
+                            }
+                        ],
+                    },
+                    "decisions": [],
+                    "promotion_actions": {},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    env = _env(tmp_path, shadow_path)
+    env["ZOE_PI_PROMOTION_EVAL_REPORT_PATH"] = str(eval_report_path)
+    env["ZOE_PI_HYBRID_PRODUCTION_ENABLED"] = "true"
+    env["ZOE_PI_HYBRID_PRODUCTION_GROUPS"] = "weather,daily_briefing"
+
+    report = pi_readiness_report(env)
+
+    assert report["state"] == "production_hybrid_operational"
+    assert report["production_hybrid"] == {
+        "enabled": True,
+        "groups": ["weather", "daily_briefing"],
+        "ignored_groups": [],
+        "operational": True,
+        "route": "pi_intent_buffer_plus_zoe_safe_fulfillment",
+    }
+    assert report["summary"]["production_hybrid_operational"] is True
+    assert report["summary"]["production_hybrid_groups"] == ["weather", "daily_briefing"]
+    assert report["next_actions"][0] == {
+        "kind": "monitor_production_hybrid",
+        "priority": "p1",
+        "detail": "Production Pi hybrid is live for operator-approved groups; keep formal default-route promotion evidence separate.",
+        "groups": ["weather", "daily_briefing"],
+    }
+    assert {
+        "kind": "collect_labeled_evidence",
+        "priority": "p2",
+        "intent_group": "weather",
+        "needed_unique_cases": 27,
+        "needed_real_source_cases": 27,
+        "detail": "Collect and label 27 more unique weather cases (27 must be real/log-derived) before formal default-route promotion.",
+        "evidence_source": "benchmark",
+    } in report["next_actions"]
+
+
 def test_readiness_report_deduplicates_shadow_and_benchmark_collection_actions(tmp_path):
     shadow_path = tmp_path / "shadow.jsonl"
     shadow_path.write_text(json.dumps(_winning_weather_row(1)) + "\n", encoding="utf-8")

--- a/services/zoe-data/tests/test_pi_readiness_report.py
+++ b/services/zoe-data/tests/test_pi_readiness_report.py
@@ -310,6 +310,32 @@ def test_readiness_report_reports_operator_hybrid_as_operational(tmp_path):
     } in report["next_actions"]
 
 
+def test_readiness_report_flags_unsupported_operator_hybrid_group(tmp_path):
+    shadow_path = tmp_path / "shadow.jsonl"
+    shadow_path.write_text("", encoding="utf-8")
+    env = _env(tmp_path, shadow_path)
+    env["ZOE_PI_HYBRID_PRODUCTION_ENABLED"] = "true"
+    env["ZOE_PI_HYBRID_PRODUCTION_GROUPS"] = "weather,device_control"
+
+    report = pi_readiness_report(env)
+
+    assert report["state"] == "configuration_blocked"
+    assert report["production_hybrid"] == {
+        "enabled": True,
+        "groups": ["weather"],
+        "ignored_groups": ["device_control"],
+        "operational": False,
+        "route": "pi_intent_buffer_plus_zoe_safe_fulfillment",
+    }
+    assert report["next_actions"][0] == {
+        "kind": "fix_configuration",
+        "priority": "p0",
+        "detail": "Remove unsupported Pi hybrid production groups from ZOE_PI_HYBRID_PRODUCTION_GROUPS.",
+        "groups": ["device_control"],
+        "env": {"ZOE_PI_HYBRID_PRODUCTION_GROUPS": "weather"},
+    }
+
+
 def test_readiness_report_deduplicates_shadow_and_benchmark_collection_actions(tmp_path):
     shadow_path = tmp_path / "shadow.jsonl"
     shadow_path.write_text(json.dumps(_winning_weather_row(1)) + "\n", encoding="utf-8")

--- a/services/zoe-data/tests/test_pi_readiness_report.py
+++ b/services/zoe-data/tests/test_pi_readiness_report.py
@@ -336,6 +336,30 @@ def test_readiness_report_flags_unsupported_operator_hybrid_group(tmp_path):
     }
 
 
+def test_readiness_report_ignores_stale_operator_groups_when_hybrid_disabled(tmp_path):
+    shadow_path = tmp_path / "shadow.jsonl"
+    shadow_path.write_text(
+        "".join(json.dumps(_winning_weather_row(index)) + "\n" for index in range(3)),
+        encoding="utf-8",
+    )
+    env = _env(tmp_path, shadow_path)
+    env["ZOE_PI_HYBRID_PRODUCTION_ENABLED"] = "false"
+    env["ZOE_PI_HYBRID_PRODUCTION_GROUPS"] = "weather,device_control"
+
+    report = pi_readiness_report(env)
+
+    assert report["state"] == "collect_more_evidence"
+    assert report["production_hybrid"]["enabled"] is False
+    assert report["production_hybrid"]["ignored_groups"] == ["device_control"]
+    assert all(
+        not (
+            action.get("kind") == "fix_configuration"
+            and action.get("groups") == ["device_control"]
+        )
+        for action in report["next_actions"]
+    )
+
+
 def test_readiness_report_deduplicates_shadow_and_benchmark_collection_actions(tmp_path):
     shadow_path = tmp_path / "shadow.jsonl"
     shadow_path.write_text(json.dumps(_winning_weather_row(1)) + "\n", encoding="utf-8")


### PR DESCRIPTION
## Summary
- report operator-approved Pi hybrid production as `production_hybrid_operational` when the live hybrid lane is enabled
- keep formal default-route promotion evidence separate and demote evidence collection to hardening when production hybrid is already live
- add a readiness regression test for the operational production state

## Why
The safe hybrid path can be production-live before formal default-route promotion has enough evidence. The report previously made that look blocked, which pushed us toward unnecessary testing instead of acknowledging the operator-approved production architecture.

## Validation
- `python3 -m pytest services/zoe-data/tests/test_pi_readiness_report.py services/zoe-data/tests/test_pi_intent_status_endpoint.py services/zoe-data/tests/test_pi_hybrid_production.py services/zoe-data/tests/test_pi_readiness_report_cli.py -q`
- `git diff --check`
- `python3 tools/audit/validate_structure.py`
- `set -a && . /home/zoe/assistant/.env && set +a && python3 scripts/maintenance/pi_readiness_report.py --summary`
