### PR TITLE
Allow public time clarification intent

### DIFF
--- a/services/zoe-data/guest_policy.py
+++ b/services/zoe-data/guest_policy.py
@@ -22,6 +22,7 @@ from memory_metrics import REGISTRY
 PUBLIC_HOUSEHOLD_INTENTS: frozenset[str] = frozenset({
     "time_query",
     "date_query",
+    "time_planning_clarification",
     "weather",
     "recipe_search",
     "timer_create",

--- a/services/zoe-data/tests/test_guest_policy.py
+++ b/services/zoe-data/tests/test_guest_policy.py
@@ -8,6 +8,7 @@ from guest_policy import (
     PAGE_IDS,
     PUBLIC_HOUSEHOLD_INTENTS,
     USER_SCOPED_INTENTS,
+    can_use_voice_intent,
     default_capability_matrix,
     is_guest_user,
     require_feature_access,
@@ -17,6 +18,19 @@ from guest_policy import (
 
 def test_household_intents_include_shared_calendar_read() -> None:
     assert "calendar_show" in PUBLIC_HOUSEHOLD_INTENTS
+
+
+def test_household_intents_include_time_planning_clarification() -> None:
+    assert "time_planning_clarification" in PUBLIC_HOUSEHOLD_INTENTS
+
+
+@pytest.mark.asyncio
+async def test_guest_can_use_time_planning_clarification_voice_intent() -> None:
+    assert await can_use_voice_intent(
+        None,
+        {"role": "guest", "user_id": "guest"},
+        "time_planning_clarification",
+    ) is True
 
 
 def test_user_scoped_intents_exclude_shared_calendar_read() -> None:

--- a/services/zoe-data/tests/test_voice_scope.py
+++ b/services/zoe-data/tests/test_voice_scope.py
@@ -85,6 +85,12 @@ def test_intent_public_time_query() -> None:
     assert d.intent_name == "time_query"
 
 
+def test_intent_time_planning_clarification_is_public() -> None:
+    d = classify("what is the best time to leave", _FakeIntent("time_planning_clarification"))
+    assert d.scope == "public"
+    assert d.intent_name == "time_planning_clarification"
+
+
 def test_intent_weather_is_public() -> None:
     d = classify("any idea what it'll do today", _FakeIntent("weather"))
     assert d.scope == "public"


### PR DESCRIPTION
## Summary
- mark `time_planning_clarification` as a public household-safe intent
- add guest policy and voice scope regression coverage
- closes the live voice wiring gap where the clarification intent was detected but blocked by role policy

## Tests
- `python3 -m pytest -q services/zoe-data/tests/test_guest_policy.py services/zoe-data/tests/test_voice_scope.py services/zoe-data/tests/test_intent_open_domain.py`