### PR TITLE
Add fast response for common curiosity prompts

### DIFF
--- a/services/zoe-data/tests/test_zoe_agent_fast_response.py
+++ b/services/zoe-data/tests/test_zoe_agent_fast_response.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import zoe_agent
+
+
+def test_fast_response_answers_known_interesting_fact_topic() -> None:
+    response = zoe_agent._check_fast_response("tell me something interesting about oceans")
+
+    assert response is not None
+    assert "oxygen" in response.lower()
+    assert "phytoplankton" in response.lower()
+
+
+def test_fast_response_unknown_interesting_fact_topic_falls_through() -> None:
+    assert zoe_agent._check_fast_response("tell me something interesting about orbital harmonics") is None
+
+
+def test_fast_response_generic_interesting_fact_uses_safe_default() -> None:
+    response = zoe_agent._check_fast_response("give me a fun fact")
+
+    assert response is not None
+    assert "ocean" in response.lower()
+
+
+def test_fast_response_answers_singular_ocean_topic() -> None:
+    response = zoe_agent._check_fast_response("tell me a fun fact about ocean")
+
+    assert response is not None
+    assert "oxygen" in response.lower()

--- a/services/zoe-data/zoe_agent.py
+++ b/services/zoe-data/zoe_agent.py
@@ -1229,6 +1229,27 @@ def _check_fast_response(message: str) -> str | None:
         spoken_day = _spoken_day_ordinal(now.day)
         return f"Today is {now.strftime('%A')}, {now.strftime('%B')} {spoken_day}."
 
+    # Lightweight curiosity prompts - keep this tiny and factual. Unknown topics fall through to the model.
+    _interesting_match = re.match(
+        r"^(?:tell me|give me|say) (?:something interesting|an interesting fact|a fun fact)(?: about (?P<topic>[a-z0-9 _-]+))?$",
+        msg,
+        re.IGNORECASE,
+    )
+    if _interesting_match:
+        topic = (_interesting_match.group("topic") or "").strip().replace("_", " ")
+        ocean_fact = "The oceans make more than half of Earth's oxygen, largely thanks to tiny drifting phytoplankton."
+        facts = {
+            "ocean": ocean_fact,
+            "oceans": ocean_fact,
+            "space": "Space is so quiet because sound needs particles to travel through, and space is almost a vacuum.",
+            "dinosaurs": "Some dinosaurs had feathers, so birds are not just dinosaur relatives - they are living dinosaurs.",
+            "bees": "Bees can recognise patterns and communicate food locations with a waggle dance.",
+        }
+        if not topic:
+            return ocean_fact
+        if topic in facts:
+            return facts[topic]
+
     # Uptime / status
     _status_triggers = {
         "status", "are you running", "are you there", "you there", "ping",


### PR DESCRIPTION
## Summary
- add a tiny local fast-response map for common "tell me something interesting/fun fact" prompts
- keep unknown topics on the normal Zoe Agent path instead of guessing
- cover known-topic, generic, and unknown-topic behavior with focused tests

## Tests
- `python3 -m pytest -q services/zoe-data/tests/test_zoe_agent_fast_response.py services/zoe-data/tests/test_intent_open_domain.py services/zoe-data/tests/test_pi_hybrid_production.py services/zoe-data/tests/test_hermes_routing.py`