### PR TITLE
[codex] Fast accept natural daily briefing hybrid requests

### DIFF
--- a/services/zoe-data/intent_router.py
+++ b/services/zoe-data/intent_router.py
@@ -911,7 +911,8 @@ def detect_intent(
         r"^what(?:'?s| is) (?:on )?(?:today|my day)(?: like)?$",
         r"^whats (?:on )?(?:today|my day)(?: like)?$",
         r"^(?:daily|morning) (?:briefing|update|rundown)$",
-        r"^give me (?:a )?rundown$",
+        r"^give me (?:a |my )?(?:daily |morning )?(?:briefing|update|rundown)$",
+        r"^what(?:'s| is) (?:coming up|on|left)(?: for me)? today$",
         r"^what (?:do i|have i got) (?:have )?(?:on )?today$",
     ]:
         if re.match(pattern, t):

--- a/services/zoe-data/pi_hybrid_production.py
+++ b/services/zoe-data/pi_hybrid_production.py
@@ -66,7 +66,7 @@ class PiHybridProductionConfig:
             min_swap_free_mb=_int_env(values.get("ZOE_PI_HYBRID_MIN_SWAP_FREE_MB"), default=256),
             resource_guard_enabled=_env_bool(values.get("ZOE_PI_HYBRID_RESOURCE_GUARD_ENABLED"), default=True),
             router_fast_accept_enabled=_env_bool(
-                values.get("ZOE_PI_HYBRID_ROUTER_FAST_ACCEPT_ENABLED"), default=True
+                values.get("ZOE_PI_HYBRID_ROUTER_FAST_ACCEPT_ENABLED"), default=False
             ),
         )
 

--- a/services/zoe-data/tests/test_daily_briefing_concurrency.py
+++ b/services/zoe-data/tests/test_daily_briefing_concurrency.py
@@ -82,3 +82,17 @@ async def test_daily_briefing_does_not_use_mcporter(monkeypatch):
     result = await _execute_daily_briefing("family-admin")
 
     assert result == "Here\'s your day:\n\nNo events on the calendar today."
+
+@pytest.mark.asyncio
+async def test_daily_briefing_natural_phrases_are_deterministic():
+    from intent_router import detect_and_extract_intent
+
+    for phrase in [
+        "give me my daily briefing",
+        "give me a morning update",
+        "what is coming up today",
+    ]:
+        intent = await detect_and_extract_intent(phrase, user_id="guest")
+        assert intent is not None
+        assert intent.name == "daily_briefing"
+        assert intent.slots == {}

--- a/services/zoe-data/tests/test_pi_hybrid_production.py
+++ b/services/zoe-data/tests/test_pi_hybrid_production.py
@@ -117,7 +117,7 @@ async def test_try_pi_hybrid_fast_accepts_deterministic_router_weather(monkeypat
             router_fast_accept_enabled=True,
         ),
     )
-    await asyncio.sleep(0)
+    await asyncio.sleep(0.01)
 
     assert decision["accepted"] is True
     assert decision["reason"] == "router_confirmed_fast_accept"
@@ -125,6 +125,7 @@ async def test_try_pi_hybrid_fast_accepts_deterministic_router_weather(monkeypat
     assert decision["pi_audit_scheduled"] is True
     assert decision["safe_fulfillment_latency_ms"] == 950.0
     assert decision["response_text"] == "It is 18.5 C."
+    assert len(calls) == 2
     assert calls[0]["run_pi"] is False
     assert calls[1]["run_pi"] is True
 
@@ -155,7 +156,7 @@ async def test_try_pi_hybrid_fast_accept_records_audit_disagreement(tmp_path, mo
             "ZOE_PI_HYBRID_PRODUCTION_EVIDENCE_PATH": str(evidence_path),
         },
     )
-    await asyncio.sleep(0)
+    await asyncio.sleep(0.01)
 
     assert decision["accepted"] is True
     records = [json.loads(line) for line in evidence_path.read_text(encoding="utf-8").splitlines()]
@@ -164,6 +165,54 @@ async def test_try_pi_hybrid_fast_accept_records_audit_disagreement(tmp_path, mo
     assert records[1]["reason"] == "audit_disagreement"
     assert records[1]["intent"] == "weather"
     assert records[1]["pi_intent"] == "daily_briefing"
+
+
+def test_router_fast_accept_requires_explicit_env_opt_in():
+    assert PiHybridProductionConfig.from_env({}).router_fast_accept_enabled is False
+    config = PiHybridProductionConfig.from_env({"ZOE_PI_HYBRID_ROUTER_FAST_ACCEPT_ENABLED": "true"})
+    assert config.router_fast_accept_enabled is True
+
+
+@pytest.mark.asyncio
+async def test_try_pi_hybrid_fast_accepts_deterministic_daily_briefing(monkeypatch):
+    _install_prefilter(monkeypatch)
+    calls = []
+
+    async def fake_compare(text, **kwargs):
+        calls.append(dict(kwargs))
+        if kwargs.get("run_pi") is False:
+            return _router_fast_lab_result(
+                intent="daily_briefing",
+                response="Here's your day: No events on the calendar today.",
+            )
+        return _accepted_lab_result(
+            intent="daily_briefing",
+            response="Here's your day: No events on the calendar today.",
+            router_intent="daily_briefing",
+        )
+
+    monkeypatch.setattr(pi_hybrid_production, "compare_pi_intent_lab", fake_compare)
+    monkeypatch.setattr(pi_hybrid_production, "_read_meminfo_mb", lambda: {"MemAvailable": 99999, "SwapFree": 99999})
+
+    decision = await try_pi_hybrid_production(
+        "give me my daily briefing",
+        user_id="jason",
+        config=PiHybridProductionConfig(
+            enabled=True,
+            resource_guard_enabled=True,
+            router_fast_accept_enabled=True,
+        ),
+    )
+    await asyncio.sleep(0.01)
+
+    assert decision["accepted"] is True
+    assert decision["intent"] == "daily_briefing"
+    assert decision["reason"] == "router_confirmed_fast_accept"
+    assert decision["agreement_kind"] == "zoe_router_fast"
+    assert decision["response_text"] == "Here's your day: No events on the calendar today."
+    assert len(calls) == 2
+    assert calls[0]["run_pi"] is False
+    assert calls[1]["run_pi"] is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- expands deterministic daily briefing routing for natural voice phrases like "give me my daily briefing" and "what is coming up today"
- lets those requests qualify for the existing router-confirmed Pi hybrid fast path instead of waiting for Pi agreement first
- makes `ZOE_PI_HYBRID_ROUTER_FAST_ACCEPT_ENABLED` default to explicit opt-in when unset
- strengthens the async Pi audit tests that Greptile previously flagged

## Why

The production touch-panel probe showed weather now returns through `zoe_router_fast` in about 1.7s, but daily briefing still waited on the slower Pi agreement path for the actual voice phrase used in the probe. The root cause was that `give me my daily briefing` was a deterministic router miss.

## Validation

- `python3 -m pytest services/zoe-data/tests/test_daily_briefing_concurrency.py services/zoe-data/tests/test_pi_hybrid_production.py -q`
- `python3 -m pytest services/zoe-data/tests/test_daily_briefing_concurrency.py services/zoe-data/tests/test_pi_intent_lab.py services/zoe-data/tests/test_pi_hybrid_production.py services/zoe-data/tests/test_pi_touch_hybrid_production_probe.py services/zoe-data/tests/test_pi_readiness_report.py -q`
- `git diff --check`
- `python3 tools/audit/validate_structure.py`
