### PR TITLE
perf(intent): broaden fast-path coverage so common utterances skip the brain (Phase 4)

### DIFF
--- a/services/zoe-data/intent_router.py
+++ b/services/zoe-data/intent_router.py
@@ -320,15 +320,18 @@ def openclaw_user_message(intent: Optional[Intent], user_text: str) -> str:
 
 _TIME_QUERY_RE = re.compile(
     r"^(what'?s?\s+the\s+time|what\s+time\s+is\s+it(\s+(right\s+now|now))?"
-    r"|tell\s+me\s+the\s+time|current\s+time|time\s+now|time\s+please|what\s+time\s+is\s+it)\??$",
+    r"|tell\s+me\s+the\s+time|current\s+time|time\s+now|time\s+please|what\s+time\s+is\s+it"
+    r"|do\s+you\s+have\s+the\s+time|(?:can\s+you\s+)?give\s+me\s+the\s+time"
+    r"|what\s+hour\s+is\s+it)\??$",
     re.IGNORECASE,
 )
 
 _DATE_QUERY_RE = re.compile(
     r"^(what'?s?\s+today'?s?\s+date|what\s+(is\s+)?the\s+date(\s+today)?"
-    r"|what\s+day\s+(is\s+it|of\s+the\s+week(\s+is\s+it)?)|today'?s?\s+date"
+    r"|what\s+day\s+(is\s+it(\s+today)?|of\s+the\s+week(\s+is\s+it)?)|today'?s?\s+date"
     r"|what\s+year\s+is\s+it(\s+now)?|what\s+month\s+is\s+it(\s+now)?"
-    r"|day\s+of\s+the\s+week|what'?s?\s+the\s+date(\s+today)?)\??$",
+    r"|day\s+of\s+the\s+week|what'?s?\s+the\s+date(\s+today)?"
+    r"|(?:show\s+me|tell\s+me)\s+(?:the\s+|today'?s?\s+)?date|what'?s?\s+today)\??$",
     re.IGNORECASE,
 )
 
