### PR TITLE
[codex] Add Pi hybrid action-form lane

### DIFF
--- a/services/zoe-data/pi_hybrid_production.py
+++ b/services/zoe-data/pi_hybrid_production.py
@@ -319,6 +319,8 @@ def _router_fast_acceptance_decision(result: Mapping[str, Any], config: PiHybrid
         "pi_audit_scheduled": True,
         "safe_fulfillment_latency_ms": safe.get("latency_ms"),
         "speculative_safe_fulfillment": safe.get("speculative_safe_fulfillment"),
+        "execution_scope": safe.get("execution_scope"),
+        "action_form": safe.get("action_form"),
     }
 
 

--- a/services/zoe-data/pi_hybrid_production.py
+++ b/services/zoe-data/pi_hybrid_production.py
@@ -15,13 +15,14 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Mapping
 
-from pi_intent_lab import SAFE_FULFILLMENT_INTENTS, compare_pi_intent_lab
+from pi_intent_lab import SAFE_ACTION_FORM_INTENTS, SAFE_FULFILLMENT_INTENTS, compare_pi_intent_lab
 from zoe_pi_promotion import LOW_RISK_PI_INTENT_GROUPS, intent_group_for_intent
 
 _SAFE_PRODUCTION_INTENTS = frozenset(
     {"weather", "daily_briefing", "list_show", "greeting", "time_query", "date_query", "calculate"}
 )
