### PR TITLE
Add fast responses for Zoe identity prompts

### DIFF
--- a/services/zoe-data/tests/test_zoe_agent_fast_response.py
+++ b/services/zoe-data/tests/test_zoe_agent_fast_response.py
@@ -27,3 +27,24 @@ def test_fast_response_answers_singular_ocean_topic() -> None:
 
     assert response is not None
     assert "oxygen" in response.lower()
+
+
+
+def test_fast_response_answers_zoe_identity_prompt() -> None:
+    response = zoe_agent._check_fast_response("who are you")
+
+    assert response is not None
+    assert response.startswith("I'm Zoe")
+    assert "local assistant" in response
+
+
+def test_fast_response_answers_capability_prompt() -> None:
+    response = zoe_agent._check_fast_response("what can you do")
+
+    assert response is not None
+    assert "reminders" in response.lower()
+    assert "weather" in response.lower()
+
+
+def test_fast_response_leaves_open_howto_to_model() -> None:
+    assert zoe_agent._check_fast_response("how do i boil an egg") is None

--- a/services/zoe-data/zoe_agent.py
+++ b/services/zoe-data/zoe_agent.py
@@ -1229,6 +1229,21 @@ def _check_fast_response(message: str) -> str | None:
         spoken_day = _spoken_day_ordinal(now.day)
         return f"Today is {now.strftime('%A')}, {now.strftime('%B')} {spoken_day}."
 
+    # Identity/capability prompts - fast and Zoe-specific, avoiding model identity drift.
+    _identity_triggers = {
+        "who are you", "what are you", "who is zoe", "what is zoe",
+        "tell me about yourself", "introduce yourself",
+    }
+    if msg in _identity_triggers:
+        return "I'm Zoe, your local assistant. I can help with quick answers, household tasks, reminders, lists, weather, and deeper work when you need it."
+
+    _capability_triggers = {
+        "what can you do", "what can you help with", "how can you help",
+        "what do you do", "what are your capabilities",
+    }
+    if msg in _capability_triggers:
+        return "I can answer questions, manage reminders and lists, check weather and daily plans, help with smart-home tasks, and work with your local tools when you ask."
+
     # Lightweight curiosity prompts - keep this tiny and factual. Unknown topics fall through to the model.
     _interesting_match = re.match(
         r"^(?:tell me|give me|say) (?:something interesting|an interesting fact|a fun fact)(?: about (?P<topic>[a-z0-9 _-]+))?$",


### PR DESCRIPTION
## Summary
- answer common Zoe identity and capability prompts through the existing fast-response helper
- avoid model identity drift on "who are you"
- leave broader how-to prompts on the normal model path

## Tests
- `python3 -m pytest -q services/zoe-data/tests/test_zoe_agent_fast_response.py services/zoe-data/tests/test_intent_open_domain.py services/zoe-data/tests/test_pi_hybrid_production.py services/zoe-data/tests/test_hermes_routing.py`