### PR TITLE
[codex] Enable list-show hybrid production smoke

### DIFF
--- a/scripts/maintenance/pi_touch_hybrid_production_probe.py
+++ b/scripts/maintenance/pi_touch_hybrid_production_probe.py
@@ -44,6 +44,13 @@ DEFAULT_CASES = (
         "intent_group": "daily_briefing",
         "source": "production_smoke",
     },
+    {
+        "case_id": "list_show_shopping",
+        "text": "what is on my shopping list",
+        "expected_intent": "list_show",
+        "intent_group": "lists",
+        "source": "production_smoke",
+    },
 )
 DEFAULT_CUE_MAX_MS = 250.0
 DEFAULT_FINAL_MAX_MS = 8000.0

--- a/services/zoe-data/pi_hybrid_production.py
+++ b/services/zoe-data/pi_hybrid_production.py
@@ -19,7 +19,7 @@ from pi_intent_lab import SAFE_FULFILLMENT_INTENTS, compare_pi_intent_lab
 from zoe_pi_promotion import LOW_RISK_PI_INTENT_GROUPS, intent_group_for_intent
 
 _SAFE_PRODUCTION_INTENTS = frozenset({"weather", "daily_briefing", "list_show"})
-_DEFAULT_GROUPS = ("weather", "daily_briefing")
+_DEFAULT_GROUPS = ("weather", "daily_briefing", "lists")
 _WEATHER_SIGNAL_RE = re.compile(
     r"\b(weather|rain|forecast|temperature|storm|windy|humid|umbrella|jacket|hot|cold|degrees|celsius)\b",
     re.I,

--- a/services/zoe-data/tests/test_pi_hybrid_production.py
+++ b/services/zoe-data/tests/test_pi_hybrid_production.py
@@ -7,6 +7,7 @@ import pytest
 
 import pi_hybrid_production
 from pi_hybrid_production import PiHybridProductionConfig, pi_hybrid_production_eligible, try_pi_hybrid_production
+from zoe_pi_promotion import intent_group_for_intent
 
 
 def _install_prefilter(monkeypatch, *, allowed=True):
@@ -26,7 +27,7 @@ def _accepted_lab_result(*, intent="weather", response="It is 18.5 C.", router_i
         "pi": {
             "ran": True,
             "intent": intent,
-            "intent_group": "weather" if intent == "weather" else "daily_briefing",
+            "intent_group": intent_group_for_intent(intent),
             "confidence": 0.94,
             "latency_ms": 123.0,
             "timed_out": False,
@@ -59,6 +60,10 @@ def test_production_eligibility_is_disabled_and_tightly_prefiltered(monkeypatch)
         "production_prefilter_rejected",
     )
     assert pi_hybrid_production_eligible("will it rain later", config=PiHybridProductionConfig(enabled=True)) == (
+        True,
+        "eligible",
+    )
+    assert pi_hybrid_production_eligible("what is on my shopping list", config=PiHybridProductionConfig(enabled=True)) == (
         True,
         "eligible",
     )
@@ -210,6 +215,50 @@ async def test_try_pi_hybrid_fast_accepts_deterministic_daily_briefing(monkeypat
     assert decision["reason"] == "router_confirmed_fast_accept"
     assert decision["agreement_kind"] == "zoe_router_fast"
     assert decision["response_text"] == "Here's your day: No events on the calendar today."
+    assert len(calls) == 2
+    assert calls[0]["run_pi"] is False
+    assert calls[1]["run_pi"] is True
+
+
+@pytest.mark.asyncio
+async def test_try_pi_hybrid_fast_accepts_deterministic_list_show(monkeypatch):
+    _install_prefilter(monkeypatch)
+    calls = []
+
+    async def fake_compare(text, **kwargs):
+        calls.append(dict(kwargs))
+        if kwargs.get("run_pi") is False:
+            return _router_fast_lab_result(
+                intent="list_show",
+                response="Your shopping list has milk and bread.",
+            )
+        return _accepted_lab_result(
+            intent="list_show",
+            response="Your shopping list has milk and bread.",
+            router_intent="list_show",
+        )
+
+    monkeypatch.setattr(pi_hybrid_production, "compare_pi_intent_lab", fake_compare)
+    monkeypatch.setattr(pi_hybrid_production, "_read_meminfo_mb", lambda: {"MemAvailable": 99999, "SwapFree": 99999})
+
+    decision = await try_pi_hybrid_production(
+        "what is on my shopping list",
+        user_id="jason",
+        config=PiHybridProductionConfig(
+            enabled=True,
+            resource_guard_enabled=True,
+            router_fast_accept_enabled=True,
+        ),
+    )
+    await asyncio.sleep(0.01)
+
+    assert decision["accepted"] is True
+    assert decision["intent"] == "list_show"
+    assert decision["intent_group"] == "lists"
+    assert decision["reason"] == "router_confirmed_fast_accept"
+    assert decision["agreement_kind"] == "zoe_router_fast"
+    assert decision["pi_audit_scheduled"] is True
+    assert decision["response_text"] == "Your shopping list has milk and bread."
     assert len(calls) == 2
     assert calls[0]["run_pi"] is False
     assert calls[1]["run_pi"] is True

--- a/services/zoe-data/tests/test_pi_touch_hybrid_production_probe.py
+++ b/services/zoe-data/tests/test_pi_touch_hybrid_production_probe.py
@@ -106,6 +106,17 @@ def test_probe_observes_panel_processing_cue_and_final_pi_response():
     assert report["summary"]["overall"]["processing_ack_rate"] == 1.0
 
 
+def test_default_probe_cases_cover_low_risk_production_groups():
+    module = _load_module()
+
+    cases = {case["case_id"]: case for case in module.DEFAULT_CASES}
+
+    assert cases["weather_rain_later"]["expected_intent"] == "weather"
+    assert cases["daily_briefing"]["expected_intent"] == "daily_briefing"
+    assert cases["list_show_shopping"]["expected_intent"] == "list_show"
+    assert cases["list_show_shopping"]["intent_group"] == "lists"
+
+
 def test_probe_marks_missing_panel_cue_as_not_ready():
     module = _load_module()
 


### PR DESCRIPTION
## Summary
- enable the low-risk `lists` production group by default while keeping production-safe intents limited to read-only `list_show`
- add `what is on my shopping list` to the production touch-panel hybrid probe
- add regression coverage proving list-show fast-accepts and side-effect list intents stay blocked

## Why
This closes the next production hybrid contract loop beyond weather and daily briefing: instant cue, safe Zoe fulfillment, Pi audit/confirmation, and real touch-panel probe coverage for read-only list requests.

## Validation
- `python3 -m pytest services/zoe-data/tests/test_list_show_direct_execution.py services/zoe-data/tests/test_pi_hybrid_production.py services/zoe-data/tests/test_pi_touch_hybrid_production_probe.py -q` (22 passed)
- `python3 -m pytest services/zoe-data/tests/test_pi_intent_lab.py services/zoe-data/tests/test_pi_readiness_report.py services/zoe-data/tests/test_pi_intent_status_endpoint.py -q` (83 passed)
- `git diff --check`
- `python3 tools/audit/validate_structure.py`
