### PR TITLE
[codex] Emit voice cue before non-Pi fallback

### DIFF
--- a/services/zoe-data/routers/voice_tts.py
+++ b/services/zoe-data/routers/voice_tts.py
@@ -3028,6 +3028,7 @@ async def voice_command(
     except Exception:
         pass
 
+    _voice_processing_ack_sent = False
     if not stream:
         try:
             from pi_hybrid_production import (
@@ -3052,6 +3053,7 @@ async def voice_command(
                             "processing_ack": True,
                             "source": "pi_hybrid_production",
                         })
+                        _voice_processing_ack_sent = True
                     except Exception:
                         pass
                 _pi_hybrid = await try_pi_hybrid_production(
@@ -3099,6 +3101,24 @@ async def voice_command(
                 logger.debug("voice/command Pi hybrid production skipped: %s", _pi_hybrid_reason)
         except Exception as _pi_hybrid_exc:
             logger.debug("voice/command Pi hybrid failed open to existing voice route: %s", _pi_hybrid_exc)
+
+    if not stream and not _voice_processing_ack_sent:
+        try:
+            from pi_hybrid_production import processing_cue_packet
+            from push import broadcaster as _bc_voice_fallback
+
+            _fallback_cue = await processing_cue_packet(text=text)
+            _fallback_ack_text = str(_fallback_cue.get("text") or "").strip()
+            if _fallback_ack_text:
+                await _bc_voice_fallback.broadcast("all", "voice:responding", {
+                    "panel_id": panel_id,
+                    "text": _fallback_ack_text,
+                    "processing_ack": True,
+                    "source": "voice_command_fallback",
+                })
+                _voice_processing_ack_sent = True
+        except Exception as _fallback_ack_exc:
+            logger.debug("voice/command fallback processing acknowledgement failed: %s", _fallback_ack_exc)
 
     # Skybridge-first touch prototype: supported visual domains render as cards
     # on the single Skybridge surface instead of navigating to domain pages.

--- a/services/zoe-data/routers/voice_tts.py
+++ b/services/zoe-data/routers/voice_tts.py
@@ -3116,7 +3116,6 @@ async def voice_command(
                     "processing_ack": True,
                     "source": "voice_command_fallback",
                 })
-                _voice_processing_ack_sent = True
         except Exception as _fallback_ack_exc:
             logger.debug("voice/command fallback processing acknowledgement failed: %s", _fallback_ack_exc)
 

--- a/services/zoe-data/tests/test_voice_weather_queue.py
+++ b/services/zoe-data/tests/test_voice_weather_queue.py
@@ -535,6 +535,91 @@ async def test_voice_command_uses_skybridge_fast_path(monkeypatch, utterance, re
 
 
 @pytest.mark.asyncio
+async def test_voice_command_emits_processing_cue_for_non_pi_fallback(monkeypatch) -> None:
+    import pi_hybrid_production
+
+    calls: dict[str, object] = {"broadcast": [], "events": []}
+
+    async def resolve_skybridge_request(text, user_id, *, context=None, db=None):
+        return {
+            "handled": True,
+            "spoken_summary": "Here is the calendar.",
+            "intent": {"domain": "calendar", "action": "current"},
+            "skybridge_context": {"domain": "calendar"},
+            "cards": [],
+        }
+
+    async def broadcast_skybridge_ui(*_args, **_kwargs):
+        return None
+
+    class Broadcaster:
+        async def broadcast(self, channel, event, payload):
+            calls["broadcast"].append((channel, event, payload))
+            calls["events"].append(event)
+
+    class Audio:
+        body = b"RIFF-test"
+        media_type = "audio/wav"
+
+    async def synthesize(payload, caller=None):
+        calls["events"].append("synthesize")
+        return Audio()
+
+    async def no_user(*_args, **_kwargs):
+        return None
+
+    async def fake_processing_cue(**_kwargs):
+        return {"available": True, "text": "One moment."}
+
+    async def save_chat(*_args, **_kwargs):
+        return None
+
+    async def memory_passes(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(
+        pi_hybrid_production.PiHybridProductionConfig,
+        "from_env",
+        classmethod(lambda cls: cls(enabled=True, resource_guard_enabled=False)),
+    )
+    monkeypatch.setattr(pi_hybrid_production, "pi_hybrid_production_eligible", lambda text, config=None: (False, "not_low_risk"))
+    monkeypatch.setattr(pi_hybrid_production, "processing_cue_packet", fake_processing_cue)
+    skybridge_module = types.SimpleNamespace(resolve_skybridge_request=resolve_skybridge_request)
+    monkeypatch.setitem(sys.modules, "skybridge_service", skybridge_module)
+    monkeypatch.setattr(skybridge_service, "resolve_skybridge_request", resolve_skybridge_request)
+    monkeypatch.setitem(sys.modules, "push", types.SimpleNamespace(broadcaster=Broadcaster()))
+    monkeypatch.setattr(voice_tts, "_broadcast_skybridge_ui", broadcast_skybridge_ui)
+    monkeypatch.setattr(voice_tts, "synthesize", synthesize)
+    monkeypatch.setattr(voice_tts, "_resolve_recent_panel_session_user", no_user)
+    monkeypatch.setattr(voice_tts, "_resolve_panel_default_user", no_user)
+    monkeypatch.setattr(voice_tts, "_schedule_voice_chat_save", save_chat)
+    monkeypatch.setattr(voice_tts, "_run_voice_memory_passes", memory_passes)
+    monkeypatch.setattr(voice_tts.asyncio, "ensure_future", lambda coro: coro.close() if hasattr(coro, "close") else None)
+    monkeypatch.setattr(voice_tts, "_VOICE_SESSIONS", {})
+
+    response = await voice_command(
+        {"text": "show my calendar", "panel_id": "panel-sky", "session_id": "session-sky"},
+        caller={"user_id": "guest", "panel_id": "panel-sky"},
+        stream=False,
+        db=object(),
+    )
+
+    assert response["ok"] is True
+    assert response["reply"] == "Here is the calendar."
+    assert (
+        "all",
+        "voice:responding",
+        {
+            "panel_id": "panel-sky",
+            "text": "One moment.",
+            "processing_ack": True,
+            "source": "voice_command_fallback",
+        },
+    ) in calls["broadcast"]
+    assert calls["events"].index("voice:responding") < calls["events"].index("synthesize")
+
+
+@pytest.mark.asyncio
 async def test_voice_skybridge_private_request_challenges_guest_before_cards(monkeypatch) -> None:
     calls: dict[str, object] = {"broadcast_called": False, "challenge_called": False}
 

--- a/services/zoe-data/tests/test_voice_weather_queue.py
+++ b/services/zoe-data/tests/test_voice_weather_queue.py
@@ -577,12 +577,17 @@ async def test_voice_command_emits_processing_cue_for_non_pi_fallback(monkeypatc
     async def memory_passes(*_args, **_kwargs):
         return None
 
+    ineligible_config = types.SimpleNamespace(enabled=True)
     monkeypatch.setattr(
         pi_hybrid_production.PiHybridProductionConfig,
         "from_env",
-        classmethod(lambda cls: cls(enabled=True, resource_guard_enabled=False)),
+        classmethod(lambda cls: ineligible_config),
     )
-    monkeypatch.setattr(pi_hybrid_production, "pi_hybrid_production_eligible", lambda text, config=None: (False, "not_low_risk"))
+    def fake_pi_eligible(text, config=None):
+        assert config is ineligible_config
+        return False, "not_low_risk"
+
+    monkeypatch.setattr(pi_hybrid_production, "pi_hybrid_production_eligible", fake_pi_eligible)
     monkeypatch.setattr(pi_hybrid_production, "processing_cue_packet", fake_processing_cue)
     skybridge_module = types.SimpleNamespace(resolve_skybridge_request=resolve_skybridge_request)
     monkeypatch.setitem(sys.modules, "skybridge_service", skybridge_module)


### PR DESCRIPTION
## What changed

- Emits one cached processing cue for non-stream voice requests even when the Pi hybrid lane is disabled, ineligible, or falls through.
- Preserves the existing Pi cue path and avoids duplicate cues by tracking whether the Pi lane already broadcast one.
- Adds regression coverage for a Pi-ineligible request that falls through to the normal Skybridge/voice path and still shows the cue before final synthesis.

## Why

The hybrid architecture should improve perceived speed for every voice request, not only the low-risk Pi-accepted groups. This keeps the instant intent-buffer feel while Zoe/Pi/Gemma continue slower work behind it.

## Validation

- `python3 -m pytest -q services/zoe-data/tests/test_voice_weather_queue.py -k "pi_hybrid_production_with_processing_cue or emits_processing_cue_for_non_pi_fallback or skybridge_fast_path"`
- `python3 -m pytest -q services/zoe-data/tests/test_voice_weather_queue.py`
- `python3 tools/audit/validate_structure.py`
