### PR TITLE
fix(greploop): converge Greptile guard loop (P1/P2a/P2b/P2c/P3)

### DIFF
--- a/scripts/maintenance/greploop_guard.py
+++ b/scripts/maintenance/greploop_guard.py
@@ -14,6 +14,7 @@ sys.path.insert(0, str(ROOT / "services" / "zoe-data"))
 
 from greploop_guard import (  # noqa: E402
     GuardError,
+    finalize_merged_guard_state,
     merge_pr_when_ready,
     read_observed_guard_state,
     run_guard_once,
@@ -47,9 +48,19 @@ def main() -> int:
         help="Squash-merge when READY (Greptile clear + CI green); optional after --once",
     )
     parser.add_argument("--state", action="store_true", help="Print file-backed guard state")
+    parser.add_argument(
+        "--finalize-merged",
+        action="store_true",
+        help="Sweep guard state and finalize already merged/closed PRs (repo-wide unless --pr given)",
+    )
     args = parser.parse_args()
 
     try:
+        if args.finalize_merged:
+            pr_numbers = [args.pr] if args.pr else None
+            result = finalize_merged_guard_state(pr_numbers=pr_numbers)
+            print(json.dumps(result, indent=2, sort_keys=True))
+            return 0
         if not args.pr:
             parser.error("--pr is required")
         if args.state:

--- a/services/zoe-data/greploop_guard.py
+++ b/services/zoe-data/greploop_guard.py
@@ -41,6 +41,24 @@ GREPTILE_REPO_ACTIVE_REVIEW_STALE_SECONDS = int(
         str(max(GREPTILE_WAIT_TIMEOUT_SECONDS, GREPTILE_WAIT_POLL_SECONDS * 2)),
     )
 )
