### PR TITLE
feat(memory): add report-only Lint pass over MemPalace memory

### DIFF
--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -7,7 +7,7 @@ Operational scripting for Zoe hosts: setup, maintenance, deployment, migrations,
 ## Ownership
 
 - `setup/` — host/platform provisioning, including `setup/jetson/` systemd unit templates (e.g. `zoe-graphify-refresh.service` / `.timer`).
-- `maintenance/` — recurring operational jobs: `refresh_graphify.sh` (nightly fail-closed OpenRouter/Gemini knowledge-graph refresh), `graphify_openrouter_cli.py` (repo-owned OpenRouter Graphify launcher), `graphify_local_refresh.py` / `graphify_local_probe.py` (offline local probes; not sufficient for full-corpus scheduled refresh), `prune_worktrees.sh` (stale worktree cleanup), `greploop_guard.py` (Greptile fix-packet loop), triage generators, and `pi_intent_probe.py` for local Pi/Gemma ambiguous-intent timing evidence.
+- `maintenance/` — recurring operational jobs: `refresh_graphify.sh` (nightly fail-closed OpenRouter/Gemini knowledge-graph refresh), `graphify_openrouter_cli.py` (repo-owned OpenRouter Graphify launcher), `graphify_local_refresh.py` / `graphify_local_probe.py` (offline local probes; not sufficient for full-corpus scheduled refresh), `prune_worktrees.sh` (stale worktree cleanup), `greploop_guard.py` (Greptile fix-packet loop), `zoe-memory-lint.py` (report-only memory Lint CLI — prints contradictions/stale/orphan/duplicate findings, never mutates stored memory), triage generators, and `pi_intent_probe.py` for local Pi/Gemma ambiguous-intent timing evidence.
 - `deploy/`, `migrations/`, `testing/`, `train/`, `utilities/`, `preview/` — task-specific script groups.
 
 ## Local Contracts

--- a/scripts/maintenance/zoe-memory-lint.py
+++ b/scripts/maintenance/zoe-memory-lint.py
@@ -23,7 +23,7 @@ import json
 import pathlib
 import sys
 
-ZOE_DATA = pathlib.Path("/home/zoe/assistant/services/zoe-data")
+ZOE_DATA = pathlib.Path(__file__).resolve().parents[2] / "services" / "zoe-data"
 if str(ZOE_DATA) not in sys.path:
     sys.path.insert(0, str(ZOE_DATA))
 

