### PR TITLE
feat(greploop): local serial merge queue (no merge_group dependency)

### DIFF
--- a/scripts/maintenance/greploop_guard.py
+++ b/scripts/maintenance/greploop_guard.py
@@ -63,6 +63,8 @@ def main() -> int:
         help="With --queue: decide but perform no mutation (safe to run while disabled)",
     )
     args = parser.parse_args()
+    if args.dry_run and not args.queue:
+        parser.error("--dry-run only applies to --queue")
 
     try:
         if args.queue:

--- a/scripts/maintenance/greploop_guard.py
+++ b/scripts/maintenance/greploop_guard.py
@@ -17,6 +17,7 @@ from greploop_guard import (  # noqa: E402
     merge_pr_when_ready,
     read_observed_guard_state,
     run_guard_once,
+    run_merge_queue,
 )
 
 
@@ -47,9 +48,32 @@ def main() -> int:
         help="Squash-merge when READY (Greptile clear + CI green); optional after --once",
     )
     parser.add_argument("--state", action="store_true", help="Print file-backed guard state")
+    parser.add_argument(
+        "--queue",
+        action="store_true",
+        help=(
+            "Run one serial local merge-queue cycle: advance or merge exactly one "
+            "labelled, ready PR (rebase-on-behind, never --admin/force). Disabled "
+            "unless ZOE_MERGE_QUEUE_ENABLED=1 and no kill file."
+        ),
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="With --queue: decide but perform no mutation (safe to run while disabled)",
+    )
     args = parser.parse_args()
 
     try:
+        if args.queue:
+            queue_result = asyncio.run(
+                run_merge_queue(
+                    target_confidence=args.target_confidence,
+                    dry_run=args.dry_run,
+                )
+            )
+            print(json.dumps(queue_result, indent=2, sort_keys=True))
+            return 0 if queue_result.get("ok") else 2
         if not args.pr:
             parser.error("--pr is required")
         if args.state:

--- a/services/zoe-data/AGENTS.md
+++ b/services/zoe-data/AGENTS.md
@@ -28,6 +28,7 @@ THE production Zoe API: FastAPI app served by host uvicorn on port 8000. Owns ch
 - Memory Lint (`memory_lint.py`) is REPORT-ONLY. It must never delete, merge, edit, archive, supersede, or otherwise mutate stored memory, and must never trigger such mutation. It reads through the `MemoryService` facade and returns flags/reports for human or curation review only.
 - Lint must not run inside the nightly dreaming cycle by default. Emitting a lint report from dreaming is opt-in via `ZOE_MEMORY_LINT_IN_DREAMING` and stays report-only even when enabled.
 - No DB schema migration, no destructive ops, and no cloud/LLM dependency from the lint detectors (they stay offline-safe heuristics).
+- The local merge queue (`run_merge_queue` in `greploop_guard.py`) is DISABLED by default (requires `ZOE_MERGE_QUEUE_ENABLED=1` and no `merge_queue.disabled` kill file). It must NEVER use `--admin` or force-merge, never bypass branch protection, never merge a PR not assessed READY, never act on PRs lacking the `auto-merge` label, never resolve rebase conflicts automatically (abort + report), never touch the live checkout (rebases run in a disposable worktree), and act on at most one PR per cycle.
 
 ## Work Guidance
 

--- a/services/zoe-data/greploop_guard.py
+++ b/services/zoe-data/greploop_guard.py
@@ -1448,8 +1448,12 @@ def _merge_queue_enabled() -> bool:
     return enabled and not MERGE_QUEUE_KILL_FILE.exists()
 
 
