### PR TITLE
docs: Loop-Engineering contracts for the 3 live Multica autopilots

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -40,3 +40,4 @@ No child AGENTS.md files yet.
 
 OKF knowledge bundles (records, not contracts — see root "Knowledge vs. Records (OKF)"):
 - [knowledge/](knowledge/index.md) — curated Zoe reference knowledge (tool stack, topology); agent-curatable.
+- [knowledge/autopilots/](knowledge/autopilots/index.md) — Loop-Engineering contracts for the live Multica autopilots (Job/Inputs/Allowed/Forbidden/Output/Evaluation); agent-curatable.

--- a/docs/knowledge/autopilots/evolution-nightly-notice.md
+++ b/docs/knowledge/autopilots/evolution-nightly-notice.md
@@ -1,0 +1,44 @@
+---
+type: Reference
+title: Evolution Nightly Notice — Loop Contract
+description: Loop-Engineering contract for the Evolution Nightly Notice autopilot (Multica id b2025eea, Self-Improvement Agent, nightly).
+tags: [autopilots, multica, evolution, self-improvement]
+timestamp: 2026-06-18T00:00:00Z
+---
+
+# Evolution Nightly Notice — Loop Contract
+
+Nightly Multica autopilot. Id `b2025eea`, assignee **Self-Improvement Agent**. See the [bundle index](index.md).
+
+## Job
+Each night, analyse `evolution_proposals` for newly surfaced capability gaps and ensure each real gap is tracked by exactly one Multica issue — creating new issues for new gaps and updating existing issues as gaps evolve.
+
+## Inputs
+- New and recently changed `evolution_proposals` records since the last run.
+- Existing open capability-gap Multica issues (for de-duplication and updates).
+- The most recent [Weekly Digest](evolution-weekly-digest.md) for priority context.
+
+## Allowed
+- Read and analyse `evolution_proposals`.
+- Create a capability-gap Multica issue for a genuinely new gap, with a clear description and evidence (linked proposals).
+- Update an existing capability-gap issue (status note, new supporting proposals) when the gap recurs or evolves.
+
+## Forbidden
+- NEVER create, modify, or delete `evolution_proposals` rows or any database record; analysis is read-only.
+- NEVER open a duplicate issue for a gap already tracked — match against existing issues first and update instead.
+- NEVER modify application code, config, skills, intents, secrets, or env files; it files capability-gap issues, it does not implement them.
+- NEVER auto-assign, start, or trigger any engineering/implementation work, and never close issues it did not open.
+- NEVER touch the live checkout or push to `main`.
+- NEVER batch-create issues for noise; a proposal must clear the gap threshold before it earns an issue, and a quiet night creates nothing.
+- NEVER escalate or change priority of issues it did not create.
+
+## Output
+- For each new qualifying gap: one new capability-gap Multica issue with evidence.
+- For each recurring gap: an updated existing issue.
+- On a quiet night: no new issues, an idempotent run record.
+
+## Evaluation
+- Runs to completion well within the 1800s budget.
+- Exactly one tracking issue per real capability gap (no duplicates, no orphan noise).
+- Every created/updated issue cites the `evolution_proposals` evidence behind it.
+- No writes to data, code, or unrelated issues.

