### PR TITLE
feat(voice): on-demand LiveKit — start on /livekit-token, reap when idle

### DIFF
--- a/services/zoe-data/routers/voice_livekit.py
+++ b/services/zoe-data/routers/voice_livekit.py
@@ -279,7 +279,17 @@ def _record_voice_connected() -> None:
 
 
 def get_voice_health() -> dict:
-    return copy.deepcopy(_VOICE_HEALTH)
+    health = copy.deepcopy(_VOICE_HEALTH)
+    idle_age = (time.monotonic() - _last_activity) if _last_activity else None
+    health["ondemand"] = {
+        "enabled": _ondemand_enabled(),
+        "idle_timeout_s": _idle_timeout_s(),
+        "idle_age_s": round(idle_age, 1) if idle_age is not None else None,
+        "active_participants": sorted(_active_participant_sids),
+        "agent_task_running": _agent_task is not None and not _agent_task.done(),
+        "idle_monitor_running": _idle_task is not None and not _idle_task.done(),
+    }
+    return health
 
 
 def reset_voice_health_for_tests() -> None:
@@ -651,7 +661,10 @@ def _build_room_handlers(room, participant_state: dict, audio_tasks: dict) -> No
     def on_participant_connected(participant) -> None:
         logger.info("LiveKit: participant joined %s (%s)", participant.identity, participant.sid[:8])
         participant_state[participant.sid] = _make_participant_state(participant.sid)
-        _active_participant_sids.add(participant.sid)
+        # Only real (non-agent) participants hold the idle reaper open.  The
+        # agent's own identity must never count, or the container never reaps.
+        if getattr(participant, "identity", None) != _AGENT_IDENTITY:
+            _active_participant_sids.add(participant.sid)
         note_voice_activity()
 
     @room.on("participant_disconnected")

--- a/services/zoe-data/routers/voice_livekit.py
+++ b/services/zoe-data/routers/voice_livekit.py
@@ -204,7 +204,7 @@ async def ensure_livekit_started(wait_ready: float = 8.0) -> bool:
 
 async def stop_livekit_ondemand(reason: str = "idle") -> None:
     """Cancel the agent loop and stop the LiveKit container."""
-    global _agent_task
+    global _agent_task, _idle_task
     async with _get_lifecycle_lock():
         task = _agent_task
         _agent_task = None
@@ -216,6 +216,14 @@ async def stop_livekit_ondemand(reason: str = "idle") -> None:
                 pass
             except Exception:
                 pass
+        # Tear the idle monitor down too, so a later ensure_livekit_started()
+        # recreates it. Skip when we're being called *from* the monitor itself
+        # (the normal _reap_if_idle path) — that task returns naturally and must
+        # not cancel itself mid-await.
+        idle = _idle_task
+        if idle is not None and idle is not asyncio.current_task() and not idle.done():
+            idle.cancel()
+            _idle_task = None
         _active_participant_sids.clear()
         logger.info("LiveKit on-demand: stopping container '%s' (reason=%s)", _CONTAINER_NAME, reason)
         await _docker_cmd("stop", _CONTAINER_NAME, timeout=30)

--- a/services/zoe-data/routers/voice_livekit.py
+++ b/services/zoe-data/routers/voice_livekit.py
@@ -242,6 +242,13 @@ async def _reap_if_idle() -> bool:
     if _active_participant_sids or idle_for < _idle_timeout_s():
         return False
     if await _container_running():
+        # Re-check after the await: _container_running() yields to the event loop,
+        # and a /livekit-token request could have started the container + bumped
+        # activity (or a participant could have connected) in that window. Don't
+        # reap a now-active room.
+        idle_for = time.monotonic() - _last_activity
+        if _active_participant_sids or idle_for < _idle_timeout_s():
+            return False
         logger.info(
             "LiveKit on-demand: idle %.0fs (no participants) → stopping", idle_for
         )