-def _merge_queue_candidates(*, repo: str = DEFAULT_REPO) -> list[dict[str, Any]]:
-    """Open, non-draft PRs carrying the queue label, oldest-first (FIFO)."""
+def _merge_queue_candidates(*, repo: str = DEFAULT_REPO) -> list[dict[str, Any]] | None:
+    """Open, non-draft PRs carrying the queue label, oldest-first (FIFO).
+
+    Returns ``None`` (not ``[]``) when the ``gh pr list`` call fails, so a broken
+    gh (auth/rate-limit/network) is never mistaken for an empty queue.
+    """
     proc = _run_gh(
         [
             "pr",
@@ -1466,11 +1470,11 @@ def _merge_queue_candidates(*, repo: str = DEFAULT_REPO) -> list[dict[str, Any]]
         repo=repo,
     )
     if proc.returncode != 0:
-        return []
+        return None  # signal failure — never conflate a broken gh with "no PRs"
     try:
         rows = json.loads(proc.stdout or "[]")
     except json.JSONDecodeError:
-        return []
+        return None
     candidates = [
         {
             "number": int(row.get("number")),
@@ -1567,6 +1571,12 @@ async def run_merge_queue(
             "detail": "set ZOE_MERGE_QUEUE_ENABLED=1 and remove the kill file to enable",
         }
     candidates = _merge_queue_candidates(repo=repo)
+    if candidates is None:
+        return {
+            "ok": False,
+            "action": "list_failed",
+            "detail": "gh pr list failed (auth/rate-limit/network); not treating as idle",
+        }
     if not candidates:
         return {"ok": True, "action": "idle", "checked": 0, "skipped": []}
     skipped: list[dict[str, Any]] = []

--- a/services/zoe-data/greploop_guard.py
+++ b/services/zoe-data/greploop_guard.py
@@ -1514,23 +1514,24 @@ def _rebase_pr_branch(
     conflict, abort and report — conflicts are never resolved automatically.
     """
     if not branch:
-        return {"ok": False, "error": "NO_BRANCH"}
+        return {"ok": False, "pr": pr_number, "error": "NO_BRANCH"}
     fetch = _run_git(["fetch", "origin", default_branch, branch], check=False)
     if fetch.returncode != 0:
-        return {"ok": False, "error": "FETCH_FAILED", "detail": (fetch.stderr or "").strip()[:500]}
+        return {"ok": False, "pr": pr_number, "error": "FETCH_FAILED", "detail": (fetch.stderr or "").strip()[:500]}
     tmp = STATE_ROOT / f"mq-rebase-{branch.replace('/', '_')}"
     _run_git(["worktree", "remove", "--force", str(tmp)], check=False)
     add = _run_git(
         ["worktree", "add", "--force", "--detach", str(tmp), f"origin/{branch}"], check=False
     )
     if add.returncode != 0:
-        return {"ok": False, "error": "WORKTREE_FAILED", "detail": (add.stderr or "").strip()[:500]}
+        return {"ok": False, "pr": pr_number, "error": "WORKTREE_FAILED", "detail": (add.stderr or "").strip()[:500]}
     try:
         rebase = _run_git(["-C", str(tmp), "rebase", f"origin/{default_branch}"], check=False)
         if rebase.returncode != 0:
             _run_git(["-C", str(tmp), "rebase", "--abort"], check=False)
             return {
                 "ok": False,
+                "pr": pr_number,
                 "error": "REBASE_CONFLICT",
                 "detail": (rebase.stdout or rebase.stderr or "").strip()[:500],
             }
@@ -1539,8 +1540,8 @@ def _rebase_pr_branch(
             check=False,
         )
         if push.returncode != 0:
-            return {"ok": False, "error": "PUSH_FAILED", "detail": (push.stderr or "").strip()[:500]}
-        return {"ok": True, "branch": branch}
+            return {"ok": False, "pr": pr_number, "error": "PUSH_FAILED", "detail": (push.stderr or "").strip()[:500]}
+        return {"ok": True, "pr": pr_number, "branch": branch}
     finally:
         _run_git(["worktree", "remove", "--force", str(tmp)], check=False)
 

--- a/services/zoe-data/greploop_guard.py
+++ b/services/zoe-data/greploop_guard.py
@@ -1407,6 +1407,224 @@ async def merge_pr_when_ready(
         }
 
 
+# --- Local serial merge queue ------------------------------------------------
+#
+# A locally-driven merge queue that processes one labelled, ready PR per cycle.
+# When a ready PR is only behind the base branch, it is rebased forward (linear,
+# NOT a merge-update commit, so Greptile re-reviews the fresh head) and the cycle
+# stops; a later cycle merges it once green. This reproduces the GitHub
+# merge-queue "test against the combined state" guarantee using ordinary PR
+# commits, so it does NOT depend on Greptile posting checks on merge_group refs.
+#
+# Loop contract (Job/Inputs/Allowed/Forbidden/Output/Evaluation):
+#   JOB: advance or merge exactly one labelled, ready PR per cycle.
+#   INPUTS: open, non-draft PRs carrying MERGE_QUEUE_LABEL; their Greptile/CI/
+#     thread state via assess_merge_readiness.
+#   ALLOWED: linear rebase + force-push of a queue-labelled branch in a disposable
+#     worktree; squash-merge via merge_pr_when_ready (gh pr merge --squash).
+#   FORBIDDEN: NEVER --admin; NEVER force-merge or bypass branch protection; NEVER
+#     merge a PR not assessed READY; NEVER act on PRs lacking the queue label;
+#     NEVER resolve rebase conflicts automatically (abort + report); NEVER touch
+#     the live checkout (rebase happens in a throwaway worktree); at most one
+#     rebase OR one merge per cycle; disabled unless explicitly enabled.
+#   OUTPUT: at most one PR merged or one branch advanced per cycle; a structured
+#     report of the action and any skipped PRs.
+#   EVALUATION: never merges a red/behind/unreviewed PR; the queue drains serially
+#     across cycles; main's required checks always pass post-merge.
+
+MERGE_QUEUE_LABEL = os.environ.get("ZOE_MERGE_QUEUE_LABEL", "auto-merge")
+MERGE_QUEUE_KILL_FILE = STATE_ROOT / "merge_queue.disabled"
+MERGE_QUEUE_MAX_CANDIDATES = int(os.environ.get("ZOE_MERGE_QUEUE_MAX_CANDIDATES", "50"))
+
+
+def _merge_queue_enabled() -> bool:
+    """Disabled by default. Requires ZOE_MERGE_QUEUE_ENABLED truthy AND no kill file."""
+    enabled = str(os.environ.get("ZOE_MERGE_QUEUE_ENABLED", "")).strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+    return enabled and not MERGE_QUEUE_KILL_FILE.exists()
+
+
+def _merge_queue_candidates(*, repo: str = DEFAULT_REPO) -> list[dict[str, Any]]:
+    """Open, non-draft PRs carrying the queue label, oldest-first (FIFO)."""
+    proc = _run_gh(
+        [
+            "pr",
+            "list",
+            "--state",
+            "open",
+            "--label",
+            MERGE_QUEUE_LABEL,
+            "--limit",
+            str(MERGE_QUEUE_MAX_CANDIDATES),
+            "--json",
+            "number,isDraft,headRefName,createdAt",
+        ],
+        repo=repo,
+    )
+    if proc.returncode != 0:
+        return []
+    try:
+        rows = json.loads(proc.stdout or "[]")
+    except json.JSONDecodeError:
+        return []
+    candidates = [
+        {
+            "number": int(row.get("number")),
+            "branch": str(row.get("headRefName") or ""),
+            "created_at": str(row.get("createdAt") or ""),
+        }
+        for row in rows
+        if isinstance(row, dict) and row.get("number") is not None and not row.get("isDraft")
+    ]
+    candidates.sort(key=lambda c: (c["created_at"], c["number"]))
+    return candidates
+
+
+def _blocked_only_behind(assessment: dict[str, Any]) -> bool:
+    """True iff the PR's sole obstacle is being behind the base branch.
+
+    Greptile must be clear (no review running, no unresolved threads, confidence
+    met, no actionable findings) and the merge state must be exactly BEHIND. Any
+    Greptile/CI/thread blocker means a rebase would not unblock it.
+    """
+    gh = assessment.get("gh") or {}
+    if str(gh.get("mergeStateStatus") or "").upper() != "BEHIND":
+        return False
+    blockers = assessment.get("blockers") or []
+    if not blockers:
+        return False
+    return all(str(blocker) == "GH_NOT_MERGEABLE" for blocker in blockers)
+
+
+def _rebase_pr_branch(
+    pr_number: int,
+    branch: str,
+    *,
+    repo: str = DEFAULT_REPO,
+    default_branch: str = DEFAULT_BASE_BRANCH,
+) -> dict[str, Any]:
+    """Rebase a PR branch linearly onto the base branch and force-push.
+
+    Runs in a disposable worktree so the live checkout is never touched. Linear
+    rebase (not a merge commit) keeps Greptile reviewing the new head. On
+    conflict, abort and report — conflicts are never resolved automatically.
+    """
+    if not branch:
+        return {"ok": False, "error": "NO_BRANCH"}
+    fetch = _run_git(["fetch", "origin", default_branch, branch], check=False)
+    if fetch.returncode != 0:
+        return {"ok": False, "error": "FETCH_FAILED", "detail": (fetch.stderr or "").strip()[:500]}
+    tmp = STATE_ROOT / f"mq-rebase-{branch.replace('/', '_')}"
+    _run_git(["worktree", "remove", "--force", str(tmp)], check=False)
+    add = _run_git(
+        ["worktree", "add", "--force", "--detach", str(tmp), f"origin/{branch}"], check=False
+    )
+    if add.returncode != 0:
+        return {"ok": False, "error": "WORKTREE_FAILED", "detail": (add.stderr or "").strip()[:500]}
+    try:
+        rebase = _run_git(["-C", str(tmp), "rebase", f"origin/{default_branch}"], check=False)
+        if rebase.returncode != 0:
+            _run_git(["-C", str(tmp), "rebase", "--abort"], check=False)
+            return {
+                "ok": False,
+                "error": "REBASE_CONFLICT",
+                "detail": (rebase.stdout or rebase.stderr or "").strip()[:500],
+            }
+        push = _run_git(
+            ["-C", str(tmp), "push", "--force-with-lease", "origin", f"HEAD:{branch}"],
+            check=False,
+        )
+        if push.returncode != 0:
+            return {"ok": False, "error": "PUSH_FAILED", "detail": (push.stderr or "").strip()[:500]}
+        return {"ok": True, "branch": branch}
+    finally:
+        _run_git(["worktree", "remove", "--force", str(tmp)], check=False)
+
+
+async def run_merge_queue(
+    *,
+    repo: str = DEFAULT_REPO,
+    default_branch: str = DEFAULT_BASE_BRANCH,
+    target_confidence: int = 5,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    """Run one serial merge-queue cycle: advance or merge exactly one labelled PR.
+
+    Strictly serial and safe: at most one rebase OR one merge per call. Disabled
+    unless ``ZOE_MERGE_QUEUE_ENABLED`` is truthy and no kill file exists. With
+    ``dry_run`` it decides but performs no mutation (and ignores the enable gate so
+    it can be inspected safely).
+    """
+    if not dry_run and not _merge_queue_enabled():
+        return {
+            "ok": True,
+            "action": "disabled",
+            "detail": "set ZOE_MERGE_QUEUE_ENABLED=1 and remove the kill file to enable",
+        }
+    candidates = _merge_queue_candidates(repo=repo)
+    if not candidates:
+        return {"ok": True, "action": "idle", "checked": 0, "skipped": []}
+    skipped: list[dict[str, Any]] = []
+    for cand in candidates:
+        pr_number = cand["number"]
+        assessment = await assess_merge_readiness(
+            pr_number,
+            target_confidence=target_confidence,
+            repo=repo,
+            default_branch=default_branch,
+        )
+        if assessment.get("ready"):
+            if dry_run:
+                return {
+                    "ok": True,
+                    "action": "would_merge",
+                    "pr": pr_number,
+                    "skipped": skipped,
+                    "checked": len(candidates),
+                }
+            merge = await merge_pr_when_ready(
+                pr_number,
+                target_confidence=target_confidence,
+                repo=repo,
+                default_branch=default_branch,
+            )
+            return {
+                "ok": bool(merge.get("ok")),
+                "action": "merged" if merge.get("ok") else "merge_attempt_failed",
+                "pr": pr_number,
+                "merge": merge,
+                "skipped": skipped,
+                "checked": len(candidates),
+            }
+        if _blocked_only_behind(assessment):
+            if dry_run:
+                return {
+                    "ok": True,
+                    "action": "would_rebase",
+                    "pr": pr_number,
+                    "branch": cand["branch"],
+                    "skipped": skipped,
+                    "checked": len(candidates),
+                }
+            rebase = _rebase_pr_branch(
+                pr_number, cand["branch"], repo=repo, default_branch=default_branch
+            )
+            return {
+                "ok": bool(rebase.get("ok")),
+                "action": "rebased" if rebase.get("ok") else "rebase_failed",
+                "pr": pr_number,
+                "rebase": rebase,
+                "skipped": skipped,
+                "checked": len(candidates),
+            }
+        skipped.append({"pr": pr_number, "blockers": assessment.get("blockers")})
+    return {"ok": True, "action": "idle", "checked": len(candidates), "skipped": skipped}
+
+
 async def run_guard_once(
     pr_number: int, *, packet_only: bool = False, target_confidence: int = 5
 ) -> dict[str, Any]:

--- a/services/zoe-data/tests/test_greploop_guard.py
+++ b/services/zoe-data/tests/test_greploop_guard.py
@@ -2265,3 +2265,224 @@ async def test_assess_merge_readiness_blocks_actionable_findings(monkeypatch):
     assert out["ready"] is False
     assert out["unaddressed_count"] == 1
     assert "GREPTILE_ACTIONABLE_FINDINGS:1" in out["blockers"]
+
+
+# --- Local serial merge queue ------------------------------------------------
+
+
+def _mq_assessment(*, ready=False, behind=False, blockers=None):
+    blk = list(blockers or [])
+    gh = {}
+    if behind:
+        gh = {"ok": False, "reason": "GH_NOT_MERGEABLE", "mergeStateStatus": "BEHIND"}
+        if "GH_NOT_MERGEABLE" not in blk:
+            blk.append("GH_NOT_MERGEABLE")
+    return {"ready": ready, "blockers": blk, "gh": gh}
+
+
+@pytest.fixture
+def _mq_enabled(monkeypatch, tmp_path):
+    """Queue enabled with a guaranteed-absent kill file."""
+    monkeypatch.setenv("ZOE_MERGE_QUEUE_ENABLED", "1")
+    monkeypatch.setattr(greploop_guard, "MERGE_QUEUE_KILL_FILE", tmp_path / "absent.disabled")
+
+
+def test_blocked_only_behind_logic():
+    assert greploop_guard._blocked_only_behind(_mq_assessment(behind=True)) is True
+    # behind but a Greptile thread also blocks -> rebase would not help
+    assert (
+        greploop_guard._blocked_only_behind(
+            _mq_assessment(behind=True, blockers=["GREPTILE_UNRESOLVED_THREADS:1"])
+        )
+        is False
+    )
+    # not BEHIND (e.g. DIRTY/BLOCKED) -> not a rebase candidate
+    assert (
+        greploop_guard._blocked_only_behind({"gh": {"mergeStateStatus": "BLOCKED"}, "blockers": ["X"]})
+        is False
+    )
+    # BEHIND but no blocker recorded -> nothing to act on
+    assert (
+        greploop_guard._blocked_only_behind({"gh": {"mergeStateStatus": "BEHIND"}, "blockers": []})
+        is False
+    )
+
+
+async def test_queue_disabled_by_default(monkeypatch):
+    monkeypatch.delenv("ZOE_MERGE_QUEUE_ENABLED", raising=False)
+    listed = {"n": 0}
+    monkeypatch.setattr(
+        greploop_guard,
+        "_merge_queue_candidates",
+        lambda **k: listed.__setitem__("n", listed["n"] + 1) or [],
+    )
+    out = await greploop_guard.run_merge_queue()
+    assert out["action"] == "disabled"
+    assert listed["n"] == 0  # never even lists candidates when disabled
+
+
+async def test_queue_kill_file_disables(monkeypatch, tmp_path):
+    monkeypatch.setenv("ZOE_MERGE_QUEUE_ENABLED", "1")
+    kill = tmp_path / "merge_queue.disabled"
+    kill.write_text("stop")
+    monkeypatch.setattr(greploop_guard, "MERGE_QUEUE_KILL_FILE", kill)
+    out = await greploop_guard.run_merge_queue()
+    assert out["action"] == "disabled"
+
+
+async def test_queue_merges_ready_head_only(monkeypatch, _mq_enabled):
+    monkeypatch.setattr(
+        greploop_guard,
+        "_merge_queue_candidates",
+        lambda **k: [
+            {"number": 101, "branch": "a", "created_at": "1"},
+            {"number": 102, "branch": "b", "created_at": "2"},
+        ],
+    )
+    merged, rebased = [], []
+
+    async def fake_assess(pr, **k):
+        return _mq_assessment(ready=(pr == 101))
+
+    async def fake_merge(pr, **k):
+        merged.append(pr)
+        return {"ok": True, "state": "MERGED"}
+
+    monkeypatch.setattr(greploop_guard, "assess_merge_readiness", fake_assess)
+    monkeypatch.setattr(greploop_guard, "merge_pr_when_ready", fake_merge)
+    monkeypatch.setattr(
+        greploop_guard, "_rebase_pr_branch", lambda *a, **k: rebased.append(a) or {"ok": True}
+    )
+    out = await greploop_guard.run_merge_queue()
+    assert out["action"] == "merged" and out["pr"] == 101
+    assert merged == [101]  # head only, one merge per cycle
+    assert rebased == []
+
+
+async def test_queue_rebases_behind_head(monkeypatch, _mq_enabled):
+    monkeypatch.setattr(
+        greploop_guard,
+        "_merge_queue_candidates",
+        lambda **k: [{"number": 201, "branch": "feat/x", "created_at": "1"}],
+    )
+    merged, rebased = [], []
+
+    async def fake_assess(pr, **k):
+        return _mq_assessment(behind=True)
+
+    async def fake_merge(pr, **k):
+        merged.append(pr)
+        return {"ok": True}
+
+    monkeypatch.setattr(greploop_guard, "assess_merge_readiness", fake_assess)
+    monkeypatch.setattr(greploop_guard, "merge_pr_when_ready", fake_merge)
+    monkeypatch.setattr(
+        greploop_guard,
+        "_rebase_pr_branch",
+        lambda pr, branch, **k: rebased.append((pr, branch)) or {"ok": True, "branch": branch},
+    )
+    out = await greploop_guard.run_merge_queue()
+    assert out["action"] == "rebased" and out["pr"] == 201
+    assert rebased == [(201, "feat/x")]
+    assert merged == []  # a behind PR is never merged directly
+
+
+async def test_queue_skips_blocked_then_acts_on_next(monkeypatch, _mq_enabled):
+    monkeypatch.setattr(
+        greploop_guard,
+        "_merge_queue_candidates",
+        lambda **k: [
+            {"number": 301, "branch": "a", "created_at": "1"},
+            {"number": 302, "branch": "b", "created_at": "2"},
+        ],
+    )
+    merged = []
+
+    async def fake_assess(pr, **k):
+        if pr == 301:
+            return _mq_assessment(blockers=["GREPTILE_UNRESOLVED_THREADS:2"])
+        return _mq_assessment(ready=True)
+
+    async def fake_merge(pr, **k):
+        merged.append(pr)
+        return {"ok": True}
+
+    monkeypatch.setattr(greploop_guard, "assess_merge_readiness", fake_assess)
+    monkeypatch.setattr(greploop_guard, "merge_pr_when_ready", fake_merge)
+    monkeypatch.setattr(greploop_guard, "_rebase_pr_branch", lambda *a, **k: {"ok": True})
+    out = await greploop_guard.run_merge_queue()
+    assert out["action"] == "merged" and out["pr"] == 302
+    assert merged == [302]
+    assert any(s["pr"] == 301 for s in out["skipped"])
+
+
+async def test_queue_dry_run_no_mutation(monkeypatch):
+    monkeypatch.delenv("ZOE_MERGE_QUEUE_ENABLED", raising=False)  # dry-run ignores the gate
+    monkeypatch.setattr(
+        greploop_guard,
+        "_merge_queue_candidates",
+        lambda **k: [{"number": 401, "branch": "a", "created_at": "1"}],
+    )
+    calls = {"merge": 0, "rebase": 0}
+
+    async def fake_assess(pr, **k):
+        return _mq_assessment(ready=True)
+
+    async def fake_merge(pr, **k):
+        calls["merge"] += 1
+        return {"ok": True}
+
+    monkeypatch.setattr(greploop_guard, "assess_merge_readiness", fake_assess)
+    monkeypatch.setattr(greploop_guard, "merge_pr_when_ready", fake_merge)
+    monkeypatch.setattr(
+        greploop_guard,
+        "_rebase_pr_branch",
+        lambda *a, **k: calls.__setitem__("rebase", calls["rebase"] + 1) or {"ok": True},
+    )
+    out = await greploop_guard.run_merge_queue(dry_run=True)
+    assert out["action"] == "would_merge" and out["pr"] == 401
+    assert calls == {"merge": 0, "rebase": 0}  # no mutation in dry-run
+
+
+async def test_queue_dry_run_would_rebase(monkeypatch):
+    monkeypatch.delenv("ZOE_MERGE_QUEUE_ENABLED", raising=False)
+    monkeypatch.setattr(
+        greploop_guard,
+        "_merge_queue_candidates",
+        lambda **k: [{"number": 402, "branch": "feat/y", "created_at": "1"}],
+    )
+    calls = {"merge": 0, "rebase": 0}
+
+    async def fake_assess(pr, **k):
+        return _mq_assessment(behind=True)
+
+    async def fake_merge(pr, **k):
+        calls["merge"] += 1
+        return {"ok": True}
+
+    monkeypatch.setattr(greploop_guard, "assess_merge_readiness", fake_assess)
+    monkeypatch.setattr(greploop_guard, "merge_pr_when_ready", fake_merge)
+    monkeypatch.setattr(
+        greploop_guard,
+        "_rebase_pr_branch",
+        lambda *a, **k: calls.__setitem__("rebase", calls["rebase"] + 1) or {"ok": True},
+    )
+    out = await greploop_guard.run_merge_queue(dry_run=True)
+    assert out["action"] == "would_rebase" and out["pr"] == 402 and out["branch"] == "feat/y"
+    assert calls == {"merge": 0, "rebase": 0}
+
+
+async def test_queue_idle_when_no_candidates(monkeypatch, _mq_enabled):
+    monkeypatch.setattr(greploop_guard, "_merge_queue_candidates", lambda **k: [])
+    out = await greploop_guard.run_merge_queue()
+    assert out["action"] == "idle" and out["checked"] == 0
+
+
+def test_merge_command_never_admin_or_force():
+    # Guardrail against a future edit sneaking in an admin/force merge.
+    import inspect
+
+    src = inspect.getsource(greploop_guard.merge_pr_when_ready)
+    assert '"--squash"' in src
+    assert "--admin" not in src
+    assert "--force" not in src

--- a/services/zoe-data/tests/test_greploop_guard.py
+++ b/services/zoe-data/tests/test_greploop_guard.py
@@ -2503,3 +2503,31 @@ def test_cli_dry_run_requires_queue():
     )
     assert proc.returncode != 0
     assert "--dry-run only applies to --queue" in (proc.stderr + proc.stdout)
+
+
+def test_candidates_none_on_gh_failure(monkeypatch):
+    # A broken gh must NOT look like an empty queue: return None, not [].
+    def fail_gh(args, **k):
+        return subprocess.CompletedProcess(args=args, returncode=1, stdout="", stderr="bad token")
+
+    monkeypatch.setattr(greploop_guard, "_run_gh", fail_gh)
+    assert greploop_guard._merge_queue_candidates() is None
+
+    def bad_json_gh(args, **k):
+        return subprocess.CompletedProcess(args=args, returncode=0, stdout="not json", stderr="")
+
+    monkeypatch.setattr(greploop_guard, "_run_gh", bad_json_gh)
+    assert greploop_guard._merge_queue_candidates() is None
+
+    def ok_gh(args, **k):
+        return subprocess.CompletedProcess(args=args, returncode=0, stdout="[]", stderr="")
+
+    monkeypatch.setattr(greploop_guard, "_run_gh", ok_gh)
+    assert greploop_guard._merge_queue_candidates() == []  # genuinely empty, not failure
+
+
+async def test_queue_reports_list_failure(monkeypatch, _mq_enabled):
+    # gh failure surfaces as a non-ok result so a scheduler sees the error.
+    monkeypatch.setattr(greploop_guard, "_merge_queue_candidates", lambda **k: None)
+    out = await greploop_guard.run_merge_queue()
+    assert out["ok"] is False and out["action"] == "list_failed"

--- a/services/zoe-data/tests/test_greploop_guard.py
+++ b/services/zoe-data/tests/test_greploop_guard.py
@@ -2486,3 +2486,20 @@ def test_merge_command_never_admin_or_force():
     assert '"--squash"' in src
     assert "--admin" not in src
     assert "--force" not in src
+
+
+def test_cli_dry_run_requires_queue():
+    # --dry-run reads as a safety net, so it must HARD-ERROR without --queue
+    # (otherwise `--dry-run --merge-when-ready` would do a real merge). The guard
+    # fires before any network/gh, so this subprocess is fast and offline-safe.
+    import subprocess
+    import sys
+
+    cli = Path(__file__).resolve().parents[3] / "scripts" / "maintenance" / "greploop_guard.py"
+    proc = subprocess.run(
+        [sys.executable, str(cli), "--dry-run", "--merge-when-ready", "--pr", "1"],
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode != 0
+    assert "--dry-run only applies to --queue" in (proc.stderr + proc.stdout)


### PR DESCRIPTION
A locally-driven serial merge queue, extending `greploop_guard.py` (not a parallel system). It reproduces the GitHub merge-queue guarantee — *test each PR against the combined state before merging* — but using **ordinary PR commits**, so it does **not** depend on Greptile posting on `merge_group` refs (which we confirmed it does not).

## How it works
One cycle = advance or merge **exactly one** labelled, ready PR:
- ready → squash-merge via the existing safe path (`gh pr merge --squash`).
- ready-but-`BEHIND` → **rebase linearly** onto main + force-push (NOT a merge-update commit, so Greptile re-reviews the fresh head) and stop; a later cycle merges it once green.
- blocked (Greptile/CI/threads) → skip, leave for the repair loop.

## Safety (no surprises)
- **DISABLED by default** — requires `ZOE_MERGE_QUEUE_ENABLED=1` **and** no `merge_queue.disabled` kill file.
- **`--dry-run`** decides but mutates nothing.
- Reuses the existing safe merge (never `--admin`, never force, never bypasses protection).
- Rebases in a **disposable worktree** — the live checkout is never touched.
- At most **one** rebase OR merge per cycle; conflicts abort + report (never auto-resolved).
- DOX **Forbidden** list recorded in `services/zoe-data/AGENTS.md`.

## Tested
- 86/86 `test_greploop_guard.py` pass (76 existing + **10 new**): disabled-by-default, kill-file, merge-ready-head-only, rebase-on-behind, skip-blocked-then-next, dry-run-no-mutation (×2), idle, `_blocked_only_behind` logic, and a guardrail test that the merge path never uses `--admin`/`--force`.
- All three CI validators exit 0.
- No systemd timer is wired here — this ships the capability **disabled**; enabling + scheduling is a separate, explicit step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)