### PR TITLE
fix(harness): review approves on CI-green only; closeout owns Greptile threads

### DIFF
--- a/services/zoe-data/pipeline_review.py
+++ b/services/zoe-data/pipeline_review.py
@@ -2,11 +2,18 @@
 
 The review phase normally depends on the zoe-reviewer agent grading the diff and
 self-approving. That agent is unreliable (it can block claiming "no code/evidence"
-even with the PR_URL in its handoff). This module lets the harness make the
-review decision from objective signals instead: the PR is OPEN, every required CI
-check is green, and Greptile left zero unresolved review threads (i.e. Greptile
-reviewed and is satisfied). Combined with the verify phase having already run the
-PR's focused tests, that is a strong, deterministic proxy for "review approved".
+even with the PR_URL in its handoff, or complete with an empty verdict). This
+module lets the harness make the review decision from objective signals instead:
+the PR is OPEN and every required CI check is green. Combined with the verify
+phase having already run the PR's focused tests, that is a deterministic proxy
+for "review approved".
+
+Greptile review threads / confidence are intentionally NOT gated here. A fresh
+implement PR almost always has open Greptile threads AT REVIEW TIME (Greptile
+auto-reviews every PR); those are resolved in CLOSEOUT by the greploop merge
+guard, which already gates the merge on confidence + zero unresolved threads.
+Gating them at review too is a chicken-and-egg deadlock (review would never
+approve a normal PR), so the thread/confidence gate lives only at closeout.
 
 Mirrors pipeline_validators / pipeline_focused_tests: bounded subprocess gh calls,
 fails OPEN (ready=False) on any error so the agent-driven flow still applies.
@@ -22,14 +29,12 @@ from hermes_http import zoe_repo_root
 
 _GH_TIMEOUT_S = 60
 _GREEN = {"SUCCESS", "NEUTRAL", "SKIPPED", "COMPLETED"}
-_OWNER_REPO = "jason-easyazz/zoe-ai-assistant"
 
 
 @dataclass(frozen=True)
 class ReviewReadiness:
     ready: bool
     reason: str
-    unresolved_threads: int | None = None
 
 
 def _run(cmd: list[str], *, cwd: str, timeout: int = _GH_TIMEOUT_S) -> tuple[int, str]:
