### PR TITLE
feat(harness): deterministic review - approve from objective signals, not the flaky agent

### DIFF
--- a/services/zoe-data/pipeline_review.py
+++ b/services/zoe-data/pipeline_review.py
@@ -63,14 +63,20 @@ def _unresolved_thread_count(pr_number: str, *, cwd: str) -> int | None:
     query = (
         "{ repository(owner:\"jason-easyazz\", name:\"zoe-ai-assistant\") { pullRequest(number:"
         + pr_number
-        + ") { reviewThreads(first:100) { nodes { isResolved } } } } }"
+        + ") { reviewThreads(first:100) { nodes { isResolved } pageInfo { hasNextPage } } } } }"
     )
     code, out = _run(["gh", "api", "graphql", "-f", f"query={query}"], cwd=cwd)
     if code != 0 or not out:
         return None
     try:
-        nodes = json.loads(out)["data"]["repository"]["pullRequest"]["reviewThreads"]["nodes"]
+        threads = json.loads(out)["data"]["repository"]["pullRequest"]["reviewThreads"]
+        nodes = threads["nodes"]
     except (ValueError, TypeError, KeyError):
+        return None
+    # Fail open (treat as unknown) when there are more thread pages than we
+    # fetched, so a PR with >100 threads can't be silently approved on a partial
+    # page that happens to show all-resolved.
+    if (threads.get("pageInfo") or {}).get("hasNextPage"):
         return None
     return sum(1 for t in nodes if not t.get("isResolved"))
 

