### PR TITLE
fix(zoe-core): bootstrap-aware brain data URL + live-port default (Phase 2.6)

### DIFF
--- a/services/zoe-data/runtime_env.py
+++ b/services/zoe-data/runtime_env.py
@@ -27,6 +27,10 @@ _BOOTSTRAP_KEYS = frozenset({
     "MULTICA_WEBHOOK_SECRET",
     "POSTGRES_URL",
     "ZOE_INTERNAL_TOKEN",
+    # zoe-core brain: loopback URL it calls back for tools/delegation. Bootstrapped
+    # so a .env value lands in os.environ at startup and the brain (which reads it
+    # lazily) picks up the right port without a launch-procedure change.
+    "ZOE_CORE_DATA_URL",
 })
 
 

--- a/services/zoe-data/tests/test_zoe_core_client.py
+++ b/services/zoe-data/tests/test_zoe_core_client.py
@@ -132,6 +132,18 @@ async def stub(monkeypatch):
         s.stop()
 
 
+def test_data_url_read_lazily_and_defaults_to_8011(monkeypatch):
+    """Not an integration test: guards the bootstrap-timing fix. The data URL
+    must be read at call time (so a .env value bootstrapped after import is
+    honored) and default to loopback :8011 (live zoe-data), never the old :8000."""
+    import zoe_core_client as zc
+    monkeypatch.delenv("ZOE_CORE_DATA_URL", raising=False)
+    monkeypatch.delenv("ZOE_DATA_URL", raising=False)
+    assert zc._data_url() == "http://127.0.0.1:8011"
+    monkeypatch.setenv("ZOE_CORE_DATA_URL", "http://127.0.0.1:9999")
+    assert zc._data_url() == "http://127.0.0.1:9999"
+
+
 @pytest.mark.integration
 @requires_env
 @pytest.mark.asyncio

--- a/services/zoe-data/zoe_core_client.py
+++ b/services/zoe-data/zoe_core_client.py
@@ -55,7 +55,6 @@ _EXTENSIONS = [
 _PI_COMMAND = os.environ.get("ZOE_CORE_PI_COMMAND", "pi")
 _PROVIDER = os.environ.get("ZOE_CORE_PROVIDER", "local-gemma")
 _MODEL = os.environ.get("ZOE_CORE_MODEL_ID", "gemma-4-E2B-it-Q4_K_M.gguf")
-_DATA_URL = os.environ.get("ZOE_CORE_DATA_URL") or os.environ.get("ZOE_DATA_URL", "http://127.0.0.1:8000")
 _TIMEOUT_S = float(os.environ.get("ZOE_CORE_TIMEOUT_S", "180"))
 # Safety valve: once an answer has streamed and a turn has ended, if no further
 # event arrives within this idle window we assume the loop is done even if
@@ -76,11 +75,27 @@ def _rpc_command() -> list[str]:
     return cmd
 
 
+def _data_url() -> str:
+    """zoe-data base URL the brain calls back for tools/delegation.
+
+    Read lazily (NOT at import): bootstrap_runtime_env() populates os.environ in
+    the lifespan startup, which runs AFTER this module is imported — a
+    module-level constant would miss a .env-provided ZOE_CORE_DATA_URL and fall
+    back to the wrong port. Default is loopback :8011 (the live zoe-data port),
+    not the legacy :8000.
+    """
+    return (
+        os.environ.get("ZOE_CORE_DATA_URL")
+        or os.environ.get("ZOE_DATA_URL")
+        or "http://127.0.0.1:8011"
+    )
+
+
 def _worker_env(user_id: str) -> dict[str, str]:
     """Env for a worker. ZOE_CORE_USER_ID is baked per worker (fail-closed:
     a guest/empty user means the memory extension fetches nothing)."""
     env = _pi_subprocess_env(os.environ)
-    env["ZOE_DATA_URL"] = _DATA_URL
+    env["ZOE_DATA_URL"] = _data_url()
     env["ZOE_CORE_SOUL_PATH"] = str(_SOUL_PATH)
     # Only known users get an identity; unknown -> empty (memory fails closed).
     env["ZOE_CORE_USER_ID"] = (user_id or "").strip()


### PR DESCRIPTION
Makes the cutover flip turnkey. The brain calls zoe-data back for tools/delegation via `ZOE_CORE_DATA_URL`, which was read at import (before `bootstrap_runtime_env()` runs in the lifespan) and defaulted to the legacy `:8000`. Now read lazily + added to the bootstrap allowlist + defaults to the live loopback `:8011`. Flip becomes: add `ZOE_CORE_DATA_URL=http://127.0.0.1:8011` to .env, restart normally. 14 tests pass (incl. a lazy-read guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)