### PR TITLE
test(calendar_utils): deepen row converter coverage (12 → 15 cases)

### DIFF
--- a/services/zoe-data/tests/test_calendar_utils.py
+++ b/services/zoe-data/tests/test_calendar_utils.py
@@ -1,120 +1,169 @@
-"""Focused unit tests for the pure ``calendar_utils`` row formatter.
+"""Focused unit tests for the pure calendar row formatter in calendar_utils.
 
-``row_to_event`` is the shared parser used by the calendar router and the
-skybridge service to normalize persisted rows into event dicts. It must
-deserialize the JSON ``metadata`` column, coerce ``all_day`` / ``deleted``
-into real booleans, and leave the remaining event fields untouched.
+`row_to_event` is a stateless parser/formatter shared by the calendar router
+and Skybridge service. These tests cover the parsing branches (metadata JSON,
+boolean coercion) without touching DB, network, or time.
 """
 
 from calendar_utils import row_to_event
 
 
-def test_parses_json_metadata_into_dict():
-    event = row_to_event(
-        {
-            "id": 1,
-            "title": "Standup",
-            "start": "2026-01-01T10:00:00Z",
-            "metadata": '{"room": "A", "attendees": ["zoe", "alex"]}',
-        }
-    )
-    assert event["metadata"] == {"room": "A", "attendees": ["zoe", "alex"]}
-    assert event["title"] == "Standup"
-    assert event["start"] == "2026-01-01T10:00:00Z"
+# ---------------------------------------------------------------------------
+# metadata parsing
+# ---------------------------------------------------------------------------
 
 
-def test_none_metadata_stays_none():
-    event = row_to_event({"id": 2, "title": "Lunch", "metadata": None})
+def test_parses_metadata_json_string_into_dict():
+    row = {
+        "id": 1,
+        "title": "Dentist",
+        "metadata": '{"location": "clinic", "reminder_minutes": 30}',
+    }
+
+    event = row_to_event(row)
+
+    assert event["metadata"] == {"location": "clinic", "reminder_minutes": 30}
+
+
+def test_invalid_metadata_json_falls_back_to_none():
+    row = {"id": 2, "title": "Broken", "metadata": "{not valid json"}
+
+    event = row_to_event(row)
+
     assert event["metadata"] is None
 
 
 def test_empty_string_metadata_becomes_none():
-    """An empty string in the metadata column should not raise and should
-    normalize to ``None`` so downstream consumers see a single sentinel."""
-    event = row_to_event({"id": 3, "title": "Call", "metadata": ""})
+    row = {"id": 3, "title": "NoMeta", "metadata": ""}
+
+    event = row_to_event(row)
+
     assert event["metadata"] is None
 
 
-def test_invalid_json_metadata_falls_back_to_none():
-    event = row_to_event({"id": 4, "title": "Call", "metadata": "not json{"})
+def test_none_metadata_stays_none():
+    row = {"id": 4, "title": "NullMeta", "metadata": None}
+
+    event = row_to_event(row)
+
     assert event["metadata"] is None
 
 
-def test_dict_metadata_is_passed_through():
-    """When the driver already returned a parsed dict, leave it alone."""
-    event = row_to_event(
-        {"id": 5, "title": "Retro", "metadata": {"room": "Z"}}
-    )
-    assert event["metadata"] == {"room": "Z"}
+def test_already_parsed_metadata_dict_is_left_alone():
+    row = {"id": 5, "title": "Pre", "metadata": {"already": "parsed"}}
+
+    event = row_to_event(row)
+
+    assert event["metadata"] == {"already": "parsed"}
 
 
-def test_missing_metadata_key_is_preserved():
-    """Rows without a metadata column should not gain a fabricated key."""
-    event = row_to_event({"id": 6, "title": "Y"})
+def test_missing_metadata_key_is_left_alone():
+    row = {"id": 6, "title": "NoKey"}
+
+    event = row_to_event(row)
+
     assert "metadata" not in event
 
 
-def test_all_day_coerced_from_int_to_bool():
-    event = row_to_event({"id": 7, "title": "Holiday", "all_day": 1})
-    assert event["all_day"] is True
-
-    event_false = row_to_event({"id": 8, "title": "Meeting", "all_day": 0})
-    assert event_false["all_day"] is False
+# ---------------------------------------------------------------------------
+# all_day / deleted boolean coercion
+# ---------------------------------------------------------------------------
 
 
-def test_all_day_none_is_not_coerced():
-    """A NULL all_day column stays ``None`` so UI code can distinguish
-    "unspecified" from "explicitly false"."""
-    event = row_to_event({"id": 9, "title": "X", "all_day": None})
-    assert event["all_day"] is None
-    assert "all_day" in event  # key present, value None
+def test_all_day_truthy_value_is_coerced_to_true():
+    row = {"id": 7, "all_day": 1}
+
+    assert row_to_event(row)["all_day"] is True
 
 
-def test_missing_all_day_key_is_preserved():
-    event = row_to_event({"id": 10, "title": "X"})
+def test_all_day_falsy_value_is_coerced_to_false():
+    row = {"id": 8, "all_day": 0}
+
+    assert row_to_event(row)["all_day"] is False
+
+
+def test_all_day_none_stays_none():
+    row = {"id": 9, "all_day": None}
+
+    assert row_to_event(row)["all_day"] is None
+
+
+def test_all_day_missing_key_is_left_alone():
+    row = {"id": 10}
+
+    event = row_to_event(row)
+
     assert "all_day" not in event
 
 
-def test_deleted_coerced_from_int_to_bool():
-    event = row_to_event({"id": 11, "title": "Old", "deleted": 1})
-    assert event["deleted"] is True
+def test_deleted_truthy_value_is_coerced_to_true():
+    row = {"id": 11, "deleted": 1}
+
+    assert row_to_event(row)["deleted"] is True
 
 
-def test_extra_event_fields_are_preserved():
-    """``row_to_event`` must not drop columns it does not recognize."""
+def test_deleted_falsy_value_is_coerced_to_false():
+    row = {"id": 12, "deleted": 0}
+
+    assert row_to_event(row)["deleted"] is False
+
+
+def test_deleted_none_stays_none():
+    row = {"id": 13, "deleted": None}
+
+    assert row_to_event(row)["deleted"] is None
+
+
+# ---------------------------------------------------------------------------
+# integration / shape preservation
+# ---------------------------------------------------------------------------
+
+
+def test_full_row_preserves_unrelated_fields_and_normalizes_known_ones():
     row = {
-        "id": 12,
-        "title": "Offsite",
-        "start": "2026-03-01T09:00:00Z",
-        "end": "2026-03-01T17:00:00Z",
-        "location": "Office",
-        "notes": "Bring laptop",
-        "calendar_id": "work",
+        "id": 42,
+        "user_id": "u-1",
+        "title": "Team standup",
+        "start_time": "2026-06-16T09:00:00",
+        "end_time": "2026-06-16T09:15:00",
+        "category": "work",
+        "visibility": "family",
+        "all_day": 0,
+        "deleted": 0,
+        "metadata": '{"join_url": "https://meet.example/x"}',
     }
+
     event = row_to_event(row)
-    for key, value in row.items():
-        assert event[key] == value
 
-
-def test_full_event_normalization_end_to_end():
-    """Integration of all branches in a single realistic row."""
-    event = row_to_event(
-        {
-            "id": 13,
-            "title": "All-day holiday",
-            "start": "2026-12-25",
-            "end": "2026-12-25",
-            "metadata": '{"reminder": "none"}',
-            "all_day": 1,
-            "deleted": 0,
-        }
-    )
     assert event == {
-        "id": 13,
-        "title": "All-day holiday",
-        "start": "2026-12-25",
-        "end": "2026-12-25",
-        "metadata": {"reminder": "none"},
-        "all_day": True,
+        "id": 42,
+        "user_id": "u-1",
+        "title": "Team standup",
+        "start_time": "2026-06-16T09:00:00",
+        "end_time": "2026-06-16T09:15:00",
+        "category": "work",
+        "visibility": "family",
+        "all_day": False,
         "deleted": False,
+        "metadata": {"join_url": "https://meet.example/x"},
+    }
+
+
+def test_row_copy_does_not_mutate_input():
+    row = {
+        "id": 99,
+        "all_day": 1,
+        "deleted": 0,
+        "metadata": '{"k": "v"}',
+    }
+
+    row_to_event(row)
+
+    # The input row should be untouched: it carried the raw SQL types
+    # (int, JSON string) and we must not normalize them in place.
+    assert row == {
+        "id": 99,
+        "all_day": 1,
+        "deleted": 0,
+        "metadata": '{"k": "v"}',
     }


### PR DESCRIPTION
Salvages broader `calendar_utils` row-converter coverage stuck in stale duplicate PRs (#600/#603/#608) from the now-disabled Multica daemon churn. Behavioral **superset** of the on-main 12 tests — same metadata cases plus granular `all_day`/`deleted` truthy/falsy coercion, `deleted_none_stays_none`, and input-mutation safety. **15 passed** against current main.

Supersedes #600, #603, #608 (will close those).

🤖 Generated with [Claude Code](https://claude.com/claude-code)