### PR TITLE
fix(zoe-core): memory resolves user per-turn + fail closed (multi-user safe)

### DIFF
--- a/services/zoe-core/extensions/memory.ts
+++ b/services/zoe-core/extensions/memory.ts
@@ -13,18 +13,22 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
 const ZOE_DATA_URL = process.env.ZOE_DATA_URL ?? "http://127.0.0.1:8000";
 const INTERNAL_TOKEN = process.env.ZOE_INTERNAL_TOKEN ?? "";
-// NOTE: resolved once per process. Fine for the current CLI-per-session model
-// (each `pi` invocation is a fresh process for one user). BEFORE promoting Pi to
-// a long-running/multi-session server, this MUST become per-turn/per-session —
-// otherwise every caller would receive family-admin's memories (a privacy bug).
-// Tracked as a cutover prerequisite.
-const USER_ID = process.env.ZOE_CORE_USER_ID ?? "family-admin";
 const TIMEOUT_MS = Number(process.env.ZOE_CORE_MEMORY_TIMEOUT_MS ?? 2000);
 
+// The acting user is resolved PER TURN (not baked at module load), with NO
+// default identity: if the user is unknown we inject NO memory packet rather
+// than leak a default user's memories. zoe-data drives one Pi session per
+// user-conversation and sets ZOE_CORE_USER_ID for that session.
+function currentUserId(): string {
+  return (process.env.ZOE_CORE_USER_ID ?? "").trim();
+}
+
 async function fetchMemoryPacket(message: string): Promise<string> {
+  const userId = currentUserId();
+  if (!userId) return ""; // fail closed: unknown user → inject no memory
   try {
     const url = new URL("/api/memories/for-prompt", ZOE_DATA_URL);
-    url.searchParams.set("user_id", USER_ID);
+    url.searchParams.set("user_id", userId);
     if (message) url.searchParams.set("message", message.slice(0, 500));
     const headers: Record<string, string> = { Accept: "application/json" };
     if (INTERNAL_TOKEN) headers["X-Internal-Token"] = INTERNAL_TOKEN;

--- a/services/zoe-core/test/test_brick3_memory.py
+++ b/services/zoe-core/test/test_brick3_memory.py
@@ -43,9 +43,15 @@ def _model_server_up() -> bool:
         return False
 
 
+# Records every /api/memories/for-prompt request the stub receives, so a test
+# can assert the brain did NOT fetch memory (fail-closed) when the user is unknown.
+_FOR_PROMPT_HITS: list[str] = []
+
+
 class _MemoryStub(BaseHTTPRequestHandler):
     def do_GET(self):  # noqa: N802
         if self.path.startswith("/api/memories/for-prompt"):
+            _FOR_PROMPT_HITS.append(self.path)
             body = json.dumps(
                 {"packet": _PACKET, "refs": [], "count": 1, "user_scoped": True}
             ).encode()
@@ -105,3 +111,47 @@ def test_memory_packet_reaches_the_brain():
     assert text, "pi returned an empty response"
     # The injected memory packet said the dog is "Pixel" — the brain should use it.
     assert "pixel" in text.lower(), f"memory not used; got: {text!r}"
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("user_env", [None, "", "   "], ids=["unset", "empty", "whitespace"])
+def test_memory_fail_closed_when_user_unknown(user_env):
+    """No known user (unset / empty / whitespace) → NO memory packet is even
+    requested. Proves the fail-closed path: we never fetch a default user's
+    memories when the acting user is unknown."""
+    if shutil.which("pi") is None:
+        pytest.skip("pi CLI not installed")
+    if not _model_server_up():
+        pytest.skip(f"model server not reachable at {_BASE_URL}")
+    _FOR_PROMPT_HITS.clear()
+
+    server = HTTPServer(("127.0.0.1", 0), _MemoryStub)
+    port = server.server_address[1]
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    try:
+        env = {k: v for k, v in os.environ.items() if k != "ZOE_CORE_USER_ID"}
+        if user_env is not None:
+            env["ZOE_CORE_USER_ID"] = user_env
+        env.update({"ZOE_DATA_URL": f"http://127.0.0.1:{port}", "ZOE_INTERNAL_TOKEN": "test"})
+        result = subprocess.run(
+            [
+                "pi", "-p",
+                "--provider", "local-gemma",
+                "--model", _MODEL,
+                "-e", str(_PROVIDER_EXT),
+                "-e", str(_MEMORY_EXT),
+                "--no-extensions", "--no-skills", "--no-prompt-templates",
+                "--no-themes", "--no-context-files", "--no-session", "--thinking", "off",
+                "What's my dog's name?",
+            ],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=180,
+        )
+    finally:
+        server.shutdown()
+
+    assert result.returncode == 0, f"pi exited {result.returncode}: {result.stderr}"
+    # The headline guarantee: unknown user → memory was never fetched.
+    assert _FOR_PROMPT_HITS == [], f"memory fetched despite unknown user ({user_env!r}): {_FOR_PROMPT_HITS}"


### PR DESCRIPTION
Applies the same multi-user-safety fix as the abilities registry to the already-merged `memory.ts`: the acting user is resolved **per turn** from `ZOE_CORE_USER_ID` (no module-load constant, no `family-admin` default). With no known user, **no memory packet is injected** rather than leaking a default user's memories. Fail-open on unreachable service is preserved (memory never blocks a turn).

Verified: brick3 memory e2e still passes (user set → packet injected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)