### PR TITLE
feat(zoe-core): revive zoe-core as the Pi-agent core + Brick 1 (local Gemma)

### DIFF
--- a/.greptile/rules.md
+++ b/.greptile/rules.md
@@ -16,7 +16,7 @@ Greptile should review Zoe as a local-first, multi-user assistant with a host-ru
 
 - Production chat API is `services/zoe-data/routers/chat.py`; do not fork it.
 - Natural-language understanding belongs in `intent_router.py`, Zoe Agent, Hermes, or OpenClaw, not broad ad hoc branches in `chat.py`.
-- `services/zoe-core/` is retired and should not receive new production features.
+- `services/zoe-core/` is Zoe's Pi-agent core (the reasoning/orchestration brain on Gemma 4) — new core features belong here. It orchestrates and delegates; it must not absorb `zoe-data`/`zoe-auth`/`zoe-database` code or become a monolith. The OLD `zoe-core` Docker monolith (replaced by `zoe-data`) is retired and archived under `docs/archive/retired-services/zoe-core/`; do not revive that legacy tree.
 - Host `llama-server`, Hermes, OpenClaw, and Multica are local services; avoid Docker-only assumptions in core code.
 
 ## Data Safety

--- a/PROJECT_STRUCTURE_RULES.md
+++ b/PROJECT_STRUCTURE_RULES.md
@@ -6,9 +6,14 @@
 
 > Runtime note (May 2026): Zoe now runs `zoe-data` host-native on port 8000,
 > `zoe-auth`/UI/PostgreSQL in Docker Compose, and OpenClaw/llama/Hermes/Kokoro
-> as host-native user services. Older `zoe-core`, LiteLLM, and Dockerized
-> llama.cpp references below are historical guardrails only; do not use them
-> for current operations.
+> as host-native user services. The older Docker `zoe-core` monolith, LiteLLM,
+> and Dockerized llama.cpp references below are historical guardrails only; do not
+> use them for current operations.
+>
+> Naming note (June 2026): `services/zoe-core/` has been REVIVED as Zoe's Pi-agent
+> core — the reasoning/orchestration brain on Gemma 4 that binds the services and
+> calls abilities. It is the center of Zoe, not a monolith. The retired Docker
+> monolith of the same name is archived at `docs/archive/retired-services/zoe-core/`.
 
 This document defines the **mandatory** structure and rules for the Zoe project. All files must follow these rules. Automated checks enforce compliance.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -237,7 +237,9 @@ services:
   # These were replaced by host-native services + OpenClaw (March 2026)
   # ═══════════════════════════════════════════════════════════════════════════
 
-  # zoe-core: RETIRED - Replaced by zoe-data (host uvicorn :8000) + OpenClaw gateway
+  # zoe-core (old Docker monolith): RETIRED - Replaced by zoe-data (host uvicorn :8000) + OpenClaw gateway.
+  #   NOTE: the name "zoe-core" is now REUSED for the new Pi-agent core (services/zoe-core/), the reasoning
+  #   brain on Gemma 4. That new service is defined separately — this comment refers only to the old monolith.
   # zoe-litellm: RETIRED - OpenClaw handles model routing (GPT-4o-mini / Gemini Flash / local Hermes)
   # zoe-llamacpp: RETIRED - Native llama-server on host :11434 (Hermes-3-8B, better GPU perf)
   # zoe-mcp-server: RETIRED - OpenClaw native tool system

--- a/services/AGENTS.md
+++ b/services/AGENTS.md
@@ -11,7 +11,7 @@ Production runtime services for the Zoe assistant: the web/chat API, static UI, 
 - `zoe-auth/` — authentication service.
 - `homeassistant-mcp-bridge/`, `n8n-mcp-bridge/` — MCP protocol bridges to external systems.
 - `livekit/` — realtime audio/video infrastructure config.
