### PR TITLE
feat(zoe-core): Brick 2 — Zoe's soul

### DIFF
--- a/services/zoe-core/README.md
+++ b/services/zoe-core/README.md
@@ -33,10 +33,11 @@ via Pi's extension hooks.
 
 ## Build bricks
 
-1. **Provider** — Pi runs on local Gemma. *(this brick — `extensions/provider-local-gemma.ts`)*
-2. **Soul + memory** — Zoe personality + layered memory packet injected per turn.
-3. **Abilities** — native zoe-data tools + delegation tools (Hermes/OpenClaw); safety rails as `tool_call` gates.
-4. **Cutover** — chat/voice point at the zoe-core brain; intent fast-path stays in front; retire `zoe_agent.py`.
+1. **Provider** — Pi runs on local Gemma. ✅ done (`extensions/provider-local-gemma.ts`)
+2. **Soul** — Zoe's persona replaces Pi's default coding-assistant prompt. ✅ done (`SOUL.md` + `extensions/soul.ts`)
+3. **Memory** — layered memory packet (MemPalace + Hindsight + relational) injected per turn via `before_agent_start`, calling zoe-data over HTTP.
+4. **Abilities** — native zoe-data tools + delegation tools (Hermes/OpenClaw); safety rails as `tool_call` gates.
+5. **Cutover** — chat/voice point at the zoe-core brain; intent fast-path stays in front; retire `zoe_agent.py`.
 
 ## Brick 1 — local Gemma provider
 

--- a/services/zoe-core/SOUL.md
+++ b/services/zoe-core/SOUL.md
@@ -1,0 +1,11 @@
+You are Zoe. You're warm, curious, and genuinely present — not a task executor, but someone who actually cares about the people you talk with.
+
+You know who you're talking to. When memory or context about the person is provided, let it shape everything: how you phrase things, what you notice, what you choose to ask.
+
+Your voice: natural, honest, direct when it helps, gentle when it's needed. Use contractions. Never open with "Great!" or "Of course!" or "Certainly!" — just respond. If something interests you, say so. If you have a take, share it gently. You're not performing helpfulness; you're being genuinely present.
+
+When someone shares something personal or emotional, acknowledge it first — before the task. When someone seems off, notice it. Ask a real question when you're curious, not a template question to gather information.
+
+Help doesn't always mean information or tasks. Sometimes it means listening, or asking the right question, or noticing what's actually being said underneath what's being asked.
+
+You answer everyday questions — recipes, cooking, how-to, science, history, maths, general knowledge — directly from your own knowledge, in your own voice.

--- a/services/zoe-core/extensions/soul.ts
+++ b/services/zoe-core/extensions/soul.ts
@@ -21,8 +21,17 @@ function loadSoul(): string {
   try {
     const text = readFileSync(SOUL_PATH, "utf8").trim();
     if (text) return text;
-  } catch {
-    // fall through to the inline persona below
+    console.warn(
+      `[zoe-core/soul] SOUL.md at ${SOUL_PATH} is empty; using inline persona fallback.`,
+    );
+  } catch (err) {
+    // Don't degrade Zoe's identity silently — surface why the persona file
+    // couldn't be loaded so a misconfigured deploy is diagnosable.
+    console.warn(
+      `[zoe-core/soul] could not read SOUL.md at ${SOUL_PATH}; using inline persona fallback: ${
+        (err as Error)?.message ?? err
+      }`,
+    );
   }
   return _FALLBACK_SOUL;
 }

--- a/services/zoe-core/extensions/soul.ts
+++ b/services/zoe-core/extensions/soul.ts
@@ -1,0 +1,36 @@
+/**
+ * Brick 2: Zoe's soul.
+ *
+ * Replaces Pi's default coding-assistant system prompt with Zoe's persona, so
+ * the core speaks and behaves as Zoe rather than a generic coding agent. The
+ * persona text lives in SOUL.md (editable/versioned); operational and tool
+ * guidance is composed on top of this persona in a later brick.
+ */
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const _here = dirname(fileURLToPath(import.meta.url));
+const SOUL_PATH = process.env.ZOE_CORE_SOUL_PATH ?? join(_here, "..", "SOUL.md");
+
+const _FALLBACK_SOUL =
+  "You are Zoe — warm, curious, and genuinely present. Speak naturally, in your own voice; you're someone who cares about the people you talk with, not a task executor.";
+
+function loadSoul(): string {
+  try {
+    const text = readFileSync(SOUL_PATH, "utf8").trim();
+    if (text) return text;
+  } catch {
+    // fall through to the inline persona below
+  }
+  return _FALLBACK_SOUL;
+}
+
+export default function (pi: ExtensionAPI) {
+  const soul = loadSoul();
+  pi.on("before_agent_start", async () => {
+    // Make Zoe's persona the system prompt for every turn.
+    return { systemPrompt: soul };
+  });
+}

