### PR TITLE
feat(harness): deterministic closeout - harness runs the greploop merge

### DIFF
--- a/services/zoe-data/pipeline_closeout.py
+++ b/services/zoe-data/pipeline_closeout.py
@@ -1,0 +1,101 @@
+"""Run the closeout merge (greploop guard) harness-side, for deterministic closeout.
+
+The closeout phase's job is to run the greploop merge guard (resolve Greptile
+findings to target confidence, then squash-merge when CLEAN + green + zero
+unresolved threads). That depended on a closeout agent worker actually invoking
+the guard script — which is unreliable (observed live: the worker bailed with
+"cannot proceed without a valid PR URL"). This module lets the harness invoke the
+exact same proven guard CLI directly and confirm the merge, so closeout doesn't
+hinge on a flaky agent.
+
+The guard itself enforces safety (squash-only, never --admin/--force, holds on
+GREPTILE_CONFIDENCE / UNRESOLVED_THREADS / GH_NOT_MERGEABLE). This wrapper only
+runs it and then checks whether the PR actually ended up MERGED. Bounded
+subprocess timeout; fails OPEN (merged=False) on any error so the agent-driven
+closeout flow still applies.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from dataclasses import dataclass
+
+from hermes_http import zoe_repo_root
+
+_GUARD_REL = "scripts/maintenance/run_greploop_guard.sh"
+_GUARD_TIMEOUT_S = 900
+_GH_TIMEOUT_S = 60
+
+
+@dataclass(frozen=True)
+class CloseoutResult:
+    merged: bool
+    merge_sha: str | None
+    reason: str
+
+
+def _pr_number(pr_url: str) -> str:
+    tail = (pr_url or "").rstrip("/").rsplit("/", 1)[-1]
+    return tail if tail.isdigit() else ""
+
+
+def _run(cmd: list[str], *, cwd: str, timeout: int) -> tuple[int, str]:
+    try:
+        proc = subprocess.run(
+            cmd, cwd=cwd, capture_output=True, text=True, timeout=timeout, check=False
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return 1, str(exc)
+    return proc.returncode, ((proc.stdout or "") + (proc.stderr or "")).strip()
+
+
+def _merge_state(pr_url: str, *, cwd: str) -> tuple[str, str | None]:
+    """Return (state, merge_commit_oid) for the PR via gh."""
+    code, out = _run(
+        ["gh", "pr", "view", pr_url, "--json", "state,mergeCommit"], cwd=cwd, timeout=_GH_TIMEOUT_S
+    )
+    if code != 0 or not out:
+        return "", None
+    try:
+        data = json.loads(out)
+    except (ValueError, TypeError):
+        return "", None
+    state = str(data.get("state") or "").upper()
+    mc = data.get("mergeCommit") or {}
+    return state, (mc.get("oid") if isinstance(mc, dict) else None)
+
+
+def run_closeout_merge(pr_url: str, *, repo_root: str | None = None) -> CloseoutResult:
+    """Invoke the greploop guard (--merge-when-ready) on the PR and confirm the merge.
+
+    Returns merged=True with the merge SHA when the PR ends up MERGED, else
+    merged=False with the guard/state reason. Fails open (merged=False) on any
+    missing-PR / script / gh error.
+    """
+    pr_url = (pr_url or "").strip()
+    if not pr_url:
+        return CloseoutResult(False, None, "no PR_URL")
+    if not _pr_number(pr_url):
+        return CloseoutResult(False, None, "could not parse PR number")
+    root = repo_root or zoe_repo_root()
+    guard = os.path.join(root, _GUARD_REL)
+    if not os.path.exists(guard):
+        return CloseoutResult(False, None, f"guard script missing: {_GUARD_REL}")
+
+    # Short-circuit: already merged?
+    state, sha = _merge_state(pr_url, cwd=root)
+    if state == "MERGED":
+        return CloseoutResult(True, sha, "already merged")
+
+    # Run the proven guard CLI (it owns confidence/threads/squash-merge safety).
+    code, out = _run(
+        [guard, "--pr", _pr_number(pr_url), "--merge-when-ready"], cwd=root, timeout=_GUARD_TIMEOUT_S
+    )
+
+    # Authoritative check: did the PR actually merge?
+    state, sha = _merge_state(pr_url, cwd=root)
+    if state == "MERGED":
+        return CloseoutResult(True, sha, "merged by greploop guard")
+    return CloseoutResult(False, None, f"guard did not merge (exit {code}); tail: {out[-200:]}")

--- a/services/zoe-data/pipeline_closeout.py
+++ b/services/zoe-data/pipeline_closeout.py
@@ -52,14 +52,27 @@ def _run(cmd: list[str], *, cwd: str, timeout: int) -> tuple[int, str]:
 
 
 def _merge_state(pr_url: str, *, cwd: str) -> tuple[str, str | None]:
-    """Return (state, merge_commit_oid) for the PR via gh."""
-    code, out = _run(
-        ["gh", "pr", "view", pr_url, "--json", "state,mergeCommit"], cwd=cwd, timeout=_GH_TIMEOUT_S
-    )
-    if code != 0 or not out:
+    """Return (state, merge_commit_oid) for the PR via gh.
+
+    Parses gh's STDOUT only — `gh pr view --json` writes JSON to stdout, and any
+    stderr notice (login/deprecation warnings) must not corrupt the JSON parse,
+    which would otherwise make the harness wrongly report the PR as not-merged.
+    """
+    try:
+        proc = subprocess.run(
+            ["gh", "pr", "view", pr_url, "--json", "state,mergeCommit"],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=_GH_TIMEOUT_S,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return "", None
+    if proc.returncode != 0 or not (proc.stdout or "").strip():
         return "", None
     try:
-        data = json.loads(out)
+        data = json.loads(proc.stdout)
     except (ValueError, TypeError):
         return "", None
     state = str(data.get("state") or "").upper()

--- a/services/zoe-data/pipeline_store.py
+++ b/services/zoe-data/pipeline_store.py
@@ -539,6 +539,54 @@ async def _append_harness_review_approval(state: PipelineState, phase: PipelineP
     )
 
 
+def _harness_closeout_merge_enabled() -> bool:
+    return (
+        os.environ.get("ZOE_PIPELINE_HARNESS_CLOSEOUT_MERGE", "true") or "true"
+    ).strip().lower() not in {"0", "false", "no"}
+
+
+async def _append_harness_closeout_merge(state: PipelineState, phase: PipelinePhase) -> PipelineState:
+    """Run the greploop merge guard harness-side and append `greptile` evidence on merge.
+
+    Makes closeout deterministic: rather than trusting the closeout agent worker to
+    invoke the greploop guard (it can bail "no valid PR URL"), the harness runs the
+    proven guard CLI itself (which owns confidence/threads/squash-merge safety) and,
+    when the PR ends up MERGED, records the closeout `greptile` evidence with the
+    merge SHA. No-ops (returns state unchanged) when disabled, when closeout greptile
+    evidence already exists, when there is no PR, or when the guard did not merge
+    (fail-open: the agent-driven closeout flow then applies and can retry next cycle).
+    """
+    if not _harness_closeout_merge_enabled():
+        return state
+    if any(
+        item.kind == "greptile" and item.passed is True and item.metadata.get("phase") == phase
+        for item in state.evidence
+    ):
+        return state
+    pr_url = _pr_url_from_state(state)
+    if not pr_url:
+        return state
+    from pipeline_closeout import run_closeout_merge
+
+    result = await _run_io(partial(run_closeout_merge, pr_url))
+    if not result.merged:
+        return state
+    return with_evidence(
+        state,
+        EvidenceItem(
+            kind="greptile",
+            summary=("harness closeout merge: " + result.reason)[:500],
+            artifact=pr_url,
+            passed=True,
+            metadata={
+                "source": "harness",
+                "phase": "closeout",
+                "merge_sha": result.merge_sha,
+            },
+        ),
+    )
+
+
 def _protocol_only_block(detail: dict[str, Any]) -> bool:
     """True when Hermes only failed the terminal protocol for a no-op phase."""
     protocol_seen = False
@@ -828,9 +876,21 @@ async def _sync_pipeline_from_chain_once(
             if can_complete_phase(state):
                 review_harness_complete = True
 
+        closeout_harness_complete = False
+        if phase == "closeout" and row_status in _TERMINAL:
+            # Deterministic closeout: the closeout agent worker can fail to invoke
+            # the greploop merge guard (observed: "cannot proceed without a valid
+            # PR URL"). Run the proven guard CLI harness-side; when it merges the
+            # PR, record the closeout greptile evidence and complete closeout
+            # regardless of the agent's signal. Otherwise fall through to the
+            # agent-derived outcome (and retry next cycle).
+            state = await _append_harness_closeout_merge(state, "closeout")
+            if can_complete_phase(state):
+                closeout_harness_complete = True
+
         outcome = (
             "complete"
-            if (verify_harness_complete or review_harness_complete)
+            if (verify_harness_complete or review_harness_complete or closeout_harness_complete)
             else infer_outcome(phase, row_status, detail)  # type: ignore[arg-type]
         )
         if not outcome:

--- a/services/zoe-data/pipeline_store.py
+++ b/services/zoe-data/pipeline_store.py
@@ -580,7 +580,7 @@ async def _append_harness_closeout_merge(state: PipelineState, phase: PipelinePh
             passed=True,
             metadata={
                 "source": "harness",
-                "phase": "closeout",
+                "phase": phase,
                 "merge_sha": result.merge_sha,
             },
         ),

--- a/services/zoe-data/tests/test_pipeline_closeout.py
+++ b/services/zoe-data/tests/test_pipeline_closeout.py
@@ -1,0 +1,54 @@
+"""Tests for the harness-side closeout merge runner (deterministic closeout)."""
+
+import json
+
+import pipeline_closeout as pc
+from pipeline_closeout import CloseoutResult, _pr_number
+
+
+def test_pr_number_parses():
+    assert _pr_number("https://github.com/o/r/pull/678") == "678"
+    assert _pr_number("https://github.com/o/r/pull/678/") == "678"
+    assert _pr_number("https://github.com/o/r/tree/main") == ""
+
+
+def test_run_closeout_merge_no_pr():
+    assert pc.run_closeout_merge("").merged is False
+
+
+def test_run_closeout_merge_already_merged(monkeypatch, tmp_path):
+    # guard script must exist for the path to proceed past the existence check
+    (tmp_path / "scripts" / "maintenance").mkdir(parents=True)
+    (tmp_path / "scripts" / "maintenance" / "run_greploop_guard.sh").write_text("#!/bin/sh\n")
+    monkeypatch.setattr(pc, "_merge_state", lambda pr_url, *, cwd: ("MERGED", "abc123"))
+    out = pc.run_closeout_merge("https://github.com/o/r/pull/9", repo_root=str(tmp_path))
+    assert out.merged is True
+    assert out.merge_sha == "abc123"
+    assert "already merged" in out.reason
+
+
+def test_run_closeout_merge_runs_guard_then_confirms_merge(monkeypatch, tmp_path):
+    (tmp_path / "scripts" / "maintenance").mkdir(parents=True)
+    (tmp_path / "scripts" / "maintenance" / "run_greploop_guard.sh").write_text("#!/bin/sh\n")
+    states = [("OPEN", None), ("MERGED", "deadbeef")]  # before guard, after guard
+    monkeypatch.setattr(pc, "_merge_state", lambda pr_url, *, cwd: states.pop(0))
+    monkeypatch.setattr(pc, "_run", lambda cmd, *, cwd, timeout: (0, "guard ran"))
+    out = pc.run_closeout_merge("https://github.com/o/r/pull/9", repo_root=str(tmp_path))
+    assert out.merged is True
+    assert out.merge_sha == "deadbeef"
+
+
+def test_run_closeout_merge_not_merged_after_guard(monkeypatch, tmp_path):
+    (tmp_path / "scripts" / "maintenance").mkdir(parents=True)
+    (tmp_path / "scripts" / "maintenance" / "run_greploop_guard.sh").write_text("#!/bin/sh\n")
+    monkeypatch.setattr(pc, "_merge_state", lambda pr_url, *, cwd: ("OPEN", None))
+    monkeypatch.setattr(pc, "_run", lambda cmd, *, cwd, timeout: (2, "BLOCKED_NOT_READY"))
+    out = pc.run_closeout_merge("https://github.com/o/r/pull/9", repo_root=str(tmp_path))
+    assert out.merged is False
+    assert "did not merge" in out.reason
+
+
+def test_run_closeout_merge_fails_open_when_guard_missing(tmp_path):
+    out = pc.run_closeout_merge("https://github.com/o/r/pull/9", repo_root=str(tmp_path))
+    assert out.merged is False
+    assert "guard script missing" in out.reason

--- a/services/zoe-data/tests/test_pipeline_store.py
+++ b/services/zoe-data/tests/test_pipeline_store.py
@@ -1237,6 +1237,77 @@ async def test_harness_review_disabled_by_env_does_not_approve(isolated_store, m
     assert not any(e.kind == "human" and e.metadata.get("source") == "harness" for e in state.evidence)
 
 
+def _patch_closeout_merge(monkeypatch, *, merged: bool):
+    import pipeline_closeout as pco
+    from pipeline_closeout import CloseoutResult
+
+    monkeypatch.setattr(
+        pco,
+        "run_closeout_merge",
+        lambda pr_url, *, repo_root=None: CloseoutResult(
+            merged, "sha123" if merged else None, "merged" if merged else "not ready"
+        ),
+    )
+
+
+def _seed_closeout_state(task_ref: str):
+    pr = "https://github.com/o/r/pull/30"
+    state = PipelineState(
+        task_ref=task_ref,
+        phase="closeout",
+        status="running",
+        attempts={"implement": 1, "verify": 1, "review": 1, "closeout": 1},
+        evidence=[
+            EvidenceItem(kind="pr", summary=pr, artifact=pr, passed=True, metadata={"phase": "implement"}),
+        ],
+    )
+    store.save_state(state, event="seed")
+
+
+async def _noop_fetch_detail(task_id: str):
+    return {"latest_summary": "", "comments": []}
+
+
+@pytest.mark.asyncio
+async def test_harness_closeout_merges_and_completes(isolated_store, monkeypatch):
+    # Deterministic closeout: the harness runs the greploop guard; when the PR
+    # merges, greptile evidence is recorded and closeout completes -> retro.
+    _patch_closeout_merge(monkeypatch, merged=True)
+    _seed_closeout_state("multica:co-ok")
+
+    phases = {"closeout": {"id": "t_co", "status": "done"}}
+    state = await store.sync_pipeline_from_chain("multica:co-ok", phases, _noop_fetch_detail)
+    assert state.phase == "retro"
+    assert any(
+        e.kind == "greptile" and e.passed and e.metadata.get("source") == "harness"
+        and e.metadata.get("merge_sha") == "sha123"
+        for e in state.evidence
+    )
+
+
+@pytest.mark.asyncio
+async def test_harness_closeout_does_not_complete_when_not_merged(isolated_store, monkeypatch):
+    _patch_closeout_merge(monkeypatch, merged=False)
+    _seed_closeout_state("multica:co-no")
+
+    phases = {"closeout": {"id": "t_co", "status": "done"}}
+    state = await store.sync_pipeline_from_chain("multica:co-no", phases, _noop_fetch_detail)
+    assert state.phase == "closeout"
+    assert not any(e.kind == "greptile" and e.metadata.get("source") == "harness" for e in state.evidence)
+
+
+@pytest.mark.asyncio
+async def test_harness_closeout_disabled_by_env(isolated_store, monkeypatch):
+    monkeypatch.setenv("ZOE_PIPELINE_HARNESS_CLOSEOUT_MERGE", "false")
+    _patch_closeout_merge(monkeypatch, merged=True)  # would merge, but gate disabled
+    _seed_closeout_state("multica:co-off")
+
+    phases = {"closeout": {"id": "t_co", "status": "done"}}
+    state = await store.sync_pipeline_from_chain("multica:co-off", phases, _noop_fetch_detail)
+    assert state.phase == "closeout"
+    assert not any(e.kind == "greptile" and e.metadata.get("source") == "harness" for e in state.evidence)
+
+
 @pytest.mark.asyncio
 async def test_sync_pipeline_audit_only_verify_skips_test_gate(isolated_store):
     await store.bootstrap_state("multica:audit-gate")


### PR DESCRIPTION
## Why
This closes the **last** operator-touch on the idea→merged-PR path. The closeout phase runs the greploop merge guard (Greptile confidence + squash-merge when CLEAN/green/0-unresolved), but it depended on a closeout **agent worker** invoking the guard script. Live (ZOE-5832) the worker bailed *"cannot proceed without a valid PR URL"*, leaving an objectively-mergeable PR at `closeout/merge_blocked` and forcing an operator merge.

## What
Apply the #632/#677 pattern to the merge step. The **harness** invokes the proven greploop guard CLI itself (`run_greploop_guard.sh --pr N --merge-when-ready` — which already enforces confidence/threads and **squash-only, never `--admin`/`--force`**) and confirms the PR ended up `MERGED`, then records the closeout `greptile` evidence (with merge SHA) and completes `closeout → retro` — regardless of the agent. Fail-open: if the guard didn't merge, it falls through to the agent outcome and retries next cycle.

- **`pipeline_closeout.run_closeout_merge(pr_url)`** (new): short-circuits if already merged, else runs the guard (bounded 900s) and re-checks `gh pr view state == MERGED`.
- **`pipeline_store`**: `_append_harness_closeout_merge` + a closeout override in `sync_pipeline_from_chain`, mirroring the verify/review overrides. Gated by `ZOE_PIPELINE_HARNESS_CLOSEOUT_MERGE` (default on).

Now **verify, review, and closeout-merge are all harness-driven** — no flaky-agent dependency anywhere on the critical path.

## Testing
- Runner: no-PR / already-merged / guard-then-merge / not-merged / guard-missing (fail-open).
- Integration: merge → `retro`; not-merged → stays `closeout`; `ZOE_PIPELINE_HARNESS_CLOSEOUT_MERGE=false` → stays `closeout`.
- `pytest -k "pipeline or verify or review or closeout or ..."` → **614 passed**; structure validator clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)