@@ -40,11 +45,6 @@ def _run(cmd: list[str], *, cwd: str, timeout: int = _GH_TIMEOUT_S) -> tuple[int
     except (OSError, subprocess.TimeoutExpired) as exc:
         return 1, str(exc)
     return proc.returncode, ((proc.stdout or "") + (proc.stderr or "")).strip()
-
-
-def _pr_number(pr_url: str) -> str:
-    tail = pr_url.rstrip("/").rsplit("/", 1)[-1]
-    return tail if tail.isdigit() else ""
 
 
 def _checks_all_green(rollup: list) -> bool:
@@ -59,37 +59,16 @@ def _checks_all_green(rollup: list) -> bool:
     return saw_one  # empty rollup is not trusted as green
 
 
-def _unresolved_thread_count(pr_number: str, *, cwd: str) -> int | None:
-    query = (
-        "{ repository(owner:\"jason-easyazz\", name:\"zoe-ai-assistant\") { pullRequest(number:"
-        + pr_number
-        + ") { reviewThreads(first:100) { nodes { isResolved } pageInfo { hasNextPage } } } } }"
-    )
-    code, out = _run(["gh", "api", "graphql", "-f", f"query={query}"], cwd=cwd)
-    if code != 0 or not out:
-        return None
-    try:
-        threads = json.loads(out)["data"]["repository"]["pullRequest"]["reviewThreads"]
-        nodes = threads["nodes"]
-    except (ValueError, TypeError, KeyError):
-        return None
-    # Fail open (treat as unknown) when there are more thread pages than we
-    # fetched, so a PR with >100 threads can't be silently approved on a partial
-    # page that happens to show all-resolved.
-    if (threads.get("pageInfo") or {}).get("hasNextPage"):
-        return None
-    return sum(1 for t in nodes if not t.get("isResolved"))
-
-
 def assess_pr_review_ready(pr_url: str, *, repo_root: str | None = None) -> ReviewReadiness:
-    """Objective review gate: PR OPEN + all required checks green + 0 unresolved
-    Greptile review threads. Fails open (ready=False) on any error."""
+    """Objective review gate: PR OPEN + all required CI checks green.
+
+    Greptile threads/confidence are owned by the closeout greploop merge gate,
+    NOT review (see module docstring). Fails open (ready=False) on any error so
+    the agent-driven review flow still applies.
+    """
     pr_url = (pr_url or "").strip()
     if not pr_url:
         return ReviewReadiness(False, "no PR_URL")
-    pr_number = _pr_number(pr_url)
-    if not pr_number:
-        return ReviewReadiness(False, "could not parse PR number")
     root = repo_root or zoe_repo_root()
 
     code, out = _run(
@@ -107,14 +86,4 @@ def assess_pr_review_ready(pr_url: str, *, repo_root: str | None = None) -> Revi
     if not _checks_all_green(data.get("statusCheckRollup") or []):
         return ReviewReadiness(False, "CI checks not all green")
 
-    unresolved = _unresolved_thread_count(pr_number, cwd=root)
-    if unresolved is None:
-        return ReviewReadiness(False, "could not read review threads")
-    if unresolved > 0:
-        return ReviewReadiness(False, f"{unresolved} unresolved review threads", unresolved)
-
-    return ReviewReadiness(
-        True,
-        "CI green + 0 unresolved Greptile threads + verify passed",
-        unresolved,
-    )
+    return ReviewReadiness(True, "CI green + verify passed (Greptile threads owned by closeout)")

--- a/services/zoe-data/pipeline_store.py
+++ b/services/zoe-data/pipeline_store.py
@@ -501,12 +501,14 @@ async def _append_harness_review_approval(state: PipelineState, phase: PipelineP
     """Append objective `human` review-approval evidence when the PR passes review.
 
     Makes review deterministic: rather than trusting the zoe-reviewer agent (which
-    can spuriously block "no code/evidence"), the harness approves review from
-    objective signals — PR OPEN + all required CI checks green + zero unresolved
-    Greptile review threads, on top of the verify phase having already run the PR's
-    focused tests. No-ops (returns state unchanged) when disabled, when human
-    evidence already exists, when there is no PR, or when the PR is not objectively
-    review-ready (fail-open: the agent-driven flow then applies).
+    can spuriously block "no code/evidence" or complete with an empty verdict), the
+    harness approves review from objective signals — PR OPEN + all required CI
+    checks green, on top of the verify phase having already run the PR's focused
+    tests. Greptile threads/confidence are owned by the closeout greploop merge
+    gate, NOT review (gating them here deadlocks, since a fresh PR has open Greptile
+    threads at review time). No-ops (returns state unchanged) when disabled, when
+    human evidence already exists, when there is no PR, or when the PR is not
+    objectively review-ready (fail-open: the agent-driven flow then applies).
     """
     if not _harness_review_approve_enabled():
         return state

--- a/services/zoe-data/tests/test_pipeline_review.py
+++ b/services/zoe-data/tests/test_pipeline_review.py
@@ -1,15 +1,20 @@
-"""Tests for the harness-side objective review-readiness gate (deterministic review)."""
+"""Tests for the harness-side objective review-readiness gate (deterministic review).
+
+Review approves on PR OPEN + all CI checks green. Greptile threads/confidence are
+deliberately NOT gated here (owned by the closeout greploop merge gate), so a
+fresh PR with open Greptile threads can still be review-approved.
+"""
 
 import json
 
 import pipeline_review as pr
-from pipeline_review import ReviewReadiness, _checks_all_green, _pr_number
+from pipeline_review import _checks_all_green
 
 
-def test_pr_number_parses_trailing_slash_and_plain():
-    assert _pr_number("https://github.com/o/r/pull/642") == "642"
-    assert _pr_number("https://github.com/o/r/pull/642/") == "642"
-    assert _pr_number("https://github.com/o/r/tree/main") == ""
+def _patch_pr_view(monkeypatch, payload: dict):
+    monkeypatch.setattr(
+        pr, "_run", lambda cmd, *, cwd, timeout=60: (0, json.dumps(payload))
+    )
 
 
 def test_checks_all_green_requires_at_least_one_and_all_green():
@@ -23,42 +28,32 @@ def test_assess_no_pr_url():
     assert pr.assess_pr_review_ready("").ready is False
 
 
-def test_assess_ready_when_open_green_and_no_unresolved(monkeypatch):
-    def fake_run(cmd, *, cwd, timeout=60):
-        if cmd[:3] == ["gh", "pr", "view"]:
-            return 0, json.dumps(
-                {"state": "OPEN", "mergeStateStatus": "CLEAN", "statusCheckRollup": [{"conclusion": "SUCCESS"}]}
-            )
-        return 0, ""
-
-    monkeypatch.setattr(pr, "_run", fake_run)
-    monkeypatch.setattr(pr, "_unresolved_thread_count", lambda n, *, cwd: 0)
-    out = pr.assess_pr_review_ready("https://github.com/o/r/pull/9", repo_root="/tmp")
-    assert out.ready is True
-    assert out.unresolved_threads == 0
+def test_assess_ready_when_open_and_green(monkeypatch):
+    _patch_pr_view(
+        monkeypatch,
+        {"state": "OPEN", "mergeStateStatus": "CLEAN", "statusCheckRollup": [{"conclusion": "SUCCESS"}]},
+    )
+    assert pr.assess_pr_review_ready("https://github.com/o/r/pull/9", repo_root="/tmp").ready is True
 
 
-def test_assess_not_ready_when_unresolved_threads(monkeypatch):
-    def fake_run(cmd, *, cwd, timeout=60):
-        return 0, json.dumps(
-            {"state": "OPEN", "statusCheckRollup": [{"conclusion": "SUCCESS"}]}
-        )
-
-    monkeypatch.setattr(pr, "_run", fake_run)
-    monkeypatch.setattr(pr, "_unresolved_thread_count", lambda n, *, cwd: 2)
-    out = pr.assess_pr_review_ready("https://github.com/o/r/pull/9", repo_root="/tmp")
-    assert out.ready is False
-    assert out.unresolved_threads == 2
+def test_assess_ready_does_not_query_or_gate_on_threads(monkeypatch):
+    # A fresh PR normally has an open Greptile thread at review time; review must
+    # still approve on green CI (the thread is the closeout gate's job). The module
+    # no longer has any thread-counting path.
+    _patch_pr_view(
+        monkeypatch, {"state": "OPEN", "statusCheckRollup": [{"conclusion": "SUCCESS"}]}
+    )
+    assert pr.assess_pr_review_ready("https://github.com/o/r/pull/9", repo_root="/tmp").ready is True
+    assert not hasattr(pr, "_unresolved_thread_count")
 
 
 def test_assess_not_ready_when_ci_pending(monkeypatch):
-    def fake_run(cmd, *, cwd, timeout=60):
-        return 0, json.dumps(
-            {"state": "OPEN", "statusCheckRollup": [{"status": "IN_PROGRESS"}]}
-        )
+    _patch_pr_view(monkeypatch, {"state": "OPEN", "statusCheckRollup": [{"status": "IN_PROGRESS"}]})
+    assert pr.assess_pr_review_ready("https://github.com/o/r/pull/9", repo_root="/tmp").ready is False
 
-    monkeypatch.setattr(pr, "_run", fake_run)
-    monkeypatch.setattr(pr, "_unresolved_thread_count", lambda n, *, cwd: 0)
+
+def test_assess_not_ready_when_pr_not_open(monkeypatch):
+    _patch_pr_view(monkeypatch, {"state": "MERGED", "statusCheckRollup": [{"conclusion": "SUCCESS"}]})
     assert pr.assess_pr_review_ready("https://github.com/o/r/pull/9", repo_root="/tmp").ready is False
 
 

--- a/services/zoe-data/tests/test_pipeline_store.py
+++ b/services/zoe-data/tests/test_pipeline_store.py
@@ -1157,7 +1157,7 @@ def _patch_review_ready(monkeypatch, *, ready: bool):
     monkeypatch.setattr(
         prv,
         "assess_pr_review_ready",
-        lambda pr_url, *, repo_root=None: ReviewReadiness(ready, "test", 0 if ready else 1),
+        lambda pr_url, *, repo_root=None: ReviewReadiness(ready, "test"),
     )
 
 


### PR DESCRIPTION
## Why
The deterministic review (#672) gate required **0 unresolved Greptile threads at review time**. Live (ZOE-5831 / PR #674) that deadlocked: a fresh implement PR has an open Greptile thread at review (Greptile auto-reviews every PR), and those threads are resolved in **closeout** by the greploop merge guard — which runs *after* review. So review could never deterministically approve a normal PR; it fell back to the flaky `zoe-reviewer` agent and bounced `request_changes`.

## Fix
Put the thread/confidence gate only where it belongs — the **closeout greploop merge guard** (which already enforces Greptile confidence + 0 unresolved before merging). Have **review** approve on the objective signals it can actually satisfy at review time: **PR OPEN + all required CI checks green** (verify already ran the focused tests). Removed `_unresolved_thread_count` and the unresolved-threads field from `pipeline_review`.

## Testing
- review-ready on open + green CI (no thread query at all);
- still review-ready with an open Greptile thread present;
- not-ready on CI-pending / PR-not-open / gh-error (fail-open).
- `pytest test_pipeline_review.py test_pipeline_store.py` → 60 passed.

Follow-up to #672; builds on #592/#597/#601/#607/#632/#637/#672.

🤖 Generated with [Claude Code](https://claude.com/claude-code)