--- a/docs/knowledge/autopilots/evolution-weekly-digest.md
+++ b/docs/knowledge/autopilots/evolution-weekly-digest.md
@@ -1,0 +1,43 @@
+---
+type: Reference
+title: Evolution Weekly Digest — Loop Contract
+description: Loop-Engineering contract for the Evolution Weekly Digest autopilot (Multica id 49d10c67, Self-Improvement Agent, weekly Fri).
+tags: [autopilots, multica, evolution, self-improvement]
+timestamp: 2026-06-18T00:00:00Z
+---
+
+# Evolution Weekly Digest — Loop Contract
+
+Weekly Multica autopilot (Fridays). Id `49d10c67`, assignee **Self-Improvement Agent**. See the [bundle index](index.md).
+
+## Job
+Produce one weekly digest summarising the state of Zoe's self-improvement signal: recent evolution proposals, recurring intent-miss patterns, and the resulting priorities for the coming week.
+
+## Inputs
+- `evolution_proposals` records from the past week.
+- Intent-miss / unmatched-intent logs and patterns over the week.
+- The existing open capability-gap issues (for cross-referencing priorities).
+- The prior week's digest (for continuity).
+
+## Allowed
+- Read and aggregate the inputs above into a single digest.
+- Create one Multica digest issue per week summarising proposals, the top intent-miss patterns, and a ranked priority list.
+- Link the digest to existing capability-gap issues by reference.
+
+## Forbidden
+- NEVER create, modify, or delete `evolution_proposals` rows or any database record; it is read-only over the data.
+- NEVER open per-gap implementation issues — that is the Nightly Notice's job; the Weekly Digest only summarises and links.
+- NEVER create more than one digest issue per run, and never reopen or rewrite past digests.
+- NEVER modify application code, config, skills, intents, secrets, or env files.
+- NEVER touch the live checkout or push to `main`.
+- NEVER auto-assign, prioritise into execution, or trigger any engineering work; it reports priorities, humans schedule them.
+- NEVER fabricate proposals or patterns to fill the digest; an empty week yields an explicit "no new signal" digest.
+
+## Output
+- Exactly one weekly digest Multica issue containing: this week's evolution proposals, the top intent-miss patterns with counts, and a ranked priority list with links to existing gap issues.
+
+## Evaluation
+- Runs to completion well within the 1800s budget.
+- One digest per week, no duplicates, continuous with the prior week.
+- Counts and links in the digest reconcile with the underlying `evolution_proposals` and intent-miss logs.
+- No writes to data, code, or other issues beyond the single digest.

--- a/docs/knowledge/autopilots/index.md
+++ b/docs/knowledge/autopilots/index.md
@@ -1,0 +1,31 @@
+---
+type: index
+title: Multica Autopilot Loop Contracts
+description: Loop-Engineering contracts for Zoe's live Multica autopilots — Job, Inputs, Allowed, Forbidden, Output, and Evaluation per agent. Records, not DOX contracts.
+tags: [autopilots, multica, loop-engineering, contracts]
+timestamp: 2026-06-18T00:00:00Z
+---
+
+# Multica Autopilot Loop Contracts (OKF bundle)
+
+Open Knowledge Format bundle recording the **Loop-Engineering contracts** for the three live Multica autopilots that run on the Multica board. Part of the parent [Zoe Knowledge bundle](../index.md); see also the [Zoe tool stack](../zoe-tool-stack.md) for what Multica, Hermes, and the Self-Improvement Agent are.
+
+This is **knowledge / records** (descriptive facts about how each autopilot is scoped), not a DOX contract. Binding rules live in `AGENTS.md`. The autonomous knowledge loop may curate this bundle.
+
+## Why these contracts exist
+
+All three autopilots `create_issue` on the Multica board. They previously failed en masse because the agent timeout was 120s and they had no scope or **Forbidden** discipline, so they ran away. The timeout is now fixed at 1800s; these contracts give each autopilot an explicit, load-bearing scope so it never runs away again. The most important field in every contract is **Forbidden** — what the agent must NEVER do.
+
+Each contract states six fields:
+- **Job** — what the autopilot owns.
+- **Inputs** — what it may inspect.
+- **Allowed** — what it may change.
+- **Forbidden** — what it must NEVER do (most load-bearing).
+- **Output** — what exists after a successful run.
+- **Evaluation** — how success is measured.
+
+## Concepts
+
+- [Platform Health Check](platform-health-check.md) — id `3f9bb428`, assignee Hermes, daily; verifies docker / PostgreSQL / zoe-data / Hermes / OpenClaw health.
+- [Evolution Weekly Digest](evolution-weekly-digest.md) — id `49d10c67`, Self-Improvement Agent, weekly (Fri); digest of evolution proposals + intent-miss patterns + priorities.
+- [Evolution Nightly Notice](evolution-nightly-notice.md) — id `b2025eea`, Self-Improvement Agent, nightly; analyses `evolution_proposals`, creates/updates capability-gap issues.

