### PR TITLE
[codex] Add Pi production label queue

### DIFF
--- a/scripts/maintenance/pi_production_label_queue.py
+++ b/scripts/maintenance/pi_production_label_queue.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Build a review queue from real Pi hybrid production evidence.
+
+The queue is read-only. It helps an operator label sanitized production records
+through the existing production-label sidecar without dumping raw logs or
+promoting routes automatically.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import sys
+from pathlib import Path
+from typing import Iterable, Mapping, Sequence
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "services" / "zoe-data"))
+
+from pi_intent_evidence import (  # noqa: E402
+    apply_pi_hybrid_production_labels,
+    build_pi_hybrid_production_label_queue,
+    load_pi_hybrid_production_labels,
+    load_pi_hybrid_production_records,
+)
+
+DEFAULT_ENV_FILES = (
+    ROOT / ".env",
+    ROOT / "services" / "zoe-data" / ".env",
+    Path("/home/zoe/assistant/.env"),
+    Path("/home/zoe/assistant/services/zoe-data/.env"),
+)
+DEFAULT_PRODUCTION_EVIDENCE_PATH = "~/.zoe/data/pi-hybrid-production-evidence.jsonl"
+DEFAULT_PRODUCTION_LABELS_PATH = "~/.zoe/data/pi-hybrid-production-labels.jsonl"
+
+
+def load_zoe_env(env_files: Iterable[str | Path] = DEFAULT_ENV_FILES) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for env_file in env_files:
+        path = Path(env_file).expanduser()
+        if path.exists():
+            values.update(_parse_env_file(path))
+    values.update(os.environ)
+    return values
+
+
+def _parse_env_file(path: Path) -> dict[str, str]:
+    parsed: dict[str, str] = {}
+    for raw_line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, raw_value = line.split("=", 1)
+        key = key.strip()
+        if key.startswith("export "):
+            key = key[len("export ") :].strip()
+        if not key or key.startswith("#"):
+            continue
+        try:
+            parts = shlex.split(raw_value, comments=True, posix=True)
+        except ValueError:
+            parts = [raw_value.strip().strip('"').strip("'")]
+        parsed[key] = parts[0] if parts else ""
+    return parsed
+
+
+def _jsonl(rows: Sequence[Mapping[str, object]]) -> str:
+    return "".join(json.dumps(row, sort_keys=True, separators=(",", ":")) + "\n" for row in rows)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Build a read-only Pi hybrid production labeling queue")
+    parser.add_argument("--evidence-path", help="Override Pi hybrid production evidence JSONL path")
+    parser.add_argument("--labels-path", help="Override Pi hybrid production labels JSONL path")
+    parser.add_argument("--env-file", action="append", default=None, help="Additional env file to load")
+    parser.add_argument("--group", action="append", default=None, help="Intent group filter; may be repeated or comma-separated")
+    parser.add_argument("--limit", type=int, default=50)
+    parser.add_argument("--include-labeled", action="store_true")
+    parser.add_argument("--include-rejected", action="store_true")
+    parser.add_argument("--format", choices=("json", "jsonl"), default="json")
+    parser.add_argument("--output", "-o", help="Output path; defaults to stdout")
+    args = parser.parse_args(argv)
+
+    env_files = [*DEFAULT_ENV_FILES, *(args.env_file or [])]
+    env = load_zoe_env(env_files)
+    evidence_path = args.evidence_path or env.get("ZOE_PI_HYBRID_PRODUCTION_EVIDENCE_PATH") or DEFAULT_PRODUCTION_EVIDENCE_PATH
+    labels_path = args.labels_path or env.get("ZOE_PI_HYBRID_PRODUCTION_LABELS_PATH") or DEFAULT_PRODUCTION_LABELS_PATH
+    records = load_pi_hybrid_production_records(evidence_path, limit=max(args.limit * 10, 500))
+    labels = load_pi_hybrid_production_labels(labels_path)
+    labeled_records = apply_pi_hybrid_production_labels(records, labels)
+    payload = build_pi_hybrid_production_label_queue(
+        labeled_records,
+        groups=args.group,
+        include_labeled=args.include_labeled,
+        include_rejected=args.include_rejected,
+        limit=args.limit,
+    )
+    payload["summary"]["path"] = str(Path(evidence_path).expanduser())
+    payload["summary"]["labels_path"] = str(Path(labels_path).expanduser())
+    text = _jsonl(payload["queue"]) if args.format == "jsonl" else json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        target = Path(args.output)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(text, encoding="utf-8")
+    else:
+        sys.stdout.write(text)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/zoe-data/pi_intent_evidence.py
+++ b/services/zoe-data/pi_intent_evidence.py
@@ -193,6 +193,176 @@ def apply_pi_hybrid_production_labels(
     return output
 
 
+def build_pi_hybrid_production_label_queue(
+    records: Sequence[Mapping[str, Any]],
+    *,
+    groups: Sequence[str] | None = None,
+    include_labeled: bool = False,
+    include_rejected: bool = False,
+    limit: int = 50,
+) -> dict[str, Any]:
+    """Build a sanitized review queue from production Pi hybrid evidence.
+
+    The queue is read-only. Rows include label examples suitable for the
+    existing production-label sidecar, but do not write labels or promote routes.
+    """
+    selected_groups = _selected_label_groups(groups)
+    latest = _latest_production_by_text_hash(records)
+    rows: list[dict[str, Any]] = []
+    skipped_labeled = 0
+    skipped_rejected = 0
+    skipped_group = 0
+    for record in latest:
+        labeled = bool(record.get("outcome_label") is not None or record.get("negative"))
+        if labeled and not include_labeled:
+            skipped_labeled += 1
+            continue
+        accepted = bool(record.get("accepted"))
+        if not accepted and not include_rejected:
+            skipped_rejected += 1
+            continue
+        row = _production_queue_row(record, labeled=labeled)
+        if selected_groups and row["intent_group"] not in selected_groups:
+            skipped_group += 1
+            continue
+        rows.append(row)
+    rows.sort(key=_production_queue_sort_key)
+    limited = rows[: max(0, int(limit))]
+    return {
+        "summary": {
+            "raw_record_count": len(records),
+            "unique_text_count": len(latest),
+            "queue_count": len(limited),
+            "available_queue_count": len(rows),
+            "skipped_labeled_count": skipped_labeled,
+            "skipped_rejected_count": skipped_rejected,
+            "skipped_group_count": skipped_group,
+            "selected_groups": selected_groups,
+            "queue_count_by_group": _count_production_queue_by_group(rows),
+        },
+        "queue": limited,
+    }
+
+
+def _selected_label_groups(groups: Sequence[str] | None) -> list[str]:
+    if not groups:
+        return []
+    allowed = {"chat"}
+    for intent in ("weather", "daily_briefing", "list_show", "greeting", "time_query", "date_query", "calculate", "timer_create"):
+        group = intent_group_for_intent(intent)
+        if group:
+            allowed.add(group)
+    selected: list[str] = []
+    for raw in groups:
+        for part in str(raw).split(","):
+            group = part.strip()
+            if not group:
+                continue
+            if group not in allowed:
+                raise ValueError(f"unsupported production label group: {group}")
+            selected.append(group)
+    return sorted(set(selected))
+
+
+def _latest_production_by_text_hash(records: Sequence[Mapping[str, Any]]) -> list[Mapping[str, Any]]:
+    by_hash: dict[str, Mapping[str, Any]] = {}
+    anonymous: list[Mapping[str, Any]] = []
+    for record in records:
+        text_hash = _optional_str(record.get("text_hash"))
+        if not text_hash:
+            anonymous.append(record)
+            continue
+        existing = by_hash.get(text_hash)
+        if existing is None or _record_ts(record) >= _record_ts(existing):
+            by_hash[text_hash] = record
+    keyed = sorted(by_hash.values(), key=_record_ts, reverse=True)
+    anonymous.sort(key=_record_ts, reverse=True)
+    return [*keyed, *anonymous]
+
+
+def _record_ts(record: Mapping[str, Any]) -> float:
+    try:
+        return float(record.get("ts") or 0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _production_queue_row(record: Mapping[str, Any], *, labeled: bool) -> dict[str, Any]:
+    suggested = _suggested_production_label(record)
+    group = intent_group_for_intent(suggested) or _optional_str(record.get("intent_group"))
+    if not group:
+        group = intent_group_for_intent(_optional_str(record.get("pi_intent"))) or "chat"
+    return {
+        "text_hash": _optional_str(record.get("text_hash")),
+        "text_preview": _optional_str(record.get("text_preview")),
+        "intent_group": group,
+        "suggested_outcome_label": suggested,
+        "suggested_negative": suggested is None,
+        "already_labeled": labeled,
+        "accepted": bool(record.get("accepted")),
+        "reason": _optional_str(record.get("reason")),
+        "intent": _optional_str(record.get("intent")),
+        "pi_intent": _optional_str(record.get("pi_intent")),
+        "agreement_kind": _optional_str(record.get("agreement_kind")),
+        "route_class": _optional_str(record.get("route_class")) or "fallback",
+        "baseline_kind": _optional_str(record.get("baseline_kind")),
+        "baseline_comparable": _bool_or_none(record.get("baseline_comparable")),
+        "zoe_latency_ms": _float_or_none(record.get("zoe_latency_ms")),
+        "pi_latency_ms": _float_or_none(record.get("pi_latency_ms")),
+        "safe_fulfillment_latency_ms": _float_or_none(record.get("safe_fulfillment_latency_ms")),
+        "production_route_change": _bool_record_value(record.get("production_route_change")),
+        "label_example": _production_label_example(record, suggested),
+    }
+
+
+def _suggested_production_label(record: Mapping[str, Any]) -> str | None:
+    for key in ("outcome_label", "intent", "pi_intent", "safe_fulfillment_intent"):
+        value = _optional_str(record.get(key))
+        if value and intent_group_for_intent(value):
+            return value
+    return None
+
+
+def _production_label_example(record: Mapping[str, Any], suggested: str | None) -> dict[str, Any]:
+    row: dict[str, Any] = {"text_hash": _optional_str(record.get("text_hash")), "source": "admin_review"}
+    if suggested:
+        row["outcome_label"] = suggested
+    else:
+        row["negative"] = True
+    route_class = _optional_str(record.get("route_class"))
+    if route_class:
+        row["route_class"] = route_class
+    baseline_kind = _optional_str(record.get("baseline_kind"))
+    if baseline_kind:
+        row["baseline_kind"] = baseline_kind
+    if record.get("baseline_comparable") is not None:
+        row["baseline_comparable"] = _bool_record_value(record.get("baseline_comparable"))
+    if record.get("zoe_latency_ms") is not None:
+        row["zoe_latency_ms"] = _float_or_none(record.get("zoe_latency_ms"))
+    return row
+
+
+def _production_queue_sort_key(row: Mapping[str, Any]) -> tuple[int, float, str]:
+    low_risk = bool(intent_group_for_intent(_optional_str(row.get("suggested_outcome_label"))))
+    accepted = bool(row.get("accepted"))
+    latency = row.get("pi_latency_ms") if isinstance(row.get("pi_latency_ms"), (int, float)) else 999999.0
+    return (0 if accepted and low_risk else 1, float(latency), str(row.get("text_hash") or ""))
+
+
+def _count_production_queue_by_group(rows: Sequence[Mapping[str, Any]]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for row in rows:
+        group = str(row.get("intent_group") or "unmapped")
+        counts[group] = counts.get(group, 0) + 1
+    return dict(sorted(counts.items()))
+
+
+def _bool_or_none(value: Any) -> bool | None:
+    if value is None:
+        return None
+    return _bool_record_value(value)
+
+
 def append_pi_hybrid_production_label(
     *,
     text_hash: str,
@@ -441,6 +611,7 @@ def _env_bool(value: str | None, *, default: bool = False) -> bool:
 
 __all__ = [
     "append_pi_hybrid_production_label",
+    "build_pi_hybrid_production_label_queue",
     "apply_pi_hybrid_production_labels",
     "has_secret_evidence_text",
     "load_pi_hybrid_production_labels",

--- a/services/zoe-data/pi_intent_evidence.py
+++ b/services/zoe-data/pi_intent_evidence.py
@@ -214,12 +214,14 @@ def build_pi_hybrid_production_label_queue(
     skipped_group = 0
     for record in latest:
         labeled = bool(record.get("outcome_label") is not None or record.get("negative"))
-        if labeled and not include_labeled:
-            skipped_labeled += 1
-            continue
         accepted = bool(record.get("accepted"))
-        if not accepted and not include_rejected:
+        skip_labeled = labeled and not include_labeled
+        skip_rejected = not accepted and not include_rejected
+        if skip_labeled:
+            skipped_labeled += 1
+        if skip_rejected:
             skipped_rejected += 1
+        if skip_labeled or skip_rejected:
             continue
         row = _production_queue_row(record, labeled=labeled)
         if selected_groups and row["intent_group"] not in selected_groups:

--- a/services/zoe-data/routers/system.py
+++ b/services/zoe-data/routers/system.py
@@ -310,6 +310,42 @@ class PiHybridProductionLabelRequest(BaseModel):
     zoe_latency_ms: Optional[float] = None
 
 
+@router.get("/pi-intent/production-label-queue")
+async def get_pi_hybrid_production_label_queue(
+    group: list[str] | None = Query(default=None),
+    limit: int = Query(default=50, ge=1, le=200),
+    include_labeled: bool = Query(default=False),
+    include_rejected: bool = Query(default=False),
+    user: dict = Depends(require_admin),
+):
+    """Read-only queue of sanitized production Pi records awaiting labels."""
+    from pi_intent_evidence import (
+        apply_pi_hybrid_production_labels,
+        build_pi_hybrid_production_label_queue,
+        load_pi_hybrid_production_labels,
+        load_pi_hybrid_production_records,
+    )
+
+    evidence_path = os.environ.get("ZOE_PI_HYBRID_PRODUCTION_EVIDENCE_PATH") or "~/.zoe/data/pi-hybrid-production-evidence.jsonl"
+    labels_path = os.environ.get("ZOE_PI_HYBRID_PRODUCTION_LABELS_PATH") or "~/.zoe/data/pi-hybrid-production-labels.jsonl"
+    try:
+        records = load_pi_hybrid_production_records(evidence_path, limit=max(limit * 10, 500))
+        labels = load_pi_hybrid_production_labels(labels_path)
+        labeled_records = apply_pi_hybrid_production_labels(records, labels)
+        payload = build_pi_hybrid_production_label_queue(
+            labeled_records,
+            groups=group,
+            include_labeled=include_labeled,
+            include_rejected=include_rejected,
+            limit=limit,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    payload["summary"]["path"] = os.path.expanduser(evidence_path)
+    payload["summary"]["labels_path"] = os.path.expanduser(labels_path)
+    return payload
+
+
 @router.post("/pi-intent/production-labels")
 async def post_pi_hybrid_production_label(
     payload: PiHybridProductionLabelRequest,

--- a/services/zoe-data/tests/test_pi_intent_evidence.py
+++ b/services/zoe-data/tests/test_pi_intent_evidence.py
@@ -202,6 +202,7 @@ def test_build_pi_hybrid_production_label_queue_prioritizes_unlabeled_accepted_r
                 "accepted": False,
                 "reason": "timeout",
                 "intent_group": "weather",
+                "outcome_label": "weather",
             },
         ],
         limit=10,
@@ -209,7 +210,7 @@ def test_build_pi_hybrid_production_label_queue_prioritizes_unlabeled_accepted_r
 
     assert payload["summary"]["raw_record_count"] == 4
     assert payload["summary"]["unique_text_count"] == 3
-    assert payload["summary"]["skipped_labeled_count"] == 1
+    assert payload["summary"]["skipped_labeled_count"] == 2
     assert payload["summary"]["skipped_rejected_count"] == 1
     assert payload["summary"]["queue_count_by_group"] == {"weather": 1}
     assert len(payload["queue"]) == 1

--- a/services/zoe-data/tests/test_pi_intent_evidence.py
+++ b/services/zoe-data/tests/test_pi_intent_evidence.py
@@ -8,6 +8,7 @@ from intent_router import detect_intent
 from pi_intent_evidence import (
     append_pi_hybrid_production_label,
     apply_pi_hybrid_production_labels,
+    build_pi_hybrid_production_label_queue,
     load_pi_hybrid_production_labels,
     production_records_to_route_samples,
     record_intent_miss_evidence,
@@ -148,6 +149,98 @@ def test_record_pi_hybrid_production_evidence_writes_compact_sanitized_jsonl(tmp
     assert saved["enabled_groups"] == ["weather"]
     assert saved["outcome_label"] is None
     assert "Jason Smith" not in path.read_text(encoding="utf-8")
+
+
+
+
+def test_build_pi_hybrid_production_label_queue_prioritizes_unlabeled_accepted_records():
+    payload = build_pi_hybrid_production_label_queue(
+        [
+            {
+                "ts": 1,
+                "text_hash": "weather-old",
+                "text_preview": "old rain",
+                "accepted": True,
+                "intent": "weather",
+                "intent_group": "weather",
+                "pi_intent": "weather",
+                "pi_latency_ms": 500.0,
+                "safe_fulfillment_latency_ms": 50.0,
+                "outcome_label": None,
+            },
+            {
+                "ts": 2,
+                "text_hash": "weather-old",
+                "text_preview": "new rain",
+                "accepted": True,
+                "intent": "weather",
+                "intent_group": "weather",
+                "pi_intent": "weather",
+                "route_class": "deterministic",
+                "baseline_kind": "router",
+                "baseline_comparable": True,
+                "zoe_latency_ms": 10.0,
+                "pi_latency_ms": 120.0,
+                "safe_fulfillment_latency_ms": 45.0,
+                "production_route_change": True,
+                "outcome_label": None,
+            },
+            {
+                "ts": 3,
+                "text_hash": "briefing",
+                "text_preview": "daily briefing",
+                "accepted": True,
+                "intent": "daily_briefing",
+                "intent_group": "daily_briefing",
+                "pi_intent": "daily_briefing",
+                "outcome_label": "daily_briefing",
+            },
+            {
+                "ts": 4,
+                "text_hash": "timeout",
+                "text_preview": "weather tomorrow",
+                "accepted": False,
+                "reason": "timeout",
+                "intent_group": "weather",
+            },
+        ],
+        limit=10,
+    )
+
+    assert payload["summary"]["raw_record_count"] == 4
+    assert payload["summary"]["unique_text_count"] == 3
+    assert payload["summary"]["skipped_labeled_count"] == 1
+    assert payload["summary"]["skipped_rejected_count"] == 1
+    assert payload["summary"]["queue_count_by_group"] == {"weather": 1}
+    assert len(payload["queue"]) == 1
+    row = payload["queue"][0]
+    assert row["text_hash"] == "weather-old"
+    assert row["text_preview"] == "new rain"
+    assert row["suggested_outcome_label"] == "weather"
+    assert row["label_example"] == {
+        "text_hash": "weather-old",
+        "source": "admin_review",
+        "outcome_label": "weather",
+        "route_class": "deterministic",
+        "baseline_kind": "router",
+        "baseline_comparable": True,
+        "zoe_latency_ms": 10.0,
+    }
+
+
+def test_build_pi_hybrid_production_label_queue_filters_groups_and_rejected():
+    records = [
+        {"text_hash": "weather", "accepted": True, "intent": "weather", "intent_group": "weather"},
+        {"text_hash": "briefing", "accepted": True, "intent": "daily_briefing", "intent_group": "daily_briefing"},
+        {"text_hash": "chat", "accepted": False, "reason": "pi_disagreed", "intent_group": "weather"},
+    ]
+
+    payload = build_pi_hybrid_production_label_queue(records, groups=["daily_briefing"], include_rejected=True)
+
+    assert [row["text_hash"] for row in payload["queue"]] == ["briefing"]
+    assert payload["summary"]["skipped_group_count"] == 2
+    with pytest.raises(ValueError, match="unsupported production label group"):
+        build_pi_hybrid_production_label_queue(records, groups=["self_evolution"])
 
 
 def test_pi_hybrid_production_label_sidecar_applies_latest_valid_label(tmp_path):

--- a/services/zoe-data/tests/test_pi_intent_status_endpoint.py
+++ b/services/zoe-data/tests/test_pi_intent_status_endpoint.py
@@ -441,6 +441,75 @@ def test_pi_intent_shadow_label_endpoint_rejects_non_admin():
     assert resp.status_code == 403
 
 
+
+
+def test_pi_hybrid_production_label_queue_endpoint_returns_sanitized_rows(tmp_path, monkeypatch):
+    production_path = tmp_path / "production.jsonl"
+    labels_path = tmp_path / "production-labels.jsonl"
+    production_path.write_text(
+        json.dumps(
+            {
+                "text_hash": "weatherhash",
+                "text_preview": "rain later",
+                "accepted": True,
+                "intent": "weather",
+                "intent_group": "weather",
+                "pi_intent": "weather",
+                "outcome_label": None,
+            }
+        )
+        + "\n"
+        + json.dumps(
+            {
+                "text_hash": "briefinghash",
+                "text_preview": "daily briefing",
+                "accepted": True,
+                "intent": "daily_briefing",
+                "intent_group": "daily_briefing",
+                "pi_intent": "daily_briefing",
+                "outcome_label": None,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    labels_path.write_text(
+        json.dumps({"text_hash": "briefinghash", "outcome_label": "daily_briefing", "source": "admin_review"}) + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("ZOE_PI_HYBRID_PRODUCTION_EVIDENCE_PATH", str(production_path))
+    monkeypatch.setenv("ZOE_PI_HYBRID_PRODUCTION_LABELS_PATH", str(labels_path))
+    app = _admin_app()
+
+    resp = TestClient(app).get("/api/system/pi-intent/production-label-queue")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["summary"]["path"] == str(production_path)
+    assert data["summary"]["labels_path"] == str(labels_path)
+    assert data["summary"]["skipped_labeled_count"] == 1
+    assert [row["text_hash"] for row in data["queue"]] == ["weatherhash"]
+    assert data["queue"][0]["label_example"] == {
+        "text_hash": "weatherhash",
+        "source": "admin_review",
+        "outcome_label": "weather",
+    }
+
+
+def test_pi_hybrid_production_label_queue_endpoint_rejects_non_admin():
+    app = FastAPI()
+    app.include_router(system_router)
+
+    async def fake_non_admin():
+        raise HTTPException(status_code=403, detail="Admin access required")
+
+    app.dependency_overrides[require_admin] = fake_non_admin
+
+    resp = TestClient(app).get("/api/system/pi-intent/production-label-queue")
+
+    assert resp.status_code == 403
+
+
 def test_pi_hybrid_production_label_endpoint_appends_trusted_label(tmp_path, monkeypatch):
     production_path = tmp_path / "production.jsonl"
     labels_path = tmp_path / "production-labels.jsonl"

--- a/services/zoe-data/tests/test_pi_production_label_queue.py
+++ b/services/zoe-data/tests/test_pi_production_label_queue.py
@@ -81,6 +81,7 @@ def test_cli_json_includes_paths_and_group_filter(tmp_path, capsys, monkeypatch)
         + json.dumps({"text_hash": "briefing", "accepted": True, "intent": "daily_briefing", "intent_group": "daily_briefing"}) + "\n",
         encoding="utf-8",
     )
+    labels_path.write_text("", encoding="utf-8")
 
     exit_code = module.main(
         [

--- a/services/zoe-data/tests/test_pi_production_label_queue.py
+++ b/services/zoe-data/tests/test_pi_production_label_queue.py
@@ -1,0 +1,101 @@
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+
+def _load_module(monkeypatch):
+    path = Path(__file__).resolve().parents[3] / "scripts" / "maintenance" / "pi_production_label_queue.py"
+    spec = importlib.util.spec_from_file_location("pi_production_label_queue_test", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    monkeypatch.setattr(sys, "path", list(sys.path))
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_cli_reads_production_evidence_and_label_sidecar(tmp_path, capsys, monkeypatch):
+    module = _load_module(monkeypatch)
+    evidence_path = tmp_path / "production.jsonl"
+    labels_path = tmp_path / "production-labels.jsonl"
+    evidence_path.write_text(
+        "".join(
+            json.dumps(row) + "\n"
+            for row in [
+                {
+                    "text_hash": "weather",
+                    "text_preview": "rain later",
+                    "accepted": True,
+                    "intent": "weather",
+                    "intent_group": "weather",
+                    "pi_intent": "weather",
+                    "outcome_label": None,
+                },
+                {
+                    "text_hash": "briefing",
+                    "text_preview": "daily briefing",
+                    "accepted": True,
+                    "intent": "daily_briefing",
+                    "intent_group": "daily_briefing",
+                    "pi_intent": "daily_briefing",
+                    "outcome_label": None,
+                },
+            ]
+        ),
+        encoding="utf-8",
+    )
+    labels_path.write_text(
+        json.dumps({"text_hash": "briefing", "outcome_label": "daily_briefing", "source": "admin_review"}) + "\n",
+        encoding="utf-8",
+    )
+
+    exit_code = module.main(
+        [
+            "--evidence-path",
+            str(evidence_path),
+            "--labels-path",
+            str(labels_path),
+            "--format",
+            "jsonl",
+        ]
+    )
+
+    rows = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
+
+    assert exit_code == 0
+    assert [row["text_hash"] for row in rows] == ["weather"]
+    assert rows[0]["suggested_outcome_label"] == "weather"
+    assert rows[0]["label_example"] == {
+        "outcome_label": "weather",
+        "source": "admin_review",
+        "text_hash": "weather",
+    }
+
+
+def test_cli_json_includes_paths_and_group_filter(tmp_path, capsys, monkeypatch):
+    module = _load_module(monkeypatch)
+    evidence_path = tmp_path / "production.jsonl"
+    labels_path = tmp_path / "production-labels.jsonl"
+    evidence_path.write_text(
+        json.dumps({"text_hash": "weather", "accepted": True, "intent": "weather", "intent_group": "weather"}) + "\n"
+        + json.dumps({"text_hash": "briefing", "accepted": True, "intent": "daily_briefing", "intent_group": "daily_briefing"}) + "\n",
+        encoding="utf-8",
+    )
+
+    exit_code = module.main(
+        [
+            "--evidence-path",
+            str(evidence_path),
+            "--labels-path",
+            str(labels_path),
+            "--group",
+            "daily_briefing",
+        ]
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert payload["summary"]["path"] == str(evidence_path)
+    assert payload["summary"]["labels_path"] == str(labels_path)
+    assert [row["text_hash"] for row in payload["queue"]] == ["briefing"]


### PR DESCRIPTION
## What changed

- Adds a read-only production Pi label queue builder for sanitized `pi-hybrid-production-evidence` records.
- Adds `scripts/maintenance/pi_production_label_queue.py` so operators can list unlabeled production evidence without opening raw logs.
- Adds admin `GET /api/system/pi-intent/production-label-queue` to expose the same queue for UI/admin tooling.
- Keeps labeling and promotion separate: this only suggests label payloads for the existing production-label sidecar.

## Why

Pi hybrid is live, but formal default-route promotion still depends on real/log-derived reviewed samples. We had production evidence writes and a label POST path, but no first-class queue for the production records that need review.

## Validation

- `python3 -m pytest -q services/zoe-data/tests/test_pi_intent_evidence.py services/zoe-data/tests/test_pi_production_label_queue.py services/zoe-data/tests/test_pi_intent_status_endpoint.py services/zoe-data/tests/test_pi_readiness_report.py`
- `python3 tools/audit/validate_structure.py`
- Live CLI smoke: `python3 scripts/maintenance/pi_production_label_queue.py --limit 10 --format json`
