### PR TITLE
fix(harness): converge no-op implement (empty worktree) to ALREADY_COVERED

### DIFF
--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -42,6 +42,15 @@ _REAP_DEAD_WORKERS = (
     os.environ.get("ZOE_KANBAN_REAP_DEAD_WORKERS", "true") or "true"
 ).strip().lower() not in {"0", "false", "no"}
 
+# When an implement row is gate-blocked for a missing PR but the task worktree
+# is provably empty (no diff, nothing unpushed), there is genuinely nothing to
+# ship — the work is already present on the base. Converge it to the proven
+# ALREADY_COVERED -> skip_implementation -> audit path instead of stranding the
+# single lane on a permanent gate block. Default on; disable with =0/false/no.
+_CONVERGE_NOOP_IMPLEMENT = (
+    os.environ.get("ZOE_KANBAN_CONVERGE_NOOP_IMPLEMENT", "true") or "true"
+).strip().lower() not in {"0", "false", "no"}
+
 logger = logging.getLogger(__name__)
 
 NAME = "kanban"
@@ -896,6 +905,11 @@ class KanbanAdapter:
                 " that wastes the run: open the PR yourself instead. `kanban_block` is ONLY for genuine"
                 " blockers where you cannot ship (dirty tree, missing auth, ambiguous product decision,"
                 " repeated test failure, scope too broad).\n"
+                "- ALREADY DONE / NO CHANGE NEEDED: if the acceptance criteria are already met on the base"
+                " branch and no code change is required (e.g. the fix already landed, or the target file"
+                " does not exist in the repo), call `kanban_block` with BLOCKER=ALREADY_COVERED and the"
+                " evidence (e.g. the passing test output). NEVER call `kanban_complete` without a PR_URL —"
+                " a completion with an empty diff and no PR fails the evidence gate and strands the ticket.\n"
                 f"{code_audit_hint}"
                 f"{harness_hint}"
                 f"{intent_gap_hint}"
@@ -1575,6 +1589,105 @@ class KanbanAdapter:
             )
             return None
 