--- a/services/zoe-data/routers/voice_livekit.py
+++ b/services/zoe-data/routers/voice_livekit.py
@@ -86,6 +86,177 @@ _VOICE_HEALTH: dict = {
 _INITIAL_VOICE_HEALTH = copy.deepcopy(_VOICE_HEALTH)
 _agent_running = False
 
+# ── On-demand lifecycle ───────────────────────────────────────────────────────
+# When ZOE_LIVEKIT_ONDEMAND=true (default) the LiveKit container is left stopped
+# at boot and started on the first /livekit-token request, then stopped again
+# after ZOE_LIVEKIT_IDLE_TIMEOUT_S of no participants.  This keeps the ~560MB
+# WebRTC server out of memory except while a voice page is actually in use.
+_CONTAINER_NAME = os.environ.get("ZOE_LIVEKIT_CONTAINER", "livekit").strip() or "livekit"
+_agent_task: Optional["asyncio.Task"] = None
+_idle_task: Optional["asyncio.Task"] = None
+_lifecycle_lock: Optional["asyncio.Lock"] = None
+_last_activity: float = 0.0
+_active_participant_sids: set = set()
+
+
+def _ondemand_enabled() -> bool:
+    return os.environ.get("ZOE_LIVEKIT_ONDEMAND", "true").strip().lower() == "true"
+
+
+def _idle_timeout_s() -> float:
+    try:
+        return float(os.environ.get("ZOE_LIVEKIT_IDLE_TIMEOUT_S", "300"))
+    except (TypeError, ValueError):
+        return 300.0
+
+
+def _get_lifecycle_lock() -> "asyncio.Lock":
+    global _lifecycle_lock
+    if _lifecycle_lock is None:
+        _lifecycle_lock = asyncio.Lock()
+    return _lifecycle_lock
+
+
+def note_voice_activity() -> None:
+    """Mark that voice is in use, so the idle reaper holds off."""
+    global _last_activity
+    _last_activity = time.monotonic()
+
+
+async def _docker_cmd(*args: str, timeout: float = 20.0) -> tuple:
+    """Run `docker <args>` off the event loop; returns (returncode, combined_output)."""
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "docker", *args,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+        )
+    except Exception as exc:  # docker not on PATH, etc.
+        return 127, str(exc)
+    try:
+        out, _ = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+    except asyncio.TimeoutError:
+        try:
+            proc.kill()
+        except Exception:
+            pass
+        return 124, "timeout"
+    return proc.returncode or 0, (out or b"").decode(errors="replace").strip()
+
+
+async def _container_running() -> bool:
+    rc, out = await _docker_cmd("inspect", "-f", "{{.State.Running}}", _CONTAINER_NAME, timeout=10)
+    return rc == 0 and out.strip() == "true"
+
+
+async def _wait_port(host: str, port: int, timeout: float) -> bool:
+    """Poll a TCP port until it accepts connections or the timeout elapses."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            _, writer = await asyncio.wait_for(
+                asyncio.open_connection(host, port), timeout=1.0
+            )
+            writer.close()
+            try:
+                await writer.wait_closed()
+            except Exception:
+                pass
+            return True
+        except Exception:
+            await asyncio.sleep(0.25)
+    return False
+
+
+async def ensure_livekit_started(wait_ready: float = 8.0) -> bool:
+    """Start the LiveKit container + agent on demand. Returns True if :7880 is reachable.
+
+    Idempotent and safe to call on every /livekit-token request.  No-op (just a
+    reachability probe) when on-demand mode is disabled — boot already started the
+    always-on agent in that case.
+    """
+    note_voice_activity()
+    if not os.environ.get("LIVEKIT_API_KEY", "").strip():
+        return False
+    if not _ondemand_enabled():
+        return await _wait_port("127.0.0.1", 7880, 1.0)
+
+    global _agent_task, _idle_task
+    async with _get_lifecycle_lock():
+        if not await _container_running():
+            logger.info("LiveKit on-demand: starting container '%s'", _CONTAINER_NAME)
+            rc, out = await _docker_cmd("start", _CONTAINER_NAME, timeout=20)
+            if rc != 0:
+                logger.warning(
+                    "LiveKit on-demand: docker start '%s' failed rc=%s out=%s",
+                    _CONTAINER_NAME, rc, out,
+                )
+                return False
+        if _agent_task is None or _agent_task.done():
+            _agent_task = asyncio.create_task(_agent_loop(), name="livekit_agent")
+            logger.info("LiveKit on-demand: agent task started")
+        if _idle_task is None or _idle_task.done():
+            _idle_task = asyncio.create_task(_idle_monitor(), name="livekit_idle_monitor")
+    ready = await _wait_port("127.0.0.1", 7880, wait_ready)
+    note_voice_activity()
+    return ready
+
+
+async def stop_livekit_ondemand(reason: str = "idle") -> None:
+    """Cancel the agent loop and stop the LiveKit container."""
+    global _agent_task
+    async with _get_lifecycle_lock():
+        task = _agent_task
+        _agent_task = None
+        if task is not None and not task.done():
+            task.cancel()
+            try:
+                await asyncio.wait_for(task, timeout=8.0)
+            except (asyncio.CancelledError, asyncio.TimeoutError):
+                pass
+            except Exception:
+                pass
+        _active_participant_sids.clear()
+        logger.info("LiveKit on-demand: stopping container '%s' (reason=%s)", _CONTAINER_NAME, reason)
+        await _docker_cmd("stop", _CONTAINER_NAME, timeout=30)
+        _health_update(status="stopped", connected=False)
+
+
+_IDLE_CHECK_INTERVAL_S = 30.0
+
+
+async def _reap_if_idle() -> bool:
+    """One idle-check tick.  Returns True when the monitor should stop looping
+    (either it reaped the container or the container is already gone)."""
+    if not _ondemand_enabled():
+        return False
+    idle_for = time.monotonic() - _last_activity
+    if _active_participant_sids or idle_for < _idle_timeout_s():
+        return False
+    if await _container_running():
+        logger.info(
+            "LiveKit on-demand: idle %.0fs (no participants) → stopping", idle_for
+        )
+        await stop_livekit_ondemand(reason="idle")
+    return True
+
+
+async def _idle_monitor() -> None:
+    """Reap the LiveKit container after ZOE_LIVEKIT_IDLE_TIMEOUT_S of no participants.
+
+    Runs only while a container is up; exits after stopping it (ensure_livekit_started
+    restarts the monitor on the next request).
+    """
+    while True:
+        try:
+            await asyncio.sleep(_IDLE_CHECK_INTERVAL_S)
+            if await _reap_if_idle():
+                return
+        except asyncio.CancelledError:
+            break
+        except Exception as exc:
+            logger.debug("LiveKit idle monitor error (non-fatal): %s", exc)
+
 
 def _utc_now() -> str:
     return datetime.now(timezone.utc).isoformat()
@@ -480,10 +651,14 @@ def _build_room_handlers(room, participant_state: dict, audio_tasks: dict) -> No
     def on_participant_connected(participant) -> None:
         logger.info("LiveKit: participant joined %s (%s)", participant.identity, participant.sid[:8])
         participant_state[participant.sid] = _make_participant_state(participant.sid)
+        _active_participant_sids.add(participant.sid)
+        note_voice_activity()
 
     @room.on("participant_disconnected")
     def on_participant_disconnected(participant) -> None:
         logger.info("LiveKit: participant left %s", participant.identity)
+        _active_participant_sids.discard(participant.sid)
+        note_voice_activity()
         participant_state.pop(participant.sid, None)
         task = audio_tasks.pop(participant.sid, None)
         if task and not task.done():
@@ -692,6 +867,9 @@ async def _agent_loop() -> None:
                     connected=False,
                     last_disconnected_at=_utc_now(),
                 )
+                # Room torn down → drop stale participant tracking so the idle
+                # reaper isn't held open by sids that can no longer disconnect.
+                _active_participant_sids.clear()
             for task in list(audio_tasks.values()):
                 if not task.done():
                     task.cancel()
@@ -713,6 +891,15 @@ async def start_livekit_agent() -> None:
     if not api_key:
         _health_update(status="disabled", connected=False, last_error="LIVEKIT_API_KEY not set")
         logger.info("LIVEKIT_API_KEY not set — LiveKit agent not started")
+        return
+    if _ondemand_enabled():
+        # On-demand mode: leave the container stopped; ensure_livekit_started()
+        # spins it up (and the agent loop) on the first /livekit-token request.
+        note_voice_activity()
+        _health_update(status="stopped", connected=False, last_error=None)
+        logger.info(
+            "LiveKit on-demand mode: agent will start on first /livekit-token request"
+        )
         return
     if _agent_running:
         logger.warning("LiveKit voice agent already running; duplicate start ignored")

--- a/services/zoe-data/routers/voice_livekit.py
+++ b/services/zoe-data/routers/voice_livekit.py
@@ -908,8 +908,13 @@ async def start_livekit_agent() -> None:
     if _ondemand_enabled():
         # On-demand mode: leave the container stopped; ensure_livekit_started()
         # spins it up (and the agent loop) on the first /livekit-token request.
+        # Start the idle monitor now so a container left running across a service
+        # restart (orphaned, with no agent/monitor) still gets reaped.
+        global _idle_task
         note_voice_activity()
         _health_update(status="stopped", connected=False, last_error=None)
+        if _idle_task is None or _idle_task.done():
+            _idle_task = asyncio.create_task(_idle_monitor(), name="livekit_idle_monitor")
         logger.info(
             "LiveKit on-demand mode: agent will start on first /livekit-token request"
         )

--- a/services/zoe-data/routers/voice_tts.py
+++ b/services/zoe-data/routers/voice_tts.py
@@ -4702,6 +4702,17 @@ async def get_livekit_token(request: Request, user: dict = Depends(get_current_u
     if not api_key or not api_secret:
         raise HTTPException(status_code=503, detail="LiveKit credentials not configured")
 
+    # On-demand: spin up the LiveKit container + agent before handing back a token,
+    # so the browser's WebRTC connect succeeds.  Best-effort and bounded — never
+    # blocks token issuance if the container is slow or docker is unavailable.
+    livekit_ready: bool = True
+    try:
+        from routers.voice_livekit import ensure_livekit_started, _ondemand_enabled
+        if _ondemand_enabled():
+            livekit_ready = await ensure_livekit_started()
+    except Exception as _lk_exc:  # pragma: no cover - defensive
+        logger.warning("livekit on-demand start failed (non-fatal): %s", _lk_exc)
+
     # Derive the LiveKit URL from the browser's request host.
     # nginx passes the original Host header and X-Forwarded-Proto so we can reconstruct
     # the correct ws(s)://<browser-host>/livekit/ URL.  This works for LAN IPs, the
@@ -4759,7 +4770,7 @@ async def get_livekit_token(request: Request, user: dict = Depends(get_current_u
         except Exception:
             return False
     livekit_lan_only = not bool(os.environ.get("LIVEKIT_TURN_URL", ""))
-    livekit_available = (not livekit_lan_only) or _is_private(_cf_ip)
+    livekit_available = ((not livekit_lan_only) or _is_private(_cf_ip)) and livekit_ready
 
     logger.debug("livekit-token: user=%s url=%s origin=%s lan_ip=%s lk_avail=%s",
                  user_id, livekit_url, origin, _cf_ip, livekit_available)

--- a/services/zoe-data/tests/test_voice_livekit_ondemand.py
+++ b/services/zoe-data/tests/test_voice_livekit_ondemand.py
@@ -17,18 +17,22 @@ def _reset_lifecycle(monkeypatch):
     # Always have credentials so the start path isn't short-circuited.
     monkeypatch.setenv("LIVEKIT_API_KEY", "test-key")
     monkeypatch.setenv("LIVEKIT_API_SECRET", "test-secret")
-    voice_livekit._agent_task = None
-    voice_livekit._idle_task = None
-    voice_livekit._lifecycle_lock = None
-    voice_livekit._active_participant_sids.clear()
-    voice_livekit._last_activity = 0.0
+    # monkeypatch.setattr restores the original bindings on teardown even if a
+    # test raises before the cleanup below — no stale global leaks into the next
+    # test. Use a fresh set so in-test mutations are discarded with it.
+    monkeypatch.setattr(voice_livekit, "_agent_task", None)
+    monkeypatch.setattr(voice_livekit, "_idle_task", None)
+    monkeypatch.setattr(voice_livekit, "_lifecycle_lock", None)
+    monkeypatch.setattr(voice_livekit, "_active_participant_sids", set())
+    monkeypatch.setattr(voice_livekit, "_last_activity", 0.0)
     voice_livekit.reset_voice_health_for_tests()
     yield
+    # Tasks created during the test must still be cancelled — monkeypatch
+    # restores the binding, not any task object the test spawned into it.
     for handle in (voice_livekit._agent_task, voice_livekit._idle_task):
         if handle is not None and not handle.done():
             handle.cancel()
-    voice_livekit._agent_task = None
-    voice_livekit._idle_task = None
+    voice_livekit.reset_voice_health_for_tests()
 
 
 async def _never_ending():
@@ -122,8 +126,7 @@ async def test_reap_if_idle_stops_when_idle(monkeypatch):
     monkeypatch.setattr(voice_livekit, "_container_running", _fake_running)
     monkeypatch.setattr(voice_livekit, "stop_livekit_ondemand", _fake_stop)
 
-    voice_livekit._last_activity = 0.0  # long ago
-    voice_livekit._active_participant_sids.clear()
+    monkeypatch.setattr(voice_livekit, "_last_activity", 0.0)  # long ago
 
     should_exit = await voice_livekit._reap_if_idle()
 
@@ -142,7 +145,8 @@ async def test_reap_if_idle_holds_open_with_participants(monkeypatch):
 
     monkeypatch.setattr(voice_livekit, "stop_livekit_ondemand", _fake_stop)
 
-    voice_livekit._last_activity = 0.0
+    monkeypatch.setattr(voice_livekit, "_last_activity", 0.0)
+    # mutating the per-test fresh set is discarded on teardown (no global leak)
     voice_livekit._active_participant_sids.add("participant-1")
 
     should_exit = await voice_livekit._reap_if_idle()
@@ -201,6 +205,25 @@ def test_agent_identity_does_not_hold_reaper_open():
     # A real browser participant → tracked.
     room.handlers["participant_connected"](_P("browser-1", "PA_browser"))
     assert "PA_browser" in voice_livekit._active_participant_sids
+
+
+@pytest.mark.asyncio
+async def test_direct_stop_tears_down_idle_monitor(monkeypatch):
+    """Calling stop_livekit_ondemand directly (not from the monitor itself) must
+    cancel + clear _idle_task, so the next ensure_livekit_started() recreates it
+    rather than skipping it via the done()-guard."""
+    async def _fake_docker(*args, timeout=20.0):
+        return 0, ""
+
+    monkeypatch.setattr(voice_livekit, "_docker_cmd", _fake_docker)
+    idle = asyncio.create_task(_never_ending())
+    monkeypatch.setattr(voice_livekit, "_idle_task", idle)
+
+    await voice_livekit.stop_livekit_ondemand(reason="manual")
+
+    assert voice_livekit._idle_task is None
+    await asyncio.sleep(0)
+    assert idle.cancelled() or idle.done()
 
 
 @pytest.mark.asyncio

--- a/services/zoe-data/tests/test_voice_livekit_ondemand.py
+++ b/services/zoe-data/tests/test_voice_livekit_ondemand.py
@@ -212,8 +212,11 @@ async def test_start_agent_ondemand_does_not_run_loop(monkeypatch):
         ran.append(True)
 
     monkeypatch.setattr(voice_livekit, "_agent_loop", _loop)
+    monkeypatch.setattr(voice_livekit, "_idle_monitor", _never_ending)
 
     await voice_livekit.start_livekit_agent()
 
     assert ran == []  # boot must not start the agent loop in on-demand mode
     assert voice_livekit.get_voice_health()["status"] == "stopped"
+    # but the idle reaper IS started so an orphaned container still gets reaped
+    assert voice_livekit._idle_task is not None and not voice_livekit._idle_task.done()

--- a/services/zoe-data/tests/test_voice_livekit_ondemand.py
+++ b/services/zoe-data/tests/test_voice_livekit_ondemand.py
@@ -171,6 +171,38 @@ async def test_reap_if_idle_waits_out_recent_activity(monkeypatch):
     assert stopped == []
 
 
+def test_agent_identity_does_not_hold_reaper_open():
+    """The agent's own join must not count as an active participant, else the
+    container never reaps (the aiortc backend emits participant_connected for
+    every participant already in the room when the agent joins)."""
+
+    class _Room:
+        def __init__(self):
+            self.handlers = {}
+
+        def on(self, event):
+            def _decorator(func):
+                self.handlers[event] = func
+                return func
+            return _decorator
+
+    class _P:
+        def __init__(self, identity, sid):
+            self.identity = identity
+            self.sid = sid
+
+    room = _Room()
+    voice_livekit._build_room_handlers(room, {}, {})
+
+    # Agent's own identity → ignored.
+    room.handlers["participant_connected"](_P(voice_livekit._AGENT_IDENTITY, "PA_agent"))
+    assert "PA_agent" not in voice_livekit._active_participant_sids
+
+    # A real browser participant → tracked.
+    room.handlers["participant_connected"](_P("browser-1", "PA_browser"))
+    assert "PA_browser" in voice_livekit._active_participant_sids
+
+
 @pytest.mark.asyncio
 async def test_start_agent_ondemand_does_not_run_loop(monkeypatch):
     monkeypatch.setenv("ZOE_LIVEKIT_ONDEMAND", "true")

--- a/services/zoe-data/tests/test_voice_livekit_ondemand.py
+++ b/services/zoe-data/tests/test_voice_livekit_ondemand.py
@@ -1,0 +1,187 @@
+"""Tests for the on-demand LiveKit lifecycle (start-on-token, idle-reap)."""
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from routers import voice_livekit
+
+
+@pytest.fixture(autouse=True)
+def _reset_lifecycle(monkeypatch):
+    # Always have credentials so the start path isn't short-circuited.
+    monkeypatch.setenv("LIVEKIT_API_KEY", "test-key")
+    monkeypatch.setenv("LIVEKIT_API_SECRET", "test-secret")
+    voice_livekit._agent_task = None
+    voice_livekit._idle_task = None
+    voice_livekit._lifecycle_lock = None
+    voice_livekit._active_participant_sids.clear()
+    voice_livekit._last_activity = 0.0
+    voice_livekit.reset_voice_health_for_tests()
+    yield
+    for handle in (voice_livekit._agent_task, voice_livekit._idle_task):
+        if handle is not None and not handle.done():
+            handle.cancel()
+    voice_livekit._agent_task = None
+    voice_livekit._idle_task = None
+
+
+async def _never_ending():
+    # Stand-in for _agent_loop: runs until cancelled.
+    while True:
+        await asyncio.sleep(3600)
+
+
+@pytest.mark.asyncio
+async def test_ensure_started_starts_container_and_agent(monkeypatch):
+    monkeypatch.setenv("ZOE_LIVEKIT_ONDEMAND", "true")
+    calls = []
+
+    async def _fake_running():
+        return False
+
+    async def _fake_docker(*args, timeout=20.0):
+        calls.append(args)
+        return 0, ""
+
+    async def _fake_wait_port(host, port, timeout):
+        return True
+
+    monkeypatch.setattr(voice_livekit, "_container_running", _fake_running)
+    monkeypatch.setattr(voice_livekit, "_docker_cmd", _fake_docker)
+    monkeypatch.setattr(voice_livekit, "_wait_port", _fake_wait_port)
+    monkeypatch.setattr(voice_livekit, "_agent_loop", _never_ending)
+    monkeypatch.setattr(voice_livekit, "_idle_monitor", _never_ending)
+
+    ready = await voice_livekit.ensure_livekit_started(wait_ready=1.0)
+
+    assert ready is True
+    assert ("start", voice_livekit._CONTAINER_NAME) in calls
+    assert voice_livekit._agent_task is not None and not voice_livekit._agent_task.done()
+    assert voice_livekit._idle_task is not None and not voice_livekit._idle_task.done()
+
+
+@pytest.mark.asyncio
+async def test_ensure_started_skips_docker_when_disabled(monkeypatch):
+    monkeypatch.setenv("ZOE_LIVEKIT_ONDEMAND", "false")
+    started = []
+
+    async def _fake_docker(*args, timeout=20.0):
+        started.append(args)
+        return 0, ""
+
+    async def _fake_wait_port(host, port, timeout):
+        return True
+
+    monkeypatch.setattr(voice_livekit, "_docker_cmd", _fake_docker)
+    monkeypatch.setattr(voice_livekit, "_wait_port", _fake_wait_port)
+
+    ready = await voice_livekit.ensure_livekit_started(wait_ready=1.0)
+
+    assert ready is True
+    assert started == []  # boot mode owns the always-on agent
+    assert voice_livekit._agent_task is None
+
+
+@pytest.mark.asyncio
+async def test_ensure_started_returns_false_when_docker_start_fails(monkeypatch):
+    monkeypatch.setenv("ZOE_LIVEKIT_ONDEMAND", "true")
+
+    async def _fake_running():
+        return False
+
+    async def _fake_docker(*args, timeout=20.0):
+        return 1, "no such container"
+
+    monkeypatch.setattr(voice_livekit, "_container_running", _fake_running)
+    monkeypatch.setattr(voice_livekit, "_docker_cmd", _fake_docker)
+
+    ready = await voice_livekit.ensure_livekit_started(wait_ready=1.0)
+
+    assert ready is False
+    assert voice_livekit._agent_task is None
+
+
+@pytest.mark.asyncio
+async def test_reap_if_idle_stops_when_idle(monkeypatch):
+    monkeypatch.setenv("ZOE_LIVEKIT_ONDEMAND", "true")
+    monkeypatch.setenv("ZOE_LIVEKIT_IDLE_TIMEOUT_S", "0")
+    stopped = []
+
+    async def _fake_running():
+        return True
+
+    async def _fake_stop(reason="idle"):
+        stopped.append(reason)
+
+    monkeypatch.setattr(voice_livekit, "_container_running", _fake_running)
+    monkeypatch.setattr(voice_livekit, "stop_livekit_ondemand", _fake_stop)
+
+    voice_livekit._last_activity = 0.0  # long ago
+    voice_livekit._active_participant_sids.clear()
+
+    should_exit = await voice_livekit._reap_if_idle()
+
+    assert should_exit is True
+    assert stopped == ["idle"]
+
+
+@pytest.mark.asyncio
+async def test_reap_if_idle_holds_open_with_participants(monkeypatch):
+    monkeypatch.setenv("ZOE_LIVEKIT_ONDEMAND", "true")
+    monkeypatch.setenv("ZOE_LIVEKIT_IDLE_TIMEOUT_S", "0")
+    stopped = []
+
+    async def _fake_stop(reason="idle"):
+        stopped.append(reason)
+
+    monkeypatch.setattr(voice_livekit, "stop_livekit_ondemand", _fake_stop)
+
+    voice_livekit._last_activity = 0.0
+    voice_livekit._active_participant_sids.add("participant-1")
+
+    should_exit = await voice_livekit._reap_if_idle()
+
+    assert should_exit is False  # keep looping
+    assert stopped == []  # never stopped while a participant is present
+
+
+@pytest.mark.asyncio
+async def test_reap_if_idle_waits_out_recent_activity(monkeypatch):
+    monkeypatch.setenv("ZOE_LIVEKIT_ONDEMAND", "true")
+    monkeypatch.setenv("ZOE_LIVEKIT_IDLE_TIMEOUT_S", "300")
+    stopped = []
+
+    async def _fake_stop(reason="idle"):
+        stopped.append(reason)
+
+    monkeypatch.setattr(voice_livekit, "stop_livekit_ondemand", _fake_stop)
+
+    voice_livekit.note_voice_activity()  # just now
+    voice_livekit._active_participant_sids.clear()
+
+    should_exit = await voice_livekit._reap_if_idle()
+
+    assert should_exit is False
+    assert stopped == []
+
+
+@pytest.mark.asyncio
+async def test_start_agent_ondemand_does_not_run_loop(monkeypatch):
+    monkeypatch.setenv("ZOE_LIVEKIT_ONDEMAND", "true")
+    ran = []
+
+    async def _loop():
+        ran.append(True)
+
+    monkeypatch.setattr(voice_livekit, "_agent_loop", _loop)
+
+    await voice_livekit.start_livekit_agent()
+
+    assert ran == []  # boot must not start the agent loop in on-demand mode
+    assert voice_livekit.get_voice_health()["status"] == "stopped"

--- a/services/zoe-data/tests/test_voice_livekit_ondemand.py
+++ b/services/zoe-data/tests/test_voice_livekit_ondemand.py
@@ -146,8 +146,7 @@ async def test_reap_if_idle_holds_open_with_participants(monkeypatch):
     monkeypatch.setattr(voice_livekit, "stop_livekit_ondemand", _fake_stop)
 
     monkeypatch.setattr(voice_livekit, "_last_activity", 0.0)
-    # mutating the per-test fresh set is discarded on teardown (no global leak)
-    voice_livekit._active_participant_sids.add("participant-1")
+    monkeypatch.setattr(voice_livekit, "_active_participant_sids", {"participant-1"})
 
     should_exit = await voice_livekit._reap_if_idle()
 

--- a/services/zoe-data/tests/test_voice_livekit_ondemand.py
+++ b/services/zoe-data/tests/test_voice_livekit_ondemand.py
@@ -135,6 +135,33 @@ async def test_reap_if_idle_stops_when_idle(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_reap_if_idle_rechecks_after_container_await(monkeypatch):
+    """TOCTOU guard: if a /livekit-token request connects a participant (or bumps
+    activity) while _container_running() yields, _reap_if_idle must NOT reap the
+    now-active room."""
+    monkeypatch.setenv("ZOE_LIVEKIT_ONDEMAND", "true")
+    monkeypatch.setenv("ZOE_LIVEKIT_IDLE_TIMEOUT_S", "0")
+    stopped = []
+
+    async def _fake_stop(reason="idle"):
+        stopped.append(reason)
+
+    async def _running_but_late_join():
+        # Simulate a participant arriving during the await window.
+        voice_livekit._active_participant_sids.add("late-joiner")
+        return True
+
+    monkeypatch.setattr(voice_livekit, "stop_livekit_ondemand", _fake_stop)
+    monkeypatch.setattr(voice_livekit, "_container_running", _running_but_late_join)
+    monkeypatch.setattr(voice_livekit, "_last_activity", 0.0)
+
+    should_exit = await voice_livekit._reap_if_idle()
+
+    assert stopped == []  # must not reap once a participant appeared mid-check
+    assert should_exit is False
+
+
+@pytest.mark.asyncio
 async def test_reap_if_idle_holds_open_with_participants(monkeypatch):
     monkeypatch.setenv("ZOE_LIVEKIT_ONDEMAND", "true")
     monkeypatch.setenv("ZOE_LIVEKIT_IDLE_TIMEOUT_S", "0")


### PR DESCRIPTION
## What
Make the LiveKit WebRTC server **on-demand** instead of always-on.

LiveKit (~560MB container) ran from boot even though:
- the **touch panel uses the REST voice path** (not LiveKit), and
- the browser voice page is used only occasionally.

On the memory-constrained Jetson that's permanent overhead that contributes to memory pressure.

## How
Default `ZOE_LIVEKIT_ONDEMAND=true`:
- **Boot** leaves the container stopped; the agent reports `stopped` instead of spinning in a reconnect loop against a down server.
- The first **`/livekit-token`** request starts the container + agent loop (idempotent, lock-guarded) and waits (bounded, ~8s) for `127.0.0.1:7880` to accept connections before returning the token — so the browser's WebRTC connect succeeds. Best-effort: token issuance never blocks on docker/livekit being slow, and `livekit_available` reflects readiness.
- An **idle monitor** reaps the container after `ZOE_LIVEKIT_IDLE_TIMEOUT_S` (default `300`) of zero participants.

`ZOE_LIVEKIT_ONDEMAND=false` preserves the legacy always-on boot path unchanged. The touch-panel REST path is untouched.

### New env vars (defaults baked into code; documented here since `.env` is gitignored)
| var | default | meaning |
|---|---|---|
| `ZOE_LIVEKIT_ONDEMAND` | `true` | start/stop LiveKit on demand |
| `ZOE_LIVEKIT_IDLE_TIMEOUT_S` | `300` | idle seconds before reaping |
| `ZOE_LIVEKIT_CONTAINER` | `livekit` | container name to control |

Requires the service user to be in the `docker` group (already true for `zoe`).

## Testing
- `tests/test_voice_livekit_ondemand.py` (7 tests): start-on-token, disabled-mode passthrough (no docker call), docker-start-failure → `False`, idle-reap decision (reap / hold-with-participants / hold-on-recent-activity), boot does not run the agent loop in on-demand mode.
- Full voice suite green: 164 tests across `test_voice_*`.
- **Live-verified on the Jetson**: restart → container stays stopped, agent `stopped` (no spin); `GET /livekit-token` → container `Up`, agent `connected` (aiortc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)