### PR TITLE
docs(dox): adopt OKF for records + Forbidden contract field + SkillSpector gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,15 @@ Trunk-based development off protected `main`. No permanent `develop` or `staging
   - Both detect **squash-merged** branches via `gh pr view` (not just git-ancestor merges) and never touch dirty, locked, unmerged, or the live checkout.
 - Manual prune still available: `scripts/maintenance/prune_worktrees.sh` (dry-run first, `--execute` after operator review).
 
+## Skill & extension safety
+
+Third-party skills and extensions run with the agent's privileges. Treat them as untrusted code.
+
+- Before installing any third-party skill, Pi/OpenClaw extension, or code-bearing MCP server into a Zoe agent runtime — and before promoting a self-authored skill from the lab to a live agent — scan it: `skillspector scan <dir|file|git-url>` (installed at `~/.local/bin/skillspector`).
+- The static stage needs no credentials but is deliberately conservative: it flags legitimately powerful, process-spawning extensions as HIGH/CRITICAL. Do not treat the raw static score as a verdict — use the optional LLM stage (`SKILLSPECTOR_PROVIDER=...`) plus human judgement for promotion decisions.
+- Do not egress internal Zoe skill content to an external LLM provider for scanning without operator consent; prefer static scans, or a local/NV provider, for internal skills.
+- Record the scan outcome (or a deliberate waiver) when adopting a new skill or extension.
+
 # DOX framework
 
 - DOX is highly performant AGENTS.md hierarchy installed here
@@ -88,6 +97,15 @@ Trunk-based development off protected `main`. No permanent `develop` or `staging
 
 - AGENTS.md files are binding work contracts for their subtrees
 - Work products, source materials, instructions, records, assets, and durable docs must stay understandable from the nearest applicable AGENTS.md plus every parent AGENTS.md above it
+
+## Knowledge vs. Records (OKF)
+
+DOX governs two kinds of document; do not conflate them.
+
+- **Contracts** — `AGENTS.md` files. Prescriptive, binding, prose. They change only through the deliberate DOX pass below — never by an autonomous loop.
+- **Records / knowledge** — curated facts, schemas, learned insights, and durable reference (e.g. the graphify wiki, memory exports, tool/topology notes). Write these as **Open Knowledge Format (OKF)** bundles: a directory of markdown files with YAML frontmatter (required `type`), an `index.md` per directory, and cross-links via relative markdown links.
+- Register every OKF bundle in the nearest owning AGENTS.md's Child DOX Index so the DOX walk discovers it. An OKF bundle stays inside DOX governance; it is not a parallel system.
+- The autonomous memory/knowledge loop may freely create, update, and lint OKF records. It must never edit an AGENTS.md contract — contract changes go through the DOX pass and human review.
 
 ## Read Before Editing
 
@@ -127,11 +145,13 @@ Update parent docs when parent-level structure, ownership, workflow, or child in
 - Create a child AGENTS.md when a folder becomes a durable boundary with its own purpose, rules, responsibilities, workflow, materials, or quality standards
 - Work Guidance must reflect the current standards of the project or user instructions; if there are no specific standards or instructions yet, leave it empty
 - Verification must reflect an existing check; if no verification framework exists yet, leave it empty and update it when one exists
+- A subtree that owns an autonomous loop or agent MUST state a Forbidden list (what the agent must never do, e.g. paths/actions out of scope). It is the most load-bearing part of the contract; omit it only when nothing is autonomous in the subtree
 
 Default section order:
 - Purpose
 - Ownership
 - Local Contracts
+- Forbidden
 - Work Guidance
 - Verification
 - Child DOX Index

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -16,6 +16,7 @@ All project documentation, organized by category. The root of the repository hol
 - New documentation goes in `docs/{category}/`, NEVER in the repository root.
 - The charter in `governance/` is normative: read it before large design changes; the enforceable subset is mirrored in `.cursorrules` and `.cursor/rules/`.
 - When in doubt about deleting a doc, move it to `archive/`.
+- `knowledge/` is an OKF knowledge bundle (markdown + YAML frontmatter, agent-curatable records — see root "Knowledge vs. Records (OKF)"). It holds descriptive facts, NOT contracts; binding rules stay in `AGENTS.md`.
 
 ## Work Guidance
 
@@ -28,3 +29,6 @@ Several loose top-level .md files predate the category structure; place new mate
 ## Child DOX Index
 
 No child AGENTS.md files yet.
+
+OKF knowledge bundles (records, not contracts — see root "Knowledge vs. Records (OKF)"):
+- [knowledge/](knowledge/index.md) — curated Zoe reference knowledge (tool stack, topology); agent-curatable.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -18,6 +18,14 @@ All project documentation, organized by category. The root of the repository hol
 - When in doubt about deleting a doc, move it to `archive/`.
 - `knowledge/` is an OKF knowledge bundle (markdown + YAML frontmatter, agent-curatable records — see root "Knowledge vs. Records (OKF)"). It holds descriptive facts, NOT contracts; binding rules stay in `AGENTS.md`.
 
+## Forbidden
+
+The autonomous knowledge/memory loop curates `knowledge/` only. It must NEVER:
+- edit any `AGENTS.md` contract (contracts change only via the DOX pass + human review)
+- create, modify, or delete documentation outside `knowledge/`
+- alter `governance/` (the normative charter) or move docs into/out of `archive/`
+- add files to the repository root
+
 ## Work Guidance
 
 Several loose top-level .md files predate the category structure; place new material in categories rather than adding more loose files.

