### PR TITLE
[codex] Fast accept greeting hybrid route

### DIFF
--- a/services/zoe-data/pi_hybrid_production.py
+++ b/services/zoe-data/pi_hybrid_production.py
@@ -18,8 +18,8 @@ from typing import Any, Mapping
 from pi_intent_lab import SAFE_FULFILLMENT_INTENTS, compare_pi_intent_lab
 from zoe_pi_promotion import LOW_RISK_PI_INTENT_GROUPS, intent_group_for_intent
 
-_SAFE_PRODUCTION_INTENTS = frozenset({"weather", "daily_briefing", "list_show"})
-_DEFAULT_GROUPS = ("weather", "daily_briefing", "lists")
+_SAFE_PRODUCTION_INTENTS = frozenset({"weather", "daily_briefing", "list_show", "greeting"})
+_DEFAULT_GROUPS = ("weather", "daily_briefing", "lists", "greetings")
 _WEATHER_SIGNAL_RE = re.compile(
     r"\b(weather|rain|forecast|temperature|storm|windy|humid|umbrella|jacket|hot|cold|degrees|celsius)\b",
     re.I,
@@ -29,6 +29,10 @@ _DAILY_BRIEFING_SIGNAL_RE = re.compile(
     re.I,
 )
 _LIST_SHOW_SIGNAL_RE = re.compile(r"\b(what(?:'s| is) on|show|read|check)\b.*\b(list|shopping|grocer)", re.I)
+_GREETING_SIGNAL_RE = re.compile(
+    r"^(?:hello|hi|hey|howdy|heya|greetings|yo)(?:\s+(?:there|zoe|there\s+zoe))?\s*[!.,]?\s*$",
+    re.I,
+)
 _SECRET_TEXT_RE = re.compile(
     r"(api[\s_-]?key|authorization\s*(?:[:=]\s*\S+|bearer\s+[a-z0-9._\-]+|token\s+\S+)|"
     r"bearer\s+[a-z0-9._\-]+|password\s*(?:is|=)|secret\s*(?:is|=)|token\s*(?:is|=))",
@@ -382,6 +386,8 @@ def _production_prefilter_allows(text: str, groups: tuple[str, ...]) -> bool:
     if "daily_briefing" in selected and _DAILY_BRIEFING_SIGNAL_RE.search(text):
         return True
     if "lists" in selected and _LIST_SHOW_SIGNAL_RE.search(text):
+        return True
+    if "greetings" in selected and _GREETING_SIGNAL_RE.search(text):
         return True
     return False
 

--- a/services/zoe-data/pi_intent_lab.py
+++ b/services/zoe-data/pi_intent_lab.py
@@ -24,6 +24,7 @@ SAFE_FULFILLMENT_INTENTS = frozenset(
     {
         "daily_briefing",
         "date_query",
+        "greeting",
         "list_show",
         "time_query",
         "weather",

--- a/services/zoe-data/tests/test_pi_hybrid_production.py
+++ b/services/zoe-data/tests/test_pi_hybrid_production.py
@@ -263,6 +263,50 @@ async def test_try_pi_hybrid_fast_accepts_deterministic_daily_briefing(monkeypat
 
 
 @pytest.mark.asyncio
+async def test_try_pi_hybrid_fast_accepts_deterministic_greeting(monkeypatch):
+    _install_prefilter(monkeypatch)
+    calls = []
+
+    async def fake_compare(text, **kwargs):
+        calls.append(dict(kwargs))
+        if kwargs.get("run_pi") is False:
+            return _router_fast_lab_result(
+                intent="greeting",
+                response="Hi, Jason! How can I help?",
+            )
+        return _accepted_lab_result(
+            intent="greeting",
+            response="Hi, Jason! How can I help?",
+            router_intent="greeting",
+        )
+
+    monkeypatch.setattr(pi_hybrid_production, "compare_pi_intent_lab", fake_compare)
+    monkeypatch.setattr(pi_hybrid_production, "_read_meminfo_mb", lambda: {"MemAvailable": 99999, "SwapFree": 99999})
+
+    decision = await try_pi_hybrid_production(
+        "hi there",
+        user_id="jason",
+        config=PiHybridProductionConfig(
+            enabled=True,
+            groups=("greetings",),
+            resource_guard_enabled=True,
+            router_fast_accept_enabled=True,
+        ),
+    )
+    await asyncio.sleep(0.01)
+
+    assert decision["accepted"] is True
+    assert decision["intent"] == "greeting"
+    assert decision["intent_group"] == "greetings"
+    assert decision["reason"] == "router_confirmed_fast_accept"
+    assert decision["agreement_kind"] == "zoe_router_fast"
+    assert decision["response_text"] == "Hi, Jason! How can I help?"
+    assert len(calls) == 2
+    assert calls[0]["run_pi"] is False
+    assert calls[1]["run_pi"] is True
+
+
+@pytest.mark.asyncio
 async def test_try_pi_hybrid_fast_accepts_deterministic_list_show(monkeypatch):
     _install_prefilter(monkeypatch)
     calls = []

--- a/services/zoe-data/zoe_pi_promotion.py
+++ b/services/zoe-data/zoe_pi_promotion.py
@@ -15,6 +15,7 @@ from typing import Any, Mapping, Sequence
 
 
 LOW_RISK_PI_INTENT_GROUPS = {
+    "greetings": {"greeting"},
     "weather": {"weather"},
     "reminders": {"reminder_list", "reminder_create"},
     "lists": {"list_show", "list_add", "list_remove"},


### PR DESCRIPTION
## Summary
- add `greeting` as a low-risk Pi intent group
- allow greeting through safe fulfillment and the production hybrid safe allowlist
- add a regression test proving deterministic greetings fast-accept through the hybrid route

## Why
The broad hybrid mode made casual greetings eligible for an instant cue, but they still fell through to the slower Zoe Agent path. Zoe already has an instant deterministic greeting executor, so this wires that existing safe path into the hybrid production lane.

## Validation
- `python3 -m pytest -q services/zoe-data/tests/test_pi_hybrid_production.py services/zoe-data/tests/test_pi_intent_lab.py services/zoe-data/tests/test_zoe_pi_promotion.py services/zoe-data/tests/test_pi_intent_status_endpoint.py::test_pi_hybrid_production_status_endpoint_reports_live_config`
- `git diff --check -- services/zoe-data/zoe_pi_promotion.py services/zoe-data/pi_intent_lab.py services/zoe-data/pi_hybrid_production.py services/zoe-data/tests/test_pi_hybrid_production.py`
