### PR TITLE
feat(voice): ZOE_SKYBRIDGE_ONLY — stop legacy domain-page bounce

### DIFF
--- a/services/zoe-data/routers/voice_tts.py
+++ b/services/zoe-data/routers/voice_tts.py
@@ -495,12 +495,25 @@ def _extract_complete_sentences(buffer: str) -> tuple[list[str], str]:
     return complete, buffer[last_end:]
 
 
+def _skybridge_only() -> bool:
+    """When set, voice never navigates the panel to legacy domain pages.
+
+    The Skybridge-first path (`_broadcast_skybridge_ui`) still renders real cards.
+    The legacy `_broadcast_*_ui` helpers below navigate to per-domain pages
+    (`/touch/weather.html`, etc.), which yanks the panel off Skybridge whenever the
+    Skybridge resolver falls through. Gating them keeps the panel on Skybridge.
+    """
+    return os.environ.get("ZOE_SKYBRIDGE_ONLY", "").strip().lower() in ("1", "true", "yes", "on")
+
+
 async def _broadcast_weather_ui(
     panel_id: str,
     summary: str = "Fetching weather...",
     turn_key: Optional[str] = None,
 ) -> None:
     """Mirror chat weather navigation on voice path with durable delivery."""
+    if _skybridge_only():
+        return
     delivery_key = turn_key or str(time.monotonic_ns())
     nav_action = {
         "id": f"voice_weather_nav_{panel_id}_{delivery_key}",
@@ -599,6 +612,8 @@ async def _broadcast_calendar_ui(
     turn_key: Optional[str] = None,
 ) -> None:
     """Mirror calendar intents on voice path with durable delivery."""
+    if _skybridge_only():
+        return
     delivery_key = turn_key or str(time.monotonic_ns())
     nav_action = {
         "id": f"voice_calendar_nav_{panel_id}_{delivery_key}",
@@ -1006,6 +1021,8 @@ async def _broadcast_lets_talk_ui(panel_id: str, turn_key: Optional[str] = None)
     (voice:start_conversation) which the voice page handles directly — it is
     never enqueued in the DB, so it cannot create a replay loop.
     """
+    if _skybridge_only():
+        return
     delivery_key = turn_key or str(time.monotonic_ns())
     # Navigation: no ?conv=1 so the action is skipped when panel is already on voice page.
     nav_action = {
@@ -1200,6 +1217,8 @@ async def _broadcast_reminder_ui(
     summary: str,
     turn_key: Optional[str] = None,
 ) -> None:
+    if _skybridge_only():
+        return
     delivery_key = turn_key or str(time.monotonic_ns())
     nav_action = {
         "id": f"voice_reminder_nav_{panel_id}_{delivery_key}",
@@ -3202,7 +3221,9 @@ async def voice_command(
             }
         _VOICE_SESSIONS.setdefault(panel_id, {})["skybridge_context"] = {}
     except Exception as _skybridge_exc:
-        logger.debug("voice/command skybridge fast path failed (non-fatal): %s", _skybridge_exc)
+        # Surfaced at warning (was debug): when this fires the turn falls through to
+        # the legacy intent path, which is the silent bounce-to-domain-page behavior.
+        logger.warning("voice/command skybridge fast path failed (non-fatal): %s", _skybridge_exc)
 
     # Fallback audio used when any part of the pipeline fails — panel never goes silent.
     _FALLBACK_PHRASE = "Sorry, something went wrong. Please try again."

--- a/services/zoe-data/tests/test_voice_skybridge_only.py
+++ b/services/zoe-data/tests/test_voice_skybridge_only.py
@@ -50,5 +50,9 @@ async def test_legacy_helpers_noop_when_flag_on(monkeypatch, helper, args):
         raise AssertionError(f"{helper} enqueued a UI action despite ZOE_SKYBRIDGE_ONLY")
 
     monkeypatch.setattr("ui_orchestrator.enqueue_ui_action", _boom, raising=False)
-    # Returns cleanly (no enqueue, no navigation) — the panel stays on Skybridge.
+    # _broadcast_lets_talk_ui broadcasts BEFORE the enqueue step, so a broken
+    # guard there would fire the broadcast and slip past the enqueue boom. Mock
+    # the broadcaster too so every helper's early-return is genuinely covered.
+    monkeypatch.setattr("push.broadcaster.broadcast", _boom, raising=False)
+    # Returns cleanly (no enqueue, no broadcast, no navigation) — stays on Skybridge.
     await getattr(vt, helper)(*args)

--- a/services/zoe-data/tests/test_voice_skybridge_only.py
+++ b/services/zoe-data/tests/test_voice_skybridge_only.py
@@ -1,0 +1,54 @@
+"""ZOE_SKYBRIDGE_ONLY gates the legacy voice domain-navigation helpers.
+
+When the flag is set, voice must not navigate the touch panel to per-domain
+legacy pages (`/touch/weather.html`, `/touch/calendar.html`, `/touch/dashboard.html`,
+`/touch/voice.html`) — the panel stays on Skybridge. The Skybridge-first path
+(`_broadcast_skybridge_ui`) is unaffected and still renders real cards.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import routers.voice_tts as vt
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [("true", True), ("1", True), ("on", True), ("YES", True),
+     ("false", False), ("0", False), ("", False)],
+)
+def test_skybridge_only_parsing(monkeypatch, value, expected):
+    monkeypatch.setenv("ZOE_SKYBRIDGE_ONLY", value)
+    assert vt._skybridge_only() is expected
+
+
+def test_skybridge_only_unset_is_false(monkeypatch):
+    monkeypatch.delenv("ZOE_SKYBRIDGE_ONLY", raising=False)
+    assert vt._skybridge_only() is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "helper,args",
+    [
+        ("_broadcast_weather_ui", ("zoe-touch-pi", "x")),
+        ("_broadcast_calendar_ui", ("zoe-touch-pi", "x")),
+        ("_broadcast_reminder_ui", ("zoe-touch-pi", "x")),
+        ("_broadcast_lets_talk_ui", ("zoe-touch-pi",)),
+    ],
+)
+async def test_legacy_helpers_noop_when_flag_on(monkeypatch, helper, args):
+    monkeypatch.setenv("ZOE_SKYBRIDGE_ONLY", "true")
+
+    # Any attempt to enqueue/broadcast would mean the helper did NOT early-return.
+    def _boom(*a, **k):
+        raise AssertionError(f"{helper} enqueued a UI action despite ZOE_SKYBRIDGE_ONLY")
+
+    monkeypatch.setattr("ui_orchestrator.enqueue_ui_action", _boom, raising=False)
+    # Returns cleanly (no enqueue, no navigation) — the panel stays on Skybridge.
+    await getattr(vt, helper)(*args)


