### PR TITLE
feat(voice): on-demand whisper-warm endpoint (safe, decoupled from startup)

### DIFF
--- a/services/zoe-data/routers/system.py
+++ b/services/zoe-data/routers/system.py
@@ -2485,9 +2485,15 @@ async def whisper_warm(_: None = Depends(require_internal_token)):
     # system-side helpers; importing at module load would risk an import cycle.
     from routers.voice_tts import (
         _create_warmup_wav_path,
+        _reset_faster_whisper_worker,
         _run_faster_whisper_worker,
         _write_warmup_silence_wav,
     )
+
+    try:
+        timeout_s = float(os.environ.get("ZOE_WHISPER_WARMUP_TIMEOUT_S", "45"))
+    except (TypeError, ValueError):
+        timeout_s = 45.0
 
     wav_path = ""
     started = time.monotonic()
@@ -2495,10 +2501,19 @@ async def whisper_warm(_: None = Depends(require_internal_token)):
         # Offload sync file I/O to a worker thread so the event loop never blocks.
         wav_path = await asyncio.to_thread(_create_warmup_wav_path)
         await asyncio.to_thread(_write_warmup_silence_wav, wav_path)
-        await _run_faster_whisper_worker(wav_path)
+        # Bound the worker call: a hung/deadlocked subprocess must not hang the
+        # request (the 30s keepwarm timer would otherwise pile up coroutines).
+        await asyncio.wait_for(_run_faster_whisper_worker(wav_path), timeout=timeout_s)
         latency_ms = int((time.monotonic() - started) * 1000)
         return {"ok": True, "warmed": True, "latency_ms": latency_ms}
     except Exception as exc:
+        # Reset the persistent worker so a broken/hung one is torn down and the
+        # NEXT warm starts fresh — otherwise every subsequent ping reuses the
+        # broken worker and the model never recovers without a service restart.
+        try:
+            await _reset_faster_whisper_worker()
+        except Exception:  # noqa: BLE001 - best-effort teardown
+            logger.warning("whisper-warm: worker reset after failure also failed", exc_info=True)
         logger.warning("whisper-warm failed: %s", exc)
         return {"ok": False, "warmed": False, "error": exc.__class__.__name__}
     finally:

--- a/services/zoe-data/routers/system.py
+++ b/services/zoe-data/routers/system.py
@@ -4,6 +4,7 @@ import json
 import logging
 import os
 import re