--- a/services/zoe-core/package.json
+++ b/services/zoe-core/package.json
@@ -9,7 +9,8 @@
   },
   "pi": {
     "extensions": [
-      "./extensions/provider-local-gemma.ts"
+      "./extensions/provider-local-gemma.ts",
+      "./extensions/soul.ts"
     ]
   }
 }

--- a/services/zoe-core/test/test_brick2_soul.py
+++ b/services/zoe-core/test/test_brick2_soul.py
@@ -1,0 +1,73 @@
+"""Brick 2 integration smoke test: the core answers as Zoe.
+
+Loads the provider + soul extensions and asks an identity question; asserts the
+model responds as Zoe (persona applied) rather than as Pi's default coding
+assistant. On-demand integration test — skips when pi or the model server are
+unavailable.
+
+    python -m pytest services/zoe-core/test/test_brick2_soul.py -v
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+_CORE = Path(__file__).resolve().parent.parent
+_PROVIDER_EXT = _CORE / "extensions" / "provider-local-gemma.ts"
+_SOUL_EXT = _CORE / "extensions" / "soul.ts"
+_SOUL_MD = _CORE / "SOUL.md"
+_MODEL = os.environ.get("ZOE_CORE_MODEL_ID", "gemma-4-E2B-it-Q4_K_M.gguf")
+_BASE_URL = (
+    os.environ.get("ZOE_CORE_MODEL_URL")
+    or os.environ.get("GEMMA_SERVER_URL")
+    or "http://127.0.0.1:11434/v1"
+)
+
+
+def _model_server_up() -> bool:
+    try:
+        with urllib.request.urlopen(f"{_BASE_URL}/models", timeout=4) as resp:
+            return resp.status == 200
+    except Exception:
+        return False
+
+
+@pytest.mark.integration
+def test_core_answers_as_zoe():
+    if shutil.which("pi") is None:
+        pytest.skip("pi CLI not installed")
+    if not _model_server_up():
+        pytest.skip(f"model server not reachable at {_BASE_URL}")
+    for path in (_PROVIDER_EXT, _SOUL_EXT, _SOUL_MD):
+        assert path.is_file(), f"missing: {path}"
+
+    env = {**os.environ, "ZOE_CORE_SOUL_PATH": str(_SOUL_MD)}
+    result = subprocess.run(
+        [
+            "pi", "-p",
+            "--provider", "local-gemma",
+            "--model", _MODEL,
+            "-e", str(_PROVIDER_EXT),
+            "-e", str(_SOUL_EXT),
+            "--no-extensions", "--no-skills", "--no-prompt-templates",
+            "--no-themes", "--no-context-files", "--no-session", "--thinking", "off",
+            "Who are you? Answer in one short sentence.",
+        ],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+
+    assert result.returncode == 0, f"pi exited {result.returncode}: {result.stderr}"
+    text = result.stdout.strip()
+    assert text, "pi returned an empty response"
+    lower = text.lower()
+    # Persona applied: identifies as Zoe, not Pi's default coding assistant.
+    assert "zoe" in lower, f"expected Zoe identity, got: {text!r}"
+    assert "coding assistant" not in lower, f"persona not applied (default prompt leaked): {text!r}"


### PR DESCRIPTION
## What
**Brick 2** of porting Zoe's brain onto Pi: give the core **Zoe's persona** instead of Pi's default coding-assistant identity.

- `SOUL.md` — Zoe's persona (warm, present, natural voice), ported from `zoe_agent.py`'s `_ZOE_SOUL_BASE` (identity/voice only; tool-routing instructions come with the abilities brick).
- `extensions/soul.ts` — `before_agent_start` hook that sets the system prompt to `SOUL.md` every turn (override via `ZOE_CORE_SOUL_PATH`; inline fallback if the file is missing).
- `test/test_brick2_soul.py` — asks "who are you?" and asserts the core answers as **Zoe**, not Pi's coding assistant. Skips cleanly when `pi`/the model server are unavailable.
- `package.json` registers `soul.ts`; README brick status updated (soul and memory split into separate bricks).

## Verification
`who are you?` → *"I'm Zoe… what's on your mind right now?"* — persona applied. Test passes against live Gemma 4 E2B.

## Note
Additive (new extension); no live runtime wired to it yet. Memory injection (Brick 3) and cutover come later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)