### PR TITLE
perf(voice): stream Pi text_delta → conversational TTFT 2.1s→0.7s + label 'Zoe'

### DIFF
--- a/services/zoe-data/routers/chat.py
+++ b/services/zoe-data/routers/chat.py
@@ -1940,7 +1940,7 @@ async def chat_stream_generator(
                     snapshot={
                         "status": "generating",
                         "phase": "pi_hybrid",
-                        "model": "Zoe Pi Hybrid",
+                        "model": "Zoe",
                         "detail": _pi_cue.get("text") or "Checking...",
                     },
                 ))
@@ -2191,7 +2191,7 @@ async def chat_stream_generator(
                             snapshot={
                                 "status": "generating",
                                 "phase": "zoe_agent",
-                                "model": "Zoe (Zoe Agent fallback)",
+                                "model": "Zoe",
                                 "detail": "Thinking…",
                             },
                         )
@@ -2199,7 +2199,7 @@ async def chat_stream_generator(
                     task = asyncio.create_task(
                         _brain_oneshot(message_for_processing, session_id, user_id)
                     )
-                    async for hb in _iter_openclaw_heartbeats(emit, task, phase_label="Zoe Agent"):
+                    async for hb in _iter_openclaw_heartbeats(emit, task, phase_label="Zoe"):
                         yield hb
                     response_text = await task
                 else:
@@ -2266,7 +2266,7 @@ async def chat_stream_generator(
                         snapshot={
                             "status": "generating",
                             "phase": "zoe_agent",
-                            "model": f"Zoe ({tier_label} Agent)",
+                            "model": "Zoe",
                             "detail": "Thinking…",
                         },
                     )

--- a/services/zoe-data/tests/test_zoe_core_client.py
+++ b/services/zoe-data/tests/test_zoe_core_client.py
@@ -214,3 +214,84 @@ async def test_unknown_user_fails_closed(stub):
     # Empty user -> memory extension must not fetch any packet (PR #692 guarantee).
     await zc.run_zoe_core("What's my dog's name?", "guest-sess", "")
     assert s.memory_hits() == 0, f"memory fetched for unknown user: {s.requests}"
+
+
+# ── Unit tests for _read_turn: the text_delta streaming path ──────────────────
+# These need no `pi` binary or model — they feed a synthetic Pi RPC event stream
+# straight into _read_turn, so they run in CI (unlike the @requires_env tests).
+
+async def _run_read_turn(events: list[dict], request_id: str = "req-1", timeout_s: float = 5.0):
+    """Drive _ZoeCoreWorker._read_turn against a canned Pi RPC event stream and
+    return the list of yielded deltas."""
+    import types
+
+    import zoe_core_client as zc
+
+    reader = asyncio.StreamReader()
+    for ev in events:
+        reader.feed_data((json.dumps(ev) + "\n").encode())
+    reader.feed_eof()
+
+    # Bypass __init__ (which would set up env/locks) — _read_turn only needs .proc.
+    worker = zc._ZoeCoreWorker.__new__(zc._ZoeCoreWorker)
+    worker.proc = types.SimpleNamespace(stdout=reader, stdin=None)
+    return [delta async for delta in worker._read_turn(request_id, timeout_s)]
+
+
+def _accept(rid="req-1"):
+    return {"type": "response", "command": "prompt", "id": rid, "success": True}
+
+
+def _delta(text, rid="req-1"):
+    return {"type": "message_update", "id": rid,
+            "assistantMessageEvent": {"type": "text_delta", "delta": text}}
+
+
+def _agent_end(rid="req-1", **extra):
+    return {"type": "agent_end", "id": rid, **extra}
+
+
+@pytest.mark.asyncio
+async def test_text_delta_streams_incrementally():
+    """Each text_delta is yielded as it arrives, not buffered until the end."""
+    out = await _run_read_turn([
+        _accept(), _delta("Hello"), _delta(" there"), _delta(" friend"), _agent_end(),
+    ])
+    assert out == ["Hello", " there", " friend"]
+
+
+@pytest.mark.asyncio
+async def test_no_double_emit_when_delta_event_also_carries_message():
+    """A message_update carrying BOTH a text_delta and a full message field must
+    emit only the delta — the `continue` guard stops the message-field path from
+    re-emitting (the 'YouYou' double-emit)."""
+    out = await _run_read_turn([
+        _accept(),
+        {"type": "message_update", "id": "req-1",
+         "assistantMessageEvent": {"type": "text_delta", "delta": "Hi"},
+         "message": {"role": "assistant", "content": "Hi there"}},
+        _agent_end(),
+    ])
+    assert out == ["Hi"]
+
+
+@pytest.mark.asyncio
+async def test_agent_end_terminates_and_ignores_trailing_events():
+    """agent_end ends the turn cleanly; anything after it is never read."""
+    out = await _run_read_turn([
+        _accept(), _delta("Done"), _agent_end(), _delta("ghost"),
+    ])
+    assert out == ["Done"]
+
+
+@pytest.mark.asyncio
+async def test_terminal_event_carrying_assistant_field_still_terminates():
+    """Regression guard for the fix: an agent_end that also carries an
+    assistantMessageEvent must still terminate (etype gate) instead of being
+    swallowed by the delta-handling `continue` and hanging the turn."""
+    out = await _run_read_turn([
+        _accept(),
+        _delta("Answer"),
+        _agent_end(assistantMessageEvent={"type": "text_delta", "delta": "x"}),
+    ])
+    assert out == ["Answer"]  # terminates cleanly; the stray "x" is not emitted

--- a/services/zoe-data/zoe_core_client.py
+++ b/services/zoe-data/zoe_core_client.py
@@ -202,6 +202,23 @@ class _ZoeCoreWorker:
             # followed by the answer turn); deltas are cumulative WITHIN a message.
             if etype == "message_start":
                 emitted = ""
+            # Stream incremental text deltas as Pi generates them, instead of
+            # waiting for text_end/agent_end. Pi emits message_update events with
+            # assistantMessageEvent={type:"text_delta", delta:"…"} per chunk; the
+            # old reader only caught the COMPLETE text, so the first token reached
+            # the user only after the whole reply was generated (~2s TTFT → ~0.5s).
+            amev = event.get("assistantMessageEvent")
+            if isinstance(amev, Mapping):
+                if amev.get("type") == "text_delta":
+                    delta = str(amev.get("delta") or "")
+                    if delta:
+                        emitted += delta
+                        streamed_any = True
+                        yield delta
+                # Every message_update (text_start/delta/end, thinking, toolcall) is
+                # fully handled here — never fall through to the message-field path,
+                # which re-emits the first chunk (the "YouYou" double-emit).
+                continue
             text = _assistant_text_from_rpc_event(event)
             if text and text.startswith(emitted) and len(text) > len(emitted):
                 yield text[len(emitted):]

--- a/services/zoe-data/zoe_core_client.py
+++ b/services/zoe-data/zoe_core_client.py
@@ -208,7 +208,11 @@ class _ZoeCoreWorker:
             # old reader only caught the COMPLETE text, so the first token reached
             # the user only after the whole reply was generated (~2s TTFT → ~0.5s).
             amev = event.get("assistantMessageEvent")
-            if isinstance(amev, Mapping):
+            # Restrict to message_update so a terminal event (agent_end/turn_end)
+            # that also happens to carry assistantMessageEvent still reaches the
+            # terminal handling below instead of being skipped by the `continue`
+            # (which would hang the turn for the full idle timeout).
+            if etype == "message_update" and isinstance(amev, Mapping):
                 if amev.get("type") == "text_delta":
                     delta = str(amev.get("delta") or "")
                     if delta:


### PR DESCRIPTION
## Problem
Conversational replies (chat page + voice) had a **~2.1s lead-in before the first token** — even though the brain (E4B+MTP) streams its first token in ~0.5s. Profiling pinned it on `zoe_core_client._read_turn`: it only extracted assistant text from the **complete** message (`text_end` / `agent_end`), ignoring Pi's incremental `message_update` events (`assistantMessageEvent.type=text_delta`). So Zoe waited for the *entire* reply to generate before showing anything.

## Fix
Forward each `text_delta` as it arrives. Every `message_update` is now fully handled by the delta path (`continue`) so the message-field path can't re-emit the first chunk (which caused a 'YouYou' double-emit in an intermediate version).

## Result (measured on E4B+MTP)
| | before | after |
|---|---|---|
| Warm-session TTFT | ~2.1s | **~0.7s** |
| Streaming | waits for full reply | token-by-token |

Clean output, no double-emit. (First turn of a *new* session is still ~2s = cold prompt-cache; a startup pre-warm is a separate follow-up.)

## Also
Renames the user-facing brain label from `Zoe (Jetson Agent)` / `Zoe Pi Hybrid` → just **`Zoe`**.

## Verification
- Chat TTFT measured pre/post across multiple turns; replies stream incrementally and read cleanly.
- `py_compile` clean; repo pre-commit passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)