--- a/scripts/maintenance/zoe-memory-lint.py
+++ b/scripts/maintenance/zoe-memory-lint.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Run Zoe's memory Lint pass and print a structured, REPORT-ONLY report.
+
+Lint is the third memory operation alongside Ingest (dreaming) and Query
+(search). It scans stored MemPalace memories and reports suspect rows:
+contradictions, stale/superseded claims, orphans, and duplicates.
+
+This tool NEVER deletes, merges, edits, or otherwise mutates stored memory.
+It reads through the MemoryService facade and emits JSON for human / curation
+review. Acting on the report is a separate, human-gated step.
+
+Usage:
+  zoe-memory-lint.py --user <user_id>     # lint one user
+  zoe-memory-lint.py --all                # lint every user with memory
+  zoe-memory-lint.py --user jason --pretty
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import pathlib
+import sys
+
+ZOE_DATA = pathlib.Path("/home/zoe/assistant/services/zoe-data")
+if str(ZOE_DATA) not in sys.path:
+    sys.path.insert(0, str(ZOE_DATA))
+
+
+async def _run(args: argparse.Namespace) -> int:
+    from memory_lint import lint_all, lint_user
+
+    if args.all:
+        reports = await lint_all()
+        payload = [r.to_dict() for r in reports]
+    else:
+        report = await lint_user(args.user)
+        payload = report.to_dict()
+
+    indent = 2 if args.pretty else None
+    print(json.dumps(payload, indent=indent, default=str))
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Report-only memory lint pass.")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--user", help="user_id to lint")
+    group.add_argument("--all", action="store_true", help="lint every user")
+    parser.add_argument("--pretty", action="store_true", help="indent JSON output")
+    args = parser.parse_args(argv)
+    return asyncio.run(_run(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/zoe-data/AGENTS.md
+++ b/services/zoe-data/AGENTS.md
@@ -10,6 +10,7 @@ THE production Zoe API: FastAPI app served by host uvicorn on port 8000. Owns ch
 - Routing/NLU: `intent_router.py`, `intent_classifier_llm.py`, `pi_intent_classifier.py`, `routers/` (see child doc).
 - Agents and tools: `mcp_server.py`, `openclaw_ws.py`, `hermes_http.py`, `zoe_agent`-related modules, `executors/` (engineering-board executors, currently `kanban_adapter.py`).
 - Memory: `hindsight_memory.py`, `hindsight_retain_candidates.py`, `conversation_context.py`.
+- Memory ops: Ingest (`memory_digest.py` dreaming), Query (`memory_service.py` search), and Lint (`memory_lint.py`) — the report-only scan for contradictions/stale/orphan/duplicate rows.
 - Streaming/UI protocol: `ag_ui_stream.py`, `card_service.py`, `card_contract.py`.
 - Engineering loop: `greptile_client.py` and `background_runner.py`. The Greploop guard script is NOT here — it lives at `scripts/maintenance/greploop_guard.py` (see `scripts/AGENTS.md`).
 
@@ -21,6 +22,12 @@ THE production Zoe API: FastAPI app served by host uvicorn on port 8000. Owns ch
 - Tools register through the allow-list mechanism; every world-changing action goes through a proposal path.
 - Schema changes go through Alembic; never DROP/DELETE without WHERE and a backup.
 - Harness engineering rules apply (charter section 9): minimize structure, ablate module by module, prefer natural-language harness over brittle Python control flow.
+
+## Forbidden
+
+- Memory Lint (`memory_lint.py`) is REPORT-ONLY. It must never delete, merge, edit, archive, supersede, or otherwise mutate stored memory, and must never trigger such mutation. It reads through the `MemoryService` facade and returns flags/reports for human or curation review only.
+- Lint must not run inside the nightly dreaming cycle by default. Emitting a lint report from dreaming is opt-in via `ZOE_MEMORY_LINT_IN_DREAMING` and stays report-only even when enabled.
+- No DB schema migration, no destructive ops, and no cloud/LLM dependency from the lint detectors (they stay offline-safe heuristics).
 
 ## Work Guidance
 

--- a/services/zoe-data/memory_digest.py
+++ b/services/zoe-data/memory_digest.py
@@ -1197,6 +1197,23 @@ async def run_dreaming_cycle(user_id: str, db=None, run_agent_sync_phase: bool =
                 logger.warning("dreaming: agent_sync failed: %s", exc)
                 result["agent_sync"] = {"status": "error", "error": str(exc)}
 
+    # Opt-in, report-only Lint pass (default OFF via ZOE_MEMORY_LINT_IN_DREAMING).
+    # Lint never mutates stored memory; it only emits a structured report of
+    # contradictions / stale / orphan / duplicate rows for human review.
+    try:
+        from memory_lint import dreaming_lint_enabled, lint_user
+
+        if dreaming_lint_enabled():
+            report = await lint_user(user_id)
+            result["lint"] = report.to_dict()
+            logger.info(
+                "dreaming: lint report user=%s scanned=%d findings=%d",
+                user_id, report.scanned, report.total,
+            )
+    except Exception as exc:
+        logger.warning("dreaming: lint pass failed user=%s: %s", user_id, exc)
+        result["lint"] = {"status": "error", "error": str(exc)}
+
     logger.info("dreaming cycle complete: %s", result)
     return result
 

--- a/services/zoe-data/memory_lint.py
+++ b/services/zoe-data/memory_lint.py
@@ -1,0 +1,500 @@
+"""Memory Lint - the report-only "Lint" pass over MemPalace memory.
+
+Zoe's memory has long had Ingest (consolidation / "dreaming") and Query
+(search) but no Lint. This module adds the third Karpathy-wiki operation: a
+scan over a user's stored memories that produces a *structured report* of
+suspect rows for human / curation review.
+
+It flags four families of issue:
+
+  * ``contradictions`` - memories that assert conflicting facts about the same
+    subject (heuristic: same entity / subject, opposing polarity or mutually
+    exclusive value for a "single-valued" relation like location).
+  * ``stale``          - expired, very old, or already-superseded claims.
+  * ``orphans``        - memories with no references, links, usage, or access.
+  * ``duplicates``     - exact and near-duplicate text within a user's store.
+
+HARD CONTRACT - this module is REPORT-ONLY.
+
+  * It NEVER deletes, merges, edits, archives, or otherwise mutates a stored
+    memory. It reads rows and returns a report. Acting on the report is a
+    separate, human-gated step (review UI, curation tooling).
+  * It performs no DB schema migration and no destructive ops.
+  * The detectors are pure, deterministic heuristics with no network / LLM /
+    cloud dependency, so they stay offline-safe and unit-testable. (Deeper
+    LLM-judged contradiction resolution already lives, write-enabled, in the
+    dreaming digest; Lint deliberately stays cheap and non-mutating.)
+
+The async entrypoints (:func:`lint_user`, :func:`lint_all`) read through the
+existing :class:`MemoryService` facade - no parallel store, no direct Chroma
+client. The nightly consolidation can emit a report via :func:`lint_user`
+only when explicitly opted in (``ZOE_MEMORY_LINT_IN_DREAMING=1``); default off.
+"""
+
+from __future__ import annotations
+
+import datetime
+import difflib
+import os
+import re
+from dataclasses import dataclass, field
+from typing import Any, Iterable, Mapping, Optional, Protocol
+
+__all__ = [
+    "LintFinding",
+    "LintReport",
+    "lint_memories",
+    "lint_user",
+    "lint_all",
+    "dreaming_lint_enabled",
+    "STALE_AGE_DAYS_DEFAULT",
+    "NEAR_DUPLICATE_RATIO_DEFAULT",
+]
+
+
+# Tunables (env-overridable, all read-only knobs - never affect stored data).
+STALE_AGE_DAYS_DEFAULT = float(os.environ.get("ZOE_MEMORY_LINT_STALE_DAYS", "365"))
+NEAR_DUPLICATE_RATIO_DEFAULT = float(
+    os.environ.get("ZOE_MEMORY_LINT_NEAR_DUP_RATIO", "0.92")
+)
+
+# Statuses that make a row already-resolved / not "live" memory.
+_SUPERSEDED_STATUSES = {"superseded", "archived", "rejected"}
+
+# Negation cues used by the heuristic contradiction detector.
+_NEGATION_RE = re.compile(
+    r"(?i)\b(?:not|no longer|never|doesn't|does not|isn't|is not|won't|"
+    r"will not|can't|cannot|hates?|dislikes?|avoids?|stopped|quit)\b"
+)
+
+# Single-valued relations: only one value can be true at a time, so two rows
+# asserting different values for the same subject are a likely contradiction.
+# Each entry: (compiled pattern with a `subject` and `value` group).
+_SINGLE_VALUED_PATTERNS = (
+    re.compile(r"(?i)\b(?P<subject>.+?)\s+lives?\s+in\s+(?P<value>[A-Za-z][\w' -]+)"),
+    re.compile(r"(?i)\b(?P<subject>.+?)\s+(?:is|are)\s+located\s+in\s+(?P<value>[A-Za-z][\w' -]+)"),
+    re.compile(r"(?i)\b(?P<subject>.+?)\s+works?\s+at\s+(?P<value>[A-Za-z][\w' -]+)"),
+    re.compile(r"(?i)\b(?P<subject>.+?)\s+(?:is|are)\s+(?P<value>\d+)\s+years?\s+old"),
+)
+
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
+
+# Trailing temporal / filler words stripped from a captured single-valued
+# relation value so "Sydney" and "Sydney now" normalise to the same value.
+_VALUE_TRAILING_RE = re.compile(
+    r"(?i)\b(?:now|currently|today|anymore|any more|these days|at the moment)\b.*$"
+)
+
+
+class _MemoryRowLike(Protocol):
+    id: str
+    text: str
+    metadata: Mapping[str, Any]
+
+
+@dataclass(frozen=True)
+class LintFinding:
+    """A single report entry. Carries IDs only - never proposes a mutation."""
+
+    kind: str  # "contradiction" | "stale" | "orphan" | "duplicate"
+    memory_ids: list[str]
+    reason: str
+    detail: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "kind": self.kind,
+            "memory_ids": list(self.memory_ids),
+            "reason": self.reason,
+            "detail": dict(self.detail),
+        }
+
+
+@dataclass(frozen=True)
+class LintReport:
+    """Structured, report-only result of a lint pass over one user's memory."""
+
+    user_id: str
+    scanned: int
+    contradictions: list[LintFinding] = field(default_factory=list)
+    stale: list[LintFinding] = field(default_factory=list)
+    orphans: list[LintFinding] = field(default_factory=list)
+    duplicates: list[LintFinding] = field(default_factory=list)
+    generated_at: str = ""
+
+    @property
+    def findings(self) -> list[LintFinding]:
+        return [*self.contradictions, *self.stale, *self.orphans, *self.duplicates]
+
+    @property
+    def total(self) -> int:
+        return len(self.findings)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "user_id": self.user_id,
+            "scanned": self.scanned,
+            "generated_at": self.generated_at,
+            "totals": {
+                "contradictions": len(self.contradictions),
+                "stale": len(self.stale),
+                "orphans": len(self.orphans),
+                "duplicates": len(self.duplicates),
+                "all": self.total,
+            },
+            "contradictions": [f.to_dict() for f in self.contradictions],
+            "stale": [f.to_dict() for f in self.stale],
+            "orphans": [f.to_dict() for f in self.orphans],
+            "duplicates": [f.to_dict() for f in self.duplicates],
+        }
+
+
+# Internal normalised row used by the pure detectors.
+@dataclass(frozen=True)
+class _Row:
+    id: str
+    text: str
+    metadata: Mapping[str, Any]
+
+
+def _coerce_rows(memories: Iterable[Any]) -> list[_Row]:
+    rows: list[_Row] = []
+    for m in memories:
+        if isinstance(m, _Row):
+            rows.append(m)
+            continue
+        mid = getattr(m, "id", None)
+        text = getattr(m, "text", None)
+        meta = getattr(m, "metadata", None)
+        if mid is None and isinstance(m, Mapping):
+            mid = m.get("id")
+            text = m.get("text")
+            meta = m.get("metadata")
+        rows.append(_Row(id=str(mid), text=str(text or ""), metadata=dict(meta or {})))
+    return rows
+
+
+def _normalise_text(text: str) -> str:
+    return re.sub(r"\s+", " ", (text or "").strip().lower())
+
+
+def _tokens(text: str) -> set[str]:
+    return set(_TOKEN_RE.findall((text or "").lower()))
+
+
+def _parse_iso(value: Any) -> Optional[datetime.datetime]:
+    if not value:
+        return None
+    try:
+        return datetime.datetime.fromisoformat(str(value).replace("Z", ""))
+    except (ValueError, TypeError):
+        return None
+
+
+def _has_link(meta: Mapping[str, Any]) -> bool:
+    """True when a row points at anything else (refs, links, relations, entity)."""
+    for key in (
+        "related_ids",
+        "evidence_refs",
+        "relationships",
+        "supersedes",
+        "supersedes_id",
+        "superseded_by_id",
+        "event_id",
+        "entity_id",
+        "session_id",
+        "user_turn_id",
+    ):
+        val = meta.get(key)
+        if val not in (None, "", "[]", "{}", "0"):
+            return True
+    return False
+
+
+def _subject_value_pairs(text: str) -> list[tuple[str, str]]:
+    pairs: list[tuple[str, str]] = []
+    for pattern in _SINGLE_VALUED_PATTERNS:
+        for match in pattern.finditer(text or ""):
+            subject = _normalise_text(match.group("subject"))
+            value = _normalise_text(_VALUE_TRAILING_RE.sub("", match.group("value")))
+            # Strip a leading negation cue from the subject so "X no longer
+            # lives in Y" still groups under subject "X".
+            subject = _NEGATION_RE.sub("", subject).strip()
+            if subject and value:
+                pairs.append((subject, value))
+    return pairs
+
+
+# Pure detectors ------------------------------------------------------------
+
+def _detect_duplicates(
+    rows: list[_Row], near_ratio: float
+) -> list[LintFinding]:
+    findings: list[LintFinding] = []
+    by_exact: dict[str, list[_Row]] = {}
+    for row in rows:
+        by_exact.setdefault(_normalise_text(row.text), []).append(row)
+
+    grouped: set[str] = set()
+    for norm, group in by_exact.items():
+        if not norm:
+            continue
+        if len(group) > 1:
+            ids = [r.id for r in group]
+            grouped.update(ids)
+            findings.append(
+                LintFinding(
+                    kind="duplicate",
+                    memory_ids=ids,
+                    reason="exact-duplicate text",
+                    detail={"similarity": 1.0, "text": group[0].text[:160]},
+                )
+            )
+
+    # Near-duplicates across distinct normalised texts (skip exact groups).
+    remaining = [g[0] for norm, g in by_exact.items() if norm]
+    for i in range(len(remaining)):
+        a = remaining[i]
+        for j in range(i + 1, len(remaining)):
+            b = remaining[j]
+            if a.id in grouped and b.id in grouped:
+                continue
+            ratio = difflib.SequenceMatcher(
+                None, _normalise_text(a.text), _normalise_text(b.text)
+            ).ratio()
+            if ratio >= near_ratio:
+                findings.append(
+                    LintFinding(
+                        kind="duplicate",
+                        memory_ids=[a.id, b.id],
+                        reason="near-duplicate text",
+                        detail={"similarity": round(ratio, 4)},
+                    )
+                )
+    return findings
+
+
+def _detect_stale(
+    rows: list[_Row], now: datetime.datetime, stale_age_days: float
+) -> list[LintFinding]:
+    findings: list[LintFinding] = []
+    now_iso = now.isoformat() + "Z"
+    for row in rows:
+        meta = row.metadata
+        status = str(meta.get("status", "approved") or "approved").strip().lower()
+        if status in _SUPERSEDED_STATUSES:
+            findings.append(
+                LintFinding(
+                    kind="stale",
+                    memory_ids=[row.id],
+                    reason=f"status={status}",
+                    detail={"status": status},
+                )
+            )
+            continue
+
+        expires = meta.get("expires_at")
+        if expires and str(expires) <= now_iso:
+            findings.append(
+                LintFinding(
+                    kind="stale",
+                    memory_ids=[row.id],
+                    reason="expired",
+                    detail={"expires_at": expires},
+                )
+            )
+            continue
+
+        added = _parse_iso(meta.get("added_at"))
+        if added is not None:
+            age_days = (now - added).total_seconds() / 86400.0
+            if age_days >= stale_age_days:
+                findings.append(
+                    LintFinding(
+                        kind="stale",
+                        memory_ids=[row.id],
+                        reason="old",
+                        detail={"age_days": round(age_days, 1)},
+                    )
+                )
+    return findings
+
+
+def _detect_orphans(rows: list[_Row]) -> list[LintFinding]:
+    findings: list[LintFinding] = []
+    for row in rows:
+        meta = row.metadata
+        try:
+            access = int(meta.get("access_count", 0) or 0)
+        except (TypeError, ValueError):
+            access = 0
+        try:
+            unique_q = int(meta.get("unique_query_count", 0) or 0)
+        except (TypeError, ValueError):
+            unique_q = 0
+        if access == 0 and unique_q == 0 and not _has_link(meta):
+            findings.append(
+                LintFinding(
+                    kind="orphan",
+                    memory_ids=[row.id],
+                    reason="no access, no queries, no links",
+                    detail={"access_count": access, "unique_query_count": unique_q},
+                )
+            )
+    return findings
+
+
+def _detect_contradictions(rows: list[_Row]) -> list[LintFinding]:
+    findings: list[LintFinding] = []
+
+    # 1. Single-valued relations: same subject, different value.
+    by_subject: dict[str, list[tuple[str, str]]] = {}  # subject -> [(value, id)]
+    for row in rows:
+        for subject, value in _subject_value_pairs(row.text):
+            by_subject.setdefault(subject, []).append((value, row.id))
+    for subject, entries in by_subject.items():
+        values = {v for v, _ in entries}
+        if len(values) > 1:
+            ids = sorted({rid for _, rid in entries})
+            if len(ids) > 1:
+                findings.append(
+                    LintFinding(
+                        kind="contradiction",
+                        memory_ids=ids,
+                        reason="single-valued relation has conflicting values",
+                        detail={"subject": subject, "values": sorted(values)},
+                    )
+                )
+
+    # 2. Polarity flip: two rows that share most content tokens but disagree on
+    #    negation (one asserts, the other negates). Heuristic, high-overlap only.
+    n = len(rows)
+    for i in range(n):
+        a = rows[i]
+        a_neg = bool(_NEGATION_RE.search(a.text or ""))
+        a_tokens = _tokens(a.text) - _NEG_STOPWORDS
+        if not a_tokens:
+            continue
+        for j in range(i + 1, n):
+            b = rows[j]
+            b_neg = bool(_NEGATION_RE.search(b.text or ""))
+            if a_neg == b_neg:
+                continue
+            b_tokens = _tokens(b.text) - _NEG_STOPWORDS
+            if not b_tokens:
+                continue
+            overlap = len(a_tokens & b_tokens)
+            union = len(a_tokens | b_tokens)
+            if union and overlap / union >= 0.6:
+                findings.append(
+                    LintFinding(
+                        kind="contradiction",
+                        memory_ids=sorted([a.id, b.id]),
+                        reason="polarity flip on overlapping facts",
+                        detail={"jaccard": round(overlap / union, 4)},
+                    )
+                )
+    return findings
+
+
+# Negation-cue tokens stripped before computing content overlap so the
+# negation itself doesn't reduce similarity between an assertion and its denial.
+_NEG_STOPWORDS = {
+    "not", "no", "longer", "never", "doesn", "does", "isn", "is", "are",
+    "won", "will", "can", "cannot", "t", "stopped", "quit", "the", "a", "an",
+}
+
+
+def lint_memories(
+    memories: Iterable[Any],
+    *,
+    user_id: str = "",
+    now: Optional[datetime.datetime] = None,
+    stale_age_days: float = STALE_AGE_DAYS_DEFAULT,
+    near_duplicate_ratio: float = NEAR_DUPLICATE_RATIO_DEFAULT,
+) -> LintReport:
+    """Pure, report-only lint over an iterable of memory rows.
+
+    Accepts ``MemoryRef`` objects, anything with ``id``/``text``/``metadata``
+    attributes, or plain ``{"id","text","metadata"}`` mappings. Returns a
+    :class:`LintReport`. Never mutates the inputs or any store.
+    """
+    now = now or datetime.datetime.utcnow()
+    rows = _coerce_rows(memories)
+    return LintReport(
+        user_id=user_id,
+        scanned=len(rows),
+        contradictions=_detect_contradictions(rows),
+        stale=_detect_stale(rows, now, stale_age_days),
+        orphans=_detect_orphans(rows),
+        duplicates=_detect_duplicates(rows, near_duplicate_ratio),
+        generated_at=now.isoformat() + "Z",
+    )
+
+
+# Async entrypoints (read through the MemoryService facade) -----------------
+
+async def lint_user(
+    user_id: str,
+    *,
+    service: Any = None,
+    stale_age_days: float = STALE_AGE_DAYS_DEFAULT,
+    near_duplicate_ratio: float = NEAR_DUPLICATE_RATIO_DEFAULT,
+) -> LintReport:
+    """Read every stored row for ``user_id`` and return a report-only LintReport.
+
+    Uses ``MemoryService.export_user`` (read-only full dump) so it sees rows of
+    every status - including ``superseded``/``archived`` - which the prompt and
+    search paths intentionally hide. Performs no writes.
+    """
+    if service is None:
+        from memory_service import get_memory_service
+
+        service = get_memory_service()
+
+    dump = await service.export_user(user_id)
+    items = dump.get("items", []) if isinstance(dump, Mapping) else []
+    rows = [
+        {"id": it.get("id"), "text": it.get("text"), "metadata": it.get("metadata") or {}}
+        for it in items
+        if isinstance(it, Mapping)
+    ]
+    return lint_memories(
+        rows,
+        user_id=user_id,
+        stale_age_days=stale_age_days,
+        near_duplicate_ratio=near_duplicate_ratio,
+    )
+
+
+async def lint_all(*, service: Any = None) -> list[LintReport]:
+    """Run :func:`lint_user` for every user with stored memory. Report-only."""
+    if service is None:
+        from memory_service import get_memory_service
+
+        service = get_memory_service()
+
+    try:
+        sizes = await service.collection_sizes_by_user()
+        user_ids = [uid for uid in sizes if uid and uid != "unknown"]
+    except Exception:
+        user_ids = []
+
+    reports: list[LintReport] = []
+    for uid in user_ids:
+        try:
+            reports.append(await lint_user(uid, service=service))
+        except Exception:
+            continue
+    return reports
+
+
+def dreaming_lint_enabled() -> bool:
+    """Opt-in flag for emitting a lint report from the nightly dreaming cycle.
+
+    Default OFF. The dreaming cycle must remain Ingest-only by default; Lint is
+    report-only and is surfaced for human/curation review, not auto-applied.
+    """
+    return str(os.environ.get("ZOE_MEMORY_LINT_IN_DREAMING", "")).strip().lower() in {
+        "1", "true", "yes", "on",
+    }

--- a/services/zoe-data/memory_lint.py
+++ b/services/zoe-data/memory_lint.py
@@ -410,16 +410,26 @@ def lint_memories(
     *,
     user_id: str = "",
     now: Optional[datetime.datetime] = None,
-    stale_age_days: float = STALE_AGE_DAYS_DEFAULT,
-    near_duplicate_ratio: float = NEAR_DUPLICATE_RATIO_DEFAULT,
+    stale_age_days: Optional[float] = None,
+    near_duplicate_ratio: Optional[float] = None,
 ) -> LintReport:
     """Pure, report-only lint over an iterable of memory rows.
 
     Accepts ``MemoryRef`` objects, anything with ``id``/``text``/``metadata``
     attributes, or plain ``{"id","text","metadata"}`` mappings. Returns a
     :class:`LintReport`. Never mutates the inputs or any store.
+
+    Tunables resolve from the environment at call time (consistent with
+    ``dreaming_lint_enabled``); the module-level ``*_DEFAULT`` constants are the
+    documented fallbacks.
     """
     now = now or datetime.datetime.utcnow()
+    if stale_age_days is None:
+        stale_age_days = float(os.environ.get("ZOE_MEMORY_LINT_STALE_DAYS", "365"))
+    if near_duplicate_ratio is None:
+        near_duplicate_ratio = float(
+            os.environ.get("ZOE_MEMORY_LINT_NEAR_DUP_RATIO", "0.92")
+        )
     rows = _coerce_rows(memories)
     return LintReport(
         user_id=user_id,
@@ -438,8 +448,8 @@ async def lint_user(
     user_id: str,
     *,
     service: Any = None,
-    stale_age_days: float = STALE_AGE_DAYS_DEFAULT,
-    near_duplicate_ratio: float = NEAR_DUPLICATE_RATIO_DEFAULT,
+    stale_age_days: Optional[float] = None,
+    near_duplicate_ratio: Optional[float] = None,
 ) -> LintReport:
     """Read every stored row for ``user_id`` and return a report-only LintReport.
 
@@ -474,11 +484,9 @@ async def lint_all(*, service: Any = None) -> list[LintReport]:
 
         service = get_memory_service()
 
-    try:
-        sizes = await service.collection_sizes_by_user()
-        user_ids = [uid for uid in sizes if uid and uid != "unknown"]
-    except Exception:
-        user_ids = []
+    # Let a real service failure surface (never mask it as "no users have memory").
+    sizes = await service.collection_sizes_by_user()
+    user_ids = [uid for uid in sizes if uid and uid != "unknown"]
 
     reports: list[LintReport] = []
     for uid in user_ids:

--- a/services/zoe-data/tests/test_memory_lint.py
+++ b/services/zoe-data/tests/test_memory_lint.py
@@ -1,0 +1,205 @@
+"""Focused unit tests for the pure, report-only memory Lint detectors.
+
+These exercise contradiction / stale / orphan / duplicate detection over
+in-memory rows only - no ChromaDB, no MemoryService, no network. They also
+assert the hard contract: lint never mutates its inputs.
+"""
+
+import datetime
+
+import pytest
+
+from memory_lint import (
+    LintReport,
+    dreaming_lint_enabled,
+    lint_memories,
+)
+
+NOW = datetime.datetime(2026, 6, 18, 12, 0, 0)
+
+
+def _row(mem_id, text, **meta):
+    base = {"status": "approved", "added_at": "2026-06-01T00:00:00", "access_count": 1}
+    base.update(meta)
+    return {"id": mem_id, "text": text, "metadata": base}
+
+
+def _lint(rows, **kw):
+    kw.setdefault("now", NOW)
+    return lint_memories(rows, user_id="jason", **kw)
+
+
+# Duplicates ----------------------------------------------------------------
+
+def test_exact_duplicate_text_is_flagged():
+    rows = [
+        _row("a", "User lives in Sydney."),
+        _row("b", "user  lives in   sydney."),  # same after normalisation
+    ]
+    report = _lint(rows)
+    assert len(report.duplicates) == 1
+    finding = report.duplicates[0]
+    assert finding.kind == "duplicate"
+    assert set(finding.memory_ids) == {"a", "b"}
+    assert finding.detail["similarity"] == 1.0
+
+
+def test_near_duplicate_text_is_flagged():
+    rows = [
+        _row("a", "User enjoys long bike rides on the weekend in summer."),
+        _row("b", "User enjoys long bike rides on the weekends in summer."),
+    ]
+    report = _lint(rows, near_duplicate_ratio=0.9)
+    kinds = {f.reason for f in report.duplicates}
+    assert "near-duplicate text" in kinds
+
+
+def test_distinct_text_is_not_a_duplicate():
+    rows = [
+        _row("a", "User likes coffee."),
+        _row("b", "User has a dog named Rex."),
+    ]
+    report = _lint(rows)
+    assert report.duplicates == []
+
+
+# Stale ---------------------------------------------------------------------
+
+def test_superseded_status_is_stale():
+    rows = [_row("a", "Old fact", status="superseded")]
+    report = _lint(rows)
+    assert len(report.stale) == 1
+    assert report.stale[0].detail["status"] == "superseded"
+
+
+def test_expired_row_is_stale():
+    rows = [_row("a", "Temporary fact", expires_at="2026-01-01T00:00:00")]
+    report = _lint(rows)
+    assert any(f.reason == "expired" for f in report.stale)
+
+
+def test_old_row_is_stale():
+    rows = [_row("a", "Ancient fact", added_at="2020-01-01T00:00:00")]
+    report = _lint(rows, stale_age_days=365)
+    assert any(f.reason == "old" for f in report.stale)
+
+
+def test_recent_approved_row_is_not_stale():
+    rows = [_row("a", "Fresh fact", added_at="2026-06-17T00:00:00")]
+    report = _lint(rows)
+    assert report.stale == []
+
+
+# Orphans -------------------------------------------------------------------
+
+def test_orphan_has_no_access_queries_or_links():
+    rows = [_row("a", "Never used", access_count=0, unique_query_count=0)]
+    report = _lint(rows)
+    assert len(report.orphans) == 1
+    assert report.orphans[0].kind == "orphan"
+
+
+def test_accessed_row_is_not_orphan():
+    rows = [_row("a", "Used fact", access_count=3, unique_query_count=0)]
+    report = _lint(rows)
+    assert report.orphans == []
+
+
+def test_linked_row_is_not_orphan():
+    rows = [_row("a", "Linked fact", access_count=0, unique_query_count=0,
+                  related_ids="zoe_jason_xyz")]
+    report = _lint(rows)
+    assert report.orphans == []
+
+
+# Contradictions ------------------------------------------------------------
+
+def test_single_valued_relation_conflict_is_contradiction():
+    rows = [
+        _row("a", "User lives in Sydney."),
+        _row("b", "User lives in Melbourne."),
+    ]
+    report = _lint(rows)
+    assert len(report.contradictions) >= 1
+    finding = report.contradictions[0]
+    assert set(finding.memory_ids) == {"a", "b"}
+    assert "sydney" in finding.detail["values"] or "melbourne" in finding.detail["values"]
+
+
+def test_same_value_single_relation_is_not_contradiction():
+    rows = [
+        _row("a", "User lives in Sydney."),
+        _row("b", "User lives in Sydney now."),
+    ]
+    report = _lint(rows)
+    # Same value -> no single-valued contradiction (may dup, but not contradict).
+    assert report.contradictions == []
+
+
+def test_polarity_flip_is_contradiction():
+    rows = [
+        _row("a", "User drinks coffee every morning before work."),
+        _row("b", "User does not drink coffee every morning before work."),
+    ]
+    report = _lint(rows)
+    assert any(f.reason == "polarity flip on overlapping facts"
+               for f in report.contradictions)
+
+
+def test_compatible_preferences_are_not_contradictions():
+    rows = [
+        _row("a", "User likes coffee."),
+        _row("b", "User likes tea."),
+    ]
+    report = _lint(rows)
+    assert report.contradictions == []
+
+
+# Report shape + contract ---------------------------------------------------
+
+def test_report_to_dict_has_totals_and_sections():
+    rows = [_row("a", "User lives in Sydney."), _row("b", "User lives in Perth.")]
+    report = _lint(rows)
+    d = report.to_dict()
+    assert d["user_id"] == "jason"
+    assert d["scanned"] == 2
+    assert "totals" in d and d["totals"]["all"] == report.total
+    for key in ("contradictions", "stale", "orphans", "duplicates"):
+        assert key in d
+
+
+def test_lint_does_not_mutate_inputs():
+    rows = [_row("a", "User lives in Sydney."), _row("a2", "User lives in Perth.")]
+    snapshot = [dict(r["metadata"]) for r in rows]
+    _lint(rows)
+    assert [r["metadata"] for r in rows] == snapshot
+
+
+def test_empty_input_produces_empty_report():
+    report = _lint([])
+    assert isinstance(report, LintReport)
+    assert report.scanned == 0
+    assert report.total == 0
+
+
+def test_dreaming_lint_disabled_by_default(monkeypatch):
+    monkeypatch.delenv("ZOE_MEMORY_LINT_IN_DREAMING", raising=False)
+    assert dreaming_lint_enabled() is False
+    monkeypatch.setenv("ZOE_MEMORY_LINT_IN_DREAMING", "1")
+    assert dreaming_lint_enabled() is True
+
+
+def test_accepts_objects_with_attributes():
+    class Ref:
+        def __init__(self, id, text, metadata):
+            self.id = id
+            self.text = text
+            self.metadata = metadata
+
+    rows = [
+        Ref("a", "User lives in Sydney.", {"status": "approved", "access_count": 1}),
+        Ref("b", "User lives in Hobart.", {"status": "approved", "access_count": 1}),
+    ]
+    report = _lint(rows)
+    assert report.scanned == 2
+    assert len(report.contradictions) >= 1


### PR DESCRIPTION
## What

Adds the third Karpathy LLM-wiki memory operation alongside **Ingest** (dreaming/consolidation) and **Query** (search): a **Lint** pass that scans stored MemPalace memories and produces a structured, **report-only** report of:

- **contradictions** — single-valued relation conflicts (e.g. "lives in Sydney" vs "lives in Melbourne") and polarity flips on high-overlap facts
- **stale** — expired, very old, or already superseded/archived/rejected claims
- **orphans** — rows with no access, no distinct queries, and no links/refs/relations
- **duplicates** — exact and near-duplicate text within a user's store

## Files

- `services/zoe-data/memory_lint.py` — pure, deterministic, offline-safe detectors + async `lint_user`/`lint_all` entrypoints that read through the existing `MemoryService` facade (no parallel store, no direct Chroma client).
- `scripts/maintenance/zoe-memory-lint.py` — opt-in CLI: `zoe-memory-lint.py --user <id>` or `--all`, prints the JSON report.
- `services/zoe-data/memory_digest.py` — opt-in dreaming hook, **default OFF** via `ZOE_MEMORY_LINT_IN_DREAMING`.
- `services/zoe-data/tests/test_memory_lint.py` — focused unit tests for every detector and the report-only contract.
- DOX: report-only **Forbidden** list added to `services/zoe-data/AGENTS.md`; CLI registered in `scripts/AGENTS.md`.

## Report-only guarantee

Lint never deletes, merges, edits, archives, supersedes, or mutates stored memory. It uses read-only `MemoryService` methods (`export_user`, `collection_sizes_by_user`) and returns flags for human/curation review. The detectors have no LLM/cloud/network dependency. The dreaming hook is opt-in and stays report-only even when enabled. This aligns with Zoe's "no prod migration before lab proof" guardrail and the human-review gate.

## Validation (local)

- `python3 tools/audit/validate_structure.py` → exit 0
- `python3 tools/audit/validate_critical_files.py` → exit 0
- `python3 tools/audit/validate_offline_memory.py` → exit 0 (scans `memory_lint.py` via the active-memory glob; clean)
- `pytest tests/test_memory_lint.py` → 19 passed; neighbor memory suites still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)