### PR TITLE
docs: fix OpenClaw backend label (Gemma 4 E2B, not Codex) + pin opensrc versions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,8 @@ Use `opensrc` for third-party library source before guessing API behavior.
 
 Rules:
 - Keep the global source cache outside the repo at `~/.opensrc/repos/`.
-- Prefer `opensrc path pypi:<package>` or `opensrc path owner/repo` to locate already-fetched source.
+- Prefer `opensrc path pypi:<package>@<version>` or `opensrc path owner/repo` to locate already-fetched source.
+- Pin the version to the one Zoe actually installs (for example `opensrc path pypi:chromadb@0.6.3`). A bare package name resolves to the latest published version (e.g. bare `chromadb` is 1.5.9), which can be a major-version mismatch from the running stack and will mislead you.
 - Search package source directly when debugging integrations, for example:
   `rg "class FastAPI" "$(opensrc path pypi:fastapi)"`
 - When source context informs an implementation, report the package files, examples, or tests that were used.

--- a/CAPABILITIES.md
+++ b/CAPABILITIES.md
@@ -7,7 +7,7 @@
 | 0 | intent_router | regex | — | <10ms fast path |
 | 1 | Zoe Agent | Gemma 4 E2B | :11434 | tool loop, escalation |
 | 1.5 | Hermes | GPT-5.4 | :8642 | default engineering, planning, review, repair |
-| 2 | OpenClaw | Codex + browser | :18789 | available fallback, not default route |
+| 2 | OpenClaw | Gemma 4 E2B + browser | :18789 | available fallback, not default route |
 
 ## MCP Tools
 - `a2a_delegate`

