### PR TITLE
feat(omnigent): Zoe-SSO (OIDC) login + Omnigent meta-harness module

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,6 +74,8 @@ services:
     - HA_OIDC_CLIENT_SECRET=${HA_OIDC_CLIENT_SECRET:-}
     - MULTICA_OIDC_CLIENT_ID=${MULTICA_OIDC_CLIENT_ID:-multica}
     - MULTICA_OIDC_CLIENT_SECRET=${MULTICA_OIDC_CLIENT_SECRET:-}
+    - OMNIGENT_OIDC_CLIENT_ID=${OMNIGENT_OIDC_CLIENT_ID:-omnigent}
+    - OMNIGENT_OIDC_CLIENT_SECRET=${OMNIGENT_OIDC_CLIENT_SECRET:-}
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8002/health"]
       interval: 30s

--- a/modules/omnigent/.gitignore
+++ b/modules/omnigent/.gitignore
@@ -1,0 +1,2 @@
+# Platform binary wheels are built locally on the aarch64 host, never committed.
+wheels/*.whl

--- a/modules/omnigent/Dockerfile
+++ b/modules/omnigent/Dockerfile
@@ -1,0 +1,53 @@
+# Omnigent meta-harness — runs as a Zoe module behind the existing cloudflared tunnel.
+# Base is python:3.12 because omnigent requires Python 3.12.
+FROM python:3.12-slim-bookworm
+
+# ── System deps ──────────────────────────────────────────────────────────────
+#   git/tmux  : harness runtime (terminal launchers, worktrees)
+#   bubblewrap: omnigent's OS sandbox (relaxed at runtime — the container is the boundary)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        curl ca-certificates git tmux bubblewrap \
+    && rm -rf /var/lib/apt/lists/*
+
+# ── Node 22 ──────────────────────────────────────────────────────────────────
+# Copied from the official image rather than piping the NodeSource bootstrap script.
+# bookworm base matches node:22-bookworm-slim, so the shared libs line up.
+COPY --from=node:22-bookworm-slim /usr/local/bin/node /usr/local/bin/node
+COPY --from=node:22-bookworm-slim /usr/local/lib/node_modules /usr/local/lib/node_modules
+RUN ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
+    && ln -s /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx \
+    && node --version && npm --version
+
+# ── Harness CLIs (verified to run on arm64/Tegra) ────────────────────────────
+# Separate layers so a failure pinpoints the culprit; the --version calls smoke-test them.
+RUN npm install -g @anthropic-ai/claude-code && claude --version
+RUN npm install -g @openai/codex && codex --version
+
+# ── Cursor harness (second-class) ────────────────────────────────────────────
+# Requires piping the cursor.com installer, which needs a remote-script permission.
+# Left opt-in: uncomment after granting permission, or COPY the host's proven binary in.
+# RUN curl https://cursor.com/install -fsS | bash && /root/.local/bin/cursor-agent --version
+
+# ── Locally-built dependency ─────────────────────────────────────────────────
+# omnigent depends on cel-expr-python, which ships NO linux/aarch64 wheel and no sdist
+# (upstream's build hardcodes amd64 bazelisk). This wheel was compiled from source for
+# aarch64 — see wheels/ and README. UV_FIND_LINKS lets uv resolve it locally.
+COPY wheels/ /opt/wheels/
+ENV UV_FIND_LINKS=/opt/wheels
+
+# ── uv + Omnigent ────────────────────────────────────────────────────────────
+# uv installed via pip (avoids piping the astral bootstrap script).
+RUN pip install --no-cache-dir uv \
+    && uv tool install --force -q --python 3.12 omnigent
+ENV PATH="/root/.local/bin:${PATH}"
+RUN timeout 30s omnigent --version || echo "WARN: confirm 'omnigent --version' at runtime"
+
+COPY entrypoint.sh /usr/local/bin/omnigent-entrypoint.sh
+RUN chmod +x /usr/local/bin/omnigent-entrypoint.sh
+
+WORKDIR /workspace
+EXPOSE 6767
+
+# Entrypoint runs the foreground OIDC server AND attaches a host/runner (see entrypoint.sh).
+# (Bare `omnigent server` alone has no runner → "no hosts"; `server start` daemonizes/crash-loops.)
+CMD ["/usr/local/bin/omnigent-entrypoint.sh"]

--- a/modules/omnigent/README.md
+++ b/modules/omnigent/README.md
@@ -1,0 +1,87 @@
+# Omnigent module (builds & runs on this aarch64/Tegra host)
+
+Meta-harness that orchestrates the agent CLIs (Claude Code, Codex, Cursor, Pi) from one
+control plane with a web/mobile UI. Intended to run as a Zoe module behind `zoe-cloudflared`,
+mirroring the `agent-zero` module pattern.
+
+## Build/run status (verified 2026-06-17 on this aarch64/Tegra host)
+
+| Component        | arm64 status | Notes |
+|------------------|--------------|-------|
+| `claude` CLI     | ✅ works      | `@anthropic-ai/claude-code` 2.1.179, npm install clean |
+| `codex` CLI      | ✅ works      | `@openai/codex` codex-cli 0.140.0, npm install clean |
+| `cursor-agent`   | ✅ works      | already installed on host (`~/.local/bin`) |
+| **omnigent core**| ✅ works      | installs via a locally-built aarch64 wheel — see below |
+
+### The blocker (resolved)
+`omnigent` depends on `cel-expr-python` (a wrapper around the CEL C++ engine, used by the
+policy system). Upstream publishes **no `linux aarch64` wheel and no sdist** — and the root
+cause is in their own `release/build_wheel.sh`, which hardcodes `bazelisk-linux-amd64`.
+
+**Fix:** we compiled the wheel from source for aarch64 (cel-cpp 0.15 + Abseil + Protobuf 33 +
+antlr4 via Bazel), swapping in arm64 bazelisk. The result is vendored at
+`wheels/cel_expr_python-0.1.2-cp312-cp312-linux_aarch64.whl`; the Dockerfile points `uv` at it
+via `UV_FIND_LINKS`. Verified: `omnigent 0.1.1` runs in the built image on this Tegra host.
+
+To rebuild the wheel (e.g. on a version bump): clone `github.com/cel-expr/cel-python`, install
+`bazelisk-linux-arm64` as `bazel`, copy `release/*` to the repo root, set the version in
+`pyproject.toml`, then `pip wheel . --no-build-isolation`. Cap memory if building on the live
+box (we used a 4 GB / `--jobs=1` container so it couldn't starve the running stack). Worth
+upstreaming as an aarch64 CI target.
+
+The `Dockerfile` here is otherwise correct and builds fine up to the omnigent install step; it
+would succeed on an x86_64 host (or once the aarch64 wheel lands).
+
+## Auth — OAuth subscriptions (not API keys)
+The harnesses authenticate with the **subscription logins** (Claude Pro/Max, ChatGPT/Codex,
+Cursor), not metered API keys.
+
+**Critical gotcha:** if `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` are set in the environment, the
+CLIs use the **API (metered billing) and ignore the subscription**. So those env vars are
+deliberately *absent* from the compose file. Don't add them back.
+
+**One-time login** (tokens then persist in the credential volumes and auto-refresh):
+```bash
+docker exec -it zoe-omnigent claude            # /login in the TUI → paste the code
+docker exec -it zoe-omnigent codex login       # "Sign in with ChatGPT"
+docker exec -it zoe-omnigent env NO_OPEN_BROWSER=1 cursor-agent login   # prints a URL to open
+docker exec -it zoe-omnigent cursor-agent status   # verify
+```
+Each is a headless device/paste flow (no browser in the container). Alternatively, copy an
+existing login in from a machine where you're already signed in: `~/.claude`, `~/.codex`,
+`~/.cursor` → the matching `omnigent-*` volume.
+
+**Security:** these credential files are bearer tokens to your paid accounts, living in Docker
+volumes on a host behind a public tunnel. Treat them like the rest of the secret/env topology —
+volume-only, never in the image or in env, and gate the tunnel with Cloudflare Access.
+
+**Heads-up:** using personal subscription OAuth inside an automated server is a gray area on
+some providers (device limits, ToS, session invalidation). Worth confirming per provider before
+leaning on it for unattended runs.
+
+## Server login — Zoe SSO via OIDC
+The Omnigent web UI authenticates against **zoe-auth** (Zoe's own OIDC provider), not its
+built-in accounts mode. Wiring:
+- `zoe-auth` seeds an `omnigent` OIDC client (`services/zoe-auth/oidc/startup.py`), secret in
+  repo `.env` as `OMNIGENT_OIDC_CLIENT_SECRET`.
+- Omnigent runs with `OMNIGENT_AUTH_PROVIDER=oidc`, issuer **`http://zoe.local`** (the nginx
+  frontend — it serves the login UI at `/` and proxies `/application/o/`, `/.well-known/`,
+  `/jwks.json` to zoe-auth; do NOT use `:8002`, whose `/` is JSON with no login page), redirect
+  `http://zoe.local:6767/auth/callback`. `extra_hosts: zoe.local:host-gateway` lets the
+  container reach the frontend with a Host header matching the browser, so the token `iss` aligns.
+- **Bring up with the repo .env** so the secrets interpolate:
+  `docker compose --env-file ../../.env -f docker-compose.module.yml up -d`
+- **Access the UI at http://zoe.local:6767** (not the raw IP) so the OIDC redirect host is
+  consistent. `/auth/login` → 302 to zoe-auth authorize (code + PKCE) → log in with your Zoe
+  identity → back to `/auth/callback`.
+- Possible first-login wrinkle: Omnigent may gate new OIDC users via
+  `OMNIGENT_OIDC_ALLOWED_DOMAINS` / invites — if login is rejected, that's the knob.
+
+## Server start / runner
+- CMD is the foreground server: `omnigent server --host 0.0.0.0 --port 6767 --no-open`
+  (bare `server` is the documented Docker entrypoint; `server start` daemonizes and crash-loops).
+- Still TODO for actually running agents: register a **host** (`omnigent host`) — the server is
+  only the control plane; "no hosts" until one is registered.
+- Tunnel: add `omnigent.<domain>` ingress to `config/cloudflared-config.yml` →
+  `http://zoe-omnigent:6767`, plus the `https://omnigent.<domain>/auth/callback` redirect URI in
+  the zoe-auth `omnigent` client. Cloudflare Access optional now that OIDC gates the UI.

--- a/modules/omnigent/docker-compose.module.yml
+++ b/modules/omnigent/docker-compose.module.yml
@@ -1,0 +1,83 @@
+version: '3.8'
+
+# Omnigent meta-harness module.
+# Public access is via zoe-cloudflared over the internal network (http://zoe-omnigent:6767)
+# gated by a Cloudflare Access policy — see README.md. Port 6767 is bound to localhost
+# only for local debugging; it is NOT published to the LAN or the public internet.
+
+services:
+  omnigent:
+    build: .
+    image: zoe-omnigent:latest
+    container_name: zoe-omnigent
+    restart: unless-stopped
+    # CMD is the image entrypoint (entrypoint.sh): runs the foreground OIDC server AND
+    # attaches the host/runner, so a single container serves the UI and runs agents.
+    ports:
+      - "6767:6767"   # LAN access (binds 0.0.0.0). cloudflared reaches it internally via zoe-network.
+                      # NOTE: the omnigent server has no auth of its own — anyone on the LAN can
+                      # reach it. Fine for a trusted home network; gate with Cloudflare Access
+                      # before ever exposing it through the tunnel.
+    # AUTH = OAuth subscriptions (Claude / ChatGPT / Cursor logins), NOT API keys.
+    # DO NOT set ANTHROPIC_API_KEY or OPENAI_API_KEY here: if present, the CLIs bill the
+    # metered API and silently ignore your subscription. Subscription tokens live in the
+    # credential volumes below, created by a one-time login (see README → Auth).
+    environment:
+      - NODE_NO_WARNINGS=1
+      # Omnigent launches agents with --dangerously-skip-permissions (autonomous, no prompts).
+      # Claude Code blocks that flag under root; IS_SANDBOX=1 is the documented container
+      # escape hatch — the container IS the isolation boundary. (User-approved 2026-06-17.)
+      - IS_SANDBOX=1
+      # Runner working directory = the mounted Zoe repo, so agents build Zoe. The host
+      # creates git worktrees under it (the repo at ../../ is bind-mounted to /workspace).
+      - OMNIGENT_RUNNER_WORKSPACE=/workspace
+      # The repo is owned by host uid 1000 but the container runs as root; tell git to
+      # trust it (otherwise "dubious ownership" breaks worktree/agent git ops).
+      - GIT_CONFIG_COUNT=1
+      - GIT_CONFIG_KEY_0=safe.directory
+      - GIT_CONFIG_VALUE_0=*
+      # Auth delegated to Zoe's own SSO (zoe-auth OIDC) — one Zoe login, UI stays protected
+      # even on the LAN. Issuer/redirect use zoe.local so the token `iss` matches across
+      # browser and server (zoe-auth derives issuer from the Host header). Access the UI at
+      # http://zoe.local:6767 (NOT the raw IP) so the OIDC redirect host stays consistent.
+      - OMNIGENT_AUTH_ENABLED=1
+      - OMNIGENT_AUTH_PROVIDER=oidc
+      # Issuer is the nginx frontend (http://zoe.local, port 80) — it serves the login UI at /
+      # and proxies /application/o/, /.well-known/, /jwks.json to zoe-auth. NOT :8002 (raw API,
+      # whose / is JSON with no login page).
+      - OMNIGENT_OIDC_ISSUER=http://zoe.local
+      - OMNIGENT_OIDC_CLIENT_ID=${OMNIGENT_OIDC_CLIENT_ID:-omnigent}
+      - OMNIGENT_OIDC_CLIENT_SECRET=${OMNIGENT_OIDC_CLIENT_SECRET}
+      - OMNIGENT_OIDC_REDIRECT_URI=http://zoe.local:6767/auth/callback
+      - OMNIGENT_OIDC_COOKIE_SECRET=${OMNIGENT_OIDC_COOKIE_SECRET}
+    # Resolve zoe.local to the host so the container reaches zoe-auth's published :8002 with
+    # a Host header of "zoe.local:8002" — keeps the OIDC issuer identical to the browser's.
+    extra_hosts:
+      - "zoe.local:host-gateway"
+    volumes:
+      # The agents' workspace IS the Zoe repo, so they can build Zoe.
+      - ../../:/workspace
+      # OAuth/subscription credentials — persisted so logins + token refresh survive restarts.
+      # (Subdir mounts only — never mount over /root or you shadow the installed CLIs.)
+      - omnigent-claude:/root/.claude
+      - omnigent-codex:/root/.codex
+      - omnigent-cursor:/root/.cursor
+      # Cursor harness: mount the host's proven arm64 cursor-agent install (avoids the
+      # cursor.com remote installer). The entrypoint symlinks the real versioned binary
+      # (which has its bundled node beside it) onto PATH. Login creds → omnigent-cursor volume.
+      - /home/zoe/.local/share/cursor-agent:/root/.local/share/cursor-agent:ro
+      # Persist omnigent's own state (mount path to confirm at first run).
+      - omnigent-data:/root/.omnigent
+    networks:
+      - zoe-network
+
+networks:
+  zoe-network:
+    name: zoe-network
+    external: true
+
+volumes:
+  omnigent-claude:
+  omnigent-codex:
+  omnigent-cursor:
+  omnigent-data:

--- a/modules/omnigent/wheels/README.md
+++ b/modules/omnigent/wheels/README.md
@@ -1,0 +1,9 @@
+# Locally-built wheels (NOT committed)
+
+`omnigent` depends on `cel-expr-python`, which ships **no linux/aarch64 wheel and
+no sdist** (upstream's `build_wheel.sh` hardcodes amd64 bazelisk). The Dockerfile
+`COPY wheels/ /opt/wheels/` + `UV_FIND_LINKS=/opt/wheels` so `uv` resolves it locally.
+
+Place the locally-built `cel_expr_python-*-linux_aarch64.whl` here before `docker build`.
+The wheel itself is **git-ignored** (it is a ~14 MB platform binary) — build it from
+source on the aarch64 host. See the module README for the build steps.

--- a/services/zoe-auth/oidc/router.py
+++ b/services/zoe-auth/oidc/router.py
@@ -5,8 +5,15 @@ import uuid
 from typing import Optional
 
 from fastapi import APIRouter, Cookie, Form, Header, HTTPException, Request
-from fastapi.responses import JSONResponse, RedirectResponse
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 
+from core.auth import auth_manager
+from core.sessions import (
+    AuthenticationRequest,
+    AuthMethod,
+    SessionType,
+    session_manager,
+)
 from oidc.clients import get_client, validate_redirect_uri, verify_secret
 from oidc.codes import (
     consume_auth_code,
@@ -35,12 +42,20 @@ def _base_url(request: Request) -> str:
 def _get_user_info(user_id: str) -> dict | None:
     with get_db() as conn:
         row = conn.execute(
-            "SELECT user_id, username, email, role FROM auth_users WHERE user_id = ?",
+            "SELECT user_id, username, email, role, is_verified FROM auth_users WHERE user_id = ?",
             (user_id,),
         ).fetchone()
     if row is None:
         return None
-    return {"user_id": row[0], "username": row[1], "email": row[2], "role": row[3]}
+    # email_verified must be carried into the OIDC id_token — clients (e.g. Omnigent)
+    # hard-reject the email claim unless email_verified is true.
+    return {
+        "user_id": row[0],
+        "username": row[1],
+        "email": row[2],
+        "role": row[3],
+        "email_verified": bool(row[4]),
+    }
 
 
 def _get_user_from_session(session_id: str) -> str | None:
@@ -49,7 +64,7 @@ def _get_user_from_session(session_id: str) -> str | None:
     now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     with get_db() as conn:
         row = conn.execute(
-            "SELECT user_id FROM auth_sessions WHERE session_id = ? AND is_active = TRUE AND expires_at > ?",
+            "SELECT user_id FROM auth_sessions WHERE session_id = ? AND is_active = 1 AND expires_at > ?",
             (session_id, now),
         ).fetchone()
     return row[0] if row else None
@@ -160,7 +175,131 @@ async def authorize(
         "code_challenge_method": code_challenge_method,
         "nonce": nonce,
     })
-    return RedirectResponse(f"/?oidc_state_id={oidc_state_id}", status_code=302)
+    return RedirectResponse(
+        f"/application/o/login?oidc_state_id={oidc_state_id}", status_code=302
+    )
+
+
+# ---------------------------------------------------------------------------
+# Login page (server-rendered) — bridges password auth into a zoe_session cookie
+# so the OIDC flow completes without depending on the SPA. Used by every OIDC
+# client (Omnigent, Home Assistant, Multica). The main app uses header-based
+# (X-Session-ID) sessions, which a browser redirect to /authorize can't carry,
+# so the consent flow needs its own cookie-setting login.
+# ---------------------------------------------------------------------------
+
+def _login_page_html(oidc_state_id: str, error: str = "") -> str:
+    err_html = f'<p class="err">{error}</p>' if error else ""
+    return f"""<!doctype html>
+<html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Sign in to Zoe</title>
+<style>
+  body {{ font-family: system-ui, sans-serif; background:#0f1115; color:#e8e8e8;
+         display:flex; min-height:100vh; align-items:center; justify-content:center; margin:0; }}
+  form {{ background:#1a1d24; padding:2rem; border-radius:12px; width:320px;
+          box-shadow:0 8px 30px rgba(0,0,0,.4); }}
+  h1 {{ font-size:1.25rem; margin:0 0 1rem; }}
+  label {{ display:block; font-size:.8rem; margin:.75rem 0 .25rem; color:#9aa0aa; }}
+  input {{ width:100%; box-sizing:border-box; padding:.6rem; border-radius:8px;
+           border:1px solid #2c313c; background:#0f1115; color:#e8e8e8; }}
+  button {{ width:100%; margin-top:1.25rem; padding:.65rem; border:0; border-radius:8px;
+            background:#4f8cff; color:#fff; font-weight:600; cursor:pointer; }}
+  .err {{ color:#ff6b6b; font-size:.85rem; margin:.5rem 0 0; }}
+  .sub {{ color:#6b7280; font-size:.75rem; margin-top:1rem; text-align:center; }}
+</style></head>
+<body>
+  <form method="post" action="/application/o/login">
+    <h1>Sign in to Zoe</h1>
+    <input type="hidden" name="oidc_state_id" value="{oidc_state_id}">
+    <label for="u">Username</label>
+    <input id="u" name="username" autocomplete="username" autofocus required>
+    <label for="p">Password</label>
+    <input id="p" name="password" type="password" autocomplete="current-password" required>
+    {err_html}
+    <button type="submit">Sign in</button>
+    <p class="sub">Authorizing an application to use your Zoe account.</p>
+  </form>
+</body></html>"""
+
+
+@router.get("/application/o/login", response_class=HTMLResponse)
+async def oidc_login_page(oidc_state_id: str, error: str = ""):
+    if get_pending_auth(oidc_state_id) is None:
+        return HTMLResponse(
+            _login_page_html("", "This login request expired — please retry from the app."),
+            status_code=400,
+        )
+    msg = {
+        "invalid": "Invalid username or password.",
+        "session_required": "Please sign in to continue.",
+        "session_expired": "Your session expired — please sign in again.",
+    }.get(error, "")
+    return HTMLResponse(_login_page_html(oidc_state_id, msg))
+
+
+@router.post("/application/o/login")
+async def oidc_login_submit(
+    request: Request,
+    username: str = Form(...),
+    password: str = Form(...),
+    oidc_state_id: str = Form(...),
+):
+    if get_pending_auth(oidc_state_id) is None:
+        return RedirectResponse("/?error=oidc_expired", status_code=302)
+
+    ip_address = request.client.host if request.client else None
+
+    # Match either username or user_id, case-insensitively — the username column is
+    # capitalized (e.g. "Jason") while user_id is lowercase ("jason"), and people type
+    # either in any case.
+    with get_db() as conn:
+        row = conn.execute(
+            "SELECT user_id, password_hash FROM auth_users"
+            " WHERE LOWER(username) = LOWER(?) OR LOWER(user_id) = LOWER(?)",
+            (username, username),
+        ).fetchone()
+
+    bad = RedirectResponse(
+        f"/application/o/login?oidc_state_id={oidc_state_id}&error=invalid",
+        status_code=302,
+    )
+    if not row or row[1] in (None, "SETUP_REQUIRED"):
+        return bad
+
+    user_id = row[0]
+    auth_result = auth_manager.verify_password(user_id, password, ip_address)
+    if not auth_result.success:
+        return bad
+
+    session_result = session_manager.authenticate(
+        AuthenticationRequest(
+            user_id=auth_result.user_id,
+            auth_method=AuthMethod.PASSWORD,
+            credentials={"password": password},
+            device_info={},
+            ip_address=ip_address,
+            user_agent=request.headers.get("user-agent"),
+            requested_session_type=SessionType.STANDARD,
+        )
+    )
+    if not session_result.success or not session_result.session:
+        return bad
+
+    # Set the zoe_session cookie the OIDC endpoints read, then resume the flow.
+    resp = RedirectResponse(
+        f"/application/o/authorize/complete?oidc_state_id={oidc_state_id}",
+        status_code=302,
+    )
+    resp.set_cookie(
+        "zoe_session",
+        session_result.session.session_id,
+        httponly=True,
+        samesite="lax",
+        max_age=8 * 3600,
+        path="/",
+    )
+    return resp
 
 
 # ---------------------------------------------------------------------------
@@ -175,13 +314,15 @@ async def authorize_complete(
 ):
     if not zoe_session:
         return RedirectResponse(
-            f"/?oidc_state_id={oidc_state_id}&error=session_required", status_code=302
+            f"/application/o/login?oidc_state_id={oidc_state_id}&error=session_required",
+            status_code=302,
         )
 
     user_id = _get_user_from_session(zoe_session)
     if not user_id:
         return RedirectResponse(
-            f"/?oidc_state_id={oidc_state_id}&error=session_expired", status_code=302
+            f"/application/o/login?oidc_state_id={oidc_state_id}&error=session_expired",
+            status_code=302,
         )
 
     params = get_pending_auth(oidc_state_id)
@@ -332,7 +473,7 @@ async def end_session(
     if zoe_session:
         with get_db() as conn:
             conn.execute(
-                "UPDATE auth_sessions SET is_active = FALSE WHERE session_id = ?",
+                "UPDATE auth_sessions SET is_active = 0 WHERE session_id = ?",
                 (zoe_session,),
             )
 

--- a/services/zoe-auth/oidc/router.py
+++ b/services/zoe-auth/oidc/router.py
@@ -187,6 +187,11 @@ async def authorize(
 # client (Omnigent, Home Assistant, Multica). The main app uses header-based
 # (X-Session-ID) sessions, which a browser redirect to /authorize can't carry,
 # so the consent flow needs its own cookie-setting login.
+#
+# Test coverage: tests/test_oidc_login.py exercises _login_page_html escaping, the
+# GET page (expired-state->400, valid form, error allow-list) and the POST submit
+# (expired state, bad credentials, unknown user, SETUP_REQUIRED hash, success ->
+# zoe_session cookie + resume to authorize/complete).
 # ---------------------------------------------------------------------------
 
 def _login_page_html(oidc_state_id: str, error: str = "") -> str:

--- a/services/zoe-auth/oidc/router.py
+++ b/services/zoe-auth/oidc/router.py
@@ -1,6 +1,7 @@
 """Native OIDC provider endpoints for zoe-auth."""
 import base64
 import hashlib
+import html
 import uuid
 from typing import Optional
 
@@ -189,7 +190,11 @@ async def authorize(
 # ---------------------------------------------------------------------------
 
 def _login_page_html(oidc_state_id: str, error: str = "") -> str:
-    err_html = f'<p class="err">{error}</p>' if error else ""
+    # Defense-in-depth: oidc_state_id is only ever a server-generated UUID and
+    # error is mapped through a fixed allow-list, but escape both reflected
+    # values so the form can never become an HTML-injection sink.
+    oidc_state_id = html.escape(oidc_state_id, quote=True)
+    err_html = f'<p class="err">{html.escape(error)}</p>' if error else ""
     return f"""<!doctype html>
 <html lang="en"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -276,6 +281,10 @@ async def oidc_login_submit(
         AuthenticationRequest(
             user_id=auth_result.user_id,
             auth_method=AuthMethod.PASSWORD,
+            # session_manager.authenticate re-verifies via _verify_password_auth ->
+            # verify_password(user_id, credentials["password"]); an empty credentials
+            # dict would verify an empty password and fail, so the password is
+            # required here (mirrors the SPA login path).
             credentials={"password": password},
             device_info={},
             ip_address=ip_address,

--- a/services/zoe-auth/oidc/startup.py
+++ b/services/zoe-auth/oidc/startup.py
@@ -57,7 +57,6 @@ def bootstrap_oidc() -> None:
             redirect_uris=[
                 f"{base_url}:6767/auth/callback",
                 "http://zoe.local:6767/auth/callback",
-                "http://192.168.1.218:6767/auth/callback",
             ],
         )
         logger.info(f"OIDC client seeded: {omnigent_client_id}")

--- a/services/zoe-auth/oidc/startup.py
+++ b/services/zoe-auth/oidc/startup.py
@@ -46,3 +46,20 @@ def bootstrap_oidc() -> None:
         logger.info(f"OIDC client seeded: {multica_client_id}")
     else:
         logger.warning("MULTICA_OIDC_CLIENT_SECRET not set — Multica OIDC client not seeded")
+
+    omnigent_secret = os.getenv("OMNIGENT_OIDC_CLIENT_SECRET", "")
+    omnigent_client_id = os.getenv("OMNIGENT_OIDC_CLIENT_ID", "omnigent")
+    if omnigent_secret:
+        upsert_client(
+            client_id=omnigent_client_id,
+            client_name="Omnigent",
+            secret=omnigent_secret,
+            redirect_uris=[
+                f"{base_url}:6767/auth/callback",
+                "http://zoe.local:6767/auth/callback",
+                "http://192.168.1.218:6767/auth/callback",
+            ],
+        )
+        logger.info(f"OIDC client seeded: {omnigent_client_id}")
+    else:
+        logger.warning("OMNIGENT_OIDC_CLIENT_SECRET not set — Omnigent OIDC client not seeded")

--- a/services/zoe-auth/tests/test_oidc_login.py
+++ b/services/zoe-auth/tests/test_oidc_login.py
@@ -1,0 +1,161 @@
+"""Tests for the server-rendered OIDC login flow (/application/o/login).
+
+The flow bridges password auth into a zoe_session cookie so the OIDC consent
+flow completes without the SPA. These tests exercise the GET page (expired vs
+valid state, error allow-list), the POST submit (bad creds, expired state,
+success -> cookie + redirect), and the login page's HTML escaping.
+"""
+import contextlib
+import types
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from oidc import router as oidc_router
+
+
+@pytest.fixture
+def client(monkeypatch):
+    app = FastAPI()
+    app.include_router(oidc_router.router)
+    return TestClient(app)
+
+
+def _fake_db(row):
+    class _Conn:
+        def execute(self, *a, **k):
+            return self
+
+        def fetchone(self):
+            return row
+
+    @contextlib.contextmanager
+    def _get_db():
+        yield _Conn()
+
+    return _get_db
+
+
+# ── _login_page_html (unit) ──────────────────────────────────────────────────
+
+
+def test_login_page_html_escapes_state_and_error():
+    out = oidc_router._login_page_html('"><script>x</script>', '<b>bad</b>')
+    assert "<script>" not in out
+    assert "&lt;script&gt;" in out
+    assert "<b>bad</b>" not in out
+    assert "&lt;b&gt;bad&lt;/b&gt;" in out
+
+
+# ── GET /application/o/login ─────────────────────────────────────────────────
+
+
+def test_login_page_expired_state_returns_400(client, monkeypatch):
+    monkeypatch.setattr(oidc_router, "get_pending_auth", lambda sid: None)
+    resp = client.get("/application/o/login", params={"oidc_state_id": "missing"})
+    assert resp.status_code == 400
+    assert "expired" in resp.text.lower()
+
+
+def test_login_page_valid_state_renders_form(client, monkeypatch):
+    monkeypatch.setattr(oidc_router, "get_pending_auth", lambda sid: {"client_id": "omnigent"})
+    resp = client.get("/application/o/login", params={"oidc_state_id": "state-1"})
+    assert resp.status_code == 200
+    assert 'name="oidc_state_id" value="state-1"' in resp.text
+    assert 'name="password"' in resp.text
+
+
+def test_login_page_error_allowlist(client, monkeypatch):
+    monkeypatch.setattr(oidc_router, "get_pending_auth", lambda sid: {"client_id": "omnigent"})
+    resp = client.get(
+        "/application/o/login", params={"oidc_state_id": "s", "error": "invalid"}
+    )
+    assert "Invalid username or password." in resp.text
+    # Unknown error codes are not reflected.
+    resp2 = client.get(
+        "/application/o/login", params={"oidc_state_id": "s", "error": "<x>"}
+    )
+    assert "<x>" not in resp2.text
+
+
+# ── POST /application/o/login ────────────────────────────────────────────────
+
+
+def test_login_submit_expired_state_redirects(client, monkeypatch):
+    monkeypatch.setattr(oidc_router, "get_pending_auth", lambda sid: None)
+    resp = client.post(
+        "/application/o/login",
+        data={"username": "jason", "password": "pw", "oidc_state_id": "gone"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 302
+    assert "/?error=oidc_expired" in resp.headers["location"]
+
+
+def test_login_submit_bad_credentials_redirects_with_error(client, monkeypatch):
+    monkeypatch.setattr(oidc_router, "get_pending_auth", lambda sid: {"client_id": "omnigent"})
+    monkeypatch.setattr(oidc_router, "get_db", _fake_db(("jason", "hash")))
+    monkeypatch.setattr(
+        oidc_router.auth_manager,
+        "verify_password",
+        lambda uid, pw, ip=None: types.SimpleNamespace(success=False, user_id=uid),
+    )
+    resp = client.post(
+        "/application/o/login",
+        data={"username": "jason", "password": "wrong", "oidc_state_id": "s1"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 302
+    assert "error=invalid" in resp.headers["location"]
+    assert "oidc_state_id=s1" in resp.headers["location"]
+
+
+def test_login_submit_unknown_user_redirects_with_error(client, monkeypatch):
+    monkeypatch.setattr(oidc_router, "get_pending_auth", lambda sid: {"client_id": "omnigent"})
+    monkeypatch.setattr(oidc_router, "get_db", _fake_db(None))  # no such user
+    resp = client.post(
+        "/application/o/login",
+        data={"username": "ghost", "password": "pw", "oidc_state_id": "s1"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 302
+    assert "error=invalid" in resp.headers["location"]
+
+
+def test_login_submit_setup_required_hash_rejected(client, monkeypatch):
+    monkeypatch.setattr(oidc_router, "get_pending_auth", lambda sid: {"client_id": "omnigent"})
+    monkeypatch.setattr(oidc_router, "get_db", _fake_db(("jason", "SETUP_REQUIRED")))
+    resp = client.post(
+        "/application/o/login",
+        data={"username": "jason", "password": "pw", "oidc_state_id": "s1"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 302
+    assert "error=invalid" in resp.headers["location"]
+
+
+def test_login_submit_success_sets_cookie_and_resumes(client, monkeypatch):
+    monkeypatch.setattr(oidc_router, "get_pending_auth", lambda sid: {"client_id": "omnigent"})
+    monkeypatch.setattr(oidc_router, "get_db", _fake_db(("jason", "hash")))
+    monkeypatch.setattr(
+        oidc_router.auth_manager,
+        "verify_password",
+        lambda uid, pw, ip=None: types.SimpleNamespace(success=True, user_id="jason"),
+    )
+    session = types.SimpleNamespace(session_id="sess-123")
+    monkeypatch.setattr(
+        oidc_router.session_manager,
+        "authenticate",
+        lambda req: types.SimpleNamespace(success=True, session=session),
+    )
+    resp = client.post(
+        "/application/o/login",
+        data={"username": "jason", "password": "right", "oidc_state_id": "s1"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 302
+    assert "/application/o/authorize/complete?oidc_state_id=s1" in resp.headers["location"]
+    set_cookie = resp.headers.get("set-cookie", "")
+    assert "zoe_session=sess-123" in set_cookie
+    assert "httponly" in set_cookie.lower()


### PR DESCRIPTION
## Provenance
Recovered intentional in-progress work from the pre-reset live checkout (`backup/live-runtime-20260618-075906`, commit `fccbd488`). Everything else in that backup was already on main, superseded by the merged Brick PRs (#684–#688), or generated noise — this is the only real chunk that wasn't yet landed.

## What

**OIDC login (zoe-auth)** — a server-rendered login page so the OIDC consent flow completes without the SPA (the main app uses header `X-Session-ID` sessions a browser redirect to `/authorize` can't carry):
- `oidc/router.py`: `GET/POST /application/o/login` renders a password form, verifies through the **existing** `auth_manager.verify_password` + `session_manager.authenticate`, sets the `httponly`+`samesite=lax` `zoe_session` cookie, then resumes the flow. `authorize`/`authorize_complete` now redirect to the login page on missing/expired session. `_get_user_info` carries `email_verified` into the id_token (clients reject unverified email). SQL stays parameterized; `is_active` booleans normalized to `1/0` for SQLite.
- `oidc/startup.py`: seed an `omnigent` OIDC client from `OMNIGENT_OIDC_CLIENT_SECRET`/`_CLIENT_ID` (nothing seeded if unset).
- `docker-compose.yml`: pass those two env vars through.

**Omnigent module (`modules/omnigent/`)** — meta-harness orchestrating the agent CLIs (Claude Code, Codex, Cursor, Pi) behind one web/mobile UI, run as a Zoe module behind `zoe-cloudflared` with auth delegated to Zoe SSO. Dockerfile + entrypoint + module compose + README.

## ⚠️ Review notes (security-sensitive — auth)
- **Login page is XSS-safe**: `oidc_state_id` is only reflected when it maps to a valid server-side pending-auth state; `error` is mapped through a fixed allow-list dict. Neither reflects attacker-controlled content.
- **Hardening follow-ups (non-blocking)**: add `html.escape()` defense-in-depth on the form, and set a `secure` cookie flag when served over HTTPS (currently behind cloudflared/LAN).
- **No automated tests** for the login flow yet (zoe-auth has limited test scaffolding) — flagged as a follow-up; I'd value a human eyeball on the auth diff before merge.

## The 14 MB wheel — intentionally excluded
`omnigent` needs `cel-expr-python`, which ships no linux/aarch64 wheel or sdist. The platform binary wheel is **git-ignored** (`modules/omnigent/.gitignore`) and built locally on the host; `wheels/README.md` documents it. Keeps a 14 MB binary out of git history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)