### PR TITLE
[codex] Cache daily briefing fast fulfillment

### DIFF
--- a/services/zoe-data/intent_router.py
+++ b/services/zoe-data/intent_router.py
@@ -30,6 +30,44 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+_DAILY_BRIEFING_RESPONSE_CACHE: dict[str, tuple[float, str]] = {}
+_DAILY_BRIEFING_CACHE_TTL_SECONDS = float(os.environ.get("ZOE_DAILY_BRIEFING_CACHE_TTL_SECONDS", "120"))
+
+
+def _daily_briefing_cache_get(user_id: str) -> Optional[str]:
+    if _DAILY_BRIEFING_CACHE_TTL_SECONDS <= 0:
+        return None
+    cached = _DAILY_BRIEFING_RESPONSE_CACHE.get(user_id)
+    if not cached:
+        return None
+    stored_at, response = cached
+    if (time.time() - stored_at) > _DAILY_BRIEFING_CACHE_TTL_SECONDS:
+        _DAILY_BRIEFING_RESPONSE_CACHE.pop(user_id, None)
+        return None
+    return response
+
+
+def _daily_briefing_cache_set(user_id: str, response: str) -> None:
+    if _DAILY_BRIEFING_CACHE_TTL_SECONDS <= 0 or not response:
+        return
+    _DAILY_BRIEFING_RESPONSE_CACHE[user_id] = (time.time(), response)
+
+
+def _daily_briefing_cached_weather() -> Optional[dict]:
+    try:
+        from routers.weather import _weather_cache
+
+        current = _weather_cache.get("current") or {}
+        if current.get("temp") is None:
+            return None
+        return {
+            "temp": current.get("temp"),
+            "city": current.get("city") or "your area",
+            "description": current.get("description", ""),
+        }
+    except Exception:
+        return None
+
 
 def _spoken_day_ordinal(day: int) -> str:
     ordinals = {
@@ -2454,6 +2492,10 @@ async def execute_intent(intent: Intent, user_id: str = "family-admin") -> Optio
 
 async def _execute_daily_briefing(user_id: str) -> Optional[str]:
     """Composite intent: weather + calendar + reminders."""
+    cached_response = _daily_briefing_cache_get(user_id)
+    if cached_response:
+        return cached_response
+
     task_keys = ["weather", "calendar", "reminders"]
     task_results = await asyncio.gather(
         _daily_briefing_weather(user_id),
@@ -2491,10 +2533,15 @@ async def _execute_daily_briefing(user_id: str) -> Optional[str]:
             suffix = f" at {t_str}" if t_str else ""
             lines.append(f"  - {r.get('title', '?')}{suffix}")
 
-    return "\n".join(lines)
+    response = "\n".join(lines)
+    _daily_briefing_cache_set(user_id, response)
+    return response
 
 
 async def _daily_briefing_weather(user_id: str) -> Optional[dict]:
+    cached_weather = _daily_briefing_cached_weather()
+    if cached_weather:
+        return cached_weather
     try:
         from database import get_db
         from routers.weather import _get_current, _resolve_location, _row_to_prefs

--- a/services/zoe-data/intent_router.py
+++ b/services/zoe-data/intent_router.py
@@ -2534,7 +2534,8 @@ async def _execute_daily_briefing(user_id: str) -> Optional[str]:
             lines.append(f"  - {r.get('title', '?')}{suffix}")
 
     response = "\n".join(lines)
-    _daily_briefing_cache_set(user_id, response)
+    if all(key in results for key in task_keys):
+        _daily_briefing_cache_set(user_id, response)
     return response
 
 

--- a/services/zoe-data/tests/test_daily_briefing_concurrency.py
+++ b/services/zoe-data/tests/test_daily_briefing_concurrency.py
@@ -140,8 +140,32 @@ async def test_daily_briefing_weather_uses_router_weather_cache(monkeypatch):
     async def fail_get_current(*_args, **_kwargs):
         raise AssertionError("cached daily briefing weather should not refetch")
 
-    monkeypatch.setattr(weather, "_get_current", fail_get_current)
-    result = await _daily_briefing_weather("family-admin")
+    try:
+        monkeypatch.setattr(weather, "_get_current", fail_get_current)
+        result = await _daily_briefing_weather("family-admin")
 
-    assert result == {"temp": 22, "city": "Geraldton", "description": "clear sky"}
-    weather._weather_cache.clear()
+        assert result == {"temp": 22, "city": "Geraldton", "description": "clear sky"}
+    finally:
+        weather._weather_cache.pop("current", None)
+
+@pytest.mark.asyncio
+async def test_daily_briefing_does_not_cache_degraded_partial_result(monkeypatch):
+    calls = []
+
+    async def fake_weather(user_id):
+        calls.append("weather")
+        if len(calls) == 1:
+            raise RuntimeError("weather unavailable")
+        return {"temp": 20, "city": "Perth", "description": "clear"}
+
+    monkeypatch.setattr("intent_router._daily_briefing_weather", fake_weather)
+    monkeypatch.setattr("intent_router._daily_briefing_calendar", lambda user_id: asyncio.sleep(0, result={"events": []}))
+    monkeypatch.setattr("intent_router._daily_briefing_reminders", lambda user_id: asyncio.sleep(0, result={"reminders": []}))
+    monkeypatch.setattr("intent_router._DAILY_BRIEFING_CACHE_TTL_SECONDS", 120)
+
+    first = await _execute_daily_briefing("family-admin")
+    second = await _execute_daily_briefing("family-admin")
+
+    assert "Weather:" not in first
+    assert "Weather: 20" in second
+    assert calls == ["weather", "weather"]

--- a/services/zoe-data/tests/test_daily_briefing_concurrency.py
+++ b/services/zoe-data/tests/test_daily_briefing_concurrency.py
@@ -4,6 +4,15 @@ import pytest
 from intent_router import _execute_daily_briefing
 
 
+@pytest.fixture(autouse=True)
+def clear_daily_briefing_cache():
+    from intent_router import _DAILY_BRIEFING_RESPONSE_CACHE
+
+    _DAILY_BRIEFING_RESPONSE_CACHE.clear()
+    yield
+    _DAILY_BRIEFING_RESPONSE_CACHE.clear()
+
+
 @pytest.mark.asyncio
 async def test_daily_briefing_runs_direct_calls_concurrently(monkeypatch):
     calls = []
@@ -96,3 +105,43 @@ async def test_daily_briefing_natural_phrases_are_deterministic():
         assert intent is not None
         assert intent.name == "daily_briefing"
         assert intent.slots == {}
+
+
+@pytest.mark.asyncio
+async def test_daily_briefing_uses_short_response_cache(monkeypatch):
+    calls = []
+
+    async def fake_weather(user_id):
+        calls.append("weather")
+        return {"temp": 18.5, "city": "Perth", "description": "clear"}
+
+    monkeypatch.setattr("intent_router._daily_briefing_weather", fake_weather)
+    monkeypatch.setattr("intent_router._daily_briefing_calendar", lambda user_id: asyncio.sleep(0, result={"events": []}))
+    monkeypatch.setattr("intent_router._daily_briefing_reminders", lambda user_id: asyncio.sleep(0, result={"reminders": []}))
+    monkeypatch.setattr("intent_router._DAILY_BRIEFING_CACHE_TTL_SECONDS", 120)
+    from intent_router import _DAILY_BRIEFING_RESPONSE_CACHE
+
+    _DAILY_BRIEFING_RESPONSE_CACHE.clear()
+    first = await _execute_daily_briefing("family-admin")
+    second = await _execute_daily_briefing("family-admin")
+
+    assert first == second
+    assert calls == ["weather"]
+    _DAILY_BRIEFING_RESPONSE_CACHE.clear()
+
+
+@pytest.mark.asyncio
+async def test_daily_briefing_weather_uses_router_weather_cache(monkeypatch):
+    from intent_router import _daily_briefing_weather
+    import routers.weather as weather
+
+    weather._weather_cache["current"] = {"temp": 22, "city": "Geraldton", "description": "clear sky"}
+
+    async def fail_get_current(*_args, **_kwargs):
+        raise AssertionError("cached daily briefing weather should not refetch")
+
+    monkeypatch.setattr(weather, "_get_current", fail_get_current)
+    result = await _daily_briefing_weather("family-admin")
+
+    assert result == {"temp": 22, "city": "Geraldton", "description": "clear sky"}
+    weather._weather_cache.clear()


### PR DESCRIPTION
## Summary

- adds a short per-user in-process cache for daily briefing responses
- reuses the existing weather router current-weather cache when daily briefing needs weather
- keeps the cache read-only and TTL-controlled via `ZOE_DAILY_BRIEFING_CACHE_TTL_SECONDS` (default 120 seconds)

## Why

The production hybrid path now fast-accepts daily briefing, but safe fulfillment still spends time rebuilding the same weather/calendar/reminder packet. This keeps the existing fulfillment contract while avoiding repeated network/database work for repeated voice turns.

## Evidence

Production-equivalent DB-initialized measurement from this branch:

- first daily briefing fulfillment: ~1678ms
- second daily briefing fulfillment within TTL: ~0.004ms

## Validation

- `python3 -m pytest services/zoe-data/tests/test_daily_briefing_concurrency.py -q`
- `python3 -m pytest services/zoe-data/tests/test_daily_briefing_concurrency.py services/zoe-data/tests/test_pi_intent_lab.py services/zoe-data/tests/test_pi_hybrid_production.py services/zoe-data/tests/test_pi_touch_hybrid_production_probe.py services/zoe-data/tests/test_pi_readiness_report.py -q`
- `git diff --check`
- `python3 tools/audit/validate_structure.py`