+# P1: do not (re)trigger a review until the PR head SHA has been unchanged for this
+# many seconds, so reviews are not restarted faster than the head settles.
+HEAD_STABILITY_WINDOW_SECONDS = int(os.environ.get("ZOE_PR_GUARD_HEAD_STABILITY_SECONDS", "90"))
+# P2c: bound how many times the guard re-triggers a clean-but-sub-confidence review
+# for the same head before escalating to Hermes instead of looping forever.
+NO_FINDINGS_RETRIGGER_LIMIT = int(os.environ.get("ZOE_PR_GUARD_NO_FINDINGS_RETRIGGER_LIMIT", "3"))
+
+
+def _env_flag(name: str, default: bool) -> bool:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() not in {"0", "false", "no", "off", ""}
+
+
+# P2c: when the Greptile check has SUCCEEDED with zero unresolved/actionable threads,
+# treat the PR as mergeable even if the summary confidence is below target.
+CLEAN_MERGE_IGNORES_CONFIDENCE = _env_flag("ZOE_PR_GUARD_CLEAN_MERGE_IGNORES_CONFIDENCE", True)
 
 # Cheap-model repair packets must never merge or bypass hooks; use merge_pr_when_ready().
 FORBIDDEN_ACTIONS = [
@@ -192,6 +210,56 @@ def read_observed_guard_state(pr_number: int, *, repo: str = DEFAULT_REPO) -> di
             state["historical_terminal_state"] = state.get("terminal_state")
             state["terminal_state"] = "GITHUB_GREPTILE_COMPLETE"
     return state
+
+
+def finalize_merged_guard_state(
+    *, repo: str = DEFAULT_REPO, pr_numbers: list[int] | None = None
+) -> dict[str, Any]:
+    """P3: mark guard state for already merged/closed PRs as finalized.
+
+    Stale ``WAITING_GREPTILE`` state for PRs that merged out-of-band (e.g. via the
+    GitHub UI) pollutes capacity and backlog scans. This sweep finalizes only PRs that
+    GitHub reports as MERGED or CLOSED; it never clears or mutates mid-flight (open)
+    PR state, so in-progress reviews are left untouched.
+    """
+    finalized: list[dict[str, Any]] = []
+    skipped: list[dict[str, Any]] = []
+    if pr_numbers is None:
+        if not STATE_ROOT.exists():
+            return {"finalized": finalized, "skipped": skipped}
+        candidates: list[int] = []
+        for status_path in STATE_ROOT.glob("pr-*/status.json"):
+            try:
+                candidates.append(int(status_path.parent.name.removeprefix("pr-")))
+            except ValueError:
+                continue
+    else:
+        candidates = [int(pr) for pr in pr_numbers]
+    for pr in sorted(set(candidates)):
+        state = read_guard_state(pr)
+        if state.get("state") in ("MISSING", "STALE_READ_RETRY"):
+            skipped.append({"pr": pr, "reason": "no_local_state"})
+            continue
+        if state.get("finalized"):
+            skipped.append({"pr": pr, "reason": "already_finalized"})
+            continue
+        observation = _gh_pr_observation(pr, repo=repo)
+        if not observation.get("ok"):
+            skipped.append({"pr": pr, "reason": "observation_failed"})
+            continue
+        gh_state = str(observation.get("state") or "").upper()
+        if gh_state not in ("MERGED", "CLOSED"):
+            # CRITICAL: never finalize an open / mid-flight PR.
+            skipped.append({"pr": pr, "reason": "still_open", "state": gh_state})
+            continue
+        state["finalized"] = True
+        state["finalized_at"] = time.time()
+        state["historical_terminal_state"] = state.get("terminal_state")
+        state["terminal_state"] = "MERGED" if gh_state == "MERGED" else "CLOSED"
+        _clear_greptile_wait_state(state)
+        _write_json(pr, "status.json", state)
+        finalized.append({"pr": pr, "state": state["terminal_state"]})
+    return {"finalized": finalized, "skipped": skipped}
 
 
 def _append_progress(pr_number: int, line: str) -> None:
@@ -647,20 +715,66 @@ def _repo_waiting_greptile_prs(*, exclude_pr_number: int, now: float) -> list[di
     return sorted(active, key=lambda item: int(item["pr"]))
 
 
-def _repo_greptile_capacity_skip(*, pr_number: int, now: float) -> dict[str, Any] | None:
+def _gh_open_prs_with_running_greptile(*, repo: str = DEFAULT_REPO) -> set[int] | None:
+    """Return open PR numbers whose GitHub "Greptile Review" check is IN_PROGRESS.
+
+    This is the authoritative source of in-flight reviews: it sees reviews started by
+    the GitHub Greptile app (auto-on-push), raw MCP triggers, and PRs that have no
+    local guard state dir. Returns ``None`` when the GitHub query fails so the caller
+    can fall back to local state only.
+    """
+    proc = _run_gh(
+        ["pr", "list", "--state", "open", "--limit", "200", "--json", "number,statusCheckRollup"],
+        repo=repo,
+    )
+    if proc.returncode != 0:
+        return None
+    try:
+        rows = json.loads(proc.stdout or "[]")
+    except json.JSONDecodeError:
+        return None
+    running: set[int] = set()
+    for row in rows if isinstance(rows, list) else []:
+        if not isinstance(row, dict):
+            continue
+        number = row.get("number")
+        try:
+            number = int(number)
+        except (TypeError, ValueError):
+            continue
+        if _gh_greptile_check_running({"statusCheckRollup": row.get("statusCheckRollup") or []}):
+            running.add(number)
+    return running
+
+
+def _repo_greptile_capacity_skip(
+    *, pr_number: int, now: float, repo: str = DEFAULT_REPO
+) -> dict[str, Any] | None:
     if GREPTILE_REPO_ACTIVE_REVIEW_LIMIT <= 0:
         return None
-    active = _repo_waiting_greptile_prs(exclude_pr_number=pr_number, now=now)
-    if len(active) < GREPTILE_REPO_ACTIVE_REVIEW_LIMIT:
+    local_active = _repo_waiting_greptile_prs(exclude_pr_number=pr_number, now=now)
+    local_prs = {int(item["pr"]) for item in local_active}
+    github_running = _gh_open_prs_with_running_greptile(repo=repo)
+    github_prs: set[int] = set()
+    if github_running is not None:
+        github_prs = {pr for pr in github_running if pr != int(pr_number)}
+    active_prs = sorted(local_prs | github_prs)
+    if len(active_prs) < GREPTILE_REPO_ACTIVE_REVIEW_LIMIT:
         return None
-    future_polls = [int(item["next_poll_after"]) for item in active if int(item.get("next_poll_after") or 0) > now]
+    future_polls = [
+        int(item["next_poll_after"])
+        for item in local_active
+        if int(item.get("next_poll_after") or 0) > now
+    ]
     retry_after = min(future_polls) - int(now) if future_polls else GREPTILE_WAIT_POLL_SECONDS
     return {
         "skipped": True,
         "reason": "repo_greptile_review_capacity",
-        "active_review_count": len(active),
+        "active_review_count": len(active_prs),
         "active_review_limit": GREPTILE_REPO_ACTIVE_REVIEW_LIMIT,
-        "active_prs": [int(item["pr"]) for item in active],
+        "active_prs": active_prs,
+        "github_active_prs": sorted(github_prs),
+        "local_waiting_prs": sorted(local_prs),
         "retry_after_seconds": max(1, int(retry_after)),
     }
 
@@ -903,6 +1017,25 @@ def _effective_greptile_confidence(
     return confidence
 
 
+def _greptile_clean_without_findings(
+    *,
+    greptile_check_success: bool,
+    thread_counts: dict[str, Any],
+    actionable_findings: list[dict[str, Any]],
+) -> bool:
+    """P2c: GitHub Greptile check passed with zero unresolved/actionable threads.
+
+    A PR in this state has no real review work left even when the summary confidence
+    is below target, so it can be treated as mergeable rather than re-triggered forever.
+    """
+    return bool(
+        greptile_check_success
+        and not actionable_findings
+        and thread_counts.get("ok")
+        and int(thread_counts.get("unresolved") or 0) == 0
+    )
+
+
 def _gh_pr_observation(pr_number: int, *, repo: str = DEFAULT_REPO) -> dict[str, Any]:
     proc = _run_gh(
         [
@@ -1029,6 +1162,35 @@ def _should_skip_greptile_trigger(
     return None
 
 
+def _head_stability_skip(
+    state: dict[str, Any], *, head_sha: str | None, now: float, force: bool = False
+) -> dict[str, Any] | None:
+    """P1: defer (re)triggering until the head SHA has been stable for the window.
+
+    The first time a head SHA is observed we record it and start the stability clock,
+    so a head that keeps drifting can never be (re)triggered fast enough to thrash the
+    Greptile check. Mutates ``state`` with ``head_seen_sha`` / ``head_seen_at`` so the
+    clock persists across guard iterations.
+    """
+    if force or HEAD_STABILITY_WINDOW_SECONDS <= 0 or not head_sha:
+        return None
+    if str(state.get("head_seen_sha") or "") != head_sha:
+        state["head_seen_sha"] = head_sha
+        state["head_seen_at"] = now
+    seen_at = _float_state(state.get("head_seen_at"), now)
+    stable_for = max(0.0, now - seen_at)
+    if stable_for >= HEAD_STABILITY_WINDOW_SECONDS:
+        return None
+    return {
+        "skipped": True,
+        "reason": "head_not_stable",
+        "head_sha": head_sha,
+        "head_stable_seconds": int(stable_for),
+        "head_stability_window_seconds": HEAD_STABILITY_WINDOW_SECONDS,
+        "retry_after_seconds": max(1, int(HEAD_STABILITY_WINDOW_SECONDS - stable_for)),
+    }
+
+
 async def trigger_review_safely(
     *,
     pr_number: int,
@@ -1080,7 +1242,9 @@ async def trigger_review_safely(
             force=force,
         )
     if not skipped and not force:
-        skipped = _repo_greptile_capacity_skip(pr_number=pr_number, now=now)
+        skipped = _repo_greptile_capacity_skip(pr_number=pr_number, now=now, repo=repo)
+    if not skipped:
+        skipped = _head_stability_skip(active_state, head_sha=head_sha, now=now, force=force)
 
     if skipped:
         decision = {
@@ -1269,12 +1433,19 @@ async def assess_merge_readiness(
         clear_when_no_unresolved=greptile_check_success,
     )
     unresolved_threads = int(thread_counts.get("unresolved") or 0) if thread_counts.get("ok") else None
+    clean_without_findings = _greptile_clean_without_findings(
+        greptile_check_success=greptile_check_success,
+        thread_counts=thread_counts,
+        actionable_findings=actionable,
+    )
+    # P2c: a clean check with no findings is mergeable even below confidence target.
+    confidence_satisfied = confidence >= int(target_confidence) or (
+        CLEAN_MERGE_IGNORES_CONFIDENCE and clean_without_findings
+    )
     stale_running_review = (
         status.get("reviewIsRunning")
-        and greptile_check_success
-        and thread_counts.get("ok")
-        and int(thread_counts.get("unresolved") or 0) == 0
-        and confidence >= int(target_confidence)
+        and clean_without_findings
+        and confidence_satisfied
     )
     blockers: list[str] = []
     if status.get("reviewIsRunning") and not stale_running_review:
@@ -1283,7 +1454,7 @@ async def assess_merge_readiness(
         blockers.append("GREPTILE_THREAD_CHECK_FAILED")
     elif unresolved_threads:
         blockers.append(f"GREPTILE_UNRESOLVED_THREADS:{unresolved_threads}")
-    if confidence < int(target_confidence):
+    if not confidence_satisfied:
         blockers.append(f"GREPTILE_CONFIDENCE:{confidence}<{target_confidence}")
     if actionable:
         blockers.append(f"GREPTILE_ACTIONABLE_FINDINGS:{len(actionable)}")
@@ -1325,6 +1496,30 @@ async def merge_pr_when_ready(
                 actionable_count=0,
                 summary_count=0,
             )
+            # P2b: a genuinely stuck review must escalate here too. Without this the
+            # merge path overwrote run_guard_once's BLOCKED_GREPTILE_STUCK with
+            # WAITING_GREPTILE, so a hung review never reached Hermes escalation.
+            if wait["stuck"]:
+                state["terminal_state"] = "BLOCKED_GREPTILE_STUCK"
+                state["merge_blockers"] = ["GREPTILE_REVIEW_STUCK"]
+                _write_json(pr_number, "status.json", state)
+                _record_guardrail(
+                    pr_number,
+                    f"merge path: Greptile review stayed active for {wait['elapsed_seconds']}s past wait limit",
+                )
+                return {
+                    "ok": False,
+                    "state": "BLOCKED_GREPTILE_STUCK",
+                    "blockers": ["GREPTILE_REVIEW_STUCK"],
+                    "retry_after_seconds": wait["retry_after_seconds"],
+                    "wait": wait,
+                    "assessment": {
+                        "ready": False,
+                        "blockers": ["GREPTILE_REVIEW_STUCK"],
+                        "greptile": status,
+                        "gh": gh_observation,
+                    },
+                }
             state["terminal_state"] = "WAITING_GREPTILE"
             state["merge_blockers"] = ["GREPTILE_REVIEW_RUNNING"]
             _write_json(pr_number, "status.json", state)
@@ -1437,12 +1632,20 @@ async def run_guard_once(
             thread_counts=thread_counts,
             clear_when_no_unresolved=greptile_check_success,
         )
+        target = int(task.get("target_confidence") or 5)
+        clean_without_findings = _greptile_clean_without_findings(
+            greptile_check_success=greptile_check_success,
+            thread_counts=thread_counts,
+            actionable_findings=actionable_findings,
+        )
+        # P2c: clean check + no findings is mergeable even below the confidence target.
+        confidence_satisfied = confidence >= target or (
+            CLEAN_MERGE_IGNORES_CONFIDENCE and clean_without_findings
+        )
         stale_running_review = (
             status.get("reviewIsRunning")
-            and greptile_check_success
-            and thread_counts.get("ok")
-            and int(thread_counts.get("unresolved") or 0) == 0
-            and confidence >= int(task.get("target_confidence") or 5)
+            and clean_without_findings
+            and confidence_satisfied
         )
         if status.get("reviewIsRunning") and not stale_running_review:
             wait = _update_greptile_wait_state(
@@ -1479,11 +1682,35 @@ async def run_guard_once(
             "summary_count": max(0, len(findings) - len(actionable_findings)),
         }
         _write_json(pr_number, "status.json", state)
-        if greptile_check_success and confidence >= int(task.get("target_confidence") or 5) and not actionable_findings:
+        if clean_without_findings and confidence_satisfied:
             state["terminal_state"] = "READY_TO_MERGE"
+            state.pop("no_findings_retrigger_count", None)
+            state.pop("no_findings_retrigger_key", None)
             _write_json(pr_number, "status.json", state)
             return {"ok": True, "state": "READY_TO_MERGE", "greptile": {**status, "confidenceScore": confidence}}
         if not actionable_findings:
+            # P2c: bound re-triggers for a clean-but-sub-confidence (or not-yet-complete)
+            # review so the guard escalates to Hermes instead of looping forever.
+            retrigger_key = f"{pr_head_sha}:{confidence}"
+            if state.get("no_findings_retrigger_key") == retrigger_key:
+                state["no_findings_retrigger_count"] = int(state.get("no_findings_retrigger_count") or 0) + 1
+            else:
+                state["no_findings_retrigger_key"] = retrigger_key
+                state["no_findings_retrigger_count"] = 1
+            if state["no_findings_retrigger_count"] > NO_FINDINGS_RETRIGGER_LIMIT:
+                state["terminal_state"] = "ESCALATE_HERMES"
+                _write_json(pr_number, "status.json", state)
+                _record_guardrail(
+                    pr_number,
+                    "Greptile review made no progress below confidence target after "
+                    f"{state['no_findings_retrigger_count']} re-triggers; escalating to Hermes",
+                )
+                return {
+                    "ok": False,
+                    "state": "ESCALATE_HERMES",
+                    "reason": "greptile_no_progress_below_confidence",
+                    "greptile": {**status, "confidenceScore": confidence},
+                }
             triggered = await trigger_review_safely(
                 pr_number=pr_number,
                 repo=DEFAULT_REPO,

--- a/services/zoe-data/tests/test_greploop_guard.py
+++ b/services/zoe-data/tests/test_greploop_guard.py
@@ -9,6 +9,7 @@ import pytest
 import greploop_guard
 
 _ORIGINAL_GH_THREAD_COUNTS = greploop_guard._gh_thread_counts
+_ORIGINAL_GH_OPEN_PRS_RUNNING = greploop_guard._gh_open_prs_with_running_greptile
 
 
 @pytest.fixture(autouse=True)
@@ -35,6 +36,14 @@ def _default_github_helpers(monkeypatch):
         greploop_guard,
         "_greptile_confidence_from_github_comments",
         lambda pr, repo=greploop_guard.DEFAULT_REPO: None,
+    )
+    # P2a: the repo-wide capacity check now consults GitHub for in-flight reviews.
+    # Default it to "no other running reviews" so tests never hit the network; tests
+    # that exercise capacity override this explicitly.
+    monkeypatch.setattr(
+        greploop_guard,
+        "_gh_open_prs_with_running_greptile",
+        lambda repo=greploop_guard.DEFAULT_REPO: set(),
     )
 
 
@@ -919,6 +928,7 @@ async def test_trigger_review_safely_does_not_cooldown_failed_trigger(tmp_path, 
         return {"success": False, "error": "provider busy"}
 
     monkeypatch.setattr(greploop_guard, "STATE_ROOT", tmp_path)
+    monkeypatch.setattr(greploop_guard, "HEAD_STABILITY_WINDOW_SECONDS", 0)
     monkeypatch.setattr(greploop_guard.time, "time", lambda: 1_000.0)
     monkeypatch.setattr("greptile_client.trigger_review", fake_trigger)
     state = {"pr": 66}
@@ -1002,6 +1012,7 @@ async def test_trigger_review_safely_triggers_on_github_head_mismatch(tmp_path, 
         return {"success": True, "triggered": True}
 
     monkeypatch.setattr(greploop_guard, "STATE_ROOT", tmp_path)
+    monkeypatch.setattr(greploop_guard, "HEAD_STABILITY_WINDOW_SECONDS", 0)
     monkeypatch.setattr(greploop_guard.time, "time", lambda: 1_000.0)
     monkeypatch.setattr("greptile_client.trigger_review", fake_trigger)
     monkeypatch.setattr(
@@ -1232,6 +1243,7 @@ async def test_run_guard_once_refreshes_head_after_repair_before_trigger(tmp_pat
     monkeypatch.setattr("greptile_client.list_pr_comments", fake_comments)
     monkeypatch.setattr("greptile_client.trigger_review", fake_trigger)
     monkeypatch.setattr(greploop_guard, "_run_cheap_agent", fake_runner)
+    monkeypatch.setattr(greploop_guard, "HEAD_STABILITY_WINDOW_SECONDS", 0)
     monkeypatch.setattr(greploop_guard, "_local_head_sha", lambda: "local-repaired-sha")
     monkeypatch.setattr(greploop_guard, "_diff_files", lambda base_sha=None: ["services/zoe-data/example.py"])
     monkeypatch.setattr(greploop_guard, "_diff_changed_lines", lambda base_sha=None: 2)
@@ -1299,6 +1311,7 @@ async def test_run_guard_once_retriggers_low_confidence_pathless_summary(tmp_pat
     monkeypatch.setattr("greptile_client.list_pr_comments", fake_comments)
     monkeypatch.setattr("greptile_client.trigger_review", fake_trigger)
     monkeypatch.setattr(greploop_guard, "_run_cheap_agent", fail_runner)
+    monkeypatch.setattr(greploop_guard, "HEAD_STABILITY_WINDOW_SECONDS", 0)
 
     out = await greploop_guard.run_guard_once(66)
 
@@ -1566,6 +1579,7 @@ async def test_run_guard_once_waits_when_historical_confidence_has_no_completed_
         "_gh_pr_observation",
         lambda pr, repo=greploop_guard.DEFAULT_REPO: {"ok": True, "state": "OPEN", "statusCheckRollup": []},
     )
+    monkeypatch.setattr(greploop_guard, "HEAD_STABILITY_WINDOW_SECONDS", 0)
 
     out = await greploop_guard.run_guard_once(66)
 
@@ -2265,3 +2279,670 @@ async def test_assess_merge_readiness_blocks_actionable_findings(monkeypatch):
     assert out["ready"] is False
     assert out["unaddressed_count"] == 1
     assert "GREPTILE_ACTIONABLE_FINDINGS:1" in out["blockers"]
+
+
+# ---------------------------------------------------------------------------
+# P2a — active-review cap counts authoritative GitHub state
+# ---------------------------------------------------------------------------
+
+
+def test_gh_open_prs_with_running_greptile_parses_rollup(monkeypatch):
+    def fake_run_gh(args, *, repo=greploop_guard.DEFAULT_REPO, check=False):
+        assert args[:2] == ["pr", "list"]
+        return type(
+            "P",
+            (),
+            {
+                "returncode": 0,
+                "stdout": json.dumps(
+                    [
+                        {
+                            "number": 688,
+                            "statusCheckRollup": [
+                                {"name": "Greptile Review", "status": "IN_PROGRESS", "conclusion": ""}
+                            ],
+                        },
+                        {
+                            "number": 690,
+                            "statusCheckRollup": [
+                                {"name": "Greptile Review", "status": "QUEUED", "conclusion": ""}
+                            ],
+                        },
+                        {
+                            "number": 691,
+                            "statusCheckRollup": [
+                                {"name": "Greptile Review", "status": "COMPLETED", "conclusion": "SUCCESS"}
+                            ],
+                        },
+                        {"number": 692, "statusCheckRollup": []},
+                    ]
+                ),
+                "stderr": "",
+            },
+        )()
+
+    monkeypatch.setattr(greploop_guard, "_run_gh", fake_run_gh)
+
+    out = _ORIGINAL_GH_OPEN_PRS_RUNNING()
+
+    assert out == {688, 690}
+
+
+def test_gh_open_prs_with_running_greptile_returns_none_on_failure(monkeypatch):
+    def fake_run_gh(args, *, repo=greploop_guard.DEFAULT_REPO, check=False):
+        return type("P", (), {"returncode": 1, "stdout": "", "stderr": "boom"})()
+
+    monkeypatch.setattr(greploop_guard, "_run_gh", fake_run_gh)
+
+    assert _ORIGINAL_GH_OPEN_PRS_RUNNING() is None
+
+
+@pytest.mark.asyncio
+async def test_repo_capacity_counts_github_running_pr_without_local_state(tmp_path, monkeypatch):
+    async def fail_trigger(**_kwargs):
+        raise AssertionError("GitHub-visible in-flight review must defer new triggers")
+
+    monkeypatch.setattr(greploop_guard, "STATE_ROOT", tmp_path)
+    monkeypatch.setattr(greploop_guard, "GREPTILE_REPO_ACTIVE_REVIEW_LIMIT", 1)
+    monkeypatch.setattr(greploop_guard, "HEAD_STABILITY_WINDOW_SECONDS", 0)
+    monkeypatch.setattr(greploop_guard.time, "time", lambda: 1_000.0)
+    monkeypatch.setattr("greptile_client.trigger_review", fail_trigger)
+    monkeypatch.setattr(
+        greploop_guard, "_gh_pr_observation", lambda pr, repo=greploop_guard.DEFAULT_REPO: {"ok": False}
+    )
+    # PR 690 is reviewing on GitHub but has NO local guard state dir.
+    monkeypatch.setattr(
+        greploop_guard, "_gh_open_prs_with_running_greptile", lambda repo=greploop_guard.DEFAULT_REPO: {690}
+    )
+
+    out = await greploop_guard.trigger_review_safely(
+        pr_number=66,
+        status={"headSha": "abc", "reviewIsRunning": False, "confidenceScore": 0},
+        state={"pr": 66},
+        source="test-gh-capacity",
+    )
+
+    assert out["triggered"] is False
+    assert out["reason"] == "repo_greptile_review_capacity"
+    assert out["active_prs"] == [690]
+    assert out["github_active_prs"] == [690]
+    assert out["local_waiting_prs"] == []
+    assert out["active_review_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_repo_capacity_unions_github_and_local_waiting(tmp_path, monkeypatch):
+    async def fail_trigger(**_kwargs):
+        raise AssertionError("union capacity should defer new triggers")
+
+    monkeypatch.setattr(greploop_guard, "STATE_ROOT", tmp_path)
+    monkeypatch.setattr(greploop_guard, "GREPTILE_REPO_ACTIVE_REVIEW_LIMIT", 1)
+    monkeypatch.setattr(greploop_guard, "GREPTILE_REPO_ACTIVE_REVIEW_STALE_SECONDS", 600)
+    monkeypatch.setattr(greploop_guard, "HEAD_STABILITY_WINDOW_SECONDS", 0)
+    monkeypatch.setattr(greploop_guard.time, "time", lambda: 1_000.0)
+    monkeypatch.setattr("greptile_client.trigger_review", fail_trigger)
+    monkeypatch.setattr(
+        greploop_guard, "_gh_pr_observation", lambda pr, repo=greploop_guard.DEFAULT_REPO: {"ok": False}
+    )
+    monkeypatch.setattr(
+        greploop_guard, "_gh_open_prs_with_running_greptile", lambda repo=greploop_guard.DEFAULT_REPO: {690}
+    )
+    greploop_guard._write_json(
+        67,
+        "status.json",
+        {
+            "pr": 67,
+            "terminal_state": "WAITING_GREPTILE",
+            "greptile_wait_started_at": 900.0,
+            "greptile_wait_last_seen_at": 990.0,
+            "greptile_next_poll_after": 1_100.0,
+        },
+    )
+
+    out = await greploop_guard.trigger_review_safely(
+        pr_number=66,
+        status={"headSha": "abc", "reviewIsRunning": False, "confidenceScore": 0},
+        state={"pr": 66},
+        source="test-union-capacity",
+    )
+
+    assert out["triggered"] is False
+    assert out["reason"] == "repo_greptile_review_capacity"
+    assert out["active_prs"] == [67, 690]
+    assert out["github_active_prs"] == [690]
+    assert out["local_waiting_prs"] == [67]
+    assert out["active_review_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_repo_capacity_excludes_current_pr_running_on_github(tmp_path, monkeypatch):
+    triggered = {}
+
+    async def fake_trigger(**kwargs):
+        triggered.update(kwargs)
+        return {"success": True, "triggered": True}
+
+    monkeypatch.setattr(greploop_guard, "STATE_ROOT", tmp_path)
+    monkeypatch.setattr(greploop_guard, "GREPTILE_REPO_ACTIVE_REVIEW_LIMIT", 1)
+    monkeypatch.setattr(greploop_guard, "HEAD_STABILITY_WINDOW_SECONDS", 0)
+    monkeypatch.setattr(greploop_guard.time, "time", lambda: 1_000.0)
+    monkeypatch.setattr("greptile_client.trigger_review", fake_trigger)
+    monkeypatch.setattr(
+        greploop_guard, "_gh_pr_observation", lambda pr, repo=greploop_guard.DEFAULT_REPO: {"ok": False}
+    )
+    # Only the current PR is "running" on GitHub; it must not count against itself.
+    monkeypatch.setattr(
+        greploop_guard, "_gh_open_prs_with_running_greptile", lambda repo=greploop_guard.DEFAULT_REPO: {66}
+    )
+
+    out = await greploop_guard.trigger_review_safely(
+        pr_number=66,
+        status={"headSha": "abc", "reviewIsRunning": False, "confidenceScore": 0},
+        state={"pr": 66},
+        source="test-self-running",
+    )
+
+    assert out == {"success": True, "triggered": True}
+    assert triggered["pr_number"] == 66
+
+
+@pytest.mark.asyncio
+async def test_repo_capacity_falls_back_to_local_when_github_unavailable(tmp_path, monkeypatch):
+    async def fail_trigger(**_kwargs):
+        raise AssertionError("local-only capacity should still defer new triggers")
+
+    monkeypatch.setattr(greploop_guard, "STATE_ROOT", tmp_path)
+    monkeypatch.setattr(greploop_guard, "GREPTILE_REPO_ACTIVE_REVIEW_LIMIT", 1)
+    monkeypatch.setattr(greploop_guard, "GREPTILE_REPO_ACTIVE_REVIEW_STALE_SECONDS", 600)
+    monkeypatch.setattr(greploop_guard, "HEAD_STABILITY_WINDOW_SECONDS", 0)
+    monkeypatch.setattr(greploop_guard.time, "time", lambda: 1_000.0)
+    monkeypatch.setattr("greptile_client.trigger_review", fail_trigger)
+    monkeypatch.setattr(
+        greploop_guard, "_gh_pr_observation", lambda pr, repo=greploop_guard.DEFAULT_REPO: {"ok": False}
+    )
+    monkeypatch.setattr(
+        greploop_guard, "_gh_open_prs_with_running_greptile", lambda repo=greploop_guard.DEFAULT_REPO: None
+    )
+    greploop_guard._write_json(
+        67,
+        "status.json",
+        {
+            "pr": 67,
+            "terminal_state": "WAITING_GREPTILE",
+            "greptile_wait_started_at": 900.0,
+            "greptile_wait_last_seen_at": 990.0,
+            "greptile_next_poll_after": 1_100.0,
+        },
+    )
+
+    out = await greploop_guard.trigger_review_safely(
+        pr_number=66,
+        status={"headSha": "abc", "reviewIsRunning": False, "confidenceScore": 0},
+        state={"pr": 66},
+        source="test-local-fallback",
+    )
+
+    assert out["triggered"] is False
+    assert out["reason"] == "repo_greptile_review_capacity"
+    assert out["active_prs"] == [67]
+    assert out["github_active_prs"] == []
+    assert out["local_waiting_prs"] == [67]
+
+
+# ---------------------------------------------------------------------------
+# P2b — stuck review escalates inside merge_pr_when_ready
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_merge_pr_when_ready_escalates_stuck_running_review(tmp_path, monkeypatch):
+    async def fake_status(**_kwargs):
+        return {
+            "confidenceScore": None,
+            "reviewIsRunning": True,
+            "headSha": "abc",
+            "reviewCompleteness": "No Greptile review comments",
+            "codeReviews": [{"status": "REVIEWING_FILES"}],
+        }
+
+    async def fail_assess(*_args, **_kwargs):
+        raise AssertionError("stuck review must not run readiness assessment")
+
+    def fail_run_gh(*_args, **_kwargs):
+        raise AssertionError("stuck review must never merge")
+
+    now = {"value": 1_000.0}
+    monkeypatch.setattr(greploop_guard, "STATE_ROOT", tmp_path)
+    monkeypatch.setattr(greploop_guard, "GREPTILE_WAIT_TIMEOUT_SECONDS", 60)
+    monkeypatch.setattr(greploop_guard, "GREPTILE_WAIT_POLL_SECONDS", 10)
+    monkeypatch.setattr(greploop_guard.time, "time", lambda: now["value"])
+    monkeypatch.setattr("greptile_client.get_pr_status", fake_status)
+    monkeypatch.setattr(greploop_guard, "assess_merge_readiness", fail_assess)
+    monkeypatch.setattr(greploop_guard, "_run_gh", fail_run_gh)
+    monkeypatch.setattr(
+        greploop_guard,
+        "_gh_pr_observation",
+        lambda pr, repo=greploop_guard.DEFAULT_REPO: {
+            "ok": True,
+            "state": "OPEN",
+            "statusCheckRollup": [
+                {"name": "Greptile Review", "status": "IN_PROGRESS", "conclusion": ""}
+            ],
+        },
+    )
+
+    first = await greploop_guard.merge_pr_when_ready(66)
+    assert first["state"] == "WAITING_GREPTILE"
+
+    now["value"] = 1_061.0
+    out = await greploop_guard.merge_pr_when_ready(66)
+
+    assert out["ok"] is False
+    assert out["state"] == "BLOCKED_GREPTILE_STUCK"
+    assert out["blockers"] == ["GREPTILE_REVIEW_STUCK"]
+    assert out["wait"]["elapsed_seconds"] == 61
+    state = greploop_guard.read_guard_state(66)
+    assert state["terminal_state"] == "BLOCKED_GREPTILE_STUCK"
+    assert state["merge_blockers"] == ["GREPTILE_REVIEW_STUCK"]
+
+
+# ---------------------------------------------------------------------------
+# P2c — clean check with no findings is mergeable below confidence target
+# ---------------------------------------------------------------------------
+
+
+def _clean_check_observation(pr, repo=greploop_guard.DEFAULT_REPO):
+    return {
+        "ok": True,
+        "state": "OPEN",
+        "statusCheckRollup": [
+            {"name": "Greptile Review", "status": "COMPLETED", "conclusion": "SUCCESS"}
+        ],
+    }
+
+
+@pytest.mark.asyncio
+async def test_run_guard_once_merges_clean_check_below_confidence(tmp_path, monkeypatch):
+    async def fake_status(**_kwargs):
+        return {
+            "confidenceScore": 4,
+            "reviewIsRunning": False,
+            "headSha": "abc",
+            "reviewCompleteness": "No Greptile review comments",
+        }
+
+    async def fake_comments(**_kwargs):
+        return {"findings": []}
+
+    async def fail_trigger(**_kwargs):
+        raise AssertionError("clean sub-confidence review must not retrigger")
+
+    monkeypatch.setattr(greploop_guard, "STATE_ROOT", tmp_path)
+    monkeypatch.setattr("greptile_client.get_pr_status", fake_status)
+    monkeypatch.setattr("greptile_client.list_pr_comments", fake_comments)
+    monkeypatch.setattr("greptile_client.trigger_review", fail_trigger)
+    monkeypatch.setattr(greploop_guard, "_gh_pr_observation", _clean_check_observation)
+
+    out = await greploop_guard.run_guard_once(66)
+
+    assert out["ok"] is True
+    assert out["state"] == "READY_TO_MERGE"
+    assert out["greptile"]["confidenceScore"] == 4
+    state = greploop_guard.read_guard_state(66)
+    assert state["terminal_state"] == "READY_TO_MERGE"
+
+
+@pytest.mark.asyncio
+async def test_run_guard_once_blocks_clean_check_below_confidence_when_flag_disabled(tmp_path, monkeypatch):
+    async def fake_status(**_kwargs):
+        return {
+            "confidenceScore": 4,
+            "reviewIsRunning": False,
+            "headSha": "abc",
+            "reviewCompleteness": "No Greptile review comments",
+        }
+
+    async def fake_comments(**_kwargs):
+        return {"findings": []}
+
+    triggered = {}
+
+    async def fake_trigger(**kwargs):
+        triggered.update(kwargs)
+        return {"triggered": True}
+
+    monkeypatch.setattr(greploop_guard, "STATE_ROOT", tmp_path)
+    monkeypatch.setattr(greploop_guard, "CLEAN_MERGE_IGNORES_CONFIDENCE", False)
+    monkeypatch.setattr(greploop_guard, "HEAD_STABILITY_WINDOW_SECONDS", 0)
+    monkeypatch.setattr("greptile_client.get_pr_status", fake_status)
+    monkeypatch.setattr("greptile_client.list_pr_comments", fake_comments)
+    monkeypatch.setattr("greptile_client.trigger_review", fake_trigger)
+    monkeypatch.setattr(greploop_guard, "_gh_pr_observation", _clean_check_observation)
+
+    out = await greploop_guard.run_guard_once(66)
+
+    assert out["ok"] is True
+    assert out["state"] == "WAITING_GREPTILE"
+    assert triggered["pr_number"] == 66
+    assert greploop_guard.read_guard_state(66)["terminal_state"] == "WAITING_GREPTILE"
+
+
+@pytest.mark.asyncio
+async def test_run_guard_once_keeps_blocking_actionable_findings_below_confidence(tmp_path, monkeypatch):
+    async def fake_status(**_kwargs):
+        return {
+            "confidenceScore": 4,
+            "reviewIsRunning": False,
+            "headSha": "abc",
+            "reviewCompleteness": "0/1 Greptile comments addressed",
+        }
+
+    async def fake_comments(**_kwargs):
+        return {
+            "findings": [
+                {
+                    "id": "comment-1",
+                    "file_path": "services/zoe-data/example.py",
+                    "line": 12,
+                    "body": "Fix this narrow bug",
+                    "addressed": False,
+                }
+            ]
+        }
+
+    async def fail_trigger(**_kwargs):
+        raise AssertionError("actionable findings must not just retrigger")
+
+    monkeypatch.setattr(greploop_guard, "STATE_ROOT", tmp_path)
+    monkeypatch.setattr("greptile_client.get_pr_status", fake_status)
+    monkeypatch.setattr("greptile_client.list_pr_comments", fake_comments)
+    monkeypatch.setattr("greptile_client.trigger_review", fail_trigger)
+    monkeypatch.setattr(greploop_guard, "_gh_pr_observation", _clean_check_observation)
+    # An unresolved thread keeps the inline finding actionable.
+    monkeypatch.setattr(
+        greploop_guard,
+        "_gh_thread_counts",
+        lambda pr, repo=greploop_guard.DEFAULT_REPO: {
+            "ok": True,
+            "unresolved": 1,
+            "resolved_greptile_keys": [],
+        },
+    )
+
+    out = await greploop_guard.run_guard_once(66, packet_only=True)
+
+    assert out["ok"] is True
+    assert out["state"] == "PACKET_READY"
+    assert out["state"] != "READY_TO_MERGE"
+
+
+@pytest.mark.asyncio
+async def test_assess_merge_readiness_ready_on_clean_check_below_confidence(monkeypatch):
+    async def fake_status(**_kwargs):
+        return {"confidenceScore": 4, "reviewIsRunning": False, "headSha": "abc"}
+
+    async def fake_comments(**_kwargs):
+        return {"findings": []}
+
+    monkeypatch.setattr("greptile_client.get_pr_status", fake_status)
+    monkeypatch.setattr("greptile_client.list_pr_comments", fake_comments)
+    monkeypatch.setattr(greploop_guard, "_gh_pr_observation", _clean_check_observation)
+    monkeypatch.setattr(
+        greploop_guard,
+        "_gh_mergeable_state",
+        lambda pr, repo=greploop_guard.DEFAULT_REPO, observation=None: {"ok": True},
+    )
+
+    out = await greploop_guard.assess_merge_readiness(66, target_confidence=5)
+
+    assert out["ready"] is True
+    assert not any("GREPTILE_CONFIDENCE" in b for b in out["blockers"])
+
+
+@pytest.mark.asyncio
+async def test_assess_merge_readiness_blocks_clean_check_below_confidence_when_flag_disabled(monkeypatch):
+    async def fake_status(**_kwargs):
+        return {"confidenceScore": 4, "reviewIsRunning": False, "headSha": "abc"}
+
+    async def fake_comments(**_kwargs):
+        return {"findings": []}
+
+    monkeypatch.setattr(greploop_guard, "CLEAN_MERGE_IGNORES_CONFIDENCE", False)
+    monkeypatch.setattr("greptile_client.get_pr_status", fake_status)
+    monkeypatch.setattr("greptile_client.list_pr_comments", fake_comments)
+    monkeypatch.setattr(greploop_guard, "_gh_pr_observation", _clean_check_observation)
+    monkeypatch.setattr(
+        greploop_guard,
+        "_gh_mergeable_state",
+        lambda pr, repo=greploop_guard.DEFAULT_REPO, observation=None: {"ok": True},
+    )
+
+    out = await greploop_guard.assess_merge_readiness(66, target_confidence=5)
+
+    assert out["ready"] is False
+    assert any("GREPTILE_CONFIDENCE" in b for b in out["blockers"])
+
+
+@pytest.mark.asyncio
+async def test_run_guard_once_escalates_after_no_findings_retrigger_limit(tmp_path, monkeypatch):
+    async def fake_status(**_kwargs):
+        return {
+            "confidenceScore": 4,
+            "reviewIsRunning": False,
+            "headSha": "abc",
+            "reviewCompleteness": "Summary-only review below confidence target",
+        }
+
+    async def fake_comments(**_kwargs):
+        return {"findings": []}
+
+    async def fake_trigger(**_kwargs):
+        return {"triggered": True}
+
+    monkeypatch.setattr(greploop_guard, "STATE_ROOT", tmp_path)
+    monkeypatch.setattr(greploop_guard, "NO_FINDINGS_RETRIGGER_LIMIT", 2)
+    monkeypatch.setattr(greploop_guard, "HEAD_STABILITY_WINDOW_SECONDS", 0)
+    monkeypatch.setattr("greptile_client.get_pr_status", fake_status)
+    monkeypatch.setattr("greptile_client.list_pr_comments", fake_comments)
+    monkeypatch.setattr("greptile_client.trigger_review", fake_trigger)
+    # Check has NOT completed (empty rollup), so this is not a clean mergeable pass.
+    monkeypatch.setattr(
+        greploop_guard,
+        "_gh_pr_observation",
+        lambda pr, repo=greploop_guard.DEFAULT_REPO: {"ok": True, "state": "OPEN", "statusCheckRollup": []},
+    )
+
+    first = await greploop_guard.run_guard_once(66)
+    assert first["state"] == "WAITING_GREPTILE"
+    second = await greploop_guard.run_guard_once(66)
+    assert second["state"] == "WAITING_GREPTILE"
+    third = await greploop_guard.run_guard_once(66)
+
+    assert third["ok"] is False
+    assert third["state"] == "ESCALATE_HERMES"
+    assert third["reason"] == "greptile_no_progress_below_confidence"
+    assert greploop_guard.read_guard_state(66)["terminal_state"] == "ESCALATE_HERMES"
+
+
+# ---------------------------------------------------------------------------
+# P1 — head-stability gating before (re)trigger
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_head_stability_defers_newly_seen_head(tmp_path, monkeypatch):
+    async def fail_trigger(**_kwargs):
+        raise AssertionError("a freshly observed head must not be triggered immediately")
+
+    monkeypatch.setattr(greploop_guard, "STATE_ROOT", tmp_path)
+    monkeypatch.setattr(greploop_guard, "HEAD_STABILITY_WINDOW_SECONDS", 90)
+    monkeypatch.setattr(greploop_guard.time, "time", lambda: 1_000.0)
+    monkeypatch.setattr("greptile_client.trigger_review", fail_trigger)
+    monkeypatch.setattr(
+        greploop_guard,
+        "_gh_pr_observation",
+        lambda pr, repo=greploop_guard.DEFAULT_REPO: {"ok": True, "headRefOid": "abc", "statusCheckRollup": []},
+    )
+
+    out = await greploop_guard.trigger_review_safely(
+        pr_number=66,
+        status={"headSha": "abc", "reviewIsRunning": False, "confidenceScore": 0},
+        state={"pr": 66},
+        source="test-head-stability",
+    )
+
+    assert out["triggered"] is False
+    assert out["reason"] == "head_not_stable"
+    assert out["retry_after_seconds"] == 90
+    saved = greploop_guard.read_guard_state(66)
+    assert saved["head_seen_sha"] == "abc"
+    assert saved["head_seen_at"] == 1_000.0
+
+
+@pytest.mark.asyncio
+async def test_head_stability_allows_head_stable_past_window(tmp_path, monkeypatch):
+    triggered = {}
+
+    async def fake_trigger(**kwargs):
+        triggered.update(kwargs)
+        return {"success": True, "triggered": True}
+
+    monkeypatch.setattr(greploop_guard, "STATE_ROOT", tmp_path)
+    monkeypatch.setattr(greploop_guard, "HEAD_STABILITY_WINDOW_SECONDS", 90)
+    monkeypatch.setattr(greploop_guard.time, "time", lambda: 1_000.0)
+    monkeypatch.setattr("greptile_client.trigger_review", fake_trigger)
+    monkeypatch.setattr(
+        greploop_guard,
+        "_gh_pr_observation",
+        lambda pr, repo=greploop_guard.DEFAULT_REPO: {"ok": True, "headRefOid": "abc", "statusCheckRollup": []},
+    )
+
+    out = await greploop_guard.trigger_review_safely(
+        pr_number=66,
+        status={"headSha": "abc", "reviewIsRunning": False, "confidenceScore": 0},
+        state={"pr": 66, "head_seen_sha": "abc", "head_seen_at": 800.0},
+        source="test-head-stable",
+    )
+
+    assert out == {"success": True, "triggered": True}
+    assert triggered["pr_number"] == 66
+
+
+@pytest.mark.asyncio
+async def test_head_stability_force_bypasses_window(tmp_path, monkeypatch):
+    triggered = {}
+
+    async def fake_trigger(**kwargs):
+        triggered.update(kwargs)
+        return {"success": True, "triggered": True}
+
+    monkeypatch.setattr(greploop_guard, "STATE_ROOT", tmp_path)
+    monkeypatch.setattr(greploop_guard, "HEAD_STABILITY_WINDOW_SECONDS", 90)
+    monkeypatch.setattr(greploop_guard.time, "time", lambda: 1_000.0)
+    monkeypatch.setattr("greptile_client.trigger_review", fake_trigger)
+
+    out = await greploop_guard.trigger_review_safely(
+        pr_number=66,
+        status={"headSha": "abc", "reviewIsRunning": False},
+        state={"pr": 66},
+        force=True,
+        source="test-head-force",
+    )
+
+    assert out == {"success": True, "triggered": True}
+    assert triggered["pr_number"] == 66
+
+
+def test_head_stability_skip_resets_clock_when_head_changes():
+    state = {"head_seen_sha": "old", "head_seen_at": 100.0}
+
+    skip = greploop_guard._head_stability_skip(state, head_sha="new", now=1_000.0)
+
+    assert skip is not None
+    assert skip["reason"] == "head_not_stable"
+    assert state["head_seen_sha"] == "new"
+    assert state["head_seen_at"] == 1_000.0
+
+
+# ---------------------------------------------------------------------------
+# P3 — finalize-on-merge sweep (only merged/closed; never mid-flight)
+# ---------------------------------------------------------------------------
+
+
+def test_finalize_merged_only_finalizes_merged_and_closed(tmp_path, monkeypatch):
+    monkeypatch.setattr(greploop_guard, "STATE_ROOT", tmp_path)
+    greploop_guard._write_json(
+        66,
+        "status.json",
+        {
+            "pr": 66,
+            "terminal_state": "WAITING_GREPTILE",
+            "greptile_wait_started_at": 1.0,
+            "greptile_wait_last_seen_at": 2.0,
+            "waiting_greptile_count": 3,
+        },
+    )
+    greploop_guard._write_json(67, "status.json", {"pr": 67, "terminal_state": "WAITING_GREPTILE"})
+    greploop_guard._write_json(68, "status.json", {"pr": 68, "terminal_state": "WAITING_GREPTILE"})
+    states = {66: "MERGED", 67: "OPEN", 68: "CLOSED"}
+    monkeypatch.setattr(
+        greploop_guard,
+        "_gh_pr_observation",
+        lambda pr, repo=greploop_guard.DEFAULT_REPO: {"ok": True, "state": states[int(pr)]},
+    )
+
+    result = greploop_guard.finalize_merged_guard_state()
+
+    assert {item["pr"] for item in result["finalized"]} == {66, 68}
+    merged = greploop_guard.read_guard_state(66)
+    assert merged["terminal_state"] == "MERGED"
+    assert merged["finalized"] is True
+    assert merged["waiting_greptile_count"] == 0
+    assert "greptile_wait_started_at" not in merged
+    closed = greploop_guard.read_guard_state(68)
+    assert closed["terminal_state"] == "CLOSED"
+    assert closed["finalized"] is True
+    # Mid-flight PR 67 must be left completely untouched.
+    open_state = greploop_guard.read_guard_state(67)
+    assert open_state["terminal_state"] == "WAITING_GREPTILE"
+    assert "finalized" not in open_state
+    assert {"pr": 67, "reason": "still_open", "state": "OPEN"} in result["skipped"]
+
+
+def test_finalize_merged_skips_already_finalized(tmp_path, monkeypatch):
+    monkeypatch.setattr(greploop_guard, "STATE_ROOT", tmp_path)
+    greploop_guard._write_json(
+        66, "status.json", {"pr": 66, "terminal_state": "MERGED", "finalized": True}
+    )
+
+    def fail_observation(*_args, **_kwargs):
+        raise AssertionError("already finalized PRs must not be re-observed")
+
+    monkeypatch.setattr(greploop_guard, "_gh_pr_observation", fail_observation)
+
+    result = greploop_guard.finalize_merged_guard_state()
+
+    assert result["finalized"] == []
+    assert {"pr": 66, "reason": "already_finalized"} in result["skipped"]
+
+
+def test_finalize_merged_never_finalizes_open_pr_for_specific_numbers(tmp_path, monkeypatch):
+    monkeypatch.setattr(greploop_guard, "STATE_ROOT", tmp_path)
+    greploop_guard._write_json(
+        70,
+        "status.json",
+        {"pr": 70, "terminal_state": "WAITING_GREPTILE", "greptile_wait_last_seen_at": 5.0},
+    )
+    monkeypatch.setattr(
+        greploop_guard,
+        "_gh_pr_observation",
+        lambda pr, repo=greploop_guard.DEFAULT_REPO: {"ok": True, "state": "OPEN"},
+    )
+
+    result = greploop_guard.finalize_merged_guard_state(pr_numbers=[70])
+
+    assert result["finalized"] == []
+    state = greploop_guard.read_guard_state(70)
+    assert state["terminal_state"] == "WAITING_GREPTILE"
+    assert "finalized" not in state
+    assert state["greptile_wait_last_seen_at"] == 5.0


### PR DESCRIPTION
## Summary

Fixes the Greptile/Greploop loop convergence bugs that drove permanent
`WAITING_GREPTILE` backlogs and review thrash. All changes are centered on
`services/zoe-data/greploop_guard.py` (the real implementation;
`scripts/maintenance/greploop_guard.py` is the thin CLI wrapper).

- **P2a — active-review cap now sees all in-flight reviews.** Added
  `_gh_open_prs_with_running_greptile()` which counts open PRs whose GitHub
  `statusCheckRollup` "Greptile Review" is IN_PROGRESS/QUEUED (via `gh pr list`).
  `_repo_greptile_capacity_skip()` unions this authoritative GitHub set with
  local `WAITING_GREPTILE` state, so reviews started by the GitHub Greptile app,
  raw MCP, or PRs with no local state dir are no longer invisible. Falls back to
  local-only when the GitHub query fails.
- **P2b — stuck reviews escalate from the merge path.** `merge_pr_when_ready()`
  now applies the same timeout check as `run_guard_once()` and returns
  `BLOCKED_GREPTILE_STUCK` past the wait limit instead of overwriting it with
  `WAITING_GREPTILE`.
- **P2c — clean PRs are no longer deadlocked by a sub-5 summary confidence.**
  A SUCCESS Greptile check with zero unresolved/actionable threads is treated as
  mergeable regardless of summary confidence (`run_guard_once` reaches
  `READY_TO_MERGE`; `assess_merge_readiness` drops the confidence blocker). When
  the check has *not* cleared, the no-findings re-trigger path is now bounded and
  escalates to `ESCALATE_HERMES` after K tries instead of looping forever.
  Behavior is unchanged when there ARE actionable findings.
- **P1 — head-stability gating.** `_head_stability_skip()` defers (re)triggering
  until the head SHA has been unchanged for a window, stopping re-trigger thrash
  as the head drifts. Uses the existing trigger/head plumbing; `force=True`
  bypasses.
- **P3 — finalize-on-merge sweep.** `finalize_merged_guard_state()` (+ a
  `--finalize-merged` CLI flag) marks guard state for already merged/closed PRs
  as finalized so they stop polluting capacity/backlog scans. It finalizes ONLY
  PRs GitHub reports as MERGED/CLOSED and never mutates mid-flight (open) state.

### New config knobs (env-overridable, sensible defaults)

| Env var | Default | Purpose |
| --- | --- | --- |
| `ZOE_PR_GUARD_HEAD_STABILITY_SECONDS` | `90` | P1 head-stability window |
| `ZOE_PR_GUARD_NO_FINDINGS_RETRIGGER_LIMIT` | `3` | P2c bound before Hermes escalation |
| `ZOE_PR_GUARD_CLEAN_MERGE_IGNORES_CONFIDENCE` | `1` (on) | P2c clean-check-merges-below-confidence |

### Files changed

- `services/zoe-data/greploop_guard.py` — config knobs + `_env_flag`;
  `_gh_open_prs_with_running_greptile`, `_repo_greptile_capacity_skip`,
  `_head_stability_skip`, `_greptile_clean_without_findings`,
  `finalize_merged_guard_state`; updates to `trigger_review_safely`,
  `assess_merge_readiness`, `merge_pr_when_ready`, `run_guard_once`.
- `scripts/maintenance/greploop_guard.py` — `--finalize-merged` flag.
- `services/zoe-data/tests/test_greploop_guard.py` — 20 new tests; 5 pre-existing
  tests updated to disable the new head-stability window for their scenarios.

## Test plan

- [x] `pytest services/zoe-data/tests/test_greploop_guard.py` — **96 passed**
  (76 pre-existing + 20 new). All `gh`/MCP/GitHub calls are mocked; no network.
- [x] `python3 tools/audit/validate_structure.py` — PASSED (0 orphans, root .md 8/10).
- [x] `python3 tools/audit/validate_critical_files.py` — PASSED (43 critical files).
- [x] `py_compile` both modules; `--finalize-merged` flag wired in CLI `--help`.

Coverage per fix: P2a (cap counting from mocked GitHub incl. PRs with no local
state, union, self-exclusion, fallback), P2b (stuck escalation in merge path),
P2c (mergeable-on-clean-no-findings, still-blocked-with-findings, flag-off,
Hermes escalation after K), P1 (defer new head / allow stable / force bypass),
P3 (finalize only merged/closed, skip finalized, never touch open).

Do not merge — leaving for Greptile review.

Made with [Cursor](https://cursor.com)