### PR TITLE
feat(zoe-core): Hermes delegation + post-tool answer synthesis fix (Phase 2.5)

### DIFF
--- a/services/zoe-core/abilities/delegate.ts
+++ b/services/zoe-core/abilities/delegate.ts
@@ -1,0 +1,85 @@
+/**
+ * delegate — hand work off to a specialist peer agent (Hermes) for things
+ * zoe-core can't do natively yet: live web research, current events, prices,
+ * news, and complex multi-step tasks. Hermes owns web browsing / Telegram / the
+ * harness; this is the synchronous parity of the legacy __ESCALATE_HERMES__ path.
+ *
+ * Calls POST /api/system/delegate-sync (internal token), which runs a
+ * synchronous Hermes completion and returns the answer to fold into the turn.
+ */
+import { Type } from "@sinclair/typebox";
+import type { AbilityContext, CapabilityEntry } from "./types";
+
+const TIMEOUT_MS = Number(process.env.ZOE_CORE_DELEGATE_TIMEOUT_MS ?? 120000);
+
+async function delegateSync(ctx: AbilityContext, task: string, target = "hermes"): Promise<string> {
+  const url = new URL("/api/system/delegate-sync", ctx.zoeDataUrl);
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    Accept: "application/json",
+  };
+  if (ctx.internalToken) headers["X-Internal-Token"] = ctx.internalToken;
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ user_id: ctx.userId, task, target }),
+      signal: AbortSignal.timeout(TIMEOUT_MS),
+    });
+    if (!res.ok) {
+      return `I couldn't reach ${target} just now (status ${res.status}).`;
+    }
+    const data = (await res.json()) as { result?: string; ok?: boolean };
+    return (data.result ?? "").trim() || "I asked but didn't get a clear answer back.";
+  } catch (err) {
+    console.warn(`[zoe-core] delegate-sync to ${target} failed:`, err);
+    return `I couldn't reach ${target} right now.`;
+  }
+}
+
+const research: CapabilityEntry = {
+  id: "research",
+  name: "research",
+  domain: "delegate",
+  description:
+    "Hand off to Hermes for anything you can't answer yourself: live web search, current events, " +
+    "prices/availability, news, sports scores, or complex multi-step research. Pass the user's full " +
+    "question as `task`. Use this ONLY when the answer genuinely needs the live web or specialist " +
+    "tools — never for chit-chat, things you remember, or the calendar/lists/notes/reminders/media/" +
+    "home tools you already have.",
+  parameters: Type.Object({
+    task: Type.String({ description: "the full question or task to research, in plain language" }),
+  }),
+  examples: [
+    "what's the weather forecast for the weekend",
+    "find the cheapest flights to Sydney next month",
+    "what's the latest news on the election",
+    "look up the opening hours for the local pharmacy",
+    "search the web for reviews of this restaurant",
+  ],
+  negativeExamples: [
+    "what's on my shopping list",
+    "add milk to the list",
+    "what's my dog's name",
+    "remind me to call mum at 5",
+    "hello",
+  ],
+  // network + user-data:read: both freely allowed (no approval prompt) and
+  // user-scoped, so the tool fails closed when the acting user is unknown.
+  permissions: ["network", "user-data:read"],
+  tier: "on-demand",
+  triggers: [
+    /\b(search|look up|google|find out|research)\b/i,
+    /\b(latest|current|today'?s|recent)\b/i,
+    /\bwhat'?s on\b/i,
+    /\b(price|prices|cheapest|how much)\b/i,
+    /\b(news|weather|forecast|score|results?)\b/i,
+  ],
+  async execute(params, ctx: AbilityContext): Promise<string> {
+    const task = String(params.task ?? "").trim();
+    if (!task) return "What would you like me to look into?";
+    return delegateSync(ctx, task, "hermes");
+  },
+};
+
+export default [research];

--- a/services/zoe-data/routers/system.py
+++ b/services/zoe-data/routers/system.py
@@ -2403,3 +2403,46 @@ async def intent_dispatch(body: _IntentDispatchBody, _: None = Depends(require_i
         logger.warning("intent-dispatch failed intent=%s: %s", intent_name, exc)
         raise HTTPException(status_code=500, detail="intent execution failed") from exc
     return {"intent": intent_name, "ok": result is not None, "result": result or ""}
+
+
+# Synchronous delegation targets the zoe-core brain may invoke in-turn. Hermes
+# only: it owns web browsing / Telegram / the harness, and returns a completion
+# we can fold into the chat answer. OpenClaw stays explicit-opt-in (see the
+# async A2A /api/agent/delegate endpoint), so it is intentionally NOT here.
+_SYNC_DELEGATE_TARGETS = frozenset({"hermes"})
+
+
+class _DelegateSyncBody(BaseModel):
+    user_id: str
+    task: str
+    target: str = "hermes"
+
+
+@router.post("/delegate-sync")
+async def delegate_sync(body: _DelegateSyncBody, _: None = Depends(require_internal_token)):
+    """Synchronously delegate one task to a peer agent and return its completion.
+
+    Internal/service endpoint — how the zoe-core Pi brain delegates work it can't
+    do natively yet (web research, complex tasks) to Hermes and folds the answer
+    into its turn, the synchronous parity of the legacy __ESCALATE_HERMES__ path.
+    Fails closed on unknown user or non-allowlisted target.
+    """
+    user_id = (body.user_id or "").strip()
+    task = (body.task or "").strip()
+    target = (body.target or "hermes").strip().lower()
+    if not user_id:
+        raise HTTPException(status_code=400, detail="user_id required")
+    if not task:
+        raise HTTPException(status_code=400, detail="task required")
+    if target not in _SYNC_DELEGATE_TARGETS:
+        raise HTTPException(status_code=400, detail=f"target not sync-delegatable: {target}")
+    try:
+        # Lazy import: routers.chat owns the Hermes client; importing at module
+        # load would be circular (chat imports system-side helpers too).
+        from routers.chat import _hermes_completion
+
+        result = await _hermes_completion(task, session_id=f"delegate-{user_id}", user_id=user_id)
+    except Exception as exc:
+        logger.warning("delegate-sync failed target=%s: %s", target, exc)
+        raise HTTPException(status_code=502, detail="delegation failed") from exc
+    return {"target": target, "ok": bool(result), "result": result or ""}

--- a/services/zoe-data/routers/system.py
+++ b/services/zoe-data/routers/system.py
@@ -2439,9 +2439,21 @@ async def delegate_sync(body: _DelegateSyncBody, _: None = Depends(require_inter
     try:
         # Lazy import: routers.chat owns the Hermes client; importing at module
         # load would be circular (chat imports system-side helpers too).
-        from routers.chat import _hermes_completion
+        from routers.chat import _hermes_completion, _mempalace_load_user_facts, _safe_load_portrait
 
-        result = await _hermes_completion(task, session_id=f"delegate-{user_id}", user_id=user_id)
+        # Attach the same user context the legacy __ESCALATE_HERMES__ path sent,
+        # so delegated answers stay personalized (preferences + memory), not generic.
+        portrait, facts = await asyncio.gather(
+            _safe_load_portrait(user_id),
+            _mempalace_load_user_facts(user_id),
+        )
+        result = await _hermes_completion(
+            task,
+            session_id=f"delegate-{user_id}",
+            user_id=user_id,
+            portrait=portrait or "",
+            facts=facts or "",
+        )
     except Exception as exc:
         logger.warning("delegate-sync failed target=%s: %s", target, exc)
         raise HTTPException(status_code=502, detail="delegation failed") from exc

--- a/services/zoe-data/tests/test_delegate_sync.py
+++ b/services/zoe-data/tests/test_delegate_sync.py
@@ -1,0 +1,114 @@
+"""Tests for /api/system/delegate-sync (Phase 2.5 — zoe-core brain delegation)."""
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import auth
+from routers.system import router as system_router
+
+
+def _app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(system_router)
+    return app
+
+
+def test_requires_internal_token(monkeypatch):
+    monkeypatch.setattr(auth, "_ZOE_INTERNAL_TOKEN", "tok")
+    resp = TestClient(_app()).post(
+        "/api/system/delegate-sync", json={"user_id": "u", "task": "hi"}
+    )
+    assert resp.status_code == 403
+
+
+def test_requires_user_id(monkeypatch):
+    monkeypatch.setattr(auth, "_ZOE_INTERNAL_TOKEN", "tok")
+    resp = TestClient(_app()).post(
+        "/api/system/delegate-sync",
+        json={"user_id": "  ", "task": "hi"},
+        headers={"X-Internal-Token": "tok"},
+    )
+    assert resp.status_code == 400
+    assert "user_id" in resp.json()["detail"]
+
+
+def test_requires_task(monkeypatch):
+    monkeypatch.setattr(auth, "_ZOE_INTERNAL_TOKEN", "tok")
+    resp = TestClient(_app()).post(
+        "/api/system/delegate-sync",
+        json={"user_id": "jason", "task": "   "},
+        headers={"X-Internal-Token": "tok"},
+    )
+    assert resp.status_code == 400
+    assert "task" in resp.json()["detail"]
+
+
+def test_rejects_non_sync_target(monkeypatch):
+    """OpenClaw is explicit-opt-in via the async A2A path, not sync-delegatable."""
+    monkeypatch.setattr(auth, "_ZOE_INTERNAL_TOKEN", "tok")
+    resp = TestClient(_app()).post(
+        "/api/system/delegate-sync",
+        json={"user_id": "jason", "task": "do it", "target": "openclaw"},
+        headers={"X-Internal-Token": "tok"},
+    )
+    assert resp.status_code == 400
+    assert "not sync-delegatable" in resp.json()["detail"]
+
+
+def test_happy_path_calls_hermes(monkeypatch):
+    monkeypatch.setattr(auth, "_ZOE_INTERNAL_TOKEN", "tok")
+    captured = {}
+
+    async def fake_hermes(message, session_id, user_id, **kwargs):
+        captured.update(message=message, session_id=session_id, user_id=user_id)
+        return "Hermes says: sunny with a high of 24."
+
+    import routers.chat as chat
+    monkeypatch.setattr(chat, "_hermes_completion", fake_hermes)
+
+    resp = TestClient(_app()).post(
+        "/api/system/delegate-sync",
+        json={"user_id": "jason", "task": "what's the weather?", "target": "hermes"},
+        headers={"X-Internal-Token": "tok"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["target"] == "hermes"
+    assert body["ok"] is True
+    assert body["result"] == "Hermes says: sunny with a high of 24."
+    assert captured["message"] == "what's the weather?"
+    assert captured["user_id"] == "jason"
+
+
+def test_target_defaults_to_hermes(monkeypatch):
+    monkeypatch.setattr(auth, "_ZOE_INTERNAL_TOKEN", "tok")
+
+    async def fake_hermes(message, session_id, user_id, **kwargs):
+        return "ok"
+
+    import routers.chat as chat
+    monkeypatch.setattr(chat, "_hermes_completion", fake_hermes)
+    resp = TestClient(_app()).post(
+        "/api/system/delegate-sync",
+        json={"user_id": "jason", "task": "anything"},  # no target -> hermes
+        headers={"X-Internal-Token": "tok"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["target"] == "hermes"
+
+
+def test_hermes_failure_surfaces_502(monkeypatch):
+    monkeypatch.setattr(auth, "_ZOE_INTERNAL_TOKEN", "tok")
+
+    async def boom(*args, **kwargs):
+        raise RuntimeError("hermes down")
+
+    import routers.chat as chat
+    monkeypatch.setattr(chat, "_hermes_completion", boom)
+    resp = TestClient(_app()).post(
+        "/api/system/delegate-sync",
+        json={"user_id": "jason", "task": "x"},
+        headers={"X-Internal-Token": "tok"},
+    )
+    assert resp.status_code == 502

--- a/services/zoe-data/tests/test_delegate_sync.py
+++ b/services/zoe-data/tests/test_delegate_sync.py
@@ -65,6 +65,10 @@ def test_happy_path_calls_hermes(monkeypatch):
         return "Hermes says: sunny with a high of 24."
 
     import routers.chat as chat
+    async def _empty(*a, **k):
+        return ""
+    monkeypatch.setattr(chat, "_safe_load_portrait", _empty)
+    monkeypatch.setattr(chat, "_mempalace_load_user_facts", _empty)
     monkeypatch.setattr(chat, "_hermes_completion", fake_hermes)
 
     resp = TestClient(_app()).post(
@@ -88,6 +92,10 @@ def test_target_defaults_to_hermes(monkeypatch):
         return "ok"
 
     import routers.chat as chat
+    async def _empty(*a, **k):
+        return ""
+    monkeypatch.setattr(chat, "_safe_load_portrait", _empty)
+    monkeypatch.setattr(chat, "_mempalace_load_user_facts", _empty)
     monkeypatch.setattr(chat, "_hermes_completion", fake_hermes)
     resp = TestClient(_app()).post(
         "/api/system/delegate-sync",
@@ -105,6 +113,10 @@ def test_hermes_failure_surfaces_502(monkeypatch):
         raise RuntimeError("hermes down")
 
     import routers.chat as chat
+    async def _empty(*a, **k):
+        return ""
+    monkeypatch.setattr(chat, "_safe_load_portrait", _empty)
+    monkeypatch.setattr(chat, "_mempalace_load_user_facts", _empty)
     monkeypatch.setattr(chat, "_hermes_completion", boom)
     resp = TestClient(_app()).post(
         "/api/system/delegate-sync",

--- a/services/zoe-data/tests/test_zoe_core_client.py
+++ b/services/zoe-data/tests/test_zoe_core_client.py
@@ -82,6 +82,9 @@ class _Stub:
                 if "intent-dispatch" in self.path:
                     item = (body.get("slots") or {}).get("item", "it")
                     self._json({"intent": body.get("intent"), "ok": True, "result": f"Added {item}."})
+                elif "delegate-sync" in self.path:
+                    self._json({"target": "hermes", "ok": True,
+                                "result": "Hermes web result: Saturday is sunny, 24 degrees."})
                 else:
                     self._json({"ok": True})
 
@@ -99,6 +102,10 @@ class _Stub:
     def dispatches(self) -> list[dict[str, Any]]:
         with self._lock:
             return [r["body"] for r in self.requests if r["m"] == "POST" and "intent-dispatch" in r["path"]]
+
+    def delegations(self) -> list[dict[str, Any]]:
+        with self._lock:
+            return [r["body"] for r in self.requests if r["m"] == "POST" and "delegate-sync" in r["path"]]
 
     def memory_hits(self) -> int:
         with self._lock:
@@ -137,6 +144,21 @@ async def test_identity_streams_as_zoe(stub):
         n_chunks += 1
     assert "zoe" in text.lower(), text
     assert n_chunks >= 1
+
+
+@pytest.mark.integration
+@requires_env
+@pytest.mark.asyncio
+async def test_web_query_delegates_and_synthesizes(stub):
+    """A web/research query delegates to Hermes AND folds the result into a
+    spoken answer. Guards the post-tool-synthesis fix: the agent loop must run
+    to agent_end (not stop at the tool-call turn_end) so the answer isn't empty."""
+    s, zc = stub
+    answer = await zc.run_zoe_core(
+        "Search the web for this weekend's weather forecast.", "deleg", "family-admin"
+    )
+    assert len(s.delegations()) >= 1, f"did not delegate; requests={s.requests}"
+    assert answer.strip(), "delegated but produced no synthesized answer (post-tool synthesis broken)"
 
 
 @pytest.mark.integration

--- a/services/zoe-data/zoe_core_client.py
+++ b/services/zoe-data/zoe_core_client.py
@@ -145,7 +145,8 @@ class _ZoeCoreWorker:
 
     async def _read_turn(self, request_id: str, timeout_s: float) -> AsyncIterator[str]:
         assert self.proc and self.proc.stdout
-        emitted = ""
+        emitted = ""           # text already streamed for the CURRENT message
+        streamed_any = False   # whether we've yielded anything this whole turn
         prompt_accepted = False
         deadline = time.monotonic() + timeout_s
         while True:
@@ -166,15 +167,30 @@ class _ZoeCoreWorker:
                 continue
             if not prompt_accepted or not _rpc_event_matches_request(event, request_id):
                 continue
+            etype = event.get("type")
+            # A new assistant message resets the per-message delta tracker. The
+            # agent loop can span multiple messages/turns (e.g. a tool-call turn
+            # followed by the answer turn); deltas are cumulative WITHIN a message.
+            if etype == "message_start":
+                emitted = ""
             text = _assistant_text_from_rpc_event(event)
             if text and text.startswith(emitted) and len(text) > len(emitted):
                 yield text[len(emitted):]
                 emitted = text
+                streamed_any = True
             elif text and not text.startswith(emitted):
-                # Non-monotonic (rare): emit the whole fresh text.
+                # Message boundary / non-monotonic update — emit the fresh text.
                 yield text
                 emitted = text
-            if event.get("type") in ("turn_end", "agent_end"):
+                streamed_any = True
+            # Only the END OF THE WHOLE AGENT LOOP terminates the turn. A bare
+            # turn_end fires after each tool-call turn too — returning there would
+            # cut off before the model synthesizes its answer from the tool result.
+            if etype == "agent_end":
+                if not streamed_any:
+                    final = _assistant_text_from_rpc_event(event)
+                    if final:
+                        yield final
                 return
 
 

--- a/services/zoe-data/zoe_core_client.py
+++ b/services/zoe-data/zoe_core_client.py
@@ -57,6 +57,11 @@ _PROVIDER = os.environ.get("ZOE_CORE_PROVIDER", "local-gemma")
 _MODEL = os.environ.get("ZOE_CORE_MODEL_ID", "gemma-4-E2B-it-Q4_K_M.gguf")
 _DATA_URL = os.environ.get("ZOE_CORE_DATA_URL") or os.environ.get("ZOE_DATA_URL", "http://127.0.0.1:8000")
 _TIMEOUT_S = float(os.environ.get("ZOE_CORE_TIMEOUT_S", "180"))
+# Safety valve: once an answer has streamed and a turn has ended, if no further
+# event arrives within this idle window we assume the loop is done even if
+# agent_end was never emitted (Pi crash / lost event / older build) — bounding
+# the worst case to ~idle seconds instead of the full _TIMEOUT_S hang.
+_IDLE_TIMEOUT_S = float(os.environ.get("ZOE_CORE_IDLE_TIMEOUT_S", "20"))
 _MAX_WORKERS = int(os.environ.get("ZOE_CORE_MAX_WORKERS", "4"))
 
 
@@ -147,13 +152,22 @@ class _ZoeCoreWorker:
         assert self.proc and self.proc.stdout
         emitted = ""           # text already streamed for the CURRENT message
         streamed_any = False   # whether we've yielded anything this whole turn
+        saw_turn_end = False   # at least one turn has completed
         prompt_accepted = False
         deadline = time.monotonic() + timeout_s
         while True:
             remaining = deadline - time.monotonic()
             if remaining <= 0:
                 raise asyncio.TimeoutError("zoe-core turn timed out")
-            line = await asyncio.wait_for(self.proc.stdout.readline(), timeout=remaining)
+            # Once we have an answer and a completed turn, bound each read to the
+            # idle window: if agent_end never comes, return rather than hang.
+            read_timeout = min(remaining, _IDLE_TIMEOUT_S) if (streamed_any and saw_turn_end) else remaining
+            try:
+                line = await asyncio.wait_for(self.proc.stdout.readline(), timeout=read_timeout)
+            except asyncio.TimeoutError:
+                if streamed_any and saw_turn_end:
+                    return  # answer delivered + a turn ended; agent_end presumed lost
+                raise
             if not line:
                 raise RuntimeError("zoe-core Pi RPC process closed")
             try:
@@ -183,6 +197,8 @@ class _ZoeCoreWorker:
                 yield text
                 emitted = text
                 streamed_any = True
+            if etype == "turn_end":
+                saw_turn_end = True
             # Only the END OF THE WHOLE AGENT LOOP terminates the turn. A bare
             # turn_end fires after each tool-call turn too — returning there would
             # cut off before the model synthesizes its answer from the tool result.


### PR DESCRIPTION
## What

Closes the "all features" gap from the cutover (#702): zoe-core can now **delegate to Hermes** for things it can't do natively (web research, current events, prices, complex tasks) — and fixes a streaming bug where the brain went silent after any tool call.

### `/api/system/delegate-sync` (system.py)
Internal-token endpoint that runs a **synchronous Hermes completion** and returns it — the parity of the legacy `__ESCALATE_HERMES__` path. Hermes only (OpenClaw stays explicit-opt-in via the async A2A `/api/agent/delegate`). Fails closed on unknown user / non-allowlisted target.

### `delegate.ts` ability
A `research` tool (`network` + `user-data:read` → freely-allowed but fail-closed) that routes web/research queries to delegate-sync, so Gemma can *choose* to delegate. Clear negative examples keep it off chit-chat / local-tool requests.

### `zoe_core_client._read_turn` — post-tool synthesis fix (important)
The Pi agent loop emits a `turn_end` after **every** turn, including the tool-call turn. The client returned on the first `turn_end` — *before* the model synthesized its answer from the tool result — so tool/delegation turns came back **empty**. Now it runs to `agent_end` and resets the per-message delta tracker at `message_start`, streaming the answer turn cleanly. **This fixes synthesis for every tool, not just delegation.**

## Tested (live, pi 0.79.3 + Gemma E2B)
- Web query → delegates to Hermes **and** returns a synthesized answer ("…sunny ~24°C Saturday, showers Sunday").
- 7 delegate-sync endpoint tests + 6 client tests (incl. a post-tool-synthesis regression test).

## Rollout
Last piece before the live flip. After this lands → restart zoe-data (Phase 3 live validation across every avenue), optimize (Phase 4), retire `zoe_agent.py` (Phase 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)