### PR TITLE
Use softer processing cues for social voice turns

### DIFF
--- a/services/zoe-data/pi_hybrid_production.py
+++ b/services/zoe-data/pi_hybrid_production.py
@@ -503,11 +503,26 @@ def _compact_lab_result(result: Mapping[str, Any]) -> dict[str, Any]:
     }
 
 
-async def processing_cue_packet(env: Mapping[str, str] | None = None) -> dict[str, Any]:
+def processing_cue_index_for_text(text: str) -> int:
+    """Choose a natural processing cue variant for the utterance."""
+    normalized = re.sub(r"\s+", " ", str(text or "").strip().lower()).strip(" .!?\t\n")
+    if not normalized:
+        return 0
+    social_or_identity = {
+        "thank you", "thanks", "cheers", "who are you", "what are you",
+        "what can you do", "what can you help with", "how can you help",
+        "tell me about yourself", "introduce yourself",
+    }
+    if normalized in social_or_identity or _GREETING_SIGNAL_RE.match(normalized):
+        return 1
+    return 0
+
+
+async def processing_cue_packet(env: Mapping[str, str] | None = None, *, text: str = "") -> dict[str, Any]:
     try:
         from voice_presence import processing_ack_event
 
-        event = processing_ack_event(env, index=0)
+        event = processing_ack_event(env, index=processing_cue_index_for_text(text))
     except Exception as exc:  # pragma: no cover - cue must never break chat
         return {"available": False, "text": "", "event": None, "error": exc.__class__.__name__}
     if not event:
@@ -616,6 +631,7 @@ def _record_production_evidence(
 __all__ = [
     "PiHybridProductionConfig",
     "pi_hybrid_production_eligible",
+    "processing_cue_index_for_text",
     "processing_cue_packet",
     "try_pi_hybrid_production",
 ]

--- a/services/zoe-data/routers/chat.py
+++ b/services/zoe-data/routers/chat.py
@@ -511,7 +511,7 @@ async def _run_chat_pi_hybrid_lane(
                 logger.debug("Pi hybrid production skipped: %s", reason)
             return {"attempted": False, "reason": reason, "config_enabled": config.enabled}
 
-        cue = await processing_cue_packet()
+        cue = await processing_cue_packet(text=message_for_processing)
         decision = await try_pi_hybrid_production(
             message_for_processing,
             user_id=user_id,

--- a/services/zoe-data/routers/voice_tts.py
+++ b/services/zoe-data/routers/voice_tts.py
@@ -3040,7 +3040,7 @@ async def voice_command(
             _pi_hybrid_config = PiHybridProductionConfig.from_env()
             _pi_hybrid_eligible, _pi_hybrid_reason = pi_hybrid_production_eligible(text, config=_pi_hybrid_config)
             if _pi_hybrid_eligible:
-                _pi_cue = await processing_cue_packet()
+                _pi_cue = await processing_cue_packet(text=text)
                 _ack_text = str(_pi_cue.get("text") or "").strip()
                 if _ack_text:
                     try:

--- a/services/zoe-data/tests/test_pi_hybrid_production.py
+++ b/services/zoe-data/tests/test_pi_hybrid_production.py
@@ -560,3 +560,26 @@ async def test_try_pi_hybrid_rejects_side_effect_intent(monkeypatch):
     assert decision["accepted"] is False
     assert decision["reason"] == "intent_not_safe_for_production"
     assert decision["production_route_change"] is False
+
+
+def test_processing_cue_index_uses_softer_variant_for_social_identity_text():
+    assert pi_hybrid_production.processing_cue_index_for_text("hi there how are you") == 1
+    assert pi_hybrid_production.processing_cue_index_for_text("what can you do") == 1
+    assert pi_hybrid_production.processing_cue_index_for_text("who are you") == 1
+    assert pi_hybrid_production.processing_cue_index_for_text("who are you?") == 1
+
+
+def test_processing_cue_index_keeps_checking_variant_for_lookup_text():
+    assert pi_hybrid_production.processing_cue_index_for_text("will it rain later") == 0
+    assert pi_hybrid_production.processing_cue_index_for_text("what is 12 times 8") == 0
+
+
+@pytest.mark.asyncio
+async def test_processing_cue_packet_uses_selected_variant_text():
+    env = {"ZOE_PROCESSING_ACK_PHRASES": "Let me check.|One moment."}
+
+    social = await pi_hybrid_production.processing_cue_packet(env, text="who are you")
+    lookup = await pi_hybrid_production.processing_cue_packet(env, text="will it rain later")
+
+    assert social["text"] == "One moment."
+    assert lookup["text"] == "Let me check."

--- a/services/zoe-data/tests/test_voice_weather_queue.py
+++ b/services/zoe-data/tests/test_voice_weather_queue.py
@@ -841,7 +841,7 @@ async def test_voice_command_uses_pi_hybrid_production_with_processing_cue(
             "response_text": response_text,
         }
 
-    async def fake_processing_cue():
+    async def fake_processing_cue(**_kwargs):
         return {"available": True, "text": "Let me check.", "event": {"type": "voice:processing_ack", "text": "Let me check."}}
 
     monkeypatch.setattr(voice_tts, "_resolve_recent_panel_session_user", panel_user)
@@ -929,7 +929,7 @@ async def test_voice_command_caps_pi_hybrid_list_show_response(monkeypatch) -> N
             "response_text": long_reply,
         }
 
-    async def fake_processing_cue():
+    async def fake_processing_cue(**_kwargs):
         return {"available": True, "text": "Let me check."}
 
     monkeypatch.setattr(voice_tts, "_resolve_recent_panel_session_user", panel_user)


### PR DESCRIPTION
## Summary
- choose the second configured processing cue variant for social, greeting, and Zoe identity/capability voice turns
- keep lookup/tool-like turns on the default “Let me check” cue
- pass utterance text into the Pi hybrid processing cue selector from the non-stream voice route

## Tests
- `python3 -m pytest -q services/zoe-data/tests/test_pi_hybrid_production.py services/zoe-data/tests/test_voice_weather_queue.py::test_voice_command_uses_pi_hybrid_production_with_processing_cue services/zoe-data/tests/test_voice_weather_queue.py::test_voice_command_caps_pi_hybrid_list_show_response services/zoe-data/tests/test_pi_intent_lab.py services/zoe-data/tests/test_pi_intent_status_endpoint.py::test_pi_hybrid_production_status_endpoint_reports_live_config`