+import time
 from typing import Any, Literal, Optional
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
@@ -2458,3 +2459,51 @@ async def delegate_sync(body: _DelegateSyncBody, _: None = Depends(require_inter
         logger.warning("delegate-sync failed target=%s: %s", target, exc)
         raise HTTPException(status_code=502, detail="delegation failed") from exc
     return {"target": target, "ok": bool(result), "result": result or ""}
+
+
+# ─── On-demand STT warm (keep faster-whisper hot via an external timer) ───────
+
+# Startup warmup (ZOE_WHISPER_WARMUP) destabilized the service — it could block
+# the :8000 bind and crash-loop. So warming is triggered post-startup instead:
+# an external timer POSTs here to load (and keep loaded) the persistent
+# faster-whisper worker by running one tiny silent transcription through it.
+
+
+@router.post("/whisper-warm")
+async def whisper_warm(_: None = Depends(require_internal_token)):
+    """Warm (and keep warm) the persistent faster-whisper STT worker on demand.
+
+    Internal/service endpoint (loopback or X-Internal-Token) — meant to be hit
+    by an external timer so STT stays hot without any warmup work during app
+    startup. Runs one tiny silent transcription through the persistent worker,
+    which loads the model in the worker subprocess if cold, else reuses it.
+
+    Best-effort: a warm failure is logged and returned as ``ok: false`` with
+    HTTP 200 — it must never 500 or raise.
+    """
+    # Lazy import: voice_tts pulls in heavy STT/TTS deps and imports back from
+    # system-side helpers; importing at module load would risk an import cycle.
+    from routers.voice_tts import (
+        _create_warmup_wav_path,
+        _run_faster_whisper_worker,
+        _write_warmup_silence_wav,
+    )
+
+    wav_path = ""
+    started = time.monotonic()
+    try:
+        # Offload sync file I/O to a worker thread so the event loop never blocks.
+        wav_path = await asyncio.to_thread(_create_warmup_wav_path)
+        await asyncio.to_thread(_write_warmup_silence_wav, wav_path)
+        await _run_faster_whisper_worker(wav_path)
+        latency_ms = int((time.monotonic() - started) * 1000)
+        return {"ok": True, "warmed": True, "latency_ms": latency_ms}
+    except Exception as exc:
+        logger.warning("whisper-warm failed: %s", exc)
+        return {"ok": False, "warmed": False, "error": exc.__class__.__name__}
+    finally:
+        if wav_path:
+            try:
+                os.unlink(wav_path)
+            except OSError:
+                pass

--- a/services/zoe-data/tests/test_whisper_warm.py
+++ b/services/zoe-data/tests/test_whisper_warm.py
@@ -1,0 +1,83 @@
+"""Tests for /api/system/whisper-warm (on-demand persistent faster-whisper warm).
+
+Startup warmup (ZOE_WHISPER_WARMUP) destabilized the service, so warming is
+triggered post-startup via this internal endpoint instead. A warm failure must
+be best-effort (ok:false, HTTP 200) and never 500.
+"""
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import auth
+from routers.system import router as system_router
+
+
+def _app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(system_router)
+    return app
+
+
+def _patch_voice_helpers(monkeypatch, *, worker):
+    """Stub the voice_tts helpers so no real model/GPU/disk work happens."""
+    import routers.voice_tts as voice_tts
+
+    def fake_create_path():
+        return "/tmp/whisper-warm-test.wav"
+
+    def fake_write_silence(path, **kwargs):
+        return None
+
+    monkeypatch.setattr(voice_tts, "_create_warmup_wav_path", fake_create_path)
+    monkeypatch.setattr(voice_tts, "_write_warmup_silence_wav", fake_write_silence)
+    monkeypatch.setattr(voice_tts, "_run_faster_whisper_worker", worker)
+
+
+def test_requires_internal_token(monkeypatch):
+    monkeypatch.setattr(auth, "_ZOE_INTERNAL_TOKEN", "tok")
+    resp = TestClient(_app()).post("/api/system/whisper-warm")
+    assert resp.status_code == 403
+
+
+def test_happy_path_returns_warmed(monkeypatch):
+    monkeypatch.setattr(auth, "_ZOE_INTERNAL_TOKEN", "tok")
+    captured = {}
+
+    async def fake_worker(wav_path):
+        captured["wav_path"] = wav_path
+        return ""  # silent transcription -> empty text
+
+    _patch_voice_helpers(monkeypatch, worker=fake_worker)
+
+    resp = TestClient(_app()).post(
+        "/api/system/whisper-warm",
+        headers={"X-Internal-Token": "tok"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is True
+    assert body["warmed"] is True
+    assert isinstance(body["latency_ms"], int)
+    assert body["latency_ms"] >= 0
+    assert captured["wav_path"] == "/tmp/whisper-warm-test.wav"
+
+
+def test_worker_failure_returns_ok_false_not_500(monkeypatch):
+    """A warm failure is best-effort: ok:false with HTTP 200, never a 500."""
+    monkeypatch.setattr(auth, "_ZOE_INTERNAL_TOKEN", "tok")
+
+    async def boom(wav_path):
+        raise RuntimeError("worker subprocess died")
+
+    _patch_voice_helpers(monkeypatch, worker=boom)
+
+    resp = TestClient(_app()).post(
+        "/api/system/whisper-warm",
+        headers={"X-Internal-Token": "tok"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is False
+    assert body["warmed"] is False
+    assert body["error"] == "RuntimeError"

--- a/services/zoe-data/tests/test_whisper_warm.py
+++ b/services/zoe-data/tests/test_whisper_warm.py
@@ -20,7 +20,8 @@ def _app() -> FastAPI:
 
 
 def _patch_voice_helpers(monkeypatch, *, worker):
-    """Stub the voice_tts helpers so no real model/GPU/disk work happens."""
+    """Stub the voice_tts helpers so no real model/GPU/disk work happens.
+    Returns a list that records _reset_faster_whisper_worker calls."""
     import routers.voice_tts as voice_tts
 
     def fake_create_path():
@@ -29,9 +30,16 @@ def _patch_voice_helpers(monkeypatch, *, worker):
     def fake_write_silence(path, **kwargs):
         return None
 
+    reset_calls: list[int] = []
+
+    async def fake_reset():
+        reset_calls.append(1)
+
     monkeypatch.setattr(voice_tts, "_create_warmup_wav_path", fake_create_path)
     monkeypatch.setattr(voice_tts, "_write_warmup_silence_wav", fake_write_silence)
     monkeypatch.setattr(voice_tts, "_run_faster_whisper_worker", worker)
+    monkeypatch.setattr(voice_tts, "_reset_faster_whisper_worker", fake_reset)
+    return reset_calls
 
 
 def test_requires_internal_token(monkeypatch):
@@ -70,7 +78,7 @@ def test_worker_failure_returns_ok_false_not_500(monkeypatch):
     async def boom(wav_path):
         raise RuntimeError("worker subprocess died")
 
-    _patch_voice_helpers(monkeypatch, worker=boom)
+    reset_calls = _patch_voice_helpers(monkeypatch, worker=boom)
 
     resp = TestClient(_app()).post(
         "/api/system/whisper-warm",
@@ -81,3 +89,28 @@ def test_worker_failure_returns_ok_false_not_500(monkeypatch):
     assert body["ok"] is False
     assert body["warmed"] is False
     assert body["error"] == "RuntimeError"
+    # The broken worker must be torn down so the next ping starts fresh.
+    assert reset_calls == [1], "failed warm must reset the persistent worker"
+
+
+def test_hung_worker_times_out_and_resets(monkeypatch):
+    """A hung worker is bounded by the timeout (not hung forever) and reset."""
+    import asyncio as _aio
+
+    monkeypatch.setattr(auth, "_ZOE_INTERNAL_TOKEN", "tok")
+    monkeypatch.setenv("ZOE_WHISPER_WARMUP_TIMEOUT_S", "0.2")
+
+    async def hang(wav_path):
+        await _aio.sleep(10)
+
+    reset_calls = _patch_voice_helpers(monkeypatch, worker=hang)
+
+    resp = TestClient(_app()).post(
+        "/api/system/whisper-warm",
+        headers={"X-Internal-Token": "tok"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is False
+    assert body["error"] in ("TimeoutError", "CancelledError")
+    assert reset_calls == [1], "timed-out warm must reset the worker"


### PR DESCRIPTION
Safe replacement for the startup STT warmup that destabilized the :8000 bind (crash-loop). Adds `POST /api/system/whisper-warm` (internal-token/loopback) that warms the persistent faster-whisper worker on demand — meant to be pinged by an external systemd timer *after* the service is healthy, so **no whisper work runs during startup**. Best-effort (warm failure → ok:false, HTTP 200, never 500); sync I/O via `asyncio.to_thread`; helpers lazy-imported. Does NOT re-enable `ZOE_WHISPER_WARMUP`. 3 tests pass.

Pairs with a `--user` systemd timer (`zoe-whisper-keepwarm`, every 30s) that pings this endpoint only when `/health` is 200 — keeps STT hot and re-warms within ~30s of any restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)