--- a/services/zoe-data/pipeline_review.py
+++ b/services/zoe-data/pipeline_review.py
@@ -1,0 +1,114 @@
+"""Assess whether a PR objectively passes review, for deterministic review approval.
+
+The review phase normally depends on the zoe-reviewer agent grading the diff and
+self-approving. That agent is unreliable (it can block claiming "no code/evidence"
+even with the PR_URL in its handoff). This module lets the harness make the
+review decision from objective signals instead: the PR is OPEN, every required CI
+check is green, and Greptile left zero unresolved review threads (i.e. Greptile
+reviewed and is satisfied). Combined with the verify phase having already run the
+PR's focused tests, that is a strong, deterministic proxy for "review approved".
+
+Mirrors pipeline_validators / pipeline_focused_tests: bounded subprocess gh calls,
+fails OPEN (ready=False) on any error so the agent-driven flow still applies.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from dataclasses import dataclass
+
+from hermes_http import zoe_repo_root
+
+_GH_TIMEOUT_S = 60
+_GREEN = {"SUCCESS", "NEUTRAL", "SKIPPED", "COMPLETED"}
+_OWNER_REPO = "jason-easyazz/zoe-ai-assistant"
+
+
+@dataclass(frozen=True)
+class ReviewReadiness:
+    ready: bool
+    reason: str
+    unresolved_threads: int | None = None
+
+
+def _run(cmd: list[str], *, cwd: str, timeout: int = _GH_TIMEOUT_S) -> tuple[int, str]:
+    try:
+        proc = subprocess.run(
+            cmd, cwd=cwd, capture_output=True, text=True, timeout=timeout, check=False
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return 1, str(exc)
+    return proc.returncode, ((proc.stdout or "") + (proc.stderr or "")).strip()
+
+
+def _pr_number(pr_url: str) -> str:
+    tail = pr_url.rstrip("/").rsplit("/", 1)[-1]
+    return tail if tail.isdigit() else ""
+
+
+def _checks_all_green(rollup: list) -> bool:
+    saw_one = False
+    for c in rollup or []:
+        saw_one = True
+        state = (c.get("conclusion") or c.get("status") or c.get("state") or "").upper()
+        if state in {"IN_PROGRESS", "PENDING", "QUEUED", "WAITING", "REQUESTED", ""}:
+            return False
+        if state not in _GREEN:
+            return False
+    return saw_one  # empty rollup is not trusted as green
+
+
+def _unresolved_thread_count(pr_number: str, *, cwd: str) -> int | None:
+    query = (
+        "{ repository(owner:\"jason-easyazz\", name:\"zoe-ai-assistant\") { pullRequest(number:"
+        + pr_number
+        + ") { reviewThreads(first:100) { nodes { isResolved } } } } }"
+    )
+    code, out = _run(["gh", "api", "graphql", "-f", f"query={query}"], cwd=cwd)
+    if code != 0 or not out:
+        return None
+    try:
+        nodes = json.loads(out)["data"]["repository"]["pullRequest"]["reviewThreads"]["nodes"]
+    except (ValueError, TypeError, KeyError):
+        return None
+    return sum(1 for t in nodes if not t.get("isResolved"))
+
+
+def assess_pr_review_ready(pr_url: str, *, repo_root: str | None = None) -> ReviewReadiness:
+    """Objective review gate: PR OPEN + all required checks green + 0 unresolved
+    Greptile review threads. Fails open (ready=False) on any error."""
+    pr_url = (pr_url or "").strip()
+    if not pr_url:
+        return ReviewReadiness(False, "no PR_URL")
+    pr_number = _pr_number(pr_url)
+    if not pr_number:
+        return ReviewReadiness(False, "could not parse PR number")
+    root = repo_root or zoe_repo_root()
+
+    code, out = _run(
+        ["gh", "pr", "view", pr_url, "--json", "state,mergeStateStatus,statusCheckRollup"], cwd=root
+    )
+    if code != 0 or not out:
+        return ReviewReadiness(False, f"gh pr view failed: {out[-160:]}")
+    try:
+        data = json.loads(out)
+    except (ValueError, TypeError):
+        return ReviewReadiness(False, "gh pr view returned non-JSON")
+
+    if (data.get("state") or "").upper() != "OPEN":
+        return ReviewReadiness(False, f"PR not open (state={data.get('state')})")
+    if not _checks_all_green(data.get("statusCheckRollup") or []):
+        return ReviewReadiness(False, "CI checks not all green")
+
+    unresolved = _unresolved_thread_count(pr_number, cwd=root)
+    if unresolved is None:
+        return ReviewReadiness(False, "could not read review threads")
+    if unresolved > 0:
+        return ReviewReadiness(False, f"{unresolved} unresolved review threads", unresolved)
+
+    return ReviewReadiness(
+        True,
+        "CI green + 0 unresolved Greptile threads + verify passed",
+        unresolved,
+    )

--- a/services/zoe-data/pipeline_store.py
+++ b/services/zoe-data/pipeline_store.py
@@ -491,6 +491,52 @@ async def _append_harness_focused_tests(state: PipelineState, phase: PipelinePha
     return with_evidence(state, focused_test_evidence_item(result, phase=phase))
 
 
+def _harness_review_approve_enabled() -> bool:
+    return (
+        os.environ.get("ZOE_PIPELINE_HARNESS_REVIEW_APPROVE", "true") or "true"
+    ).strip().lower() not in {"0", "false", "no"}
+
+
+async def _append_harness_review_approval(state: PipelineState, phase: PipelinePhase) -> PipelineState:
+    """Append objective `human` review-approval evidence when the PR passes review.
+
+    Makes review deterministic: rather than trusting the zoe-reviewer agent (which
+    can spuriously block "no code/evidence"), the harness approves review from
+    objective signals — PR OPEN + all required CI checks green + zero unresolved
+    Greptile review threads, on top of the verify phase having already run the PR's
+    focused tests. No-ops (returns state unchanged) when disabled, when human
+    evidence already exists, when there is no PR, or when the PR is not objectively
+    review-ready (fail-open: the agent-driven flow then applies).
+    """
+    if not _harness_review_approve_enabled():
+        return state
+    if any(item.kind == "human" and item.passed is True for item in state.evidence):
+        return state
+    pr_url = _pr_url_from_state(state)
+    if not pr_url:
+        return state
+    from pipeline_evidence import EvidenceItem
+    from pipeline_review import assess_pr_review_ready
+
+    readiness = await _run_io(partial(assess_pr_review_ready, pr_url))
+    if not readiness.ready:
+        return state
+    return with_evidence(
+        state,
+        EvidenceItem(
+            kind="human",
+            summary=("harness review approval: " + readiness.reason)[:500],
+            passed=True,
+            metadata={
+                "source": "harness",
+                "phase": "review",
+                "approver": "harness",
+                "merge_readiness": "merge_ready",
+            },
+        ),
+    )
+
+
 def _protocol_only_block(detail: dict[str, Any]) -> bool:
     """True when Hermes only failed the terminal protocol for a no-op phase."""
     protocol_seen = False
@@ -767,9 +813,22 @@ async def _sync_pipeline_from_chain_once(
             if can_complete_phase(state):
                 verify_harness_complete = True
 
+        review_harness_complete = False
+        if phase == "review" and row_status in _TERMINAL:
+            # Deterministic review: the zoe-reviewer agent can spuriously block
+            # ("cannot review without code/evidence") even with the PR_URL in its
+            # handoff. Approve review from objective signals instead — PR open +
+            # CI green + zero unresolved Greptile threads, on top of the verify
+            # phase having already run the PR's focused tests. When that satisfies
+            # the evidence gate, complete review regardless of the agent's signal;
+            # otherwise fall through to the agent-derived outcome.
+            state = await _append_harness_review_approval(state, "review")
+            if can_complete_phase(state):
+                review_harness_complete = True
+
         outcome = (
             "complete"
-            if verify_harness_complete
+            if (verify_harness_complete or review_harness_complete)
             else infer_outcome(phase, row_status, detail)  # type: ignore[arg-type]
         )
         if not outcome:

--- a/services/zoe-data/tests/test_pipeline_review.py
+++ b/services/zoe-data/tests/test_pipeline_review.py
@@ -1,0 +1,67 @@
+"""Tests for the harness-side objective review-readiness gate (deterministic review)."""
+
+import json
+
+import pipeline_review as pr
+from pipeline_review import ReviewReadiness, _checks_all_green, _pr_number
+
+
+def test_pr_number_parses_trailing_slash_and_plain():
+    assert _pr_number("https://github.com/o/r/pull/642") == "642"
+    assert _pr_number("https://github.com/o/r/pull/642/") == "642"
+    assert _pr_number("https://github.com/o/r/tree/main") == ""
+
+
+def test_checks_all_green_requires_at_least_one_and_all_green():
+    assert _checks_all_green([{"conclusion": "SUCCESS"}, {"conclusion": "SKIPPED"}]) is True
+    assert _checks_all_green([]) is False  # empty rollup is not trusted as green
+    assert _checks_all_green([{"status": "IN_PROGRESS"}]) is False
+    assert _checks_all_green([{"conclusion": "SUCCESS"}, {"conclusion": "FAILURE"}]) is False
+
+
+def test_assess_no_pr_url():
+    assert pr.assess_pr_review_ready("").ready is False
+
+
+def test_assess_ready_when_open_green_and_no_unresolved(monkeypatch):
+    def fake_run(cmd, *, cwd, timeout=60):
+        if cmd[:3] == ["gh", "pr", "view"]:
+            return 0, json.dumps(
+                {"state": "OPEN", "mergeStateStatus": "CLEAN", "statusCheckRollup": [{"conclusion": "SUCCESS"}]}
+            )
+        return 0, ""
+
+    monkeypatch.setattr(pr, "_run", fake_run)
+    monkeypatch.setattr(pr, "_unresolved_thread_count", lambda n, *, cwd: 0)
+    out = pr.assess_pr_review_ready("https://github.com/o/r/pull/9", repo_root="/tmp")
+    assert out.ready is True
+    assert out.unresolved_threads == 0
+
+
+def test_assess_not_ready_when_unresolved_threads(monkeypatch):
+    def fake_run(cmd, *, cwd, timeout=60):
+        return 0, json.dumps(
+            {"state": "OPEN", "statusCheckRollup": [{"conclusion": "SUCCESS"}]}
+        )
+
+    monkeypatch.setattr(pr, "_run", fake_run)
+    monkeypatch.setattr(pr, "_unresolved_thread_count", lambda n, *, cwd: 2)
+    out = pr.assess_pr_review_ready("https://github.com/o/r/pull/9", repo_root="/tmp")
+    assert out.ready is False
+    assert out.unresolved_threads == 2
+
+
+def test_assess_not_ready_when_ci_pending(monkeypatch):
+    def fake_run(cmd, *, cwd, timeout=60):
+        return 0, json.dumps(
+            {"state": "OPEN", "statusCheckRollup": [{"status": "IN_PROGRESS"}]}
+        )
+
+    monkeypatch.setattr(pr, "_run", fake_run)
+    monkeypatch.setattr(pr, "_unresolved_thread_count", lambda n, *, cwd: 0)
+    assert pr.assess_pr_review_ready("https://github.com/o/r/pull/9", repo_root="/tmp").ready is False
+
+
+def test_assess_fails_open_on_gh_error(monkeypatch):
+    monkeypatch.setattr(pr, "_run", lambda *a, **k: (1, "gh boom"))
+    assert pr.assess_pr_review_ready("https://github.com/o/r/pull/9", repo_root="/tmp").ready is False

--- a/services/zoe-data/tests/test_pipeline_store.py
+++ b/services/zoe-data/tests/test_pipeline_store.py
@@ -1150,6 +1150,74 @@ async def test_harness_verify_failing_tests_do_not_complete(isolated_store, monk
     assert any(e.kind == "test" and e.passed is False for e in state.evidence)
 
 
+def _patch_review_ready(monkeypatch, *, ready: bool):
+    import pipeline_review as prv
+    from pipeline_review import ReviewReadiness
+
+    monkeypatch.setattr(
+        prv,
+        "assess_pr_review_ready",
+        lambda pr_url, *, repo_root=None: ReviewReadiness(ready, "test", 0 if ready else 1),
+    )
+
+
+def _review_chain_fetch_detail():
+    async def fetch_detail(task_id: str):
+        if task_id == "t_impl":
+            return {
+                "latest_summary": "TOOLS_USED=graphify\nPR_URL=https://github.com/o/r/pull/20",
+                "comments": [],
+            }
+        if task_id == "t_verify":
+            return {
+                "latest_summary": "TESTS=pytest 5 passed\nVALIDATORS=validate_structure pass",
+                "comments": [],
+            }
+        return {"latest_summary": "", "comments": []}  # review row
+
+    return fetch_detail
+
+
+@pytest.mark.asyncio
+async def test_harness_review_approves_when_pr_objectively_ready(isolated_store, monkeypatch):
+    # Deterministic review: PR objectively ready (CI green + 0 unresolved) -> the
+    # harness writes human evidence and review completes -> closeout, regardless
+    # of the (here, no-op) review agent signal.
+    monkeypatch.setenv("ZOE_PIPELINE_HARNESS_VERIFY_TESTS", "false")  # isolate the review path
+    _patch_review_ready(monkeypatch, ready=True)
+    await store.bootstrap_state("multica:hr-ok")
+
+    phases = {
+        "implement": {"id": "t_impl", "status": "done"},
+        "verify": {"id": "t_verify", "status": "done"},
+        "review": {"id": "t_review", "status": "done"},
+    }
+    state = await store.sync_pipeline_from_chain("multica:hr-ok", phases, _review_chain_fetch_detail())
+    assert state.phase == "closeout"
+    assert any(
+        e.kind == "human" and e.passed and e.metadata.get("source") == "harness"
+        for e in state.evidence
+    )
+
+
+@pytest.mark.asyncio
+async def test_harness_review_does_not_approve_when_not_ready(isolated_store, monkeypatch):
+    # PR not objectively ready (e.g. unresolved threads) -> no harness approval;
+    # review does not advance to closeout.
+    monkeypatch.setenv("ZOE_PIPELINE_HARNESS_VERIFY_TESTS", "false")
+    _patch_review_ready(monkeypatch, ready=False)
+    await store.bootstrap_state("multica:hr-no")
+
+    phases = {
+        "implement": {"id": "t_impl", "status": "done"},
+        "verify": {"id": "t_verify", "status": "done"},
+        "review": {"id": "t_review", "status": "done"},
+    }
+    state = await store.sync_pipeline_from_chain("multica:hr-no", phases, _review_chain_fetch_detail())
+    assert state.phase == "review"
+    assert not any(e.kind == "human" and e.metadata.get("source") == "harness" for e in state.evidence)
+
+
 @pytest.mark.asyncio
 async def test_sync_pipeline_audit_only_verify_skips_test_gate(isolated_store):
     await store.bootstrap_state("multica:audit-gate")

--- a/services/zoe-data/tests/test_pipeline_store.py
+++ b/services/zoe-data/tests/test_pipeline_store.py
@@ -1219,6 +1219,25 @@ async def test_harness_review_does_not_approve_when_not_ready(isolated_store, mo
 
 
 @pytest.mark.asyncio
+async def test_harness_review_disabled_by_env_does_not_approve(isolated_store, monkeypatch):
+    # Kill switch: ZOE_PIPELINE_HARNESS_REVIEW_APPROVE=false -> no harness approval
+    # even when the PR is objectively ready; review must not advance to closeout.
+    monkeypatch.setenv("ZOE_PIPELINE_HARNESS_VERIFY_TESTS", "false")
+    monkeypatch.setenv("ZOE_PIPELINE_HARNESS_REVIEW_APPROVE", "false")
+    _patch_review_ready(monkeypatch, ready=True)  # ready, but the gate is disabled
+    await store.bootstrap_state("multica:hr-off")
+
+    phases = {
+        "implement": {"id": "t_impl", "status": "done"},
+        "verify": {"id": "t_verify", "status": "done"},
+        "review": {"id": "t_review", "status": "done"},
+    }
+    state = await store.sync_pipeline_from_chain("multica:hr-off", phases, _review_chain_fetch_detail())
+    assert state.phase == "review"
+    assert not any(e.kind == "human" and e.metadata.get("source") == "harness" for e in state.evidence)
+
+
+@pytest.mark.asyncio
 async def test_sync_pipeline_audit_only_verify_skips_test_gate(isolated_store):
     await store.bootstrap_state("multica:audit-gate")
 


### PR DESCRIPTION
## Why
The live proof (ZOE-5830) reached a merged PR, with the **deterministic verify (#632) confirmed working** — but the **review** phase flaked the same way verify used to: the `zoe-reviewer` agent `kanban_block`ed claiming *"cannot review without code/evidence"* even with `PR_URL` in its handoff, stranding an objectively-ready PR (#642) at review. The operator had to drive the final merge. Review was the last non-deterministic, flaky-agent dependency on the idea→merged-PR path.

## What
Apply the #632 pattern to review. When the PR is **OPEN**, **all required CI checks are green**, and **zero unresolved Greptile review threads** remain — on top of the verify phase having already run the PR's focused tests — the harness writes the `human` review-approval evidence itself and completes `review → closeout`, regardless of the agent. Otherwise it falls through to the agent-derived outcome (**fail-open**).

- **`pipeline_review.assess_pr_review_ready(pr_url)`** (new): bounded `gh pr view --json statusCheckRollup` + graphql `reviewThreads`; `ready` iff OPEN + all checks green + 0 unresolved threads; fails open on any gh/parse error.
- **`pipeline_store`**: `_append_harness_review_approval` + a review override in `sync_pipeline_from_chain` mirroring the verify override. Gated by `ZOE_PIPELINE_HARNESS_REVIEW_APPROVE` (default on).

This removes the last flaky-agent dependency from the autonomous path: verify and review are now both objective/harness-driven.

## Testing
- Readiness unit: PR-number parse (incl. trailing slash), all-green rule (empty rollup not trusted), unresolved threads / CI pending / gh-error → not ready (fail-open).
- Integration: objectively-ready PR → harness `human` approval → `review` completes → `closeout`; not ready → review does not advance.
- `pytest -k "pipeline or verify or review or evidence or kanban or focused"` → **603 passed**; structure validator clean.

Builds on #592/#597/#601/#607/#632/#637.

🤖 Generated with [Claude Code](https://claude.com/claude-code)