--- a/docs/knowledge/autopilots/platform-health-check.md
+++ b/docs/knowledge/autopilots/platform-health-check.md
@@ -1,0 +1,45 @@
+---
+type: Reference
+title: Platform Health Check — Loop Contract
+description: Loop-Engineering contract for the Platform Health Check autopilot (Multica id 3f9bb428, assignee Hermes, daily).
+tags: [autopilots, multica, health, hermes]
+timestamp: 2026-06-18T00:00:00Z
+---
+
+# Platform Health Check — Loop Contract
+
+Daily Multica autopilot. Id `3f9bb428`, assignee **Hermes**. See the [bundle index](index.md).
+
+## Job
+Verify that Zoe's platform is healthy once per day: docker services up, PostgreSQL reachable, and the zoe-data API, Hermes runtime, and OpenClaw runtime responding. Raise a single high-priority issue when a check fails.
+
+## Inputs
+- Docker service/container status (`docker compose ps` / health states).
+- PostgreSQL connectivity and basic liveness.
+- zoe-data HTTP health endpoint.
+- Hermes and OpenClaw runtime health/readiness.
+- Existing open Multica issues (to avoid duplicates).
+
+## Allowed
+- Run read-only health probes against the services above.
+- Create one high-priority Multica issue summarising the failed check(s), with the failing component, observed symptom, and probe output.
+- Update or comment on the existing health issue for the same component instead of opening a duplicate.
+
+## Forbidden
+- NEVER restart, stop, redeploy, scale, or otherwise mutate any docker service, container, or systemd unit.
+- NEVER run write/DDL/DML against PostgreSQL or any database; probes are read-only.
+- NEVER modify application code, config, secrets, or env files.
+- NEVER touch the live checkout or push to `main`; this loop only reads and files issues.
+- NEVER open more than one issue per failing component per run, and never escalate priority above high.
+- NEVER attempt remediation itself — it reports, a human or a separate engineering task fixes.
+- NEVER exceed its scope to "investigate" unrelated subsystems; on an all-green run it exits without creating anything.
+
+## Output
+- On all-green: no new issue; an idempotent run record (run completed, all checks passed).
+- On failure: exactly one high-priority Multica issue per failing component, naming the component, symptom, and evidence, or an updated comment on the existing issue.
+
+## Evaluation
+- Runs to completion well within the 1800s budget.
+- Zero false-positive issues on a healthy platform; an issue exists within one cycle of a real failure.
+- No duplicate issues for the same ongoing failure.
+- No side effects on services, data, or code.

--- a/docs/knowledge/index.md
+++ b/docs/knowledge/index.md
@@ -13,3 +13,7 @@ This is **knowledge / records** (descriptive facts), not a DOX contract. See the
 ## Concepts
 
 - [Zoe tool stack](zoe-tool-stack.md) — the installed agent tooling (graphify, opensrc, Multica, Pi, Hermes, OpenClaw, MemPalace, SkillSpector) and how the pieces relate.
+
+## Bundles
+
+- [Multica autopilot loop contracts](autopilots/index.md) — Loop-Engineering contracts (Job / Inputs / Allowed / Forbidden / Output / Evaluation) for the three live Multica autopilots.


### PR DESCRIPTION
## What

Adds an OKF knowledge bundle `docs/knowledge/autopilots/` with explicit **Loop-Engineering contracts** for Zoe's three live Multica autopilots. Each concept doc states **Job / Inputs / Allowed / Forbidden / Output / Evaluation**, with **Forbidden** as the load-bearing scope guard.

Autopilots covered (all `create_issue` on the Multica board):
- **Platform Health Check** (`3f9bb428`, Hermes, daily)
- **Evolution Weekly Digest** (`49d10c67`, Self-Improvement Agent, Fri)
- **Evolution Nightly Notice** (`b2025eea`, Self-Improvement Agent, nightly)

## Why

These previously failed en masse under the old 120s agent timeout with no scope/Forbidden discipline. The timeout is now 1800s; these contracts give each loop an explicit scope so it never runs away again.

## DOX

- Read root `AGENTS.md` ("Knowledge vs. Records (OKF)", Forbidden requirement) and `docs/AGENTS.md` before editing.
- New bundle is an OKF record (markdown + YAML frontmatter with required `type`, `index.md`, relative cross-links), not a contract.
- Registered in `docs/knowledge/index.md` (extended, not clobbering `zoe-tool-stack`) and in `docs/AGENTS.md`'s Child DOX Index.
- DOX Update-After-Editing pass done.

## Verification

- `validate_structure.py`, `validate_critical_files.py`, `validate_offline_memory.py` all exit 0.
- OKF frontmatter `type` present on every file; all cross-links resolve.

## Follow-up (operator applies)

Drafted `multica autopilot update` commands are in the task report; not executed here (they mutate shared board state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)