+    async def _maybe_converge_noop_implement(
+        self,
+        task_id: str,
+        phase: str,
+        row: dict[str, Any],
+        *,
+        detail: dict[str, Any] | None = None,
+    ) -> bool:
+        """Converge a no-op implement (empty worktree, missing-PR gate) to ALREADY_COVERED.
+
+        ``_maybe_recover_unshipped_diff`` salvages a *non-empty* diff the worker
+        never pushed. This handles the other case observed live (ZOE-5856): the fix
+        was already present on the base branch, so implement produced NO diff, then
+        completed without a PR -> the evidence gate blocks on missing ``pr`` and the
+        single lane strands on a permanent gate block. When the task worktree is
+        provably empty (clean tree, nothing unpushed) there is nothing to ship, so
+        re-block with ``BLOCKER=ALREADY_COVERED`` and let pipeline_store converge it
+        via the proven skip_implementation -> audit path (no PR required).
+
+        Safety: only fires for an implement row blocked specifically on the
+        missing-PR evidence gate (never real blockers like TEST_ENVIRONMENT /
+        IMPLEMENT_BUDGET / a dirty or unpushed tree), and only inside the task's own
+        ``wt/<task_id>`` branch. Gated by ZOE_KANBAN_CONVERGE_NOOP_IMPLEMENT.
+        """
+        if not _CONVERGE_NOOP_IMPLEMENT:
+            return False
+        if phase != "implement" or (row.get("status") or "").lower() != "blocked":
+            return False
+        low = str(row.get("block_reason") or "").lower()
+        if "already_covered" in low:
+            return False  # already on the convergence path
+        # Strictly the missing-PR evidence gate, not a substantive blocker.
+        if not ("missing required evidence" in low and "pr" in low):
+            return False
+        try:
+            from worktree_bootstrap import worktree_branch, worktree_path
+
+            if "PR_URL=" in latest_log_session(task_id, max_lines=120):
+                return False  # worker did hand off a PR -> not a no-op
+            task = detail.get("task") if isinstance((detail or {}).get("task"), dict) else {}
+            wt_path = Path(
+                row.get("workspace_path") or task.get("workspace_path") or worktree_path(task_id)
+            ).expanduser()
+            if not wt_path.exists():
+                return False
+            branch = (
+                await self._run_worktree_command(
+                    ["git", "branch", "--show-current"], cwd=wt_path, timeout=10
+                )
+            ).strip()
+            # Hard safety gate: only the task's own worktree branch.
+            if not branch or branch in {"main", "master"} or branch != worktree_branch(task_id):
+                return False
+            dirty = bool(
+                (
+                    await self._run_worktree_command(
+                        ["git", "status", "--porcelain"], cwd=wt_path, timeout=20
+                    )
+                ).strip()
+            )
+            if dirty:
+                return False  # there IS uncommitted work -> unshipped-diff salvage owns it
+            unpushed = (
+                await self._run_worktree_command(
+                    ["git", "rev-list", "--count", "HEAD", "--not", "--remotes"],
+                    cwd=wt_path,
+                    timeout=15,
+                )
+            ).strip()
+            if unpushed not in {"", "0"}:
+                return False  # commits to push -> not a no-op
+        except Exception as exc:  # noqa: BLE001 - convergence check must not break poll.
+            logger.warning(
+                "kanban_adapter: no-op implement convergence check failed for %s: %s",
+                task_id,
+                exc,
+            )
+            return False
+
+        reason = (
+            "BLOCKER=ALREADY_COVERED: implement produced no diff and the task worktree "
+            "is empty (no changes, nothing to push) — the work is already present on the "
+            "base branch; converging to audit (no PR required)."
+        )
+        try:
+            await self._run(["block", task_id, reason])
+        except KanbanCLIError as exc:
+            logger.warning(
+                "kanban_adapter: no-op implement converge-block failed for %s: %s", task_id, exc
+            )
+            return False
+        row["block_reason"] = reason
+        logger.warning(
+            "kanban_adapter: converged no-op implement %s to ALREADY_COVERED "
+            "(empty worktree, missing-pr gate)",
+            task_id,
+        )
+        return True
+
     async def dispatch(self, issue: dict) -> dict:
         """Create the single current ready phase for a Multica engineering run.
 
@@ -2011,6 +2124,12 @@ class KanbanAdapter:
                     "TESTS=recovered; downstream verify/review must validate\n"
                     "SUMMARY=Recovered PR handoff after worker interruption"
                 )
+                phases[phase] = row
+            elif await self._maybe_converge_noop_implement(
+                task_id, phase, row, detail=detail
+            ):
+                # No PR and an empty worktree: the work is already present, so
+                # converge to ALREADY_COVERED rather than strand the lane.
                 phases[phase] = row
 
         statuses = {p: (r.get("status") or "") for p, r in phases.items()}

--- a/services/zoe-data/executors/kanban_adapter.py
+++ b/services/zoe-data/executors/kanban_adapter.py
@@ -1620,8 +1620,11 @@ class KanbanAdapter:
         low = str(row.get("block_reason") or "").lower()
         if "already_covered" in low:
             return False  # already on the convergence path
-        # Strictly the missing-PR evidence gate, not a substantive blocker.
-        if not ("missing required evidence" in low and "pr" in low):
+        # Strictly the missing-PR evidence gate, not a substantive blocker. Match
+        # "pr" as a whole word (the gate joins the missing-evidence kinds, e.g.
+        # "missing required evidence pr" or "...pr,tool") so reasons like
+        # "process"/"approved"/"prior" never trip this.
+        if not ("missing required evidence" in low and re.search(r"\bpr\b", low)):
             return False
         try:
             from worktree_bootstrap import worktree_branch, worktree_path

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -5851,3 +5851,97 @@ def test_auto_block_dead_worker_swallows_cli_error(monkeypatch):
     # CLI failure -> returns False, row left untouched (next poll retries)
     assert asyncio.run(adapter._maybe_auto_block_dead_worker("t", "verify", row, _dead_detail())) is False
     assert row["status"] == "running"
+
+
+# ---------------------------------------------------------------------------
+# _maybe_converge_noop_implement — no-op implement (empty worktree) -> ALREADY_COVERED
+# ---------------------------------------------------------------------------
+
+
+def _noop_adapter(monkeypatch, tmp_path, *, dirty="", unpushed="0", branch="wt/t_x", log=""):
+    import worktree_bootstrap as wb
+    wt = tmp_path / "wt"
+    wt.mkdir(exist_ok=True)
+    monkeypatch.setattr(ka, "_CONVERGE_NOOP_IMPLEMENT", True)
+    monkeypatch.setattr(ka, "latest_log_session", lambda task_id, max_lines=120: log)
+    monkeypatch.setattr(wb, "worktree_branch", lambda task_id: "wt/t_x")
+    monkeypatch.setattr(wb, "worktree_path", lambda task_id: str(wt))
+    adapter = ka.KanbanAdapter()
+    calls = {"run": [], "wt": []}
+
+    async def fake_run(args, *, expect_json=False):
+        calls["run"].append(args)
+        return ""
+
+    async def fake_wt(args, *, cwd, timeout=45.0):
+        calls["wt"].append(args)
+        if args[:3] == ["git", "branch", "--show-current"]:
+            return branch
+        if args[:2] == ["git", "status"]:
+            return dirty
+        if args[:3] == ["git", "rev-list", "--count"]:
+            return unpushed
+        raise AssertionError(args)
+
+    adapter._run = fake_run  # type: ignore[assignment]
+    adapter._run_worktree_command = fake_wt  # type: ignore[assignment]
+    return adapter, calls, str(wt)
+
+
+def _gate_row(wt, reason="BLOCKER=GATE_BLOCKED: missing required evidence pr"):
+    return {"status": "blocked", "block_reason": reason, "workspace_path": wt}
+
+
+def test_converge_noop_implement_blocks_already_covered(monkeypatch, tmp_path):
+    a, calls, wt = _noop_adapter(monkeypatch, tmp_path)  # clean tree, nothing unpushed
+    row = _gate_row(wt)
+    out = asyncio.run(a._maybe_converge_noop_implement("t_x", "implement", row, detail={}))
+    assert out is True
+    assert calls["run"] and calls["run"][0][0] == "block" and calls["run"][0][1] == "t_x"
+    assert "ALREADY_COVERED" in calls["run"][0][2]
+    assert "ALREADY_COVERED" in row["block_reason"]
+
+
+def test_converge_noop_implement_noop_when_dirty(monkeypatch, tmp_path):
+    # A dirty tree means there IS a diff -> unshipped-diff salvage owns it, not this.
+    a, calls, wt = _noop_adapter(monkeypatch, tmp_path, dirty=" M file.py")
+    row = _gate_row(wt)
+    assert asyncio.run(a._maybe_converge_noop_implement("t_x", "implement", row, detail={})) is False
+    assert not calls["run"]
+
+
+def test_converge_noop_implement_noop_when_unpushed_commits(monkeypatch, tmp_path):
+    a, calls, wt = _noop_adapter(monkeypatch, tmp_path, unpushed="2")
+    row = _gate_row(wt)
+    assert asyncio.run(a._maybe_converge_noop_implement("t_x", "implement", row, detail={})) is False
+    assert not calls["run"]
+
+
+def test_converge_noop_implement_ignores_real_blockers(monkeypatch, tmp_path):
+    a, calls, wt = _noop_adapter(monkeypatch, tmp_path)
+    row = _gate_row(wt, reason="BLOCKER=TEST_ENVIRONMENT: import error")
+    assert asyncio.run(a._maybe_converge_noop_implement("t_x", "implement", row, detail={})) is False
+    assert not calls["run"]
+
+
+def test_converge_noop_implement_skips_when_pr_in_log(monkeypatch, tmp_path):
+    a, calls, wt = _noop_adapter(monkeypatch, tmp_path, log="PR_URL=https://x/pull/1")
+    row = _gate_row(wt)
+    assert asyncio.run(a._maybe_converge_noop_implement("t_x", "implement", row, detail={})) is False
+    assert not calls["run"]
+
+
+def test_converge_noop_implement_respects_kill_switch(monkeypatch, tmp_path):
+    a, calls, wt = _noop_adapter(monkeypatch, tmp_path)
+    monkeypatch.setattr(ka, "_CONVERGE_NOOP_IMPLEMENT", False)
+    row = _gate_row(wt)
+    assert asyncio.run(a._maybe_converge_noop_implement("t_x", "implement", row, detail={})) is False
+    assert not calls["run"]
+
+
+def test_converge_noop_implement_noop_when_not_blocked(monkeypatch, tmp_path):
+    a, calls, wt = _noop_adapter(monkeypatch, tmp_path)
+    row = {"status": "running", "block_reason": "", "workspace_path": wt}
+    assert asyncio.run(a._maybe_converge_noop_implement("t_x", "implement", row, detail={})) is False
+    assert asyncio.run(a._maybe_converge_noop_implement("t_x", "verify", _gate_row(wt), detail={})) is False
+    assert not calls["run"]

--- a/services/zoe-data/tests/test_kanban_adapter.py
+++ b/services/zoe-data/tests/test_kanban_adapter.py
@@ -5945,3 +5945,22 @@ def test_converge_noop_implement_noop_when_not_blocked(monkeypatch, tmp_path):
     assert asyncio.run(a._maybe_converge_noop_implement("t_x", "implement", row, detail={})) is False
     assert asyncio.run(a._maybe_converge_noop_implement("t_x", "verify", _gate_row(wt), detail={})) is False
     assert not calls["run"]
+
+
+@pytest.mark.parametrize("branch", ["main", "master", "wt/other_task"])
+def test_converge_noop_implement_noop_wrong_branch(monkeypatch, tmp_path, branch):
+    # Safety gate: never converge on main/master or a different task's worktree
+    # branch — a regression here would converge on the wrong branch.
+    a, calls, wt = _noop_adapter(monkeypatch, tmp_path, branch=branch)
+    row = _gate_row(wt)
+    assert asyncio.run(a._maybe_converge_noop_implement("t_x", "implement", row, detail={})) is False
+    assert not calls["run"]
+
+
+def test_converge_noop_implement_ignores_pr_substring_in_other_words(monkeypatch, tmp_path):
+    # "pr" must match as a whole word: a missing-evidence reason naming e.g.
+    # "prior_result" must NOT trip the missing-PR convergence.
+    a, calls, wt = _noop_adapter(monkeypatch, tmp_path)
+    row = _gate_row(wt, reason="BLOCKER=GATE_BLOCKED: missing required evidence prior_result")
+    assert asyncio.run(a._maybe_converge_noop_implement("t_x", "implement", row, detail={})) is False
+    assert not calls["run"]


### PR DESCRIPTION
## Why
Live on **ZOE-5856**: the greeting-test fix was already present on the base branch, so the implement worker produced **no diff** and completed without a PR. The missing-PR evidence gate then blocked implement (`GATE_BLOCKED: missing required evidence pr`) and the **single ticket lane stranded** on a permanent block. The harness couldn't tell "nothing to do" from "failed to do it."

## What
`_maybe_recover_unshipped_diff` already salvages a *non-empty* diff the worker never pushed. This adds the **empty-worktree** case:

- **`_maybe_converge_noop_implement`** — when an implement row is blocked specifically on the missing-PR gate AND the task's own `wt/<task_id>` branch is provably empty (clean tree, nothing unpushed) AND no PR was handed off, re-block with `BLOCKER=ALREADY_COVERED` so `pipeline_store` converges it via the proven `skip_implementation -> audit` path (no PR required), freeing the lane. Wired into `poll()` after the unshipped-diff salvage. Gated by `ZOE_KANBAN_CONVERGE_NOOP_IMPLEMENT` (default on).
- **Safety:** never fires for real blockers (`TEST_ENVIRONMENT`/`IMPLEMENT_BUDGET`), a dirty or unpushed tree, a handed-off PR, or `main`/`master`.
- **Prompt:** explicit *ALREADY DONE / NO CHANGE NEEDED* rule — the worker must `kanban_block BLOCKER=ALREADY_COVERED` with evidence, never `kanban_complete` without a `PR_URL`.

Paired with the scout-model change (zoe-planner → `minimax/minimax-m3`, applied separately to the Hermes profile) these address the two friction levers from the 2026-06-18 batch run.

## Testing
- Converges on an empty worktree; no-ops on dirty tree / unpushed commits / real blockers / PR-in-log / kill-switch off / non-blocked or non-implement row.
- **332 passed** (`test_kanban_adapter.py` + `test_kanban_phase_budget.py` + `test_pipeline_store.py`); structure validator clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)