-- `zoe-core/` does not exist here anymore: it is RETIRED legacy reference code. Never extend it for new features.
+- `zoe-core/` — Zoe's reasoning/orchestration core: the Pi agent (Gemma 4) that binds the other services together and calls abilities. This is the center of Zoe, not a monolith — it orchestrates and delegates; it does not absorb the other services' code. NOTE: a *different*, older `zoe-core` (the retired Docker monolith, replaced by `zoe-data`) is archived at `docs/archive/retired-services/zoe-core/` — that legacy tree must never be revived or extended. This service is the new Pi core, not that archive.
 
 ## Local Contracts
 

--- a/services/zoe-core/README.md
+++ b/services/zoe-core/README.md
@@ -42,8 +42,12 @@ via Pi's extension hooks.
 
 `extensions/provider-local-gemma.ts` registers a Pi provider `local-gemma`
 pointing at the host model server (`GEMMA_SERVER_URL`, default
-`http://127.0.0.1:11434/v1`, OpenAI-compatible). Smoke test:
+`http://127.0.0.1:11434/v1`, OpenAI-compatible). `package.json` declares the Pi
+dependency and the extension manifest; `tsconfig.json` type-checks the extension
+(Pi loads `.ts` directly via jiti — no build step).
+
+Smoke test (integration; skips if `pi` or the model server are unavailable):
 
 ```bash
-./test/brick1_smoke.sh
+python -m pytest services/zoe-core/test/test_brick1_provider.py -v
 ```

