### PR TITLE
[codex] Accept Pi validated action forms

### DIFF
--- a/services/zoe-data/intent_router.py
+++ b/services/zoe-data/intent_router.py
@@ -32,11 +32,29 @@ logger = logging.getLogger(__name__)
 
 _DAILY_BRIEFING_RESPONSE_CACHE: dict[str, tuple[float, str]] = {}
 _DAILY_BRIEFING_CACHE_TTL_SECONDS = float(os.environ.get("ZOE_DAILY_BRIEFING_CACHE_TTL_SECONDS", "120"))
+_DAILY_BRIEFING_CACHE_MAX_USERS = max(1, int(os.environ.get("ZOE_DAILY_BRIEFING_CACHE_MAX_USERS", "64")))
+
+
+def _daily_briefing_cache_sweep(now: float | None = None) -> None:
+    if not _DAILY_BRIEFING_RESPONSE_CACHE:
+        return
+    current = time.time() if now is None else now
+    expired = [
+        user_id
+        for user_id, (stored_at, _response) in _DAILY_BRIEFING_RESPONSE_CACHE.items()
+        if (current - stored_at) > _DAILY_BRIEFING_CACHE_TTL_SECONDS
+    ]
+    for user_id in expired:
+        _DAILY_BRIEFING_RESPONSE_CACHE.pop(user_id, None)
+    while len(_DAILY_BRIEFING_RESPONSE_CACHE) > _DAILY_BRIEFING_CACHE_MAX_USERS:
+        oldest_user = min(_DAILY_BRIEFING_RESPONSE_CACHE, key=lambda key: _DAILY_BRIEFING_RESPONSE_CACHE[key][0])
+        _DAILY_BRIEFING_RESPONSE_CACHE.pop(oldest_user, None)
 
 
 def _daily_briefing_cache_get(user_id: str) -> Optional[str]:
     if _DAILY_BRIEFING_CACHE_TTL_SECONDS <= 0:
         return None
+    _daily_briefing_cache_sweep()
     cached = _DAILY_BRIEFING_RESPONSE_CACHE.get(user_id)
     if not cached:
         return None
@@ -50,7 +68,9 @@ def _daily_briefing_cache_get(user_id: str) -> Optional[str]:
 def _daily_briefing_cache_set(user_id: str, response: str) -> None:
     if _DAILY_BRIEFING_CACHE_TTL_SECONDS <= 0 or not response:
         return
+    _daily_briefing_cache_sweep()
     _DAILY_BRIEFING_RESPONSE_CACHE[user_id] = (time.time(), response)
+    _daily_briefing_cache_sweep()
 
 
 def _daily_briefing_cached_weather() -> Optional[dict]:

--- a/services/zoe-data/pi_hybrid_production.py
+++ b/services/zoe-data/pi_hybrid_production.py
@@ -463,6 +463,8 @@ def _acceptance_decision(result: Mapping[str, Any], config: PiHybridProductionCo
         agreement_kind = "zoe_router"
     elif speculative_state == "used" and safe.get("validated_by_pi"):
         agreement_kind = "intent_buffer_hint"
+    elif intent in SAFE_ACTION_FORM_INTENTS and safe.get("validated_by_pi"):
+        agreement_kind = "pi_validated_action_form"
     elif not config.require_agreement:
         agreement_kind = "pi_only"
     else:

--- a/services/zoe-data/pi_hybrid_production.py
+++ b/services/zoe-data/pi_hybrid_production.py
@@ -60,6 +60,7 @@ _TIMER_SIGNAL_RE = re.compile(
     r"\s*(?:second|seconds|minute|minutes|hour|hours|min|mins|hr|hrs)\b",
     re.I,
 )
+_PI_AUDIT_TASKS: set[asyncio.Task[Any]] = set()
 
 
 @dataclass(frozen=True)
@@ -135,6 +136,11 @@ class PiHybridProductionConfig:
             "min_swap_free_mb": self.min_swap_free_mb,
             "router_fast_accept_enabled": self.router_fast_accept_enabled,
             "attempt_all_requests_enabled": self.attempt_all_requests_enabled,
+            "fast_accept_posture": (
+                "router_speculative_pi_audited"
+                if self.router_fast_accept_enabled
+                else "pi_gated_before_response"
+            ),
         }
 
 
