### PR TITLE
feat(voice): Moonshine STT + brain→TTS sentence streaming

### DIFF
--- a/scripts/setup/zoe_voice_daemon.py
+++ b/scripts/setup/zoe_voice_daemon.py
@@ -31,6 +31,7 @@ import math
 
 import http.server
 import numpy as np
+from collections import deque
 import pyaudio
 import requests
 
@@ -161,6 +162,9 @@ _recording_active = threading.Event()
 _WAKE_QUEUE: "queue.Queue[bytes]" = None   # type: ignore  # set in main()
 _BARGE_QUEUE: "queue.Queue[bytes]" = None  # type: ignore  # set in main()
 _AMBIENT_QUEUE: "queue.Queue[bytes]" = None  # type: ignore  # set in main()
+# Pre-roll ring buffer so the wake->record stream-open gap does not clip the
+# START of the command (the "what's the" that went missing).
+_PREROLL: deque = deque(maxlen=int(os.environ.get("PREROLL_CHUNKS", "7")))  # ~560ms @1280/16k
 import queue as _queue_module
 
 
@@ -586,7 +590,7 @@ def record_command(pa: pyaudio.PyAudio) -> bytes | None:
             wait_s = 0.15 * attempt
             log.warning("Mic open failed (%s), retrying in %.2fs [%d/5]...", exc, wait_s, attempt)
             time.sleep(wait_s)
-    frames = []
+    frames = list(_PREROLL)  # prepend pre-roll so the start of speech is kept
     silent_chunks = 0
     stop_reason = "max_duration"
     max_silent = int(SILENCE_TIMEOUT_S * SAMPLE_RATE / CHUNK_SIZE)
@@ -733,6 +737,163 @@ def _play_buffer_phrase():
     except Exception as exc:
         log.debug("buffer phrase skipped: %s", exc)
         return None
