### PR TITLE
fix(harness): closeout completes only on a harness-confirmed merge, not an agent greptile claim

### DIFF
--- a/services/zoe-data/pipeline_store.py
+++ b/services/zoe-data/pipeline_store.py
@@ -558,8 +558,16 @@ async def _append_harness_closeout_merge(state: PipelineState, phase: PipelinePh
     """
     if not _harness_closeout_merge_enabled():
         return state
+    # Idempotent only on the harness's OWN confirmed-merge evidence. We must NOT
+    # skip just because the closeout agent recorded a greptile item (source!=
+    # "harness"): that agent evidence can be written WITHOUT an actual merge, and
+    # skipping here is exactly what let closeout false-complete (PR left open).
     if any(
-        item.kind == "greptile" and item.passed is True and item.metadata.get("phase") == phase
+        item.kind == "greptile"
+        and item.passed is True
+        and item.metadata.get("phase") == phase
+        and item.metadata.get("source") == "harness"
+        and item.metadata.get("merge_sha")
         for item in state.evidence
     ):
         return state
@@ -877,22 +885,48 @@ async def _sync_pipeline_from_chain_once(
                 review_harness_complete = True
 
         closeout_harness_complete = False
-        if phase == "closeout" and row_status in _TERMINAL:
-            # Deterministic closeout: the closeout agent worker can fail to invoke
-            # the greploop merge guard (observed: "cannot proceed without a valid
-            # PR URL"). Run the proven guard CLI harness-side; when it merges the
-            # PR, record the closeout greptile evidence and complete closeout
-            # regardless of the agent's signal. Otherwise fall through to the
-            # agent-derived outcome (and retry next cycle).
+        closeout_merge_pending = False
+        # Only the real-PR closeout path requires a harness-confirmed merge. The
+        # audit / no-code closeout (no PR evidence, audit profile) has nothing to
+        # merge and completes on its recorded evidence as before.
+        if (
+            phase == "closeout"
+            and row_status in _TERMINAL
+            and _harness_closeout_merge_enabled()
+            and getattr(state, "evidence_profile", "") != "audit"
+            and _pr_url_from_state(state)
+        ):
+            # Deterministic, AUTHORITATIVE closeout: run the proven greploop guard
+            # CLI harness-side (regardless of any agent greptile claim) and complete
+            # closeout ONLY on a harness-confirmed merge (source="harness" greptile +
+            # merge_sha). An agent greptile item can be recorded without an actual
+            # merge, so it must NOT advance closeout->retro (that left PRs open). If
+            # the harness hasn't merged yet, hold closeout (retry next cycle) rather
+            # than completing on the agent's unverified evidence.
             state = await _append_harness_closeout_merge(state, "closeout")
-            if can_complete_phase(state):
+            harness_merged = any(
+                e.kind == "greptile"
+                and e.passed is True
+                and e.metadata.get("phase") == "closeout"
+                and e.metadata.get("source") == "harness"
+                and e.metadata.get("merge_sha")
+                for e in state.evidence
+            )
+            if harness_merged and can_complete_phase(state):
                 closeout_harness_complete = True
+            else:
+                closeout_merge_pending = True
 
         outcome = (
             "complete"
             if (verify_harness_complete or review_harness_complete or closeout_harness_complete)
             else infer_outcome(phase, row_status, detail)  # type: ignore[arg-type]
         )
+        if closeout_merge_pending and outcome == "complete":
+            # The PR is not actually merged yet; do not advance closeout->retro on
+            # agent-claimed greptile evidence. Leave closeout pending so the harness
+            # merge retries on the next poll cycle.
+            continue
         if not outcome:
             continue
         if (

--- a/services/zoe-data/pipeline_store.py
+++ b/services/zoe-data/pipeline_store.py
@@ -545,6 +545,23 @@ def _harness_closeout_merge_enabled() -> bool:
     ).strip().lower() not in {"0", "false", "no"}
 
 
+def _is_harness_closeout_merge_evidence(item: Any) -> bool:
+    """True for the harness's OWN confirmed-merge closeout evidence.
+
+    Single source of truth for both the _append_harness_closeout_merge idempotency
+    guard and the sync_pipeline_from_chain closeout-completion check, so the two
+    cannot drift if the evidence schema evolves.
+    """
+    md = getattr(item, "metadata", {}) or {}
+    return (
+        getattr(item, "kind", "") == "greptile"
+        and getattr(item, "passed", None) is True
+        and md.get("phase") == "closeout"
+        and md.get("source") == "harness"
+        and bool(md.get("merge_sha"))
+    )
+
+
 async def _append_harness_closeout_merge(state: PipelineState, phase: PipelinePhase) -> PipelineState:
     """Run the greploop merge guard harness-side and append `greptile` evidence on merge.
 
@@ -562,14 +579,7 @@ async def _append_harness_closeout_merge(state: PipelineState, phase: PipelinePh
     # skip just because the closeout agent recorded a greptile item (source!=
     # "harness"): that agent evidence can be written WITHOUT an actual merge, and
     # skipping here is exactly what let closeout false-complete (PR left open).
-    if any(
-        item.kind == "greptile"
-        and item.passed is True
-        and item.metadata.get("phase") == phase
-        and item.metadata.get("source") == "harness"
-        and item.metadata.get("merge_sha")
-        for item in state.evidence
-    ):
+    if any(_is_harness_closeout_merge_evidence(item) for item in state.evidence):
         return state
     pr_url = _pr_url_from_state(state)
     if not pr_url:
@@ -905,16 +915,16 @@ async def _sync_pipeline_from_chain_once(
             # than completing on the agent's unverified evidence.
             state = await _append_harness_closeout_merge(state, "closeout")
             harness_merged = any(
-                e.kind == "greptile"
-                and e.passed is True
-                and e.metadata.get("phase") == "closeout"
-                and e.metadata.get("source") == "harness"
-                and e.metadata.get("merge_sha")
-                for e in state.evidence
+                _is_harness_closeout_merge_evidence(e) for e in state.evidence
             )
             if harness_merged and can_complete_phase(state):
                 closeout_harness_complete = True
-            else:
+            elif not harness_merged:
+                # Only the NOT-merged case suppresses completion (so an agent's
+                # unverified greptile claim can't advance closeout). If the harness
+                # DID merge but the gate is somehow unsatisfied, fall through to the
+                # normal outcome path so the appended merge evidence is persisted
+                # (gate_block) rather than discarded by a bare continue.
                 closeout_merge_pending = True
 
         outcome = (

--- a/services/zoe-data/tests/test_pipeline_store.py
+++ b/services/zoe-data/tests/test_pipeline_store.py
@@ -1250,16 +1250,28 @@ def _patch_closeout_merge(monkeypatch, *, merged: bool):
     )
 
 
-def _seed_closeout_state(task_ref: str):
+def _seed_closeout_state(task_ref: str, *, agent_greptile: bool = False):
     pr = "https://github.com/o/r/pull/30"
+    evidence = [
+        EvidenceItem(kind="pr", summary=pr, artifact=pr, passed=True, metadata={"phase": "implement"}),
+    ]
+    if agent_greptile:
+        # Greptile evidence as the closeout AGENT would record it (source != harness,
+        # no merge_sha) — recorded without an actual merge.
+        evidence.append(
+            EvidenceItem(
+                kind="greptile",
+                summary="greptile loop done",
+                passed=True,
+                metadata={"source": "skills", "phase": "closeout"},
+            )
+        )
     state = PipelineState(
         task_ref=task_ref,
         phase="closeout",
         status="running",
         attempts={"implement": 1, "verify": 1, "review": 1, "closeout": 1},
-        evidence=[
-            EvidenceItem(kind="pr", summary=pr, artifact=pr, passed=True, metadata={"phase": "implement"}),
-        ],
+        evidence=evidence,
     )
     store.save_state(state, event="seed")
 
@@ -1294,6 +1306,38 @@ async def test_harness_closeout_does_not_complete_when_not_merged(isolated_store
     state = await store.sync_pipeline_from_chain("multica:co-no", phases, _noop_fetch_detail)
     assert state.phase == "closeout"
     assert not any(e.kind == "greptile" and e.metadata.get("source") == "harness" for e in state.evidence)
+
+
+@pytest.mark.asyncio
+async def test_harness_closeout_ignores_agent_greptile_without_real_merge(isolated_store, monkeypatch):
+    # Regression for the #679 bypass: the closeout AGENT recorded greptile evidence
+    # (source='skills') but there was NO actual merge. Closeout must NOT advance to
+    # retro on that unverified claim — it must hold pending a harness-confirmed merge.
+    _patch_closeout_merge(monkeypatch, merged=False)
+    _seed_closeout_state("multica:co-agent", agent_greptile=True)
+
+    phases = {"closeout": {"id": "t_co", "status": "done"}}
+    state = await store.sync_pipeline_from_chain("multica:co-agent", phases, _noop_fetch_detail)
+    assert state.phase == "closeout"  # did NOT false-complete to retro on agent greptile
+    assert not any(
+        e.kind == "greptile" and e.metadata.get("source") == "harness" for e in state.evidence
+    )
+
+
+@pytest.mark.asyncio
+async def test_harness_closeout_merges_even_with_agent_greptile_present(isolated_store, monkeypatch):
+    # The harness merge runs regardless of an agent greptile item; on a real merge
+    # closeout completes -> retro (authoritative harness merge, not the agent claim).
+    _patch_closeout_merge(monkeypatch, merged=True)
+    _seed_closeout_state("multica:co-agent-ok", agent_greptile=True)
+
+    phases = {"closeout": {"id": "t_co", "status": "done"}}
+    state = await store.sync_pipeline_from_chain("multica:co-agent-ok", phases, _noop_fetch_detail)
+    assert state.phase == "retro"
+    assert any(
+        e.kind == "greptile" and e.metadata.get("source") == "harness" and e.metadata.get("merge_sha") == "sha123"
+        for e in state.evidence
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Why (follow-up to #679)
Live on ZOE-5833 (PR #680): the closeout **agent** recorded `greptile` evidence (`source='skills'`) from the greptile-loop skill **without actually merging**. That satisfied the closeout evidence gate and advanced `closeout → retro` while **PR #680 stayed OPEN**. The harness merge (#679) was **bypassed** because `_append_harness_closeout_merge` skipped whenever *any* closeout greptile evidence existed — so the agent's unverified claim short-circuited the real merge.

## What
Make the harness closeout **authoritative** for the real-PR path:
- `_append_harness_closeout_merge` is idempotent only on its **own** confirmed-merge evidence (`source='harness'` + `merge_sha`) — so it runs regardless of an agent greptile claim.
- Closeout completes **only** on a harness-confirmed merge. An agent-only greptile item no longer advances `closeout → retro`; closeout holds pending and the harness merge retries next cycle.
- The **audit / no-PR closeout** path is unaffected (no PR to merge → completes on recorded evidence as before).

## Testing
- Regression: agent greptile (`source='skills'`) **without** a real merge → closeout stays (does not false-complete).
- Harness merges even with an agent greptile present → `retro`.
- Plus existing merge / not-merged / disabled / audit cases. **393 passed** in the pipeline sweep; structure validator clean.

Completes the deterministic-closeout work (#679) so verify, review, and closeout-merge are all harness-driven *and* closeout cannot complete without a real merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)