### PR TITLE
[codex] Fast accept clock and calculation hybrid routes

### DIFF
--- a/services/zoe-data/pi_hybrid_production.py
+++ b/services/zoe-data/pi_hybrid_production.py
@@ -18,8 +18,10 @@ from typing import Any, Mapping
 from pi_intent_lab import SAFE_FULFILLMENT_INTENTS, compare_pi_intent_lab
 from zoe_pi_promotion import LOW_RISK_PI_INTENT_GROUPS, intent_group_for_intent
 
-_SAFE_PRODUCTION_INTENTS = frozenset({"weather", "daily_briefing", "list_show", "greeting"})
-_DEFAULT_GROUPS = ("weather", "daily_briefing", "lists", "greetings")
+_SAFE_PRODUCTION_INTENTS = frozenset(
+    {"weather", "daily_briefing", "list_show", "greeting", "time_query", "date_query", "calculate"}
+)
+_DEFAULT_GROUPS = ("weather", "daily_briefing", "lists", "greetings", "clock", "calculations")
 _WEATHER_SIGNAL_RE = re.compile(
     r"\b(weather|rain|forecast|temperature|storm|windy|humid|umbrella|jacket|hot|cold|degrees|celsius)\b",
     re.I,
@@ -31,6 +33,17 @@ _DAILY_BRIEFING_SIGNAL_RE = re.compile(
 _LIST_SHOW_SIGNAL_RE = re.compile(r"\b(what(?:'s| is) on|show|read|check)\b.*\b(list|shopping|grocer)", re.I)
 _GREETING_SIGNAL_RE = re.compile(
     r"^(?:hello|hi|hey|howdy|heya|greetings|yo)(?:\s+(?:there|zoe|there\s+zoe))?\s*[!.,]?\s*$",
+    re.I,
+)
+_CLOCK_SIGNAL_RE = re.compile(
+    r"\b(?:what(?:'s| is) the time|what time is it|current time|today(?:'s)? date|what(?:'s| is) the date|what day is it)\b",
+    re.I,
+)
+_CALCULATION_SIGNAL_RE = re.compile(
+    r"(?:\b(?:calculate|compute|what(?:'s| is)|how much is)\s+"
+    r"(?:\d+(?:\.\d+)?\s*(?:plus|minus|times|multiplied by|divided by|percent|%)\s*\d*(?:\.\d+)?|"
+    r"\d+(?:\.\d+)?\s*(?:\+|-|x|×|\*|/|÷)\s*\d+(?:\.\d+)?)\b|"
+    r"\b\d+(?:\.\d+)?\s*(?:\+|-|x|×|\*|/|÷)\s*\d+(?:\.\d+)?\b)",
     re.I,
 )
 _SECRET_TEXT_RE = re.compile(
@@ -388,6 +401,10 @@ def _production_prefilter_allows(text: str, groups: tuple[str, ...]) -> bool:
     if "lists" in selected and _LIST_SHOW_SIGNAL_RE.search(text):
         return True
     if "greetings" in selected and _GREETING_SIGNAL_RE.search(text):
+        return True
+    if "clock" in selected and _CLOCK_SIGNAL_RE.search(text):
+        return True
+    if "calculations" in selected and _CALCULATION_SIGNAL_RE.search(text):
         return True
     return False
 

--- a/services/zoe-data/pi_intent_lab.py
+++ b/services/zoe-data/pi_intent_lab.py
@@ -22,6 +22,7 @@ from zoe_pi_promotion import LOW_RISK_PI_INTENT_GROUPS, intent_group_for_intent
 _ENV_LOCK = asyncio.Lock()
 SAFE_FULFILLMENT_INTENTS = frozenset(
     {
+        "calculate",
         "daily_briefing",
         "date_query",
         "greeting",

--- a/services/zoe-data/tests/test_pi_hybrid_production.py
+++ b/services/zoe-data/tests/test_pi_hybrid_production.py
@@ -67,6 +67,19 @@ def test_production_eligibility_is_disabled_and_tightly_prefiltered(monkeypatch)
         True,
         "eligible",
     )
+    assert pi_hybrid_production_eligible(
+        "what is the date", config=PiHybridProductionConfig(enabled=True, groups=("clock",))
+    ) == (True, "eligible")
+    assert pi_hybrid_production_eligible(
+        "what is the best time to leave", config=PiHybridProductionConfig(enabled=True, groups=("clock",))
+    ) == (False, "production_prefilter_rejected")
+    assert pi_hybrid_production_eligible(
+        "what is 12 times 8", config=PiHybridProductionConfig(enabled=True, groups=("calculations",))
+    ) == (True, "eligible")
+    assert pi_hybrid_production_eligible(
+        "what is the meeting time plus travel time",
+        config=PiHybridProductionConfig(enabled=True, groups=("calculations",)),
+    ) == (False, "production_prefilter_rejected")
 
 
 
@@ -301,6 +314,53 @@ async def test_try_pi_hybrid_fast_accepts_deterministic_greeting(monkeypatch):
     assert decision["reason"] == "router_confirmed_fast_accept"
     assert decision["agreement_kind"] == "zoe_router_fast"
     assert decision["response_text"] == "Hi, Jason! How can I help?"
+    assert len(calls) == 2
+    assert calls[0]["run_pi"] is False
+    assert calls[1]["run_pi"] is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("utterance", "intent", "group", "response"),
+    [
+        ("what time is it", "time_query", "clock", "It's 4:05 PM."),
+        ("what is the date", "date_query", "clock", "Today is Wednesday, June seventeenth."),
+        ("what is 12 times 8", "calculate", "calculations", "12 times 8 = 96"),
+    ],
+)
+async def test_try_pi_hybrid_fast_accepts_deterministic_clock_and_calculation(
+    monkeypatch, utterance, intent, group, response
+):
+    _install_prefilter(monkeypatch)
+    calls = []
+
+    async def fake_compare(text, **kwargs):
+        calls.append(dict(kwargs))
+        if kwargs.get("run_pi") is False:
+            return _router_fast_lab_result(intent=intent, response=response)
+        return _accepted_lab_result(intent=intent, response=response, router_intent=intent)
+
+    monkeypatch.setattr(pi_hybrid_production, "compare_pi_intent_lab", fake_compare)
+    monkeypatch.setattr(pi_hybrid_production, "_read_meminfo_mb", lambda: {"MemAvailable": 99999, "SwapFree": 99999})
+
+    decision = await try_pi_hybrid_production(
+        utterance,
+        user_id="jason",
+        config=PiHybridProductionConfig(
+            enabled=True,
+            groups=(group,),
+            resource_guard_enabled=True,
+            router_fast_accept_enabled=True,
+        ),
+    )
+    await asyncio.sleep(0.01)
+
+    assert decision["accepted"] is True
+    assert decision["intent"] == intent
+    assert decision["intent_group"] == group
+    assert decision["reason"] == "router_confirmed_fast_accept"
+    assert decision["agreement_kind"] == "zoe_router_fast"
+    assert decision["response_text"] == response
     assert len(calls) == 2
     assert calls[0]["run_pi"] is False
     assert calls[1]["run_pi"] is True

--- a/services/zoe-data/zoe_pi_promotion.py
+++ b/services/zoe-data/zoe_pi_promotion.py
@@ -15,6 +15,7 @@ from typing import Any, Mapping, Sequence
 
 
 LOW_RISK_PI_INTENT_GROUPS = {
+    "clock": {"time_query", "date_query"},
     "greetings": {"greeting"},
     "weather": {"weather"},
     "reminders": {"reminder_list", "reminder_create"},


### PR DESCRIPTION
## Summary
- add `clock` low-risk group for `time_query` and `date_query`
- allow deterministic `calculate` through safe Pi hybrid fulfillment
- add production prefilter branches for clock and calculation requests
- add regression coverage for standard prefilter fast-accept paths

## Why
Clock and arithmetic requests are pure deterministic Zoe fast paths. They should not wait on the general agent path, and they fit the same safe hybrid production lane as greetings, weather, briefing, and list-show.

## Validation
- `python3 -m pytest -q services/zoe-data/tests/test_pi_hybrid_production.py services/zoe-data/tests/test_pi_intent_lab.py services/zoe-data/tests/test_zoe_pi_promotion.py services/zoe-data/tests/test_pi_intent_status_endpoint.py::test_pi_hybrid_production_status_endpoint_reports_live_config`
- `git diff --check -- services/zoe-data/zoe_pi_promotion.py services/zoe-data/pi_intent_lab.py services/zoe-data/pi_hybrid_production.py services/zoe-data/tests/test_pi_hybrid_production.py`