+
+
+# ── Streaming turn: play TTS sentence chunks the instant they arrive ──────────
+# When enabled, the panel hits /api/voice/turn_stream and plays each sentence as
+# Kokoro finishes it (first audio ~1.3s) instead of waiting for the whole reply
+# to synthesize. This makes the "thinking" buffer phrase unnecessary on most
+# turns. Any failure falls back to the blocking _do_single_turn.
+VOICE_STREAM_ENABLED = os.environ.get("ZOE_VOICE_STREAM", "1").strip().lower() in ("1", "true", "yes", "on")
+
+
+def _pcm_from_wav(wav_bytes: bytes):
+    """Return (pcm_frames, rate, channels, sampwidth) from one WAV chunk."""
+    with wave.open(io.BytesIO(wav_bytes), "rb") as wf:
+        return wf.readframes(wf.getnframes()), wf.getframerate(), wf.getnchannels(), wf.getsampwidth()
+
+
+def _feed_pcm_chunk(aplay, wav_bytes: bytes):
+    """Strip the WAV header and stream raw PCM into a single persistent aplay so
+    sentence chunks play gaplessly. Starts aplay on the first chunk (format taken
+    from that chunk's header) and registers it as the active TTS process so the
+    barge-in thread can stop it."""
+    global _tts_process
+    try:
+        pcm, rate, ch, width = _pcm_from_wav(wav_bytes)
+    except Exception as exc:
+        log.debug("bad wav chunk: %s", exc)
+        return aplay
+    if aplay is None:
+        fmt = {1: "U8", 2: "S16_LE", 3: "S24_3LE", 4: "S32_LE"}.get(width, "S16_LE")
+        cmd = ["aplay", "-q", "-t", "raw", "-f", fmt, "-c", str(ch), "-r", str(rate)]
+        if AUDIO_OUTPUT_DEVICE != "default":
+            cmd += ["-D", AUDIO_OUTPUT_DEVICE]
+        aplay = subprocess.Popen(cmd, stdin=subprocess.PIPE)
+        with _tts_process_lock:
+            _tts_process = aplay
+    try:
+        if aplay.stdin:
+            aplay.stdin.write(pcm)
+            aplay.stdin.flush()
+    except (BrokenPipeError, ValueError, OSError):
+        pass
+    return aplay
+
+
+def _do_single_turn_stream(pa: pyaudio.PyAudio, wav: bytes, *, prompt_on_empty: bool = True) -> bool:
+    """Streaming turn: POST audio to /api/voice/turn_stream and play each TTS
+    sentence chunk as it arrives (no buffer phrase — first audio ~1.3s). Falls
+    back to the blocking _do_single_turn on any error."""
+    global _tts_process
+    import time as _time
+
+    audio_b64_wav = base64.b64encode(wav).decode()
+    identified_user_id = None
+    try:
+        identified_user_id = _identify_speaker_from_wav(wav)
+        if identified_user_id:
+            log.info("Speaker identified: %s", identified_user_id)
+    except Exception:
+        pass
+    payload: dict = {"audio_base64": audio_b64_wav, "panel_id": PANEL_ID}
+    if identified_user_id:
+        payload["identified_user_id"] = identified_user_id
+
+    url = f"{ZOE_URL}/api/voice/turn_stream"
+    _barge_in_requested.clear()
+    t0 = _time.monotonic()
+    aplay = None
+    ttfa = None
+    transcript = ""
+    reply = ""
+    played_any = False
+    expect_audio = False
+
+    try:
+        r = requests.post(url, json=payload, headers=_headers, timeout=60, stream=True, verify=VERIFY_SSL)
+        r.raise_for_status()
+        for raw_line in r.iter_lines(decode_unicode=False):
+            if _barge_in_requested.is_set():
+                log.info("Barge-in during streamed reply.")
+                break
+            if not raw_line:
+                continue
+            if expect_audio:
+                expect_audio = False
+                try:
+                    wav_bytes = base64.b64decode(raw_line)
+                except Exception:
+                    continue
+                if not played_any:
+                    _recording_active.clear()
+                aplay = _feed_pcm_chunk(aplay, wav_bytes)
+                if ttfa is None:
+                    ttfa = _time.monotonic() - t0
+                played_any = True
+                continue
+            try:
+                obj = json.loads(raw_line.decode("utf-8", "ignore"))
+            except Exception:
+                continue
+            if obj.get("error"):
+                log.warning("turn_stream server error: %s", obj["error"])
+                break
+            if obj.get("done"):
+                reply = obj.get("reply", "") or reply
+                break
+            if "transcript" in obj and "chunk" not in obj:
+                transcript = obj.get("transcript", "") or transcript
+                continue
+            if "chunk" in obj:
+                expect_audio = True
+                continue
+    except requests.exceptions.SSLError:
+        raise
+    except Exception as exc:
+        log.warning("turn_stream failed (%s) — falling back to blocking turn", exc)
+        if aplay is not None:
+            try:
+                aplay.kill()
+            except Exception:
+                pass
+            with _tts_process_lock:
+                _tts_process = None
+        return _do_single_turn(pa, wav, prompt_on_empty=prompt_on_empty)
+
+    # Drain playback (respecting barge-in) once the stream ends.
+    if aplay is not None:
+        try:
+            if aplay.stdin:
+                aplay.stdin.close()
+        except Exception:
+            pass
+        while aplay.poll() is None:
+            if _barge_in_requested.is_set():
+                try:
+                    aplay.terminate()
+                except Exception:
+                    pass
+                break
+            _time.sleep(0.05)
+        with _tts_process_lock:
+            _tts_process = None
+
+    if transcript and _is_junk_transcript(transcript):
+        log.info("Ignoring junk/hallucination transcript: %r", transcript)
+        return False
+    if played_any:
+        log.info("turn_stream TTFA=%.2fs transcript=%r", ttfa if ttfa is not None else -1.0, transcript[:80])
+        return True
+    # Stream produced no audio.
+    if not transcript:
+        if prompt_on_empty:
+            log.info("Empty transcript with no audio — retry chime.")
+            _recording_active.clear()
+            play_follow_up_beep()
+        return False
+    log.info("turn_stream: transcript but no audio (reply=%r) — blocking fallback.", reply[:80])
+    return _do_single_turn(pa, wav, prompt_on_empty=prompt_on_empty)
 
 
 def _do_single_turn(pa: pyaudio.PyAudio, wav: bytes, *, prompt_on_empty: bool = True) -> bool:
@@ -956,7 +1117,8 @@ def voice_command(pa: pyaudio.PyAudio, oww) -> None:
         if not wav:
             return
 
-        played_audio = _do_single_turn(pa, wav)
+        _turn_fn = _do_single_turn_stream if VOICE_STREAM_ENABLED else _do_single_turn
+        played_audio = _turn_fn(pa, wav)
         if FOLLOW_UP_LISTEN_S > 0 and FOLLOW_UP_MAX_TURNS <= 0:
             log.info("Follow-up disabled by config (FOLLOW_UP_MAX_TURNS=%d).", _FOLLOW_UP_MAX_TURNS_RAW)
 
@@ -972,7 +1134,7 @@ def voice_command(pa: pyaudio.PyAudio, oww) -> None:
                 break
             # Follow-up misses should fall back silently to wake mode, not speak a
             # robotic retry prompt after a successful prior answer.
-            played_audio = _do_single_turn(pa, follow_wav, prompt_on_empty=False)
+            played_audio = _turn_fn(pa, follow_wav, prompt_on_empty=False)
             follow_ups_done += 1
 
         if POST_PLAY_TAIL_S > 0:
@@ -1217,6 +1379,7 @@ def main():
                     continue
 
             audio_chunk = stream.read(CHUNK_SIZE, exception_on_overflow=False)
+            _PREROLL.append(audio_chunk)
             # OpenWakeWord expects int16 PCM at 16 kHz (not float32 [-1,1] — that yields ~0 scores forever).
             audio_pcm = np.frombuffer(audio_chunk, dtype=np.int16)
 