--- a/scripts/setup/populate_multica.py
+++ b/scripts/setup/populate_multica.py
@@ -459,7 +459,7 @@ _AGENT_DEFS = [
         "description": (
             "Agentic execution runtime. Handles browser automation, code execution, and skill "
             "building. In Multica issue capture, route simple-English ticket creation through "
-            "the Hermes runtime until OpenClaw's Codex-backed harness has non-rate-limited capacity."
+            "the Hermes runtime until OpenClaw's Gemma 4 E2B-backed harness has non-rate-limited capacity."
         ),
         "instructions": (
             "You are OpenClaw, Zoe's native agentic execution runtime. For Multica simple-English "

--- a/scripts/setup/systemd/README.md
+++ b/scripts/setup/systemd/README.md
@@ -13,7 +13,7 @@ Secrets are never inlined — they are read from `.env` files.
 |------|------|---------|
 | `llama-server.service`     | 11434 | Local LLM (Gemma 4 E2B via llama.cpp) — **platform-specific paths** |
 | `hermes-agent.service`     | 8642  | Engineering/planning/review agent gateway |
-| `openclaw-gateway.service` | 18789 | Codex + browser agent fallback (needs `openclaw` npm pkg) |
+| `openclaw-gateway.service` | 18789 | Gemma 4 E2B + browser agent fallback (needs `openclaw` npm pkg) |
 | `kokoro-tts.service`       | 10201 | Local neural TTS sidecar (optional) |
 | `zoe-data.service`         | 8000  | Primary backend API |
 

--- a/scripts/setup/systemd/openclaw-gateway.service
+++ b/scripts/setup/systemd/openclaw-gateway.service
@@ -1,4 +1,4 @@
-# OpenClaw agent gateway (Codex + browser fallback), port 18789.
+# OpenClaw agent gateway (Gemma 4 E2B + browser fallback), port 18789.
 # Requires the `openclaw` npm package installed globally (see README).
 [Unit]
 Description=OpenClaw Gateway (agent fallback, port 18789)

--- a/services/zoe-data/agent_sync.py
+++ b/services/zoe-data/agent_sync.py
@@ -311,7 +311,7 @@ def _build_capabilities_md(
         "| 0 | intent_router | regex | — | <10ms fast path |",
         "| 1 | Zoe Agent | Gemma 4 E2B | :11434 | tool loop, escalation |",
         "| 1.5 | Hermes | GPT-5.4 | :8642 | default engineering, planning, review, repair |",
-        "| 2 | OpenClaw | Codex + browser | :18789 | available fallback, not default route |",
+        "| 2 | OpenClaw | Gemma 4 E2B + browser | :18789 | available fallback, not default route |",
         "",
         "## MCP Tools",
     ]

--- a/services/zoe-data/agents_registry.yml
+++ b/services/zoe-data/agents_registry.yml
@@ -50,7 +50,7 @@ agents:
     base_url: "http://localhost:18789"
     a2a_token: ""          # OpenClaw uses ACP; A2A is a secondary path
     description: "OpenClaw — available fallback, not the default route"
-    model: "Codex"
+    model: "Gemma 4 E2B"
     skills:
       - browser_automation
       - persistent_login_sessions

--- a/services/zoe-data/openclaw_ws.py
+++ b/services/zoe-data/openclaw_ws.py
@@ -32,7 +32,7 @@ OPENCLAW_AGENT_TIMEOUT_S = float(os.environ.get("OPENCLAW_AGENT_TIMEOUT_S", "900
 
 _ZOE_SELF_COMPACT_DEFAULT = (
     "Zoe is a personal AI companion (3-tier: Zoe Agent/Gemma4 :11434, Hermes/GPT-5.4 :8642, "
-    "OpenClaw/Codex :18789). Tools: calendar, reminders, lists, notes, people, weather, "
+    "OpenClaw/Gemma4 :18789). Tools: calendar, reminders, lists, notes, people, weather, "
     "Home Assistant, memory (MemPalace semantic + SQLite portrait), push notifications, "
     "panel display (show_map, show_chart, show_image), web_search (DDG). "
     "OpenClaw has full Playwright browser + bash exec + skills. "

--- a/services/zoe-data/routers/system.py
+++ b/services/zoe-data/routers/system.py
@@ -937,7 +937,7 @@ def _build_agent_card() -> dict:
         {
             "tier": 2,
             "name": "openclaw",
-            "model": "Codex",
+            "model": "Gemma 4 E2B",
             "browser": True,
             "status": "online" if _RUNTIME_HEALTH.get("openclaw") else "offline",
         },
@@ -1423,7 +1423,7 @@ async def get_agent_runtimes():
             },
             "openclaw": {
                 "port": 18789,
-                "description": "OpenClaw Gateway (Codex mini, browser/exec)",
+                "description": "OpenClaw Gateway (Gemma 4 E2B, browser/exec)",
                 "online": _RUNTIME_HEALTH.get("openclaw", False),
             },
         },


### PR DESCRIPTION
## Summary

Two documentation/source corrections.

### Correction 1 — OpenClaw backend mislabeled as "Codex"
OpenClaw's default agent runs the **local Gemma 4 E2B model** (`custom-127-0-0-1-11434/gemma4-e2b`, the llama-server at `127.0.0.1:11434`). It is **not** Codex — the `codex` CLI is not installed on this host. Corrected the label everywhere it appeared:

- **`services/zoe-data/agent_sync.py`** — the source of truth: `_build_capabilities_md()` tier table row (line 314). This is the generator for the auto-generated `CAPABILITIES.md`.
- **`CAPABILITIES.md`** — regenerated-by-hand so the committed output matches the generator (this file is auto-generated by `agent_sync`; a regen via `POST /api/system/agent-sync` will reproduce the same corrected text).
- **`services/zoe-data/agents_registry.yml`** — OpenClaw `model:` field.
- **`services/zoe-data/routers/system.py`** — agent-card and agent-runtimes endpoint descriptions.
- **`services/zoe-data/openclaw_ws.py`** — compact self-description string.
- **`scripts/setup/systemd/openclaw-gateway.service`** + **`scripts/setup/systemd/README.md`** — unit comment / service table.
- **`scripts/setup/populate_multica.py`** — Multica OpenClaw agent definition.

Left untouched (different backend, not the OpenClaw label): the executor-seam listings in `executors/__init__.py` and `executor_registry.py` (OpenClaw / Codex / Cursor as separate future adapter drop-ins), and all Hermes (`GPT-5.4/Codex`) and ChatGPT/OpenAI Codex OAuth references.

### Correction 2 — opensrc usage guidance
The root `AGENTS.md` `## opensrc` section told agents to use a bare `opensrc path pypi:<package>`, which resolves to the **latest published** version, not the one Zoe runs (e.g. bare `chromadb` → 1.5.9 vs. Zoe's installed 0.6.3). Updated the guidance to pin the version to the running stack (`opensrc path pypi:chromadb@0.6.3`) and added a caution that bare names resolve to latest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)