### PR TITLE
test: stabilize environment-dependent pi/intent tests

### DIFF
--- a/services/zoe-data/tests/test_intent_open_domain.py
+++ b/services/zoe-data/tests/test_intent_open_domain.py
@@ -85,4 +85,11 @@ async def test_greeting_wellbeing_executes_without_open_domain_agent():
     response = await execute_intent(intent)
 
     assert response.startswith(("Hi", "Good"))
-    assert "help" in response.lower() or "do for you" in response.lower()
+    # The greeting has time-of-day variants (morning/afternoon/evening/night), each
+    # of which offers assistance in slightly different words. Assert against the full
+    # family so the test is deterministic regardless of wall-clock time.
+    offers_assistance = any(
+        phrase in response.lower()
+        for phrase in ("help", "do for you", "what do you need", "what do you want")
+    )
+    assert offers_assistance, response

--- a/services/zoe-data/tests/test_pi_hybrid_stream_http_probe.py
+++ b/services/zoe-data/tests/test_pi_hybrid_stream_http_probe.py
@@ -382,6 +382,7 @@ def test_select_cases_can_keep_safe_fulfillment_eligible_defaults_only():
         "weather_rain_later",
         "weather_jacket",
         "list_show",
+        "calc",
         "briefing",
     ]
     assert all(case.expected_intent in module.SAFE_FULFILLMENT_INTENTS for case in selected)

--- a/services/zoe-data/tests/test_pi_intent_lab.py
+++ b/services/zoe-data/tests/test_pi_intent_lab.py
@@ -1080,6 +1080,12 @@ async def test_pi_lab_resource_pressure_guard_can_be_disabled(monkeypatch):
 
     payload = route_module.PiIntentLabCompareRequest(text="rain later", run_pi=True)
     monkeypatch.setenv("ZOE_PI_LAB_RESOURCE_GUARD_ENABLED", "0")
+    # Set real (non-zero) thresholds so the `min_*_mb <= 0` short-circuit does NOT
+    # fire (the autouse fixture zeros them by default). With low meminfo + these
+    # thresholds, the guard would block IF enabled — so a None result here proves
+    # the GUARD_ENABLED=0 flag specifically, not the zeroed-threshold short-circuit.
+    monkeypatch.setenv("ZOE_PI_LAB_MIN_AVAILABLE_MB", "2048")
+    monkeypatch.setenv("ZOE_PI_LAB_MIN_SWAP_FREE_MB", "256")
     monkeypatch.setattr(route_module, "_read_meminfo_mb", lambda: {"MemAvailable": 1, "SwapFree": 1})
 
     assert await route_module._pi_lab_resource_pressure_blocker(payload) is None

--- a/services/zoe-data/tests/test_pi_intent_lab.py
+++ b/services/zoe-data/tests/test_pi_intent_lab.py
@@ -14,6 +14,19 @@ from pi_intent_lab import _await_speculative_safe_fulfillment, compare_pi_intent
 from routers.pi_intent_lab import router as pi_intent_lab_router
 
 
+@pytest.fixture(autouse=True)
+def _neutralize_pi_lab_resource_guard(monkeypatch):
+    """These tests assert routing/endpoint behavior, not host memory.
+
+    The lab resource-pressure guard reads live /proc/meminfo, so under a loaded
+    full-suite run available memory can dip below the default 2048MB floor and the
+    endpoint 503s — making these tests flaky by machine state. Default the guard
+    off here; the guard-specific tests below re-enable it via their own setenv.
+    """
+    monkeypatch.setenv("ZOE_PI_LAB_MIN_AVAILABLE_MB", "0")
+    monkeypatch.setenv("ZOE_PI_LAB_MIN_SWAP_FREE_MB", "0")
+
+
 class _Intent:
     def __init__(self, name, slots=None, confidence=0.9):
         self.name = name


### PR DESCRIPTION
## What
Stabilizes three tests that failed nondeterministically based on host state, so the full suite is a reliable signal again.

| Test | Failure mode | Fix |
|---|---|---|
| `test_pi_hybrid_stream_http_probe` | stale expected case list (missing `calc`) | update assertion |
| `test_pi_intent_lab` (6 tests) | 503 under load — hit live `/proc/meminfo` guard | autouse fixture neutralizes guard; guard-specific tests re-enable it |
| `test_intent_open_domain` | night-time greeting variant ("what do you need?") fails `help`/`do for you` assertion | broaden to the full time-of-day family |

## Verification
Full suite: **2415 passed** (was 2 failing + flaky under load).

🤖 Generated with [Claude Code](https://claude.com/claude-code)