@@ -151,8 +157,8 @@ async def try_pi_hybrid_production(
     active_config.validate()
     stripped = (text or "").strip()
 
-    def _with_evidence(decision: dict[str, Any]) -> dict[str, Any]:
-        _record_production_evidence(stripped, user_id=user_id, decision=decision, env=env)
+    async def _with_evidence(decision: dict[str, Any]) -> dict[str, Any]:
+        await asyncio.to_thread(_record_production_evidence, stripped, user_id=user_id, decision=decision, env=env)
         return decision
 
     base = {
@@ -168,13 +174,13 @@ async def try_pi_hybrid_production(
     eligible, reason = pi_hybrid_production_eligible(stripped, config=active_config)
     if not eligible:
         base["reason"] = reason
-        return _with_evidence(base)
+        return await _with_evidence(base)
 
     pressure = await _resource_pressure(active_config)
     if pressure:
         base["reason"] = "resource_pressure"
         base["resource"] = pressure
-        return _with_evidence(base)
+        return await _with_evidence(base)
 
     if active_config.router_fast_accept_enabled:
         fast = await _try_router_confirmed_fast_accept(
@@ -192,7 +198,7 @@ async def try_pi_hybrid_production(
                 env=env,
                 fast_decision=fast,
             )
-            return _with_evidence({
+            return await _with_evidence({
                 **base,
                 **fast,
                 "response_text": str(fast.get("response_text") or ""),
@@ -219,19 +225,19 @@ async def try_pi_hybrid_production(
         )
     except asyncio.TimeoutError:
         base["reason"] = "timeout"
-        return _with_evidence(base)
+        return await _with_evidence(base)
     except ValueError as exc:
         base["reason"] = "validation_error"
         base["error"] = str(exc)
-        return _with_evidence(base)
+        return await _with_evidence(base)
     except Exception as exc:  # pragma: no cover - production guard must fall back closed
         base["reason"] = "exception"
         base["error"] = exc.__class__.__name__
-        return _with_evidence(base)
+        return await _with_evidence(base)
 
     decision = _acceptance_decision(result, active_config)
     response_text = str(decision.get("response_text") or "")
-    return _with_evidence({
+    return await _with_evidence({
         **base,
         **decision,
         "response_text": response_text,
@@ -358,7 +364,8 @@ def _schedule_pi_audit_after_fast_accept(
                         fast_decision.get("intent"),
                         pi.get("intent"),
                     )
-                    _record_production_evidence(
+                    await asyncio.to_thread(
+                        _record_production_evidence,
                         text,
                         user_id=user_id,
                         decision={
@@ -378,7 +385,9 @@ def _schedule_pi_audit_after_fast_accept(
         except Exception:
             return
 
-    asyncio.create_task(_runner())
+    task = asyncio.create_task(_runner())
+    _PI_AUDIT_TASKS.add(task)
+    task.add_done_callback(_PI_AUDIT_TASKS.discard)
 
 
 def pi_hybrid_production_eligible(text: str, *, config: PiHybridProductionConfig | None = None) -> tuple[bool, str]:

--- a/services/zoe-data/pi_intent_lab.py
+++ b/services/zoe-data/pi_intent_lab.py
@@ -488,7 +488,9 @@ async def _safe_fulfill_pi_intent(
             and speculative_slots == pi_slots
             and isinstance(speculative_task, asyncio.Task)
         ):
-            return await _await_speculative_safe_fulfillment(speculative, timeout_seconds=timeout_seconds)
+            result = await _await_speculative_safe_fulfillment(speculative, timeout_seconds=timeout_seconds)
+            result["validated_by_pi"] = bool(result.get("allowed") and not result.get("timed_out") and not result.get("error"))
+            return result
         reason = "speculative_slots_mismatch" if speculative_intent == intent_name else "speculative_pi_disagreed"
         discarded_speculative = await _discard_speculative_safe_fulfillment(
             speculative,
@@ -504,6 +506,7 @@ async def _safe_fulfill_pi_intent(
         timeout_seconds=timeout_seconds,
         started_before_pi=False,
     )
+    result["validated_by_pi"] = bool(result.get("allowed") and not result.get("timed_out") and not result.get("error"))
     if discarded_speculative is not None:
         result["speculative_safe_fulfillment"] = "discarded"
         result["speculative_intent"] = discarded_speculative.get("speculative_intent")

--- a/services/zoe-data/tests/test_daily_briefing_concurrency.py
+++ b/services/zoe-data/tests/test_daily_briefing_concurrency.py
@@ -130,6 +130,26 @@ async def test_daily_briefing_uses_short_response_cache(monkeypatch):
     _DAILY_BRIEFING_RESPONSE_CACHE.clear()
 
 
+def test_daily_briefing_cache_evicts_oldest_when_capped(monkeypatch):
+    from intent_router import (
+        _DAILY_BRIEFING_RESPONSE_CACHE,
+        _daily_briefing_cache_set,
+    )
+
+    _DAILY_BRIEFING_RESPONSE_CACHE.clear()
+    monkeypatch.setattr("intent_router._DAILY_BRIEFING_CACHE_TTL_SECONDS", 120)
+    monkeypatch.setattr("intent_router._DAILY_BRIEFING_CACHE_MAX_USERS", 2)
+
+    try:
+        _daily_briefing_cache_set("user-1", "one")
+        _daily_briefing_cache_set("user-2", "two")
+        _daily_briefing_cache_set("user-3", "three")
+
+        assert set(_DAILY_BRIEFING_RESPONSE_CACHE) == {"user-2", "user-3"}
+    finally:
+        _DAILY_BRIEFING_RESPONSE_CACHE.clear()
+
+
 @pytest.mark.asyncio
 async def test_daily_briefing_weather_uses_router_weather_cache(monkeypatch):
     from intent_router import _daily_briefing_weather

--- a/services/zoe-data/tests/test_pi_hybrid_production.py
+++ b/services/zoe-data/tests/test_pi_hybrid_production.py
@@ -249,15 +249,20 @@ async def test_try_pi_hybrid_fast_accept_records_audit_disagreement(tmp_path, mo
             "ZOE_PI_HYBRID_PRODUCTION_EVIDENCE_PATH": str(evidence_path),
         },
     )
+    assert pi_hybrid_production._PI_AUDIT_TASKS
     await asyncio.sleep(0.01)
 
     assert decision["accepted"] is True
     records = [json.loads(line) for line in evidence_path.read_text(encoding="utf-8").splitlines()]
-    assert records[0]["accepted"] is True
-    assert records[1]["accepted"] is False
-    assert records[1]["reason"] == "audit_disagreement"
-    assert records[1]["intent"] == "weather"
-    assert records[1]["pi_intent"] == "daily_briefing"
+    accepted = [record for record in records if record.get("accepted") is True]
+    disagreements = [record for record in records if record.get("reason") == "audit_disagreement"]
+
+    assert len(accepted) == 1
+    assert len(disagreements) == 1
+    assert disagreements[0]["accepted"] is False
+    assert disagreements[0]["intent"] == "weather"
+    assert disagreements[0]["pi_intent"] == "daily_briefing"
+    assert not pi_hybrid_production._PI_AUDIT_TASKS
 
 
 def test_router_fast_accept_and_attempt_all_require_explicit_env_opt_in():
@@ -273,6 +278,7 @@ def test_router_fast_accept_and_attempt_all_require_explicit_env_opt_in():
 
     assert config.router_fast_accept_enabled is True
     assert config.attempt_all_requests_enabled is True
+    assert config.to_dict()["fast_accept_posture"] == "router_speculative_pi_audited"
 
 
 @pytest.mark.asyncio

--- a/services/zoe-data/tests/test_pi_hybrid_production.py
+++ b/services/zoe-data/tests/test_pi_hybrid_production.py
@@ -579,6 +579,37 @@ async def test_try_pi_hybrid_records_rejected_production_evidence_when_enabled(t
 
 
 @pytest.mark.asyncio
+async def test_try_pi_hybrid_accepts_pi_validated_timer_action_form_when_router_misses(monkeypatch):
+    _install_prefilter(monkeypatch)
+
+    async def fake_compare(text, **kwargs):
+        result = _accepted_lab_result(intent="timer_create", response="Timer is ready to confirm.", router_intent=None)
+        result["zoe_router"] = {"intent": None, "route_class": "fallback", "baseline_kind": "router_only_not_comparable"}
+        result["safe_fulfillment"]["validated_by_pi"] = True
+        result["safe_fulfillment"]["execution_scope"] = "action_form_prefill"
+        result["safe_fulfillment"]["would_execute"] = False
+        result["safe_fulfillment"]["action_form"] = {
+            "component": "timer_create_form",
+            "prefill": {"duration": "ten minute"},
+        }
+        return result
+
+    monkeypatch.setattr(pi_hybrid_production, "compare_pi_intent_lab", fake_compare)
+    monkeypatch.setattr(pi_hybrid_production, "_read_meminfo_mb", lambda: {"MemAvailable": 99999, "SwapFree": 99999})
+
+    decision = await try_pi_hybrid_production(
+        "set a ten minute timer",
+        user_id="jason",
+        config=PiHybridProductionConfig(enabled=True, groups=("timers",), require_agreement=True),
+    )
+
+    assert decision["accepted"] is True
+    assert decision["agreement_kind"] == "pi_validated_action_form"
+    assert decision["execution_scope"] == "action_form_prefill"
+    assert decision["action_form"] == {"component": "timer_create_form", "prefill": {"duration": "ten minute"}}
+
+
+@pytest.mark.asyncio
 async def test_try_pi_hybrid_accepts_timer_as_action_form_prefill(monkeypatch):
     _install_prefilter(monkeypatch)
 

--- a/services/zoe-data/tests/test_pi_hybrid_production.py
+++ b/services/zoe-data/tests/test_pi_hybrid_production.py
@@ -604,6 +604,7 @@ async def test_try_pi_hybrid_accepts_pi_validated_timer_action_form_when_router_
     )
 
     assert decision["accepted"] is True
+    assert decision["intent"] == "timer_create"
     assert decision["agreement_kind"] == "pi_validated_action_form"
     assert decision["execution_scope"] == "action_form_prefill"
     assert decision["action_form"] == {"component": "timer_create_form", "prefill": {"duration": "ten minute"}}

--- a/services/zoe-data/tests/test_pi_intent_lab.py
+++ b/services/zoe-data/tests/test_pi_intent_lab.py
@@ -752,7 +752,7 @@ async def test_lab_discards_speculative_safe_fulfillment_when_pi_slots_differ(mo
 
     assert [call["intent"].slots for call in calls] == [{"forecast": False}, {"forecast": True}]
     assert result["safe_fulfillment"]["started_before_pi"] is False
-    assert result["safe_fulfillment"]["validated_by_pi"] is False
+    assert result["safe_fulfillment"]["validated_by_pi"] is True
     assert result["safe_fulfillment"]["speculative_safe_fulfillment"] == "discarded"
     assert result["safe_fulfillment"]["speculative_intent"] == "weather"
     assert result["safe_fulfillment"]["speculative_discard_reason"] == "speculative_slots_mismatch"


### PR DESCRIPTION
## Summary
- mark Pi-owned safe fulfillment results as validated by Pi
- allow accepted action-form fulfillment when Zoe router misses but Pi safely prefills the form
- add regression coverage for timer_create action-form acceptance

## Tests
- python3 -m pytest -q services/zoe-data/tests/test_pi_hybrid_production.py services/zoe-data/tests/test_pi_intent_lab.py services/zoe-data/tests/test_chat_pi_hybrid_action_form.py
- python3 tools/audit/validate_structure.py