--- a/services/zoe-core/README.md
+++ b/services/zoe-core/README.md
@@ -1,0 +1,49 @@
+# zoe-core
+
+**Zoe's reasoning/orchestration core — the Pi agent (Gemma 4) that binds the
+other services together and calls Zoe's abilities.**
+
+This is the *center* of Zoe: the brain. The other services are leaf functions —
+`zoe-data` stores/serves data, `zoe-auth` authenticates, `zoe-database` is the
+database. `zoe-core` is the thing that reasons, decides, and orchestrates them.
+
+Built on **[`pi`](https://www.npmjs.com/package/@earendil-works/pi-coding-agent)**
+(the extensible agent framework, run on local **Gemma 4 E2B**). Zoe's
+capabilities are Pi **extensions/tools**; her personality and memory are wired in
+via Pi's extension hooks.
+
+> **Core ≠ monolith.** zoe-core *orchestrates and delegates*; it does not absorb
+> the code of `zoe-data`/`zoe-auth`/`zoe-database`. Abilities stay modular
+> (extensions/tools). The retired Docker monolith that once held this name is
+> archived at `docs/archive/retired-services/zoe-core/` — do not revive it.
+
+## Architecture (target)
+
+```
+                 ┌───────────────── zoe-core (Pi / Gemma 4) ─────────────────┐
+   user ──▶ intent fast-path ─miss─▶  the brain: reason + call tools         │
+   (speed cache, top commands)       ├─ native tools  → zoe-data endpoints   │
+                                     ├─ delegation     → Hermes / OpenClaw    │
+                                     ├─ memory packet  → layered memory       │
+                                     └─ soul/personality                       │
+                 └───────────────────────────────────────────────────────────┘
+   zoe-core registers as an agent in Multica (peer to Hermes / OpenClaw).
+   Omnigent orchestrates above; not called from inside the brain.
+```
+
+## Build bricks
+
+1. **Provider** — Pi runs on local Gemma. *(this brick — `extensions/provider-local-gemma.ts`)*
+2. **Soul + memory** — Zoe personality + layered memory packet injected per turn.
+3. **Abilities** — native zoe-data tools + delegation tools (Hermes/OpenClaw); safety rails as `tool_call` gates.
+4. **Cutover** — chat/voice point at the zoe-core brain; intent fast-path stays in front; retire `zoe_agent.py`.
+
+## Brick 1 — local Gemma provider
+
+`extensions/provider-local-gemma.ts` registers a Pi provider `local-gemma`
+pointing at the host model server (`GEMMA_SERVER_URL`, default
+`http://127.0.0.1:11434/v1`, OpenAI-compatible). Smoke test:
+
+```bash
+./test/brick1_smoke.sh
+```

--- a/services/zoe-core/extensions/provider-local-gemma.ts
+++ b/services/zoe-core/extensions/provider-local-gemma.ts
@@ -1,0 +1,57 @@
+/**
+ * Brick 1: point Pi (zoe-core's brain) at the local Gemma 4 model server.
+ *
+ * Registers a Pi provider named "local-gemma" backed by the host's
+ * OpenAI-compatible endpoint (the same one zoe_agent.py already uses via
+ * GEMMA_SERVER_URL). Models are discovered from /v1/models when reachable,
+ * falling back to a configured default so the provider still registers offline.
+ *
+ * Select it with:  pi --provider local-gemma --model <id>
+ */
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+const BASE_URL =
+  process.env.ZOE_CORE_MODEL_URL ??
+  process.env.GEMMA_SERVER_URL ??
+  "http://127.0.0.1:11434/v1";
+// llama-server / ollama don't require a real key, but OpenAI clients want a
+// non-empty one.
+const API_KEY = process.env.ZOE_CORE_MODEL_API_KEY ?? "local";
+const DEFAULT_MODEL_ID = process.env.ZOE_CORE_MODEL_ID ?? "gemma-4-E2B-it-Q4_K_M.gguf";
+const CONTEXT_WINDOW = Number(process.env.ZOE_CORE_MODEL_CONTEXT ?? 32768);
+const MAX_TOKENS = Number(process.env.ZOE_CORE_MODEL_MAXTOKENS ?? 2048);
+
+async function discoverModelIds(): Promise<string[]> {
+  try {
+    const res = await fetch(`${BASE_URL}/models`, {
+      signal: AbortSignal.timeout(4000),
+    });
+    if (!res.ok) return [];
+    const payload = (await res.json()) as { data?: Array<{ id?: string }> };
+    return (payload.data ?? [])
+      .map((m) => m.id)
+      .filter((id): id is string => typeof id === "string" && id.length > 0);
+  } catch {
+    return [];
+  }
+}
+
+export default async function (pi: ExtensionAPI) {
+  const discovered = await discoverModelIds();
+  const ids = discovered.length > 0 ? discovered : [DEFAULT_MODEL_ID];
+
+  pi.registerProvider("local-gemma", {
+    baseUrl: BASE_URL,
+    apiKey: API_KEY,
+    api: "openai-completions",
+    models: ids.map((id) => ({
+      id,
+      name: id,
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: CONTEXT_WINDOW,
+      maxTokens: MAX_TOKENS,
+    })),
+  });
+}

--- a/services/zoe-core/extensions/provider-local-gemma.ts
+++ b/services/zoe-core/extensions/provider-local-gemma.ts
@@ -18,8 +18,8 @@ const BASE_URL =
 // non-empty one.
 const API_KEY = process.env.ZOE_CORE_MODEL_API_KEY ?? "local";
 const DEFAULT_MODEL_ID = process.env.ZOE_CORE_MODEL_ID ?? "gemma-4-E2B-it-Q4_K_M.gguf";
-const CONTEXT_WINDOW = Number(process.env.ZOE_CORE_MODEL_CONTEXT ?? 32768);
-const MAX_TOKENS = Number(process.env.ZOE_CORE_MODEL_MAXTOKENS ?? 2048);
+const CONTEXT_WINDOW = Number(process.env.ZOE_CORE_MODEL_CONTEXT) || 32768;
+const MAX_TOKENS = Number(process.env.ZOE_CORE_MODEL_MAXTOKENS) || 2048;
 
 async function discoverModelIds(): Promise<string[]> {
   try {

--- a/services/zoe-core/package.json
+++ b/services/zoe-core/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@zoe/zoe-core",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Zoe's reasoning/orchestration core — Pi-agent extensions (provider, soul, memory, abilities).",
+  "type": "module",
+  "dependencies": {
+    "@earendil-works/pi-coding-agent": "^0.79.3"
+  },
+  "pi": {
+    "extensions": [
+      "./extensions/provider-local-gemma.ts"
+    ]
+  }
+}

--- a/services/zoe-core/test/test_brick1_provider.py
+++ b/services/zoe-core/test/test_brick1_provider.py
@@ -1,0 +1,69 @@
+"""Brick 1 integration smoke test.
+
+Proves Pi (zoe-core's brain) answers a prompt on the local Gemma model through
+the `local-gemma` provider extension.
+
+This is an on-demand integration test: it needs the `pi` CLI and a reachable
+OpenAI-compatible model server (`GEMMA_SERVER_URL`, default
+`http://127.0.0.1:11434/v1`). It skips cleanly when either is unavailable, so it
+is safe to run anywhere.
+
+Run it explicitly:
+    python -m pytest services/zoe-core/test/test_brick1_provider.py -v
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+_EXT = Path(__file__).resolve().parent.parent / "extensions" / "provider-local-gemma.ts"
+_MODEL = os.environ.get("ZOE_CORE_MODEL_ID", "gemma-4-E2B-it-Q4_K_M.gguf")
+_BASE_URL = (
+    os.environ.get("ZOE_CORE_MODEL_URL")
+    or os.environ.get("GEMMA_SERVER_URL")
+    or "http://127.0.0.1:11434/v1"
+)
+_SENTINEL = "ZOE_CORE_BRICK1_OK"
+
+
+def _model_server_up() -> bool:
+    try:
+        with urllib.request.urlopen(f"{_BASE_URL}/models", timeout=4) as resp:
+            return resp.status == 200
+    except Exception:
+        return False
+
+
+@pytest.mark.integration
+def test_pi_answers_on_local_gemma_via_provider():
+    if shutil.which("pi") is None:
+        pytest.skip("pi CLI not installed")
+    if not _model_server_up():
+        pytest.skip(f"model server not reachable at {_BASE_URL}")
+    assert _EXT.is_file(), f"extension missing: {_EXT}"
+
+    result = subprocess.run(
+        [
+            "pi", "-p",
+            "--provider", "local-gemma",
+            "--model", _MODEL,
+            "-e", str(_EXT),
+            "--no-extensions", "--no-skills", "--no-prompt-templates",
+            "--no-themes", "--no-context-files", "--no-session", "--thinking", "off",
+            f"Reply with exactly this token and nothing else: {_SENTINEL}",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+
+    assert result.returncode == 0, f"pi exited {result.returncode}: {result.stderr}"
+    assert result.stdout.strip(), "pi returned an empty response"
+    # The whole point of Brick 1: Pi reached the local Gemma model through our
+    # provider and produced the requested answer.
+    assert _SENTINEL in result.stdout, f"unexpected response: {result.stdout!r}"

--- a/services/zoe-core/tsconfig.json
+++ b/services/zoe-core/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["extensions/**/*.ts"]
+}


### PR DESCRIPTION
## What
Establishes **`services/zoe-core/`** as Zoe's reasoning/orchestration core — the **Pi agent** (`@earendil-works/pi-coding-agent`) run on local **Gemma 4 E2B**. This is the center of Zoe (the brain), distinct from the leaf services (`zoe-data`/`zoe-auth`/`zoe-database`).

First of a staged port of Zoe's brain onto Pi. **Brick 1: point Pi at the local model.**

## Changes
- `extensions/provider-local-gemma.ts` — registers Pi provider `local-gemma` against the OpenAI-compatible endpoint `zoe_agent` already uses (`GEMMA_SERVER_URL`, default `http://127.0.0.1:11434/v1`); discovers models from `/v1/models` with an offline fallback.
- `test/brick1_smoke.sh` — proves Pi answers a prompt on local Gemma via the provider.
- `README.md` — what zoe-core is, target architecture, brick plan.
- **Name reclamation**: redefines the formerly-retired `zoe-core` across `AGENTS.md`, `.greptile/rules.md`, `PROJECT_STRUCTURE_RULES.md`, and the `docker-compose.yml` comment. Principle baked in: **core = orchestrator that binds services and calls abilities, not a monolith.** The retired Docker monolith stays archived at `docs/archive/retired-services/zoe-core/`.

## Verification
- Smoke test: Pi 0.79.3 answers on `gemma-4-E2B-it-Q4_K_M.gguf` via the provider ✅
- Offline fallback: provider still registers with an unreachable URL (no crash) ✅

## Note
This is additive (new service dir) — no live runtime is wired to it yet. Cutover (chat/voice → zoe-core) is a later brick and will be coordinated separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)