### PR TITLE
Clarify ambiguous time planning intents

### DIFF
--- a/services/zoe-data/intent_router.py
+++ b/services/zoe-data/intent_router.py
@@ -312,6 +312,17 @@ _DATE_QUERY_RE = re.compile(
     re.IGNORECASE,
 )
 
+_TIME_PLANNING_CLARIFICATION_RE = re.compile(
+    r"^(?:what(?:'s|\s+is)\s+)?(?:the\s+)?best\s+time\s+to\s+(?:leave|go|head\s+out)\b",
+    re.IGNORECASE,
+)
+
+_TIME_MATH_CLARIFICATION_RE = re.compile(
+    r"^(?:what(?:'s|\s+is)\s+)?(?:the\s+)?(?:meeting|travel|arrival|departure)\s+time\s+"
+    r"(?:plus|minus|\+|-)\s+(?:the\s+)?(?:meeting|travel|arrival|departure)\s+time\b",
+    re.IGNORECASE,
+)
+
 
 _CONNECT_CHATGPT_RE = re.compile(
     r"^(?:can you |please |could you )?(?:connect|link|auth(?:orize|orise|)?|set\s*up|add|enable)\b"
@@ -637,6 +648,12 @@ def detect_intent(
         return Intent("memory_remember", {"raw": text})
 
     # === CLOCK / CALENDAR QUERIES — checked before domain patterns (no slots needed) ===
+
+    if _TIME_PLANNING_CLARIFICATION_RE.match(t):
+        return Intent("time_planning_clarification", {"kind": "best_time_to_leave"})
+
+    if _TIME_MATH_CLARIFICATION_RE.match(t):
+        return Intent("time_planning_clarification", {"kind": "time_math"})
 
     # Modelled on HA's HassGetCurrentTime and HassGetCurrentDate — two separate intents
     if _TIME_QUERY_RE.match(t):
@@ -1944,6 +1961,11 @@ async def execute_intent(intent: Intent, user_id: str = "family-admin") -> Optio
         now = datetime.now()
         spoken_day = _spoken_day_ordinal(now.day)
         return f"Today is {now.strftime('%A')}, {now.strftime('%B')} {spoken_day}."
+
+    if intent.name == "time_planning_clarification":
+        if intent.slots.get("kind") == "time_math":
+            return "I need the actual times before I can work that out."
+        return "What time do you need to arrive?"
 
     if intent.name == "connect_chatgpt":
         # Handled directly by chat.py via _chatgpt_connect_flow() — which runs

--- a/services/zoe-data/pi_hybrid_production.py
+++ b/services/zoe-data/pi_hybrid_production.py
@@ -41,7 +41,7 @@ _CLOCK_SIGNAL_RE = re.compile(
 )
 _CALCULATION_SIGNAL_RE = re.compile(
     r"(?:\b(?:calculate|compute|what(?:'s| is)|how much is)\s+"
-    r"(?:\d+(?:\.\d+)?\s*(?:plus|minus|times|multiplied by|divided by|percent|%)\s*\d*(?:\.\d+)?|"
+    r"(?:\d+(?:\.\d+)?\s*(?:plus|minus|times|multiplied by|divided by|percent|%)\s*\d+(?:\.\d+)?|"
     r"\d+(?:\.\d+)?\s*(?:\+|-|x|×|\*|/|÷)\s*\d+(?:\.\d+)?)\b|"
     r"\b\d+(?:\.\d+)?\s*(?:\+|-|x|×|\*|/|÷)\s*\d+(?:\.\d+)?\b)",
     re.I,

--- a/services/zoe-data/tests/test_intent_open_domain.py
+++ b/services/zoe-data/tests/test_intent_open_domain.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from intent_router import detect_intent
+from intent_router import detect_intent, execute_intent
 
 
 @pytest.mark.parametrize("text", ["Tell me a joke.", "Tell me a joke", "Tell me another joke.", "make me laugh", "do you have any jokes?", "have you got any jokes?", "know any good jokes?"])
@@ -25,3 +25,46 @@ def test_say_exactly_routes_to_open_domain_agent(text: str):
 
 def test_bare_say_exactly_does_not_route_to_open_domain_agent():
     assert detect_intent("say exactly") is None
+
+
+@pytest.mark.parametrize(
+    ("text", "kind"),
+    [
+        ("what is the best time to leave", "best_time_to_leave"),
+        ("the best time to head out", "best_time_to_leave"),
+        ("what is the best time to go", "best_time_to_leave"),
+        ("what is the meeting time plus travel time", "time_math"),
+    ],
+)
+def test_ambiguous_time_phrases_route_to_clarification(text: str, kind: str):
+    intent = detect_intent(text)
+
+    assert intent is not None
+    assert intent.name == "time_planning_clarification"
+    assert intent.slots == {"kind": kind}
+
+
+def test_exact_clock_queries_still_route_to_clock_intents():
+    assert detect_intent("what time is it").name == "time_query"
+    assert detect_intent("what is the date").name == "date_query"
+
+
+@pytest.mark.parametrize("text", ["what is the best time to start", "what is the best time to arrive"])
+def test_unobserved_time_planning_verbs_do_not_use_arrival_clarification(text: str):
+    intent = detect_intent(text)
+
+    assert intent is None or intent.name != "time_planning_clarification"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("text", "response"),
+    [
+        ("what is the best time to leave", "What time do you need to arrive?"),
+        ("what is the meeting time plus travel time", "I need the actual times before I can work that out."),
+    ],
+)
+async def test_ambiguous_time_clarification_executes_as_question(text: str, response: str):
+    intent = detect_intent(text)
+
+    assert await execute_intent(intent) == response

--- a/services/zoe-data/tests/test_pi_hybrid_production.py
+++ b/services/zoe-data/tests/test_pi_hybrid_production.py
@@ -77,6 +77,9 @@ def test_production_eligibility_is_disabled_and_tightly_prefiltered(monkeypatch)
         "what is 12 times 8", config=PiHybridProductionConfig(enabled=True, groups=("calculations",))
     ) == (True, "eligible")
     assert pi_hybrid_production_eligible(
+        "what is 12 plus", config=PiHybridProductionConfig(enabled=True, groups=("calculations",))
+    ) == (False, "production_prefilter_rejected")
+    assert pi_hybrid_production_eligible(
         "what is the meeting time plus travel time",
         config=PiHybridProductionConfig(enabled=True, groups=("calculations",)),
     ) == (False, "production_prefilter_rejected")


### PR DESCRIPTION
## Summary
- add a clarification intent for ambiguous time-planning phrases observed in production hybrid probes
- keep exact clock/date queries on their fast deterministic route
- tighten calculation prefilter so incomplete arithmetic does not enter the Pi hybrid lane

## Tests
- `python3 -m pytest -q services/zoe-data/tests/test_intent_open_domain.py services/zoe-data/tests/test_pi_hybrid_production.py services/zoe-data/tests/test_pi_intent_lab.py services/zoe-data/tests/test_zoe_pi_promotion.py services/zoe-data/tests/test_pi_intent_status_endpoint.py::test_pi_hybrid_production_status_endpoint_reports_live_config`