--- a/scripts/setup/zoe_voice_daemon.py
+++ b/scripts/setup/zoe_voice_daemon.py
@@ -851,6 +851,29 @@ def _do_single_turn_stream(pa: pyaudio.PyAudio, wav: bytes, *, prompt_on_empty: 
     except requests.exceptions.SSLError:
         raise
     except Exception as exc:
+        # If we've already started speaking, re-running the blocking turn would
+        # double-play (user hears a fragment, then the whole reply again). Only
+        # fall back when nothing has played yet; otherwise let the partial reply
+        # stand and finish draining what's queued.
+        if played_any:
+            log.warning("turn_stream failed mid-reply (%s) — keeping partial, no re-play", exc)
+            if aplay is not None:
+                try:
+                    if aplay.stdin:
+                        aplay.stdin.close()
+                except Exception:
+                    pass
+                while aplay.poll() is None:
+                    if _barge_in_requested.is_set():
+                        try:
+                            aplay.terminate()
+                        except Exception:
+                            pass
+                        break
+                    time.sleep(0.05)
+                with _tts_process_lock:
+                    _tts_process = None
+            return True
         log.warning("turn_stream failed (%s) — falling back to blocking turn", exc)
         if aplay is not None:
             try:

--- a/scripts/setup/zoe_voice_daemon.py
+++ b/scripts/setup/zoe_voice_daemon.py
@@ -839,6 +839,17 @@ def _do_single_turn_stream(pa: pyaudio.PyAudio, wav: bytes, *, prompt_on_empty: 
             if obj.get("error"):
                 log.warning("turn_stream server error: %s", obj["error"])
                 break
+            if "full_audio" in obj:
+                # Skybridge/confirmation path: voice_command returned one full
+                # audio blob (wav or mp3). Play it via the robust player.
+                if not played_any:
+                    _recording_active.clear()
+                if ttfa is None:
+                    ttfa = _time.monotonic() - t0
+                play_audio_b64(str(obj.get("full_audio") or ""), obj.get("content_type") or "audio/wav")
+                played_any = True
+                reply = obj.get("reply", "") or reply
+                continue
             if obj.get("done"):
                 reply = obj.get("reply", "") or reply
                 break

--- a/services/zoe-data/main.py
+++ b/services/zoe-data/main.py
@@ -690,9 +690,10 @@ async def lifespan(app: FastAPI):
     _zoe_update_bg_task = start_zoe_update_background_tasks()
 
     try:
-        from routers.voice_tts import warm_faster_whisper_worker
+        from routers.voice_tts import warm_faster_whisper_worker, warm_moonshine
+        asyncio.create_task(warm_moonshine(), name="moonshine_warmup")
         asyncio.create_task(warm_faster_whisper_worker(), name="faster_whisper_warmup")
-        logger.info("Voice STT worker warmup scheduled")
+        logger.info("Voice STT worker warmup scheduled (moonshine + whisper)")
     except Exception as _voice_warmup_exc:
         logger.warning("Voice STT worker warmup scheduling failed (non-fatal): %s", _voice_warmup_exc)
 

--- a/services/zoe-data/routers/voice_tts.py
+++ b/services/zoe-data/routers/voice_tts.py
@@ -1898,6 +1898,7 @@ model = WhisperModel(model_name, device=device, compute_type=compute_type)
 segments, _info = model.transcribe(
     wav_path,
     language=lang,
+    beam_size=_env_int("ZOE_WHISPER_BEAM_SIZE", 5),
     vad_filter=True,
     vad_parameters={
         "threshold": _env_float("ZOE_WHISPER_VAD_THRESHOLD", 0.50),
@@ -2021,6 +2022,7 @@ for line in sys.stdin:
         segments, _info = model.transcribe(
             wav_path,
             language=lang,
+            beam_size=_env_int("ZOE_WHISPER_BEAM_SIZE", 5),
             vad_filter=True,
             vad_parameters={
                 "threshold": _env_float("ZOE_WHISPER_VAD_THRESHOLD", 0.50),
@@ -2271,6 +2273,7 @@ async def _run_faster_whisper_in_process(wav_path: str) -> str:
                 segments, _info = model.transcribe(
                     wav_path,
                     language=lang,
+                    beam_size=int(os.environ.get("ZOE_WHISPER_BEAM_SIZE", "5")),
                     vad_filter=True,
                     vad_parameters={
                         "threshold": vad_threshold,
@@ -2395,12 +2398,67 @@ def _log_voice_stt_sample(
         logger.debug("voice STT audit log failed: %s", exc)
 
 
+# --- Moonshine ONNX STT (edge real-time; faster on short commands, CPU-only so
+# it never competes with the brain's GPU). Model + tokenizer are cached once. ---
+_moonshine_model = None
+_moonshine_tok = None
+
+
+def _ensure_moonshine():
+    global _moonshine_model, _moonshine_tok
+    if _moonshine_model is None:
+        from moonshine_onnx import MoonshineOnnxModel, load_tokenizer
+
+        name = (os.environ.get("ZOE_MOONSHINE_MODEL") or "moonshine/base").strip()
+        _moonshine_model = MoonshineOnnxModel(model_name=name)
+        _moonshine_tok = load_tokenizer()
+    return _moonshine_model, _moonshine_tok
+
+
+async def _run_moonshine(wav_path: str) -> str:
+    from moonshine_onnx import load_audio
+
+    def _work() -> str:
+        model, tok = _ensure_moonshine()
+        audio = load_audio(wav_path)
+        tokens = model.generate(audio)
+        out = tok.decode_batch(tokens)
+        return (out[0] if out else "").strip()
+
+    return await asyncio.get_running_loop().run_in_executor(None, _work)
+
+
+async def warm_moonshine() -> bool:
+    """Pre-load the Moonshine STT model+tokenizer so the first panel turn isn't
+    cold (saves the ~1-2s ONNX session load on the first utterance)."""
+    if (os.environ.get("ZOE_STT_BACKEND") or "moonshine").strip().lower() != "moonshine":
+        logger.info("Moonshine warmup skipped; ZOE_STT_BACKEND is not moonshine")
+        return False
+    started = time.monotonic()
+    try:
+        await asyncio.get_running_loop().run_in_executor(None, _ensure_moonshine)
+        logger.info("Moonshine STT warmup completed in %.2fs", time.monotonic() - started)
+        return True
+    except Exception as exc:
+        logger.warning("Moonshine STT warmup failed (non-fatal): %s", exc)
+        return False
+
+
 async def _transcribe_audio(wav_path: str) -> str:
     """
     Transcription waterfall:
+    0. Moonshine ONNX (default; edge real-time, CPU) — falls through on error
     1. whisper.cpp CLI (if binary + ggml model configured)
     2. faster-whisper Python (auto-downloaded model, GPU/CPU)
     """
+    if (os.environ.get("ZOE_STT_BACKEND") or "moonshine").strip().lower() == "moonshine":
+        try:
+            text = await _run_moonshine(wav_path)
+            if text:
+                return text
+            logger.warning("Moonshine STT returned empty; falling back to whisper")
+        except Exception as exc:
+            logger.warning("Moonshine STT failed (%s); falling back to whisper", exc)
     if _whisper_cpp_binary():
         model = (os.environ.get("ZOE_WHISPER_MODEL") or "").strip()
         if model and os.path.isfile(model):
@@ -3127,12 +3185,14 @@ async def voice_command(
         _voice_entry = _VOICE_SESSIONS.get(panel_id, {})
         _skybridge_context = _voice_entry.get("skybridge_context") or {}
         _skybridge_user = _scope_identity_user or "guest"
+        _sky_t0 = time.monotonic()
         _skybridge_result = await resolve_skybridge_request(
             text,
             _skybridge_user,
             context=_skybridge_context,
             db=db,
         )
+        _sky_t_resolve = time.monotonic() - _sky_t0
         if _skybridge_result and _skybridge_result.get("auth_required"):
             _intent = _skybridge_result.get("intent") or {}
             try:
@@ -3176,13 +3236,18 @@ async def voice_command(
                 _skybridge_result.get("skybridge_context") or {}
             )
             _skybridge_reply = str(_skybridge_result.get("spoken_summary") or "Showing that in Skybridge.")
+            _bcast_t0 = time.monotonic()
             await _broadcast_skybridge_ui(
                 panel_id,
                 _skybridge_result,
                 utterance=text,
                 turn_key=_turn_key,
             )
+            _bcast_dt = time.monotonic() - _bcast_t0
+            _synth_t0 = time.monotonic()
             _skybridge_audio = await synthesize({"text": _skybridge_reply}, caller=caller)
+            logger.info("SKYBRIDGE TIMING resolve=%.2fs broadcast=%.2fs synth=%.2fs reply=%r",
+                        _sky_t_resolve, _bcast_dt, time.monotonic() - _synth_t0, _skybridge_reply[:50])
             try:
                 from push import broadcaster as _bc_sky
                 await _bc_sky.broadcast("all", "voice:responding", {"panel_id": panel_id, "text": _skybridge_reply[:200]})
@@ -4303,6 +4368,100 @@ async def voice_turn(payload: dict, caller: dict = Depends(_require_voice_auth),
         pass
     logger.info("voice/turn total=%.1fs (STT=%.1fs LLM+TTS=%.1fs)", t_total, t_stt, t_total - t_stt)
     return result
+
+
+@router.post("/turn_stream")
+async def voice_turn_stream(payload: dict, caller: dict = Depends(_require_voice_auth), db=Depends(get_db)):
+    """Streaming variant of /turn: STT, then stream brain→sentence→TTS audio
+    chunks as they are produced, so the panel starts speaking the answer ~1.3s
+    in instead of waiting for the whole reply to synthesize.
+
+    Wire format (media type application/x-zoe-audio-stream):
+      line 1:        {"transcript": "..."}
+      per chunk:     {"chunk": N, "text": "...", "provider": "..."}\n<base64 wav>\n
+      final:         {"done": true, "reply": "...", "panel_id": "..."}
+    Reuses voice_command(stream=True) for the LLM+TTS pipeline.
+    """
+    b64 = str((payload or {}).get("audio_base64") or "").strip()
+    panel_id = str((payload or {}).get("panel_id", caller.get("panel_id") or "unknown"))
+    if not b64:
+        raise HTTPException(status_code=400, detail="audio_base64 is required")
+
+    t_turn_start = time.monotonic()
+    try:
+        raw = base64.b64decode(b64, validate=True)
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail="invalid base64 audio") from exc
+    suffix = ".wav" if (len(raw) >= 4 and raw[:4] == b"RIFF") else ".raw"
+
+    # ── STT (Moonshine, same waterfall as /turn) ──
+    t_stt_start = time.monotonic()
+    duration_s: float | None = None
+    try:
+        with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
+            tmp.write(raw)
+            wav_path = tmp.name
+        duration_s = _wav_duration_seconds(wav_path) if suffix == ".wav" else None
+        try:
+            transcript = await _transcribe_audio(wav_path)
+        finally:
+            try:
+                os.unlink(wav_path)
+            except OSError:
+                pass
+    except Exception as exc:
+        logger.error("voice/turn_stream STT failed: %s", exc)
+        raise HTTPException(status_code=500, detail=f"Transcription failed: {exc}") from exc
+
+    t_stt = time.monotonic() - t_stt_start
+    transcript = (transcript or "").strip()
+    _log_voice_stt_sample(
+        route="turn_stream",
+        panel_id=panel_id,
+        audio_bytes=len(raw),
+        suffix=suffix,
+        transcript=transcript,
+        duration_seconds=duration_s,
+        stt_seconds=t_stt,
+    )
+
+    import json as _json
+
+    if not transcript:
+        async def _empty():
+            yield (_json.dumps({"transcript": "", "done": True, "reply": ""}) + "\n").encode()
+        return StreamingResponse(
+            _empty(), media_type="application/x-zoe-audio-stream", headers={"Cache-Control": "no-cache"}
+        )
+
+    logger.info("voice/turn_stream panel=%s STT=%.2fs transcript=%r", panel_id, t_stt, transcript[:80])
+    try:
+        from push import broadcaster as _bc_t
+        await _bc_t.broadcast("all", "voice:transcript", {"panel_id": panel_id, "text": transcript})
+    except Exception:
+        pass
+
+    command_payload = {
+        "text": transcript,
+        "panel_id": panel_id,
+        "_t_turn_start": t_turn_start,
+    }
+    if (payload or {}).get("identified_user_id"):
+        command_payload["identified_user_id"] = payload["identified_user_id"]
+
+    # Delegate LLM + per-sentence TTS to the existing streaming pipeline.
+    sub = await voice_command(command_payload, caller=caller, stream=True, db=db)
+
+    async def _wrapped():
+        # Lead with the transcript so the panel can show/log what was heard
+        # before the first audio chunk arrives.
+        yield (_json.dumps({"transcript": transcript}) + "\n").encode()
+        async for chunk in sub.body_iterator:
+            yield chunk
+
+    return StreamingResponse(
+        _wrapped(), media_type="application/x-zoe-audio-stream", headers={"Cache-Control": "no-cache"}
+    )
 
 
 @router.post("/wake")

--- a/services/zoe-data/routers/voice_tts.py
+++ b/services/zoe-data/routers/voice_tts.py
@@ -4486,8 +4486,26 @@ async def voice_turn_stream(payload: dict, caller: dict = Depends(_require_voice
         # Lead with the transcript so the panel can show/log what was heard
         # before the first audio chunk arrives.
         yield (_json.dumps({"transcript": transcript}) + "\n").encode()
-        async for chunk in sub.body_iterator:
-            yield chunk
+        if hasattr(sub, "body_iterator"):
+            async for chunk in sub.body_iterator:
+                yield chunk
+            return
+        # voice_command returns a plain dict (not a StreamingResponse) on the
+        # skybridge / confirmation-dialog / pi-direct paths regardless of the
+        # stream flag. Those already hold the full reply + synthesized audio, so
+        # forward it as a one-shot full_audio frame the panel plays via its
+        # robust player (handles wav AND mp3) instead of crashing on the missing
+        # body_iterator.
+        result = sub if isinstance(sub, dict) else {}
+        reply_text = str(result.get("reply") or "")
+        audio_b64 = result.get("audio_base64")
+        if audio_b64:
+            yield (_json.dumps({
+                "full_audio": str(audio_b64),
+                "content_type": result.get("content_type") or "audio/wav",
+                "reply": reply_text[:200],
+            }) + "\n").encode()
+        yield (_json.dumps({"done": True, "reply": reply_text}) + "\n").encode()
 
     return StreamingResponse(
         _wrapped(), media_type="application/x-zoe-audio-stream", headers={"Cache-Control": "no-cache"}

--- a/services/zoe-data/routers/voice_tts.py
+++ b/services/zoe-data/routers/voice_tts.py
@@ -7,6 +7,7 @@ import re
 import shutil
 import sys
 import tempfile
+import threading
 import time
 import wave
 from datetime import datetime, timezone
@@ -2402,16 +2403,26 @@ def _log_voice_stt_sample(
 # it never competes with the brain's GPU). Model + tokenizer are cached once. ---
 _moonshine_model = None
 _moonshine_tok = None
+_moonshine_lock = threading.Lock()
 
 
 def _ensure_moonshine():
     global _moonshine_model, _moonshine_tok
-    if _moonshine_model is None:
-        from moonshine_onnx import MoonshineOnnxModel, load_tokenizer
+    if _moonshine_model is not None and _moonshine_tok is not None:
+        return _moonshine_model, _moonshine_tok
+    # Lock the lazy init so a second concurrent caller can't observe a
+    # half-initialised state (model set, tokenizer still None) and crash in
+    # tok.decode_batch(). Runs in a threadpool worker, so a threading.Lock.
+    with _moonshine_lock:
+        if _moonshine_model is None or _moonshine_tok is None:
+            from moonshine_onnx import MoonshineOnnxModel, load_tokenizer
 
-        name = (os.environ.get("ZOE_MOONSHINE_MODEL") or "moonshine/base").strip()
-        _moonshine_model = MoonshineOnnxModel(model_name=name)
-        _moonshine_tok = load_tokenizer()
+            name = (os.environ.get("ZOE_MOONSHINE_MODEL") or "moonshine/base").strip()
+            tok = load_tokenizer()
+            model = MoonshineOnnxModel(model_name=name)
+            # Publish both only once both are ready.
+            _moonshine_tok = tok
+            _moonshine_model = model
     return _moonshine_model, _moonshine_tok
 
 
@@ -4392,6 +4403,7 @@ async def voice_turn_stream(payload: dict, caller: dict = Depends(_require_voice
         raw = base64.b64decode(b64, validate=True)
     except Exception as exc:
         raise HTTPException(status_code=400, detail="invalid base64 audio") from exc
+    t_upload = time.monotonic() - t_turn_start
     suffix = ".wav" if (len(raw) >= 4 and raw[:4] == b"RIFF") else ".raw"
 
     # ── STT (Moonshine, same waterfall as /turn) ──
@@ -4414,6 +4426,12 @@ async def voice_turn_stream(payload: dict, caller: dict = Depends(_require_voice
         raise HTTPException(status_code=500, detail=f"Transcription failed: {exc}") from exc
 
     t_stt = time.monotonic() - t_stt_start
+    try:
+        from voice_metrics import voice_stage_seconds
+        voice_stage_seconds.labels(stage="upload").observe(t_upload)
+        voice_stage_seconds.labels(stage="stt").observe(t_stt)
+    except Exception:
+        pass
     transcript = (transcript or "").strip()
     _log_voice_stt_sample(
         route="turn_stream",
@@ -4428,6 +4446,11 @@ async def voice_turn_stream(payload: dict, caller: dict = Depends(_require_voice
     import json as _json
 
     if not transcript:
+        try:
+            from voice_metrics import voice_turn_count
+            voice_turn_count.labels(outcome="empty_transcript", path="turn_stream").inc()
+        except Exception:
+            pass
         async def _empty():
             yield (_json.dumps({"transcript": "", "done": True, "reply": ""}) + "\n").encode()
         return StreamingResponse(
@@ -4450,7 +4473,14 @@ async def voice_turn_stream(payload: dict, caller: dict = Depends(_require_voice
         command_payload["identified_user_id"] = payload["identified_user_id"]
 
     # Delegate LLM + per-sentence TTS to the existing streaming pipeline.
+    # (voice_command's stream generator records the downstream llm_first_token /
+    # tts_first_byte / total stage metrics + a path="command" turn count.)
     sub = await voice_command(command_payload, caller=caller, stream=True, db=db)
+    try:
+        from voice_metrics import voice_turn_count
+        voice_turn_count.labels(outcome="ok", path="turn_stream").inc()
+    except Exception:
+        pass
 
     async def _wrapped():
         # Lead with the transcript so the panel can show/log what was heard


### PR DESCRIPTION
## Summary
Two CPU-side voice-latency wins (neither contends with the brain's GPU):

**1. Moonshine STT** — replaces whisper base.en with `moonshine_onnx` (edge-built, no 30s padding on short clips).
- ~0.17s warm/clip vs ~0.6–0.9s before; 5/5 test clips correct.
- Default backend with automatic **whisper fallback** on empty/error; startup pre-warm so the first turn isn't cold.
- Toggle: `ZOE_STT_BACKEND=moonshine|whisper`, `ZOE_MOONSHINE_MODEL` (default `moonshine/base`).

**2. brain→TTS sentence streaming** — new `POST /api/voice/turn_stream`: STT then delegates to the existing `voice_command(stream=True)` brain→sentence→TTS generator.
- Panel starts speaking **~1.3s in** instead of waiting 2.7–4.2s for the whole reply to synthesize.
- Panel daemon gains a streaming consumer: pipes each sentence's PCM into one persistent `aplay` (gapless), preserves barge-in, **drops the "thinking" filler**.
- Gated by `ZOE_VOICE_STREAM` (default on) with fallback to the blocking turn.

Also reconverges the repo copy of `zoe_voice_daemon.py` with the live panel (picks up the previously un-committed pre-roll VAD capture fix).

## Why
Once Moonshine cut STT to ~0.17s, measurements showed **TTS synthesis (1.2–1.9s, RTF ~0.5) is now the dominant cost** — so faster STT alone didn't retire the buffer fillers. Streaming starts the real answer ~when a filler would have, making fillers redundant on most turns.

## Test status
- ✅ Moonshine: in-process on real WAVs (165ms, correct); both fallback paths verified; live service loads the ONNX session at startup.
- ✅ `/turn_stream` wired + auth-gated (401 without token); panel daemon deployed, compiles on panel Python 3.11, restarted clean + wake-ready.
- ⏳ **Pending live panel validation** (real-voice TTFA) before this leaves draft / merges. Panel logs `turn_stream TTFA=..s`; server records `tts_first_byte`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)