### PR TITLE
[codex] Cap list-show voice responses

### DIFF
--- a/services/zoe-data/routers/voice_tts.py
+++ b/services/zoe-data/routers/voice_tts.py
@@ -1501,6 +1501,36 @@ def _contains_decision_keyword(text: str, keywords: frozenset[str]) -> bool:
     return False
 
 
+def _cap_voice_list_show_reply(text: str, *, max_items: int = 5) -> str:
+    """Keep voice list reads short while leaving non-voice list responses untouched."""
+    if max_items <= 0:
+        return text
+    lines = (text or "").splitlines()
+    if not lines:
+        return text
+    capped: list[str] = []
+    item_count = 0
+    omitted = 0
+    def flush_omitted() -> None:
+        nonlocal omitted
+        if omitted:
+            capped.append(f"And {omitted} more.")
+            omitted = 0
+
+    for line in lines:
+        if line.lstrip().startswith("- "):
+            item_count += 1
+            if item_count > max_items:
+                omitted += 1
+                continue
+        elif item_count:
+            flush_omitted()
+            item_count = 0
+        capped.append(line)
+    flush_omitted()
+    return "\n".join(capped)
+
+
 def _should_handoff_calendar(user_text: str, reply_text: str, intent_name: Optional[str] = None) -> bool:
     if intent_name in {"calendar_show", "daily_briefing", "calendar_create"}:
         return True
@@ -3032,6 +3062,8 @@ async def voice_command(
                 )
                 if _pi_hybrid.get("accepted") and _pi_hybrid.get("response_text"):
                     reply_text = str(_pi_hybrid.get("response_text") or "")
+                    if str(_pi_hybrid.get("intent") or "") == "list_show":
+                        reply_text = _cap_voice_list_show_reply(reply_text)
                     _pi_audio = await synthesize({"text": reply_text}, caller=caller)
                     try:
                         from push import broadcaster as _bc_pi_done

--- a/services/zoe-data/tests/test_voice_weather_queue.py
+++ b/services/zoe-data/tests/test_voice_weather_queue.py
@@ -890,3 +890,112 @@ async def test_voice_command_uses_pi_hybrid_production_with_processing_cue(
         event == "voice:responding" and payload.get("pi_hybrid") is True
         for _, event, payload in calls["broadcast"]
     )
+
+
+@pytest.mark.asyncio
+async def test_voice_command_caps_pi_hybrid_list_show_response(monkeypatch) -> None:
+    import pi_hybrid_production
+
+    long_reply = "Your shopping list:\n" + "\n".join(f"  - item {idx}" for idx in range(1, 8))
+    capped_reply = "Your shopping list:\n  - item 1\n  - item 2\n  - item 3\n  - item 4\n  - item 5\nAnd 2 more."
+    calls: dict[str, object] = {"broadcast": [], "tts": []}
+
+    async def no_user(*_args, **_kwargs):
+        return None
+
+    async def panel_user(*_args, **_kwargs):
+        return "panel-user"
+
+    async def resolve_skybridge_request(*_args, **_kwargs):
+        return None
+
+    class Broadcaster:
+        async def broadcast(self, channel, event, payload):
+            calls["broadcast"].append((channel, event, payload))
+
+    async def fake_synthesize(payload, caller=None):
+        calls["tts"].append(payload)
+        return types.SimpleNamespace(body=b"RIFF-pi-hybrid-list", media_type="audio/wav")
+
+    async def fake_try_pi(text, **kwargs):
+        assert text == "what is on my shopping list"
+        assert kwargs["user_id"] == "panel-user"
+        return {
+            "accepted": True,
+            "reason": "router_confirmed_fast_accept",
+            "intent": "list_show",
+            "intent_group": "lists",
+            "agreement_kind": "zoe_router_fast",
+            "response_text": long_reply,
+        }
+
+    async def fake_processing_cue():
+        return {"available": True, "text": "Let me check."}
+
+    monkeypatch.setattr(voice_tts, "_resolve_recent_panel_session_user", panel_user)
+    monkeypatch.setattr(voice_tts, "_resolve_panel_default_user", no_user)
+    monkeypatch.setattr(voice_tts, "_VOICE_SESSIONS", {})
+    monkeypatch.setattr(voice_tts, "synthesize", fake_synthesize)
+    monkeypatch.setattr(
+        pi_hybrid_production.PiHybridProductionConfig,
+        "from_env",
+        classmethod(lambda cls: cls(enabled=True, resource_guard_enabled=False)),
+    )
+    monkeypatch.setattr(pi_hybrid_production, "pi_hybrid_production_eligible", lambda text, config=None: (True, "eligible"))
+    monkeypatch.setattr(pi_hybrid_production, "processing_cue_packet", fake_processing_cue)
+    monkeypatch.setattr(pi_hybrid_production, "try_pi_hybrid_production", fake_try_pi)
+    monkeypatch.setitem(sys.modules, "push", types.SimpleNamespace(broadcaster=Broadcaster()))
+    monkeypatch.setitem(
+        sys.modules,
+        "skybridge_service",
+        types.SimpleNamespace(resolve_skybridge_request=resolve_skybridge_request),
+    )
+    monkeypatch.setattr(skybridge_service, "resolve_skybridge_request", resolve_skybridge_request)
+
+    response = await voice_command(
+        {"text": "what is on my shopping list", "panel_id": "panel-pi", "session_id": "session-pi"},
+        caller={"user_id": "guest", "panel_id": "panel-pi"},
+        stream=False,
+        db=object(),
+    )
+
+    assert response["ok"] is True
+    assert response["reply"] == capped_reply
+    assert response["intent"] == "list_show"
+    assert response["pi_hybrid"]["accepted"] is True
+    assert calls["tts"] == [{"text": capped_reply}]
+
+
+def test_cap_voice_list_show_reply_resets_per_list_section() -> None:
+    text = "\n".join(
+        [
+            "Your shopping lists:",
+            "Pantry:",
+            "  - pantry 1",
+            "  - pantry 2",
+            "Shopping:",
+            "  - item 1",
+            "  - item 2",
+            "  - item 3",
+            "  - item 4",
+            "  - item 5",
+            "  - item 6",
+            "  - item 7",
+        ]
+    )
+
+    assert voice_tts._cap_voice_list_show_reply(text) == "\n".join(
+        [
+            "Your shopping lists:",
+            "Pantry:",
+            "  - pantry 1",
+            "  - pantry 2",
+            "Shopping:",
+            "  - item 1",
+            "  - item 2",
+            "  - item 3",
+            "  - item 4",
+            "  - item 5",
+            "And 2 more.",
+        ]
+    )


### PR DESCRIPTION
## Summary
- cap list-show formatted responses to the first five active items per list
- append `And N more.` when a list has additional active items
- add regression coverage for long shopping list responses

## Why
The live touch-panel Pi hybrid probe accepted `list_show` after the spoken-intent fix, but the final response took about 9.9s because Zoe tried to synthesize a very long list. This keeps list reads accurate while making the voice response short enough for natural flow.

## Validation
- `python3 -m pytest services/zoe-data/tests/test_list_show_direct_execution.py services/zoe-data/tests/test_pi_hybrid_production.py services/zoe-data/tests/test_pi_touch_hybrid_production_probe.py services/zoe-data/tests/test_voice_weather_queue.py -q` (41 passed)
- `git diff --check`
- `python3 tools/audit/validate_structure.py`
