### PR TITLE
feat(voice): complete voice→zoe-core cutover + voice fast-path

### DIFF
--- a/services/zoe-data/brain_dispatch.py
+++ b/services/zoe-data/brain_dispatch.py
@@ -1,0 +1,49 @@
+"""Single source of truth for which brain answers a turn.
+
+zoe-core (Pi on local Gemma) by default; the legacy ``zoe_agent`` brain only when
+``ZOE_USE_CORE_BRAIN`` is explicitly off (the validation-window fallback). Every
+entry point — text chat AND all the voice paths — routes through here so the
+cutover flag controls them consistently. (chat.py keeps its own equivalent
+helpers, which are exercised by the routing tests; this module is what the voice
+paths use to avoid circular imports with chat.py.)
+
+Imports are lazy inside each function to avoid import-time cycles
+(main.py → routers.chat → ... ).
+"""
+from __future__ import annotations
+
+import os
+from typing import Any, AsyncIterator
+
+
+def use_core_brain() -> bool:
+    """True when the brain is zoe-core (default); read lazily so a .env value
+    bootstrapped after import is honored."""
+    return (os.environ.get("ZOE_USE_CORE_BRAIN", "true") or "").strip().lower() not in {
+        "0",
+        "false",
+        "no",
+        "off",
+    }
+
+
+def brain_streaming(message: str, session_id: str, user_id: str = "", **kwargs: Any) -> AsyncIterator[str]:
+    """Streaming brain turn — zoe-core by default, legacy on fallback."""
+    if use_core_brain():
+        from zoe_core_client import run_zoe_core_streaming
+
+        return run_zoe_core_streaming(message, session_id, user_id, **kwargs)
+    from zoe_agent import run_zoe_agent_streaming
+
+    return run_zoe_agent_streaming(message, session_id, user_id, **kwargs)
+
+
+async def brain_oneshot(message: str, session_id: str, user_id: str = "", **kwargs: Any) -> str:
+    """Non-streaming brain turn — zoe-core by default, legacy on fallback."""
+    if use_core_brain():
+        from zoe_core_client import run_zoe_core
+
+        return await run_zoe_core(message, session_id, user_id, **kwargs)
+    from zoe_agent import run_zoe_agent
+
+    return await run_zoe_agent(message, session_id, user_id, **kwargs)