-_DEFAULT_GROUPS = ("weather", "daily_briefing", "lists", "greetings", "clock", "calculations")
+_SAFE_PRODUCTION_ACTION_FORM_INTENTS = frozenset({"timer_create"})
+_DEFAULT_GROUPS = ("weather", "daily_briefing", "lists", "timers", "greetings", "clock", "calculations")
 _WEATHER_SIGNAL_RE = re.compile(
     r"\b(weather|rain|forecast|temperature|storm|windy|humid|umbrella|jacket|hot|cold|degrees|celsius)\b",
     re.I,
@@ -50,6 +51,13 @@ _CALCULATION_SIGNAL_RE = re.compile(
 _SECRET_TEXT_RE = re.compile(
     r"(api[\s_-]?key|authorization\s*(?:[:=]\s*\S+|bearer\s+[a-z0-9._\-]+|token\s+\S+)|"
     r"bearer\s+[a-z0-9._\-]+|password\s*(?:is|=)|secret\s*(?:is|=)|token\s*(?:is|=))",
+    re.I,
+)
+_TIMER_SIGNAL_RE = re.compile(
+    r"\b(?:set|start|create)\s+(?:a\s+)?(?:\d+|one|two|three|four|five|six|seven|eight|nine|ten|fifteen|twenty|thirty)"
+    r"\s*(?:second|seconds|minute|minutes|hour|hours|min|mins|hr|hrs)\s+(?:timer|alarm)\b"
+    r"|\b(?:timer|alarm)\s+(?:for\s+)?(?:\d+|one|two|three|four|five|six|seven|eight|nine|ten|fifteen|twenty|thirty)"
+    r"\s*(?:second|seconds|minute|minutes|hour|hours|min|mins|hr|hrs)\b",
     re.I,
 )
 
@@ -287,7 +295,10 @@ def _router_fast_acceptance_decision(result: Mapping[str, Any], config: PiHybrid
         return {**base, "reason": "router_not_deterministic"}
     if group not in set(config.groups):
         return {**base, "reason": "group_not_enabled"}
-    if intent not in _SAFE_PRODUCTION_INTENTS or intent not in SAFE_FULFILLMENT_INTENTS:
+    if (
+        intent not in _SAFE_PRODUCTION_INTENTS
+        and intent not in _SAFE_PRODUCTION_ACTION_FORM_INTENTS
+    ) or (intent not in SAFE_FULFILLMENT_INTENTS and intent not in SAFE_ACTION_FORM_INTENTS):
         return {**base, "reason": "intent_not_safe_for_production"}
     if not safe.get("attempted") or not safe.get("allowed"):
         return {**base, "reason": safe.get("blocked_reason") or "safe_fulfillment_blocked"}
@@ -407,6 +418,8 @@ def _production_prefilter_allows(text: str, groups: tuple[str, ...]) -> bool:
         return True
     if "calculations" in selected and _CALCULATION_SIGNAL_RE.search(text):
         return True
+    if "timers" in selected and _TIMER_SIGNAL_RE.search(text):
+        return True
     return False
 
 
@@ -428,7 +441,10 @@ def _acceptance_decision(result: Mapping[str, Any], config: PiHybridProductionCo
         return {**base, "reason": "pi_error", "error": pi.get("error")}
     if group not in set(config.groups):
         return {**base, "reason": "group_not_enabled"}
-    if intent not in _SAFE_PRODUCTION_INTENTS or intent not in SAFE_FULFILLMENT_INTENTS:
+    if (
+        intent not in _SAFE_PRODUCTION_INTENTS
+        and intent not in _SAFE_PRODUCTION_ACTION_FORM_INTENTS
+    ) or (intent not in SAFE_FULFILLMENT_INTENTS and intent not in SAFE_ACTION_FORM_INTENTS):
         return {**base, "reason": "intent_not_safe_for_production"}
     if not safe.get("attempted") or not safe.get("allowed"):
         return {**base, "reason": safe.get("blocked_reason") or "safe_fulfillment_blocked"}
@@ -459,6 +475,8 @@ def _acceptance_decision(result: Mapping[str, Any], config: PiHybridProductionCo
         "pi_latency_ms": pi.get("latency_ms"),
         "safe_fulfillment_latency_ms": safe.get("latency_ms"),
         "speculative_safe_fulfillment": speculative_state,
+        "execution_scope": safe.get("execution_scope"),
+        "action_form": safe.get("action_form"),
     }
 
 
@@ -487,6 +505,8 @@ def _compact_lab_result(result: Mapping[str, Any]) -> dict[str, Any]:
             "attempted": safe.get("attempted"),
             "allowed": safe.get("allowed"),
             "intent": safe.get("intent"),
+            "execution_scope": safe.get("execution_scope"),
+            "action_form": safe.get("action_form"),
             "latency_ms": safe.get("latency_ms"),
             "timed_out": safe.get("timed_out"),
             "error": safe.get("error"),

--- a/services/zoe-data/pi_intent_lab.py
+++ b/services/zoe-data/pi_intent_lab.py
@@ -31,6 +31,13 @@ SAFE_FULFILLMENT_INTENTS = frozenset(
         "weather",
     }
 )
+SAFE_ACTION_FORM_INTENTS = frozenset({"timer_create"})
+_ACTION_FORM_COMPONENTS = {
+    "timer_create": "timer_create_form",
+}
+_ACTION_FORM_RESPONSES = {
+    "timer_create": "Timer is ready to confirm.",
+}
 _SPECULATIVE_WEATHER_STRONG_RE = re.compile(
     r"\b(rain|forecast|weather|temperature|storm|windy|humid)\b",
     re.I,
@@ -150,11 +157,12 @@ async def compare_pi_intent_lab(
         "report_kind": "zoe_pi_intent_lab_comparison",
         "contract": {
             "admin_only": True,
-            "side_effects": "read_only_external_only" if include_safe_fulfillment else "none",
+            "side_effects": "read_only_external_or_action_form_prefill" if include_safe_fulfillment else "none",
             "intent_dispatch_enabled": bool(include_safe_fulfillment),
-            "intent_dispatch_scope": "read_only_allowlist_only" if include_safe_fulfillment else "none",
+            "intent_dispatch_scope": "read_only_or_action_form_prefill" if include_safe_fulfillment else "none",
             "safe_read_only_fulfillment_enabled": bool(include_safe_fulfillment),
             "safe_read_only_fulfillment_intents": sorted(SAFE_FULFILLMENT_INTENTS),
+            "safe_action_form_intents": sorted(SAFE_ACTION_FORM_INTENTS),
             "memory_writes_enabled": False,
             "shadow_writes_enabled": False,
             "promotion_enabled": False,
@@ -379,7 +387,7 @@ async def _safe_fulfill_router_intent(
         return await block("router_no_intent")
     if str(router.get("route_class") or "") != "deterministic" or not router.get("baseline_comparable"):
         return await block("router_not_deterministic", intent=intent_name)
-    if intent_name not in SAFE_FULFILLMENT_INTENTS:
+    if intent_name not in SAFE_FULFILLMENT_INTENTS and intent_name not in SAFE_ACTION_FORM_INTENTS:
         return await block("side_effect_or_unsupported_intent", intent=intent_name)
     if intent_group_for_intent(intent_name) not in LOW_RISK_PI_INTENT_GROUPS:
         return await block("not_low_risk_group", intent=intent_name)
@@ -458,7 +466,7 @@ async def _safe_fulfill_pi_intent(
         return await block("pi_timed_out", intent=intent_name)
     if pi.get("error"):
         return await block("pi_error", intent=intent_name, error=pi.get("error"))
-    if intent_name not in SAFE_FULFILLMENT_INTENTS:
+    if intent_name not in SAFE_FULFILLMENT_INTENTS and intent_name not in SAFE_ACTION_FORM_INTENTS:
         return await block("side_effect_or_unsupported_intent", intent=intent_name)
     if not pi.get("low_risk_group"):
         return await block("not_low_risk_group", intent=intent_name)
@@ -537,7 +545,11 @@ def _start_speculative_safe_fulfillment(
 
 def _speculative_safe_fulfillment_candidate(zoe_router: Mapping[str, Any], *, text: str) -> dict[str, Any] | None:
     intent_name = str(zoe_router.get("intent") or "")
-    if intent_name and intent_name in SAFE_FULFILLMENT_INTENTS and zoe_router.get("baseline_comparable"):
+    if (
+        intent_name
+        and (intent_name in SAFE_FULFILLMENT_INTENTS or intent_name in SAFE_ACTION_FORM_INTENTS)
+        and zoe_router.get("baseline_comparable")
+    ):
         return {
             "intent": intent_name,
             "slots": dict(zoe_router.get("slots") or {}),
@@ -580,6 +592,30 @@ async def _execute_safe_fulfillment_intent(
     from intent_router import execute_intent
 
     intent_name = str(getattr(intent, "name", "") or "")
+    slots = dict(getattr(intent, "slots", {}) or {})
+    if intent_name in SAFE_ACTION_FORM_INTENTS:
+        response_text = _ACTION_FORM_RESPONSES.get(intent_name, "Prepared for confirmation.")
+        return {
+            "requested": True,
+            "attempted": True,
+            "allowed": True,
+            "intent": intent_name,
+            "latency_ms": 0.0,
+            "timed_out": False,
+            "error": None,
+            "response_chars": len(response_text),
+            "response_preview": response_text,
+            "response_text": response_text,
+            "would_execute": False,
+            "execution_scope": "action_form_prefill",
+            "action_form": {
+                "component": _ACTION_FORM_COMPONENTS.get(intent_name),
+                "prefill": slots,
+            },
+            "started_before_pi": started_before_pi,
+            "validated_by_pi": False,
+        }
+
     started = time.perf_counter()
     try:
         response = await asyncio.wait_for(execute_intent(intent, user_id=user_id), timeout=timeout_seconds)

--- a/services/zoe-data/routers/chat.py
+++ b/services/zoe-data/routers/chat.py
@@ -51,6 +51,7 @@ _ACTION_FORM_INTENTS: frozenset[str] = frozenset({
     "calendar_create",
     "list_add",
     "list_show",
+    "timer_create",
 })
 
 
@@ -213,13 +214,24 @@ def _intent_action_form_payload(intent, panel_id: str | None = None) -> dict | N
             **({"panel_id": panel_id} if panel_id else {}),
         }
 
+    if name == "timer_create":
+        return {
+            "panel_type": "timer",
+            "title": "New Timer",
+            "data": {
+                "minutes": slots.get("minutes") or slots.get("duration") or 5,
+                "label": slots.get("label") or "Timer",
+            },
+            **({"panel_id": panel_id} if panel_id else {}),
+        }
+
     return None
 
 
 async def _broadcast_intent_nav(intent, panel_id: str | None = None) -> None:
     """Broadcast UI actions to the touch panel when an intent is detected.
 
-    For action-form intents (calendar_create, list_add/show), a full-screen
+    For action-form intents (calendar_create, list_add/show, timer_create), a full-screen
     interactive form overlay is shown instead of navigating to a detail page.
     For all other intents, the classic panel_navigate + panel_open_form flow runs.
     A show_card is always emitted so the dashboard overlay shows intent-specific info.

--- a/services/zoe-data/routers/chat.py
+++ b/services/zoe-data/routers/chat.py
@@ -494,6 +494,7 @@ async def _run_chat_pi_hybrid_lane(
     request_text: str | None = None,
     run_id: str | None = None,
     record_run_state: bool = False,
+    panel_id: str | None = None,
 ) -> dict:
     """Run the production Pi hybrid lane once and persist accepted chat output."""
     try:
@@ -519,20 +520,41 @@ async def _run_chat_pi_hybrid_lane(
             config=config,
         )
         response_text = str(decision.get("response_text") or "")
-        accepted = bool(decision.get("accepted") and response_text)
-        payload = {"attempted": True, "cue": cue, "decision": decision, "accepted": accepted, "response_text": response_text}
+        action_form = decision.get("action_form") if isinstance(decision.get("action_form"), dict) else None
+        accepted = bool(decision.get("accepted") and (response_text or action_form))
+        payload = {
+            "attempted": True,
+            "cue": cue,
+            "decision": decision,
+            "accepted": accepted,
+            "response_text": response_text,
+            "action_form": action_form,
+        }
         if not accepted:
             return payload
 
-        asyncio.ensure_future(chat_inject_background(
-            message_for_processing,
-            response_text,
-            str(decision.get("intent") or "pi_hybrid"),
-            user_id,
-            session_id,
-        ))
-        asyncio.ensure_future(_persist_memory_candidates(user_id, session_id, message_for_processing, response_text))
-        await _save_chat_message(session_id, "assistant", response_text)
+        intent_name = str(decision.get("intent") or "pi_hybrid")
+        if action_form and panel_id and intent_name in _INTENT_PANEL_NAV:
+            try:
+                from intent_router import Intent
+
+                asyncio.ensure_future(_broadcast_intent_nav(
+                    Intent(intent_name, dict(action_form.get("prefill") or {}), 1.0),
+                    panel_id=panel_id,
+                ))
+            except Exception as exc:
+                logger.debug("Pi hybrid action form broadcast skipped: %s", exc)
+        if not action_form:
+            asyncio.ensure_future(chat_inject_background(
+                message_for_processing,
+                response_text,
+                intent_name,
+                user_id,
+                session_id,
+            ))
+            asyncio.ensure_future(_persist_memory_candidates(user_id, session_id, message_for_processing, response_text))
+        if response_text:
+            await _save_chat_message(session_id, "assistant", response_text)
         if record_run_state:
             active_run_id = run_id or new_run_ids()[0]
             await _record_run_state(
@@ -550,6 +572,8 @@ async def _run_chat_pi_hybrid_lane(
                         "intent": decision.get("intent"),
                         "intent_group": decision.get("intent_group"),
                         "agreement_kind": decision.get("agreement_kind"),
+                        "execution_scope": decision.get("execution_scope"),
+                        "action_form": bool(action_form),
                     }
                 },
             )
@@ -1857,6 +1881,7 @@ async def chat_stream_generator(
                 request_text=message,
                 run_id=run_id,
                 record_run_state=True,
+                panel_id=req_panel_id,
             )
             if _pi_hybrid.get("attempted"):
                 _pi_cue = _pi_hybrid.get("cue") or {}
@@ -1884,8 +1909,19 @@ async def chat_stream_generator(
                     "agreement_kind": _pi_decision.get("agreement_kind"),
                     "production_route_change": _pi_decision.get("production_route_change"),
                     "lab_result": _pi_decision.get("lab_result"),
+                    "execution_scope": _pi_decision.get("execution_scope"),
+                    "action_form": _pi_hybrid.get("action_form"),
                 }))
                 if _pi_hybrid.get("accepted"):
+                    action_form = _pi_hybrid.get("action_form") or {}
+                    if action_form:
+                        component = action_form.get("component")
+                        prefill = action_form.get("prefill") or {}
+                        if component:
+                            yield emit(CustomEvent(
+                                name="zoe.ui_component",
+                                value={"component": component, "props": prefill},
+                            ))
                     response_text = str(_pi_hybrid.get("response_text") or "")
                     yield emit(TextMessageStartEvent(
                         type=EventType.TEXT_MESSAGE_START,
@@ -3092,6 +3128,7 @@ async def chat(request: Request, user: dict = Depends(get_current_user), stream:
                 context=_CHAT_CONTEXTS.get(session_id),
                 request_text=message,
                 record_run_state=True,
+                panel_id=req_panel_id,
             )
             if _pi_hybrid.get("accepted"):
                 _pi_cue = _pi_hybrid.get("cue") or {}
@@ -3110,6 +3147,8 @@ async def chat(request: Request, user: dict = Depends(get_current_user), stream:
                         "intent": _pi_decision.get("intent"),
                         "intent_group": _pi_decision.get("intent_group"),
                         "agreement_kind": _pi_decision.get("agreement_kind"),
+                        "execution_scope": _pi_decision.get("execution_scope"),
+                        "action_form": _pi_hybrid.get("action_form"),
                     },
                 }
 

--- a/services/zoe-data/tests/test_chat_pi_hybrid_action_form.py
+++ b/services/zoe-data/tests/test_chat_pi_hybrid_action_form.py
@@ -83,3 +83,18 @@ async def test_chat_pi_hybrid_action_form_broadcasts_without_tool_memory_side_ef
     assert saved == [{"session_id": "session-1", "role": "assistant", "content": "Timer is ready to confirm."}]
     assert run_states[0]["metadata"]["pi_hybrid"]["execution_scope"] == "action_form_prefill"
     assert run_states[0]["metadata"]["pi_hybrid"]["action_form"] is True
+
+
+
+def test_timer_create_has_touch_panel_action_form_payload():
+    class Intent:
+        name = "timer_create"
+        slots = {"minutes": 10, "label": "Tea"}
+
+    assert "timer_create" in chat._ACTION_FORM_INTENTS
+    assert chat._intent_action_form_payload(Intent(), panel_id="panel-1") == {
+        "panel_type": "timer",
+        "title": "New Timer",
+        "data": {"minutes": 10, "label": "Tea"},
+        "panel_id": "panel-1",
+    }

--- a/services/zoe-data/tests/test_chat_pi_hybrid_action_form.py
+++ b/services/zoe-data/tests/test_chat_pi_hybrid_action_form.py
@@ -1,0 +1,85 @@
+import asyncio
+import sys
+import types
+
+import pytest
+
+from routers import chat
+
+
+@pytest.mark.asyncio
+async def test_chat_pi_hybrid_action_form_broadcasts_without_tool_memory_side_effects(monkeypatch):
+    module = types.ModuleType("pi_hybrid_production")
+
+    class PiHybridProductionConfig:
+        @classmethod
+        def from_env(cls):
+            return cls()
+
+    def pi_hybrid_production_eligible(text, *, config=None):
+        return True, "eligible"
+
+    async def processing_cue_packet(*, text=""):
+        return {"available": True, "text": "Let me set that up.", "event": {"type": "voice:processing_ack"}}
+
+    async def try_pi_hybrid_production(text, *, user_id, context_turns="", config=None):
+        return {
+            "accepted": True,
+            "reason": "accepted",
+            "intent": "timer_create",
+            "intent_group": "timers",
+            "agreement_kind": "zoe_router",
+            "execution_scope": "action_form_prefill",
+            "response_text": "Timer is ready to confirm.",
+            "action_form": {"component": "timer_create_form", "prefill": {"minutes": 10}},
+        }
+
+    module.PiHybridProductionConfig = PiHybridProductionConfig
+    module.pi_hybrid_production_eligible = pi_hybrid_production_eligible
+    module.processing_cue_packet = processing_cue_packet
+    module.try_pi_hybrid_production = try_pi_hybrid_production
+    monkeypatch.setitem(sys.modules, "pi_hybrid_production", module)
+
+    broadcasts = []
+
+    async def fake_broadcast(intent, panel_id=None):
+        broadcasts.append({"intent": intent.name, "slots": intent.slots, "panel_id": panel_id})
+
+    async def fail_background(*args, **kwargs):
+        raise AssertionError("action-form Pi hybrid should not inject background tool results")
+
+    async def fail_memory(*args, **kwargs):
+        raise AssertionError("action-form Pi hybrid should not persist fulfillment memory")
+
+    saved = []
+
+    async def fake_save(session_id, role, content):
+        saved.append({"session_id": session_id, "role": role, "content": content})
+
+    run_states = []
+
+    async def fake_record_run_state(*args, **kwargs):
+        run_states.append(kwargs)
+
+    monkeypatch.setattr(chat, "_broadcast_intent_nav", fake_broadcast)
+    monkeypatch.setattr(chat, "chat_inject_background", fail_background)
+    monkeypatch.setattr(chat, "_persist_memory_candidates", fail_memory)
+    monkeypatch.setattr(chat, "_save_chat_message", fake_save)
+    monkeypatch.setattr(chat, "_record_run_state", fake_record_run_state)
+
+    result = await chat._run_chat_pi_hybrid_lane(
+        "set a ten minute timer",
+        user_id="jason",
+        session_id="session-1",
+        panel_id="panel-1",
+        record_run_state=True,
+        run_id="run-1",
+    )
+
+    assert result["accepted"] is True
+    assert result["action_form"] == {"component": "timer_create_form", "prefill": {"minutes": 10}}
+    await asyncio.sleep(0)
+    assert broadcasts == [{"intent": "timer_create", "slots": {"minutes": 10}, "panel_id": "panel-1"}]
+    assert saved == [{"session_id": "session-1", "role": "assistant", "content": "Timer is ready to confirm."}]
+    assert run_states[0]["metadata"]["pi_hybrid"]["execution_scope"] == "action_form_prefill"
+    assert run_states[0]["metadata"]["pi_hybrid"]["action_form"] is True

--- a/services/zoe-data/tests/test_pi_hybrid_production.py
+++ b/services/zoe-data/tests/test_pi_hybrid_production.py
@@ -192,6 +192,37 @@ async def test_try_pi_hybrid_fast_accepts_deterministic_router_weather(monkeypat
     assert calls[1]["run_pi"] is True
 
 
+
+
+@pytest.mark.asyncio
+async def test_try_pi_hybrid_fast_accept_preserves_timer_action_form(monkeypatch):
+    _install_prefilter(monkeypatch)
+
+    async def fake_compare(text, **kwargs):
+        result = _accepted_lab_result(intent="timer_create", response="Timer is ready to confirm.", router_intent="timer_create")
+        result["zoe_router"]["baseline_comparable"] = True
+        result["safe_fulfillment"]["validated_by_router"] = True
+        result["safe_fulfillment"]["execution_scope"] = "action_form_prefill"
+        result["safe_fulfillment"]["action_form"] = {
+            "component": "timer_create_form",
+            "prefill": {"minutes": 10},
+        }
+        return result
+
+    monkeypatch.setattr(pi_hybrid_production, "compare_pi_intent_lab", fake_compare)
+    monkeypatch.setattr(pi_hybrid_production, "_read_meminfo_mb", lambda: {"MemAvailable": 99999, "SwapFree": 99999})
+
+    decision = await try_pi_hybrid_production(
+        "set a ten minute timer",
+        user_id="jason",
+        config=PiHybridProductionConfig(enabled=True, groups=("timers",), router_fast_accept_enabled=True),
+    )
+
+    assert decision["accepted"] is True
+    assert decision["reason"] == "router_confirmed_fast_accept"
+    assert decision["execution_scope"] == "action_form_prefill"
+    assert decision["action_form"] == {"component": "timer_create_form", "prefill": {"minutes": 10}}
+
 @pytest.mark.asyncio
 async def test_try_pi_hybrid_fast_accept_records_audit_disagreement(tmp_path, monkeypatch):
     _install_prefilter(monkeypatch)

--- a/services/zoe-data/tests/test_pi_hybrid_production.py
+++ b/services/zoe-data/tests/test_pi_hybrid_production.py
@@ -83,6 +83,14 @@ def test_production_eligibility_is_disabled_and_tightly_prefiltered(monkeypatch)
         "what is the meeting time plus travel time",
         config=PiHybridProductionConfig(enabled=True, groups=("calculations",)),
     ) == (False, "production_prefilter_rejected")
+    assert pi_hybrid_production_eligible(
+        "set a ten minute timer",
+        config=PiHybridProductionConfig(enabled=True, groups=("timers",)),
+    ) == (True, "eligible")
+    assert pi_hybrid_production_eligible(
+        "timer ideas for cooking",
+        config=PiHybridProductionConfig(enabled=True, groups=("timers",)),
+    ) == (False, "production_prefilter_rejected")
 
 
 
@@ -537,6 +545,39 @@ async def test_try_pi_hybrid_records_rejected_production_evidence_when_enabled(t
     assert saved["accepted"] is False
     assert saved["reason"] == "disabled"
     assert saved["production_route_change"] is False
+
+
+@pytest.mark.asyncio
+async def test_try_pi_hybrid_accepts_timer_as_action_form_prefill(monkeypatch):
+    _install_prefilter(monkeypatch)
+
+    async def fake_compare(text, **kwargs):
+        result = _accepted_lab_result(intent="timer_create", response="Timer is ready to confirm.", router_intent="timer_create")
+        result["safe_fulfillment"]["execution_scope"] = "action_form_prefill"
+        result["safe_fulfillment"]["would_execute"] = False
+        result["safe_fulfillment"]["action_form"] = {
+            "component": "timer_create_form",
+            "prefill": {"minutes": 10},
+        }
+        return result
+
+    monkeypatch.setattr(pi_hybrid_production, "compare_pi_intent_lab", fake_compare)
+    monkeypatch.setattr(pi_hybrid_production, "_read_meminfo_mb", lambda: {"MemAvailable": 99999, "SwapFree": 99999})
+
+    decision = await try_pi_hybrid_production(
+        "set a ten minute timer",
+        user_id="jason",
+        config=PiHybridProductionConfig(enabled=True, groups=("timers",)),
+    )
+
+    assert decision["accepted"] is True
+    assert decision["intent"] == "timer_create"
+    assert decision["execution_scope"] == "action_form_prefill"
+    assert decision["action_form"] == {
+        "component": "timer_create_form",
+        "prefill": {"minutes": 10},
+    }
+    assert decision["production_route_change"] is True
 
 
 @pytest.mark.asyncio

--- a/services/zoe-data/tests/test_pi_intent_lab.py
+++ b/services/zoe-data/tests/test_pi_intent_lab.py
@@ -287,8 +287,8 @@ async def test_lab_can_fulfill_safe_read_only_pi_result(monkeypatch):
     assert calls[0]["intent"].slots == {"forecast": False}
     assert calls[0]["user_id"] == "pi-intent-lab"
     assert result["contract"]["intent_dispatch_enabled"] is True
-    assert result["contract"]["side_effects"] == "read_only_external_only"
-    assert result["contract"]["intent_dispatch_scope"] == "read_only_allowlist_only"
+    assert result["contract"]["side_effects"] == "read_only_external_or_action_form_prefill"
+    assert result["contract"]["intent_dispatch_scope"] == "read_only_or_action_form_prefill"
     assert result["safe_fulfillment"]["attempted"] is True
     assert result["safe_fulfillment"]["allowed"] is True
     assert result["safe_fulfillment"]["would_execute"] is True
@@ -330,7 +330,7 @@ async def test_lab_counts_non_string_safe_fulfillment_response_chars(monkeypatch
 
 
 @pytest.mark.asyncio
-async def test_lab_blocks_side_effect_pi_fulfillment(monkeypatch):
+async def test_lab_prefills_timer_action_form_without_dispatching(monkeypatch):
     calls = []
     _install_fake_intent_router(monkeypatch, raw=None, extracted=None, execute_response="timer started", execute_calls=calls)
     _install_fake_pi_classifier(
@@ -353,12 +353,15 @@ async def test_lab_blocks_side_effect_pi_fulfillment(monkeypatch):
     )
 
     assert calls == []
-    assert result["safe_fulfillment"]["attempted"] is False
-    assert result["safe_fulfillment"]["allowed"] is False
-    assert result["safe_fulfillment"]["blocked_reason"] == "side_effect_or_unsupported_intent"
+    assert result["safe_fulfillment"]["attempted"] is True
+    assert result["safe_fulfillment"]["allowed"] is True
     assert result["safe_fulfillment"]["intent"] == "timer_create"
-    assert result["safe_fulfillment"]["response_chars"] == 0
-    assert result["safe_fulfillment"]["response_preview"] == ""
+    assert result["safe_fulfillment"]["execution_scope"] == "action_form_prefill"
+    assert result["safe_fulfillment"]["action_form"] == {
+        "component": "timer_create_form",
+        "prefill": {"minutes": 10},
+    }
+    assert result["safe_fulfillment"]["response_preview"] == "Timer is ready to confirm."
     assert result["safe_fulfillment"]["would_execute"] is False
 
 

--- a/services/zoe-data/tests/test_pi_intent_lab.py
+++ b/services/zoe-data/tests/test_pi_intent_lab.py
@@ -366,6 +366,37 @@ async def test_lab_prefills_timer_action_form_without_dispatching(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_lab_blocks_non_allowlisted_side_effect_pi_fulfillment(monkeypatch):
+    calls = []
+    _install_fake_intent_router(monkeypatch, raw=None, extracted=None, execute_response="reminder set", execute_calls=calls)
+    _install_fake_pi_classifier(
+        monkeypatch,
+        result=types.SimpleNamespace(
+            intent="reminder_create",
+            slots={"title": "take bins out"},
+            confidence=0.95,
+            task_lane="fast_tool",
+            source="fake_pi",
+            latency_ms=90.0,
+            reason="reminder signal",
+        ),
+    )
+
+    result = await compare_pi_intent_lab(
+        "remind me to take the bins out",
+        include_hybrid_status=False,
+        include_safe_fulfillment=True,
+    )
+
+    assert calls == []
+    assert result["safe_fulfillment"]["attempted"] is False
+    assert result["safe_fulfillment"]["allowed"] is False
+    assert result["safe_fulfillment"]["blocked_reason"] == "side_effect_or_unsupported_intent"
+    assert result["safe_fulfillment"]["intent"] == "reminder_create"
+    assert result["safe_fulfillment"]["would_execute"] is False
+
+
+@pytest.mark.asyncio
 async def test_lab_safe_fulfillment_timeout_is_reported(monkeypatch):
     calls = []
     _install_fake_intent_router(


### PR DESCRIPTION
## Summary
- add a distinct Pi hybrid action-form prefill lane for timer_create
- keep timer fulfillment non-executing while returning component/prefill metadata
- pass Pi hybrid action forms through chat/touch-panel broadcast without tool/memory side effects

## Tests
- python3 -m pytest -q services/zoe-data/tests/test_chat_pi_hybrid_action_form.py services/zoe-data/tests/test_pi_intent_lab.py services/zoe-data/tests/test_pi_hybrid_production.py services/zoe-data/tests/test_pi_intent_status_endpoint.py services/zoe-data/tests/test_pi_readiness_report.py
- python3 tools/audit/validate_structure.py