### PR TITLE
[codex] Expose Pi production latency summary

### DIFF
--- a/services/zoe-data/pi_readiness_report.py
+++ b/services/zoe-data/pi_readiness_report.py
@@ -213,6 +213,7 @@ def _production_group_metric(production: Mapping[str, Any], metric: str) -> dict
             values[str(group)] = _float_or_none(stats.get(metric))
     return values
 
+
 def _candidate_details(candidate_wins: Mapping[str, Any]) -> list[dict[str, Any]]:
     details: list[dict[str, Any]] = []
     for item in candidate_wins.get("details") or []:

--- a/services/zoe-data/pi_readiness_report.py
+++ b/services/zoe-data/pi_readiness_report.py
@@ -155,6 +155,10 @@ def _summary(
         "production_label_count": int(production.get("label_count") or 0),
         "production_unlabeled_count": int(production.get("unlabeled_count") or 0),
         "production_groups": list((production.get("by_group") or {}).keys()),
+        "production_pi_p95_latency_ms_by_group": _production_group_metric(production, "pi_p95_latency_ms"),
+        "production_safe_fulfillment_p95_latency_ms_by_group": _production_group_metric(
+            production, "safe_fulfillment_p95_latency_ms"
+        ),
     }
 
 
@@ -195,8 +199,19 @@ def _evidence(
             for group, stats in (production.get("by_group") or {}).items()
             if isinstance(stats, Mapping)
         },
+        "production_pi_p95_latency_ms_by_group": _production_group_metric(production, "pi_p95_latency_ms"),
+        "production_safe_fulfillment_p95_latency_ms_by_group": _production_group_metric(
+            production, "safe_fulfillment_p95_latency_ms"
+        ),
     }
 
+
+def _production_group_metric(production: Mapping[str, Any], metric: str) -> dict[str, float | None]:
+    values: dict[str, float | None] = {}
+    for group, stats in (production.get("by_group") or {}).items():
+        if isinstance(stats, Mapping):
+            values[str(group)] = _float_or_none(stats.get(metric))
+    return values
 
 def _candidate_details(candidate_wins: Mapping[str, Any]) -> list[dict[str, Any]]:
     details: list[dict[str, Any]] = []

--- a/services/zoe-data/tests/test_pi_readiness_report.py
+++ b/services/zoe-data/tests/test_pi_readiness_report.py
@@ -534,7 +534,17 @@ def test_readiness_report_surfaces_production_evidence_summary(tmp_path):
     assert report["summary"]["production_accepted_count"] == 2
     assert report["summary"]["production_unlabeled_count"] == 2
     assert report["summary"]["production_groups"] == ["daily_briefing", "weather"]
+    assert report["summary"]["production_pi_p95_latency_ms_by_group"] == {"daily_briefing": 2200.0, "weather": 8000.0}
+    assert report["summary"]["production_safe_fulfillment_p95_latency_ms_by_group"] == {
+        "daily_briefing": 1100.0,
+        "weather": 900.0,
+    }
     assert report["evidence"]["production_record_count_by_group"] == {"daily_briefing": 1, "weather": 2}
+    assert report["evidence"]["production_pi_p95_latency_ms_by_group"] == {"daily_briefing": 2200.0, "weather": 8000.0}
+    assert report["evidence"]["production_safe_fulfillment_p95_latency_ms_by_group"] == {
+        "daily_briefing": 1100.0,
+        "weather": 900.0,
+    }
     assert report["evidence"]["production_sample_count"] == 0
     assert report["production_evidence"]["promotion_report"]["sample_count"] == 0
     production_evidence = dict(report["production_evidence"])


### PR DESCRIPTION
## Summary
- expose production Pi p95 latency by intent group in the readiness summary and evidence sections
- include both Pi classification and safe-fulfillment p95 latency maps
- extend the production evidence readiness test to pin the new fields

## Why
The hybrid lane is now operational, but speed needs to be visible in the standard readiness report. These fields make production latency regressions and optimization targets obvious without digging through JSONL evidence.

## Validation
- `python3 -m pytest services/zoe-data/tests/test_pi_readiness_report.py services/zoe-data/tests/test_pi_intent_status_endpoint.py services/zoe-data/tests/test_pi_hybrid_production.py services/zoe-data/tests/test_pi_readiness_report_cli.py -q`
- `git diff --check`
- `python3 tools/audit/validate_structure.py`
- `set -a && . /home/zoe/assistant/.env && set +a && python3 scripts/maintenance/pi_readiness_report.py --summary`
