### PR TITLE
feat(zoe-core): Brick 4a — capability registry foundation

### DIFF
--- a/services/zoe-core/abilities/info.ts
+++ b/services/zoe-core/abilities/info.ts
@@ -5,7 +5,7 @@
  * time/date answer locally; weather calls zoe-data. Copy this shape for
  * calendar, lists, notes, people, media, home, etc.
  */
-import { Type } from "typebox";
+import { Type } from "@sinclair/typebox";
 import type { CapabilityEntry } from "./types";
 
 const info: CapabilityEntry = {

--- a/services/zoe-core/abilities/info.ts
+++ b/services/zoe-core/abilities/info.ts
@@ -1,0 +1,62 @@
+/**
+ * Reference domain tool: `info` — weather / time / date.
+ *
+ * Demonstrates the CapabilityEntry contract every domain tool follows:
+ * time/date answer locally; weather calls zoe-data. Copy this shape for
+ * calendar, lists, notes, people, media, home, etc.
+ */
+import { Type } from "typebox";
+import type { CapabilityEntry } from "./types";
+
+const info: CapabilityEntry = {
+  id: "info.query",
+  name: "info",
+  domain: "info",
+  description:
+    "Answer weather, current time, and date questions. Use when the user asks about weather/forecast/temperature, what time it is, or what today's date/day is.",
+  parameters: Type.Object({
+    kind: Type.String({ description: "one of: weather | time | date" }),
+  }),
+  examples: ["what's the weather", "is it going to rain", "what time is it", "what's the date today"],
+  negativeExamples: ["set a timer for ten minutes", "add milk to my shopping list"],
+  permissions: ["read-only", "network"],
+  tier: "on-demand",
+  triggers: [
+    /\b(weather|rain|forecast|temperature|temp|umbrella|jacket|hot|cold|sunny|wind)\b/i,
+    /\b(time|clock|o'?clock|date|day|today)\b/i,
+  ],
+  async execute(params, ctx) {
+    const kind = String(params.kind ?? "").toLowerCase();
+    if (kind === "time") {
+      return `It's ${new Date().toLocaleTimeString([], { hour: "numeric", minute: "2-digit" })}.`;
+    }
+    if (kind === "date") {
+      return `Today is ${new Date().toLocaleDateString(undefined, {
+        weekday: "long",
+        year: "numeric",
+        month: "long",
+        day: "numeric",
+      })}.`;
+    }
+    // weather → zoe-data
+    try {
+      const url = new URL("/api/weather/current", ctx.zoeDataUrl);
+      const headers: Record<string, string> = { Accept: "application/json" };
+      if (ctx.internalToken) headers["X-Internal-Token"] = ctx.internalToken;
+      const res = await fetch(url, { headers, signal: AbortSignal.timeout(4000) });
+      if (!res.ok) return "I couldn't reach the weather service right now.";
+      const d = (await res.json()) as Record<string, any>;
+      const cur = d.current ?? d;
+      const temp = cur.temp ?? cur.temperature;
+      const desc = cur.description ?? cur.summary ?? "";
+      const city = cur.city ?? "your area";
+      return temp != null
+        ? `It's ${temp}°${desc ? ` and ${desc}` : ""} in ${city}.`
+        : "I don't have the current weather right now.";
+    } catch {
+      return "I couldn't reach the weather service right now.";
+    }
+  },
+};
+
+export default [info];

--- a/services/zoe-core/abilities/types.ts
+++ b/services/zoe-core/abilities/types.ts
@@ -1,0 +1,64 @@
+/**
+ * Brick 4 — the capability contract.
+ *
+ * Each domain tool lives in its own `abilities/<domain>.ts` file and default-
+ * exports a `CapabilityEntry[]`. `extensions/abilities.ts` auto-discovers them,
+ * registers them with Pi, enforces the permission envelope, and does
+ * progressive disclosure (only surfaces relevant tools per turn). Adding a
+ * domain = adding ONE file; no manifest or shared-file edits.
+ */
+import type { TSchema } from "typebox";
+
+/** Permission envelope (validated before every tool execution). */
+export type Permission =
+  | "read-only"
+  | "user-data:read"
+  | "user-data:write"
+  | "fs:write"
+  | "network"
+  | "browser"
+  | "home-device:action"
+  | "code:mutate"
+  | "credential:access";
+
+/** Ambient context handed to every ability's execute(). */
+export interface AbilityContext {
+  /** Base URL of zoe-data (the capability backend). */
+  zoeDataUrl: string;
+  /** Internal service token for zoe-data calls (X-Internal-Token). */
+  internalToken: string;
+  /** The Zoe user whose data this turn operates on. */
+  userId: string;
+}
+
+export interface CapabilityEntry {
+  /** Stable id, e.g. "calendar.create_event". */
+  id: string;
+  /** Tool name the model calls (snake_case, one per domain), e.g. "calendar". */
+  name: string;
+  /** Routing domain, e.g. "calendar". */
+  domain: string;
+  /** One line — WHAT it does and WHEN to use it (the model's routing signal). */
+  description: string;
+  /** typebox schema for the tool's parameters (validated before execute). */
+  parameters: TSchema;
+  /** Phrasings that SHOULD trigger this tool (few-shot + relevance gating). */
+  examples: string[];
+  /** Phrasings that should NOT trigger it (reduces false fires on a small model). */
+  negativeExamples?: string[];
+  /** Permission scopes this tool needs (enforced before execute). */
+  permissions: Permission[];
+  /** "core" = always in the prompt; "on-demand" = surfaced only when relevant. */
+  tier: "core" | "on-demand";
+  /** Keyword triggers for lightweight relevance gating (pre-embedding Tool-RAG). */
+  triggers?: RegExp[];
+  /** Runtime eligibility (peer health, device presence, time-of-day). */
+  gate?: (ctx: AbilityContext) => boolean;
+  /** Do the thing. Return a short natural-language result for the model. */
+  execute: (params: Record<string, unknown>, ctx: AbilityContext) => Promise<string>;
+}
+
+/** A domain file default-exports CapabilityEntry[] (or exports `abilities`). */
+export type AbilityModule =
+  | { default: CapabilityEntry[] }
+  | { abilities: CapabilityEntry[] };

--- a/services/zoe-core/abilities/types.ts
+++ b/services/zoe-core/abilities/types.ts
@@ -7,7 +7,7 @@
  * progressive disclosure (only surfaces relevant tools per turn). Adding a
  * domain = adding ONE file; no manifest or shared-file edits.
  */
-import type { TSchema } from "typebox";
+import type { TSchema } from "@sinclair/typebox";
 
 /** Permission envelope (validated before every tool execution). */
 export type Permission =

--- a/services/zoe-core/extensions/abilities.ts
+++ b/services/zoe-core/extensions/abilities.ts
@@ -59,9 +59,10 @@ async function loadAbilities(): Promise<CapabilityEntry[]> {
 function isRelevant(entry: CapabilityEntry, msg: string): boolean {
   if (entry.tier === "core") return true;
   if ((entry.triggers ?? []).some((re) => re.test(msg))) return true;
+  const normalizedMsg = msg.replace(/[^a-z0-9 ]/g, "");
   return entry.examples.some((ex) => {
     const key = ex.toLowerCase().replace(/[^a-z0-9 ]/g, "").trim();
-    return key.length >= 4 && msg.includes(key.slice(0, Math.min(key.length, 16)));
+    return key.length >= 4 && normalizedMsg.includes(key.slice(0, Math.min(key.length, 16)));
   });
 }
 

--- a/services/zoe-core/extensions/abilities.ts
+++ b/services/zoe-core/extensions/abilities.ts
@@ -19,17 +19,30 @@ import type { AbilityContext, CapabilityEntry, Permission } from "../abilities/t
 const _here = dirname(fileURLToPath(import.meta.url));
 const ABILITIES_DIR = join(_here, "..", "abilities");
 
-// NOTE: userId is resolved once per process — correct for the current
-// CLI-per-session model (each `pi` run serves one user). BEFORE promoting Pi to
-// a long-running/multi-session server, CTX.userId MUST become per-turn/
-// per-session, or every caller would act on family-admin's data (a privacy bug).
-// Same cutover prerequisite tracked in memory.ts. zoeDataUrl/internalToken are
-// process-stable and fine as constants.
-const CTX: AbilityContext = {
-  zoeDataUrl: process.env.ZOE_DATA_URL ?? "http://127.0.0.1:8000",
-  internalToken: process.env.ZOE_INTERNAL_TOKEN ?? "",
-  userId: process.env.ZOE_CORE_USER_ID ?? "family-admin",
-};
+// The acting user is resolved PER TURN (not baked at module load), so a single
+// Pi process is never pinned to one identity. zoe-data drives one Pi session per
+// user-conversation and sets ZOE_CORE_USER_ID for that session; we read it fresh
+// each call. There is NO default user — if the identity is unknown, user-scoped
+// tools fail closed (below) rather than silently acting as someone else.
+function abilityContext(): AbilityContext {
+  return {
+    zoeDataUrl: process.env.ZOE_DATA_URL ?? "http://127.0.0.1:8000",
+    internalToken: process.env.ZOE_INTERNAL_TOKEN ?? "",
+    userId: (process.env.ZOE_CORE_USER_ID ?? "").trim(),
+  };
+}
+
+// A tool touches the user's data/devices if it needs anything beyond read-only/
+// network — those MUST have a known user. Pure-info tools (e.g. time/weather) do not.
+const USER_SCOPED_PERMS: Permission[] = [
+  "user-data:read",
+  "user-data:write",
+  "home-device:action",
+  "credential:access",
+];
+function needsUser(entry: CapabilityEntry): boolean {
+  return entry.permissions.some((p) => USER_SCOPED_PERMS.includes(p));
+}
 
 // Lab permission policy: reads are free; writes/device/credential/code need an
 // explicit allow (stand-in for per-action human approval — see harness kernel).
@@ -82,13 +95,23 @@ export default async function (pi: ExtensionAPI) {
       description: entry.description,
       parameters: entry.parameters,
       async execute(_toolCallId: string, params: Record<string, unknown>) {
+        const ctx = abilityContext();
+        // Fail closed: a user-scoped tool with no known acting user must NOT run
+        // (never silently act as a default identity).
+        if (needsUser(entry) && !ctx.userId) {
+          return {
+            content: [
+              { type: "text", text: "I'm not sure whose account I'd be acting on, so I can't do that safely right now." },
+            ],
+          };
+        }
         const denied = permissionDenial(entry);
         if (denied) return { content: [{ type: "text", text: denied }] };
-        if (entry.gate && !entry.gate(CTX)) {
+        if (entry.gate && !entry.gate(ctx)) {
           return { content: [{ type: "text", text: `${entry.name} is unavailable right now.` }] };
         }
         try {
-          const out = await entry.execute(params, CTX);
+          const out = await entry.execute(params, ctx);
           return { content: [{ type: "text", text: String(out) }] };
         } catch (err) {
           return { content: [{ type: "text", text: `${entry.name} failed: ${(err as Error)?.message ?? err}` }] };

--- a/services/zoe-core/extensions/abilities.ts
+++ b/services/zoe-core/extensions/abilities.ts
@@ -1,0 +1,103 @@
+/**
+ * Brick 4 foundation: Zoe's capability registry.
+ *
+ * Auto-discovers `abilities/*.ts` (each default-exports CapabilityEntry[]),
+ * registers them as Pi tools wrapped with permission-envelope enforcement, and
+ * does PROGRESSIVE DISCLOSURE — only the always-on core plus relevance-matched
+ * tools are active each turn, so a ~2B local model isn't drowned in 56 tools.
+ *
+ * Relevance is keyword/example based for now (deterministic, no embedder);
+ * vector Tool-RAG is the documented upgrade. Domain tools are independent files
+ * — adding one needs no edit here.
+ */
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { readdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import type { AbilityContext, CapabilityEntry, Permission } from "../abilities/types";
+
+const _here = dirname(fileURLToPath(import.meta.url));
+const ABILITIES_DIR = join(_here, "..", "abilities");
+
+const CTX: AbilityContext = {
+  zoeDataUrl: process.env.ZOE_DATA_URL ?? "http://127.0.0.1:8000",
+  internalToken: process.env.ZOE_INTERNAL_TOKEN ?? "",
+  userId: process.env.ZOE_CORE_USER_ID ?? "family-admin",
+};
+
+// Lab permission policy: reads are free; writes/device/credential/code need an
+// explicit allow (stand-in for per-action human approval — see harness kernel).
+const ALLOW_WRITES = (process.env.ZOE_CORE_ALLOW_WRITES ?? "false").toLowerCase() === "true";
+const FREELY_ALLOWED: Permission[] = ["read-only", "user-data:read", "network"];
+
+function permissionDenial(entry: CapabilityEntry): string | null {
+  const escalations = entry.permissions.filter((p) => !FREELY_ALLOWED.includes(p));
+  if (escalations.length === 0 || ALLOW_WRITES) return null;
+  return `That needs permission not enabled here (${escalations.join(", ")}). Ask the user to confirm.`;
+}
+
+async function loadAbilities(): Promise<CapabilityEntry[]> {
+  let files: string[] = [];
+  try {
+    files = readdirSync(ABILITIES_DIR).filter((f) => f.endsWith(".ts") && f !== "types.ts");
+  } catch {
+    return [];
+  }
+  const entries: CapabilityEntry[] = [];
+  for (const file of files.sort()) {
+    try {
+      const mod = await import(pathToFileURL(join(ABILITIES_DIR, file)).href);
+      const list: unknown = mod.default ?? mod.abilities;
+      if (Array.isArray(list)) entries.push(...(list as CapabilityEntry[]));
+    } catch (err) {
+      console.warn(`[zoe-core/abilities] failed to load ${file}: ${(err as Error)?.message ?? err}`);
+    }
+  }
+  return entries;
+}
+
+function isRelevant(entry: CapabilityEntry, msg: string): boolean {
+  if (entry.tier === "core") return true;
+  if ((entry.triggers ?? []).some((re) => re.test(msg))) return true;
+  return entry.examples.some((ex) => {
+    const key = ex.toLowerCase().replace(/[^a-z0-9 ]/g, "").trim();
+    return key.length >= 4 && msg.includes(key.slice(0, Math.min(key.length, 16)));
+  });
+}
+
+export default async function (pi: ExtensionAPI) {
+  const abilities = await loadAbilities();
+
+  for (const entry of abilities) {
+    pi.registerTool({
+      name: entry.name,
+      label: entry.name,
+      description: entry.description,
+      parameters: entry.parameters,
+      async execute(_toolCallId: string, params: Record<string, unknown>) {
+        const denied = permissionDenial(entry);
+        if (denied) return { content: [{ type: "text", text: denied }] };
+        if (entry.gate && !entry.gate(CTX)) {
+          return { content: [{ type: "text", text: `${entry.name} is unavailable right now.` }] };
+        }
+        try {
+          const out = await entry.execute(params, CTX);
+          return { content: [{ type: "text", text: String(out) }] };
+        } catch (err) {
+          return { content: [{ type: "text", text: `${entry.name} failed: ${(err as Error)?.message ?? err}` }] };
+        }
+      },
+    });
+  }
+
+  // Progressive disclosure — surface core + relevance-matched tools each turn.
+  pi.on("before_agent_start", async (event) => {
+    const msg = String((event as { prompt?: unknown })?.prompt ?? "").toLowerCase();
+    const active = abilities.filter((a) => isRelevant(a, msg)).map((a) => a.name);
+    try {
+      (pi as { setActiveTools?: (names: string[]) => void }).setActiveTools?.(active);
+    } catch {
+      /* setActiveTools is best-effort; if unavailable, all registered tools stay active */
+    }
+  });
+}

--- a/services/zoe-core/extensions/abilities.ts
+++ b/services/zoe-core/extensions/abilities.ts
@@ -19,6 +19,12 @@ import type { AbilityContext, CapabilityEntry, Permission } from "../abilities/t
 const _here = dirname(fileURLToPath(import.meta.url));
 const ABILITIES_DIR = join(_here, "..", "abilities");
 
+// NOTE: userId is resolved once per process — correct for the current
+// CLI-per-session model (each `pi` run serves one user). BEFORE promoting Pi to
+// a long-running/multi-session server, CTX.userId MUST become per-turn/
+// per-session, or every caller would act on family-admin's data (a privacy bug).
+// Same cutover prerequisite tracked in memory.ts. zoeDataUrl/internalToken are
+// process-stable and fine as constants.
 const CTX: AbilityContext = {
   zoeDataUrl: process.env.ZOE_DATA_URL ?? "http://127.0.0.1:8000",
   internalToken: process.env.ZOE_INTERNAL_TOKEN ?? "",
@@ -95,10 +101,25 @@ export default async function (pi: ExtensionAPI) {
   pi.on("before_agent_start", async (event) => {
     const msg = String((event as { prompt?: unknown })?.prompt ?? "").toLowerCase();
     const active = abilities.filter((a) => isRelevant(a, msg)).map((a) => a.name);
+    const setActiveTools = (pi as { setActiveTools?: (names: string[]) => void }).setActiveTools;
+    if (typeof setActiveTools !== "function") {
+      // Observability: if the Pi build lacks setActiveTools, progressive
+      // disclosure is a no-op (ALL tools stay active) — surface it once so a
+      // 2B model getting drowned in tools is diagnosable, not silent.
+      if (!(globalThis as Record<string, unknown>).__zoeAbilitiesDisclosureWarned) {
+        (globalThis as Record<string, unknown>).__zoeAbilitiesDisclosureWarned = true;
+        console.warn(
+          "[zoe-core/abilities] setActiveTools unavailable — progressive disclosure disabled; all tools stay active.",
+        );
+      }
+      return;
+    }
     try {
-      (pi as { setActiveTools?: (names: string[]) => void }).setActiveTools?.(active);
-    } catch {
-      /* setActiveTools is best-effort; if unavailable, all registered tools stay active */
+      setActiveTools(active);
+    } catch (err) {
+      console.warn(
+        `[zoe-core/abilities] setActiveTools failed (${active.length} tools intended): ${(err as Error)?.message ?? err}`,
+      );
     }
   });
 }

--- a/services/zoe-core/package.json
+++ b/services/zoe-core/package.json
@@ -10,7 +10,8 @@
   "pi": {
     "extensions": [
       "./extensions/provider-local-gemma.ts",
-      "./extensions/soul.ts"
+      "./extensions/soul.ts",
+      "./extensions/abilities.ts"
     ]
   }
 }

--- a/services/zoe-core/package.json
+++ b/services/zoe-core/package.json
@@ -5,7 +5,8 @@
   "description": "Zoe's reasoning/orchestration core — Pi-agent extensions (provider, soul, memory, abilities).",
   "type": "module",
   "dependencies": {
-    "@earendil-works/pi-coding-agent": "^0.79.3"
+    "@earendil-works/pi-coding-agent": "^0.79.3",
+    "@sinclair/typebox": "^0.34.0"
   },
   "pi": {
     "extensions": [

--- a/services/zoe-core/test/test_brick4a_abilities.py
+++ b/services/zoe-core/test/test_brick4a_abilities.py
@@ -1,0 +1,77 @@
+"""Brick 4a integration smoke test: the capability registry works end-to-end.
+
+Loads the provider + abilities extensions and asks a question the reference
+`info` tool answers locally (time/date) — proving auto-discovery, progressive
+disclosure (the tool gets surfaced), registration, and execution all work.
+
+On-demand integration test: needs `pi` + a reachable model server; skips
+otherwise.
+
+    python -m pytest services/zoe-core/test/test_brick4a_abilities.py -v
+"""
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+_CORE = Path(__file__).resolve().parent.parent
+_PROVIDER_EXT = _CORE / "extensions" / "provider-local-gemma.ts"
+_ABILITIES_EXT = _CORE / "extensions" / "abilities.ts"
+_INFO_ABILITY = _CORE / "abilities" / "info.ts"
+_MODEL = os.environ.get("ZOE_CORE_MODEL_ID", "gemma-4-E2B-it-Q4_K_M.gguf")
+_BASE_URL = (
+    os.environ.get("ZOE_CORE_MODEL_URL")
+    or os.environ.get("GEMMA_SERVER_URL")
+    or "http://127.0.0.1:11434/v1"
+)
+
+
+def _model_server_up() -> bool:
+    try:
+        with urllib.request.urlopen(f"{_BASE_URL}/models", timeout=4) as resp:
+            return resp.status == 200
+    except Exception:
+        return False
+
+
+def _run_pi(prompt: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [
+            "pi", "-p",
+            "--provider", "local-gemma",
+            "--model", _MODEL,
+            "-e", str(_PROVIDER_EXT),
+            "-e", str(_ABILITIES_EXT),
+            "--no-extensions", "--no-skills", "--no-prompt-templates",
+            "--no-themes", "--no-context-files", "--no-session", "--thinking", "off",
+            prompt,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+
+
+@pytest.mark.integration
+def test_registry_loads_and_info_tool_answers():
+    if shutil.which("pi") is None:
+        pytest.skip("pi CLI not installed")
+    if not _model_server_up():
+        pytest.skip(f"model server not reachable at {_BASE_URL}")
+    for p in (_ABILITIES_EXT, _INFO_ABILITY):
+        assert p.is_file(), f"missing: {p}"
+
+    result = _run_pi("What is today's date? Use your tools, then answer in one short sentence.")
+    assert result.returncode == 0, f"pi exited {result.returncode}: {result.stderr}"
+    text = result.stdout.strip()
+    assert text, "pi returned an empty response"
+    # The `info` tool was discovered, surfaced (progressive disclosure), and run:
+    # the answer should name the current year (deterministic, from local date()).
+    year = str(__import__("datetime").date.today().year)
+    assert year in text, f"info tool result not reflected; got: {text!r}"


### PR DESCRIPTION
## What
The **foundation** for Zoe's abilities: a capability registry that auto-discovers domain-tool files, enforces a permission envelope, and does progressive disclosure — designed so domain tools (Brick 4b) are independent files that parallelize cleanly with **zero shared-manifest edits**.

- `abilities/types.ts` — the `CapabilityEntry` contract + `Permission` envelope.
- `extensions/abilities.ts` — discovery + registration + permission gates + relevance-gated tool surfacing (so a ~2B model sees only relevant tools, not all 56). Vector Tool-RAG is the documented next step.
- `abilities/info.ts` — reference domain tool (weather/time/date); the shape every other domain copies.

## Verification
e2e: pi loads the registry → progressive disclosure surfaces `info` → model answers "today's date" with the current year via the tool. ✅ Passing against live Gemma 4 E2B.

## Design provenance
Flue (tool/skill split, subagent delegation), RAG-MCP (progressive disclosure), CASE (permission envelope). Lab-only; `zoe_agent` untouched; cutover benchmark-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)