### PR TITLE
fix(harness): reap zombie 'running' tasks whose worker died (fast lane recovery)

### DIFF
--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -30,12 +30,17 @@ from typing import Any
 
 from hermes_http import hermes_bin, zoe_repo_root
 from kanban_phase_budget import (
+    dead_worker_reason,
     latest_log_session,
     phase_budget_reason,
     phase_budget_reason_from_log,
     task_log_tail,
     terminate_running_workers,
 )
+
+_REAP_DEAD_WORKERS = (
+    os.environ.get("ZOE_KANBAN_REAP_DEAD_WORKERS", "true") or "true"
+).strip().lower() not in {"0", "false", "no"}
 
 logger = logging.getLogger(__name__)
 
@@ -1197,6 +1202,41 @@ class KanbanAdapter:
         )
         return True
 
+    async def _maybe_auto_block_dead_worker(
+        self,
+        task_id: str,
+        phase: str,
+        row: dict[str, Any],
+        detail: dict[str, Any],
+    ) -> bool:
+        """Reap a zombie 'running' task whose worker process has died.
+
+        A crashed/killed worker (e.g. out-of-context HTTP error, OOM) can leave its
+        run 'running' forever, holding the single lane. Block it so the row becomes
+        terminal — which both frees the lane and lets the deterministic verify/
+        review/closeout overrides engage (they fire on a terminal row)."""
+        if not _REAP_DEAD_WORKERS:
+            return False
+        if (row.get("status") or "").lower() != "running":
+            return False
+        reason = dead_worker_reason(detail)
+        if not reason:
+            return False
+        reason = f"BLOCKER={reason}"
+        try:
+            await self._run(["block", task_id, reason])
+        except KanbanCLIError as exc:
+            logger.warning(
+                "kanban_adapter: dead-worker reap failed for %s (%s): %s", task_id, phase, exc
+            )
+            return False
+        row["status"] = "blocked"
+        row["block_reason"] = reason
+        logger.warning(
+            "kanban_adapter: reaped zombie running task %s (%s): %s", task_id, phase, reason
+        )
+        return True
+
     async def _maybe_auto_block_phase_budget(
         self,
         task_id: str,
@@ -1922,6 +1962,9 @@ class KanbanAdapter:
                 phases[phase] = row
                 continue
             if await self._maybe_auto_block_protocol_violation(task_id, phase, row, detail):
+                phases[phase] = row
+                continue
+            if await self._maybe_auto_block_dead_worker(task_id, phase, row, detail):
                 phases[phase] = row
 
         for phase, row in list(phases.items()):

--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -1214,7 +1214,12 @@ class KanbanAdapter:
         A crashed/killed worker (e.g. out-of-context HTTP error, OOM) can leave its
         run 'running' forever, holding the single lane. Block it so the row becomes
         terminal — which both frees the lane and lets the deterministic verify/
-        review/closeout overrides engage (they fire on a terminal row)."""
+        review/closeout overrides engage (they fire on a terminal row).
+
+        Covered by tests/test_kanban_adapter.py::test_auto_block_dead_worker_*
+        (blocks zombie, no-op when worker alive / row not running / kill-switch
+        off, swallows KanbanCLIError); detector covered by
+        tests/test_kanban_phase_budget.py::test_dead_worker_reason_*."""
         if not _REAP_DEAD_WORKERS:
             return False
         if (row.get("status") or "").lower() != "running":

--- a/services/zoe-data/kanban_phase_budget.py
+++ b/services/zoe-data/kanban_phase_budget.py
@@ -851,7 +851,9 @@ def dead_worker_reason(detail: dict[str, Any], *, grace_s: float | None = None) 
         if _is_expected_worker(pid):
             continue  # worker still alive
         started = _timestamp(run.get("started_at"))
-        if started is not None and (now - started) < grace:
+        if started is None:
+            continue  # no usable start time — treat as brand-new, don't reap yet
+        if (now - started) < grace:
             continue  # within grace; pid may simply not be published yet
         return f"WORKER_DIED: running worker pid {pid} is no longer alive (zombie running task)"
     return None

--- a/services/zoe-data/kanban_phase_budget.py
+++ b/services/zoe-data/kanban_phase_budget.py
@@ -819,6 +819,44 @@ def terminate_running_workers(detail: dict[str, Any]) -> None:
             logger.warning("kanban_phase_budget: failed to stop worker pid=%s: %s", pid, exc)
 
 
+def dead_worker_reason(detail: dict[str, Any], *, grace_s: float | None = None) -> str | None:
+    """Detect a zombie 'running' task whose worker process is no longer alive.
+
+    A worker can die without emitting a terminal kanban signal (e.g. an
+    out-of-context/HTTP crash, OOM, or external kill), leaving its run marked
+    ``running`` with a ``worker_pid`` that no longer points at a live
+    ``hermes ... work kanban task`` process. Such a zombie holds the single lane
+    (poll_ref reports the chain as running) and blocks dispatch until something
+    reaps it. Return a reason string when a running run has a usable ``worker_pid``
+    that is definitively NOT a live worker and the run is older than a short grace
+    (so a just-started worker whose pid isn't published yet is never misjudged).
+    """
+    try:
+        grace = float(
+            grace_s if grace_s is not None
+            else os.environ.get("ZOE_KANBAN_DEAD_WORKER_GRACE_S", "180") or "180"
+        )
+    except (TypeError, ValueError):
+        grace = 180.0
+    now = time.time()
+    for run in detail.get("runs") or []:
+        if not isinstance(run, dict) or str(run.get("status") or "").lower() != "running":
+            continue
+        try:
+            pid = int(run.get("worker_pid") or 0)
+        except (TypeError, ValueError):
+            continue
+        if pid <= 100:
+            continue  # no usable pid to judge liveness — leave to other guards
+        if _is_expected_worker(pid):
+            continue  # worker still alive
+        started = _timestamp(run.get("started_at"))
+        if started is not None and (now - started) < grace:
+            continue  # within grace; pid may simply not be published yet
+        return f"WORKER_DIED: running worker pid {pid} is no longer alive (zombie running task)"
+    return None
+
+
 def _timestamp(value: Any) -> float | None:
     if isinstance(value, (int, float)):
         return float(value)

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -1,4 +1,5 @@
 """Tests for the Hermes Kanban executor adapter (CLI mocked)."""
+import asyncio
 import json
 from pathlib import Path
 
@@ -5763,3 +5764,90 @@ async def test_recover_unshipped_diff_skips_when_pr_already_handed_off(monkeypat
 
     a = _A()
     assert await a._maybe_recover_unshipped_diff("t_implement", "implement", row) is None
+
+
+# ---------------------------------------------------------------------------
+# _maybe_auto_block_dead_worker — adapter glue that reaps zombie running tasks
+# ---------------------------------------------------------------------------
+
+
+def _dead_detail():
+    # past-grace running run; liveness is decided by the mocked _is_expected_worker
+    return {"runs": [{"status": "running", "worker_pid": 987654, "started_at": "2000-01-01T00:00:00+00:00"}]}
+
+
+def test_auto_block_dead_worker_blocks_zombie(monkeypatch):
+    monkeypatch.setattr(ka, "_REAP_DEAD_WORKERS", True)
+    monkeypatch.setattr(kb, "_is_expected_worker", lambda pid: False)  # worker dead
+    adapter = ka.KanbanAdapter()
+    calls: list[list[str]] = []
+
+    async def fake_run(args, *, expect_json=False):
+        calls.append(args)
+        return ""
+
+    adapter._run = fake_run  # type: ignore[assignment]
+    row = {"status": "running"}
+    out = asyncio.run(adapter._maybe_auto_block_dead_worker("t_verify", "verify", row, _dead_detail()))
+
+    assert out is True
+    assert calls and calls[0][0] == "block" and calls[0][1] == "t_verify"
+    assert calls[0][2].startswith("BLOCKER=WORKER_DIED")
+    assert row["status"] == "blocked"
+    assert row["block_reason"].startswith("BLOCKER=WORKER_DIED")
+
+
+def test_auto_block_dead_worker_noop_when_worker_alive(monkeypatch):
+    monkeypatch.setattr(ka, "_REAP_DEAD_WORKERS", True)
+    monkeypatch.setattr(kb, "_is_expected_worker", lambda pid: True)  # worker alive
+    adapter = ka.KanbanAdapter()
+
+    async def fake_run(args, *, expect_json=False):  # pragma: no cover - must not run
+        raise AssertionError("must not block a live worker")
+
+    adapter._run = fake_run  # type: ignore[assignment]
+    row = {"status": "running"}
+    assert asyncio.run(adapter._maybe_auto_block_dead_worker("t", "verify", row, _dead_detail())) is False
+    assert row["status"] == "running"
+
+
+def test_auto_block_dead_worker_noop_when_row_not_running(monkeypatch):
+    monkeypatch.setattr(ka, "_REAP_DEAD_WORKERS", True)
+    monkeypatch.setattr(kb, "_is_expected_worker", lambda pid: False)
+    adapter = ka.KanbanAdapter()
+
+    async def fake_run(args, *, expect_json=False):  # pragma: no cover
+        raise AssertionError("row not running -> no block")
+
+    adapter._run = fake_run  # type: ignore[assignment]
+    row = {"status": "todo"}
+    assert asyncio.run(adapter._maybe_auto_block_dead_worker("t", "verify", row, _dead_detail())) is False
+
+
+def test_auto_block_dead_worker_respects_kill_switch(monkeypatch):
+    monkeypatch.setattr(ka, "_REAP_DEAD_WORKERS", False)  # disabled
+    monkeypatch.setattr(kb, "_is_expected_worker", lambda pid: False)
+    adapter = ka.KanbanAdapter()
+
+    async def fake_run(args, *, expect_json=False):  # pragma: no cover
+        raise AssertionError("reaper disabled -> no block")
+
+    adapter._run = fake_run  # type: ignore[assignment]
+    row = {"status": "running"}
+    assert asyncio.run(adapter._maybe_auto_block_dead_worker("t", "verify", row, _dead_detail())) is False
+    assert row["status"] == "running"
+
+
+def test_auto_block_dead_worker_swallows_cli_error(monkeypatch):
+    monkeypatch.setattr(ka, "_REAP_DEAD_WORKERS", True)
+    monkeypatch.setattr(kb, "_is_expected_worker", lambda pid: False)
+    adapter = ka.KanbanAdapter()
+
+    async def fake_run(args, *, expect_json=False):
+        raise ka.KanbanCLIError("block failed")
+
+    adapter._run = fake_run  # type: ignore[assignment]
+    row = {"status": "running"}
+    # CLI failure -> returns False, row left untouched (next poll retries)
+    assert asyncio.run(adapter._maybe_auto_block_dead_worker("t", "verify", row, _dead_detail())) is False
+    assert row["status"] == "running"

--- a/services/zoe-data/tests/test_kanban_phase_budget.py
+++ b/services/zoe-data/tests/test_kanban_phase_budget.py
@@ -366,3 +366,44 @@ def test_edit_safety_covers_implement_revision_phase(monkeypatch):
         "BLOCKER=IMPLEMENT_EDIT_SAFETY: Python patch was followed by more "
         "exploration before py_compile/focused tests"
     )
+
+
+# ---------------------------------------------------------------------------
+# dead_worker_reason — zombie 'running' task reaper detector
+# ---------------------------------------------------------------------------
+
+
+def _running_run(pid, started_at="2000-01-01T00:00:00+00:00"):
+    return {"runs": [{"status": "running", "worker_pid": pid, "started_at": started_at}]}
+
+
+def test_dead_worker_reason_flags_dead_pid_past_grace(monkeypatch):
+    monkeypatch.setattr(kb, "_is_expected_worker", lambda pid: False)  # process gone
+    reason = kb.dead_worker_reason(_running_run(987654), grace_s=0)
+    assert reason and "WORKER_DIED" in reason and "987654" in reason
+
+
+def test_dead_worker_reason_none_when_worker_alive(monkeypatch):
+    monkeypatch.setattr(kb, "_is_expected_worker", lambda pid: True)  # still running
+    assert kb.dead_worker_reason(_running_run(987654), grace_s=0) is None
+
+
+def test_dead_worker_reason_respects_grace(monkeypatch):
+    import time as _t
+
+    monkeypatch.setattr(kb, "_is_expected_worker", lambda pid: False)
+    # started 'now' -> within a long grace -> not yet reaped
+    now_iso = kb.datetime.fromtimestamp(_t.time(), tz=kb.timezone.utc).isoformat()
+    assert kb.dead_worker_reason({"runs": [{"status": "running", "worker_pid": 987654, "started_at": now_iso}]}, grace_s=3600) is None
+
+
+def test_dead_worker_reason_ignores_low_or_missing_pid(monkeypatch):
+    monkeypatch.setattr(kb, "_is_expected_worker", lambda pid: False)
+    assert kb.dead_worker_reason({"runs": [{"status": "running", "worker_pid": 0}]}, grace_s=0) is None
+    assert kb.dead_worker_reason({"runs": [{"status": "running"}]}, grace_s=0) is None
+
+
+def test_dead_worker_reason_none_when_not_running(monkeypatch):
+    monkeypatch.setattr(kb, "_is_expected_worker", lambda pid: False)
+    assert kb.dead_worker_reason({"runs": [{"status": "done", "worker_pid": 987654}]}, grace_s=0) is None
+    assert kb.dead_worker_reason({"runs": []}, grace_s=0) is None

--- a/services/zoe-data/tests/test_kanban_phase_budget.py
+++ b/services/zoe-data/tests/test_kanban_phase_budget.py
@@ -403,6 +403,14 @@ def test_dead_worker_reason_ignores_low_or_missing_pid(monkeypatch):
     assert kb.dead_worker_reason({"runs": [{"status": "running"}]}, grace_s=0) is None
 
 
+def test_dead_worker_reason_missing_started_at_not_reaped(monkeypatch):
+    # No started_at -> cannot prove the run is past grace; treat as brand-new and
+    # do NOT reap (conservative: avoids a false-positive block in a write race
+    # where worker_pid lands before started_at). grace_s=0 would otherwise reap.
+    monkeypatch.setattr(kb, "_is_expected_worker", lambda pid: False)
+    assert kb.dead_worker_reason({"runs": [{"status": "running", "worker_pid": 987654}]}, grace_s=0) is None
+
+
 def test_dead_worker_reason_none_when_not_running(monkeypatch):
     monkeypatch.setattr(kb, "_is_expected_worker", lambda pid: False)
     assert kb.dead_worker_reason({"runs": [{"status": "done", "worker_pid": 987654}]}, grace_s=0) is None


### PR DESCRIPTION
## Why
Live on ZOE-5834: a verify worker crashed (HTTP 400 context-length-exceeded) **without** emitting a terminal kanban signal, leaving its run `running` with a dead `worker_pid`. That zombie **held the single ticket lane ~13 minutes** (`poll_ref` reports the chain as running → dispatch is gated) until the gateway eventually reaped it. It also stalls the deterministic verify/review/closeout overrides, which only fire on a **terminal** row.

## What
A harness-side reaper (mirrors the existing phase-budget / protocol-violation auto-blocks):
- **`kanban_phase_budget.dead_worker_reason(detail)`** — flags a `running` run whose usable `worker_pid` (>100) is no longer a live `hermes … work kanban task` process, past a short grace (`ZOE_KANBAN_DEAD_WORKER_GRACE_S`, default 180s, so a just-started worker whose pid isn't published yet is never misjudged).
- **`kanban_adapter._maybe_auto_block_dead_worker`** — in `poll()`, blocks such a zombie with `BLOCKER=WORKER_DIED`. The terminal row both frees the lane and lets the deterministic phase overrides engage. Gated by `ZOE_KANBAN_REAP_DEAD_WORKERS` (default on).

A dead worker is now reaped in ~grace seconds instead of ~13 minutes.

## Testing
- dead-pid-past-grace → flagged; alive worker / within-grace / low|missing pid / non-running → None.
- **261 passed** (`test_kanban_phase_budget.py` + `test_kanban_adapter.py`); structure validator clean.

Reliability follow-up to the full-autonomy push (#592…#681). Companion recommendation (operational, not in this PR): the zoe-reviewer profile's `auto` model slot resolved to a 16,384-ctx local model that caused the crash — point verify/review at a larger-context model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)