### PR TITLE
feat(zoe-core): Brick 3 — wire MemPalace memory into the Pi brain

### DIFF
--- a/services/zoe-core/README.md
+++ b/services/zoe-core/README.md
@@ -17,6 +17,12 @@ via Pi's extension hooks.
 > (extensions/tools). The retired Docker monolith that once held this name is
 > archived at `docs/archive/retired-services/zoe-core/` — do not revive it.
 
+> **Status: lab-only / additive.** zoe-core is the destination brain (Pi on
+> Gemma 4 E2B), built and proven *beside* the live system. `zoe_agent` remains
+> the production chat brain until zoe-core clears the Samantha tests +
+> Pi-vs-`zoe_agent` benchmarks — then cutover. Nothing here is wired into
+> production yet.
+
 ## Architecture (target)
 
 ```
@@ -35,9 +41,9 @@ via Pi's extension hooks.
 
 1. **Provider** — Pi runs on local Gemma. ✅ done (`extensions/provider-local-gemma.ts`)
 2. **Soul** — Zoe's persona replaces Pi's default coding-assistant prompt. ✅ done (`SOUL.md` + `extensions/soul.ts`)
-3. **Memory** — layered memory packet (MemPalace + Hindsight + relational) injected per turn via `before_agent_start`, calling zoe-data over HTTP.
+3. **Memory** — MemPalace packet injected per turn via `before_agent_start`, fetched from zoe-data's internal `/api/memories/for-prompt` (compact, cited, fail-open). ✅ done (`extensions/memory.ts`). Hindsight/Graphiti compose into the same packet later.
 4. **Abilities** — native zoe-data tools + delegation tools (Hermes/OpenClaw); safety rails as `tool_call` gates.
-5. **Cutover** — chat/voice point at the zoe-core brain; intent fast-path stays in front; retire `zoe_agent.py`.
+5. **Cutover (benchmark-gated)** — only after the Samantha tests + Pi-vs-`zoe_agent` benchmarks pass: point chat/voice at the zoe-core brain, intent fast-path in front, retire `zoe_agent.py`. Until then, lab-only; `zoe_agent` stays production.
 
 ## Brick 1 — local Gemma provider
 

--- a/services/zoe-core/extensions/memory.ts
+++ b/services/zoe-core/extensions/memory.ts
@@ -13,6 +13,11 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
 const ZOE_DATA_URL = process.env.ZOE_DATA_URL ?? "http://127.0.0.1:8000";
 const INTERNAL_TOKEN = process.env.ZOE_INTERNAL_TOKEN ?? "";
+// NOTE: resolved once per process. Fine for the current CLI-per-session model
+// (each `pi` invocation is a fresh process for one user). BEFORE promoting Pi to
+// a long-running/multi-session server, this MUST become per-turn/per-session —
+// otherwise every caller would receive family-admin's memories (a privacy bug).
+// Tracked as a cutover prerequisite.
 const USER_ID = process.env.ZOE_CORE_USER_ID ?? "family-admin";
 const TIMEOUT_MS = Number(process.env.ZOE_CORE_MEMORY_TIMEOUT_MS ?? 2000);
 

--- a/services/zoe-core/extensions/memory.ts
+++ b/services/zoe-core/extensions/memory.ts
@@ -1,0 +1,43 @@
+/**
+ * Brick 3: inject Zoe's memory into the Pi brain.
+ *
+ * Each turn, fetches a compact, cited memory packet from zoe-data's internal
+ * `/api/memories/for-prompt` endpoint and composes it onto the system prompt
+ * (on top of the soul). MemPalace-backed today; the Samantha plan's
+ * Hindsight/Graphiti layers compose into the same packet server-side later.
+ *
+ * Fails OPEN: if memory is slow or unavailable, chat continues without it —
+ * memory must never block or break a turn (latency budget honored via timeout).
+ */
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+const ZOE_DATA_URL = process.env.ZOE_DATA_URL ?? "http://127.0.0.1:8000";
+const INTERNAL_TOKEN = process.env.ZOE_INTERNAL_TOKEN ?? "";
+const USER_ID = process.env.ZOE_CORE_USER_ID ?? "family-admin";
+const TIMEOUT_MS = Number(process.env.ZOE_CORE_MEMORY_TIMEOUT_MS ?? 2000);
+
+async function fetchMemoryPacket(message: string): Promise<string> {
+  try {
+    const url = new URL("/api/memories/for-prompt", ZOE_DATA_URL);
+    url.searchParams.set("user_id", USER_ID);
+    if (message) url.searchParams.set("message", message.slice(0, 500));
+    const headers: Record<string, string> = { Accept: "application/json" };
+    if (INTERNAL_TOKEN) headers["X-Internal-Token"] = INTERNAL_TOKEN;
+    const res = await fetch(url, { headers, signal: AbortSignal.timeout(TIMEOUT_MS) });
+    if (!res.ok) return "";
+    const data = (await res.json()) as { packet?: string };
+    return (data.packet ?? "").trim();
+  } catch {
+    return ""; // fail open — memory is best-effort, never block a turn
+  }
+}
+
+export default function (pi: ExtensionAPI) {
+  pi.on("before_agent_start", async (event) => {
+    const packet = await fetchMemoryPacket(String((event as { prompt?: unknown })?.prompt ?? ""));
+    if (!packet) return;
+    const base = event.systemPrompt ?? "";
+    // Compose under the soul (soul.ts runs earlier and sets the persona).
+    return { systemPrompt: base ? `${base}\n\n${packet}` : packet };
+  });
+}

--- a/services/zoe-core/package.json
+++ b/services/zoe-core/package.json
@@ -9,7 +9,8 @@
   },
   "pi": {
     "extensions": [
-      "./extensions/provider-local-gemma.ts"
+      "./extensions/provider-local-gemma.ts",
+      "./extensions/memory.ts"
     ]
   }
 }

--- a/services/zoe-core/test/test_brick3_memory.py
+++ b/services/zoe-core/test/test_brick3_memory.py
@@ -1,0 +1,107 @@
+"""Brick 3 integration smoke test: memory packet reaches the Pi brain.
+
+Stands up a tiny stub of zoe-data's /api/memories/for-prompt that returns a
+distinctive fact, runs Pi with the provider + memory extensions pointed at the
+stub, and asserts the model's answer reflects the injected memory — proving the
+fetch → inject path works end to end.
+
+On-demand integration test: needs `pi` + a reachable model server; skips
+otherwise.
+
+    python -m pytest services/zoe-core/test/test_brick3_memory.py -v
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import threading
+import urllib.request
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+import pytest
+
+_CORE = Path(__file__).resolve().parent.parent
+_PROVIDER_EXT = _CORE / "extensions" / "provider-local-gemma.ts"
+_MEMORY_EXT = _CORE / "extensions" / "memory.ts"
+_MODEL = os.environ.get("ZOE_CORE_MODEL_ID", "gemma-4-E2B-it-Q4_K_M.gguf")
+_BASE_URL = (
+    os.environ.get("ZOE_CORE_MODEL_URL")
+    or os.environ.get("GEMMA_SERVER_URL")
+    or "http://127.0.0.1:11434/v1"
+)
+_PACKET = "## What I know about you\n- Jason's dog is named Pixel [mem:test0001]"
+
+
+def _model_server_up() -> bool:
+    try:
+        with urllib.request.urlopen(f"{_BASE_URL}/models", timeout=4) as resp:
+            return resp.status == 200
+    except Exception:
+        return False
+
+
+class _MemoryStub(BaseHTTPRequestHandler):
+    def do_GET(self):  # noqa: N802
+        if self.path.startswith("/api/memories/for-prompt"):
+            body = json.dumps(
+                {"packet": _PACKET, "refs": [], "count": 1, "user_scoped": True}
+            ).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def log_message(self, *_args):  # silence
+        pass
+
+
+@pytest.mark.integration
+def test_memory_packet_reaches_the_brain():
+    if shutil.which("pi") is None:
+        pytest.skip("pi CLI not installed")
+    if not _model_server_up():
+        pytest.skip(f"model server not reachable at {_BASE_URL}")
+    assert _MEMORY_EXT.is_file()
+
+    server = HTTPServer(("127.0.0.1", 0), _MemoryStub)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        env = {
+            **os.environ,
+            "ZOE_DATA_URL": f"http://127.0.0.1:{port}",
+            "ZOE_CORE_USER_ID": "family-admin",
+            "ZOE_INTERNAL_TOKEN": "test",
+        }
+        result = subprocess.run(
+            [
+                "pi", "-p",
+                "--provider", "local-gemma",
+                "--model", _MODEL,
+                "-e", str(_PROVIDER_EXT),
+                "-e", str(_MEMORY_EXT),
+                "--no-extensions", "--no-skills", "--no-prompt-templates",
+                "--no-themes", "--no-context-files", "--no-session", "--thinking", "off",
+                "What is my dog's name? Answer with just the name.",
+            ],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=180,
+        )
+    finally:
+        server.shutdown()
+
+    assert result.returncode == 0, f"pi exited {result.returncode}: {result.stderr}"
+    text = result.stdout.strip()
+    assert text, "pi returned an empty response"
+    # The injected memory packet said the dog is "Pixel" — the brain should use it.
+    assert "pixel" in text.lower(), f"memory not used; got: {text!r}"

--- a/services/zoe-data/routers/memories.py
+++ b/services/zoe-data/routers/memories.py
@@ -16,7 +16,7 @@ from typing import Any, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 
-from auth import get_current_user, require_admin
+from auth import get_current_user, require_admin, require_internal_token
 from database import get_db
 from guest_policy import require_feature_access
 from memory_service import (
@@ -235,6 +235,90 @@ async def search_memories(
         row["score"] = ref.score
         results.append(row)
     return {"query": q, "results": results, "count": len(results)}
+
+
+_PROMPT_PACKET_MAX_FACTS = 12
+
+
+def _build_memory_prompt_packet(
+    facts: list[MemoryRef],
+    hits: list[MemoryRef],
+    *,
+    max_facts: int = _PROMPT_PACKET_MAX_FACTS,
+) -> dict[str, Any]:
+    """Compile a compact, cited memory packet for system-prompt injection.
+
+    Honors the Samantha memory prompt-policy: a small packet (not a raw dump),
+    every line carries a source/evidence id, superseded/archived facts are
+    dropped (prefer current), and disputed facts are surfaced as uncertain.
+    Message-relevant semantic hits lead; general facts follow.
+    """
+    seen: set[str] = set()
+    lines: list[str] = []
+    refs: list[dict[str, Any]] = []
+
+    def _consider(ref: MemoryRef, *, from_search: bool) -> None:
+        if len(lines) >= max_facts:
+            return
+        meta = ref.metadata or {}
+        status = str(meta.get("status") or "active").lower()
+        if status in {"superseded", "archived", "rejected"}:
+            return
+        text = (ref.text or "").strip()
+        if not text or ref.id in seen:
+            return
+        seen.add(ref.id)
+        cite = f"[mem:{str(ref.id)[:8]}]"
+        prefix = "(uncertain) " if status == "disputed" else ""
+        lines.append(f"- {prefix}{text[:200]} {cite}")
+        refs.append(
+            {
+                "id": ref.id,
+                "memory_type": meta.get("memory_type", "fact"),
+                "status": status,
+                "from_search": from_search,
+            }
+        )
+
+    for ref in hits:
+        _consider(ref, from_search=True)
+    for ref in facts:
+        _consider(ref, from_search=False)
+
+    if not lines:
+        return {"packet": "", "refs": [], "count": 0}
+    return {"packet": "## What I know about you\n" + "\n".join(lines), "refs": refs, "count": len(refs)}
+
+
+@router.get("/for-prompt")
+async def memory_for_prompt(
+    user_id: str = Query(..., min_length=1),
+    message: str = Query("", description="Current user message, for relevance ranking"),
+    limit: int = Query(_PROMPT_PACKET_MAX_FACTS, ge=1, le=40),
+    _: None = Depends(require_internal_token),
+):
+    """Compact, cited memory packet for injection into an agent's system prompt.
+
+    Internal/service endpoint (loopback or `X-Internal-Token`) — this is how the
+    zoe-core Pi brain pulls Zoe's memory each turn. Fails closed: guest/unknown
+    users get an empty packet. MemPalace-backed today; the Samantha plan's
+    Hindsight/Graphiti layers compose into this same packet later.
+    """
+    from memory_service import is_guest_memory_user
+
+    if not user_id or is_guest_memory_user(user_id):
+        return {"packet": "", "refs": [], "count": 0, "user_scoped": False}
+    svc = _svc()
+    facts = await svc.load_for_prompt(user_id, limit=limit)
+    hits: list[MemoryRef] = []
+    if message.strip():
+        try:
+            hits = await svc.search(message, user_id=user_id, limit=6)
+        except Exception:
+            hits = []
+    result = _build_memory_prompt_packet(facts, hits, max_facts=limit)
+    result["user_scoped"] = True
+    return result
 
 
 @router.get("/people")

--- a/services/zoe-data/routers/memories.py
+++ b/services/zoe-data/routers/memories.py
@@ -262,6 +262,13 @@ def _build_memory_prompt_packet(
             return
         meta = ref.metadata or {}
         status = str(meta.get("status") or "active").lower()
+        # Drop-set mirrors memory_service._BLOCKED_READ_STATUSES *except* "disputed",
+        # which the Samantha prompt-policy surfaces as "(uncertain)" rather than
+        # hiding. NOTE: today's callers (load_for_prompt / search) already pre-filter
+        # disputed at the service layer, so the disputed branch below is exercised
+        # only by future direct callers (e.g. Hindsight/Graphiti passing refs in) —
+        # it is intentional policy, not dead code. Keep this drop-set in sync with
+        # the service block list if statuses change.
         if status in {"superseded", "archived", "rejected", "pending"}:
             return
         text = (ref.text or "").strip()

--- a/services/zoe-data/routers/memories.py
+++ b/services/zoe-data/routers/memories.py
@@ -262,7 +262,7 @@ def _build_memory_prompt_packet(
             return
         meta = ref.metadata or {}
         status = str(meta.get("status") or "active").lower()
-        if status in {"superseded", "archived", "rejected"}:
+        if status in {"superseded", "archived", "rejected", "pending"}:
             return
         text = (ref.text or "").strip()
         if not text or ref.id in seen:

--- a/services/zoe-data/tests/test_memory_for_prompt.py
+++ b/services/zoe-data/tests/test_memory_for_prompt.py
@@ -1,0 +1,132 @@
+"""Tests for the /api/memories/for-prompt packet endpoint (Brick 3 memory).
+
+Covers the packet prompt-policy (compact, cited, current-over-superseded,
+disputed-as-uncertain, dedup, capped) and the endpoint contract (internal-token
+auth, fail-closed for guests, happy path).
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import auth
+import memory_service
+import routers.memories as memories_mod
+from memory_service import MemoryRef
+from routers.memories import _build_memory_prompt_packet, router as memories_router
+
+
+def _ref(mem_id: str, text: str, **meta) -> MemoryRef:
+    score = meta.pop("score", 0.0)
+    return MemoryRef(id=mem_id, text=text, metadata=meta, score=score)
+
+
+# ── packet builder (the prompt-policy) ────────────────────────────────────
+
+def test_packet_is_compact_and_cited():
+    facts = [_ref("abc12345", "Jason prefers concise answers"), _ref("def67890", "Lives in Geraldton")]
+    out = _build_memory_prompt_packet(facts, [])
+    assert out["count"] == 2
+    assert out["packet"].startswith("## What I know about you")
+    assert "[mem:abc12345]" in out["packet"]
+    assert "[mem:def67890]" in out["packet"]
+
+
+def test_packet_drops_superseded_and_archived():
+    facts = [
+        _ref("1", "Old job title", status="superseded"),
+        _ref("2", "Current job title", status="active"),
+        _ref("3", "Old address", status="archived"),
+    ]
+    out = _build_memory_prompt_packet(facts, [])
+    assert out["count"] == 1
+    assert "Current job title" in out["packet"]
+    assert "Old job title" not in out["packet"]
+    assert "Old address" not in out["packet"]
+
+
+def test_packet_marks_disputed_uncertain():
+    out = _build_memory_prompt_packet([_ref("9", "Maybe allergic to nuts", status="disputed")], [])
+    assert "(uncertain)" in out["packet"]
+
+
+def test_packet_dedups_and_caps():
+    facts = [_ref(str(i), f"fact {i}") for i in range(20)] + [_ref("0", "fact 0 dup")]
+    out = _build_memory_prompt_packet(facts, [], max_facts=5)
+    assert out["count"] == 5  # capped
+    assert out["packet"].count("[mem:") == 5
+
+
+def test_packet_search_hits_lead():
+    facts = [_ref("f1", "general fact")]
+    hits = [_ref("h1", "relevant to the question")]
+    out = _build_memory_prompt_packet(facts, hits)
+    # the search hit appears before the general fact
+    assert out["packet"].index("relevant to the question") < out["packet"].index("general fact")
+    assert out["refs"][0]["from_search"] is True
+
+
+def test_packet_empty_when_no_memories():
+    out = _build_memory_prompt_packet([], [])
+    assert out == {"packet": "", "refs": [], "count": 0}
+
+
+# ── endpoint (auth + fail-closed + happy path) ────────────────────────────
+
+class _FakeSvc:
+    def __init__(self, facts=None, hits=None):
+        self._facts = facts or []
+        self._hits = hits or []
+
+    async def load_for_prompt(self, user_id, *, limit=20):
+        return self._facts
+
+    async def search(self, q, *, user_id, limit=10):
+        return self._hits
+
+
+def _app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(memories_router)
+    return app
+
+
+def test_endpoint_requires_internal_token(monkeypatch):
+    monkeypatch.setattr(auth, "_ZOE_INTERNAL_TOKEN", "tok")
+    resp = TestClient(_app()).get("/api/memories/for-prompt", params={"user_id": "family-admin"})
+    assert resp.status_code == 403
+
+
+def test_endpoint_fails_closed_for_guest(monkeypatch):
+    monkeypatch.setattr(auth, "_ZOE_INTERNAL_TOKEN", "tok")
+    monkeypatch.setattr(memories_mod, "_svc", lambda: _FakeSvc(facts=[_ref("x", "should not appear")]))
+    monkeypatch.setattr(memory_service, "is_guest_memory_user", lambda uid: True)
+    resp = TestClient(_app()).get(
+        "/api/memories/for-prompt",
+        params={"user_id": "guest"},
+        headers={"X-Internal-Token": "tok"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body == {"packet": "", "refs": [], "count": 0, "user_scoped": False}
+
+
+def test_endpoint_happy_path(monkeypatch):
+    monkeypatch.setattr(auth, "_ZOE_INTERNAL_TOKEN", "tok")
+    monkeypatch.setattr(memory_service, "is_guest_memory_user", lambda uid: False)
+    monkeypatch.setattr(
+        memories_mod,
+        "_svc",
+        lambda: _FakeSvc(facts=[_ref("abc12345", "Jason prefers concise answers")]),
+    )
+    resp = TestClient(_app()).get(
+        "/api/memories/for-prompt",
+        params={"user_id": "family-admin", "message": "what do you know about me"},
+        headers={"X-Internal-Token": "tok"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["user_scoped"] is True
+    assert body["count"] == 1
+    assert "[mem:abc12345]" in body["packet"]


### PR DESCRIPTION
## What
**Brick 3** closes the gap both prior memory plans (Nov-2025 research package, June-2026 evolution-harness, Codex's lost Samantha slice) stalled at: **nobody injected memory into the brain.** Implemented per the Samantha plan's memory prompt-policy.

### zoe-data
- `GET /api/memories/for-prompt` (internal-token: loopback or `X-Internal-Token`) returns a **compact, cited** memory packet from MemPalace. Honors the policy: small packet (not a raw dump), every line carries a `[mem:id]` evidence cite, superseded/archived dropped (prefer current), disputed surfaced as `(uncertain)`, semantic hits lead. **Fails closed** — guest/unknown users get an empty packet.

### zoe-core
- `extensions/memory.ts` — `before_agent_start` fetches the packet and composes it onto the system prompt (under the soul). **Fails open** with a 2s timeout — memory never blocks or breaks a turn.

## Verification
- `test_memory_for_prompt.py` (9 tests): packet policy (compact / cited / supersession / disputed / dedup / cap / search-lead) + endpoint auth + guest fail-closed + happy path.
- `test_brick3_memory.py`: **end-to-end** — a stub memory server returns "Jason's dog is named Pixel"; Pi fetches, injects, and the brain answers **"Pixel."** ✅
- Full zoe-data suite: **2446 passed** (no regressions).

## Scope / guardrails
MemPalace-backed today; Hindsight/Graphiti compose into the same packet later (measured sidecars). `zoe_agent` untouched. **Lab-only / additive** — nothing wired to production; cutover is benchmark-gated on the Samantha tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)