--- a/services/zoe-data/main.py
+++ b/services/zoe-data/main.py
@@ -1782,6 +1782,13 @@ async def _resolve_voice_cards(message_text: str, user_id: str, context: dict | 
         return {"handled": False, "cards": [], "spoken_summary": ""}
 
 
+# Read-only intents the voice WS may answer instantly (no writes → cannot
+# double-execute a skybridge-card action). Kept narrow on purpose.
+_VOICE_INSTANT_INTENTS = frozenset({
+    "calculate", "time_query", "date_query", "greeting", "acknowledgement", "status_check",
+})
+
+
 @app.websocket("/ws/voice/")
 async def websocket_voice(websocket: WebSocket, session_id: str = Query("")):
     """Local voice session WebSocket for voice.html.
@@ -1888,6 +1895,34 @@ async def websocket_voice(websocket: WebSocket, session_id: str = Query("")):
                 continue
             skybridge_context = {}
 
+            # ── Instant intent fast-path ────────────────────────────────────────
+            # Side-effect-free commands the card path doesn't cover (calc, clock,
+            # greeting, acknowledgement, presence check) — answer + speak without
+            # waking the ~2-4s brain. Restricted to READ-ONLY intents so it can
+            # never double-execute a write the skybridge path already handled.
+            try:
+                from intent_router import detect_intent as _fp_detect, execute_intent as _fp_exec
+                _fp_intent = _fp_detect(message_text, log_miss=False, user_id=user_id)
+                if _fp_intent is not None and _fp_intent.name in _VOICE_INSTANT_INTENTS:
+                    _fp_reply = await _fp_exec(_fp_intent, user_id=user_id)
+                    if _fp_reply:
+                        import base64 as _b64fp
+                        from routers.voice_tts import _synthesize_kokoro_sidecar as _fp_tts
+                        await websocket.send_json({"type": "state", "state": "responding"})
+                        await websocket.send_json({"type": "transcript", "role": "zoe", "text": _fp_reply})
+                        _fp_wav = await _fp_tts(_fp_reply)
+                        if _fp_wav:
+                            await websocket.send_json({
+                                "type": "audio",
+                                "audio_base64": _b64fp.b64encode(_fp_wav).decode("ascii"),
+                                "content_type": "audio/wav",
+                            })
+                        await websocket.send_json({"type": "state", "state": "ambient"})
+                        await websocket.send_json({"type": "done"})
+                        continue
+            except Exception as _fp_exc:
+                logger.debug("voice instant fast-path skipped: %s", _fp_exc)
+
             # ── Streaming LLM + per-sentence TTS ────────────────────────────────
             # Track LLM output and TTS output separately so fallback only re-runs
             # what actually failed (avoids double-transcript if LLM works but TTS is down).
@@ -1895,14 +1930,14 @@ async def websocket_voice(websocket: WebSocket, session_id: str = Query("")):
             _stream_tts_ok = False   # True if at least one audio chunk was sent
             try:
                 import base64 as _b64
-                from zoe_agent import run_zoe_agent_streaming  # type: ignore
+                from brain_dispatch import brain_streaming  # zoe-core by default
                 from routers.voice_tts import _extract_complete_sentences, _synthesize_kokoro_sidecar  # type: ignore
 
                 token_buf = ""
                 full_reply: list[str] = []
                 tts_started = False
 
-                async for delta in run_zoe_agent_streaming(
+                async for delta in brain_streaming(
                     message_text, ws_session_id, user_id=user_id, voice_mode=True
                 ):
                     if _ws_cancelled[0]:
@@ -1951,9 +1986,9 @@ async def websocket_voice(websocket: WebSocket, session_id: str = Query("")):
                     # LLM streaming failed entirely → full single-shot fallback
                     try:
                         import base64 as _b64
-                        from zoe_agent import run_zoe_agent  # type: ignore
+                        from brain_dispatch import brain_oneshot  # zoe-core by default
                         from routers.voice_tts import synthesize as _synth  # type: ignore
-                        _fallback_response = await run_zoe_agent(
+                        _fallback_response = await brain_oneshot(
                             message_text, ws_session_id, user_id, voice_mode=True
                         )
                         await websocket.send_json({"type": "state", "state": "responding"})

--- a/services/zoe-data/main.py
+++ b/services/zoe-data/main.py
@@ -1900,28 +1900,38 @@ async def websocket_voice(websocket: WebSocket, session_id: str = Query("")):
             # greeting, acknowledgement, presence check) — answer + speak without
             # waking the ~2-4s brain. Restricted to READ-ONLY intents so it can
             # never double-execute a write the skybridge path already handled.
+            #
+            # Detect+execute is wrapped so a FAILURE THERE (before any send) falls
+            # through to the brain. But once we have a reply and start sending, we
+            # are committed: TTS is best-effort and we never fall through (avoids a
+            # duplicate transcript if the brain path also ran).
+            _fp_reply = None
             try:
                 from intent_router import detect_intent as _fp_detect, execute_intent as _fp_exec
                 _fp_intent = _fp_detect(message_text, log_miss=False, user_id=user_id)
                 if _fp_intent is not None and _fp_intent.name in _VOICE_INSTANT_INTENTS:
                     _fp_reply = await _fp_exec(_fp_intent, user_id=user_id)
-                    if _fp_reply:
-                        import base64 as _b64fp
-                        from routers.voice_tts import _synthesize_kokoro_sidecar as _fp_tts
-                        await websocket.send_json({"type": "state", "state": "responding"})
-                        await websocket.send_json({"type": "transcript", "role": "zoe", "text": _fp_reply})
-                        _fp_wav = await _fp_tts(_fp_reply)
-                        if _fp_wav:
-                            await websocket.send_json({
-                                "type": "audio",
-                                "audio_base64": _b64fp.b64encode(_fp_wav).decode("ascii"),
-                                "content_type": "audio/wav",
-                            })
-                        await websocket.send_json({"type": "state", "state": "ambient"})
-                        await websocket.send_json({"type": "done"})
-                        continue
             except Exception as _fp_exc:
-                logger.debug("voice instant fast-path skipped: %s", _fp_exc)
+                logger.debug("voice instant fast-path detect/execute skipped: %s", _fp_exc)
+                _fp_reply = None
+            if _fp_reply:
+                import base64 as _b64fp
+                await websocket.send_json({"type": "state", "state": "responding"})
+                await websocket.send_json({"type": "transcript", "role": "zoe", "text": _fp_reply})
+                try:
+                    from routers.voice_tts import _synthesize_kokoro_sidecar as _fp_tts
+                    _fp_wav = await _fp_tts(_fp_reply)
+                    if _fp_wav:
+                        await websocket.send_json({
+                            "type": "audio",
+                            "audio_base64": _b64fp.b64encode(_fp_wav).decode("ascii"),
+                            "content_type": "audio/wav",
+                        })
+                except Exception as _fp_tts_exc:
+                    logger.debug("voice fast-path TTS failed (text already sent): %s", _fp_tts_exc)
+                await websocket.send_json({"type": "state", "state": "ambient"})
+                await websocket.send_json({"type": "done"})
+                continue
 
             # ── Streaming LLM + per-sentence TTS ────────────────────────────────
             # Track LLM output and TTS output separately so fallback only re-runs

--- a/services/zoe-data/routers/voice_livekit.py
+++ b/services/zoe-data/routers/voice_livekit.py
@@ -243,8 +243,8 @@ async def _run_pipeline(local_participant, frames: list[bytes], user_id: str, se
     stage_started = time.monotonic()
     _health_update(last_stage="llm")
     try:
-        from zoe_agent import run_zoe_agent
-        response = await run_zoe_agent(transcript, session_id, user_id, voice_mode=True)
+        from brain_dispatch import brain_oneshot
+        response = await brain_oneshot(transcript, session_id, user_id, voice_mode=True)
     except Exception as exc:
         llm_ok = False
         _VOICE_HEALTH["pipeline_failures"] += 1
@@ -303,8 +303,8 @@ async def _run_text_pipeline(local_participant, message: str, user_id: str, sess
     stage_started = time.monotonic()
     _health_update(last_stage="llm", last_error=None)
     try:
-        from zoe_agent import run_zoe_agent
-        response = await run_zoe_agent(message, session_id, user_id, voice_mode=True)
+        from brain_dispatch import brain_oneshot
+        response = await brain_oneshot(message, session_id, user_id, voice_mode=True)
     except Exception as exc:
         llm_ok = False
         _VOICE_HEALTH["pipeline_failures"] += 1
@@ -803,8 +803,8 @@ async def livekit_audio(
         return JSONResponse({"ok": True, "cancelled": True})
 
     try:
-        from zoe_agent import run_zoe_agent
-        response_text = await run_zoe_agent(transcript, sid, user_id, voice_mode=True)
+        from brain_dispatch import brain_oneshot
+        response_text = await brain_oneshot(transcript, sid, user_id, voice_mode=True)
     except Exception as exc:
         logger.error("LiveKit HTTP LLM error: %s", exc)
         response_text = "Sorry, I had trouble processing that."

--- a/services/zoe-data/routers/voice_tts.py
+++ b/services/zoe-data/routers/voice_tts.py
@@ -3700,7 +3700,7 @@ async def voice_command(
         #   * Streaming tokens are accumulated so that Pass 2b can hand the
         #     sentence-buffered stream to Kokoro.create_stream() and bring
         #     first-audio-byte latency down further.
-        from zoe_agent import run_zoe_agent_streaming
+        from brain_dispatch import brain_streaming  # zoe-core by default
 
         voice_timeout = float(os.environ.get("ZOE_VOICE_CHAT_TIMEOUT_S", "20"))
         try:
@@ -3827,7 +3827,7 @@ async def voice_command(
                         logger.debug("voice/command stream processing acknowledgement failed: %s", ack_exc)
 
                     _voice_history = await _load_voice_history(session_id, limit=3)
-                    async for delta in run_zoe_agent_streaming(
+                    async for delta in brain_streaming(
                         text, session_id, user_id=effective_user,
                         voice_mode=True, history=_voice_history or None
                     ):
@@ -3928,7 +3928,7 @@ async def voice_command(
 
         async def _stream_collect() -> None:
             nonlocal _t_first_token
-            async for delta in run_zoe_agent_streaming(
+            async for delta in brain_streaming(
                 text,
                 session_id,
                 user_id=effective_user,

--- a/services/zoe-data/tests/test_brain_dispatch.py
+++ b/services/zoe-data/tests/test_brain_dispatch.py
@@ -51,3 +51,16 @@ async def test_streaming_routes_to_core_by_default(monkeypatch):
     monkeypatch.setenv("ZOE_USE_CORE_BRAIN", "true")
     chunks = [c async for c in bd.brain_streaming("hi", "s", "jason")]
     assert chunks == ["a", "b"]
+
+
+@pytest.mark.asyncio
+async def test_streaming_routes_to_legacy_when_off(monkeypatch):
+    import zoe_agent
+
+    async def fake_legacy_stream(msg, sid, uid="family-admin", **kw):
+        yield f"legacy:{msg}"
+
+    monkeypatch.setattr(zoe_agent, "run_zoe_agent_streaming", fake_legacy_stream)
+    monkeypatch.setenv("ZOE_USE_CORE_BRAIN", "false")
+    chunks = [c async for c in bd.brain_streaming("hi", "s", "jason")]
+    assert chunks == ["legacy:hi"]

--- a/services/zoe-data/tests/test_brain_dispatch.py
+++ b/services/zoe-data/tests/test_brain_dispatch.py
@@ -1,0 +1,53 @@
+"""brain_dispatch routes every entry point (chat + voice) to the right brain."""
+from __future__ import annotations
+
+import pytest
+
+import brain_dispatch as bd
+
+
+def test_use_core_brain_flag(monkeypatch):
+    monkeypatch.delenv("ZOE_USE_CORE_BRAIN", raising=False)
+    assert bd.use_core_brain() is True  # default ON (cutover)
+    monkeypatch.setenv("ZOE_USE_CORE_BRAIN", "false")
+    assert bd.use_core_brain() is False
+    monkeypatch.setenv("ZOE_USE_CORE_BRAIN", "true")
+    assert bd.use_core_brain() is True
+
+
+@pytest.mark.asyncio
+async def test_oneshot_routes_to_core_by_default(monkeypatch):
+    import zoe_core_client
+
+    async def fake_core(msg, sid, uid="", **kw):
+        return f"core:{msg}:{uid}"
+
+    monkeypatch.setattr(zoe_core_client, "run_zoe_core", fake_core)
+    monkeypatch.setenv("ZOE_USE_CORE_BRAIN", "true")
+    assert await bd.brain_oneshot("hi", "s", "jason") == "core:hi:jason"
+
+
+@pytest.mark.asyncio
+async def test_oneshot_routes_to_legacy_when_off(monkeypatch):
+    import zoe_agent
+
+    async def fake_legacy(msg, sid, uid="family-admin", **kw):
+        return f"legacy:{msg}"
+
+    monkeypatch.setattr(zoe_agent, "run_zoe_agent", fake_legacy)
+    monkeypatch.setenv("ZOE_USE_CORE_BRAIN", "false")
+    assert await bd.brain_oneshot("hi", "s", "jason") == "legacy:hi"
+
+
+@pytest.mark.asyncio
+async def test_streaming_routes_to_core_by_default(monkeypatch):
+    import zoe_core_client
+
+    async def fake_stream(msg, sid, uid="", **kw):
+        yield "a"
+        yield "b"
+
+    monkeypatch.setattr(zoe_core_client, "run_zoe_core_streaming", fake_stream)
+    monkeypatch.setenv("ZOE_USE_CORE_BRAIN", "true")
+    chunks = [c async for c in bd.brain_streaming("hi", "s", "jason")]
+    assert chunks == ["a", "b"]

--- a/services/zoe-data/tests/test_skybridge_static.py
+++ b/services/zoe-data/tests/test_skybridge_static.py
@@ -192,7 +192,7 @@ def test_livekit_voice_router_accepts_text_commands():
 
     assert "async def _run_text_pipeline" in router
     assert "elif msg_type == \"text\"" in router
-    assert "run_zoe_agent(message, session_id, user_id, voice_mode=True)" in router
+    assert "brain_oneshot(message, session_id, user_id, voice_mode=True)" in router
 
 
 def test_skybridge_renderer_keeps_button_actions_functional():
@@ -267,7 +267,8 @@ def test_skybridge_auth_and_voice_bus_contracts_are_wired():
     assert '"type": "cards", "result": skybridge_result' in main
     assert '"type": "skybridge_context", "context": skybridge_context' in main
     assert '"type": "transcript", "role": "assistant", "text": spoken_summary' in main
-    assert 'skybridge_context = {}\n\n            # ── Streaming LLM' in main
+    assert 'skybridge_context = {}\n\n            # ── Instant intent fast-path' in main
+    assert "# ── Streaming LLM + per-sentence TTS" in main
 
 
 def test_skybridge_touch_executor_card_shell_spans_panel_grid():

--- a/services/zoe-data/tests/test_voice_fastpath.py
+++ b/services/zoe-data/tests/test_voice_fastpath.py
@@ -1,0 +1,122 @@
+"""Voice WS instant fast-path: listed read-only intents answer + speak without
+waking the brain; unlisted utterances fall through to the brain; and a fast-path
+TTS failure (after the transcript is sent) must NOT fall through (no duplicate
+transcript / double brain run).
+
+Drives main.websocket_voice with a fake WebSocket so the full app lifespan never
+runs (matches the existing voice tests' approach).
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+from starlette.websockets import WebSocketDisconnect
+
+import main
+import brain_dispatch
+import routers.voice_tts as voice_tts
+
+
+class _FakeWS:
+    def __init__(self, inbound):
+        self._inbound = list(inbound)
+        self.sent: list[dict] = []
+
+    async def accept(self):
+        return None
+
+    async def send_json(self, obj):
+        self.sent.append(obj)
+
+    async def receive(self):
+        if self._inbound:
+            return self._inbound.pop(0)
+        raise WebSocketDisconnect()
+
+    def types(self):
+        return [m.get("type") for m in self.sent]
+
+    def transcripts(self):
+        return [m for m in self.sent if m.get("type") == "transcript"]
+
+
+@pytest.fixture
+def voice_env(monkeypatch):
+    async def _user(_sid):
+        return "family-admin"
+
+    async def _cards(_msg, _uid, context=None):
+        return {"handled": False, "cards": [], "spoken_summary": ""}
+
+    async def _tts_ok(_text):
+        return b"WAVDATA"
+
+    monkeypatch.setattr(main, "_resolve_ws_user", _user)
+    monkeypatch.setattr(main, "_resolve_voice_cards", _cards)
+    monkeypatch.setattr(voice_tts, "_synthesize_kokoro_sidecar", _tts_ok)
+    monkeypatch.setenv("ZOE_USE_CORE_BRAIN", "true")
+    return monkeypatch
+
+
+@pytest.mark.asyncio
+async def test_listed_intent_bypasses_brain(voice_env):
+    called = {"brain": False}
+
+    async def _brain(*_a, **_k):
+        called["brain"] = True
+        if False:
+            yield ""  # pragma: no cover — make it an async generator
+
+    voice_env.setattr(brain_dispatch, "brain_streaming", _brain)
+
+    ws = _FakeWS([{"text": json.dumps({"type": "text", "message": "what time is it"})}])
+    await main.websocket_voice(ws, session_id="t1")
+
+    assert called["brain"] is False, "instant intent must NOT wake the brain"
+    tr = ws.transcripts()
+    assert len(tr) == 1, f"exactly one transcript expected, got {ws.types()}"
+    assert "done" in ws.types()
+
+
+@pytest.mark.asyncio
+async def test_unlisted_utterance_falls_through_to_brain(voice_env):
+    called = {"brain": False}
+
+    async def _brain(*_a, **_k):
+        called["brain"] = True
+        yield "Once upon a time."
+
+    voice_env.setattr(brain_dispatch, "brain_streaming", _brain)
+    # brain path synthesizes per sentence; keep it simple/fast
+    voice_env.setattr(voice_tts, "_extract_complete_sentences", lambda buf: ([buf], "") if buf.strip() else ([], buf))
+
+    ws = _FakeWS([{"text": json.dumps({"type": "text", "message": "tell me a story about dragons"})}])
+    await main.websocket_voice(ws, session_id="t2")
+
+    assert called["brain"] is True, "unlisted utterance must reach the brain"
+
+
+@pytest.mark.asyncio
+async def test_fastpath_tts_failure_does_not_fall_through(voice_env):
+    """If TTS raises AFTER the transcript is sent, we must still finish on the
+    fast-path (one transcript + done) and never run the brain (no duplicate)."""
+    called = {"brain": False}
+
+    async def _brain(*_a, **_k):
+        called["brain"] = True
+        if False:
+            yield ""
+
+    async def _tts_boom(_text):
+        raise RuntimeError("kokoro down")
+
+    voice_env.setattr(brain_dispatch, "brain_streaming", _brain)
+    voice_env.setattr(voice_tts, "_synthesize_kokoro_sidecar", _tts_boom)
+
+    ws = _FakeWS([{"text": json.dumps({"type": "text", "message": "what time is it"})}])
+    await main.websocket_voice(ws, session_id="t3")
+
+    assert called["brain"] is False, "must not fall through to brain after committing"
+    assert len(ws.transcripts()) == 1, f"exactly one transcript (no duplicate), got {ws.types()}"
+    assert "done" in ws.types()

--- a/services/zoe-data/tests/test_voice_livekit_health.py
+++ b/services/zoe-data/tests/test_voice_livekit_health.py
@@ -119,6 +119,9 @@ async def test_pipeline_emits_processing_ack_before_slow_response(monkeypatch):
 
     monkeypatch.setattr(voice_tts, "_transcribe_audio", _fake_transcribe)
     monkeypatch.setattr(voice_tts, "synthesize", _fake_synthesize)
+    # Pipeline behaviour is brain-agnostic; pin the legacy brain so the dispatch
+    # routes to the mocked zoe_agent (default is now zoe-core).
+    monkeypatch.setenv("ZOE_USE_CORE_BRAIN", "false")
     monkeypatch.setitem(sys.modules, "zoe_agent", types.SimpleNamespace(run_zoe_agent=_fake_agent))
     monkeypatch.setenv("ZOE_PROCESSING_ACK_PHRASE", "Let me check.")
     local = _LocalParticipant()

--- a/services/zoe-data/tests/test_voice_weather_queue.py
+++ b/services/zoe-data/tests/test_voice_weather_queue.py
@@ -850,6 +850,9 @@ async def test_voice_command_stream_emits_processing_ack_before_slow_response(mo
         "skybridge_service",
         types.SimpleNamespace(resolve_skybridge_request=resolve_skybridge_request),
     )
+    # Pipeline behaviour is brain-agnostic; pin the legacy brain so the dispatch
+    # routes to the mocked zoe_agent (default is now zoe-core).
+    monkeypatch.setenv("ZOE_USE_CORE_BRAIN", "false")
     monkeypatch.setitem(sys.modules, "zoe_agent", types.SimpleNamespace(run_zoe_agent_streaming=run_zoe_agent_streaming))
     monkeypatch.setattr(skybridge_service, "resolve_skybridge_request", resolve_skybridge_request)
 


### PR DESCRIPTION
Completes the cutover the text path got in #702. **Every voice path still called the legacy `zoe_agent` brain** (the cutover only touched chat.py's 3 text call sites). This routes them all to zoe-core and adds the missing instant fast-path.

- **brain_dispatch.py** — single source of truth: `brain_streaming`/`brain_oneshot`, zoe-core by default (`ZOE_USE_CORE_BRAIN`), legacy fallback. Lazy imports avoid cycles.
- Routed to it: `main.py` voice WS (stream + single-shot fallback), `voice_livekit.py` (3 sites), `voice_tts.py` (2 sites).
- **Voice fast-path** in the touch-screen WS: side-effect-free intents (calc/time/date/greeting/ack/status) the skybridge card path doesn't cover now answer + speak instantly instead of waking the ~2-4s brain. Restricted to READ-ONLY intents — cannot double-execute a card write.

**Tests:** 306 voice/chat/intent pass (incl. brain_dispatch routing; updated 4 tests that mocked the legacy module or asserted the old call). Pairs with the separate `ZOE_WHISPER_WARMUP=true` fix (already live) that removed the 9.5s STT cold-load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)