### PR TITLE
[codex] Handle spoken list-show intent

### DIFF
--- a/services/zoe-data/intent_router.py
+++ b/services/zoe-data/intent_router.py
@@ -1055,8 +1055,7 @@ def detect_intent(
     # --- LIST SHOW ---
     for pattern in [
         r"^(?:show|read|check) (?:me )?(?:the |my )?(.+?) ?list$",
-        r"^what'?s on (?:the |my )?(.+?) ?list$",
-        r"^whats on (?:the |my )?(.+?) ?list$",
+        r"^what(?:'?s| is) on (?:the |my )?(.+?) ?list$",
         r"^what do i need to (?:buy|get)$",
         r"^what'?s on my list$",
         r"^show my list$",

--- a/services/zoe-data/tests/test_list_show_direct_execution.py
+++ b/services/zoe-data/tests/test_list_show_direct_execution.py
@@ -2,7 +2,7 @@ from contextlib import asynccontextmanager
 
 import pytest
 
-from intent_router import Intent, _execute_list_show_direct, execute_intent
+from intent_router import Intent, _execute_list_show_direct, detect_intent, execute_intent
 
 
 class _Cursor:
@@ -29,6 +29,13 @@ def _install_fake_db(monkeypatch, db):
         yield db
 
     monkeypatch.setattr("database.get_db_ctx", fake_get_db_ctx)
+
+
+def test_detect_intent_handles_spoken_what_is_list_show():
+    intent = detect_intent("what is on my shopping list")
+
+    assert intent.name == "list_show"
+    assert intent.slots == {"list_type": "shopping"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- recognize the spoken/STT phrase `what is on my shopping list` as deterministic `list_show`
- add a regression test for that exact list-show wording

## Why
The production hybrid touch probe showed Pi correctly classified `list_show`, but Zoe router fell back for `what is on...`, so production rejected with `pi_not_agreed` and then Skybridge asked for auth. This keeps the guard strict by fixing Zoe deterministic intent matching instead of loosening Pi acceptance.

## Validation
- `python3 -m pytest services/zoe-data/tests/test_list_show_direct_execution.py services/zoe-data/tests/test_pi_hybrid_production.py services/zoe-data/tests/test_pi_touch_hybrid_production_probe.py -q` (23 passed)
- `python3 -m pytest services/zoe-data/tests/test_voice_weather_queue.py -q` (17 passed)
- `git diff --check`
- `python3 tools/audit/validate_structure.py`