@@ -472,12 +475,35 @@ _LETS_TALK_RE = re.compile(
 # Placed after lets_talk so "let's chat" doesn't become a greeting.
 # good_morning/good_evening are kept as separate intents for the daily-briefing flow.
 _GREETING_RE = re.compile(
-    r"^(?:hello|hi|hey|howdy|heya|greetings|yo)(?:\s+(?:there|zoe|there\s+zoe))?\s*[!.,]?\s*$"
-    r"|^(?:hello|hi|hey|howdy|heya|yo)(?:\s+(?:there|zoe|there\s+zoe))?\s+how\s+are\s+you(?:\s+today)?\s*[!.,?]?\s*$"
+    r"^(?:hello|hi|hey|howdy|heya|hiya|greetings|yo|g'?day)(?:\s+(?:there|zoe|there\s+zoe))?\s*[!.,]?\s*$"
+    r"|^(?:hello|hi|hey|howdy|heya|hiya|yo)(?:\s+(?:there|zoe|there\s+zoe))?\s+how\s+are\s+you(?:\s+today)?\s*[!.,?]?\s*$"
     r"|^sup(?:\s+zoe)?\s*\??$"
     r"|^what'?s\s+up(?:\s+zoe)?\s*\??\s*$"
     r"|^how\s+are\s+you(?:\s+today)?(?:\s+zoe)?\s*\??\s*$"
+    r"|^how'?s\s+it\s+going(?:\s+zoe)?\s*\??\s*$"
     r"|^good\s+(?:afternoon|night)(?:\s+zoe)?\s*[!.,]?\s*$",
+    re.IGNORECASE,
+)
+
+# Social acknowledgements ("thanks", "got it") and presence checks ("are you
+# there?") — instant canned replies so they never wake the ~2-4s brain. All
+# anchored ^...$ so they can't swallow a real request ("okay add milk" won't match).
+_THANKS_RE = re.compile(
+    r"^(?:thanks?|thank\s+you|thank\s+u|thx|ty|cheers|much\s+appreciated)"
+    r"(?:\s+(?:so\s+much|a\s+lot|very\s+much|heaps))?(?:\s+zoe)?\s*[!.,]*$",
+    re.IGNORECASE,
+)
+_ACK_RE = re.compile(
+    r"^(?:got\s+it|gotcha|understood|makes\s+sense|good\s+to\s+know|noted|fair\s+enough)\s*[!.,]*$"
+    r"|^(?:ok|okay|okey|k|alright|cool|nice|great|perfect|awesome|lovely|sweet|sounds\s+good)\s*[!.,]*$"
+    r"|^(?:no\s+(?:problem|worries)|all\s+good)\s*[!.,]*$",
+    re.IGNORECASE,
+)
+_STATUS_CHECK_RE = re.compile(
+    r"^(?:are\s+you\s+|you\s+)?(?:there|listening|awake|around|still\s+(?:there|listening|awake|with\s+me))\s*\??$"
+    r"|^(?:can\s+you\s+)?hear\s+me(?:\s+(?:ok|okay|now))?\s*\??$"
+    r"|^(?:are\s+you\s+)?(?:still\s+)?(?:working|online|up|ready)\s*\??$"
+    r"|^zoe\s*\??$",
     re.IGNORECASE,
 )
 
@@ -655,6 +681,14 @@ def detect_intent(
 
     if re.match(r"^ping\.?$", t):
         return Intent("greeting", {})
+
+    # Social acknowledgements & presence checks — instant, no brain.
+    if _THANKS_RE.match(t):
+        return Intent("acknowledgement", {"kind": "thanks"})
+    if _ACK_RE.match(t):
+        return Intent("acknowledgement", {"kind": "ack"})
+    if _STATUS_CHECK_RE.match(t):
+        return Intent("status_check", {})
 
     if re.match(r"^what lists do i have\??$", t):
         return Intent("list_show", {})
@@ -1982,6 +2016,17 @@ async def execute_intent(intent: Intent, user_id: str = "family-admin") -> Optio
         now = datetime.now()
         spoken_day = _spoken_day_ordinal(now.day)
         return f"Today is {now.strftime('%A')}, {now.strftime('%B')} {spoken_day}."
+
+    # Social acknowledgements & presence checks — instant canned replies (no LLM).
+    if intent.name == "acknowledgement":
+        import random
+        if intent.slots.get("kind") == "thanks":
+            return random.choice(["You're welcome!", "Anytime.", "Happy to help.", "No worries."])
+        return random.choice(["Got it.", "Sure thing.", "Okay.", "No problem."])
+
+    if intent.name == "status_check":
+        import random
+        return random.choice(["I'm here.", "Still here.", "Listening.", "Ready when you are."])
 
     if intent.name == "time_planning_clarification":
         if intent.slots.get("kind") == "time_math":

--- a/services/zoe-data/tests/test_fastpath_coverage.py
+++ b/services/zoe-data/tests/test_fastpath_coverage.py
@@ -71,7 +71,7 @@ def test_real_requests_not_short_circuited(text):
     n = _name(text)
     assert n not in ("acknowledgement", "status_check"), f"{text!r} wrongly caught as {n}"
     # also must not be reduced to a bare clock read
-    assert n not in ("time_query", "date_query") or "weather" not in text, f"{text!r} -> {n}"
+    assert n not in ("time_query", "date_query"), f"{text!r} -> {n}"
 
 
 @pytest.mark.asyncio

--- a/services/zoe-data/tests/test_fastpath_coverage.py
+++ b/services/zoe-data/tests/test_fastpath_coverage.py
@@ -1,0 +1,85 @@
+"""Fast-path coverage: common utterances answered instantly, never the slow brain.
+
+Critically also asserts the new instant patterns do NOT swallow real requests
+that genuinely need the brain (the ^...$ anchoring must hold).
+"""
+from __future__ import annotations
+
+import pytest
+
+from intent_router import Intent, detect_intent, execute_intent
+
+
+def _name(text: str) -> str | None:
+    i = detect_intent(text, log_miss=False)
+    return i.name if i else None
+
+
+@pytest.mark.parametrize("text,expected", [
+    # time paraphrases that previously fell through
+    ("do you have the time", "time_query"),
+    ("give me the time", "time_query"),
+    ("what hour is it", "time_query"),
+    ("what time is it now", "time_query"),
+    # date paraphrases
+    ("show me the date", "date_query"),
+    ("tell me today's date", "date_query"),
+    ("what's today", "date_query"),
+    ("what day is it today", "date_query"),
+    # greetings
+    ("hiya", "greeting"),
+    ("g'day", "greeting"),
+    ("how's it going", "greeting"),
+    # thanks / acknowledgements
+    ("thanks", "acknowledgement"),
+    ("thank you so much", "acknowledgement"),
+    ("cheers", "acknowledgement"),
+    ("ty", "acknowledgement"),
+    ("got it", "acknowledgement"),
+    ("okay", "acknowledgement"),
+    ("cool", "acknowledgement"),
+    ("perfect", "acknowledgement"),
+    ("sounds good", "acknowledgement"),
+    ("no worries", "acknowledgement"),
+    # presence checks
+    ("are you there", "status_check"),
+    ("you there?", "status_check"),
+    ("can you hear me", "status_check"),
+    ("still there", "status_check"),
+    ("zoe?", "status_check"),
+])
+def test_instant_intents_match(text, expected):
+    assert _name(text) == expected, f"{text!r} -> {_name(text)!r}, expected {expected}"
+
+
+@pytest.mark.parametrize("text", [
+    # acknowledgement words that LEAD a real request must NOT be canned-replied
+    "okay add milk to my shopping list",
+    "thanks but what's the weather tomorrow",
+    "great idea, let's build a budget tracker",
+    "cool can you set a timer for ten minutes",
+    "perfect, remind me at 5pm",
+    # presence-ish words that are real requests
+    "are you free tomorrow at 3",
+    "is it going to rain today",
+    "are you able to book a table",
+    # time/date planning that needs reasoning, not a clock read
+    "what's the best time to leave for the airport",
+    "what's today's weather",
+])
+def test_real_requests_not_short_circuited(text):
+    n = _name(text)
+    assert n not in ("acknowledgement", "status_check"), f"{text!r} wrongly caught as {n}"
+    # also must not be reduced to a bare clock read
+    assert n not in ("time_query", "date_query") or "weather" not in text, f"{text!r} -> {n}"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("intent,expect_in", [
+    (Intent("acknowledgement", {"kind": "thanks"}), {"You're welcome!", "Anytime.", "Happy to help.", "No worries."}),
+    (Intent("acknowledgement", {"kind": "ack"}), {"Got it.", "Sure thing.", "Okay.", "No problem."}),
+    (Intent("status_check", {}), {"I'm here.", "Still here.", "Listening.", "Ready when you are."}),
+])
+async def test_canned_replies(intent, expect_in):
+    reply = await execute_intent(intent, user_id="family-admin")
+    assert reply in expect_in, f"{intent.name}/{intent.slots} -> {reply!r}"


### PR DESCRIPTION
Post-cutover optimization. The brain is now a local ~2-4s model (warm turns ~0.65s); high-frequency simple utterances were needlessly hitting it. Now instant via the intent fast-path:

- **time/date**: broadened `_TIME_QUERY_RE`/`_DATE_QUERY_RE` ("do you have the time", "give me the time", "what hour is it", "show me the date", "tell me today's date", "what's today").
- **greeting**: + hiya / g'day / how's it going.
- **acknowledgement** (new): "thanks"/"got it"/"okay"/"cool"/"perfect" → instant canned reply (thanks vs ack split for sensible wording).
- **status_check** (new): "are you there"/"can you hear me"/"still there"/"zoe?" → instant.

**Safety:** every new pattern is anchored `^...$`. Negative tests assert real requests still reach the brain ("okay add milk to my list", "thanks but what's the weather", "are you free tomorrow", "what's the best time to leave", "what's today's weather"). 39 fast-path + 341 intent tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)