### PR TITLE
perf(multica): throttle poll loop while dispatch is paused — cut the ~minutely 2-3GB spike

### DIFF
--- a/services/zoe-data/main.py
+++ b/services/zoe-data/main.py
@@ -113,8 +113,14 @@ def _multica_poll_interval_s(paused: bool, *, active_s: float, paused_s: float) 
     Throttle to ``paused_s`` while dispatch is paused — the per-issue chain
     reconcile (worktree + git ops) is expensive and pointless when nothing is
     being dispatched — and use the normal ``active_s`` otherwise.
+
+    Floors the paused cadence at ``active_s`` so a misconfigured
+    ``ZOE_MULTICA_PAUSED_POLL_S`` of 0 or a negative value can't turn the paused
+    path into a tight spin loop that burns *more* CPU than the active cadence.
     """
-    return paused_s if paused else active_s
+    if not paused:
+        return active_s
+    return max(paused_s, active_s)
 
 
 async def _poll_chain_guarded(ref: str, *, issue: dict | None, timeout: float) -> dict:
@@ -807,6 +813,7 @@ async def lifespan(app: FastAPI):
             )
             _paused_poll_s = 300.0
         _ACTIVE_POLL_S = 30.0
+        _pause_check_warned = False
         while True:
             try:
                 # Re-checked inside the cycle, so a resume still takes effect
@@ -816,7 +823,19 @@ async def lifespan(app: FastAPI):
                     _poll_interval = _multica_poll_interval_s(
                         _dispatch_is_paused(), active_s=_ACTIVE_POLL_S, paused_s=_paused_poll_s
                     )
-                except Exception:
+                    _pause_check_warned = False
+                except Exception as _pause_exc:
+                    # A pause-check failure must not silently disable the throttle
+                    # forever with no trace. Warn once (then debug), and fall back
+                    # to the active cadence until it recovers.
+                    if not _pause_check_warned:
+                        logger.warning(
+                            "multica_poll: pause check failed (%s); using active poll "
+                            "cadence until it recovers", _pause_exc,
+                        )
+                        _pause_check_warned = True
+                    else:
+                        logger.debug("multica_poll: pause check still failing: %s", _pause_exc)
                     _poll_interval = _ACTIVE_POLL_S
                 await asyncio.sleep(_poll_interval)
                 from multica_client import MULClient  # type: ignore[import]

--- a/services/zoe-data/main.py
+++ b/services/zoe-data/main.py
@@ -107,6 +107,16 @@ def _bounded_blocked_resume_window(
     return window, (start + budget) % count
 
 
+def _multica_poll_interval_s(paused: bool, *, active_s: float, paused_s: float) -> float:
+    """Cadence for the Multica poll loop.
+
+    Throttle to ``paused_s`` while dispatch is paused — the per-issue chain
+    reconcile (worktree + git ops) is expensive and pointless when nothing is
+    being dispatched — and use the normal ``active_s`` otherwise.
+    """
+    return paused_s if paused else active_s
+
+
 async def _poll_chain_guarded(ref: str, *, issue: dict | None, timeout: float) -> dict:
     """Poll a chain without letting one dead ref wedge the whole poll loop.
 
@@ -783,9 +793,32 @@ async def lifespan(app: FastAPI):
                 os.environ.get("ZOE_WORKTREE_PRUNE_INTERVAL_S"),
             )
             _prune_interval_s = 86400.0
+        # Cadence when dispatch is paused. The per-issue chain reconcile below
+        # (poll_ref → worktree+git ops) costs ~30s CPU and a multi-GB transient
+        # allocation each pass; running it every 30s while nothing is being
+        # dispatched is pure waste. Poll every 30s when active, every
+        # ZOE_MULTICA_PAUSED_POLL_S (default 300s) when paused.
+        try:
+            _paused_poll_s = float(os.environ.get("ZOE_MULTICA_PAUSED_POLL_S", "300") or "300")
+        except ValueError:
+            logger.warning(
+                "multica_poll: invalid ZOE_MULTICA_PAUSED_POLL_S=%r; using 300",
+                os.environ.get("ZOE_MULTICA_PAUSED_POLL_S"),
+            )
+            _paused_poll_s = 300.0
+        _ACTIVE_POLL_S = 30.0
         while True:
             try:
-                await asyncio.sleep(30)
+                # Re-checked inside the cycle, so a resume still takes effect
+                # promptly on the next pass.
+                try:
+                    from multica_dispatch_control import dispatch_is_paused as _dispatch_is_paused
+                    _poll_interval = _multica_poll_interval_s(
+                        _dispatch_is_paused(), active_s=_ACTIVE_POLL_S, paused_s=_paused_poll_s
+                    )
+                except Exception:
+                    _poll_interval = _ACTIVE_POLL_S
+                await asyncio.sleep(_poll_interval)
                 from multica_client import MULClient  # type: ignore[import]
                 client = MULClient()
                 if not client.is_configured():