### PR DESCRIPTION
Part of the Skybridge cutover (plan: #724). **Flag defaults off → zero behavior change** until `ZOE_SKYBRIDGE_ONLY` is set.

## Problem
`voice_command` has two routing families. When the Skybridge resolver falls through (e.g. its external weather fetch throws — silently swallowed at `debug`), the turn drops to the legacy `_broadcast_*_ui` helpers, which emit `panel_navigate` to per-domain pages (`/touch/weather.html`, `/touch/calendar.html`, `/touch/dashboard.html`, `/touch/voice.html`). That yanks the panel off Skybridge — the "overlapping/confused" behavior.

## Change
- Add `ZOE_SKYBRIDGE_ONLY`. When set, the four legacy domain-nav helpers early-return, so voice never navigates to legacy pages. The Skybridge-first path (`_broadcast_skybridge_ui`) is untouched and still renders real cards via `SkybridgeRenderer` (verified: `touch-ui-executor.js` renders polled `show_card` on `skybridge.html`).
- Raise the swallowed Skybridge resolve error `debug → warning` so fall-throughs are observable (root-cause for the weather-fetch reliability work).

## Verification
- `routers.voice_tts` imports clean.
- New `tests/test_voice_skybridge_only.py` (12 cases): flag parsing + all four helpers no-op when on.
- 100 existing skybridge/voice tests pass.

## Notes
- Degraded case with flag on: if the Skybridge resolver fails, the turn is audio-only (no card) but **stays on Skybridge** — no bounce. The raised warning surfaces these so we can fix resolver reliability next.
- Reminders / lets_talk have no Skybridge domain yet, so with the flag on they go audio-only (no card). Tracked for a later phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)