--- a/docs/knowledge/index.md
+++ b/docs/knowledge/index.md
@@ -1,0 +1,15 @@
+---
+type: index
+title: Zoe Knowledge Bundle
+description: Curated, agent- and human-readable reference knowledge for Zoe, in Open Knowledge Format (OKF). Governed by docs/AGENTS.md.
+---
+
+# Zoe Knowledge (OKF bundle)
+
+Open Knowledge Format bundle — markdown + YAML frontmatter, cross-linked, readable by humans without tooling and by agents without bespoke SDKs.
+
+This is **knowledge / records** (descriptive facts), not a DOX contract. See the root `AGENTS.md` rule "Knowledge vs. Records (OKF)": binding rules live in `AGENTS.md`; this bundle curates what is *true* about Zoe and may be maintained by the autonomous knowledge loop.
+
+## Concepts
+
+- [Zoe tool stack](zoe-tool-stack.md) — the installed agent tooling (graphify, opensrc, Multica, Pi, Hermes, OpenClaw, MemPalace, SkillSpector) and how the pieces relate.

--- a/docs/knowledge/zoe-tool-stack.md
+++ b/docs/knowledge/zoe-tool-stack.md
@@ -1,0 +1,25 @@
+---
+type: Reference
+title: Zoe Tool Stack
+description: The agent tooling installed in Zoe and how the pieces relate — knowledge graph, source cache, agent orchestration, the brain, memory, and skill security.
+tags: [tooling, architecture, agents]
+timestamp: 2026-06-18T00:00:00Z
+---
+
+# Zoe Tool Stack
+
+Descriptive map of the tools in Zoe's agent layer. See [index](index.md). For *binding rules* on each tool, the `AGENTS.md` contracts are authoritative; this page records what each tool is and how they connect.
+
+## Knowledge & source
+- **graphify** (`~/.local/bin/graphify`, the `graphifyy` uv tool) — repo knowledge graph at `graphify-out/`. Rebuilt nightly by `scripts/maintenance/refresh_graphify.sh` (systemd `zoe-graphify-refresh.timer`), which opens an auto-merging PR so the committed graph tracks HEAD.
+- **opensrc** (`~/.local/bin/opensrc`, vercel-labs) — third-party source cache at `~/.opensrc/`, refreshed weekly by `~/bin/refresh-opensrc.sh` (`zoe-opensrc-refresh.timer`) and pinned to Zoe's *installed* versions. Bare `opensrc path pypi:<pkg>` resolves to the latest published version, so pin versions to match the running stack.
+
+## Agents & orchestration
+- **Pi** (`pi`, earendil-works/pi-coding-agent) — the local coding-agent runtime; backs the **Zoe** brain agent on local Gemma 4 E2B (`:11434`). Reads `AGENTS.md` on demand, supports progressively-disclosed skills, and has no built-in subagents (use an extension such as `pi-subagents`, pi-spawns-pi, or Multica routing).
+- **Multica** (`multica`, multica-ai) — agent/board orchestration. A systemd daemon auto-detects runtimes (`pi`, `hermes`, `cursor`, `openclaw`, …) and runs autopilots; squads let a leader agent route to members.
+- **Hermes** (`hermes`, NousResearch, GPT-5.4) — default engineering agent (planning, code, review, repair, Greptile loops). Heavy work is delegated here from the lean voice brain via `escalate_to_hermes` / `a2a_delegate`.
+- **OpenClaw** (`openclaw`) — Pi plus multi-agent orchestration, a skills marketplace, and messaging ("OpenClaw is Pi, plus everything built on top"). Runs local Gemma 4 E2B, not Codex. Explicit/manual fallback, not the default route.
+
+## Memory & safety
+- **MemPalace** — ChromaDB-backed semantic memory plus user portrait and open-loops engine (in `services/zoe-data`). Consolidated nightly ("dreaming"). A periodic lint pass (contradictions / stale / orphans) is the missing third operation to add.
+- **SkillSpector** (`~/.local/bin/skillspector`, NVIDIA) — security scanner for agent skills/extensions. Gate before installing or promoting a skill/extension; the static stage is conservative, so use the LLM stage plus human judgement for verdicts. See the root `AGENTS.md` "Skill & extension safety" contract.


### PR DESCRIPTION
Integrates the external patterns we vetted (NVIDIA SkillSpector, Google OKF, Karpathy LLM-wiki, Loop Engineering) into the DOX framework — additive, no behavior change.

## Changes (root `AGENTS.md`)
- **Knowledge vs. Records (OKF)** — distinguishes binding prose *contracts* (AGENTS.md) from descriptive *records/knowledge*, which now use Open Knowledge Format bundles (markdown + YAML frontmatter), registered in the nearest Child DOX Index. The autonomous knowledge/memory loop may curate records but never contracts.
- **Forbidden field** — added to the Child Doc Shape: any subtree owning an autonomous loop/agent must state a Forbidden list (the Loop-Engineering gap; Verification already maps to Evaluation).
- **Skill & extension safety** — codifies the SkillSpector gate before installing/promoting any skill or extension; static stage is conservative (use the LLM stage + human judgement); no egress of internal skill content without consent.

## Reference OKF bundle
- `docs/knowledge/` (`index.md` + `zoe-tool-stack.md`), registered in `docs/AGENTS.md` Child DOX Index — makes the OKF clause operational, not aspirational.

## Tested
- `validate_structure.py`, `validate_critical_files.py`, `validate_offline_memory.py` all exit 0 locally.
- OKF frontmatter has required `type`; cross-links resolve both ways.
- SkillSpector (the gate this mandates) is installed and verified scanning real targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)