--- a/services/zoe-data/tests/test_main_multica_poll.py
+++ b/services/zoe-data/tests/test_main_multica_poll.py
@@ -66,6 +66,10 @@ def test_multica_poll_interval_throttles_when_paused():
     assert _multica_poll_interval_s(False, active_s=30.0, paused_s=300.0) == 30.0
     # ...and the throttled cadence while it's paused.
     assert _multica_poll_interval_s(True, active_s=30.0, paused_s=300.0) == 300.0
+    # A misconfigured 0/negative paused interval is floored at the active cadence
+    # so the paused path can never become a tighter spin loop than active.
+    assert _multica_poll_interval_s(True, active_s=30.0, paused_s=0.0) == 30.0
+    assert _multica_poll_interval_s(True, active_s=30.0, paused_s=-5.0) == 30.0
 
 
 def test_multica_poll_loop_routes_sleep_through_paused_interval_helper():

--- a/services/zoe-data/tests/test_main_multica_poll.py
+++ b/services/zoe-data/tests/test_main_multica_poll.py
@@ -59,6 +59,25 @@ def test_poll_dispatches_ready_work_only_when_runtime_pause_is_inactive():
     assert active_branch < backfill < paused_branch
 
 
+def test_multica_poll_interval_throttles_when_paused():
+    from main import _multica_poll_interval_s
+
+    # Normal cadence while dispatch is active...
+    assert _multica_poll_interval_s(False, active_s=30.0, paused_s=300.0) == 30.0
+    # ...and the throttled cadence while it's paused.
+    assert _multica_poll_interval_s(True, active_s=30.0, paused_s=300.0) == 300.0
+
+
+def test_multica_poll_loop_routes_sleep_through_paused_interval_helper():
+    # Guard the wiring: the loop must derive its sleep from the helper (re-checking
+    # dispatch_is_paused each cycle) and honour ZOE_MULTICA_PAUSED_POLL_S, so a
+    # paused pipeline stops running the expensive per-issue reconcile every 30s.
+    source = (Path(__file__).resolve().parents[1] / "main.py").read_text(encoding="utf-8")
+    assert "_multica_poll_interval_s(" in source
+    assert "ZOE_MULTICA_PAUSED_POLL_S" in source
+    assert "await asyncio.sleep(30)" not in source  # no hardcoded poll cadence
+
+
 def test_poll_dispatch_backfills_ready_blocked_pipeline_before_todo():
     source = (Path(__file__).resolve().parents[1] / "main.py").read_text(encoding="utf-8")
     blocked_fetch = source.index('blocked_issues = await client.list_issues(status="blocked")')


### PR DESCRIPTION
## What
After capping glibc malloc arenas (which dropped zoe-data's baseline from ~3.2GB to ~370MB), profiling showed the worker **still spiked transiently to ~2-3GB roughly every ~60s**, then returned to baseline. With the arena cap that memory is now reclaimed (no longer an OOM risk), but it's wasted peak memory + CPU.

## Root cause
Timing-correlation (the spike lands 2-3s after each poll cycle) localized it to the **Multica poll loop's per-issue chain reconcile** — `_poll_chain_guarded` → `executor_registry.poll_ref` ("worktree + git ops") — which runs **every 30s even while dispatch is paused**. So roughly every minute it burns ~30s of CPU + a multi-GB transient allocation reconciling chains for a pipeline that isn't dispatching anything.

(The exact allocating line inside `poll_ref` couldn't be pinned — `ptrace_scope=1` with no sudo blocks py-spy, and the allocation is likely C++/numpy so tracemalloc wouldn't catch it. But the trigger is unambiguously this loop.)

## Change
Throttle the whole cycle when dispatch is paused:
- Poll every **30s when active** (unchanged), every **`ZOE_MULTICA_PAUSED_POLL_S`** (default **300s**) when paused.
- Pause state is re-checked each cycle via `dispatch_is_paused()` (a cheap pause-file existence check), so a **resume takes effect on the next pass** — no lag in active operation.
- Active-dispatch cadence and all per-cycle work are **unchanged**.
- Interval selection extracted to `_multica_poll_interval_s()` for unit testing (matches the existing testable-helper pattern in this loop).

### New env var
| var | default | meaning |
|---|---|---|
| `ZOE_MULTICA_PAUSED_POLL_S` | `300` | poll cadence (seconds) while dispatch is paused |

## Testing
- `tests/test_main_multica_poll.py` — 42 pass, incl. a unit test for `_multica_poll_interval_s` and a wiring guard (loop routes its sleep through the helper + honours the env var; no hardcoded `sleep(30)`).
- **Live-verified on the Jetson** (dispatch paused): spike cadence dropped from ~1/min to ~0 over a 4-min window; worker held at ~301MB; poll cycles spaced ~300s apart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)