### PR TITLE
Fast accept greeting wellbeing phrases

### DIFF
--- a/services/zoe-data/intent_router.py
+++ b/services/zoe-data/intent_router.py
@@ -453,6 +453,7 @@ _LETS_TALK_RE = re.compile(
 # good_morning/good_evening are kept as separate intents for the daily-briefing flow.
 _GREETING_RE = re.compile(
     r"^(?:hello|hi|hey|howdy|heya|greetings|yo)(?:\s+(?:there|zoe|there\s+zoe))?\s*[!.,]?\s*$"
+    r"|^(?:hello|hi|hey|howdy|heya|yo)(?:\s+(?:there|zoe|there\s+zoe))?\s+how\s+are\s+you(?:\s+today)?\s*[!.,?]?\s*$"
     r"|^sup(?:\s+zoe)?\s*\??$"
     r"|^what'?s\s+up(?:\s+zoe)?\s*\??\s*$"
     r"|^how\s+are\s+you(?:\s+today)?(?:\s+zoe)?\s*\??\s*$"

--- a/services/zoe-data/pi_hybrid_production.py
+++ b/services/zoe-data/pi_hybrid_production.py
@@ -32,7 +32,8 @@ _DAILY_BRIEFING_SIGNAL_RE = re.compile(
 )
 _LIST_SHOW_SIGNAL_RE = re.compile(r"\b(what(?:'s| is) on|show|read|check)\b.*\b(list|shopping|grocer)", re.I)
 _GREETING_SIGNAL_RE = re.compile(
-    r"^(?:hello|hi|hey|howdy|heya|greetings|yo)(?:\s+(?:there|zoe|there\s+zoe))?\s*[!.,]?\s*$",
+    r"^(?:hello|hi|hey|howdy|heya|greetings|yo)(?:\s+(?:there|zoe|there\s+zoe))?\s*[!.,]?\s*$"
+    r"|^(?:hello|hi|hey|howdy|heya|yo)(?:\s+(?:there|zoe|there\s+zoe))?\s+how\s+are\s+you(?:\s+today)?\s*[!.,?]?\s*$",
     re.I,
 )
 _CLOCK_SIGNAL_RE = re.compile(

--- a/services/zoe-data/tests/test_intent_open_domain.py
+++ b/services/zoe-data/tests/test_intent_open_domain.py
@@ -68,3 +68,21 @@ async def test_ambiguous_time_clarification_executes_as_question(text: str, resp
     intent = detect_intent(text)
 
     assert await execute_intent(intent) == response
+
+
+@pytest.mark.parametrize("text", ["hi there how are you", "hey zoe how are you?", "hello how are you today"])
+def test_greeting_wellbeing_phrases_route_to_fast_greeting(text: str):
+    intent = detect_intent(text)
+
+    assert intent is not None
+    assert intent.name == "greeting"
+
+
+@pytest.mark.asyncio
+async def test_greeting_wellbeing_executes_without_open_domain_agent():
+    intent = detect_intent("hi there how are you")
+
+    response = await execute_intent(intent)
+
+    assert response.startswith(("Hi", "Good"))
+    assert "help" in response.lower() or "do for you" in response.lower()

--- a/services/zoe-data/tests/test_pi_hybrid_production.py
+++ b/services/zoe-data/tests/test_pi_hybrid_production.py
@@ -279,7 +279,8 @@ async def test_try_pi_hybrid_fast_accepts_deterministic_daily_briefing(monkeypat
 
 
 @pytest.mark.asyncio
-async def test_try_pi_hybrid_fast_accepts_deterministic_greeting(monkeypatch):
+@pytest.mark.parametrize("utterance", ["hi there", "hi there how are you"])
+async def test_try_pi_hybrid_fast_accepts_deterministic_greeting(monkeypatch, utterance):
     _install_prefilter(monkeypatch)
     calls = []
 
@@ -300,7 +301,7 @@ async def test_try_pi_hybrid_fast_accepts_deterministic_greeting(monkeypatch):
     monkeypatch.setattr(pi_hybrid_production, "_read_meminfo_mb", lambda: {"MemAvailable": 99999, "SwapFree": 99999})
 
     decision = await try_pi_hybrid_production(
-        "hi there",
+        utterance,
         user_id="jason",
         config=PiHybridProductionConfig(
             enabled=True,
@@ -438,7 +439,7 @@ async def test_try_pi_hybrid_attempt_all_casual_chat_falls_through_safely(monkey
     monkeypatch.setattr(pi_hybrid_production, "_read_meminfo_mb", lambda: {"MemAvailable": 99999, "SwapFree": 99999})
 
     decision = await try_pi_hybrid_production(
-        "hi there how are you",
+        "tell me something interesting about oceans",
         user_id="jason",
         config=PiHybridProductionConfig(
             enabled=True,
@@ -452,7 +453,7 @@ async def test_try_pi_hybrid_attempt_all_casual_chat_falls_through_safely(monkey
     assert decision["intent"] is None
     assert decision["production_route_change"] is False
     assert len(calls) == 1
-    assert calls[0][0] == "hi there how are you"
+    assert calls[0][0] == "tell me something interesting about oceans"
     assert calls[0][1]["run_pi"] is True
 
 


### PR DESCRIPTION
## Summary
- route common "hi/hey/hello ... how are you" phrases through the deterministic greeting path
- allow the same phrases through the Pi hybrid greeting production prefilter
- keep a separate casual open-domain sentence as the fallback safety regression

## Tests
- `python3 -m pytest -q services/zoe-data/tests/test_intent_open_domain.py services/zoe-data/tests/test_pi_hybrid_production.py services/zoe-data/tests/test_pi_intent_lab.py services/zoe-data/tests/test_zoe_pi_promotion.py services/zoe-data/tests/test_pi_intent_status_endpoint.py::test_pi_hybrid_production_status_endpoint_reports_live_config`