### PR TITLE
fix(chat): thread panel_id into chat_stream_generator — fixes fast-path NameError breaking web chat

### DIFF
--- a/services/zoe-data/routers/chat.py
+++ b/services/zoe-data/routers/chat.py
@@ -1645,6 +1645,7 @@ async def chat_stream_generator(
     *,
     force_openclaw: bool = False,
     force_agent: str = "auto",
+    req_panel_id: str | None = None,
 ):
     user_id = user["user_id"]
     user_role = user.get("role")
@@ -3070,6 +3071,7 @@ async def chat(request: Request, user: dict = Depends(get_current_user), stream:
                     user,
                     force_openclaw=force_openclaw,
                     force_agent=force_agent,
+                    req_panel_id=req_panel_id,
                 ):
                     yield chunk
             finally:

--- a/services/zoe-data/tests/test_chat_pi_hybrid_action_form.py
+++ b/services/zoe-data/tests/test_chat_pi_hybrid_action_form.py
@@ -86,6 +86,20 @@ async def test_chat_pi_hybrid_action_form_broadcasts_without_tool_memory_side_ef
 
 
 
+def test_chat_stream_generator_accepts_req_panel_id():
+    """Regression for aea6456a: chat_stream_generator's intent fast-path calls
+    the Pi hybrid lane with panel_id=req_panel_id, but the parameter was never
+    threaded into the function — so every fast-path chat raised
+    `NameError: name 'req_panel_id' is not defined`. The existing lane test
+    exercised _run_chat_pi_hybrid_lane directly and missed the caller bug."""
+    import inspect
+
+    sig = inspect.signature(chat.chat_stream_generator)
+    assert "req_panel_id" in sig.parameters, (
+        "chat_stream_generator must accept req_panel_id or the fast-path NameErrors"
+    )
+
+
 def test_timer_create_has_touch_panel_action_form_payload():
     class Intent:
         name = "timer_create"

--- a/services/zoe-data/tests/test_chat_pi_hybrid_action_form.py
+++ b/services/zoe-data/tests/test_chat_pi_hybrid_action_form.py
@@ -100,6 +100,20 @@ def test_chat_stream_generator_accepts_req_panel_id():
     )
 
 
+def test_chat_stream_generator_forwards_panel_id_to_hybrid_lane():
+    """Stronger guard (per review): accepting req_panel_id isn't enough — the
+    fast-path must actually forward it to the Pi hybrid lane. A refactor that
+    keeps the parameter but drops it before the call would silently reintroduce
+    the NameError-era bug; this asserts the call site still wires it through."""
+    import inspect
+    import re
+
+    src = inspect.getsource(chat.chat_stream_generator)
+    assert re.search(
+        r"_run_chat_pi_hybrid_lane\([^)]*panel_id\s*=\s*req_panel_id", src, re.S
+    ), "fast-path must forward req_panel_id into _run_chat_pi_hybrid_lane(panel_id=...)"
+
+
 def test_timer_create_has_touch_panel_action_form_payload():
     class Intent:
         name = "timer_create"


### PR DESCRIPTION
## Critical: web/text chat has been broken for ~2 days

Since [aea6456a](https://github.com/jason-easyazz/zoe-ai-assistant/commit/aea6456a) ("Add Pi hybrid action-form lane", 2026-06-17), the intent fast-path inside `chat_stream_generator` calls the Pi hybrid lane with `panel_id=req_panel_id`, but **`req_panel_id` was never threaded into that function**.

With `OPENCLAW_ALL_TOOLS_ENABLED=true` (the default), every non-OpenClaw chat takes that path, so the SSE streaming chat endpoint (`POST /api/chat/`) raised:

```
NameError: name 'req_panel_id' is not defined   (chat.py:1927)
```

and returned `RUN_ERROR / internal_error` on **every fast-path message**.

### Why it wasn't noticed
**Voice was unaffected** — the voice paths call `brain_streaming` / `brain_oneshot` directly and never go through `chat_stream_generator`. So voice kept working while web/text chat was broken. The existing test (`test_chat_pi_hybrid_action_form`) exercised `_run_chat_pi_hybrid_lane` **directly**, never the broken caller.

## Fix
- Add `req_panel_id` as a keyword-only parameter to `chat_stream_generator`.
- Pass it from the POST handler (where `req_panel_id` is already read from the request body).
- Add a signature regression guard so the parameter can't silently drop again.

## Testing
- `tests/test_chat_pi_hybrid_action_form.py` — 3 pass (incl. new guard).
- **Live-verified on the Jetson**: before → `RUN_ERROR/internal_error`; after → `"hello"` returns *"Good evening! What can I do for you?"* and the fast-path no longer errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)